### PR TITLE
Make `signoff.yml` more searchable.

### DIFF
--- a/scripts/signoff
+++ b/scripts/signoff
@@ -1183,7 +1183,7 @@ cmd_remote() {
   info "Dispatching GitHub Actions Remote Sign-off for ${branch} on ${repo}…"
   # --repo so non-colocated JJ workspaces (no .git) still resolve the remote;
   # --raw-field avoids shell re-quoting pitfalls; the branch was validated above.
-  gh workflow run signoff.yml --repo "$repo" --raw-field "branch=${branch}" \
+  gh workflow run signoff.yml --repo "$repo" --ref "${branch}"" --raw-field "branch=${branch}" \
     || fail "failed to dispatch signoff.yml"
   echo "${OK} Dispatched. Watch with: gh run watch --repo ${repo} --workflow signoff.yml"
 }

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -1183,7 +1183,7 @@ cmd_remote() {
   info "Dispatching GitHub Actions Remote Sign-off for ${branch} on ${repo}…"
   # --repo so non-colocated JJ workspaces (no .git) still resolve the remote;
   # --raw-field avoids shell re-quoting pitfalls; the branch was validated above.
-  gh workflow run signoff.yml --repo "$repo" --ref "${branch}"" --raw-field "branch=${branch}" \
+  gh workflow run signoff.yml --repo "$repo" --ref "${branch}" --raw-field "branch=${branch}" \
     || fail "failed to dispatch signoff.yml"
   echo "${OK} Dispatched. Watch with: gh run watch --repo ${repo} --workflow signoff.yml"
 }


### PR DESCRIPTION
When running `signoff.yml`, use it from the branch to run on. This makes it easier to search for runs for a given PR/branch (when there are many workflow runs, this is important).

Now safe after #12025
