### PR TITLE
fix(runtime): correctly classify a memory-pool refusal as ResourcesExhausted (fixes #12380)

### DIFF
--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1771,6 +1771,22 @@ fn parameter_schema_for_plan(plan: &LogicalPlan) -> Result<Option<Schema>, DataF
     Ok(maybe_schema)
 }
 
+/// The `err_code` a failure raised while batches are being polled is recorded
+/// under.
+///
+/// A memory-pool refusal is characteristically mid-stream — an operator grows
+/// its reservation as batches arrive — so this site has to name it, or capacity
+/// never appears in a `query_failures{err_code}` breakdown. Everything else
+/// stays `QueryExecutionError`: the stream is executing, and `ErrorCode::from`
+/// would put Arrow, IO and Parquet failures under `InternalError`, which reads
+/// as a runtime bug rather than a data-plane one.
+fn stream_error_code(error: &DataFusionError) -> ErrorCode {
+    match ErrorCode::from(error) {
+        ErrorCode::ResourcesExhausted => ErrorCode::ResourcesExhausted,
+        _ => ErrorCode::QueryExecutionError,
+    }
+}
+
 #[must_use]
 /// Attaches a query tracker to a stream of record batches.
 ///
@@ -1823,7 +1839,7 @@ fn attach_query_tracker_to_stream(
                         .finish_with_error(
                             &request_context,
                             e.to_string(),
-                            ErrorCode::QueryExecutionError,
+                            stream_error_code(e),
                         );
                     if capture_task_history {
                         tracing::error!(target: "task_history", parent: &inner_span, "{e}");
@@ -2783,6 +2799,53 @@ mod tests {
     };
 
     use super::*;
+
+    /// A pool refusal is the one condition this site names, in every wrapper
+    /// the join and execution paths produce.
+    #[test]
+    fn stream_error_code_names_a_pool_refusal() {
+        assert_eq!(
+            stream_error_code(&DataFusionError::ResourcesExhausted("oom".to_string())),
+            ErrorCode::ResourcesExhausted
+        );
+        assert_eq!(
+            stream_error_code(&DataFusionError::Shared(Arc::new(
+                DataFusionError::ResourcesExhausted("oom".to_string())
+            ))),
+            ErrorCode::ResourcesExhausted
+        );
+        assert_eq!(
+            stream_error_code(&DataFusionError::Context(
+                "Join Error".to_string(),
+                Box::new(DataFusionError::ResourcesExhausted("oom".to_string()))
+            )),
+            ErrorCode::ResourcesExhausted
+        );
+    }
+
+    /// Everything else keeps the code it had before capacity was split out —
+    /// including the variants `ErrorCode::from` would otherwise move to
+    /// `InternalError`.
+    #[test]
+    fn stream_error_code_leaves_every_other_failure_alone() {
+        for error in [
+            DataFusionError::Execution("boom".to_string()),
+            DataFusionError::External("connector failed".into()),
+            DataFusionError::ArrowError(
+                Box::new(arrow::error::ArrowError::ComputeError("cast".to_string())),
+                None,
+            ),
+            DataFusionError::IoError(std::io::Error::other("disk")),
+            DataFusionError::Internal("bug".to_string()),
+            DataFusionError::Plan("bad plan".to_string()),
+        ] {
+            assert_eq!(
+                stream_error_code(&error),
+                ErrorCode::QueryExecutionError,
+                "{error} must stay on the execution code"
+            );
+        }
+    }
 
     #[derive(Debug)]
     struct NoopDmlHandler;

--- a/crates/runtime/src/datafusion/query/error_code.rs
+++ b/crates/runtime/src/datafusion/query/error_code.rs
@@ -69,6 +69,10 @@ impl From<&DataFusionError> for ErrorCode {
             | DataFusionError::Execution(..) => ErrorCode::QueryExecutionError,
             DataFusionError::ResourcesExhausted(..) => ErrorCode::ResourcesExhausted,
             DataFusionError::Context(_, err) => ErrorCode::from(err.as_ref()),
+            // A join wraps its build-side failure in `Shared` before handing it
+            // to each probe partition (datafusion physical-plan joins/utils.rs).
+            // Without this arm a join's memory refusal is `InternalError`.
+            DataFusionError::Shared(err) => ErrorCode::from(err.as_ref()),
             _ => ErrorCode::InternalError,
         }
     }
@@ -78,6 +82,7 @@ impl From<&DataFusionError> for ErrorCode {
 mod tests {
     use super::ErrorCode;
     use datafusion::error::DataFusionError;
+    use std::sync::Arc;
 
     /// A memory-pool refusal must not be labelled `InternalError`: that is the
     /// label for "spiced has a bug", and conflating the two leaves an operator
@@ -104,6 +109,61 @@ mod tests {
         );
 
         assert_eq!(ErrorCode::from(&err), ErrorCode::ResourcesExhausted);
+    }
+
+    /// A join's build-side refusal reaches the runtime wrapped in `Shared`, and
+    /// must classify the same as a bare one.
+    #[test]
+    fn resources_exhausted_is_found_through_shared() {
+        let err = DataFusionError::Shared(Arc::new(DataFusionError::ResourcesExhausted(
+            "Additional allocation failed for HashJoinInput[135]".to_string(),
+        )));
+
+        assert_eq!(ErrorCode::from(&err), ErrorCode::ResourcesExhausted);
+    }
+
+    /// `Shared` and `Context` nest in both orders, so the recursion has to
+    /// survive either.
+    #[test]
+    fn resources_exhausted_is_found_through_shared_and_context() {
+        let shared_in_context = DataFusionError::Context(
+            "Join Error".to_string(),
+            Box::new(DataFusionError::Shared(Arc::new(
+                DataFusionError::ResourcesExhausted("out of memory".to_string()),
+            ))),
+        );
+        assert_eq!(
+            ErrorCode::from(&shared_in_context),
+            ErrorCode::ResourcesExhausted
+        );
+
+        let context_in_shared = DataFusionError::Shared(Arc::new(DataFusionError::Context(
+            "Join Error".to_string(),
+            Box::new(DataFusionError::ResourcesExhausted(
+                "out of memory".to_string(),
+            )),
+        )));
+        assert_eq!(
+            ErrorCode::from(&context_in_shared),
+            ErrorCode::ResourcesExhausted
+        );
+    }
+
+    /// Unwrapping `Shared` must not flatten every shared failure to one code.
+    #[test]
+    fn shared_preserves_the_inner_code() {
+        assert_eq!(
+            ErrorCode::from(&DataFusionError::Shared(Arc::new(
+                DataFusionError::Execution("boom".to_string())
+            ))),
+            ErrorCode::QueryExecutionError
+        );
+        assert_eq!(
+            ErrorCode::from(&DataFusionError::Shared(Arc::new(
+                DataFusionError::Internal("bug".to_string())
+            ))),
+            ErrorCode::InternalError
+        );
     }
 
     /// The codes are a stable external surface, so a new variant must not

--- a/crates/runtime/src/http/v1/mod.rs
+++ b/crates/runtime/src/http/v1/mod.rs
@@ -897,6 +897,40 @@ mod tests {
         assert_eq!(read_only_response.status(), StatusCode::FORBIDDEN);
     }
 
+    /// A join wraps its build-side failure in `Shared`, which renders with no
+    /// prefix, so the body reads like a bare refusal while the status stays on
+    /// 400. The status has to be derived from the variant, not the text.
+    #[test]
+    fn a_shared_pool_refusal_reaches_the_same_status() {
+        let shared = datafusion::error::DataFusionError::Shared(std::sync::Arc::new(
+            datafusion::error::DataFusionError::ResourcesExhausted(
+                "Additional allocation failed for HashJoinInput[135]".to_string(),
+            ),
+        ));
+        assert!(
+            shared.to_string().starts_with("Resources exhausted: "),
+            "`Shared` must delegate its message, or this test is not covering the real shape"
+        );
+        assert!(matches!(
+            SqlErrorKind::of_datafusion_error(&shared),
+            SqlErrorKind::ResourcesExhausted
+        ));
+        let response = sql_error_response(
+            shared.to_string(),
+            SqlErrorKind::of_datafusion_error(&shared),
+        );
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        // A shared failure that is not a refusal must not be swept up with it.
+        let shared_other = datafusion::error::DataFusionError::Shared(std::sync::Arc::new(
+            datafusion::error::DataFusionError::Execution("boom".to_string()),
+        ));
+        assert!(matches!(
+            SqlErrorKind::of_datafusion_error(&shared_other),
+            SqlErrorKind::General
+        ));
+    }
+
     /// `TrackConsumersPool` writes its breakdown as `"… (across reservations)
     /// as:\n{consumers}\nError: {msg}"`, so the message reaching
     /// `sql_error_response` is genuinely multi-line. The log record has to stay

--- a/crates/runtime/tests/query_failure_err_code.rs
+++ b/crates/runtime/tests/query_failure_err_code.rs
@@ -1,0 +1,139 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! `query_failures{err_code}` must name the condition that failed.
+//!
+//! A memory-pool refusal is characteristically mid-stream, and that path used
+//! to finish the tracker with a hardcoded `QueryExecutionError`.
+//!
+//! This needs its own test binary, for the same reason `query_metrics.rs` does:
+//! the metric handles are `LazyLock`s over `global::meter(..)`, so an instrument
+//! first touched before the `MeterProvider` is installed binds to the no-op
+//! meter for the whole process. Keep it to a single test.
+
+use app::AppBuilder;
+use futures::StreamExt;
+use opentelemetry::global;
+use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
+use runtime::{Runtime, datafusion::query::QueryBuilder};
+use spicepod::component::runtime::{Query, Runtime as SpicepodRuntime};
+
+/// Small enough that the sort below cannot fit, large enough that the runtime
+/// still starts.
+const QUERY_MEMORY_LIMIT: &str = "16MiB";
+
+/// A `TopK` cannot spill, so it refuses while batches are polled — the path
+/// under test. `fetch` is deliberately larger than the limit can hold.
+const EXHAUSTING_QUERY: &str =
+    "SELECT value FROM generate_series(1, 5000000) ORDER BY value DESC LIMIT 4000000";
+
+/// Installs a `MeterProvider` backed by a scrapable Prometheus registry, as
+/// `spiced` does for the `--metrics` endpoint.
+fn install_prometheus_meter_provider() -> prometheus::Registry {
+    let registry = prometheus::Registry::new();
+
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .without_scope_info()
+        .without_units()
+        .without_counter_suffixes()
+        .without_target_info()
+        .build()
+        .expect("to build the prometheus exporter");
+
+    let provider = SdkMeterProvider::builder()
+        .with_resource(Resource::builder().build())
+        .with_reader(exporter)
+        .build();
+    global::set_meter_provider(provider);
+
+    registry
+}
+
+/// Every `err_code` label recorded on `query_failures`, with its count.
+fn failures_by_err_code(registry: &prometheus::Registry) -> Vec<(String, f64)> {
+    registry
+        .gather()
+        .iter()
+        .filter(|family| family.name() == "query_failures")
+        .flat_map(|family| {
+            family.get_metric().iter().map(|metric| {
+                let err_code = metric
+                    .get_label()
+                    .iter()
+                    .find(|label| label.name() == "err_code")
+                    .map_or_else(String::new, |label| label.value().to_string());
+                (err_code, metric.get_counter().value())
+            })
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn a_mid_stream_pool_refusal_is_counted_as_resources_exhausted() {
+    let registry = install_prometheus_meter_provider();
+
+    let app = AppBuilder::new("query_failure_err_code")
+        .with_runtime(SpicepodRuntime {
+            query: Some(Query {
+                memory_limit: Some(QUERY_MEMORY_LIMIT.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .build();
+
+    let rt = Runtime::builder().with_app(app).build().await;
+
+    let result = QueryBuilder::new(EXHAUSTING_QUERY, rt.datafusion())
+        .build()
+        .run()
+        .await;
+
+    // The refusal can surface from `run()` or from the stream, depending on how
+    // eagerly the plan is polled. Both must reach the same label.
+    let error = match result {
+        Ok(mut result) => {
+            let mut stream_error = None;
+            while let Some(batch) = result.data.next().await {
+                if let Err(e) = batch {
+                    stream_error = Some(e.to_string());
+                    break;
+                }
+            }
+            stream_error.expect("the query must not succeed within the memory limit")
+        }
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        error.contains("Resources exhausted"),
+        "the query must fail for want of memory, not for another reason: {error}"
+    );
+
+    let recorded = failures_by_err_code(&registry);
+    assert!(
+        recorded
+            .iter()
+            .any(|(code, count)| code == "ResourcesExhausted" && *count > 0.0),
+        "a memory-pool refusal must be counted as err_code=\"ResourcesExhausted\"; recorded: {recorded:?}"
+    );
+    assert!(
+        !recorded
+            .iter()
+            .any(|(code, count)| code == "QueryExecutionError" && *count > 0.0),
+        "capacity must not also be counted as a generic execution failure; recorded: {recorded:?}"
+    );
+}


### PR DESCRIPTION
## Summary

#12289 added `ErrorCode::ResourcesExhausted` and the 503, but a refusal was still reported as something else on two paths.

**`query_failures{err_code}` never carried the new code.** The mid-stream tracker path finished with a hardcoded `ErrorCode::QueryExecutionError` (`datafusion/query.rs`). A pool refusal is characteristically mid-stream — an operator grows its reservation while batches are polled — so the common case was recorded as a generic execution failure and never appeared in an `err_code` breakdown.

**A join's refusal was not recognised at all.** `OnceFut` hands the build-side error to every probe partition wrapped in `DataFusionError::Shared` (`physical-plan/src/joins/utils.rs:386`, `:1020`), and `ErrorCode::from` recursed through `Context` only, so `Shared` fell to the `InternalError` catch-all. The HTTP layer classifies through the same conversion, so a join answered **400** with no `warn!` — invisible from the response, because `Shared` renders with an empty prefix and delegates its message, making the body read exactly like a bare refusal.

Fixes #12380

## Changes

- **`error_code.rs`** — `DataFusionError::Shared(err) => ErrorCode::from(err.as_ref())`, alongside the existing `Context` recursion.
- **`datafusion/query.rs`** — the mid-stream tracker site calls a new `stream_error_code` instead of hardcoding the code. **Only capacity is reclassified**: everything else stays `QueryExecutionError`, so `ArrowError`, `IoError` and `ParquetError` do not move to `InternalError` and start reading as runtime bugs.

Nothing else moves: a malformed query still gets 400, a read-only rejection 403, cancellation 499, timeout 504.

## Test plan

`cargo fmt --check` clean; 12 unit tests and the new integration test pass on this branch. `make lint` was run on the equivalent backport (identical diff apart from the `SqlErrorKind` wrapper the HTTP test uses) and is clean there.

- `error_code.rs`: `Shared`-wrapped refusal classifies as `ResourcesExhausted`; `Shared`/`Context` nested both ways; `Shared` preserves a non-refusal inner code.
- `datafusion/query.rs`: `stream_error_code` names a refusal in every wrapper, and leaves `Execution`, `External`, `ArrowError`, `IoError`, `Internal` and `Plan` on `QueryExecutionError`.
- `http/v1/mod.rs`: a `Shared`-wrapped refusal reaches 503; a `Shared`-wrapped execution error stays `General`.
- New `crates/runtime/tests/query_failure_err_code.rs`: 16MiB pool, non-spilling `TopK`, asserts the scraped `query_failures` carries `err_code="ResourcesExhausted"`. Reverting the `query.rs` change alone fails it with `recorded: [("QueryExecutionError", 1.0)]`.

### Manual

`spiced` built from the backport branch, file/parquet datasets, no acceleration, `memory_limit: 256MiB`, `target_partitions: 16`, no `temp_directory`. "Today" is the released behaviour with #12289 already in.

| | today | with this change |
|---|---|---|
| three-way hash join | 400 | **503** |
| `ORDER BY … LIMIT n` (TopK) | 503 | 503 |
| `query_failures{err_code}` for both | `QueryExecutionError` | **`ResourcesExhausted`** |
| divide-by-zero mid-stream | 400 / `QueryExecutionError` | unchanged |
| `SELECT 1` / malformed SQL | 200 / 400 | unchanged |

`warn!` records stay single-line with the consumer table folded.
