### PR TITLE
fix(postgres): publish a member's held CDC envelope before a bulk transaction (fixes #12311)

### DIFF
--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -2762,10 +2762,29 @@ async fn push_eager_envelope(
     let limits = settings.limits;
     // Eager holding disabled, or this transaction alone already fills an
     // envelope: publish straight through rather than paying the hold.
+    //
+    // Whatever this member already holds absorbed earlier commits, so it is
+    // sealed and published FIRST. Changes are applied in delivery order and
+    // nothing downstream re-sorts by LSN, so letting this transaction overtake
+    // the hold would apply an older commit's rows over a newer one's; and
+    // because `SharedLsnCommitter` takes a monotonic max, the overtaking
+    // envelope acks the higher LSN, so the skipped WAL is recyclable and never
+    // replayed. This is the same invariant the idle-heartbeat path keeps, and
+    // the one `MergeOutcome::Limited` keeps below. The sealed hold carries its
+    // own member handle, so it stays correct across a detach + re-subscribe
+    // that installs a new handle under the same key.
     if limits.max_envelope_age.is_zero()
         || next.envelope.rows.num_rows_hint() >= limits.eager_max_rows
     {
-        return publish_eager_envelope(source, member_key, next, settings.shutdown_epoch).await;
+        let mut waited: u64 = 0;
+        if let Some(sealed) = hold.pending.remove(member_key) {
+            hold.refresh_deadline(limits.max_envelope_age);
+            waited =
+                publish_eager_envelope(source, member_key, sealed, settings.shutdown_epoch).await;
+        }
+        return waited.saturating_add(
+            publish_eager_envelope(source, member_key, next, settings.shutdown_epoch).await,
+        );
     }
 
     let Some(current) = hold.pending.get_mut(member_key) else {
@@ -3005,6 +3024,25 @@ mod tests {
         Arc::clone(&TINY_SCHEMA)
     }
 
+    /// A pending envelope buffering `rows` change messages, for a transaction big
+    /// enough to reach `eager_max_rows` on its own.
+    fn pending_change_rows(
+        slot: &Arc<AckSlot>,
+        flush_to: u64,
+        source_commit_ts_ms: i64,
+        rows: usize,
+    ) -> PendingPgEnvelope {
+        PendingPgEnvelope {
+            rows: PgChangeRows::new(
+                tiny_schema(),
+                Arc::clone(&TINY_RELATION),
+                vec![Bytes::from_static(b"I"); rows],
+                Some(source_commit_ts_ms),
+            ),
+            ..pending_change(slot, flush_to, source_commit_ts_ms, false)
+        }
+    }
+
     fn pending_change(
         slot: &Arc<AckSlot>,
         flush_to: u64,
@@ -3060,6 +3098,17 @@ mod tests {
     /// and (capacity-4) channels, returning a probe per member so tests can read
     /// its metrics and drive its channel.
     fn test_source_with_members(n: usize) -> (Arc<SharedSource>, Vec<MemberProbe>) {
+        test_source_with_member_limits(n, *COALESCING_LIMITS)
+    }
+
+    /// As [`test_source_with_members`], with the member mailboxes' coalescing
+    /// limits chosen by the caller. A `backpressure_max_rows` low enough to
+    /// refuse the fold keeps each delivery a distinct mailbox item, which is how
+    /// a test observes *delivery order* rather than a merged result.
+    fn test_source_with_member_limits(
+        n: usize,
+        limits: CoalescingLimits,
+    ) -> (Arc<SharedSource>, Vec<MemberProbe>) {
         let source_key = SourceKey::from_params(&test_params());
         let source = Arc::new(SharedSource::new(source_key, test_params()));
         let schema: SchemaRef = Arc::new(arrow::datatypes::Schema::empty());
@@ -3067,7 +3116,7 @@ mod tests {
         for i in 0..n {
             let member_key = key(&format!("t{i}"));
             let metrics = ReplicationMetricsCollector::new();
-            let (sender, receiver) = member_mailbox(4);
+            let (sender, receiver) = member_mailbox_with_limits(4, limits);
             lock(&source.members).insert(
                 member_key.clone(),
                 Arc::new(MemberHandle {
@@ -3591,6 +3640,199 @@ mod tests {
             .expect("eager envelope")
             .expect("valid envelope");
         assert_eq!(envelope.num_rows_hint(), 2);
+    }
+
+    /// Regression test for #12311. A transaction that fills an envelope on its own
+    /// publishes straight through, but it must not overtake what this member
+    /// already holds: changes are applied in delivery order, so the earlier
+    /// commit arriving second would apply its rows over the later commit's — and
+    /// since `SharedLsnCommitter` takes a monotonic max, the overtaking envelope
+    /// acks the higher LSN, so the skipped WAL is recyclable and never replayed.
+    #[tokio::test]
+    async fn eager_oversized_transaction_does_not_overtake_the_held_envelope() {
+        // `backpressure_max_rows` 1 stops the mailbox folding the two deliveries
+        // into one item, leaving the order directly observable.
+        let limits = test_limits(2, 1);
+        let settings = eager_settings(limits);
+        let (source, mut probes) = test_source_with_member_limits(1, limits);
+        let (member_key, _metrics, mut rx) = probes.remove(0);
+        let member = source.member(&member_key).expect("member");
+        let slot = Arc::new(AckSlot::new(0, false));
+        let mut hold = EagerHold::default();
+
+        // A small commit starts the hold.
+        let _ = push_eager_envelope(
+            &source,
+            &mut hold,
+            &member_key,
+            EagerPendingEnvelope {
+                member: Arc::clone(&member),
+                envelope: pending_change(&slot, 100, 100, false),
+            },
+            settings,
+        )
+        .await;
+        assert_eq!(hold.pending.len(), 1, "the small commit should be held");
+
+        // A bulk transaction reaching `eager_max_rows` on its own takes the
+        // straight-through path.
+        let _ = push_eager_envelope(
+            &source,
+            &mut hold,
+            &member_key,
+            EagerPendingEnvelope {
+                member: Arc::clone(&member),
+                envelope: pending_change_rows(&slot, 120, 120, 2),
+            },
+            settings,
+        )
+        .await;
+
+        assert!(
+            hold.pending.is_empty() && hold.next_deadline.is_none(),
+            "the hold should be sealed and its deadline cleared"
+        );
+        let first = rx
+            .next()
+            .await
+            .expect("first envelope")
+            .expect("valid first envelope");
+        let second = rx
+            .next()
+            .await
+            .expect("second envelope")
+            .expect("valid second envelope");
+        assert_eq!(
+            (first.source_commit_ts_ms(), second.source_commit_ts_ms()),
+            (Some(100), Some(120)),
+            "the held commit must be delivered before the bulk transaction"
+        );
+        assert_eq!(first.num_rows_hint(), 1);
+        assert_eq!(second.num_rows_hint(), 2);
+    }
+
+    /// Sealing the hold is scoped to the member being published to: a bulk
+    /// transaction on one table must not flush another table's coalescing
+    /// envelope, whose age deadline has to survive intact.
+    #[tokio::test]
+    async fn eager_oversized_transaction_leaves_other_members_held() {
+        let limits = test_limits(2, 1);
+        let settings = eager_settings(limits);
+        let (source, mut probes) = test_source_with_member_limits(2, limits);
+        let (first_key, _first_metrics, mut first_rx) = probes.remove(0);
+        let (second_key, _second_metrics, mut second_rx) = probes.remove(0);
+        let first_member = source.member(&first_key).expect("first member");
+        let second_member = source.member(&second_key).expect("second member");
+        let slot = Arc::new(AckSlot::new(0, false));
+        let mut hold = EagerHold::default();
+
+        let _ = push_eager_envelope(
+            &source,
+            &mut hold,
+            &first_key,
+            EagerPendingEnvelope {
+                member: Arc::clone(&first_member),
+                envelope: pending_change(&slot, 100, 100, false),
+            },
+            settings,
+        )
+        .await;
+        let first_deadline = hold.next_deadline.expect("the first member holds");
+
+        let _ = push_eager_envelope(
+            &source,
+            &mut hold,
+            &second_key,
+            EagerPendingEnvelope {
+                member: Arc::clone(&second_member),
+                envelope: pending_change_rows(&slot, 120, 120, 2),
+            },
+            settings,
+        )
+        .await;
+
+        assert_eq!(
+            hold.pending.len(),
+            1,
+            "only the published member's hold should be sealed"
+        );
+        assert!(hold.pending.contains_key(&first_key));
+        assert_eq!(
+            hold.next_deadline,
+            Some(first_deadline),
+            "the untouched member's age deadline must survive"
+        );
+        assert!(
+            futures::FutureExt::now_or_never(first_rx.next()).is_none(),
+            "the other member's envelope should still be held"
+        );
+        assert_eq!(
+            second_rx
+                .next()
+                .await
+                .expect("bulk envelope")
+                .expect("valid envelope")
+                .source_commit_ts_ms(),
+            Some(120)
+        );
+    }
+
+    /// The straight-through path drains the hold whichever condition selected it.
+    /// A zero `max_envelope_age` means no hold is ever started, so this guards the
+    /// shape of the drain rather than a state the pump reaches today: the two
+    /// conditions share one branch, and a future dynamic `max_envelope_age` would
+    /// make holding reachable after a hold already exists.
+    #[tokio::test]
+    async fn eager_disabled_hold_still_publishes_held_data_first() {
+        let enabled = test_limits(8, 1);
+        let (source, mut probes) = test_source_with_member_limits(1, enabled);
+        let (member_key, _metrics, mut rx) = probes.remove(0);
+        let member = source.member(&member_key).expect("member");
+        let slot = Arc::new(AckSlot::new(0, false));
+        let mut hold = EagerHold::default();
+        let mut disabled = enabled;
+        disabled.max_envelope_age = std::time::Duration::ZERO;
+
+        // Start the hold while holding is on, then publish with it off.
+        let _ = push_eager_envelope(
+            &source,
+            &mut hold,
+            &member_key,
+            EagerPendingEnvelope {
+                member: Arc::clone(&member),
+                envelope: pending_change(&slot, 100, 100, false),
+            },
+            eager_settings(enabled),
+        )
+        .await;
+        let _ = push_eager_envelope(
+            &source,
+            &mut hold,
+            &member_key,
+            EagerPendingEnvelope {
+                member: Arc::clone(&member),
+                envelope: pending_change(&slot, 120, 120, false),
+            },
+            eager_settings(disabled),
+        )
+        .await;
+
+        assert!(hold.pending.is_empty() && hold.next_deadline.is_none());
+        let first = rx
+            .next()
+            .await
+            .expect("first envelope")
+            .expect("valid first envelope");
+        let second = rx
+            .next()
+            .await
+            .expect("second envelope")
+            .expect("valid second envelope");
+        assert_eq!(
+            (first.source_commit_ts_ms(), second.source_commit_ts_ms()),
+            (Some(100), Some(120)),
+            "disabling the hold must not let the new commit overtake held data"
+        );
     }
 
     /// One hold per member, not one most-recently-used slot: a transaction


### PR DESCRIPTION
## Summary (root cause)

On a shared Postgres replication slot, the pump holds one unpublished envelope per member so consecutive commits for a table coalesce before crossing the member boundary (`EagerHold`). `push_eager_envelope` has a straight-through path for a transaction that already fills an envelope by itself:

```rust
if limits.max_envelope_age.is_zero()
    || next.envelope.rows.num_rows_hint() >= limits.eager_max_rows
{
    return publish_eager_envelope(source, member_key, next, settings.shutdown_epoch).await;
}
```

It published `next` **without first sealing the envelope this member already held**. That hold is older, so the member received the later commit's rows before the earlier commit's.

That is a wrong result, not just a reordering. Changes are applied in delivery order and nothing downstream re-sorts by LSN, so `INSERT k (v=1)` held at LSN 100 followed by a bulk `UPDATE k SET v=2` at LSN 120 arrived as 120 then 100 and the accelerator ended at `v=1` — the update silently lost. A bulk `DELETE` ahead of a held `INSERT` resurrects the row.

The ack accounting then made the loss permanent: `SharedLsnCommitter::commit` is a monotonic `max` into the member's `committed`, so the overtaking envelope committed 120 and the held envelope's later `commit(110)` was a no-op. With `committed == delivered`, `AckTable::credit_idle` also treated the member as idle, `flush_lsn()` advanced, and `confirmed_flush_lsn = 120` was reported to Postgres — making WAL that had never been applied recyclable, so a crash before the held envelope was applied could not replay it.

Defaults make this ordinary rather than a corner case: `SPICE_POSTGRES_CDC_MAX_ENVELOPE_AGE_MS` is 10 ms so holds are on, and `SPICE_POSTGRES_CDC_MAX_ROWS_PER_ENVELOPE` is 8192, which any bulk `UPDATE`/`DELETE`/`INSERT … SELECT` on a CDC'd table reaches (`num_rows_hint()` is an upper bound that counts a PK-changing UPDATE twice, so ~4096 updates already trip it). Under back-pressure the window is not even bounded by `max_envelope_age`: while a member's mailbox is `Full` the held envelope cannot be published, but the straight-through path still awaits capacity and gets in first.

Introduced by #12147.

Fixes #12311

## Changes

- `push_eager_envelope` now seals and publishes the member's existing hold **before** publishing straight through, mirroring what the idle-heartbeat path and `MergeOutcome::Limited` already do. The sealed hold is delivered via its own `member` handle, so it stays correct across a detach + re-subscribe that installs a new handle under the same key; `refresh_deadline` is recomputed after the removal; and both waits are folded into the returned wait so back-pressure stays attributed to the member rather than to decode cost.
- Sealing is scoped to the member being published to, so a bulk transaction on one table does not flush another table's coalescing envelope or disturb its age deadline.
- Test-only: `test_source_with_member_limits` (which `test_source_with_members` now delegates to) lets a test choose the member mailboxes' coalescing limits. A `backpressure_max_rows` low enough to refuse the fold keeps each delivery a distinct mailbox item, which is what makes *delivery order* observable instead of a merged result.

### Scope

`rg` finds `EagerHold` only in `crates/data_components/src/postgres_replication/shared.rs`, and the MySQL shared pump has no equivalent hold on trunk, so this is a single-site fix. The other paths that can deliver to a member while a hold exists were checked and already keep the invariant: the idle-heartbeat path drains the hold first (non-blockingly, putting it back on `Full`), and `flush_expired_eager_envelopes` publishes the hold itself.

### Performance impact

None to the coalescing behaviour: the straight-through path is unchanged whenever nothing is held, which is the common case. When a hold does exist, one extra envelope is delivered before the bulk transaction — to the same mailbox the bulk transaction was already going to block on — so the added wait is bounded by one envelope's admission, and it is accounted into `member_send_wait_micros_total` like every other delivery.

### What this does not establish

- Ordering under a `Full` mailbox is correct by construction (the hold's delivery completes before the second call is made) but is not covered by a new test; adding one would need a concurrent drainer and a timing window, and `deliver_to_member`'s await path is already covered by `deliver_to_member_backpressure_lands_in_send_wait` and `close_releases_a_sender_parked_on_a_full_mailbox`.
- Shutdown remains best-effort: a `ShutdownAbandon` on the hold followed by a successful delivery of the bulk transaction would still skip the earlier commit. That shape is pre-existing on trunk (the hold was simply dropped at shutdown) and this change strictly narrows the window rather than closing it.

## Test plan

- `make lint`
- `make nextest`
- Three new unit tests in `crates/data_components/src/postgres_replication/shared.rs`:
  - `eager_oversized_transaction_does_not_overtake_the_held_envelope` — the regression test: a small commit starts the hold, a bulk transaction reaching `eager_max_rows` takes the straight-through path, and both envelopes must arrive in commit order.
  - `eager_oversized_transaction_leaves_other_members_held` — sealing is scoped to the published member; the other member's envelope and age deadline survive.
  - `eager_disabled_hold_still_publishes_held_data_first` — the drain applies whichever condition selected the straight-through path.
- Verified load-bearing with two independent neuters: reverting the fix to trunk's behaviour fails the first and third tests deterministically (`assertion failed: hold.pending.is_empty() && hold.next_deadline.is_none()`), and an over-broad variant that drains *every* member's hold fails the second (`left: 0, right: 1`).

## Checklist

- [x] Root cause identified and stated
- [x] Regression test that fails on the old code
- [x] Bug-class sweep for sibling sites (single-site; other delivery paths verified)
- [x] `cargo clippy -p data_components --features postgres`, both the `--lib --bins` and `--tests` passes, clean
- [x] `cargo fmt`
- [ ] `make signoff` green and `Attestation` re-run