### PR TITLE
fix(ci): name an incoherent Cargo.lock before every cargo job fails on it (fixes #12375)

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -9,6 +9,62 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # The merge queue can textually merge two branches into a Cargo.lock that is valid
+    # TOML but not a valid lockfile: git sees two edits to different regions, and emits
+    # the same `[[package]]` block twice. Cargo then refuses to parse it, so every job
+    # that shells out to cargo dies at once — on 2026-08-02 that was 42 failed runs
+    # across 7 queue branches and 6 workflows in 40 minutes, each reporting only
+    # `make build-cli Error 101` / `exit code 101` with the real cause one line deep in
+    # a 4,000-line log. Every affected workflow already uses this action, so asserting
+    # it here names the problem once, before any expensive cargo work.
+    #
+    # Deliberately textual rather than `cargo metadata`: no registry index, no network,
+    # no warm cache, so it runs in milliseconds and cannot itself become a flake. Note
+    # for anyone tempted by the cargo route that `cargo metadata --locked --no-deps`
+    # exits 0 on this corruption — it skips the dependency resolution that notices a
+    # duplicate — so `--no-deps` would pass on exactly the input it exists to catch.
+    - name: Validate Cargo.lock is coherent
+      shell: bash
+      run: |
+        set -uo pipefail
+
+        [ -f Cargo.lock ] || exit 0
+        command -v awk >/dev/null 2>&1 || {
+          echo "::warning::awk is unavailable, skipping the Cargo.lock coherence check."
+          exit 0
+        }
+
+        # Keyed on (name, version, source) because that is cargo's own package
+        # identity: several versions of one crate are legal, and so is one version from
+        # two different sources (a [patch] against a registry dep). Only an exact
+        # triple duplicate is something cargo rejects, so a lockfile cargo accepts can
+        # never trip this.
+        dupes="$(
+          awk '
+            function flush() {
+              if (inpkg && name != "") {
+                key = name " " version " " source
+                if (key in seen) dup[name " " version] = 1
+                seen[key] = 1
+              }
+              inpkg = 0; name = ""; version = ""; source = ""
+            }
+            { sub(/\r$/, "") }
+            /^\[\[package\]\][[:space:]]*$/ { flush(); inpkg = 1; next }
+            /^\[/                           { flush(); next }
+            inpkg && /^name = "/    { name = $0;    sub(/^name = "/, "", name);       sub(/"[[:space:]]*$/, "", name) }
+            inpkg && /^version = "/ { version = $0; sub(/^version = "/, "", version); sub(/"[[:space:]]*$/, "", version) }
+            inpkg && /^source = "/  { source = $0;  sub(/^source = "/, "", source);   sub(/"[[:space:]]*$/, "", source) }
+            END { flush(); for (k in dup) print k }
+          ' Cargo.lock
+        )"
+
+        if [ -n "${dupes}" ]; then
+          list="$(echo "${dupes}" | tr '\n' ';' | sed 's/;$//')"
+          echo "::error::Cargo.lock lists the same package twice: ${list}. Cargo cannot parse this lockfile, so every cargo job in this run will fail. This is usually the merge queue textually merging two branches that each edited the same package entry — regenerate the lockfile on the PR branch ('cargo update --workspace') and re-queue."
+          exit 1
+        fi
+
     - name: Set up Rust toolchain (Linux/macOS)
       if: runner.os != 'Windows'
       shell: bash

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -10,13 +10,12 @@ runs:
   using: 'composite'
   steps:
     # The merge queue can textually merge two branches into a Cargo.lock that is valid
-    # TOML but not a valid lockfile: git sees two edits to different regions, and emits
+    # TOML but not a valid lockfile: git sees two edits to different regions and emits
     # the same `[[package]]` block twice. Cargo then refuses to parse it, so every job
-    # that shells out to cargo dies at once — on 2026-08-02 that was 42 failed runs
-    # across 7 queue branches and 6 workflows in 40 minutes, each reporting only
-    # `make build-cli Error 101` / `exit code 101` with the real cause one line deep in
-    # a 4,000-line log. Every affected workflow already uses this action, so asserting
-    # it here names the problem once, before any expensive cargo work.
+    # that shells out to cargo dies at once, each reporting only an opaque `exit code
+    # 101` with the real cause buried deep in the log. Every affected workflow already
+    # uses this action, so asserting it here names the problem once, before any
+    # expensive cargo work.
     #
     # Deliberately textual rather than `cargo metadata`: no registry index, no network,
     # no warm cache, so it runs in milliseconds and cannot itself become a flake. Note
@@ -39,7 +38,11 @@ runs:
         # two different sources (a [patch] against a registry dep). Only an exact
         # triple duplicate is something cargo rejects, so a lockfile cargo accepts can
         # never trip this.
-        dupes="$(
+        # `set -e` is deliberately not used: a guard that hard-fails when the guard
+        # itself misbehaves would be worse than the problem it detects. But an awk that
+        # runs and errors must not be mistaken for an awk that ran and found nothing —
+        # that would silently retire the check — so its status is captured and surfaced.
+        if ! dupes="$(
           awk '
             function flush() {
               if (inpkg && name != "") {
@@ -57,7 +60,10 @@ runs:
             inpkg && /^source = "/  { source = $0;  sub(/^source = "/, "", source);   sub(/"[[:space:]]*$/, "", source) }
             END { flush(); for (k in dup) print k }
           ' Cargo.lock
-        )"
+        )"; then
+          echo "::warning::The Cargo.lock coherence check could not run (awk exited non-zero); skipping it."
+          exit 0
+        fi
 
         if [ -n "${dupes}" ]; then
           list="$(echo "${dupes}" | tr '\n' ';' | sed 's/;$//')"


### PR DESCRIPTION
Fixes #12375

## Why

The merge queue can textually merge two branches into a `Cargo.lock` that is valid TOML but
**not a valid lockfile** — git sees edits to different regions of the file and emits the same
`[[package]]` block twice. Cargo refuses to parse the result, so every job that shells out to
cargo dies at once, and every PR in the batch is dequeued.

On **2026-08-02, 17:13Z–17:55Z** that was **42 failed runs across 7 queue branches and 6
workflows in 40 minutes**, dequeuing PRs #12302, #12314, #12321, #12326, #12334 and #12362.

| Workflow | Failing job → step |
|---|---|
| `pr.yml` | `Build and Test`, `Rust Lint`, `Build (release profile)` |
| `e2e_test_ci.yml` | `Build macOS aarch64 (Apple Silicon) binaries` → Build spiced and spice CLI |
| `license_check.yml` | `Check Rust Licenses` |
| `integration.yml` | `Build Test Binary` |
| `integration_llms.yml` | `Build Test Binary` |
| `integration_adbc.yml` | `ADBC Integration Tests` |

Sample runs: [30759877881](https://github.com/spiceai/spiceai/actions/runs/30759877881) (license),
[30758389774](https://github.com/spiceai/spiceai/actions/runs/30758389774) (integration),
[30759877896](https://github.com/spiceai/spiceai/actions/runs/30759877896) (E2E).

What each of them *showed* was `make build-cli Error 101` / `exit code 101` / `exit code 64`, on
three runner OSes simultaneously. The actual cause —

```
error: failed to parse lock file at: /…/spiceai/Cargo.lock
Caused by:
  package `mach2` is specified twice in the lockfile
```

— was one line inside a 4,000-line log, in six different places. Nothing named the merge as the
culprit, so the natural (and wrong) conclusion was "my PR broke the build". Each PR was
individually valid; the *merge* was not. `trunk` and every retained queue branch each had exactly
one `mach2` entry.

## What changed

One step at the top of `.github/actions/setup-rust`. All six affected workflows already use that
action (as do 16 others), so this covers every cluster above with **no new job and no new required
check**, and it fails before any expensive cargo work.

**Textual on purpose.** No registry index, no network, no warm cache — it runs in milliseconds and
cannot itself become a flake.

**It keys on `(name, version, source)`**, which is cargo's own package identity. Several versions
of one crate are legal, and so is one version from two different sources (a `[patch]` against a
registry dependency). Only an exact triple duplicate fires, so **a lockfile cargo accepts can
never trip this.** That property is what makes the check safe to put in front of 22 workflows.

If you are about to suggest `cargo metadata` instead: `cargo metadata --locked --no-deps` exits
**0** on this corruption, because `--no-deps` skips the dependency resolution that notices a
duplicate package. It would pass on exactly the input it exists to catch.

## What this does **not** weaken

It only adds a check. Nothing is retried, relaxed, skipped, or removed; no `continue-on-error`, no
timeout raised, no required check dropped. It cannot mask a real build failure — it runs *before*
the build and fails only on input cargo itself rejects. Cases where it does nothing at all: no
`Cargo.lock` present, or `awk` unavailable (warns and exits 0, so it can never break the 22
workflows it sits in front of).

## Test plan

The step was extracted **verbatim from the YAML** and run against seven lockfiles:

| Case | Expect | Result |
|---|---|---|
| Real `trunk` `Cargo.lock` (24,886 lines, 1,959 packages) | pass | exit 0 |
| Exact duplicate `[[package]]` block — reproduces production | fail, named | exit 1, reports `mach2 0.6.0` |
| **Two different versions of one crate (`0.6.0` + `0.4.3`) — legal** | **pass** | **exit 0** |
| **Same version from two different sources (registry + git `[patch]`) — legal** | **pass** | **exit 0** |
| Duplicate block with CRLF line endings | fail, named | exit 1 |
| No `Cargo.lock` present | no-op | exit 0 |
| Workspace member (no `source` line) duplicated | fail, named | exit 1, reports `spiced 2.2.0` |

Rows 3 and 4 are the ones that matter: they are the false positives that would have made this
check worse than nothing, and both pass.

- [x] `python .github/scripts/test_check_workflow_yaml.py -v` equivalent —
      `python .github/scripts/check_workflow_yaml.py` → `OK: 100 GitHub Actions definitions parse
      and declare the required keys`
- [x] Seven-case behavioural matrix above, against the verbatim step
- [ ] `Attestation` green (this is a non-Rust diff, so the sign-off gate fast-tracks it per #12081)

No Rust source changes, so `make lint` / `make test` have nothing to exercise here; the merge
queue will run the full suite as usual.

## Follow-up

Validation catches the corruption; it does not prevent it. The durable fix is upstream — a
lockfile merge driver, or regenerating `Cargo.lock` on the queue branch before the batch is built
— so the invalid state is never built at all. Worth a separate issue; this is the cheap first step
and is useful on its own.
