### PR TITLE
fix(search): map Elasticsearch primary-key columns so a chunked delete can match (fixes #12272)

### DIFF
--- a/crates/data_components/src/elasticsearch/schema.rs
+++ b/crates/data_components/src/elasticsearch/schema.rs
@@ -116,27 +116,23 @@ mod tests {
             "title".to_string(),
             FieldMapping {
                 field_type: Some("text".to_string()),
-                properties: None,
-                dims: None,
-                similarity: None,
+                ..Default::default()
             },
         );
         properties.insert(
             "count".to_string(),
             FieldMapping {
                 field_type: Some("integer".to_string()),
-                properties: None,
-                dims: None,
-                similarity: None,
+                ..Default::default()
             },
         );
         properties.insert(
             "embedding".to_string(),
             FieldMapping {
                 field_type: Some("dense_vector".to_string()),
-                properties: None,
                 dims: Some(384),
                 similarity: Some("cosine".to_string()),
+                ..Default::default()
             },
         );
 
@@ -162,9 +158,7 @@ mod tests {
             "big".to_string(),
             FieldMapping {
                 field_type: Some("unsigned_long".to_string()),
-                properties: None,
-                dims: None,
-                similarity: None,
+                ..Default::default()
             },
         );
 

--- a/crates/elasticsearch/src/lib.rs
+++ b/crates/elasticsearch/src/lib.rs
@@ -83,12 +83,20 @@ pub struct Mappings {
     pub properties: HashMap<String, FieldMapping>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct FieldMapping {
     #[serde(rename = "type")]
     pub field_type: Option<String>,
     #[serde(default)]
     pub properties: Option<HashMap<String, FieldMapping>>,
+    /// Multi-fields — the same value indexed a second way under `<field>.<sub-field>`, e.g. the
+    /// `keyword` sub-field a dynamically mapped string gets alongside its analyzed `text` form.
+    /// A `term` query against an analyzed field has to address one of these to match.
+    #[serde(default)]
+    pub fields: Option<HashMap<String, FieldMapping>>,
+    /// For `keyword` fields: values longer than this many characters are not indexed at all, so
+    /// an exact-match query cannot find them.
+    pub ignore_above: Option<usize>,
     /// For `dense_vector` fields.
     pub dims: Option<i64>,
     /// Similarity metric for `dense_vector` (e.g. `cosine`, `l2_norm`, `dot_product`).

--- a/crates/elasticsearch/src/lib.rs
+++ b/crates/elasticsearch/src/lib.rs
@@ -77,10 +77,35 @@ pub struct IndexMapping {
     pub mappings: Mappings,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct Mappings {
     #[serde(default)]
     pub properties: HashMap<String, FieldMapping>,
+    /// The index's `dynamic` setting — `true` (map new fields), `false` (keep them in `_source`
+    /// but leave them unindexed and unsearchable), `"strict"` (reject them), or `"runtime"`.
+    /// A JSON bool or string, so it is kept raw; [`Mappings::maps_new_fields`] interprets it.
+    #[serde(default)]
+    pub dynamic: Option<serde_json::Value>,
+}
+
+impl Mappings {
+    /// Whether a field absent from [`Self::properties`] would be indexed if a document carried it.
+    ///
+    /// `false` means an absent field is *not* searchable — a `term` query against it can never
+    /// match, even though the value is in `_source`.
+    #[must_use]
+    pub fn maps_new_fields(&self) -> bool {
+        match self.dynamic.as_ref() {
+            Some(serde_json::Value::Bool(false)) => false,
+            // `"true"`/`"false"` are also accepted as strings; `"strict"` rejects an unmapped
+            // field, while `"runtime"` maps it to a runtime field, which is searchable.
+            Some(serde_json::Value::String(dynamic)) => {
+                matches!(dynamic.as_str(), "true" | "runtime")
+            }
+            // Absent is Elasticsearch's default, `true`.
+            _ => true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -97,6 +122,13 @@ pub struct FieldMapping {
     /// For `keyword` fields: values longer than this many characters are not indexed at all, so
     /// an exact-match query cannot find them.
     pub ignore_above: Option<usize>,
+    /// For `keyword` fields: a normalizer applied both when indexing and to a `term` query's
+    /// value, so two distinct values (`BÀR`, `bar`) can collapse to the same term. An exact-match
+    /// query against such a field does not address one value.
+    pub normalizer: Option<String>,
+    /// `index: false` stores the value in `_source` without an inverted index, so no query can
+    /// match on the field at all. Absent means Elasticsearch's default, `true`.
+    pub index: Option<bool>,
     /// For `dense_vector` fields.
     pub dims: Option<i64>,
     /// Similarity metric for `dense_vector` (e.g. `cosine`, `l2_norm`, `dot_product`).

--- a/crates/runtime/src/embeddings/index/elasticsearch/mod.rs
+++ b/crates/runtime/src/embeddings/index/elasticsearch/mod.rs
@@ -518,17 +518,32 @@ fn insert_key_column_mappings(
     }
 }
 
-/// The Elasticsearch mapping for a primary-key column: exact-matchable, never analyzed.
+/// The Elasticsearch mapping for a primary-key column: exact-matchable, never analyzed, and wide
+/// enough for every value the Arrow type can hold.
+///
+/// Deliberately not [`arrow_type_to_es_mapping`], which is tuned for metadata columns and would
+/// hurt a key twice: it maps a string to analyzed `text` (unmatchable by an exact filter), and it
+/// narrows the unsigned integers to signed Elasticsearch types — `UInt32` to `integer` and
+/// `UInt64` to `long` — so a key above `i32::MAX`/`i64::MAX` would fail to index at all.
 fn key_column_es_mapping(dt: &DataType) -> serde_json::Value {
     match dt {
-        // The analyzed `text` mapping `arrow_type_to_es_mapping` gives a string cannot be matched
-        // exactly, which is the whole point here.
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
             serde_json::json!({ "type": "keyword" })
         }
-        // Every other mapping it produces (`long`, `boolean`, `date`, `keyword`, …) already
-        // indexes the value itself.
-        other => arrow_type_to_es_mapping(other),
+        // Elasticsearch's integers are signed, so each unsigned Arrow type takes the next width up
+        // and `UInt64` takes `unsigned_long` — otherwise a key above the signed maximum, which the
+        // Arrow type allows, could not be indexed.
+        DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::UInt8 | DataType::UInt16 => {
+            serde_json::json!({ "type": "integer" })
+        }
+        DataType::Int64 | DataType::UInt32 => serde_json::json!({ "type": "long" }),
+        DataType::UInt64 => serde_json::json!({ "type": "unsigned_long" }),
+        DataType::Boolean => serde_json::json!({ "type": "boolean" }),
+        DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, _) => {
+            serde_json::json!({ "type": "date" })
+        }
+        // `keyword` round-trips anything else losslessly via `_source` and stays exact-matchable.
+        _ => serde_json::json!({ "type": "keyword" }),
     }
 }
 
@@ -659,7 +674,17 @@ pub(crate) async fn ensure_index_with_text_mapping(
             tracing::info!("Created Elasticsearch FTS index '{es_index}'.");
             Ok(())
         }
-        Err(e) if is_index_already_exists_error(&e) => Ok(()),
+        // TOCTOU: another runtime instance created the index between `index_exists` and here.
+        // Apply the mapping update as the `exists` branch above would, so the key columns are
+        // mapped either way.
+        Err(e) if is_index_already_exists_error(&e) => {
+            if let Err(mapping_error) = client.put_mapping(es_index, &mapping_body).await {
+                tracing::warn!(
+                    "Elasticsearch FTS index '{es_index}' exists after concurrent creation but mapping update failed (continuing; existing mapping will be used): {mapping_error}"
+                );
+            }
+            Ok(())
+        }
         Err(e) => Err(Box::new(e) as Box<dyn std::error::Error + Send + Sync>),
     }
 }
@@ -744,6 +769,37 @@ mod tests {
         insert_key_column_mappings(&mut properties, &[field("id", DataType::Utf8)]);
 
         assert_eq!(properties["id"], text_mapping);
+    }
+
+    /// The metadata-column mapping narrows the unsigned integers to signed Elasticsearch types, so
+    /// reusing it for a key would stop `UInt32` keys above `i32::MAX` — which a dynamic mapping
+    /// indexes fine as `long` — from being indexed at all.
+    #[test]
+    fn an_unsigned_key_column_is_mapped_wide_enough_for_every_value() {
+        let mut properties = serde_json::Map::new();
+        insert_key_column_mappings(
+            &mut properties,
+            &[
+                field("small", DataType::UInt16),
+                field("wide", DataType::UInt32),
+                field("widest", DataType::UInt64),
+            ],
+        );
+
+        assert_eq!(properties["small"]["type"], "integer");
+        assert_eq!(
+            properties["wide"]["type"], "long",
+            "a u32 key exceeds Elasticsearch's signed `integer`"
+        );
+        assert_eq!(
+            properties["widest"]["type"], "unsigned_long",
+            "a u64 key exceeds Elasticsearch's signed `long`"
+        );
+        assert_eq!(
+            arrow_type_to_es_mapping(&DataType::UInt32)["type"],
+            "integer",
+            "the metadata mapping this deliberately does not reuse still narrows u32"
+        );
     }
 
     /// Every key column of a composite key needs mapping, not just the first.

--- a/crates/runtime/src/embeddings/index/elasticsearch/mod.rs
+++ b/crates/runtime/src/embeddings/index/elasticsearch/mod.rs
@@ -268,6 +268,7 @@ pub async fn try_from_table(
             vector_field: &vector_field,
             dims,
             text_fields: &text_fields,
+            primary_key: &primary_key,
             mapping_opts: &mapping_opts,
             metadata_columns: &metadata_columns,
             index_settings: index_settings.as_ref(),
@@ -342,6 +343,7 @@ async fn ensure_index_with_mapping(
         vector_field,
         dims,
         text_fields,
+        primary_key,
         mapping_opts,
         metadata_columns,
         index_settings,
@@ -424,6 +426,8 @@ async fn ensure_index_with_mapping(
         properties.insert(name, mapping);
     }
 
+    insert_key_column_mappings(&mut properties, primary_key);
+
     let exists = client
         .index_exists(es_index)
         .await
@@ -479,9 +483,53 @@ struct VectorIndexMapping<'a> {
     vector_field: &'a str,
     dims: i32,
     text_fields: &'a [String],
+    primary_key: &'a [arrow_schema::Field],
     mapping_opts: &'a VectorMappingOptions,
     metadata_columns: &'a MetadataColumns,
     index_settings: Option<&'a serde_json::Value>,
+}
+
+/// Adds an exact-match mapping for every primary-key column not already in `properties`.
+///
+/// Without one, Elasticsearch maps a string key dynamically as `text`, whose inverted index holds
+/// analyzed tokens — and a delete that has to filter on the key column (the chunked-index case,
+/// which cannot address documents by `_id`) then matches nothing and silently removes no
+/// documents (#12272).
+///
+/// `keyword` is declared without an `ignore_above` so that a long key is still indexed: the
+/// default that a *dynamic* string mapping applies to its `keyword` sub-field drops values over
+/// 256 characters, which fails in exactly the same silent way.
+///
+/// A key column already in `properties` — a configured text field, or a declared metadata column —
+/// keeps that mapping: overriding it would silently take away the full-text search the user asked
+/// for. The delete path resolves those through the mapping's `keyword` sub-field instead.
+fn insert_key_column_mappings(
+    properties: &mut serde_json::Map<String, serde_json::Value>,
+    primary_key: &[arrow_schema::Field],
+) {
+    for field in primary_key {
+        if properties.contains_key(field.name()) {
+            continue;
+        }
+        properties.insert(
+            field.name().clone(),
+            key_column_es_mapping(field.data_type()),
+        );
+    }
+}
+
+/// The Elasticsearch mapping for a primary-key column: exact-matchable, never analyzed.
+fn key_column_es_mapping(dt: &DataType) -> serde_json::Value {
+    match dt {
+        // The analyzed `text` mapping `arrow_type_to_es_mapping` gives a string cannot be matched
+        // exactly, which is the whole point here.
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+            serde_json::json!({ "type": "keyword" })
+        }
+        // Every other mapping it produces (`long`, `boolean`, `date`, `keyword`, …) already
+        // indexes the value itself.
+        other => arrow_type_to_es_mapping(other),
+    }
 }
 
 /// Check whether an error from `create_index` indicates the index already exists
@@ -561,12 +609,14 @@ async fn get_store_params(
     .await?)
 }
 
-/// Ensure the Elasticsearch index exists with `text` field mappings for the given fields.
+/// Ensure the Elasticsearch index exists with `text` field mappings for the given fields, plus an
+/// exact-match mapping for the primary-key columns (see [`insert_key_column_mappings`]).
 /// Does NOT create a `dense_vector` field. Best-effort: if the index already exists, leaves it.
 pub(crate) async fn ensure_index_with_text_mapping(
     client: &dyn Elasticsearch,
     es_index: &str,
     text_fields: &[String],
+    primary_key: &[arrow_schema::Field],
     index_settings: Option<&serde_json::Value>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut properties = serde_json::Map::new();
@@ -579,6 +629,8 @@ pub(crate) async fn ensure_index_with_text_mapping(
             }),
         );
     }
+
+    insert_key_column_mappings(&mut properties, primary_key);
 
     let exists = client
         .index_exists(es_index)
@@ -609,5 +661,102 @@ pub(crate) async fn ensure_index_with_text_mapping(
         }
         Err(e) if is_index_already_exists_error(&e) => Ok(()),
         Err(e) => Err(Box::new(e) as Box<dyn std::error::Error + Send + Sync>),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(name: &str, data_type: DataType) -> arrow_schema::Field {
+        arrow_schema::Field::new(name, data_type, false)
+    }
+
+    /// The reported bug (#12272): without an explicit mapping Elasticsearch maps a string key as
+    /// analyzed `text`, and a delete that has to filter on the key column then matches nothing.
+    /// `keyword` indexes the key itself.
+    #[test]
+    fn a_string_key_column_is_mapped_as_keyword() {
+        let mut properties = serde_json::Map::new();
+        insert_key_column_mappings(&mut properties, &[field("id", DataType::Utf8)]);
+
+        assert_eq!(
+            properties.get("id"),
+            Some(&serde_json::json!({ "type": "keyword" })),
+        );
+    }
+
+    /// `ignore_above` is the other way a `keyword` field silently fails to match: a value over the
+    /// limit is not indexed at all. The mapping the runtime writes must not declare one.
+    #[test]
+    fn a_key_column_mapping_declares_no_ignore_above() {
+        let mut properties = serde_json::Map::new();
+        insert_key_column_mappings(
+            &mut properties,
+            &[
+                field("id", DataType::Utf8),
+                field("wide", DataType::LargeUtf8),
+                field("viewed", DataType::Utf8View),
+            ],
+        );
+
+        for name in ["id", "wide", "viewed"] {
+            let mapping = properties.get(name).expect("key column should be mapped");
+            assert_eq!(mapping["type"], "keyword", "{name}: {mapping}");
+            assert!(
+                mapping.get("ignore_above").is_none(),
+                "{name} must be indexed however long the key is: {mapping}"
+            );
+        }
+    }
+
+    /// Non-string keys were never broken by analysis — they keep the mapping that matches how the
+    /// column reads back, rather than being coerced to `keyword`.
+    #[test]
+    fn a_non_string_key_column_keeps_its_natural_mapping() {
+        let mut properties = serde_json::Map::new();
+        insert_key_column_mappings(
+            &mut properties,
+            &[
+                field("i", DataType::Int64),
+                field("flag", DataType::Boolean),
+                field("day", DataType::Date32),
+            ],
+        );
+
+        assert_eq!(properties["i"], serde_json::json!({ "type": "long" }));
+        assert_eq!(properties["flag"], serde_json::json!({ "type": "boolean" }));
+        assert_eq!(properties["day"], serde_json::json!({ "type": "date" }));
+    }
+
+    /// A key column the user also configured for full-text search keeps the `text` mapping that
+    /// makes it searchable — overriding it would silently take that away. The delete path resolves
+    /// such a column through the `keyword` sub-field the text mapping carries.
+    #[test]
+    fn a_key_column_already_mapped_for_full_text_search_is_left_alone() {
+        let text_mapping = serde_json::json!({
+            "type": "text",
+            "fields": { "keyword": { "type": "keyword", "ignore_above": 256 } },
+        });
+        let mut properties = serde_json::Map::new();
+        properties.insert("id".to_string(), text_mapping.clone());
+
+        insert_key_column_mappings(&mut properties, &[field("id", DataType::Utf8)]);
+
+        assert_eq!(properties["id"], text_mapping);
+    }
+
+    /// Every key column of a composite key needs mapping, not just the first.
+    #[test]
+    fn every_column_of_a_composite_key_is_mapped() {
+        let mut properties = serde_json::Map::new();
+        insert_key_column_mappings(
+            &mut properties,
+            &[field("id", DataType::Utf8), field("region", DataType::Utf8)],
+        );
+
+        assert_eq!(properties.len(), 2);
+        assert_eq!(properties["id"]["type"], "keyword");
+        assert_eq!(properties["region"]["type"], "keyword");
     }
 }

--- a/crates/runtime/src/search/full_text/table.rs
+++ b/crates/runtime/src/search/full_text/table.rs
@@ -402,6 +402,7 @@ pub(crate) async fn build_elasticsearch_text_index(
         client.as_ref(),
         &fts_params.es_index,
         &search_fields,
+        &pk_fields,
         index_settings.as_ref(),
     )
     .await?;

--- a/crates/search/src/index/elasticsearch/delete.rs
+++ b/crates/search/src/index/elasticsearch/delete.rs
@@ -18,7 +18,7 @@ use arrow::array::RecordBatch;
 use arrow_schema::Field;
 use datafusion::common::ScalarValue;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
-use elasticsearch::Elasticsearch;
+use elasticsearch::{Elasticsearch, FieldMapping};
 use serde_json::{Value, json};
 use snafu::ResultExt;
 
@@ -47,13 +47,11 @@ const DELETE_CHUNK_ROWS: usize = 512;
 /// `key_columns` covers every `primary_key` column, a prefix delete when it's a strict subset
 /// (the chunked-index case).
 ///
-/// The two cases address documents differently, because filtering on a key *column* is not
-/// reliable. Nothing maps the primary-key columns: the index mapping the runtime creates covers
-/// the vector field, the configured text fields, and declared metadata columns only, so a string
-/// key is dynamically mapped `text` and its inverted index holds *analyzed* tokens. A `term`
-/// query is not analyzed, so `{"term": {"id": "ORDER-1024"}}` looks for one token in an index
-/// holding `[order, 1024]` and matches nothing — a delete that reports success having removed
-/// no documents (#12267).
+/// The two cases address documents differently, because filtering on a key *column* depends on
+/// how that column is mapped. A key that Elasticsearch mapped dynamically as `text` has an
+/// inverted index of *analyzed* tokens, and a `term` query is not analyzed — so
+/// `{"term": {"id": "ORDER-1024"}}` looks for one token in an index holding `[order, 1024]` and
+/// matches nothing, a delete that reports success having removed no documents (#12267).
 ///
 /// So when `key_columns` covers the whole primary key, this addresses documents by `_id` via an
 /// `ids` query. `_id` is the value the write path already stores for the row, derived by the
@@ -61,8 +59,10 @@ const DELETE_CHUNK_ROWS: usize = 512;
 /// the write produced — no field mapping, no analysis, and no dependence on the key's type.
 ///
 /// A strict subset of the key (the chunked-index case) cannot use `_id`, because the chunk id is
-/// part of it and is unknown at delete time; that case still filters on the key columns and so
-/// remains subject to the mapping gap above.
+/// part of it and is unknown at delete time. That case filters on the key columns, and so has to
+/// know how each one is actually indexed: [`resolve_term_fields`] reads the live mapping and
+/// addresses the analyzed-string case through its `keyword` sub-field, rather than assuming the
+/// bare field name is exact-matchable (#12272).
 ///
 /// Only reads `key_columns` from `keys`, ignoring any other column present — `keys` may be
 /// shaped by [`runtime_datafusion_index::Index::required_columns`] (a superset of the primary
@@ -90,6 +90,14 @@ pub async fn delete_by_keys(
             .iter()
             .all(|f| key_columns.iter().any(|c| c == f.name()));
 
+    // Resolved once per call rather than per request chunk: the mapping is a property of the
+    // index, not of the keys being deleted. Only the term-filter path needs it.
+    let term_fields = if addresses_whole_key || keys.num_rows() == 0 || key_columns.is_empty() {
+        Vec::new()
+    } else {
+        resolve_term_fields(client, es_index, key_columns).await?
+    };
+
     let mut offset = 0;
     while offset < keys.num_rows() {
         let len = DELETE_CHUNK_ROWS.min(keys.num_rows() - offset);
@@ -99,7 +107,7 @@ pub async fn delete_by_keys(
         let query = if addresses_whole_key {
             build_ids_query(primary_key, es_index, &chunk)?
         } else {
-            build_or_of_row_term_queries(key_columns, &chunk)?
+            build_or_of_row_term_queries(&term_fields, &chunk)?
         };
         let Some(query) = query else {
             continue;
@@ -137,30 +145,166 @@ fn build_ids_query(
     Ok(Some(json!({ "ids": { "values": values } })))
 }
 
-/// Builds `{"bool": {"should": [{"bool": {"filter": [{"term": {...}}, ...]}}, ...], "minimum_should_match": 1}}`
-/// — one `should` clause (`key_columns` ANDed) per row of `keys`, rows ORed together.
-fn build_or_of_row_term_queries(
+/// Elasticsearch field types that index *analyzed* tokens, so an unanalyzed `term` query against
+/// the bare field name cannot match the value that was written.
+const ANALYZED_FIELD_TYPES: &[&str] = &[
+    "text",
+    "match_only_text",
+    "annotated_text",
+    "search_as_you_type",
+];
+
+/// How to address one key column in a `term` query: which field path actually holds an
+/// exact-matchable copy of the value, and the `ignore_above` beyond which that copy does not
+/// exist at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TermField {
+    /// The column to read values from in the key batch.
+    column: String,
+    /// The Elasticsearch field path to filter on — the column name, or a `keyword` sub-field of it.
+    path: String,
+    /// `keyword`'s character limit, when the resolved field declares one.
+    ignore_above: Option<usize>,
+}
+
+impl TermField {
+    /// The resolution for a column whose mapping makes the bare field name exact-matchable.
+    fn bare(column: &str) -> Self {
+        Self {
+            column: column.to_string(),
+            path: column.to_string(),
+            ignore_above: None,
+        }
+    }
+}
+
+/// Resolves how to filter on each of `key_columns` by reading the index's live mapping.
+///
+/// Nothing guarantees a key column is exact-matchable under its own name. The runtime maps its
+/// key columns as `keyword` when it creates the index, but an index that predates that — or one
+/// the user pre-created, or one where the key is also a configured text field — can have the key
+/// mapped as analyzed `text`, whose inverted index holds tokens (`ORDER-1024` → `[order, 1024]`)
+/// that no `term` query can match.
+///
+/// Per column:
+/// - mapped as an exact type (`keyword`, `long`, `boolean`, `date`, …) → filter on the bare name.
+/// - mapped as analyzed text with a `keyword` sub-field → filter on `<column>.<sub-field>`. The
+///   sub-field cannot simply be assumed: for a key mapped `keyword` outright the bare name is the
+///   correct one, and for analyzed text without such a sub-field there is no exact-matchable copy
+///   at all, which is an error rather than a delete that silently removes nothing.
+/// - absent from the mapping → the bare name. Nothing has ever been indexed under it, so there is
+///   no document for the filter to match either way.
+async fn resolve_term_fields(
+    client: &dyn Elasticsearch,
+    es_index: &str,
     key_columns: &[String],
+) -> DataFusionResult<Vec<TermField>> {
+    let mapping = client
+        .get_mapping(es_index)
+        .await
+        .boxed()
+        .map_err(DataFusionError::External)?;
+
+    // `es_index` may name an alias, in which case the response is keyed by the concrete indexes
+    // behind it. Sorted so a mismatch is reported the same way every time.
+    let mut indexes: Vec<_> = mapping.iter().collect();
+    indexes.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    key_columns
+        .iter()
+        .map(|column| {
+            // Resolve against each index and require agreement — a column addressed one way in one
+            // index and another way in the next cannot be deleted by a single query.
+            let mut resolved: Option<TermField> = None;
+            for (_, index) in &indexes {
+                let candidate = match index.mappings.properties.get(column) {
+                    None => TermField::bare(column),
+                    Some(field) => resolve_one_term_field(es_index, column, field)?,
+                };
+                match &resolved {
+                    None => resolved = Some(candidate),
+                    Some(previous) if previous == &candidate => {}
+                    Some(previous) => {
+                        return Err(DataFusionError::External(format!(
+                            "Failed to delete from Elasticsearch index '{es_index}': primary key column '{column}' is indexed as '{}' in one of the index's mappings and '{}' in another, so one delete cannot address both. Point the dataset at a single index, or give the column the same mapping in each.",
+                            previous.path, candidate.path
+                        ).into()));
+                    }
+                }
+            }
+            Ok(resolved.unwrap_or_else(|| TermField::bare(column)))
+        })
+        .collect()
+}
+
+/// Resolves one key column against its [`FieldMapping`]; see [`resolve_term_fields`].
+fn resolve_one_term_field(
+    es_index: &str,
+    column: &str,
+    field: &FieldMapping,
+) -> DataFusionResult<TermField> {
+    let field_type = field.field_type.as_deref().unwrap_or_default();
+    if !ANALYZED_FIELD_TYPES.contains(&field_type) {
+        return Ok(TermField {
+            column: column.to_string(),
+            path: column.to_string(),
+            ignore_above: field.ignore_above,
+        });
+    }
+
+    // Prefer the conventional `keyword` name, then the first remaining candidate by name — a
+    // multi-field map is unordered, and which sub-field a delete filters on cannot be a coin flip.
+    let mut candidates: Vec<_> = field
+        .fields
+        .iter()
+        .flatten()
+        .filter(|(_, sub)| sub.field_type.as_deref() == Some("keyword"))
+        .collect();
+    candidates.sort_by(|(a, _), (b, _)| {
+        (a.as_str() != "keyword", a.as_str()).cmp(&(b.as_str() != "keyword", b.as_str()))
+    });
+
+    let Some((sub_name, sub)) = candidates.first() else {
+        return Err(DataFusionError::External(
+            format!(
+                "Failed to delete from Elasticsearch index '{es_index}': primary key column '{column}' is mapped as '{field_type}', which indexes analyzed tokens rather than the key itself, and has no 'keyword' sub-field to match exactly against. Deleting a row would silently remove nothing. Re-create the index so '{column}' is mapped as 'keyword', or add a 'keyword' sub-field to it. See: https://spiceai.org/docs/components/vectors/elasticsearch"
+            )
+            .into(),
+        ));
+    };
+
+    Ok(TermField {
+        column: column.to_string(),
+        path: format!("{column}.{sub_name}"),
+        ignore_above: sub.ignore_above,
+    })
+}
+
+/// Builds `{"bool": {"should": [{"bool": {"filter": [{"term": {...}}, ...]}}, ...], "minimum_should_match": 1}}`
+/// — one `should` clause (`term_fields` ANDed) per row of `keys`, rows ORed together.
+fn build_or_of_row_term_queries(
+    term_fields: &[TermField],
     keys: &RecordBatch,
 ) -> DataFusionResult<Option<Value>> {
-    if keys.num_rows() == 0 || key_columns.is_empty() {
+    if keys.num_rows() == 0 || term_fields.is_empty() {
         return Ok(None);
     }
 
-    let arrays: Vec<_> = key_columns
+    let arrays: Vec<_> = term_fields
         .iter()
-        .map(|name| keys.column_by_name(name).cloned())
+        .map(|f| keys.column_by_name(&f.column).cloned())
         .collect::<Option<Vec<_>>>()
         .ok_or_else(|| {
+            let names: Vec<&str> = term_fields.iter().map(|f| f.column.as_str()).collect();
             DataFusionError::Plan(format!(
-                "delete key batch is missing one of the requested key columns: {key_columns:?}"
+                "delete key batch is missing one of the requested key columns: {names:?}"
             ))
         })?;
 
     let mut row_clauses = Vec::with_capacity(keys.num_rows());
     for row in 0..keys.num_rows() {
-        let mut terms = Vec::with_capacity(key_columns.len());
-        for (name, array) in key_columns.iter().zip(&arrays) {
+        let mut terms = Vec::with_capacity(term_fields.len());
+        for (term_field, array) in term_fields.iter().zip(&arrays) {
             let value = ScalarValue::try_from_array(array.as_ref(), row)?;
             let Some(json_value) = scalar_to_term_value(&value) else {
                 // A NULL/unsupported key column can never equal anything via `term` — skip this
@@ -168,7 +312,8 @@ fn build_or_of_row_term_queries(
                 terms.clear();
                 break;
             };
-            terms.push(json!({ "term": { name.as_str(): json_value } }));
+            ensure_within_ignore_above(term_field, &json_value)?;
+            terms.push(json!({ "term": { term_field.path.as_str(): json_value } }));
         }
         if !terms.is_empty() {
             row_clauses.push(json!({ "bool": { "filter": terms } }));
@@ -185,6 +330,27 @@ fn build_or_of_row_term_queries(
             "minimum_should_match": 1
         }
     })))
+}
+
+/// Elasticsearch does not index a `keyword` value longer than the field's `ignore_above`, so a
+/// `term` query for such a key matches nothing. Report that rather than issue a delete that
+/// succeeds having removed the row from nowhere.
+fn ensure_within_ignore_above(term_field: &TermField, value: &Value) -> DataFusionResult<()> {
+    let (Some(limit), Value::String(text)) = (term_field.ignore_above, value) else {
+        return Ok(());
+    };
+    // `ignore_above` counts characters, not bytes.
+    let length = text.chars().count();
+    if length <= limit {
+        return Ok(());
+    }
+    Err(DataFusionError::External(
+        format!(
+            "Failed to delete from Elasticsearch: primary key column '{}' has a key of {length} characters, but the index maps '{}' with ignore_above={limit}, so Elasticsearch never indexed it and the delete would remove nothing. Re-create the index mapping '{}' as 'keyword' without an 'ignore_above'. See: https://spiceai.org/docs/components/vectors/elasticsearch",
+            term_field.column, term_field.path, term_field.column
+        )
+        .into(),
+    ))
 }
 
 fn scalar_to_term_value(value: &ScalarValue) -> Option<Value> {
@@ -210,6 +376,7 @@ fn scalar_to_term_value(value: &ScalarValue) -> Option<Value> {
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     use arrow::array::{Int64Array, StringArray};
     use arrow_schema::{DataType, Schema};
@@ -222,14 +389,48 @@ mod tests {
     use crate::index::chunking::{CHUNKED_INDEX_CHUNK_KEY, ChunkedSearchIndex};
     use arrow::array::{ArrayRef, UInt64Array};
 
-    /// Records the `_delete_by_query` bodies it is asked to issue; every other trait method is
-    /// an error, so a test that reaches one fails loudly rather than silently passing.
+    /// Records the `_delete_by_query` bodies it is asked to issue, and serves `mapping` (when set)
+    /// as the index's live mapping; every other trait method is an error, so a test that reaches
+    /// one fails loudly rather than silently passing.
+    ///
+    /// `get_mapping` errors while `mapping` is `None`, which is what pins that the exact-key
+    /// (`_id`) path never consults the mapping at all.
     #[derive(Debug, Default)]
     struct RecordingClient {
         queries: Mutex<Vec<Value>>,
+        mapping: Option<MappingResponse>,
+        get_mapping_calls: AtomicU32,
     }
 
     impl RecordingClient {
+        /// A client serving one index whose `properties` are the given `(field, mapping)` pairs,
+        /// as Elasticsearch's `GET /<index>/_mapping` would return them.
+        fn with_properties(properties: &[(&str, Value)]) -> Self {
+            Self::with_indexes(&[("idx", properties)])
+        }
+
+        /// A client serving several concrete indexes — what `get_mapping` returns for an alias.
+        fn with_indexes(indexes: &[(&str, &[(&str, Value)])]) -> Self {
+            let mapping = indexes
+                .iter()
+                .map(|(index, properties)| {
+                    let properties: serde_json::Map<String, Value> = properties
+                        .iter()
+                        .map(|(name, mapping)| ((*name).to_string(), mapping.clone()))
+                        .collect();
+                    let index_mapping = serde_json::from_value(json!({
+                        "mappings": { "properties": properties }
+                    }))
+                    .expect("index mapping should deserialize");
+                    ((*index).to_string(), index_mapping)
+                })
+                .collect();
+            Self {
+                mapping: Some(mapping),
+                ..Default::default()
+            }
+        }
+
         fn queries(&self) -> Vec<Value> {
             self.queries
                 .lock()
@@ -256,7 +457,10 @@ mod tests {
         }
 
         async fn get_mapping(&self, _index: &str) -> EsResult<MappingResponse> {
-            Err(unexpected("get_mapping"))
+            self.get_mapping_calls.fetch_add(1, Ordering::AcqRel);
+            self.mapping
+                .clone()
+                .ok_or_else(|| unexpected("get_mapping"))
         }
         async fn search(&self, _index: &str, _body: &SearchRequest) -> EsResult<SearchResponse> {
             Err(unexpected("search"))
@@ -394,9 +598,10 @@ mod tests {
 
     /// A strict subset of the primary key (the chunked-index case) cannot use `_id`, because the
     /// chunk id is part of it and unknown at delete time — that path still filters on columns.
+    /// An index the runtime created maps the key as `keyword`, so the bare field name is exact.
     #[tokio::test]
     async fn partial_key_falls_back_to_term_filters() {
-        let client = RecordingClient::default();
+        let client = RecordingClient::with_properties(&[("id", json!({"type": "keyword"}))]);
 
         delete_by_keys(
             &client,
@@ -419,6 +624,290 @@ mod tests {
                     "minimum_should_match": 1
                 }
             })],
+        );
+    }
+
+    /// The chunked key columns a partial-key delete filters on, as a chunked index hands them over.
+    fn chunked_key(name: &str, data_type: DataType) -> (Vec<Field>, Vec<String>) {
+        (
+            vec![
+                pk(name, data_type),
+                pk(CHUNKED_INDEX_CHUNK_KEY, DataType::UInt64),
+            ],
+            vec![name.to_string()],
+        )
+    }
+
+    /// The reported bug (#12272): a key that Elasticsearch mapped dynamically as analyzed `text`
+    /// is not matchable under its own name, so the partial-key delete has to address the `keyword`
+    /// sub-field. Filtering on the bare name would remove nothing while reporting success.
+    #[tokio::test]
+    async fn a_dynamically_mapped_text_key_is_deleted_through_its_keyword_sub_field() {
+        let client = RecordingClient::with_properties(&[(
+            "id",
+            json!({
+                "type": "text",
+                "fields": { "keyword": { "type": "keyword", "ignore_above": 256 } },
+            }),
+        )]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert_eq!(
+            client.queries(),
+            vec![json!({
+                "bool": {
+                    "should": [{"bool": {"filter": [{"term": {"id.keyword": "ORDER-1024"}}]}}],
+                    "minimum_should_match": 1
+                }
+            })],
+            "an analyzed key must be matched through its keyword sub-field, not the bare field"
+        );
+    }
+
+    /// The sub-field cannot simply be assumed: for a key mapped `keyword` outright there is no
+    /// `id.keyword`, and filtering on it would match nothing.
+    #[tokio::test]
+    async fn a_keyword_mapped_key_is_deleted_on_the_bare_field_name() {
+        let client = RecordingClient::with_properties(&[("id", json!({"type": "keyword"}))]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert_eq!(
+            client.queries()[0]["bool"]["should"][0]["bool"]["filter"],
+            json!([{ "term": { "id": "ORDER-1024" } }]),
+        );
+    }
+
+    /// An analyzed key with no exact-matchable copy anywhere cannot be deleted at all. Reporting
+    /// that beats issuing a query that removes nothing and returns success.
+    #[tokio::test]
+    async fn an_analyzed_key_with_no_keyword_sub_field_is_an_error() {
+        let client = RecordingClient::with_properties(&[("id", json!({"type": "text"}))]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        let err = delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect_err("an unmatchable key must not report a successful delete");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("'id'") && message.contains("keyword"),
+            "the error must name the column and the fix: {message}"
+        );
+        assert!(
+            client.queries().is_empty(),
+            "no delete request should be issued when the key cannot be matched"
+        );
+    }
+
+    /// `ignore_above` is the second way a `keyword` field silently fails to match: Elasticsearch
+    /// does not index a value longer than the limit, so the key is simply absent from the index.
+    #[tokio::test]
+    async fn a_key_longer_than_ignore_above_is_an_error() {
+        let client = RecordingClient::with_properties(&[(
+            "id",
+            json!({"type": "keyword", "ignore_above": 8}),
+        )]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        let err = delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect_err("a key Elasticsearch never indexed must not report a successful delete");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("ignore_above=8") && message.contains("10 characters"),
+            "the error must give both the limit and the key's length: {message}"
+        );
+        assert!(client.queries().is_empty());
+    }
+
+    /// The limit is a character count, not a byte count, so a multi-byte key within it still
+    /// deletes — erring the other way would reject keys Elasticsearch indexed perfectly well.
+    #[tokio::test]
+    async fn a_multi_byte_key_within_ignore_above_still_deletes() {
+        let client = RecordingClient::with_properties(&[(
+            "id",
+            json!({"type": "keyword", "ignore_above": 4}),
+        )]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        // 4 characters, 12 UTF-8 bytes.
+        delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("注文書類")]),
+        )
+        .await
+        .expect("a key within the character limit should delete");
+
+        assert_eq!(client.queries().len(), 1);
+    }
+
+    /// A key column absent from the mapping has never had a value indexed under it, so there is no
+    /// document for the filter to match either way — the bare name is the right query and this is
+    /// not an error.
+    #[tokio::test]
+    async fn a_key_column_absent_from_the_mapping_uses_the_bare_field_name() {
+        let client = RecordingClient::with_properties(&[("other", json!({"type": "keyword"}))]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert_eq!(
+            client.queries()[0]["bool"]["should"][0]["bool"]["filter"],
+            json!([{ "term": { "id": "ORDER-1024" } }]),
+        );
+    }
+
+    /// `get_mapping` on an alias answers for each concrete index behind it. One `_delete_by_query`
+    /// cannot address a column mapped two different ways, so that is reported rather than half
+    /// applied.
+    #[tokio::test]
+    async fn an_alias_whose_indexes_map_the_key_differently_is_an_error() {
+        let text_key = json!({
+            "type": "text",
+            "fields": { "keyword": { "type": "keyword" } },
+        });
+        let client = RecordingClient::with_indexes(&[
+            ("idx-000001", &[("id", json!({"type": "keyword"}))]),
+            ("idx-000002", &[("id", text_key)]),
+        ]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        let err = delete_by_keys(
+            &client,
+            "alias",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect_err("an ambiguous mapping must not be silently resolved one way");
+
+        assert!(err.to_string().contains("'id'"), "unexpected error: {err}");
+        assert!(client.queries().is_empty());
+    }
+
+    /// The mapping is a property of the index, not of the keys, so a delete large enough to be
+    /// split across requests must still read it once.
+    #[tokio::test]
+    async fn the_mapping_is_read_once_per_delete_not_once_per_request() {
+        let client = RecordingClient::with_properties(&[("id", json!({"type": "keyword"}))]);
+        let rows = DELETE_CHUNK_ROWS + 3;
+        let values: Vec<String> = (0..rows).map(|i| format!("key-{i}")).collect();
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, true)]));
+        let keys = RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(values))])
+            .expect("large key batch should build");
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        delete_by_keys(&client, "idx", &primary_key, &key_columns, &keys)
+            .await
+            .expect("delete should succeed");
+
+        assert_eq!(
+            client.queries().len(),
+            2,
+            "the delete should still be split"
+        );
+        assert_eq!(client.get_mapping_calls.load(Ordering::Acquire), 1);
+    }
+
+    /// The exact-key path addresses documents by `_id` and so must not depend on — or even read —
+    /// the mapping. `RecordingClient::default()` errors from `get_mapping`, which is what proves it.
+    #[tokio::test]
+    async fn the_exact_key_path_never_reads_the_mapping() {
+        let client = RecordingClient::default();
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &[pk("id", DataType::Utf8)],
+            &["id".to_string()],
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert_eq!(client.get_mapping_calls.load(Ordering::Acquire), 0);
+    }
+
+    /// A batch with nothing to delete must not spend a mapping round-trip either.
+    #[tokio::test]
+    async fn an_empty_partial_key_batch_reads_no_mapping_and_issues_no_request() {
+        let client = RecordingClient::default();
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![]),
+        )
+        .await
+        .expect("delete should succeed");
+
+        assert_eq!(client.get_mapping_calls.load(Ordering::Acquire), 0);
+        assert!(client.queries().is_empty());
+    }
+
+    /// A non-string key is exact-matchable under its own name whatever the mapping says about
+    /// analysis, and carries no `ignore_above` to trip over.
+    #[tokio::test]
+    async fn an_integer_partial_key_is_deleted_on_the_bare_field_name() {
+        let client = RecordingClient::with_properties(&[("id", json!({"type": "long"}))]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Int64);
+        let keys = base_keys(&[7]);
+
+        delete_by_keys(&client, "idx", &primary_key, &key_columns, &keys)
+            .await
+            .expect("delete should succeed");
+
+        assert_eq!(
+            client.queries()[0]["bool"]["should"][0]["bool"]["filter"],
+            json!([{ "term": { "id": 7 } }]),
         );
     }
 
@@ -567,6 +1056,14 @@ mod tests {
         Field::new("id", DataType::Int64, false)
     }
 
+    /// The term fields for a chunked index's base key, resolved as an exactly-mapped index would.
+    fn bare_term_fields(primary_key: &[Field]) -> Vec<TermField> {
+        document_key_columns(primary_key)
+            .iter()
+            .map(|c| TermField::bare(c))
+            .collect()
+    }
+
     /// A key batch carrying only the base key, as a chunked index hands it over.
     fn base_keys(ids: &[i64]) -> RecordBatch {
         RecordBatch::try_new(
@@ -593,7 +1090,7 @@ mod tests {
     #[test]
     fn a_chunked_index_deletes_every_chunk_of_a_base_key() {
         let chunked = ChunkedSearchIndex::augment_primary_key(vec![id_field()]);
-        let query = build_or_of_row_term_queries(&document_key_columns(&chunked), &base_keys(&[7]))
+        let query = build_or_of_row_term_queries(&bare_term_fields(&chunked), &base_keys(&[7]))
             .expect("query builds")
             .expect("non-empty batch produces a query");
 
@@ -612,9 +1109,9 @@ mod tests {
     /// ids under it, so a query addressing the full composite key cannot be built at all.
     #[test]
     fn the_full_composite_key_cannot_address_a_base_key_batch() {
-        let full: Vec<String> = ChunkedSearchIndex::augment_primary_key(vec![id_field()])
+        let full: Vec<TermField> = ChunkedSearchIndex::augment_primary_key(vec![id_field()])
             .iter()
-            .map(|f| f.name().clone())
+            .map(|f| TermField::bare(f.name()))
             .collect();
 
         let err = build_or_of_row_term_queries(&full, &base_keys(&[7]))
@@ -638,7 +1135,7 @@ mod tests {
         )
         .expect("valid batch");
 
-        let query = build_or_of_row_term_queries(&document_key_columns(&chunked), &keys)
+        let query = build_or_of_row_term_queries(&bare_term_fields(&chunked), &keys)
             .expect("query builds")
             .expect("non-empty batch produces a query");
 

--- a/crates/search/src/index/elasticsearch/delete.rs
+++ b/crates/search/src/index/elasticsearch/delete.rs
@@ -43,6 +43,9 @@ pub fn document_key_columns(primary_key: &[Field]) -> Vec<String> {
 /// request-size limits, regardless of how many keys the caller is deleting in one call.
 const DELETE_CHUNK_ROWS: usize = 512;
 
+/// Where a user goes to fix a key column that Elasticsearch cannot match exactly.
+const ES_VECTORS_DOCS: &str = "https://spiceai.org/docs/components/vectors/elasticsearch";
+
 /// Deletes every document whose `key_columns` match a row of `keys` — an exact-key delete when
 /// `key_columns` covers every `primary_key` column, a prefix delete when it's a strict subset
 /// (the chunked-index case).
@@ -69,9 +72,9 @@ const DELETE_CHUNK_ROWS: usize = 512;
 /// key) rather than the primary key alone, since that's what the default
 /// [`runtime_datafusion_index::Index::resolve_delete_keys`] resolves against.
 ///
-/// Issues one `_delete_by_query` request per [`DELETE_CHUNK_ROWS`]-row slice of `keys` rather
-/// than a single request for the whole batch, so a large delete can't build an unbounded
-/// clause or id list.
+/// Issues one `_delete_by_query` request per [`DELETE_CHUNK_ROWS`] addressed keys rather than a
+/// single request for the whole batch, so a large delete can't build an unbounded clause or id
+/// list.
 ///
 /// Shared by [`super::ElasticsearchIndex`] and [`super::ElasticsearchTextIndex`], which both
 /// address documents the same way (client + index name + primary key columns).
@@ -90,31 +93,23 @@ pub async fn delete_by_keys(
             .iter()
             .all(|f| key_columns.iter().any(|c| c == f.name()));
 
-    // Resolved once per call rather than per request chunk: the mapping is a property of the
-    // index, not of the keys being deleted. Only the term-filter path needs it.
-    let term_fields = if addresses_whole_key || keys.num_rows() == 0 || key_columns.is_empty() {
-        Vec::new()
-    } else {
-        resolve_term_fields(client, es_index, key_columns).await?
-    };
+    if addresses_whole_key {
+        return delete_by_document_id(client, es_index, primary_key, keys).await;
+    }
+    if keys.num_rows() == 0 || key_columns.is_empty() {
+        return Ok(());
+    }
 
-    let mut offset = 0;
-    while offset < keys.num_rows() {
-        let len = DELETE_CHUNK_ROWS.min(keys.num_rows() - offset);
-        let chunk = keys.slice(offset, len);
-        offset += len;
+    // The mapping is a property of the index, not of the keys, so it is read once — and every
+    // row's key is turned into a filter clause *before* the first request goes out. A delete
+    // cannot be rolled back, so a key the 513th row cannot express must not be discovered after
+    // the first 512 rows are already gone.
+    let term_fields = resolve_term_fields(client, es_index, key_columns).await?;
+    let row_clauses = build_row_term_clauses(es_index, &term_fields, keys)?;
 
-        let query = if addresses_whole_key {
-            build_ids_query(primary_key, es_index, &chunk)?
-        } else {
-            build_or_of_row_term_queries(&term_fields, &chunk)?
-        };
-        let Some(query) = query else {
-            continue;
-        };
-
+    for chunk in row_clauses.chunks(DELETE_CHUNK_ROWS) {
         client
-            .delete_by_query(es_index, &query)
+            .delete_by_query(es_index, &or_of_row_clauses(chunk))
             .await
             .boxed()
             .map_err(DataFusionError::External)?;
@@ -123,26 +118,44 @@ pub async fn delete_by_keys(
     Ok(())
 }
 
-/// Builds `{"ids": {"values": ["<_id>", ...]}}` — the documents written for `keys`, addressed by
-/// the `_id` the write path derives for each row.
+/// Deletes the documents `keys` names by the `_id` the write path derived for each row.
+async fn delete_by_document_id(
+    client: &dyn Elasticsearch,
+    es_index: &str,
+    primary_key: &[Field],
+    keys: &RecordBatch,
+) -> DataFusionResult<()> {
+    let ids = document_ids(primary_key, es_index, keys)?;
+
+    for chunk in ids.chunks(DELETE_CHUNK_ROWS) {
+        client
+            .delete_by_query(es_index, &ids_query(chunk))
+            .await
+            .boxed()
+            .map_err(DataFusionError::External)?;
+    }
+
+    Ok(())
+}
+
+/// The `_id`s the write path derived for `keys`, as the values of an `ids` query.
 ///
 /// Rows whose key is NULL (any component, for a composite key) yield no `_id`: the write path
 /// skips them rather than writing under a generated `_id`, so there is no document to delete.
-/// Returns `None` when that leaves nothing to address, so the caller issues no request.
-fn build_ids_query(
+fn document_ids(
     primary_key: &[Field],
     es_index: &str,
     keys: &RecordBatch,
-) -> DataFusionResult<Option<Value>> {
+) -> DataFusionResult<Vec<Value>> {
     let ids = write::extract_primary_key_from_fields(primary_key, es_index, keys)
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-    let values: Vec<Value> = ids.into_iter().flatten().map(Value::String).collect();
-    if values.is_empty() {
-        return Ok(None);
-    }
+    Ok(ids.into_iter().flatten().map(Value::String).collect())
+}
 
-    Ok(Some(json!({ "ids": { "values": values } })))
+/// `{"ids": {"values": ["<_id>", ...]}}` — the documents to remove, addressed by `_id`.
+fn ids_query(ids: &[Value]) -> Value {
+    json!({ "ids": { "values": ids } })
 }
 
 /// Elasticsearch field types that index *analyzed* tokens, so an unanalyzed `term` query against
@@ -192,8 +205,15 @@ impl TermField {
 ///   sub-field cannot simply be assumed: for a key mapped `keyword` outright the bare name is the
 ///   correct one, and for analyzed text without such a sub-field there is no exact-matchable copy
 ///   at all, which is an error rather than a delete that silently removes nothing.
-/// - absent from the mapping → the bare name. Nothing has ever been indexed under it, so there is
-///   no document for the filter to match either way.
+/// - absent from the mapping, and the index maps new fields → the bare name. Nothing has ever been
+///   indexed under it, so there is no document for the filter to match either way. Under
+///   `dynamic: false` or `strict`, an absent field is *never* searchable however, so that is an
+///   error instead.
+/// - carrying a `normalizer` → an error. A normalizer applies to the `term` query's value too, so
+///   two distinct keys can collapse to one term and the delete would remove *more* rows than asked.
+///
+/// Every rejection is a `term` filter that cannot address one row's key. Erring is the
+/// conservative outcome in both directions: neither removing nothing nor removing too much.
 async fn resolve_term_fields(
     client: &dyn Elasticsearch,
     es_index: &str,
@@ -208,7 +228,7 @@ async fn resolve_term_fields(
     // `es_index` may name an alias, in which case the response is keyed by the concrete indexes
     // behind it. Sorted so a mismatch is reported the same way every time.
     let mut indexes: Vec<_> = mapping.iter().collect();
-    indexes.sort_by(|(a, _), (b, _)| a.cmp(b));
+    indexes.sort_by_key(|(name, _)| *name);
 
     key_columns
         .iter()
@@ -218,8 +238,15 @@ async fn resolve_term_fields(
             let mut resolved: Option<TermField> = None;
             for (_, index) in &indexes {
                 let candidate = match index.mappings.properties.get(column) {
-                    None => TermField::bare(column),
                     Some(field) => resolve_one_term_field(es_index, column, field)?,
+                    None if index.mappings.maps_new_fields() => TermField::bare(column),
+                    // `dynamic: false` keeps an unmapped field in `_source` and never indexes it,
+                    // so documents can carry the key while no `term` query can reach it.
+                    None => {
+                        return Err(DataFusionError::External(format!(
+                            "Failed to delete from Elasticsearch index '{es_index}': primary key column '{column}' is not in the index mapping and the index does not map new fields (dynamic is not enabled), so Elasticsearch never indexed the key and the delete would remove nothing. Add '{column}' to the index mapping as 'keyword' and reindex the existing documents. See: {ES_VECTORS_DOCS}"
+                        ).into()));
+                    }
                 };
                 match &resolved {
                     None => resolved = Some(candidate),
@@ -245,6 +272,7 @@ fn resolve_one_term_field(
 ) -> DataFusionResult<TermField> {
     let field_type = field.field_type.as_deref().unwrap_or_default();
     if !ANALYZED_FIELD_TYPES.contains(&field_type) {
+        ensure_addresses_one_value(es_index, column, column, field)?;
         return Ok(TermField {
             column: column.to_string(),
             path: column.to_string(),
@@ -267,29 +295,69 @@ fn resolve_one_term_field(
     let Some((sub_name, sub)) = candidates.first() else {
         return Err(DataFusionError::External(
             format!(
-                "Failed to delete from Elasticsearch index '{es_index}': primary key column '{column}' is mapped as '{field_type}', which indexes analyzed tokens rather than the key itself, and has no 'keyword' sub-field to match exactly against. Deleting a row would silently remove nothing. Re-create the index so '{column}' is mapped as 'keyword', or add a 'keyword' sub-field to it. See: https://spiceai.org/docs/components/vectors/elasticsearch"
+                "Failed to delete from Elasticsearch index '{es_index}': primary key column '{column}' is mapped as '{field_type}', which indexes analyzed tokens rather than the key itself, and has no 'keyword' sub-field to match exactly against. Deleting a row would silently remove nothing. Re-create the index with '{column}' mapped as 'keyword' and reindex the existing documents — adding a sub-field to the live mapping does not populate it for documents already indexed. See: {ES_VECTORS_DOCS}"
             )
             .into(),
         ));
     };
 
+    let path = format!("{column}.{sub_name}");
+    ensure_addresses_one_value(es_index, column, &path, sub)?;
+
     Ok(TermField {
         column: column.to_string(),
-        path: format!("{column}.{sub_name}"),
+        path,
         ignore_above: sub.ignore_above,
     })
 }
 
-/// Builds `{"bool": {"should": [{"bool": {"filter": [{"term": {...}}, ...]}}, ...], "minimum_should_match": 1}}`
-/// — one `should` clause (`term_fields` ANDed) per row of `keys`, rows ORed together.
-fn build_or_of_row_term_queries(
-    term_fields: &[TermField],
-    keys: &RecordBatch,
-) -> DataFusionResult<Option<Value>> {
-    if keys.num_rows() == 0 || term_fields.is_empty() {
-        return Ok(None);
+/// Rejects a resolved field whose `term` query would not address exactly the key it is given.
+///
+/// A `normalizer` is applied to the indexed value *and* to a `term` query's value, so two distinct
+/// keys can reduce to the same term — `{"term": {"id": "bar"}}` against a lowercase-normalized
+/// field also matches the row keyed `BÀR`. The `_id` path is immune because it compares the raw
+/// key, so accepting a normalized field here would make a partial-key delete remove *more* rows
+/// than the exact-key delete would: worse than the under-deletion this whole path guards against.
+fn ensure_addresses_one_value(
+    es_index: &str,
+    column: &str,
+    path: &str,
+    field: &FieldMapping,
+) -> DataFusionResult<()> {
+    if let Some(normalizer) = field.normalizer.as_deref() {
+        return Err(DataFusionError::External(
+            format!(
+                "Failed to delete from Elasticsearch index '{es_index}': primary key column '{column}' is indexed at '{path}' with normalizer '{normalizer}', which rewrites the key both when indexing and when matching, so one key can match another row's documents and the delete could remove rows it was not asked to. Re-create the index with '{column}' mapped as 'keyword' without a normalizer, and reindex the existing documents. See: {ES_VECTORS_DOCS}"
+            )
+            .into(),
+        ));
     }
 
+    // `index: false` — the value is in `_source` but has no inverted index, so no query reaches it.
+    // A declared non-filterable metadata column that is also the primary key lands here.
+    if field.index == Some(false) {
+        return Err(DataFusionError::External(
+            format!(
+                "Failed to delete from Elasticsearch index '{es_index}': primary key column '{column}' is mapped at '{path}' with index=false, so Elasticsearch stores the key without indexing it and no filter can match it — the delete would remove nothing. Declare '{column}' as filterable, or re-create the index with it mapped as an indexed 'keyword', and reindex the existing documents. See: {ES_VECTORS_DOCS}"
+            )
+            .into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// One `{"bool": {"filter": [{"term": {...}}, ...]}}` clause per row of `keys` whose key can be
+/// addressed — `term_fields` ANDed together. Rows whose key is NULL contribute no clause: the
+/// write path stored no document for them, so there is nothing to remove.
+///
+/// Every row is converted here, before any request is issued, so a key that cannot be expressed
+/// fails the whole delete rather than half of it.
+fn build_row_term_clauses(
+    es_index: &str,
+    term_fields: &[TermField],
+    keys: &RecordBatch,
+) -> DataFusionResult<Vec<Value>> {
     let arrays: Vec<_> = term_fields
         .iter()
         .map(|f| keys.column_by_name(&f.column).cloned())
@@ -306,12 +374,20 @@ fn build_or_of_row_term_queries(
         let mut terms = Vec::with_capacity(term_fields.len());
         for (term_field, array) in term_fields.iter().zip(&arrays) {
             let value = ScalarValue::try_from_array(array.as_ref(), row)?;
-            let Some(json_value) = scalar_to_term_value(&value) else {
-                // A NULL/unsupported key column can never equal anything via `term` — skip this
-                // row's clause entirely rather than emit a filter that matches everything.
+            if value.is_null() {
+                // A NULL key component has no stable identity, so the write path never stored a
+                // document under it — skip this row's clause rather than emit a filter that would
+                // match everything.
                 terms.clear();
                 break;
-            };
+            }
+            let json_value = scalar_to_term_value(&value).ok_or_else(|| {
+                DataFusionError::External(format!(
+                    "Failed to delete from Elasticsearch index '{es_index}': primary key column '{column}' has type {data_type}, which this delete cannot express as an exact-match filter, so it would remove nothing. Use a string or integer primary key for a chunked Elasticsearch index. See: {ES_VECTORS_DOCS}",
+                    column = term_field.column,
+                    data_type = value.data_type(),
+                ).into())
+            })?;
             ensure_within_ignore_above(term_field, &json_value)?;
             terms.push(json!({ "term": { term_field.path.as_str(): json_value } }));
         }
@@ -320,16 +396,17 @@ fn build_or_of_row_term_queries(
         }
     }
 
-    if row_clauses.is_empty() {
-        return Ok(None);
-    }
+    Ok(row_clauses)
+}
 
-    Ok(Some(json!({
+/// `{"bool": {"should": [<row clause>, ...], "minimum_should_match": 1}}` — the rows ORed together.
+fn or_of_row_clauses(row_clauses: &[Value]) -> Value {
+    json!({
         "bool": {
             "should": row_clauses,
             "minimum_should_match": 1
         }
-    })))
+    })
 }
 
 /// Elasticsearch does not index a `keyword` value longer than the field's `ignore_above`, so a
@@ -346,7 +423,7 @@ fn ensure_within_ignore_above(term_field: &TermField, value: &Value) -> DataFusi
     }
     Err(DataFusionError::External(
         format!(
-            "Failed to delete from Elasticsearch: primary key column '{}' has a key of {length} characters, but the index maps '{}' with ignore_above={limit}, so Elasticsearch never indexed it and the delete would remove nothing. Re-create the index mapping '{}' as 'keyword' without an 'ignore_above'. See: https://spiceai.org/docs/components/vectors/elasticsearch",
+            "Failed to delete from Elasticsearch: primary key column '{}' has a key of {length} characters, but the index maps '{}' with ignore_above={limit}, so Elasticsearch never indexed it and the delete would remove nothing. Re-create the index mapping '{}' as 'keyword' without an 'ignore_above', and reindex the existing documents. See: {ES_VECTORS_DOCS}",
             term_field.column, term_field.path, term_field.column
         )
         .into(),
@@ -588,9 +665,8 @@ mod tests {
 
         let written = write::extract_primary_key_from_fields(&primary_key, "idx", &keys)
             .expect("write path should derive ids");
-        let query = build_ids_query(&primary_key, "idx", &keys)
-            .expect("ids query should build")
-            .expect("ids query should be present");
+        let query =
+            ids_query(&document_ids(&primary_key, "idx", &keys).expect("ids should derive"));
 
         let addressed: Vec<Value> = written.into_iter().flatten().map(Value::String).collect();
         assert_eq!(query, json!({"ids": {"values": addressed}}));
@@ -893,6 +969,176 @@ mod tests {
         assert!(client.queries().is_empty());
     }
 
+    /// A `normalizer` rewrites the key when indexing *and* when matching, so `bar` matches the row
+    /// keyed `BÀR`. That makes the partial-key delete remove **more** rows than the exact-key
+    /// (`_id`) delete would — worse than the under-deletion this path exists to fix.
+    #[tokio::test]
+    async fn a_normalized_keyword_key_is_an_error_because_it_could_over_delete() {
+        let client = RecordingClient::with_properties(&[(
+            "id",
+            json!({"type": "keyword", "normalizer": "lowercase"}),
+        )]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        let err = delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("BAR")]),
+        )
+        .await
+        .expect_err("a normalized key could match another row's documents");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("normalizer 'lowercase'") && message.contains("'id'"),
+            "the error must name the normalizer and the column: {message}"
+        );
+        assert!(client.queries().is_empty());
+    }
+
+    /// The same hazard reached through a text field's `keyword` sub-field.
+    #[tokio::test]
+    async fn a_normalized_keyword_sub_field_is_also_an_error() {
+        let client = RecordingClient::with_properties(&[(
+            "id",
+            json!({
+                "type": "text",
+                "fields": { "keyword": { "type": "keyword", "normalizer": "lowercase" } },
+            }),
+        )]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        let err = delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("BAR")]),
+        )
+        .await
+        .expect_err("a normalized sub-field could match another row's documents");
+
+        assert!(err.to_string().contains("id.keyword"), "unexpected: {err}");
+    }
+
+    /// `index: false` stores the key in `_source` without an inverted index, so no filter reaches
+    /// it. A primary-key column the user declared `non-filterable` lands here.
+    #[tokio::test]
+    async fn an_unindexed_key_is_an_error() {
+        let client =
+            RecordingClient::with_properties(&[("id", json!({"type": "keyword", "index": false}))]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        let err = delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect_err("an unindexed key cannot be matched");
+
+        assert!(
+            err.to_string().contains("index=false"),
+            "unexpected error: {err}"
+        );
+        assert!(client.queries().is_empty());
+    }
+
+    /// Under `dynamic: false` an unmapped field stays in `_source` and is never indexed, so
+    /// "absent from the mapping" no longer implies "no document carries it".
+    #[tokio::test]
+    async fn a_key_absent_from_a_non_dynamic_mapping_is_an_error() {
+        let index_mapping = serde_json::from_value(json!({
+            "mappings": { "dynamic": false, "properties": { "other": {"type": "keyword"} } }
+        }))
+        .expect("index mapping should deserialize");
+        let client = RecordingClient {
+            mapping: Some([("idx".to_string(), index_mapping)].into_iter().collect()),
+            ..Default::default()
+        };
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        let err = delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect_err("an unmapped key under dynamic:false is never searchable");
+
+        assert!(
+            err.to_string().contains("does not map new fields"),
+            "unexpected error: {err}"
+        );
+        assert!(client.queries().is_empty());
+    }
+
+    /// A key type the filter cannot express is not the same thing as a NULL key: NULL means no
+    /// document was written, while an unsupported type means one was and cannot be addressed.
+    /// Conflating them turns the second into a delete that removes nothing and returns success.
+    #[tokio::test]
+    async fn an_unsupported_key_type_is_an_error_not_a_skipped_row() {
+        let client = RecordingClient::with_properties(&[("day", json!({"type": "date"}))]);
+        let keys = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("day", DataType::Date32, true)])),
+            vec![Arc::new(arrow::array::Date32Array::from(vec![19_723])) as ArrayRef],
+        )
+        .expect("date key batch should build");
+
+        let err = delete_by_keys(
+            &client,
+            "idx",
+            &[
+                pk("day", DataType::Date32),
+                pk(CHUNKED_INDEX_CHUNK_KEY, DataType::UInt64),
+            ],
+            &["day".to_string()],
+            &keys,
+        )
+        .await
+        .expect_err("an inexpressible key must not report a successful delete");
+
+        assert!(
+            err.to_string().contains("'day'"),
+            "the error must name the column: {err}"
+        );
+        assert!(client.queries().is_empty());
+    }
+
+    /// A delete cannot be rolled back, so a key the last row cannot express must be found before
+    /// the first request goes out — not after 512 rows have already been removed.
+    #[tokio::test]
+    async fn a_key_that_cannot_be_expressed_fails_before_any_row_is_deleted() {
+        let client = RecordingClient::with_properties(&[(
+            "id",
+            json!({"type": "keyword", "ignore_above": 8}),
+        )]);
+        // The over-long key is in the second request's slice, past the first full chunk.
+        let mut values: Vec<String> = (0..DELETE_CHUNK_ROWS).map(|i| format!("k{i}")).collect();
+        values.push("a-key-past-the-limit".to_string());
+        let keys = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, true)])),
+            vec![Arc::new(StringArray::from(values))],
+        )
+        .expect("large key batch should build");
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        delete_by_keys(&client, "idx", &primary_key, &key_columns, &keys)
+            .await
+            .expect_err("the unmatchable key must fail the delete");
+
+        assert!(
+            client.queries().is_empty(),
+            "no row may be deleted when one of them cannot be addressed"
+        );
+    }
+
     /// A non-string key is exact-matchable under its own name whatever the mapping says about
     /// analysis, and carries no `ignore_above` to trip over.
     #[tokio::test]
@@ -1090,9 +1336,10 @@ mod tests {
     #[test]
     fn a_chunked_index_deletes_every_chunk_of_a_base_key() {
         let chunked = ChunkedSearchIndex::augment_primary_key(vec![id_field()]);
-        let query = build_or_of_row_term_queries(&bare_term_fields(&chunked), &base_keys(&[7]))
-            .expect("query builds")
-            .expect("non-empty batch produces a query");
+        let query = or_of_row_clauses(
+            &build_row_term_clauses("idx", &bare_term_fields(&chunked), &base_keys(&[7]))
+                .expect("clauses build"),
+        );
 
         let clauses = query["bool"]["should"]
             .as_array()
@@ -1114,7 +1361,7 @@ mod tests {
             .map(|f| TermField::bare(f.name()))
             .collect();
 
-        let err = build_or_of_row_term_queries(&full, &base_keys(&[7]))
+        let err = build_row_term_clauses("idx", &full, &base_keys(&[7]))
             .expect_err("the chunk id is not in the batch");
         assert!(
             err.to_string().contains(CHUNKED_INDEX_CHUNK_KEY),
@@ -1135,9 +1382,10 @@ mod tests {
         )
         .expect("valid batch");
 
-        let query = build_or_of_row_term_queries(&bare_term_fields(&chunked), &keys)
-            .expect("query builds")
-            .expect("non-empty batch produces a query");
+        let query = or_of_row_clauses(
+            &build_row_term_clauses("idx", &bare_term_fields(&chunked), &keys)
+                .expect("clauses build"),
+        );
 
         assert_eq!(
             query["bool"]["should"][0]["bool"]["filter"],

--- a/crates/search/src/index/elasticsearch/delete.rs
+++ b/crates/search/src/index/elasticsearch/delete.rs
@@ -388,7 +388,7 @@ fn build_row_term_clauses(
                     data_type = value.data_type(),
                 ).into())
             })?;
-            ensure_within_ignore_above(term_field, &json_value)?;
+            ensure_within_ignore_above(es_index, term_field, &json_value)?;
             terms.push(json!({ "term": { term_field.path.as_str(): json_value } }));
         }
         if !terms.is_empty() {
@@ -412,7 +412,11 @@ fn or_of_row_clauses(row_clauses: &[Value]) -> Value {
 /// Elasticsearch does not index a `keyword` value longer than the field's `ignore_above`, so a
 /// `term` query for such a key matches nothing. Report that rather than issue a delete that
 /// succeeds having removed the row from nowhere.
-fn ensure_within_ignore_above(term_field: &TermField, value: &Value) -> DataFusionResult<()> {
+fn ensure_within_ignore_above(
+    es_index: &str,
+    term_field: &TermField,
+    value: &Value,
+) -> DataFusionResult<()> {
     let (Some(limit), Value::String(text)) = (term_field.ignore_above, value) else {
         return Ok(());
     };
@@ -421,10 +425,21 @@ fn ensure_within_ignore_above(term_field: &TermField, value: &Value) -> DataFusi
     if length <= limit {
         return Ok(());
     }
+    let column = &term_field.column;
+    let path = &term_field.path;
+    // The limit belongs to whichever field the filter actually addresses, which is the column
+    // itself only when its own mapping is exact-matchable — otherwise it is the `keyword`
+    // sub-field the resolver picked, and re-mapping the column alone would not lift the limit.
+    let remedy = if path == column {
+        format!("Re-create the index with '{column}' mapped as 'keyword' without an 'ignore_above'")
+    } else {
+        format!(
+            "Re-create the index so the key is exact-matchable with no 'ignore_above' — either map '{column}' as 'keyword' outright, or give its analyzed mapping a 'keyword' sub-field that declares no 'ignore_above'"
+        )
+    };
     Err(DataFusionError::External(
         format!(
-            "Failed to delete from Elasticsearch: primary key column '{}' has a key of {length} characters, but the index maps '{}' with ignore_above={limit}, so Elasticsearch never indexed it and the delete would remove nothing. Re-create the index mapping '{}' as 'keyword' without an 'ignore_above', and reindex the existing documents. See: {ES_VECTORS_DOCS}",
-            term_field.column, term_field.path, term_field.column
+            "Failed to delete from Elasticsearch index '{es_index}': primary key column '{column}' has a key of {length} characters, but the delete filters on '{path}', which the index maps with ignore_above={limit}, so Elasticsearch never indexed that key and the delete would remove nothing. {remedy}, and reindex the existing documents. See: {ES_VECTORS_DOCS}"
         )
         .into(),
     ))
@@ -825,6 +840,50 @@ mod tests {
         assert!(
             message.contains("ignore_above=8") && message.contains("10 characters"),
             "the error must give both the limit and the key's length: {message}"
+        );
+        assert!(
+            !message.contains("sub-field"),
+            "the column's own mapping carries the limit here, so the remedy is the column: {message}"
+        );
+        assert!(client.queries().is_empty());
+    }
+
+    /// The limit that stops the delete belongs to the field the filter addresses, which for an
+    /// analyzed key is the `keyword` sub-field. Re-mapping the column alone would not lift it, so
+    /// the error has to name the sub-field it read the limit from and say what to change.
+    #[tokio::test]
+    async fn a_key_longer_than_a_sub_fields_ignore_above_names_the_sub_field() {
+        let client = RecordingClient::with_properties(&[(
+            "id",
+            json!({
+                "type": "text",
+                "fields": { "keyword": { "type": "keyword", "ignore_above": 8 } },
+            }),
+        )]);
+        let (primary_key, key_columns) = chunked_key("id", DataType::Utf8);
+
+        let err = delete_by_keys(
+            &client,
+            "idx",
+            &primary_key,
+            &key_columns,
+            &string_key_batch(vec![Some("ORDER-1024")]),
+        )
+        .await
+        .expect_err("a key the sub-field never indexed must not report a successful delete");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("'id.keyword'"),
+            "the error must name the field the delete filters on: {message}"
+        );
+        assert!(
+            message.contains("sub-field"),
+            "the remedy must cover the sub-field, not just the column: {message}"
+        );
+        assert!(
+            message.contains("index 'idx'"),
+            "the error must name the index: {message}"
         );
         assert!(client.queries().is_empty());
     }


### PR DESCRIPTION
## Summary

Fixes #12272

A chunked Elasticsearch index stores one document per chunk, keyed by the base row key plus `_spice.chunk_id`. A delete only carries the base key, so it cannot address documents by `_id` (the chunk id is part of it, and is unknown at delete time) and filters on the key columns instead.

**Root cause:** nothing mapped those columns. `ensure_index_with_mapping` put only three things in the index `properties` — the `dense_vector` field, the configured `text_fields`, and declared metadata columns — so Elasticsearch mapped a string key *dynamically*, as `text`. A `text` field's inverted index holds **analyzed** tokens, and a `term` query is not analyzed: `{"term": {"id": "ORDER-1024"}}` looks for one token in an index holding `[order, 1024]` and matches nothing. `_delete_by_query` returns `2xx`, the delete reports success, and every chunk of the row stays in Elasticsearch — search keeps returning a row the dataset no longer has.

#12273 removed the consequence for the **exact-key** delete by addressing documents by `_id`, which depends on no mapping at all. The **partial-key** (chunked) delete could not follow it there, and this is the remainder.

## Changes

**Map the key columns when creating the index** (`crates/runtime/src/embeddings/index/elasticsearch/mod.rs`) — every primary-key column not already in `properties`, for both the vector index and the FTS index. A new index is then correct by construction:

- Strings are mapped `keyword` with **no `ignore_above`**. The 256-character cap a *dynamic* string mapping puts on its `keyword` sub-field drops longer values from the index entirely, which fails in exactly the same silent way.
- Integers get a mapping wide enough for the Arrow type, which is why this does not reuse `arrow_type_to_es_mapping`: that narrows `UInt32` to signed `integer` and `UInt64` to signed `long`, so a key above `i32::MAX` would stop being indexable — a *regression* against today's dynamic mapping, which infers `long`.
- A key column already in `properties` (a configured text field, or a declared metadata column) keeps its mapping. Overriding it would silently take away the full-text search the user asked for.

**Resolve each key column against the live mapping at delete time** (`crates/search/src/index/elasticsearch/delete.rs`), which is what repairs an index that already exists, with no reindex, for the common case: a dynamically mapped string key already carries the `keyword` sub-field its first document created, so the delete addresses `id.keyword` and works. The sub-field cannot simply be assumed — for a key mapped `keyword` outright the bare name is the correct one — hence reading rather than guessing.

**Report the shapes that cannot address one key, rather than deleting nothing (or too much).** Each of these previously produced a delete that removed no documents and returned success:

| Mapping | Why a `term` filter is wrong | Now |
| --- | --- | --- |
| analyzed, no `keyword` sub-field | no exact copy of the key exists | error naming the column + the reindex |
| `index: false` | value is in `_source`, never indexed | error |
| absent under `dynamic: false`/`strict` | unmapped fields are never indexed | error |
| key longer than the field's `ignore_above` | Elasticsearch did not index that value | error with the length and the limit |
| key type the filter cannot express (date, decimal, …) | previously conflated with a NULL key and skipped | error |
| a `normalizer` on the resolved field | rewrites the key when indexing **and** when matching, so `bar` matches the row keyed `BÀR` | error — this one would **over**-delete |

The normalizer case is worth calling out: it is the only one where the wrong outcome is deleting rows that were not asked for. `_id` is immune (it compares the raw key), so accepting a normalized field here would have made the partial-key delete broader than the exact-key delete.

**Validate every row before the first request.** The term-filter path now converts the whole key batch to filter clauses up front and only then issues its `_delete_by_query` requests. A delete cannot be rolled back, so a key the 513th row cannot express must not be discovered after the first 512 rows are already gone.

Also: the FTS index's concurrent-creation branch now applies the mapping update like the vector index's already did, instead of returning success with the mapping unapplied.

## What this does not establish

- **The error is a loud log, not a failed refresh.** Both callers of `Index::delete_by_keys` log its error and continue by design (`runtime-datafusion-index/src/provider.rs`, `accelerated_table/refresh_task/changes.rs`), because the authoritative row is already gone by then. So a rejected mapping surfaces as an `ERROR` naming the column and the fix — materially better than a silent success, and not the same thing as the refresh failing. Making it fail is a separate decision about a fail-open cleanup path.
- **Reading the mapping cannot prove what existing documents contain.** `put_mapping` does not backfill, so a field added to a live mapping stays empty for already-indexed documents. This is why the errors say "reindex" and not just "change the mapping", and why the durable fix is a Spice-owned base-key field the write path populates — filed as #12363.
- **A `_delete_by_query` response is still discarded**, so a partially applied delete (per-document `failures`, `version_conflicts`) still reports success. Pre-existing, and out of scope here — filed as #12364.
- **An alias can roll over between the mapping read and the requests.** Inherent to aliasing rather than to this change; the per-index agreement check covers disagreement at read time, not a change afterwards. Also addressed structurally by #12363.

## Test plan

- `make lint`
- `make nextest`
- **23 new unit tests** — 17 in `crates/search`'s Elasticsearch delete module (32 passing there, up from 15) and 6 covering the runtime mapping helper (which had none). Every rejection in the table above has a test asserting both the message and that **no** `_delete_by_query` request was issued.
- Neutered each half of the delete-side fix; all three fail deterministically:
  - resolver forced back to the bare field name → **8** tests fail, including the dynamically-mapped-`text` regression test
  - normalizer rejection removed → **2** tests fail
  - NULL and unsupported key type conflated again → **1** test fails
- The runtime mapping side is neutered by construction instead: `an_unsigned_key_column_is_mapped_wide_enough_for_every_value` asserts both that a `UInt32` key maps to `long` **and** that `arrow_type_to_es_mapping(UInt32)` is still `integer`, so re-delegating to it fails the test. (Not run as a separate neuter — the runtime crate's dev-dependency graph makes each rebuild ~45 minutes.)
- The mock Elasticsearch client's `get_mapping` errors unless a test supplies a mapping, which is what pins that the exact-key (`_id`) path never reads it.
- Scoped `clippy` run locally in the gate's two passes (`--lib --bins`, then `--tests`) over `search`, `elasticsearch`, `data_components` and `runtime` with the `elasticsearch` feature: clean. Three lints it caught (`match_same_arms` twice, `sort_by_key`) are fixed in the second commit.

## Checklist

- [x] Root cause identified and stated
- [x] Regression tests that fail on the old code
- [x] Bug class swept: both Elasticsearch index types share `delete_by_keys`, so both are covered by one fix; no other code path builds a `term` filter on a key column (reads do not push filters down to Elasticsearch — `supports_filters_pushdown` returns `Unsupported`)
- [x] Adversarial and security review run on the diff; findings either fixed here or filed (#12363, #12364)
- [x] User-facing errors name the dataset column, the mapping that is wrong, and the fix, with a docs link
- [x] No new `.unwrap()`/`.expect()` in non-test code
