### PR TITLE
fix(search): resolve a chunked index's entries from the authoritative store, not the read listing (fixes #12266)

### DIFF
--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -15,6 +15,7 @@ use arrow::{
     compute::concat,
 };
 
+use crate::index::primary_key_projection;
 use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use chunking::Chunker;
@@ -139,10 +140,10 @@ impl Index for ChunkedSearchIndex {
 /// Deletes every entry in `inner` whose primary-key columns match a row of `outer_keys` (which
 /// carry only the outer/pre-chunk key columns — `inner`'s own key additionally has the chunk id,
 /// whose values aren't known here). Resolves the exact matching entries by scanning `inner`'s own
-/// [`VectorIndex::list_all_entries`] with a predicate built from `outer_keys`, then deletes
+/// [`VectorIndex::list_all_entry_keys`] with a predicate built from `outer_keys`, then deletes
 /// those resolved (chunk-key-included) rows via `inner`'s normal [`Index::delete_by_keys`].
 ///
-/// Resolution goes through [`VectorIndex::list_all_entries`], not
+/// Resolution goes through [`VectorIndex::list_all_entry_keys`], not
 /// [`VectorIndex::list_table_provider`]: the read listing can be narrower than what the index
 /// stores (a compound index's read mode may serve only its warm primary), and a chunk entry that
 /// does not resolve is never passed to [`Index::delete_by_keys`] at all — the delete then reports
@@ -164,13 +165,9 @@ async fn delete_chunked_vector_by_outer_keys(
     // `delete_by_keys` reads only the primary-key columns, so project to them and drop the
     // duplicates a multi-store listing can carry (the same entry held by more than one half).
     // This also keeps the embedding vectors — the bulk of the listing — out of a delete.
-    let key_projection = inner
-        .primary_fields()
-        .iter()
-        .map(|f| Expr::Column(Column::new_unqualified(f.name())))
-        .collect::<Vec<_>>();
+    let key_projection = primary_key_projection(&inner.primary_fields());
 
-    let list_plan = inner.list_all_entries()?;
+    let list_plan = inner.list_all_entry_keys()?;
     let filtered_plan = LogicalPlanBuilder::from(list_plan)
         .filter(predicate)?
         .project(key_projection)?
@@ -740,27 +737,7 @@ impl VectorIndex for ChunkedVectorIndex {
     }
 
     fn list_table_provider(&self) -> Result<LogicalPlan, DataFusionError> {
-        self.aggregate_chunk_listing(self.inner.list_table_provider()?)
-    }
-
-    /// Forwards to the inner index's authoritative listing, aggregated the same way
-    /// [`Self::list_table_provider`] aggregates the read listing.
-    fn list_all_entries(&self) -> Result<LogicalPlan, DataFusionError> {
-        self.aggregate_chunk_listing(self.inner.list_all_entries()?)
-    }
-
-    fn dimension(&self) -> i32 {
-        self.inner.dimension()
-    }
-}
-
-impl ChunkedVectorIndex {
-    /// Collapses a chunk-keyed listing of `self.inner` into one row per *base* row, aggregating
-    /// each base row's chunk offsets and embeddings in chunk-id order.
-    fn aggregate_chunk_listing(
-        &self,
-        base_index_table: LogicalPlan,
-    ) -> Result<LogicalPlan, DataFusionError> {
+        let base_index_table = self.inner.list_table_provider()?;
         let primary_key_names = ChunkedSearchIndex::base_key_columns(&self.inner.primary_fields());
 
         // Primary key, offsets and embeddings.
@@ -837,6 +814,17 @@ impl ChunkedVectorIndex {
             )
             .boxed()?,
         ))
+    }
+
+    /// Forwards to the index this wraps. The inner index's keys carry the chunk id on top of the
+    /// base key, which is a superset of this index's own key — the contract asks for at least the
+    /// key columns, so no aggregation is needed here.
+    fn list_all_entry_keys(&self) -> Result<LogicalPlan, DataFusionError> {
+        self.inner.list_all_entry_keys()
+    }
+
+    fn dimension(&self) -> i32 {
+        self.inner.dimension()
     }
 }
 
@@ -1505,48 +1493,6 @@ mod tests {
         assert_eq!(ids, &vec![1, 1], "both chunks of id 1, and nothing else");
     }
 
-    /// [`chunk_keyed_rows`] plus the offset and embedding columns a real inner index's listing
-    /// carries, so [`ChunkedVectorIndex::list_table_provider`]'s aggregation can be built over it.
-    fn chunk_keyed_listing(rows: &[(i64, u64)]) -> RecordBatch {
-        let keys = chunk_keyed_rows(rows);
-        let offset_field = Arc::new(Field::new("item", DataType::Int32, true));
-        let offsets = FixedSizeListArray::try_new(
-            Arc::clone(&offset_field),
-            2,
-            // The values are irrelevant — these columns exist only so the chunk-listing
-            // aggregation, which references them by name, can be built over this batch.
-            Arc::new(Int32Array::from(vec![0; rows.len() * 2])),
-            None,
-        )
-        .expect("valid offsets");
-        let embedding_field = Arc::new(Field::new("item", DataType::Float32, true));
-        let embeddings = FixedSizeListArray::try_new(
-            Arc::clone(&embedding_field),
-            4,
-            Arc::new(Float32Array::from(vec![0.0_f32; rows.len() * 4])),
-            None,
-        )
-        .expect("valid embeddings");
-
-        let mut fields = keys.schema().fields().to_vec();
-        fields.push(Arc::new(Field::new(
-            ChunkedSearchIndex::chunking_offset_col("content"),
-            offsets.data_type().clone(),
-            true,
-        )));
-        fields.push(Arc::new(Field::new(
-            embedding_col("content"),
-            embeddings.data_type().clone(),
-            true,
-        )));
-
-        let mut columns = keys.columns().to_vec();
-        columns.push(Arc::new(offsets) as ArrayRef);
-        columns.push(Arc::new(embeddings) as ArrayRef);
-
-        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).expect("valid listing batch")
-    }
-
     /// An inner index shaped like the S3-Vectors-with-warm-tier case: a warm `primary` holding
     /// only what the write path has passed through it, over an authoritative `secondary`.
     fn compound_inner(
@@ -1713,12 +1659,12 @@ mod tests {
         );
     }
 
-    /// `ChunkedVectorIndex` is a wrapper, so it must forward `list_all_entries` to its inner index
+    /// `ChunkedVectorIndex` is a wrapper, so it must forward `list_all_entry_keys` to its inner index
     /// rather than inherit the default (which would resolve against the read listing again).
     #[tokio::test]
-    async fn chunked_vector_index_forwards_list_all_entries_to_its_inner_index() {
-        let warm = Arc::new(RecordingInner::chunked(vec![chunk_keyed_listing(&[])]));
-        let durable = Arc::new(RecordingInner::chunked(vec![chunk_keyed_listing(&[
+    async fn chunked_vector_index_forwards_list_all_entry_keys_to_its_inner_index() {
+        let warm = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[])]));
+        let durable = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[
             (1, 0),
             (1, 1),
         ])]));
@@ -1728,29 +1674,19 @@ mod tests {
             chunker: chunker(),
         };
 
-        // A `PrimaryOnly` read listing is the warm primary's scan alone; the authoritative
-        // listing unions both halves. Comparing the two plans is what shows the forward: had
-        // `ChunkedVectorIndex` inherited the default, both would be the read listing.
-        let read = format!(
+        // The compound inner unions its two halves, so the forward is visible in the plan. Had
+        // `ChunkedVectorIndex` inherited the default, this would be the *read* listing — the warm
+        // primary's scan alone under `PrimaryOnly`, with no `Union` in it.
+        let plan = format!(
             "{}",
-            idx.list_table_provider()
-                .expect("read plan builds")
-                .display_indent()
-        );
-        let all = format!(
-            "{}",
-            idx.list_all_entries()
+            idx.list_all_entry_keys()
                 .expect("authoritative plan builds")
                 .display_indent()
         );
 
         assert!(
-            all.contains("Union"),
-            "the authoritative listing must reach both halves of the compound inner:\n{all}"
-        );
-        assert!(
-            !read.contains("Union"),
-            "a PrimaryOnly read listing is the warm primary alone:\n{read}"
+            plan.contains("Union"),
+            "the authoritative listing must reach both halves of the compound inner:\n{plan}"
         );
     }
 

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -1483,14 +1483,23 @@ mod tests {
             .await
             .expect("delete succeeds");
 
+        // Asserted over the union of the delete calls rather than a single batch: the resolving
+        // query ends in a `distinct()`, whose hash aggregate emits one batch per non-empty
+        // partition, so how many calls the inner index sees tracks DataFusion's partitioning —
+        // and hence the host's CPU count — not this fix. Which keys get deleted is the guarantee.
         let deletes = inner.deletes();
-        assert_eq!(deletes.len(), 1, "one resolved batch: {deletes:?}");
-        let (columns, ids) = &deletes[0];
+        assert!(!deletes.is_empty(), "the resolved chunks reach the inner index");
         assert!(
-            columns.contains(&CHUNKED_INDEX_CHUNK_KEY.to_string()),
-            "resolved keys carry the chunk id: {columns:?}"
+            deletes
+                .iter()
+                .all(|(columns, _)| columns.contains(&CHUNKED_INDEX_CHUNK_KEY.to_string())),
+            "resolved keys carry the chunk id: {deletes:?}"
         );
-        assert_eq!(ids, &vec![1, 1], "both chunks of id 1, and nothing else");
+        assert_eq!(
+            resolved_ids(&deletes),
+            vec![1, 1],
+            "both chunks of id 1, and nothing else"
+        );
     }
 
     /// An inner index shaped like the S3-Vectors-with-warm-tier case: a warm `primary` holding

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -1488,7 +1488,10 @@ mod tests {
         // partition, so how many calls the inner index sees tracks DataFusion's partitioning —
         // and hence the host's CPU count — not this fix. Which keys get deleted is the guarantee.
         let deletes = inner.deletes();
-        assert!(!deletes.is_empty(), "the resolved chunks reach the inner index");
+        assert!(
+            !deletes.is_empty(),
+            "the resolved chunks reach the inner index"
+        );
         assert!(
             deletes
                 .iter()

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -139,8 +139,14 @@ impl Index for ChunkedSearchIndex {
 /// Deletes every entry in `inner` whose primary-key columns match a row of `outer_keys` (which
 /// carry only the outer/pre-chunk key columns — `inner`'s own key additionally has the chunk id,
 /// whose values aren't known here). Resolves the exact matching entries by scanning `inner`'s own
-/// [`VectorIndex::list_table_provider`] with a predicate built from `outer_keys`, then deletes
+/// [`VectorIndex::list_all_entries`] with a predicate built from `outer_keys`, then deletes
 /// those resolved (chunk-key-included) rows via `inner`'s normal [`Index::delete_by_keys`].
+///
+/// Resolution goes through [`VectorIndex::list_all_entries`], not
+/// [`VectorIndex::list_table_provider`]: the read listing can be narrower than what the index
+/// stores (a compound index's read mode may serve only its warm primary), and a chunk entry that
+/// does not resolve is never passed to [`Index::delete_by_keys`] at all — the delete then reports
+/// success having removed nothing.
 async fn delete_chunked_vector_by_outer_keys(
     inner: &Arc<dyn VectorIndex>,
     outer_keys: RecordBatch,
@@ -155,9 +161,20 @@ async fn delete_chunked_vector_by_outer_keys(
         return Ok(());
     };
 
-    let list_plan = inner.list_table_provider()?;
+    // `delete_by_keys` reads only the primary-key columns, so project to them and drop the
+    // duplicates a multi-store listing can carry (the same entry held by more than one half).
+    // This also keeps the embedding vectors — the bulk of the listing — out of a delete.
+    let key_projection = inner
+        .primary_fields()
+        .iter()
+        .map(|f| Expr::Column(Column::new_unqualified(f.name())))
+        .collect::<Vec<_>>();
+
+    let list_plan = inner.list_all_entries()?;
     let filtered_plan = LogicalPlanBuilder::from(list_plan)
         .filter(predicate)?
+        .project(key_projection)?
+        .distinct()?
         .build()?;
 
     let ctx = SessionContext::new();
@@ -723,7 +740,27 @@ impl VectorIndex for ChunkedVectorIndex {
     }
 
     fn list_table_provider(&self) -> Result<LogicalPlan, DataFusionError> {
-        let base_index_table = self.inner.list_table_provider()?;
+        self.aggregate_chunk_listing(self.inner.list_table_provider()?)
+    }
+
+    /// Forwards to the inner index's authoritative listing, aggregated the same way
+    /// [`Self::list_table_provider`] aggregates the read listing.
+    fn list_all_entries(&self) -> Result<LogicalPlan, DataFusionError> {
+        self.aggregate_chunk_listing(self.inner.list_all_entries()?)
+    }
+
+    fn dimension(&self) -> i32 {
+        self.inner.dimension()
+    }
+}
+
+impl ChunkedVectorIndex {
+    /// Collapses a chunk-keyed listing of `self.inner` into one row per *base* row, aggregating
+    /// each base row's chunk offsets and embeddings in chunk-id order.
+    fn aggregate_chunk_listing(
+        &self,
+        base_index_table: LogicalPlan,
+    ) -> Result<LogicalPlan, DataFusionError> {
         let primary_key_names = ChunkedSearchIndex::base_key_columns(&self.inner.primary_fields());
 
         // Primary key, offsets and embeddings.
@@ -800,10 +837,6 @@ impl VectorIndex for ChunkedVectorIndex {
             )
             .boxed()?,
         ))
-    }
-
-    fn dimension(&self) -> i32 {
-        self.inner.dimension()
     }
 }
 
@@ -924,6 +957,7 @@ impl SearchIndex for ChunkedVectorIndex {
 )]
 mod tests {
     use super::*;
+    use crate::index::compound::{CompoundReadMode, CompoundVectorIndex};
     use arrow::array::{Float32Array, Int32Array, Int64Array, StringArray};
     use chunking::Chunker;
     use std::fmt::Write as _;
@@ -1469,6 +1503,255 @@ mod tests {
             "resolved keys carry the chunk id: {columns:?}"
         );
         assert_eq!(ids, &vec![1, 1], "both chunks of id 1, and nothing else");
+    }
+
+    /// [`chunk_keyed_rows`] plus the offset and embedding columns a real inner index's listing
+    /// carries, so [`ChunkedVectorIndex::list_table_provider`]'s aggregation can be built over it.
+    fn chunk_keyed_listing(rows: &[(i64, u64)]) -> RecordBatch {
+        let keys = chunk_keyed_rows(rows);
+        let offset_field = Arc::new(Field::new("item", DataType::Int32, true));
+        let offsets = FixedSizeListArray::try_new(
+            Arc::clone(&offset_field),
+            2,
+            // The values are irrelevant — these columns exist only so the chunk-listing
+            // aggregation, which references them by name, can be built over this batch.
+            Arc::new(Int32Array::from(vec![0; rows.len() * 2])),
+            None,
+        )
+        .expect("valid offsets");
+        let embedding_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let embeddings = FixedSizeListArray::try_new(
+            Arc::clone(&embedding_field),
+            4,
+            Arc::new(Float32Array::from(vec![0.0_f32; rows.len() * 4])),
+            None,
+        )
+        .expect("valid embeddings");
+
+        let mut fields = keys.schema().fields().to_vec();
+        fields.push(Arc::new(Field::new(
+            ChunkedSearchIndex::chunking_offset_col("content"),
+            offsets.data_type().clone(),
+            true,
+        )));
+        fields.push(Arc::new(Field::new(
+            embedding_col("content"),
+            embeddings.data_type().clone(),
+            true,
+        )));
+
+        let mut columns = keys.columns().to_vec();
+        columns.push(Arc::new(offsets) as ArrayRef);
+        columns.push(Arc::new(embeddings) as ArrayRef);
+
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).expect("valid listing batch")
+    }
+
+    /// An inner index shaped like the S3-Vectors-with-warm-tier case: a warm `primary` holding
+    /// only what the write path has passed through it, over an authoritative `secondary`.
+    fn compound_inner(
+        warm: &Arc<RecordingInner>,
+        durable: &Arc<RecordingInner>,
+        read_mode: CompoundReadMode,
+    ) -> Arc<CompoundVectorIndex> {
+        Arc::new(
+            CompoundVectorIndex::try_new(
+                Arc::clone(warm) as Arc<dyn VectorIndex>,
+                Arc::clone(durable) as Arc<dyn VectorIndex>,
+                read_mode,
+            )
+            .expect("the two mocks share a search column, primary key and dimension"),
+        )
+    }
+
+    /// Deletes base key 1 through a chunked index over a compound inner, returning what each half
+    /// was asked to delete.
+    async fn delete_through_compound(
+        warm: &Arc<RecordingInner>,
+        durable: &Arc<RecordingInner>,
+        read_mode: CompoundReadMode,
+    ) -> (Vec<(Vec<String>, Vec<i64>)>, Vec<(Vec<String>, Vec<i64>)>) {
+        let idx = ChunkedSearchIndex::new(
+            compound_inner(warm, durable, read_mode) as Arc<dyn SearchIndex>,
+            chunker(),
+        );
+
+        idx.delete_by_keys(outer_keys(&[1]))
+            .await
+            .expect("delete succeeds");
+
+        (warm.deletes(), durable.deletes())
+    }
+
+    /// The resolved chunk ids across every `delete_by_keys` call a half received.
+    fn resolved_ids(deletes: &[(Vec<String>, Vec<i64>)]) -> Vec<i64> {
+        deletes.iter().flat_map(|(_, ids)| ids.clone()).collect()
+    }
+
+    /// Regression test for #12266. A compound inner index serves *reads* from its warm primary
+    /// (`PrimaryOnly`) or falls back per-plan (`FallbackToSecondary`) — neither is authoritative
+    /// for what is stored. Resolving the chunk-keyed entries against that read listing found
+    /// nothing for a row the warm tier does not hold, so `delete_by_keys` was never called for it
+    /// and the delete reported success having removed nothing from the durable store.
+    #[tokio::test]
+    async fn a_compound_inner_resolves_chunks_the_warm_primary_does_not_hold() {
+        for read_mode in [
+            CompoundReadMode::PrimaryOnly,
+            CompoundReadMode::FallbackToSecondary,
+        ] {
+            let warm = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[])]));
+            let durable = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[
+                (1, 0),
+                (1, 1),
+            ])]));
+
+            let (warm_deletes, durable_deletes) =
+                delete_through_compound(&warm, &durable, read_mode).await;
+
+            assert_eq!(
+                resolved_ids(&durable_deletes),
+                vec![1, 1],
+                "both chunks the durable half holds must be deleted ({read_mode:?})"
+            );
+            assert!(
+                durable_deletes
+                    .iter()
+                    .all(|(columns, _)| columns.contains(&CHUNKED_INDEX_CHUNK_KEY.to_string())),
+                "resolved keys carry the chunk id: {durable_deletes:?}"
+            );
+            assert_eq!(
+                resolved_ids(&warm_deletes),
+                vec![1, 1],
+                "the delete fans out to both halves, whichever resolved the entries ({read_mode:?})"
+            );
+        }
+    }
+
+    /// The narrower half of the same bug: a *partially* populated warm tier. `FallbackToSecondary`
+    /// falls back only when the primary's plan is entirely empty, so a warm tier holding one of
+    /// two chunks resolved just that one and left the other in the durable store.
+    #[tokio::test]
+    async fn a_compound_inner_resolves_chunks_a_partial_warm_primary_is_missing() {
+        for read_mode in [
+            CompoundReadMode::PrimaryOnly,
+            CompoundReadMode::FallbackToSecondary,
+        ] {
+            let warm = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])]));
+            let durable = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[
+                (1, 0),
+                (1, 1),
+            ])]));
+
+            let (_, durable_deletes) = delete_through_compound(&warm, &durable, read_mode).await;
+
+            assert_eq!(
+                resolved_ids(&durable_deletes),
+                vec![1, 1],
+                "the chunk the warm tier is missing must still be resolved ({read_mode:?})"
+            );
+        }
+    }
+
+    /// The other direction: resolving from the durable half *alone* would be equally wrong. The
+    /// two halves can disagree either way, so an entry only the warm tier holds must also be
+    /// resolved — hence a union rather than a switch to the secondary.
+    #[tokio::test]
+    async fn a_compound_inner_resolves_an_entry_only_the_warm_primary_holds() {
+        let warm = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 7)])]));
+        let durable = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[])]));
+
+        let (warm_deletes, _) =
+            delete_through_compound(&warm, &durable, CompoundReadMode::FallbackToSecondary).await;
+
+        assert_eq!(
+            resolved_ids(&warm_deletes),
+            vec![1],
+            "an entry only the warm tier holds must still be resolved and deleted"
+        );
+    }
+
+    /// The union must not turn one stored entry into two deletes just because both halves hold it.
+    #[tokio::test]
+    async fn a_compound_inner_resolves_a_shared_entry_once() {
+        let warm = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])]));
+        let durable = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])]));
+
+        let (warm_deletes, durable_deletes) =
+            delete_through_compound(&warm, &durable, CompoundReadMode::PrimaryOnly).await;
+
+        assert_eq!(
+            resolved_ids(&durable_deletes),
+            vec![1],
+            "an entry both halves hold resolves once, not once per half"
+        );
+        assert_eq!(resolved_ids(&warm_deletes), vec![1]);
+    }
+
+    /// Resolving from the union must not widen *which* rows are deleted — only the requested base
+    /// key's chunks may be removed, from either half.
+    #[tokio::test]
+    async fn a_compound_inner_delete_leaves_other_base_keys_alone() {
+        let warm = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(2, 0)])]));
+        let durable = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[
+            (1, 0),
+            (2, 0),
+            (3, 0),
+        ])]));
+
+        let (warm_deletes, durable_deletes) =
+            delete_through_compound(&warm, &durable, CompoundReadMode::PrimaryOnly).await;
+
+        assert_eq!(
+            resolved_ids(&durable_deletes),
+            vec![1],
+            "only base key 1's chunk is deleted: {durable_deletes:?}"
+        );
+        assert_eq!(
+            resolved_ids(&warm_deletes),
+            vec![1],
+            "the other base keys the warm tier holds are untouched: {warm_deletes:?}"
+        );
+    }
+
+    /// `ChunkedVectorIndex` is a wrapper, so it must forward `list_all_entries` to its inner index
+    /// rather than inherit the default (which would resolve against the read listing again).
+    #[tokio::test]
+    async fn chunked_vector_index_forwards_list_all_entries_to_its_inner_index() {
+        let warm = Arc::new(RecordingInner::chunked(vec![chunk_keyed_listing(&[])]));
+        let durable = Arc::new(RecordingInner::chunked(vec![chunk_keyed_listing(&[
+            (1, 0),
+            (1, 1),
+        ])]));
+        let idx = ChunkedVectorIndex {
+            inner: compound_inner(&warm, &durable, CompoundReadMode::PrimaryOnly)
+                as Arc<dyn VectorIndex>,
+            chunker: chunker(),
+        };
+
+        // A `PrimaryOnly` read listing is the warm primary's scan alone; the authoritative
+        // listing unions both halves. Comparing the two plans is what shows the forward: had
+        // `ChunkedVectorIndex` inherited the default, both would be the read listing.
+        let read = format!(
+            "{}",
+            idx.list_table_provider()
+                .expect("read plan builds")
+                .display_indent()
+        );
+        let all = format!(
+            "{}",
+            idx.list_all_entries()
+                .expect("authoritative plan builds")
+                .display_indent()
+        );
+
+        assert!(
+            all.contains("Union"),
+            "the authoritative listing must reach both halves of the compound inner:\n{all}"
+        );
+        assert!(
+            !read.contains("Union"),
+            "a PrimaryOnly read listing is the warm primary alone:\n{read}"
+        );
     }
 
     /// A chunked index with no listing and no partial-key delete has no way to reach its inner

--- a/crates/search/src/index/compound/vector_index.rs
+++ b/crates/search/src/index/compound/vector_index.rs
@@ -21,7 +21,7 @@ use arrow_schema::Field;
 use async_trait::async_trait;
 use datafusion::{
     error::{DataFusionError, Result as DataFusionResult},
-    logical_expr::LogicalPlan,
+    logical_expr::{LogicalPlan, LogicalPlanBuilder},
 };
 use futures::future::try_join_all;
 use runtime_datafusion_index::Index;
@@ -102,6 +102,20 @@ impl VectorIndex for CompoundVectorIndex {
                 fallback_on_empty_plan(primary, secondary)
             }
         }
+    }
+
+    /// Both halves, unioned — never narrowed by [`Self::read_mode`].
+    ///
+    /// `list_table_provider` answers "what should a read see", and for
+    /// [`CompoundReadMode::PrimaryOnly`] that is the warm primary alone; the primary only holds
+    /// rows the write path has passed through it, so it is not authoritative for what is stored.
+    /// A union rather than a fallback because the two halves can disagree in *either* direction:
+    /// an entry either one holds is an entry a delete still has to resolve, and
+    /// [`Index::delete_by_keys`] already fans out to both.
+    fn list_all_entries(&self) -> Result<LogicalPlan, DataFusionError> {
+        let primary = self.primary.list_all_entries()?;
+        let secondary = self.secondary.list_all_entries()?;
+        LogicalPlanBuilder::from(primary).union(secondary)?.build()
     }
 
     fn dimension(&self) -> i32 {

--- a/crates/search/src/index/compound/vector_index.rs
+++ b/crates/search/src/index/compound/vector_index.rs
@@ -26,7 +26,7 @@ use datafusion::{
 use futures::future::try_join_all;
 use runtime_datafusion_index::Index;
 
-use crate::index::{SearchIndex, VectorIndex};
+use crate::index::{SearchIndex, VectorIndex, primary_key_projection};
 
 use super::{
     CompoundReadMode, Error, compound_delete_by_keys, compound_on_write_start,
@@ -112,10 +112,21 @@ impl VectorIndex for CompoundVectorIndex {
     /// A union rather than a fallback because the two halves can disagree in *either* direction:
     /// an entry either one holds is an entry a delete still has to resolve, and
     /// [`Index::delete_by_keys`] already fans out to both.
-    fn list_all_entries(&self) -> Result<LogicalPlan, DataFusionError> {
-        let primary = self.primary.list_all_entries()?;
-        let secondary = self.secondary.list_all_entries()?;
-        LogicalPlanBuilder::from(primary).union(secondary)?.build()
+    ///
+    /// Each half is projected to the key columns *before* the union. [`validate_compatibility`]
+    /// guarantees the halves agree there on name, type and nullability; it guarantees nothing of
+    /// the rest of their listings, which is why [`fallback_on_empty_plan`] has to cast and
+    /// re-project to reconcile them for reads.
+    fn list_all_entry_keys(&self) -> Result<LogicalPlan, DataFusionError> {
+        let keys = |half: &Arc<dyn VectorIndex>| {
+            LogicalPlanBuilder::from(half.list_all_entry_keys()?)
+                .project(primary_key_projection(&half.primary_fields()))?
+                .build()
+        };
+
+        LogicalPlanBuilder::from(keys(&self.primary)?)
+            .union(keys(&self.secondary)?)?
+            .build()
     }
 
     fn dimension(&self) -> i32 {

--- a/crates/search/src/index/mod.rs
+++ b/crates/search/src/index/mod.rs
@@ -19,7 +19,10 @@ use std::sync::Arc;
 use arrow::array::RecordBatch;
 use arrow_schema::Field;
 use async_trait::async_trait;
-use datafusion::{error::DataFusionError, logical_expr::LogicalPlan};
+use datafusion::{
+    error::DataFusionError,
+    logical_expr::{Expr, LogicalPlan, ident},
+};
 use runtime_datafusion_index::Index;
 
 pub mod chunking;
@@ -247,11 +250,8 @@ fn embedding_col(search_column: &str) -> String {
 /// Projection expressions selecting `fields` by name — the key columns
 /// [`VectorIndex::list_all_entry_keys`] promises, used both to narrow a listing to them and to
 /// bring two stores' listings to a common schema before combining them.
-pub(crate) fn primary_key_projection(fields: &[Field]) -> Vec<datafusion::logical_expr::Expr> {
-    fields
-        .iter()
-        .map(|f| datafusion::logical_expr::ident(f.name()))
-        .collect()
+pub(crate) fn primary_key_projection(fields: &[Field]) -> Vec<Expr> {
+    fields.iter().map(|f| ident(f.name())).collect()
 }
 
 #[cfg(test)]

--- a/crates/search/src/index/mod.rs
+++ b/crates/search/src/index/mod.rs
@@ -210,6 +210,23 @@ pub trait VectorIndex: SearchIndex {
     /// not be wrapped by [`VectorScanTableProvider`].
     fn list_table_provider(&self) -> Result<LogicalPlan, DataFusionError>;
 
+    /// A [`LogicalPlan`] enumerating every entry the index holds, for maintenance paths that must
+    /// resolve *stored* entries rather than serve a read — currently resolving a chunked index's
+    /// chunk-keyed entries so they can be deleted.
+    ///
+    /// Distinct from [`VectorIndex::list_table_provider`], which serves reads and may deliberately
+    /// return less than the index holds: a [`compound`](crate::index::compound) index's read mode
+    /// can restrict listing to its warm primary, which is not authoritative for what is stored.
+    /// Resolving a delete against that narrowed listing silently leaves entries behind.
+    ///
+    /// The schema matches [`VectorIndex::list_table_provider`]'s.
+    ///
+    /// Wrapper implementations MUST forward this to the index they wrap — inheriting the default
+    /// silently resolves maintenance work against a read-narrowed listing.
+    fn list_all_entries(&self) -> Result<LogicalPlan, DataFusionError> {
+        self.list_table_provider()
+    }
+
     fn dimension(&self) -> i32;
 
     /// Returns column names in [`VectorIndex::list_table_provider`] and/or [`SearchIndex::query_table_provider`] that

--- a/crates/search/src/index/mod.rs
+++ b/crates/search/src/index/mod.rs
@@ -227,6 +227,11 @@ pub trait VectorIndex: SearchIndex {
     /// what lets a multi-store implementation combine its stores: the key fields are the only ones
     /// guaranteed to agree across them.
     ///
+    /// **Keys may repeat.** A multi-store implementation combines its stores by union, so an entry
+    /// both stores hold appears once per store. Callers that need each key once must apply their
+    /// own `DISTINCT` — as the chunked delete resolution does, since deleting a key twice is
+    /// wasted work.
+    ///
     /// Wrapper implementations MUST forward this to the index they wrap — inheriting the default
     /// silently resolves maintenance work against a read-narrowed listing.
     fn list_all_entry_keys(&self) -> Result<LogicalPlan, DataFusionError> {

--- a/crates/search/src/index/mod.rs
+++ b/crates/search/src/index/mod.rs
@@ -210,7 +210,7 @@ pub trait VectorIndex: SearchIndex {
     /// not be wrapped by [`VectorScanTableProvider`].
     fn list_table_provider(&self) -> Result<LogicalPlan, DataFusionError>;
 
-    /// A [`LogicalPlan`] enumerating every entry the index holds, for maintenance paths that must
+    /// A [`LogicalPlan`] identifying every entry the index holds, for maintenance paths that must
     /// resolve *stored* entries rather than serve a read — currently resolving a chunked index's
     /// chunk-keyed entries so they can be deleted.
     ///
@@ -219,11 +219,14 @@ pub trait VectorIndex: SearchIndex {
     /// can restrict listing to its warm primary, which is not authoritative for what is stored.
     /// Resolving a delete against that narrowed listing silently leaves entries behind.
     ///
-    /// The schema matches [`VectorIndex::list_table_provider`]'s.
+    /// The plan carries *at least* the [`SearchIndex::primary_fields`] columns, and callers must
+    /// not depend on any other column being present. Keeping the contract to the key columns is
+    /// what lets a multi-store implementation combine its stores: the key fields are the only ones
+    /// guaranteed to agree across them.
     ///
     /// Wrapper implementations MUST forward this to the index they wrap — inheriting the default
     /// silently resolves maintenance work against a read-narrowed listing.
-    fn list_all_entries(&self) -> Result<LogicalPlan, DataFusionError> {
+    fn list_all_entry_keys(&self) -> Result<LogicalPlan, DataFusionError> {
         self.list_table_provider()
     }
 
@@ -239,6 +242,16 @@ pub trait VectorIndex: SearchIndex {
 
 fn embedding_col(search_column: &str) -> String {
     format!("{search_column}_embedding")
+}
+
+/// Projection expressions selecting `fields` by name — the key columns
+/// [`VectorIndex::list_all_entry_keys`] promises, used both to narrow a listing to them and to
+/// bring two stores' listings to a common schema before combining them.
+pub(crate) fn primary_key_projection(fields: &[Field]) -> Vec<datafusion::logical_expr::Expr> {
+    fields
+        .iter()
+        .map(|f| datafusion::logical_expr::ident(f.name()))
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary (root cause)

A chunked index stores one document per chunk, keyed by the base row key plus `_spice.chunk_id`. A delete carries only the base key, so `ChunkedSearchIndex`/`ChunkedVectorIndex` first resolve the exact chunk-keyed entries by scanning the inner index's listing under a predicate on the base key, then delete the resolved rows.

That resolution used `VectorIndex::list_table_provider` — which serves **reads**. For an S3 Vectors column with a warm in-memory tier the inner index is a `CompoundVectorIndex { primary: MemoryVectorIndex, secondary: S3Vector }`, and its read listing is narrowed by the read mode:

- `PrimaryOnly` (`on_zero_results: return_empty`) — the warm in-memory tier alone.
- `FallbackToSecondary` (`on_zero_results: use_source`) — falls back only when the primary's plan is entirely empty, never per key.

The warm tier only holds rows the write path has passed through it, so any base key it was missing resolved to **zero** chunk rows. `Index::delete_by_keys` was then never called for those rows at all, and the delete returned `Ok` while every vector stayed in the durable store. Search keeps returning rows the dataset no longer has. The narrowest case is `PrimaryOnly` with a persisting accelerator: after a restart nothing re-writes existing rows through the index, so the warm tier is empty or partial while S3 still holds everything.

Fixes #12266

## Changes

- **`VectorIndex::list_all_entry_keys`** (new) — identifies every entry the index holds, for maintenance paths that must see what is *stored* rather than what a read should see. Defaults to `list_table_provider`, which is correct for a single-store index. The contract is *at least* the `primary_fields` columns, deliberately: those are the only columns a multi-store implementation can guarantee agree across its stores.
- **`CompoundVectorIndex`** overrides it with the **union of both halves**, never narrowed by `read_mode`. Each half is projected to the key columns *before* the union — `validate_compatibility` guarantees the halves agree there on name, type and nullability, and guarantees nothing about the rest of their listings (which is why the read path's `fallback_on_empty_plan` has to cast and re-project to reconcile them).
- **`ChunkedVectorIndex`** forwards it to the index it wraps, rather than inheriting the default.
- **The delete resolution** now goes through `list_all_entry_keys`, projects to the key columns and applies `DISTINCT` — so an entry both halves hold resolves once, and embedding vectors stay out of a delete entirely.

`CompoundSearchIndex` needs no separate change: its `as_vector_index` builds a `CompoundVectorIndex` from its halves, so it routes through the same override.

### Why a union rather than resolving from the secondary

The issue suggests mapping the accessor to the secondary. That fixes the reported direction but is wrong in the other one: the two halves can disagree either way, and an entry only the warm tier holds would then never be resolved. A neuter implementing exactly that suggestion fails `a_compound_inner_resolves_an_entry_only_the_warm_primary_holds` with `left: [], right: [1]`. `delete_by_keys` already fans out to both halves, so the union costs nothing.

## Test plan

7 new tests in `crates/search/src/index/chunking.rs`, exercising the real production path (`ChunkedSearchIndex::delete_by_keys` over a `CompoundVectorIndex`): the reported case under both read modes, a *partially* populated warm tier under both read modes, the warm-tier-only direction, shared-entry dedup, scoping to the requested base key, and the `ChunkedVectorIndex` forward.

Five deterministic neuters, one per direction of wrongness — each fails a different set:

| Neuter | Tests failed |
| --- | --- |
| Consumer reverted to the read listing (trunk's behaviour) | 3 |
| Secondary-only instead of the union | 2 |
| `DISTINCT` dropped | 2 |
| Key predicate dropped (over-deletion) | 2 |
| `ChunkedVectorIndex` inherits the default | 1 |

Verified locally: 131 crate tests pass, both clippy passes clean (lib/bins, then tests), fmt clean. Full gate is make lint and make nextest via sign-off.

## What this does not establish

- **#12102 is not fixed by this.** The warm tier still holds only rows refreshed since startup; this makes deletes independent of that, it does not repopulate the tier.
- **Already-orphaned vectors are not swept.** This stops new ones accruing; entries stranded by earlier deletes need a separate reconciliation pass.
- **The read path is unchanged.** `list_table_provider` and `query_table_provider` keep their read-mode semantics; only maintenance resolution moved.

## Checklist

- [x] Root cause identified and stated
- [x] Regression tests that fail on the old code
- [x] Neuters validating every direction of the fix
- [x] Wrapper-delegation audit: every `impl VectorIndex` reviewed; both production wrappers (`ChunkedVectorIndex`, `CompoundVectorIndex`) implement the new method explicitly
- [x] Clippy (both passes) and fmt clean
- [ ] Sign-off green / `Attestation` green
