### PR TITLE
ci: limit remote signoff concurrency

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -48,8 +48,32 @@ env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
+  assign-slot:
+    name: Assign sign-off slot
+    runs-on: ubuntu-24.04
+    permissions: {}
+    outputs:
+      slot: ${{ steps.slot.outputs.slot }}
+    steps:
+      - name: Assign one of four sign-off slots
+        id: slot
+        env:
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          slot=$((RUN_ID % 4))
+          echo "Assigned sign-off slot ${slot}"
+          echo "slot=${slot}" >> "${GITHUB_OUTPUT}"
+
   sign-off:
     name: Sign off on ${{ github.event.inputs.branch }}
+    needs: assign-slot
+    # A concurrency group permits one running job. Four groups provide four
+    # sign-off slots, while queue:max keeps additional dispatches pending.
+    concurrency:
+      group: signoff-slot-${{ needs.assign-slot.outputs.slot }}
+      cancel-in-progress: false
+      queue: max
     runs-on: spiceai-macos
     permissions:
       contents: read

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -228,6 +228,10 @@ runner. It deliberately never SSHes into ad-hoc hosts — the LAN lab boxes
 double as benchmark machines, and a workspace build there mid-run silently
 corrupts the measurement.
 
+Remote sign-off has four concurrency slots. Additional dispatches remain queued
+until a slot is available, so long-running sign-offs cannot consume the whole
+self-hosted runner pool.
+
 The Actions workflow:
 
 1. Checks out your branch (full history) and fetches `trunk`


### PR DESCRIPTION
## Summary

- Limit remote sign-off jobs to four concurrent self-hosted macOS runners.
- Queue additional sign-off dispatches without replacing pending runs.
- Document the capacity limit.

## Why

Remote sign-off and merge-queue jobs share the self-hosted runner pool. Independent sign-off runs could consume the available capacity and prevent smaller jobs from starting. Four fixed job-level concurrency slots leave the rest of the pool available while preserving same-branch cancellation.

## Validation

- `python3 .github/scripts/check_workflow_yaml.py`
- `python3 .github/scripts/test_check_workflow_yaml.py` (18 tests)
- YAML structure and whitespace checks