### PR TITLE
Clean up SQLite sidecar files in cold bloom catalog test

### DIFF
--- a/crates/cayenne/src/cayenne_catalog.rs
+++ b/crates/cayenne/src/cayenne_catalog.rs
@@ -5267,7 +5267,12 @@ mod tests {
         );
 
         drop(catalog);
-        let _ = std::fs::remove_file(test_db.trim_start_matches("sqlite://"));
+
+        // Cleanup test database
+        let db_path = test_db.strip_prefix("sqlite://").unwrap_or(&test_db);
+        let _ = std::fs::remove_file(db_path);
+        let _ = std::fs::remove_file(format!("{db_path}-shm"));
+        let _ = std::fs::remove_file(format!("{db_path}-wal"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`cold_tier_file_pk_bloom_round_trips` removed only the `.db` file at the end of the test. The catalog opens SQLite in WAL mode, so each run also left `<db>-wal` (272 KB) and `<db>-shm` (32 KB) behind in `crates/cayenne/`, accumulating over time until a `git clean -xdf`.

It was the only test in the module that didn't remove all three files.

## Change

Delete the `-wal` and `-shm` sidecars alongside the `.db` file, matching the cleanup pattern used by the other tests in `cayenne_catalog.rs`.

## Testing

`cargo test -p cayenne --lib cold_tier_file_pk_bloom_round_trips` passes and leaves no files behind.