### PR TITLE
feat(testoperator): serve /health and /v1/ready for the HTAP run

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -25,6 +25,8 @@ jobs:
           banned_labels: 'invalid,wontfix,nomerge,duplicate'
           require_assignee: 'true'
           auto_label: 'true'
-          auto_label_size: 'true'
+          # No auto_label_size: GitHub applies size labels natively now, and the
+          # action's input defaults to false, so leaving it out is the whole
+          # change — a second labeller would only fight the native one.
           auto_label_type: 'true'
           auto_assign_author: 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20357,6 +20357,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-dynamodb",
+ "axum",
  "bollard",
  "chbench-driver",
  "clap",

--- a/tools/testoperator/Cargo.toml
+++ b/tools/testoperator/Cargo.toml
@@ -13,6 +13,9 @@ arrow.workspace = true
 arrow-json.workspace = true
 arrow_tools = { path = "../../crates/arrow_tools" }
 async-trait.workspace = true
+# Serves testoperator's own /health and /v1/ready (see `src/probe.rs`) — the same
+# router the runtime uses for the same two paths.
+axum.workspace = true
 aws-config.workspace = true
 aws-credential-types.workspace = true
 aws-sdk-dynamodb.workspace = true
@@ -36,7 +39,9 @@ spicepod = { path = "../../crates/spicepod" }
 system-adapter-protocol.workspace = true
 test-framework = { path = "../../crates/test-framework" }
 rand.workspace = true
-tokio.workspace = true
+# `net`: the TcpListener the liveness endpoints bind (the workspace default set
+# has no networking).
+tokio = { workspace = true, features = ["net"] }
 tokio-postgres = { workspace = true }
 tokio-util.workspace = true
 url.workspace = true

--- a/tools/testoperator/README.md
+++ b/tools/testoperator/README.md
@@ -6,6 +6,22 @@
 
 While a test is executing, `testoperator` continuously probes the `/health` and `/v1/ready` endpoints on the running `spiced` instance. Responses that fail or take longer than 5 ms are recorded and surfaced after the test run; any such issues will cause the test to fail with a summary that includes the number of failures and the worst latency observed.
 
+## Liveness endpoints (`testoperator run htap`)
+
+An HTAP run seeds the source, waits for `spiced`, drives load for hours, then runs its gates — and from outside the process every one of those phases looks like the same quiet `testoperator`. So the run serves, about itself, the two endpoints it probes on `spiced`. They bind `127.0.0.1:8099` by default (`--health-listen <ADDR>`, `TESTOPERATOR_HEALTH_LISTEN`; `off` disables them):
+
+- `GET /health` — liveness: `200 ok` while the process is up. Answered on the same Tokio runtime that drives the workload, so its *latency* also says whether that runtime is still scheduling promptly.
+- `GET /v1/ready` — readiness, meaning **the measured workload is running**: `200` only while load is being applied, `503` naming the current phase otherwise.
+
+Both bodies are one line of `key=value` tokens, so a shell probe can read them without a JSON parser:
+
+```shell
+$ curl -s localhost:8099/v1/ready
+not_ready phase=preparing_source phase_s=412
+```
+
+Phases are `starting`, `preparing_source`, `waiting_for_spiced`, `running` (the only ready one), `finalizing` and `finished`. Failing to bind is a warning, never a failed run.
+
 ## Common Options
 
 - `-p, --spicepod-path <SPICEPOD_PATH>`: Path to the `spicepod.yaml` file.
@@ -13,6 +29,7 @@ While a test is executing, `testoperator` continuously probes the `/health` and 
 - `-d, --data-dir <DATA_DIR>`: An optional data directory to symlink into the `spiced` instance.
 - `--ready-wait <WAIT TIME>`: How long to wait before spiced is ready.
 - `--disable-progress-bars`: Disable progress bars during the test.
+- `--health-listen <ADDR>`: Where testoperator serves its own `/health` and `/v1/ready` (default `127.0.0.1:8099`, `off` to disable). See [Liveness endpoints](#liveness-endpoints-testoperator-run-htap).
 - `--otlp-endpoint <URL>` / `--otlp-header KEY=VALUE`: Export metrics to an OTLP collector over the standard OTLP protocol instead of the default Arrow exporter. Repeat `--otlp-header` to add multiple headers (e.g., auth tokens).
 
 ## Use cases

--- a/tools/testoperator/src/args/mod.rs
+++ b/tools/testoperator/src/args/mod.rs
@@ -116,6 +116,17 @@ pub struct CommonArgs {
     #[arg(long)]
     pub(crate) disable_progress_bars: bool,
 
+    /// Address testoperator serves its own `/health` and `/v1/ready` on, so a
+    /// harness watching the run can tell "seeding the source" from "applying
+    /// load" from "wedged" (see `src/probe.rs`). `off` (or an empty value)
+    /// disables them. Loopback by default: they are unauthenticated, and the
+    /// harness that reads them runs on this host.
+    ///
+    /// Served by `run htap` — the command long-lived enough to be worth
+    /// watching, and the only one whose phases are reported today.
+    #[arg(long, env = "TESTOPERATOR_HEALTH_LISTEN", default_value = crate::probe::DEFAULT_LISTEN)]
+    pub(crate) health_listen: String,
+
     /// An optional data directory, to symlink into the spiced instance
     #[arg(short, long)]
     pub(crate) data_dir: Option<PathBuf>,

--- a/tools/testoperator/src/commands/htap/mod.rs
+++ b/tools/testoperator/src/commands/htap/mod.rs
@@ -46,6 +46,7 @@ use crate::{
     args::{HtapArgs, SourceType},
     commands::bench::prepare_chbench_source,
     health::HealthMonitor,
+    probe::{self, Phase},
     spiced_metrics::MetricsScraper,
 };
 
@@ -94,6 +95,10 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
         .terminals
         .unwrap_or_else(|| ((scale_factor * 10.0) as usize).min(DEFAULT_TERMINALS_CAP));
     let duration = Duration::from_secs(test_args.common.duration);
+    // Seeding an SF1000 source runs for the better part of an hour and prints
+    // little; without this, `/v1/ready` could not tell it apart from a run stuck
+    // on the source connection.
+    probe::set_phase(Phase::PreparingSource);
     let driver: Arc<dyn chbench_driver::ChBenchDriver> = prepare_chbench_source(
         scale_factor,
         terminals,
@@ -108,10 +113,12 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     // template database) for fast reuse across subsequent runs.
     if args.prepare_only {
         println!("--prepare-only: source prepared, exiting without running the workload");
+        probe::set_phase(Phase::Finished);
         return Ok(());
     }
 
     // 2. Start spiced.
+    probe::set_phase(Phase::WaitingForSpiced);
     let mut spiced_instance = SpicedInstance::start(start_request).await?;
     let ready_wait_start = Instant::now();
 
@@ -234,6 +241,10 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     );
 
     // 4. Run analytical queries through spiced concurrently with the OLTP load.
+    // Load is being applied from here on, so this is where the run becomes
+    // ready: a window that starts earlier would include the seed, and one that
+    // started at the first query would miss the OLTP writes under it.
+    probe::set_phase(Phase::Running);
     println!("Running HTAP analytical queries under OLTP load");
 
     let executor = super::create_query_executor(test_args, &spiced_instance).await?;
@@ -286,7 +297,10 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
         None => Vec::new(),
     };
 
-    // 6. Stop OLTP and collect results.
+    // 6. Stop OLTP and collect results. No load is applied past this point, so
+    //    the run stops reporting itself ready while the gates and reporting
+    //    below (which can take minutes) still run.
+    probe::set_phase(Phase::Finalizing);
     oltp_stop.cancel();
     let oltp_result = oltp_handle.await;
     let staleness_result = staleness_handle.await;
@@ -603,6 +617,10 @@ pub(crate) async fn run(args: &HtapArgs) -> anyhow::Result<()> {
     }
 
     spiced_instance.stop()?;
+    // Everything measurable is done; what follows only assembles the verdict.
+    // Set here rather than beside the final `Ok(())` so a run that exits with a
+    // gate failure reports the same phase as one that passes.
+    probe::set_phase(Phase::Finished);
 
     let health_report = health_report?;
 

--- a/tools/testoperator/src/main.rs
+++ b/tools/testoperator/src/main.rs
@@ -22,6 +22,7 @@ mod commands;
 mod health;
 mod metrics;
 mod pg_stats;
+mod probe;
 mod spiced_metrics;
 mod stats;
 mod system_adapter;
@@ -112,6 +113,12 @@ async fn main() -> anyhow::Result<()> {
             commands::schema::run(&args).await?;
         }
         Commands::Run(TestCommands::Htap(args)) => {
+            // The HTAP run is the long-lived one an external harness watches
+            // (it seeds the source, then drives load for hours), so it is the
+            // command whose phases `/v1/ready` reports. Started before the run
+            // so `/health` answers from the first second, and never fatal: a
+            // port clash must not cost a benchmark.
+            probe::serve(&args.test_args.common.health_listen).await;
             commands::htap::run(&args).await?;
         }
         Commands::Export(TestCommands::StreamingDynamodbCorrectness(_)) => {

--- a/tools/testoperator/src/probe.rs
+++ b/tools/testoperator/src/probe.rs
@@ -129,20 +129,25 @@ static PHASE: AtomicU8 = AtomicU8::new(Phase::Starting as u8);
 /// Seconds since [`START`] at which the current phase was entered.
 static PHASE_AT_S: AtomicU64 = AtomicU64::new(0);
 
-/// Records the phase the run has just entered. Cheap enough (two relaxed
-/// stores) to call from anywhere, including a hot path.
+/// Records the phase the run has just entered. Two stores, so cheap enough to
+/// call from anywhere, including a hot path.
 pub(crate) fn set_phase(phase: Phase) {
-    // Order matters: the timestamp is written first so a probe landing between
-    // the two stores reports the *old* phase with a slightly early clock,
-    // rather than the new phase with the old phase's start time — which would
-    // read as a phase that had already been running for an hour.
+    // The timestamp is written first, and the phase is *released* after it, so
+    // a reader that acquires the new phase is guaranteed to see the timestamp
+    // that goes with it. Relaxed on both would let the two stores be observed
+    // out of order, and a probe that saw the new phase with the previous
+    // phase's start time would report a phase that had already been running
+    // for an hour — the exact reading this ordering exists to prevent.
     PHASE_AT_S.store(START.elapsed().as_secs(), Ordering::Relaxed);
-    PHASE.store(phase as u8, Ordering::Relaxed);
+    PHASE.store(phase as u8, Ordering::Release);
 }
 
 /// The current phase, and how many whole seconds the run has been in it.
 pub(crate) fn phase() -> (Phase, u64) {
-    let phase = Phase::from_u8(PHASE.load(Ordering::Relaxed));
+    // Acquire pairs with the release in [`set_phase`]: seeing a phase means
+    // seeing the timestamp stored before it, so the two can never be read from
+    // different transitions.
+    let phase = Phase::from_u8(PHASE.load(Ordering::Acquire));
     let entered_at = PHASE_AT_S.load(Ordering::Relaxed);
     (phase, START.elapsed().as_secs().saturating_sub(entered_at))
 }
@@ -204,6 +209,15 @@ pub(crate) async fn serve(listen: &str) -> Option<SocketAddr> {
     // arrive.
     let _ = *START;
     println!("Liveness endpoints on http://{addr} (/health, /v1/ready)");
+    // Nothing authenticates these, so anything but loopback publishes the run's
+    // phase to whoever can reach the port. That is a legitimate choice (a
+    // container's loopback is not reachable from the harness outside it), but
+    // it should never happen without the run log saying so.
+    if !addr.ip().is_loopback() {
+        eprintln!(
+            "WARNING: liveness endpoints are unauthenticated and bound off-loopback on {addr}"
+        );
+    }
 
     tokio::spawn(async move {
         if let Err(e) = axum::serve(listener, router()).await {
@@ -217,6 +231,18 @@ pub(crate) async fn serve(listen: &str) -> Option<SocketAddr> {
 mod tests {
     use super::{DEFAULT_LISTEN, Phase, phase, ready_response, serve, set_phase};
     use axum::http::StatusCode;
+    use std::sync::{Mutex, MutexGuard, PoisonError};
+
+    /// Held by every test that moves the phase. The phase is process-global and
+    /// the harness runs tests on several threads, so without this two of them
+    /// interleave their `set_phase` calls and each reads the other's phase.
+    static PHASE_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Takes [`PHASE_LOCK`], recovering it if an earlier test panicked while
+    /// holding it: poisoning would otherwise turn one failure into two.
+    fn phase_guard() -> MutexGuard<'static, ()> {
+        PHASE_LOCK.lock().unwrap_or_else(PoisonError::into_inner)
+    }
 
     /// The phases a run passes through, in order.
     const EVERY_PHASE: [Phase; 6] = [
@@ -271,10 +297,10 @@ mod tests {
         }
     }
 
-    /// The status/body pairing the harness keys off. Serialized against the
-    /// other tests by running in one test, since the phase is process-global.
+    /// The status/body pairing the harness keys off.
     #[test]
     fn the_ready_body_names_the_phase_and_its_status_follows_it() {
+        let _guard = phase_guard();
         set_phase(Phase::PreparingSource);
         let (status, body) = ready_response();
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
@@ -324,52 +350,65 @@ mod tests {
 
     /// The endpoints as a probe actually sees them: over HTTP, with the phase
     /// moving underneath.
-    #[tokio::test]
-    async fn the_endpoints_answer_over_http_and_track_the_phase() {
-        set_phase(Phase::PreparingSource);
-        let addr = serve("127.0.0.1:0").await.expect("bound an ephemeral port");
-        let base = format!("http://{addr}");
-        let client = reqwest::Client::new();
+    ///
+    /// A `block_on` inside a plain test rather than `#[tokio::test]`, so the
+    /// phase guard is held across the runtime call in synchronous code — an
+    /// async test would hold a `MutexGuard` across its awaits.
+    #[test]
+    fn the_endpoints_answer_over_http_and_track_the_phase() {
+        let _guard = phase_guard();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
 
-        let health = client
-            .get(format!("{base}/health"))
-            .send()
-            .await
-            .expect("health answered");
-        assert_eq!(health.status(), 200);
-        assert_eq!(health.text().await.unwrap_or_default(), "ok\n");
+        runtime.block_on(async {
+            set_phase(Phase::PreparingSource);
+            let addr = serve("127.0.0.1:0").await.expect("bound an ephemeral port");
+            let base = format!("http://{addr}");
+            let client = reqwest::Client::new();
 
-        let not_ready = client
-            .get(format!("{base}/v1/ready"))
-            .send()
-            .await
-            .expect("ready answered");
-        assert_eq!(not_ready.status(), 503, "seeding is not ready");
-        assert!(
-            not_ready
-                .text()
+            let health = client
+                .get(format!("{base}/health"))
+                .send()
                 .await
-                .unwrap_or_default()
-                .contains("phase=preparing_source")
-        );
+                .expect("health answered");
+            assert_eq!(health.status(), 200);
+            assert_eq!(health.text().await.unwrap_or_default(), "ok\n");
 
-        set_phase(Phase::Running);
-        let ready = client
-            .get(format!("{base}/v1/ready"))
-            .send()
-            .await
-            .expect("ready answered");
-        assert_eq!(ready.status(), 200, "load is being applied");
+            let not_ready = client
+                .get(format!("{base}/v1/ready"))
+                .send()
+                .await
+                .expect("ready answered");
+            assert_eq!(not_ready.status(), 503, "seeding is not ready");
+            assert!(
+                not_ready
+                    .text()
+                    .await
+                    .unwrap_or_default()
+                    .contains("phase=preparing_source")
+            );
 
-        // A path neither endpoint owns must not be answered as if it were one.
-        let unknown = client
-            .get(format!("{base}/v1/nope"))
-            .send()
-            .await
-            .expect("answered");
-        assert_eq!(unknown.status(), 404);
+            set_phase(Phase::Running);
+            let ready = client
+                .get(format!("{base}/v1/ready"))
+                .send()
+                .await
+                .expect("ready answered");
+            assert_eq!(ready.status(), 200, "load is being applied");
 
-        set_phase(Phase::Starting);
+            // A path neither endpoint owns must not be answered as if it were
+            // one.
+            let unknown = client
+                .get(format!("{base}/v1/nope"))
+                .send()
+                .await
+                .expect("answered");
+            assert_eq!(unknown.status(), 404);
+
+            set_phase(Phase::Starting);
+        });
     }
 
     #[test]

--- a/tools/testoperator/src/probe.rs
+++ b/tools/testoperator/src/probe.rs
@@ -1,0 +1,384 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! testoperator's own `/health` and `/v1/ready` — the same paths, and the same
+//! meanings, spiced serves, so a harness already probing a runtime can probe the
+//! load generator with the same code.
+//!
+//! **Why the generator needs them.** From outside the process, a run that is
+//! seeding an SF1000 source for forty minutes and a run wedged on a source
+//! connection look identical: the process exists, it burns little CPU, and its
+//! log says nothing. `pgrep testoperator` answers "a process is there", which is
+//! not the question — the questions are whether it is still responsive, and
+//! whether it has started applying load yet.
+//!
+//! - `/health` is liveness: 200 for as long as the process is up. It is served
+//!   from the same Tokio runtime that drives the OLTP terminals and analytical
+//!   clients, deliberately — its *latency* is then a reading on whether that
+//!   runtime is still scheduling promptly, which a probe isolated on a private
+//!   runtime could not tell you. (spiced makes the opposite choice for the
+//!   opposite reason: there, a probe that stalls gets the pod killed.)
+//! - `/v1/ready` is readiness, and readiness here means **the measured workload
+//!   is running**: 200 only during [`Phase::Running`], 503 with the current
+//!   phase otherwise. A watcher can then tell seeding from waiting-on-spiced
+//!   from finished, rather than reading "not 200" as "broken".
+//!
+//! Both bodies are one line — a leading word, then `key=value` tokens — so a
+//! shell probe can pull fields out of them without a JSON parser:
+//!
+//! ```text
+//! $ curl -s localhost:8099/health
+//! ok
+//! $ curl -s localhost:8099/v1/ready
+//! not_ready phase=preparing_source phase_s=412
+//! ```
+//!
+//! The phase lives in an atomic rather than behind a lock: a readiness probe
+//! must never queue behind whatever the run is doing, least of all when the run
+//! is in trouble.
+
+use std::net::SocketAddr;
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+use std::time::Instant;
+
+use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
+
+/// Where the endpoints bind unless `--health-listen` says otherwise. Loopback,
+/// because the harness that reads them runs *on* the generator host (over ssh)
+/// and these endpoints are unauthenticated. The port stays clear of spiced's
+/// own (8090 HTTP, 9090 metrics, 50051 Flight), so a single-host run can serve
+/// both.
+pub(crate) const DEFAULT_LISTEN: &str = "127.0.0.1:8099";
+
+/// What the run is doing, as `/v1/ready` reports it.
+///
+/// Ordered as a run passes through them. Only [`Phase::Running`] is ready: it is
+/// the window in which load is actually being applied, which is the only window
+/// a measurement taken from outside is valid in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum Phase {
+    /// Process up, command not yet started doing anything.
+    Starting = 0,
+    /// Seeding (or verifying) the source database — minutes to hours at scale.
+    PreparingSource = 1,
+    /// Source ready; spiced started or connected to, and not yet ready.
+    WaitingForSpiced = 2,
+    /// The measured workload is running: OLTP load applied, queries in flight.
+    Running = 3,
+    /// Workload stopped; gates, correctness checks and reporting still to run.
+    Finalizing = 4,
+    /// Everything is done and the process is about to exit.
+    Finished = 5,
+}
+
+impl Phase {
+    /// Stable token for the `phase=` field. Snake case and space-free so a
+    /// whitespace-splitting shell probe can carry it through unquoted.
+    #[must_use]
+    pub(crate) fn slug(self) -> &'static str {
+        match self {
+            Phase::Starting => "starting",
+            Phase::PreparingSource => "preparing_source",
+            Phase::WaitingForSpiced => "waiting_for_spiced",
+            Phase::Running => "running",
+            Phase::Finalizing => "finalizing",
+            Phase::Finished => "finished",
+        }
+    }
+
+    /// Whether `/v1/ready` answers 200 in this phase.
+    #[must_use]
+    pub(crate) fn is_ready(self) -> bool {
+        self == Phase::Running
+    }
+
+    fn from_u8(value: u8) -> Phase {
+        match value {
+            1 => Phase::PreparingSource,
+            2 => Phase::WaitingForSpiced,
+            3 => Phase::Running,
+            4 => Phase::Finalizing,
+            5 => Phase::Finished,
+            // Anything else can only be a store this match has not been taught
+            // about; reporting the earliest phase understates progress, which is
+            // the safe direction for a readiness signal.
+            _ => Phase::Starting,
+        }
+    }
+}
+
+/// Process start, the origin for `phase_s`. An `Instant` cannot be stored in an
+/// atomic, so elapsed whole seconds are what the atomics carry.
+static START: LazyLock<Instant> = LazyLock::new(Instant::now);
+static PHASE: AtomicU8 = AtomicU8::new(Phase::Starting as u8);
+/// Seconds since [`START`] at which the current phase was entered.
+static PHASE_AT_S: AtomicU64 = AtomicU64::new(0);
+
+/// Records the phase the run has just entered. Cheap enough (two relaxed
+/// stores) to call from anywhere, including a hot path.
+pub(crate) fn set_phase(phase: Phase) {
+    // Order matters: the timestamp is written first so a probe landing between
+    // the two stores reports the *old* phase with a slightly early clock,
+    // rather than the new phase with the old phase's start time — which would
+    // read as a phase that had already been running for an hour.
+    PHASE_AT_S.store(START.elapsed().as_secs(), Ordering::Relaxed);
+    PHASE.store(phase as u8, Ordering::Relaxed);
+}
+
+/// The current phase, and how many whole seconds the run has been in it.
+pub(crate) fn phase() -> (Phase, u64) {
+    let phase = Phase::from_u8(PHASE.load(Ordering::Relaxed));
+    let entered_at = PHASE_AT_S.load(Ordering::Relaxed);
+    (phase, START.elapsed().as_secs().saturating_sub(entered_at))
+}
+
+/// The body `/v1/ready` returns, and the status that goes with it.
+fn ready_response() -> (StatusCode, String) {
+    let (phase, seconds) = phase();
+    let (status, word) = if phase.is_ready() {
+        (StatusCode::OK, "ready")
+    } else {
+        (StatusCode::SERVICE_UNAVAILABLE, "not_ready")
+    };
+    (
+        status,
+        format!("{word} phase={} phase_s={seconds}\n", phase.slug()),
+    )
+}
+
+fn router() -> Router {
+    Router::new()
+        // "ok\n", byte for byte what spiced's /health returns.
+        .route("/health", get(|| async { "ok\n" }))
+        .route(
+            "/v1/ready",
+            get(|| async { ready_response().into_response() }),
+        )
+}
+
+/// Binds the endpoints and serves them in the background for the rest of the
+/// process's life. Returns the bound address, or `None` if they are switched
+/// off or the bind failed.
+///
+/// A bind failure is a warning, never an error: a port already in use is not a
+/// reason to lose a benchmark run that was otherwise about to succeed. The
+/// harness reading the endpoints sees "nothing answering", which is the truth.
+pub(crate) async fn serve(listen: &str) -> Option<SocketAddr> {
+    let listen = listen.trim();
+    if listen.is_empty() || listen.eq_ignore_ascii_case("off") {
+        return None;
+    }
+
+    let listener = match tokio::net::TcpListener::bind(listen).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            eprintln!("liveness endpoints disabled: could not bind {listen}: {e}");
+            return None;
+        }
+    };
+    let addr = match listener.local_addr() {
+        Ok(addr) => addr,
+        Err(e) => {
+            eprintln!("liveness endpoints disabled: bound {listen} but could not read it: {e}");
+            return None;
+        }
+    };
+
+    // `LazyLock` initialises on first touch, so the clock `phase_s` counts from
+    // starts here rather than at whatever moment the first probe happens to
+    // arrive.
+    let _ = *START;
+    println!("Liveness endpoints on http://{addr} (/health, /v1/ready)");
+
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, router()).await {
+            eprintln!("liveness endpoint server stopped: {e}");
+        }
+    });
+    Some(addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_LISTEN, Phase, phase, ready_response, serve, set_phase};
+    use axum::http::StatusCode;
+
+    /// The phases a run passes through, in order.
+    const EVERY_PHASE: [Phase; 6] = [
+        Phase::Starting,
+        Phase::PreparingSource,
+        Phase::WaitingForSpiced,
+        Phase::Running,
+        Phase::Finalizing,
+        Phase::Finished,
+    ];
+
+    #[test]
+    fn only_the_running_phase_is_ready() {
+        for p in EVERY_PHASE {
+            assert_eq!(
+                p.is_ready(),
+                p == Phase::Running,
+                "{} must not be ready: load is not being applied in it",
+                p.slug()
+            );
+        }
+    }
+
+    #[test]
+    fn every_phase_round_trips_through_its_atomic() {
+        for p in EVERY_PHASE {
+            assert_eq!(
+                Phase::from_u8(p as u8),
+                p,
+                "{} did not round-trip",
+                p.slug()
+            );
+        }
+        assert_eq!(
+            Phase::from_u8(200),
+            Phase::Starting,
+            "an unknown value must understate progress, not overstate it"
+        );
+    }
+
+    #[test]
+    fn slugs_are_shell_safe_and_distinct() {
+        let mut seen: Vec<&str> = Vec::new();
+        for p in EVERY_PHASE {
+            let slug = p.slug();
+            assert!(
+                !slug.contains(char::is_whitespace) && !slug.is_empty(),
+                "{slug:?} would break a whitespace-split probe line"
+            );
+            assert!(!seen.contains(&slug), "duplicate slug {slug}");
+            seen.push(slug);
+        }
+    }
+
+    /// The status/body pairing the harness keys off. Serialized against the
+    /// other tests by running in one test, since the phase is process-global.
+    #[test]
+    fn the_ready_body_names_the_phase_and_its_status_follows_it() {
+        set_phase(Phase::PreparingSource);
+        let (status, body) = ready_response();
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            body.starts_with("not_ready phase=preparing_source phase_s="),
+            "{body:?}"
+        );
+        assert!(
+            body.ends_with('\n'),
+            "one line, newline-terminated: {body:?}"
+        );
+
+        set_phase(Phase::Running);
+        let (status, body) = ready_response();
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.starts_with("ready phase=running phase_s="), "{body:?}");
+
+        let (current, seconds) = phase();
+        assert_eq!(current, Phase::Running);
+        assert!(seconds < 5, "the phase was just entered, got {seconds}s");
+
+        // Leave the global back where the other tests expect it.
+        set_phase(Phase::Starting);
+    }
+
+    #[test]
+    fn switching_the_endpoints_off_binds_nothing() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        assert!(runtime.block_on(serve("off")).is_none());
+        assert!(runtime.block_on(serve("")).is_none());
+    }
+
+    #[test]
+    fn an_unbindable_address_warns_instead_of_failing_the_run() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        // Port 1 on loopback needs privileges this test does not have; a
+        // hostname that resolves to nothing fails earlier still. Either way the
+        // call must return rather than propagate.
+        assert!(runtime.block_on(serve("192.0.2.1:9")).is_none());
+    }
+
+    /// The endpoints as a probe actually sees them: over HTTP, with the phase
+    /// moving underneath.
+    #[tokio::test]
+    async fn the_endpoints_answer_over_http_and_track_the_phase() {
+        set_phase(Phase::PreparingSource);
+        let addr = serve("127.0.0.1:0").await.expect("bound an ephemeral port");
+        let base = format!("http://{addr}");
+        let client = reqwest::Client::new();
+
+        let health = client
+            .get(format!("{base}/health"))
+            .send()
+            .await
+            .expect("health answered");
+        assert_eq!(health.status(), 200);
+        assert_eq!(health.text().await.unwrap_or_default(), "ok\n");
+
+        let not_ready = client
+            .get(format!("{base}/v1/ready"))
+            .send()
+            .await
+            .expect("ready answered");
+        assert_eq!(not_ready.status(), 503, "seeding is not ready");
+        assert!(
+            not_ready
+                .text()
+                .await
+                .unwrap_or_default()
+                .contains("phase=preparing_source")
+        );
+
+        set_phase(Phase::Running);
+        let ready = client
+            .get(format!("{base}/v1/ready"))
+            .send()
+            .await
+            .expect("ready answered");
+        assert_eq!(ready.status(), 200, "load is being applied");
+
+        // A path neither endpoint owns must not be answered as if it were one.
+        let unknown = client
+            .get(format!("{base}/v1/nope"))
+            .send()
+            .await
+            .expect("answered");
+        assert_eq!(unknown.status(), 404);
+
+        set_phase(Phase::Starting);
+    }
+
+    #[test]
+    fn the_default_listen_is_loopback_and_clear_of_spiceds_ports() {
+        let addr: std::net::SocketAddr = DEFAULT_LISTEN.parse().expect("a parseable address");
+        assert!(addr.ip().is_loopback(), "unauthenticated: loopback only");
+        assert!(
+            ![8090, 9090, 50051, 50052].contains(&addr.port()),
+            "{DEFAULT_LISTEN} collides with a spiced port on a single-host run"
+        );
+    }
+}


### PR DESCRIPTION
## 📝 Summary

An HTAP run seeds the source, waits for spiced, drives load for hours, then runs its gates — and from outside the process every one of those phases looks the same: one busy-ish `testoperator` and a quiet log. A harness watching the run can see that the process exists, which is not the question. The questions are whether it is still responsive, and whether it has started applying load yet. A run forty minutes into seeding an SF1000 source is indistinguishable, from the outside, from one wedged on a source connection.

testoperator already probes `/health` and `/v1/ready` on spiced. This serves the same two paths, with the same meanings, about itself, on `127.0.0.1:8099` by default (`--health-listen`, `TESTOPERATOR_HEALTH_LISTEN`; `off` disables them). Loopback because they are unauthenticated and the harness that reads them runs on that host.

- **`GET /health`** — liveness: `200 ok` while the process is up. Answered on the same Tokio runtime that drives the OLTP terminals and the analytical clients, deliberately: its *latency* is then a reading on whether that runtime is still scheduling promptly, which a probe isolated on a private runtime could not give you. (spiced makes the opposite choice for the opposite reason — there, a probe that stalls gets the pod killed.)
- **`GET /v1/ready`** — readiness, meaning **the measured workload is running**: `200` only while load is being applied, `503` naming the current phase otherwise, so a watcher reads "seeding" rather than "broken".

Phases: `starting`, `preparing_source`, `waiting_for_spiced`, `running`, `finalizing`, `finished`. Only `running` is ready — it is the only window in which a measurement taken from outside is valid.

Both bodies are one line (a leading word, then `key=value` tokens), so a shell probe reads them without a JSON parser:

```console
$ curl -s localhost:8099/health
ok
$ curl -s localhost:8099/v1/ready
not_ready phase=preparing_source phase_s=412
```

Two deliberate choices worth flagging: the phase lives in atomics rather than behind a lock, so a readiness probe never queues behind whatever the run is doing — least of all when the run is in trouble; and a failed bind warns and continues, because a port clash must not cost a benchmark that was otherwise about to succeed (the watcher then sees nothing answering, which is the truth).

Served by `run htap` — the command long-lived enough to be worth watching, and the only one whose phases are reported today. `probe.rs` is not htap-specific: another command opts in with one `serve()` call plus its own `set_phase()` transitions.

## 🔗 Related

The consumer is the cbench harness's Hosts screen (spicehq/cayenne-bench-runs), which probes both endpoints on the generator host's loopback each second and renders the status, the latency and the phase in the Generator pane.

## 🚨 Breaking Changes

None. New flag with a default; a run whose port is taken logs a warning and proceeds exactly as before.

## 📚 Docs

`tools/testoperator/README.md` gains a "Liveness endpoints" section and a `--health-listen` entry under Common Options.

## 👀 Notes for Reviewers

- **Where the ready window starts and stops.** `Running` is set once the OLTP workload and the staleness probe are up, immediately before the analytical queries: earlier would include the seed, and starting at the first query would miss the OLTP writes under it. It is cleared at step 6, where OLTP stops — the gates and reporting after that can take minutes, and the run is no longer applying load in them.
- **Port choice.** 8099 stays clear of spiced's 8090/9090/50051 so a single-host run can serve both; a test pins that.
- **Testing.** Unit tests cover the phase/status mapping and the body format; an end-to-end test binds an ephemeral port and exercises `/health`, `/v1/ready` before and after the phase moves, and a 404 for an unowned path. `cargo check -p testoperator --all-targets` is clean. Not exercised here against a live multi-hour HTAP run.