### PR TITLE
docs: Spice v2.1.3 release notes

### DIFF
--- a/docs/release_notes/v2.1.3.md
+++ b/docs/release_notes/v2.1.3.md
@@ -1,4 +1,4 @@
-# Spice v2.1.3 (August 2, 2026)
+# Spice v2.1.3 (August 3, 2026)
 
 Spice v2.1.3 is a patch release focused on resource efficiency: explicit CPU sizing with the new `runtime.cpu.cores` setting, more query memory for Cayenne deployments, and improved memory and crash diagnostics.
 

--- a/docs/release_notes/v2.1.3.md
+++ b/docs/release_notes/v2.1.3.md
@@ -34,7 +34,7 @@ Memory pool refusals now return `ResourcesExhausted` and HTTP `503`, distinguish
 
 Fatal native signals (`SIGSEGV`, `SIGBUS`, `SIGILL`, `SIGFPE`) report the signal, faulting address, and thread before exit, so a crash can be diagnosed from logs.
 
-Query metrics are now reported when task history is disabled.
+Fixed a bug where setting `runtime.task_history.enabled: false` also disabled every query metric — `query_duration_ms`, `query_execution_duration_ms`, `query_executions`, `query_failures`, `query_returned_rows`, and `query_returned_bytes` — because the query tracker that emits them was skipped along with task history. The tracker now always runs, and the setting controls only task history events and captured output, so latency, throughput, and error signals stay available with task history off.
 
 ## Contributors
 

--- a/docs/release_notes/v2.1.3.md
+++ b/docs/release_notes/v2.1.3.md
@@ -1,4 +1,4 @@
-# Spice v2.1.3 (August 3, 2026)
+# Spice v2.1.3 (August 2, 2026)
 
 Spice v2.1.3 is a patch release focused on resource efficiency. A new `runtime.cpu.cores` setting lets a deployment state its CPU entitlement once, and every CPU-derived pool in the runtime sizes itself from it. Memory budgets get a matching improvement, keeping more of the configured limit available for queries.
 
@@ -18,7 +18,7 @@ Also settable as `--cpu-cores` or `SPICE_CPU_CORES` (precedence: flag > env > Sp
 
 This matters most when a Spice pod runs on a very large node. A Kubernetes pod that sets `resources.requests.cpu` without a CPU limit has no cgroup quota to read, so the runtime sizes itself for every core on the node rather than the share allocated to it. Stating the entitlement tunes the whole runtime to the optimal CPU budget: query partitioning, thread pools, and accelerator concurrency all match the target CPU count — better-matched parallelism, a smaller memory footprint, and more room for the pod's neighbors.
 
-The effective value, its source, and every quantity derived from it are logged at startup, and a new `spiced_cpu_budget_cores{source}` gauge makes sizing greppable across a fleet:
+The effective value, its source, and every quantity derived from it are logged at startup, and a new `spiced_cpu_budget_cores{source}` gauge makes sizing visible across a fleet.
 
 ### More Query Memory, Sized to the Container
 
@@ -28,7 +28,7 @@ Memory budgets are also derived from the process's own cgroup limit rather than 
 
 ### Memory Observability
 
-New gauges expose the query memory pool limit and reservation, plus the Cayenne compaction and in-memory CDC tier budgets — so headroom can be watched on a dashboard rather than reconstructed after the fact. Memory pool refusals now return the standard `ResourcesExhausted` error code and an HTTP `503`, making them clearly distinguishable from query errors by clients and load balancers.
+New gauges expose live query memory pool usage (`query_memory_pool_used_bytes`), Cayenne compaction pool usage (`cayenne_compaction_memory_pool_used_bytes`), and process resident memory (`process_resident_memory_bytes`) — so headroom can be watched on a dashboard rather than reconstructed after the fact. Memory pool refusals now return the standard `ResourcesExhausted` error code and an HTTP `503`, making them clearly distinguishable from query errors by clients and load balancers.
 
 Fixed an issue that prevented query metrics from being reported when task history is disabled, so latency and throughput stay visible in that configuration.
 

--- a/docs/release_notes/v2.1.3.md
+++ b/docs/release_notes/v2.1.3.md
@@ -1,0 +1,105 @@
+# Spice v2.1.3 (August 3, 2026)
+
+Spice v2.1.3 is a patch release focused on resource efficiency. A new `runtime.cpu.cores` setting lets a deployment state its CPU entitlement once, and every CPU-derived pool in the runtime sizes itself from it. Memory budgets get a matching improvement, keeping more of the configured limit available for queries.
+
+## What's New in v2.1.3
+
+### One CPU Setting Sizes the Whole Runtime
+
+Use the new `runtime.cpu.cores` setting to control how many cores the runtime should target. Thread pools, query parallelism, and accelerator concurrency all follow from that number.
+
+```yaml
+runtime:
+  cpu:
+    cores: 4 # `auto` (default) = detect. Accepts 4, 3.5, 3500m
+```
+
+Also settable as `--cpu-cores` or `SPICE_CPU_CORES` (precedence: flag > env > Spicepod).
+
+This matters most when a Spice pod runs on a very large node. A Kubernetes pod that sets `resources.requests.cpu` without a CPU limit has no cgroup quota to read, so the runtime sizes itself for every core on the node rather than the share allocated to it. Stating the entitlement tunes the whole runtime to the optimal CPU budget: query partitioning, thread pools, and accelerator concurrency all match the target CPU count — better-matched parallelism, a smaller memory footprint, and more room for the pod's neighbors.
+
+The effective value, its source, and every quantity derived from it are logged at startup, and a new `spiced_cpu_budget_cores{source}` gauge makes sizing greppable across a fleet:
+
+### More Query Memory, Sized to the Container
+
+The [Cayenne](https://spiceai.org/docs/components/data-accelerators/cayenne) compaction memory pool is now reserved only when a dataset can actually compact into it — a file-mode acceleration on a small-write refresh profile. Deployments that don't fit that shape, such as datasets on `refresh_mode: full`, keep the full memory limit available to queries: up to 6.4 GiB returned on a 32 GiB limit, with no configuration change.
+
+Memory budgets are also derived from the process's own cgroup limit rather than total host memory, so a container sized well below its node gets budgets matching what it was given.
+
+### Memory Observability
+
+New gauges expose the query memory pool limit and reservation, plus the Cayenne compaction and in-memory CDC tier budgets — so headroom can be watched on a dashboard rather than reconstructed after the fact. Memory pool refusals now return the standard `ResourcesExhausted` error code and an HTTP `503`, making them clearly distinguishable from query errors by clients and load balancers.
+
+Fixed an issue that prevented query metrics from being reported when task history is disabled, so latency and throughput stay visible in that configuration.
+
+A fatal native signal (`SIGSEGV`, `SIGBUS`, `SIGILL`, `SIGFPE`) now prints crash information before exit — the signal, faulting address, and thread — that can be used to pinpoint the fault in the source, straight from collected logs and with no node access.
+
+## Contributors
+
+- [@lukekim](https://github.com/lukekim)
+- [@sgrebnov](https://github.com/sgrebnov)
+- [@phillipleblanc](https://github.com/phillipleblanc)
+- [@bjchambers](https://github.com/bjchambers)
+
+## Breaking Changes
+
+No breaking changes.
+
+## Cookbook Updates
+
+No new cookbook recipes.
+
+The [Spice Cookbook](https://spiceai.org/cookbook) includes more than 100 recipes to help you get started with Spice quickly and easily.
+
+## Upgrading
+
+To upgrade to v2.1.3, use one of the following methods:
+
+**CLI**:
+
+```console
+spice upgrade
+```
+
+**Homebrew**:
+
+```console
+brew upgrade spiceai/spiceai/spice
+```
+
+**Docker**:
+
+Pull the `spiceai/spiceai:2.1.3` image:
+
+```console
+docker pull spiceai/spiceai:2.1.3
+```
+
+For available tags, see [DockerHub](https://hub.docker.com/r/spiceai/spiceai/tags).
+
+**Helm**:
+
+```console
+helm repo update
+helm upgrade spiceai spiceai/spiceai --version 2.1.3
+```
+
+**AWS Marketplace**:
+
+Spice is available in the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-jmf6jskjvnq7i).
+
+## What's Changed
+
+### Changelog
+
+- feat(runtime): size every CPU-derived pool from the CPU entitlement by [@bjchambers](https://github.com/bjchambers) in [#12276](https://github.com/spiceai/spiceai/pull/12276)
+- fix(runtime): carve the Cayenne compaction memory pool only when a dataset can compact into it by [@sgrebnov](https://github.com/sgrebnov) in [#12326](https://github.com/spiceai/spiceai/pull/12326)
+- fix(runtime): size memory budgets from the process's own cgroup limit by [@lukekim](https://github.com/lukekim) in [#12263](https://github.com/spiceai/spiceai/pull/12263)
+- fix(telemetry): read the cgroup CPU quota along the whole cgroup path by [@sgrebnov](https://github.com/sgrebnov) in [#12300](https://github.com/spiceai/spiceai/pull/12300)
+- feat(runtime): expose the memory numbers that explain an OOM as gauges by [@lukekim](https://github.com/lukekim) in [#12195](https://github.com/spiceai/spiceai/pull/12195)
+- fix(runtime): report a memory-pool refusal as ResourcesExhausted and answer it with 503 by [@sgrebnov](https://github.com/sgrebnov) in [#12289](https://github.com/spiceai/spiceai/pull/12289)
+- fix(cayenne): the write-concurrency raise must respect the memory brake by [@lukekim](https://github.com/lukekim) in [#12317](https://github.com/spiceai/spiceai/pull/12317)
+- feat(spiced): report fatal signals before exit by [@sgrebnov](https://github.com/sgrebnov) in [#12334](https://github.com/spiceai/spiceai/pull/12334)
+- fix: report query metrics when task history is disabled by [@sgrebnov](https://github.com/sgrebnov) in [#12227](https://github.com/spiceai/spiceai/pull/12227)
+
+**Full Changelog**: <https://github.com/spiceai/spiceai/compare/v2.1.2...v2.1.3>

--- a/docs/release_notes/v2.1.3.md
+++ b/docs/release_notes/v2.1.3.md
@@ -1,38 +1,40 @@
 # Spice v2.1.3 (August 2, 2026)
 
-Spice v2.1.3 is a patch release focused on resource efficiency. A new `runtime.cpu.cores` setting lets a deployment state its CPU entitlement once, and every CPU-derived pool in the runtime sizes itself from it. Memory budgets get a matching improvement, keeping more of the configured limit available for queries.
+Spice v2.1.3 is a patch release focused on resource efficiency: explicit CPU sizing with the new `runtime.cpu.cores` setting, more query memory for Cayenne deployments, and improved memory and crash diagnostics.
 
 ## What's New in v2.1.3
 
-### One CPU Setting Sizes the Whole Runtime
+### CPU Sizing with `runtime.cpu.cores`
 
-Use the new `runtime.cpu.cores` setting to control how many cores the runtime should target. Thread pools, query parallelism, and accelerator concurrency all follow from that number.
+The new `runtime.cpu.cores` setting controls how many cores the runtime targets. Thread pools, query partitioning, and accelerator concurrency are all derived from it.
 
 ```yaml
 runtime:
   cpu:
-    cores: 4 # `auto` (default) = detect. Accepts 4, 3.5, 3500m
+    cores: 4 # `auto` (default) detects. Accepts 4, 3.5, 3500m
 ```
 
-Also settable as `--cpu-cores` or `SPICE_CPU_CORES` (precedence: flag > env > Spicepod).
+Also available as `--cpu-cores` and `SPICE_CPU_CORES` (precedence: flag > environment > Spicepod).
 
-This matters most when a Spice pod runs on a very large node. A Kubernetes pod that sets `resources.requests.cpu` without a CPU limit has no cgroup quota to read, so the runtime sizes itself for every core on the node rather than the share allocated to it. Stating the entitlement tunes the whole runtime to the optimal CPU budget: query partitioning, thread pools, and accelerator concurrency all match the target CPU count — better-matched parallelism, a smaller memory footprint, and more room for the pod's neighbors.
+This is most useful on large, shared nodes. A pod that sets `resources.requests.cpu` without a CPU limit exposes no cgroup quota, so the runtime sizes itself for every core on the node rather than its allocated share. Setting the entitlement aligns parallelism and memory footprint with the CPU the pod actually receives.
 
-The effective value, its source, and every quantity derived from it are logged at startup, and a new `spiced_cpu_budget_cores{source}` gauge makes sizing visible across a fleet.
+The effective value, its source, and the derived sizing are logged at startup and exported as the `spiced_cpu_budget_cores` gauge.
 
-### More Query Memory, Sized to the Container
+### More Query Memory for Cayenne Deployments
 
-The [Cayenne](https://spiceai.org/docs/components/data-accelerators/cayenne) compaction memory pool is now reserved only when a dataset can actually compact into it — a file-mode acceleration on a small-write refresh profile. Deployments that don't fit that shape, such as datasets on `refresh_mode: full`, keep the full memory limit available to queries: up to 6.4 GiB returned on a 32 GiB limit, with no configuration change.
+The [Cayenne](https://spiceai.org/docs/components/data-accelerators/cayenne) compaction memory pool is now reserved only for accelerations that can compact into it: file mode with a small-write refresh profile. Other deployments, including `refresh_mode: full`, keep the full memory limit available to queries — up to 6.4 GiB on a 32 GiB limit, with no configuration change.
 
-Memory budgets are also derived from the process's own cgroup limit rather than total host memory, so a container sized well below its node gets budgets matching what it was given.
+Memory budgets are now derived from the process's own cgroup limit rather than total host memory.
 
-### Memory Observability
+### Diagnostics
 
-New gauges expose live query memory pool usage (`query_memory_pool_used_bytes`), Cayenne compaction pool usage (`cayenne_compaction_memory_pool_used_bytes`), and process resident memory (`process_resident_memory_bytes`) — so headroom can be watched on a dashboard rather than reconstructed after the fact. Memory pool refusals now return the standard `ResourcesExhausted` error code and an HTTP `503`, making them clearly distinguishable from query errors by clients and load balancers.
+Three new gauges report memory in use: `query_memory_pool_used_bytes`, `cayenne_compaction_memory_pool_used_bytes`, and `process_resident_memory_bytes`.
 
-Fixed an issue that prevented query metrics from being reported when task history is disabled, so latency and throughput stay visible in that configuration.
+Memory pool refusals now return `ResourcesExhausted` and HTTP `503`, distinguishing them from query errors.
 
-A fatal native signal (`SIGSEGV`, `SIGBUS`, `SIGILL`, `SIGFPE`) now prints crash information before exit — the signal, faulting address, and thread — that can be used to pinpoint the fault in the source, straight from collected logs and with no node access.
+Fatal native signals (`SIGSEGV`, `SIGBUS`, `SIGILL`, `SIGFPE`) report the signal, faulting address, and thread before exit, so a crash can be diagnosed from logs.
+
+Query metrics are now reported when task history is disabled.
 
 ## Contributors
 

--- a/docs/release_notes/v2.1.3.md
+++ b/docs/release_notes/v2.1.3.md
@@ -34,7 +34,7 @@ Memory pool refusals now return `ResourcesExhausted` and HTTP `503`, distinguish
 
 Fatal native signals (`SIGSEGV`, `SIGBUS`, `SIGILL`, `SIGFPE`) report the signal, faulting address, and thread before exit, so a crash can be diagnosed from logs.
 
-Fixed a bug where setting `runtime.task_history.enabled: false` also disabled every query metric — `query_duration_ms`, `query_execution_duration_ms`, `query_executions`, `query_failures`, `query_returned_rows`, and `query_returned_bytes` — because the query tracker that emits them was skipped along with task history. The tracker now always runs, and the setting controls only task history events and captured output, so latency, throughput, and error signals stay available with task history off.
+Fixed a bug where setting `runtime.task_history.enabled: false` also disabled every query metric — `query_duration_ms`, `query_execution_duration_ms`, `query_executions`, `query_failures`, `query_returned_rows`, and `query_returned_bytes`. These are now reported regardless of the task history setting.
 
 ## Contributors
 


### PR DESCRIPTION
Draft release notes for Spice v2.1.3.

Leads with the new `runtime.cpu.cores` setting (#12276) — one CPU entitlement that sizes every thread pool, query partitioning, and accelerator concurrency limit — followed by the memory improvements (#12326, #12263) and observability changes (#12195, #12289, #12227, #12317, #12334).

Notes:

- #12276  is not yet on the release branch; the notes assume they land in 2.1.3.
- Release date is a placeholder (August 3, 2026) — update before publishing.