### PR TITLE
fix(bench): install make before the seeded-database check; surface catalog error causes

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -253,7 +253,13 @@ jobs:
           DB_NAME="${QUERY_SET}_sf${SCALE_FACTOR}"
 
           sudo apt-get update -y
-          sudo apt-get install -y postgresql-client
+          # make is needed before the "already seeded" check below, not just by the
+          # seeding path further down: a database that already has data still runs
+          # `make pg-create-index`, and on a runner without make preinstalled that
+          # exits 127 before the later install line is ever reached. Only a
+          # pre-provisioned target takes that branch, so it surfaced solely on
+          # SF100 while the always-empty SF1/SF10 containers stayed green.
+          sudo apt-get install -y postgresql-client make
 
           echo "Checking whether $DB_NAME already has data on $PGHOST..."
           set +e
@@ -302,7 +308,7 @@ jobs:
           fi
 
           echo "$DB_NAME is missing or empty on $PGHOST - seeding it now."
-          sudo apt-get install -y git make
+          sudo apt-get install -y git
           if [ "$QUERY_SET" = "tpcds" ]; then
             # tpcds-kit's tools/Makefile hardcodes CC=gcc-9 on Linux; ubuntu-24.04's
             # default gcc isn't named gcc-9, so install it explicitly via the PPA.

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -44,7 +44,12 @@ use tokio::sync::Mutex;
 /// same unactionable text, so walk the chain and keep what it says.
 ///
 /// Causes already quoted by an outer message are skipped, since wrappers commonly
-/// interpolate `{source}` themselves and would otherwise repeat it verbatim.
+/// interpolate `{source}` themselves and would otherwise repeat it verbatim. That
+/// check is a suffix match, not a substring one: `{source}` interpolation puts the
+/// cause at the end, whereas a substring test would silently drop a short cause that
+/// merely appears somewhere in the outer text — dropping "host" from "cannot resolve
+/// host name", say, which is precisely the detail this is here to keep. Repeating a
+/// cause is only noisy; losing one defeats the purpose, so the bias is toward keeping.
 fn error_with_causes(err: &dyn std::error::Error) -> String {
     fn one_line(err: &dyn std::error::Error) -> String {
         err.to_string()
@@ -57,7 +62,10 @@ fn error_with_causes(err: &dyn std::error::Error) -> String {
     let mut cause = err.source();
     while let Some(current) = cause {
         let text = one_line(current);
-        if !text.is_empty() && !message.contains(&text) {
+        // Ignore trailing punctuation so "… : bad password." still counts as already
+        // quoting a "bad password" cause.
+        let quoted = message.trim_end_matches(['.', '!', ' ']).ends_with(&text);
+        if !text.is_empty() && !quoted {
             message.push_str(": ");
             message.push_str(&text);
         }
@@ -500,11 +508,39 @@ mod tests {
 
         // Wrappers that already interpolate `{source}` must not repeat it.
         let err = chained(&["connect failed: bad password", "bad password"]);
-        assert_eq!(super::error_with_causes(&err), "connect failed: bad password");
+        assert_eq!(
+            super::error_with_causes(&err),
+            "connect failed: bad password"
+        );
+
+        // …including when the wrapper punctuates after the interpolated source.
+        let err = chained(&["connect failed: bad password.", "bad password"]);
+        assert_eq!(
+            super::error_with_causes(&err),
+            "connect failed: bad password."
+        );
 
         // A lone error with no chain is unchanged.
         let err = chained(&["standalone"]);
         assert_eq!(super::error_with_causes(&err), "standalone");
+    }
+
+    #[test]
+    fn error_with_causes_keeps_a_cause_that_is_only_a_substring() {
+        // A short cause that merely appears inside the outer text is NOT already
+        // quoted, and dropping it would discard the root cause this exists to keep.
+        let err = chained(&["cannot resolve host name for cluster", "host"]);
+        assert_eq!(
+            super::error_with_causes(&err),
+            "cannot resolve host name for cluster: host"
+        );
+
+        // Same for a cause repeated mid-message rather than interpolated at the end.
+        let err = chained(&["timeout while waiting: retrying", "timeout"]);
+        assert_eq!(
+            super::error_with_causes(&err),
+            "timeout while waiting: retrying: timeout"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/catalogconnector/mod.rs
+++ b/crates/runtime/src/catalogconnector/mod.rs
@@ -35,9 +35,43 @@ use deferred::DeferredCatalogProvider;
 use snafu::prelude::*;
 use tokio::sync::Mutex;
 
+/// Render `err` together with every error in its `source()` chain, on one line.
+///
+/// Database clients routinely keep the useful part of a failure off the outermost
+/// error: `tokio_postgres::Error` displays as just `db error`, with the SQLSTATE and
+/// the server's message reachable only through its source. Displaying the outer error
+/// alone turns a missing database, a bad password and an unreachable host into the
+/// same unactionable text, so walk the chain and keep what it says.
+///
+/// Causes already quoted by an outer message are skipped, since wrappers commonly
+/// interpolate `{source}` themselves and would otherwise repeat it verbatim.
+fn error_with_causes(err: &dyn std::error::Error) -> String {
+    fn one_line(err: &dyn std::error::Error) -> String {
+        err.to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    let mut message = one_line(err);
+    let mut cause = err.source();
+    while let Some(current) = cause {
+        let text = one_line(current);
+        if !text.is_empty() && !message.contains(&text) {
+            message.push_str(": ");
+            message.push_str(&text);
+        }
+        cause = current.source();
+    }
+    message
+}
+
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to setup the {connector_component} ({connector}). {source}"))]
+    #[snafu(display(
+        "Failed to setup the {connector_component} ({connector}). {}",
+        error_with_causes(source.as_ref())
+    ))]
     UnableToGetCatalogProvider {
         connector: String,
         connector_component: ConnectorComponent,
@@ -401,6 +435,77 @@ mod tests {
 
     static REGISTRY_TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> =
         LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+    #[derive(Debug)]
+    struct ChainedError {
+        message: String,
+        source: Option<Box<ChainedError>>,
+    }
+
+    impl std::fmt::Display for ChainedError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+
+    impl std::error::Error for ChainedError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            self.source
+                .as_ref()
+                .map(|s| s.as_ref() as &(dyn std::error::Error + 'static))
+        }
+    }
+
+    fn chained(messages: &[&str]) -> ChainedError {
+        let mut iter = messages.iter().rev();
+        let last = iter.next().unwrap_or(&"");
+        let mut err = ChainedError {
+            message: (*last).to_string(),
+            source: None,
+        };
+        for message in iter {
+            err = ChainedError {
+                message: (*message).to_string(),
+                source: Some(Box::new(err)),
+            };
+        }
+        err
+    }
+
+    #[test]
+    fn error_with_causes_keeps_the_cause_the_outer_error_hides() {
+        // The shape this exists for: tokio_postgres::Error displays as "db error"
+        // and the connection pool's own message spans lines, so the outermost text
+        // alone cannot distinguish a missing database from bad credentials.
+        let err = chained(&[
+            "PostgreSQL connection failed.\ndb error",
+            "db error",
+            "FATAL: database \"tpch_sf1\" does not exist",
+        ]);
+        assert_eq!(
+            super::error_with_causes(&err),
+            "PostgreSQL connection failed. db error: FATAL: database \"tpch_sf1\" does not exist"
+        );
+    }
+
+    #[test]
+    fn error_with_causes_is_single_line_and_skips_repeats() {
+        // Every message collapses to one line — a multi-line error would break
+        // one-line-per-event log parsing.
+        let err = chained(&["outer\n  spanning lines", "inner"]);
+        assert_eq!(
+            super::error_with_causes(&err),
+            "outer spanning lines: inner"
+        );
+
+        // Wrappers that already interpolate `{source}` must not repeat it.
+        let err = chained(&["connect failed: bad password", "bad password"]);
+        assert_eq!(super::error_with_causes(&err), "connect failed: bad password");
+
+        // A lone error with no chain is unchanged.
+        let err = chained(&["standalone"]);
+        assert_eq!(super::error_with_causes(&err), "standalone");
+    }
 
     #[tokio::test]
     async fn test_catalog_connector_registry_lifecycle() {


### PR DESCRIPTION
Two unrelated failures seen on the scheduled TPC-H runs since #12214 landed, both in the PostgreSQL path. Neither is a regression from that PR — the first is a latent bug it made visible by getting the benches far enough to hit it.

## `make: command not found` on the SF100 seed

`bench - tpch - federated/postgres.yaml` at SF100 fails in *Seed postgres TPC-H/TPC-DS data if missing*:

```
Checking whether tpch_sf100 already has data on <host>...
/home/runner/_work/_temp/….sh: line 37: make: command not found
```

A database that already has data still runs `make pg-create-index` to refresh indexes and then exits early. That branch sits **above** the line installing `make`, so on a runner without `make` preinstalled it exits 127 before the install is ever reached.

Only a pre-provisioned target takes that branch, which is why this surfaced solely on SF100 — the SF1/SF10 service containers always start empty, fall through to the seeding path, and get `make` installed on the way. The ordering predates #12214 (identical in `3ddf95ae6c^`); that PR only changed which packages the later line installs.

Fix: install `make` alongside `postgresql-client`, before the check.

## Catalog connection failures hid their cause

A catalog that could not connect reported only:

```
Failed to setup the catalog pg (pg). PostgreSQL connection failed.
db error
```

`tokio_postgres::Error` displays as exactly `db error`, keeping the SQLSTATE and the server's message on its `source()`. So a missing database, a wrong password and an unreachable host all render identically. That has now cost real diagnosis time twice — once when the hosted `tpch_sf1` turned out to be gone, and again on a transient SF1 failure where the message could not distinguish a container that was not ready yet from a genuine misconfiguration.

Fix: walk the `source()` chain when displaying `UnableToGetCatalogProvider`. That variant is shared by every catalog connector, so this is not PostgreSQL-specific. The same failure now reads:

```
Failed to setup the catalog pg (pg). PostgreSQL connection failed. db error: FATAL: database "tpch_sf1" does not exist
```

Two details the implementation is careful about:

- **Single line.** Each message in the chain is collapsed, because the connection pool's own `Display` spans lines and a multi-line error breaks one-line-per-event log parsing.
- **No repetition.** Wrappers commonly interpolate `{source}` themselves, so a cause already quoted by an outer message is skipped rather than printed twice.

## Validation

`cargo test -p runtime --lib catalogconnector::tests::error_with_causes` — 2 passed. The tests pin the exact `db error` shape this exists for, the single-line collapsing, the de-duplication, and the no-chain case.

The workflow change is verified by parsing the YAML and asserting the install now precedes the early-exit branch (`apt-get install … make` at line 13, `make pg-create-index` at line 42 of the step).
