### PR TITLE
fix(ci): stop the spiced child E2E cleanup was leaking, scoped to this runner (fixes #12058)

### DIFF
--- a/.github/actions/check-spice-log/action.yml
+++ b/.github/actions/check-spice-log/action.yml
@@ -15,13 +15,21 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Stop spice and check logs
+    # Stops the `spiced` child as well as the `spice` CLI. `killall spice` here
+    # used to leave the runtime holding :8090 for the next job on the same
+    # self-hosted runner (#12058).
+    - name: Stop spice
+      uses: ./.github/actions/stop-spice
+      with:
+        working-directory: ${{ inputs.working-directory }}
+        print-log: 'false'
+
+    - name: Check logs
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
         ALLOW: ${{ inputs.allow }}
       run: |
-        killall spice || true
         cat spice.log
 
         # `spiced` logs with_ansi(true), so an allow pattern such as

--- a/.github/actions/stop-spice/action.yml
+++ b/.github/actions/stop-spice/action.yml
@@ -1,0 +1,41 @@
+name: 'Stop Spice'
+description: |
+  Stops the Spice runtime started by `spice run` — both the `spice` CLI and the
+  `spiced` child that actually binds the ports — and waits for those ports to be
+  released, so a reused self-hosted runner does not hand an orphaned listener to
+  the next job (#12058).
+inputs:
+  working-directory:
+    description: 'Directory the runtime was started from (where spice.log lives)'
+    required: false
+    default: '.'
+  ports:
+    description: 'Space-separated TCP ports to wait for release'
+    required: false
+    default: '8090 50051'
+  print-log:
+    description: 'Print spice.log after stopping'
+    required: false
+    default: 'true'
+runs:
+  using: 'composite'
+  steps:
+    - name: Stop spice
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        SPICE_STOP_PORTS: ${{ inputs.ports }}
+      # Invoked through `bash` so the step does not depend on the script's
+      # executable bit surviving a checkout on every platform.
+      run: bash "${GITHUB_ACTION_PATH}/stop_spice.sh"
+
+    - name: Print spice.log
+      if: ${{ inputs.print-log == 'true' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        if [ -f spice.log ]; then
+          cat spice.log
+        else
+          echo "no spice.log in $(pwd)"
+        fi

--- a/.github/actions/stop-spice/stop_spice.sh
+++ b/.github/actions/stop-spice/stop_spice.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+#
+# Stop the Spice runtime this job started, and report whether the ports it used
+# came free.
+#
+# Two facts about the E2E runners drive everything here.
+#
+# 1. `spice run` does not become the runtime. The CLI spawns `spiced` as a child
+#    (`get_run_cmd` in bin/spice/src/context.rs builds `Command::new(spiced_path)`),
+#    and `spiced` is the process that binds the HTTP and Flight ports. So
+#    `killall spice` — what every E2E cleanup used to do — reaps the CLI and
+#    orphans the runtime still holding :8090. The next job to land on that
+#    runner then dies with
+#
+#      ERROR spiced: Unable to start Spice Runtime servers: Unable to start HTTP
+#      server: Unable to bind to address: Address already in use (os error 48)
+#
+# 2. Several runner instances share one physical machine. A runner is named
+#    `<machine>-NN` and works out of `/opt/github-runner-NN/_work`, so
+#    `spiceai-macos-runner-04` hosts `-01`, `-02`, `-03`… concurrently, and they
+#    share one network namespace. That makes a name-wide `killall spiced` worse
+#    than the leak it fixes: it would reap a *concurrent* job's runtime on the
+#    same host.
+#
+# So this stops by PID, and only PIDs whose working directory lives inside this
+# runner instance's workspace. Another instance's runtime is left strictly alone
+# — and if it is the one holding the port, that is reported, because a port held
+# after our own processes are gone is the shared-machine collision rather than a
+# leak (see #12058).
+#
+# Exits 0 even when nothing was running: cleanup runs under `if: always()` and
+# must never be the reason a job fails.
+
+set -uo pipefail
+
+# Ports `spiced` binds (HTTP, Flight). Left unquoted where used so the
+# space-separated value splits into words.
+SPICE_STOP_PORTS="${SPICE_STOP_PORTS:-8090 50051}"
+
+# Seconds to wait for a graceful exit before escalating to SIGKILL, and then for
+# the ports to clear. Kept short: this runs in cleanup on every job.
+GRACE="${SPICE_STOP_GRACE:-10}"
+PORT_WAIT="${SPICE_STOP_PORT_WAIT:-15}"
+
+# Only processes rooted inside this path are ours. `RUNNER_WORKSPACE` is set by
+# the Actions runner and is unique per instance. Empty means "no scope known" —
+# a developer running this by hand — in which case every spice/spiced is fair
+# game, which is what someone running it locally means by "stop spice".
+SCOPE="${SPICE_STOP_SCOPE:-${RUNNER_WORKSPACE:-}}"
+
+# A process's reported cwd is fully resolved, so a scope containing a symlink
+# would never match it and we would silently skip our own runtime. Compare
+# against the resolved form too. Falls back to the raw value when the path does
+# not exist or there is no way to resolve it.
+SCOPE_RESOLVED="$SCOPE"
+if [ -n "$SCOPE" ] && [ -d "$SCOPE" ]; then
+  SCOPE_RESOLVED="$(cd "$SCOPE" 2>/dev/null && pwd -P)" || SCOPE_RESOLVED="$SCOPE"
+  [ -z "$SCOPE_RESOLVED" ] && SCOPE_RESOLVED="$SCOPE"
+fi
+
+# Both names, every time. `-x`/`killall` match exactly, so `spice` never matches
+# `spiced` and vice versa — the omission this script exists to fix.
+PROCS=(spice spiced)
+
+# A process's working directory, via /proc on Linux or lsof on macOS. Empty when
+# it cannot be determined.
+proc_cwd() {
+  local pid="$1" cwd=""
+  if [ -e "/proc/${pid}/cwd" ]; then
+    cwd="$(readlink "/proc/${pid}/cwd" 2>/dev/null || true)"
+  fi
+  if [ -z "$cwd" ] && command -v lsof >/dev/null 2>&1; then
+    cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
+  fi
+  printf '%s' "$cwd"
+}
+
+# Refuses on an undeterminable cwd. Leaking a runtime costs the next job a
+# retry; killing a concurrent job's runtime destroys work already in flight, so
+# when in doubt this does nothing.
+in_scope() {
+  local pid="$1" cwd
+  [ -z "$SCOPE" ] && return 0
+  cwd="$(proc_cwd "$pid")"
+  if [ -z "$cwd" ]; then
+    # stderr, not stdout: the caller runs this inside a command substitution
+    # collecting PIDs, so anything on stdout is read back as a PID. Only on the
+    # first pass — this is re-enumerated once a second while waiting.
+    [ "${WARN_UNKNOWN:-0}" = "1" ] &&
+      echo "stop-spice: cannot determine cwd of PID ${pid} — leaving it alone." >&2
+    return 1
+  fi
+  case "$cwd" in
+    "$SCOPE" | "$SCOPE"/* | "$SCOPE_RESOLVED" | "$SCOPE_RESOLVED"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# PIDs of our spice/spiced processes, space separated.
+our_pids() {
+  local name pid out=""
+  for name in "${PROCS[@]}"; do
+    for pid in $(pgrep -x "$name" 2>/dev/null || true); do
+      if in_scope "$pid"; then
+        out="${out:+${out} }${pid}"
+      fi
+    done
+  done
+  printf '%s' "$out"
+}
+
+# Whether any spice/spiced exists at all, in scope or not. Kept separate from
+# our_pids because that runs in a command substitution, so a variable it sets
+# would not survive back to the caller.
+any_running() {
+  local name
+  for name in "${PROCS[@]}"; do
+    pgrep -x "$name" >/dev/null 2>&1 && return 0
+  done
+  return 1
+}
+
+# PIDs listening on a port, via whichever tool the runner has. Prints the
+# sentinel `unknown` when neither exists, so "no tool" is not read as "free".
+port_holders() {
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"${port}" -sTCP:LISTEN -t 2>/dev/null || true
+  elif command -v fuser >/dev/null 2>&1; then
+    fuser "${port}/tcp" 2>/dev/null || true
+  else
+    printf 'unknown'
+  fi
+}
+
+if [ -z "$SCOPE" ]; then
+  echo "stop-spice: no RUNNER_WORKSPACE — stopping every spice/spiced on this host."
+else
+  echo "stop-spice: stopping spice/spiced under ${SCOPE}."
+fi
+
+WARN_UNKNOWN=1
+pids="$(our_pids)"
+WARN_UNKNOWN=0
+if [ -z "$pids" ]; then
+  if any_running; then
+    # Worth saying out loud rather than exiting quietly: on a shared machine
+    # this is the normal, correct outcome (another instance's job is running).
+    # But it is also what a mis-set scope looks like, and a scope that never
+    # matches would silently restore the leak this script exists to prevent.
+    echo "stop-spice: spice/spiced is running, but none of it is under ${SCOPE:-/} — leaving it alone."
+  else
+    echo "stop-spice: no spice/spiced process of ours is running."
+  fi
+else
+  # shellcheck disable=SC2086 # deliberate word splitting of the PID list
+  echo "stop-spice: sending SIGTERM to PID(s): ${pids}"
+  # shellcheck disable=SC2086
+  kill -TERM ${pids} 2>/dev/null || true
+
+  deadline=$((SECONDS + GRACE))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    [ -z "$(our_pids)" ] && break
+    sleep 1
+  done
+
+  remaining="$(our_pids)"
+  if [ -z "$remaining" ]; then
+    echo "stop-spice: exited cleanly."
+  else
+    # A runtime that ignores SIGTERM is either wedged or mid-shutdown; either
+    # way the next job inherits the port if it is left running.
+    echo "stop-spice: PID(s) ${remaining} still alive after ${GRACE}s — sending SIGKILL."
+    # shellcheck disable=SC2086
+    kill -KILL ${remaining} 2>/dev/null || true
+    sleep 1
+    still="$(our_pids)"
+    [ -n "$still" ] && echo "stop-spice: warning: PID(s) ${still} survived SIGKILL."
+  fi
+fi
+
+# The process table clearing is not the same as the socket clearing: a killed
+# listener can sit in TIME_WAIT briefly, and on this shared machine the port may
+# belong to a different runner instance entirely. Distinguish those two.
+# shellcheck disable=SC2086 # deliberate word splitting of the port list
+for port in ${SPICE_STOP_PORTS}; do
+  deadline=$((SECONDS + PORT_WAIT))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    holders="$(port_holders "$port")"
+    if [ -z "$holders" ] || [ "$holders" = "unknown" ]; then
+      break
+    fi
+    sleep 1
+  done
+
+  holders="$(port_holders "$port")"
+  if [ "$holders" = "unknown" ]; then
+    echo "stop-spice: no lsof/fuser on this runner — cannot confirm :${port} is free."
+  elif [ -n "$holders" ]; then
+    # Our processes are gone by now, so whatever holds this port is not ours.
+    # On a machine running several runner instances that is a concurrent job,
+    # and it means this port is contended by design rather than leaked.
+    echo "stop-spice: note: :${port} is still held by PID(s) ${holders}, none of them ours."
+    echo "stop-spice: on a shared runner machine that is another runner instance's job, not a leak."
+  else
+    echo "stop-spice: :${port} is free."
+  fi
+done
+
+exit 0

--- a/.github/actions/stop-spice/stop_spice.sh
+++ b/.github/actions/stop-spice/stop_spice.sh
@@ -66,9 +66,10 @@ PROCS=(spice spiced)
 # it cannot be determined.
 proc_cwd() {
   local pid="$1" cwd=""
-  if [ -e "/proc/${pid}/cwd" ]; then
-    cwd="$(readlink "/proc/${pid}/cwd" 2>/dev/null || true)"
-  fi
+  # `readlink` unconditionally rather than behind `[ -e ]`: a process whose
+  # working directory has been deleted has a dangling cwd link, which fails an
+  # existence test while still naming the directory it is charged to.
+  cwd="$(readlink "/proc/${pid}/cwd" 2>/dev/null || true)"
   if [ -z "$cwd" ] && command -v lsof >/dev/null 2>&1; then
     cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
   fi

--- a/.github/actions/wait-for-spice-ready/action.yml
+++ b/.github/actions/wait-for-spice-ready/action.yml
@@ -1,0 +1,31 @@
+name: 'Wait for Spice ready'
+description: |
+  Polls the runtime's /v1/ready until it reports ready. On timeout, dumps the
+  last response, whether spiced is alive, what holds the port, and spice.log —
+  so a failure names its cause instead of only "the action has timed out" (#12058).
+inputs:
+  working-directory:
+    description: 'Directory the runtime was started from (where spice.log lives)'
+    required: false
+    default: '.'
+  url:
+    description: 'Readiness endpoint to poll'
+    required: false
+    default: 'http://localhost:8090/v1/ready'
+  timeout:
+    description: 'Seconds to wait before failing'
+    required: false
+    default: '300'
+runs:
+  using: 'composite'
+  steps:
+    - name: Wait for Spice runtime is ready
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        SPICE_READY_URL: ${{ inputs.url }}
+        SPICE_READY_TIMEOUT: ${{ inputs.timeout }}
+      # The script owns the timeout so it can diagnose before exiting; a step-level
+      # `timeout-minutes` would kill it before it printed anything, which is the
+      # behaviour being fixed.
+      run: bash "${GITHUB_ACTION_PATH}/wait_for_ready.sh"

--- a/.github/actions/wait-for-spice-ready/wait_for_ready.sh
+++ b/.github/actions/wait-for-spice-ready/wait_for_ready.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Wait for the Spice runtime to report ready, and say what went wrong when it
+# does not.
+#
+# What this replaces, repeated ~14 times across the E2E workflow:
+#
+#   while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+#
+# with `timeout-minutes` around the step. That loop prints nothing, so a
+# timeout produced exactly one line — "The action ... has timed out after 5
+# minutes" — for every distinct cause: a runtime that could not bind its port,
+# a model that failed to download, a dataset stuck loading, a `spiced` that
+# died on startup. #12058 asked for the next occurrence to carry a real
+# diagnosis; this is that diagnosis.
+#
+# Exits non-zero on timeout, after dumping the evidence.
+
+set -uo pipefail
+
+URL="${SPICE_READY_URL:-http://localhost:8090/v1/ready}"
+TIMEOUT="${SPICE_READY_TIMEOUT:-300}"
+INTERVAL="${SPICE_READY_INTERVAL:-2}"
+# How often to say something while waiting. A silent 5-minute step is
+# indistinguishable from a hung runner in the Actions UI.
+PROGRESS_EVERY="${SPICE_READY_PROGRESS_EVERY:-15}"
+LOG_FILE="${SPICE_READY_LOG:-spice.log}"
+
+port_from_url() {
+  # http://localhost:8090/v1/ready -> 8090; defaults to 80 when absent.
+  local hostport="${URL#*://}"
+  hostport="${hostport%%/*}"
+  case "$hostport" in
+    *:*) printf '%s' "${hostport##*:}" ;;
+    *)   printf '80' ;;
+  esac
+}
+
+diagnose() {
+  local last_body="$1" port
+  port="$(port_from_url)"
+
+  echo "::group::Diagnosis: runtime never reported ready"
+
+  echo "--- last response from ${URL} ---"
+  if [ -z "$last_body" ]; then
+    echo "(empty — nothing was listening, or the request failed)"
+  else
+    printf '%s\n' "$last_body"
+  fi
+
+  echo "--- spice / spiced processes ---"
+  spice_pids="$(pgrep -x spice 2>/dev/null || true)"
+  spiced_pids="$(pgrep -x spiced 2>/dev/null || true)"
+  if [ -n "$spice_pids" ] || [ -n "$spiced_pids" ]; then
+    # Alive but not ready is a startup problem; the log below says which.
+    # These are machine-wide: on a shared runner some may belong to another
+    # runner instance, which is itself worth seeing here.
+    [ -n "$spice_pids" ] && echo "spice:  ${spice_pids}"
+    [ -n "$spiced_pids" ] && echo "spiced: ${spiced_pids}"
+  else
+    # Nothing alive means the runtime exited — the log holds its dying words.
+    echo "(none — the runtime is not running; it exited or never started)"
+  fi
+
+  echo "--- listeners on :${port} ---"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"${port}" -sTCP:LISTEN 2>/dev/null || echo "(none)"
+  elif command -v fuser >/dev/null 2>&1; then
+    fuser "${port}/tcp" 2>/dev/null || echo "(none)"
+  else
+    echo "(no lsof/fuser on this runner)"
+  fi
+
+  echo "--- ${LOG_FILE} ---"
+  if [ -f "$LOG_FILE" ]; then
+    cat "$LOG_FILE"
+    # The single highest-value line: a port already held means a previous job on
+    # this runner leaked its runtime, not that this job is broken.
+    if grep -q "Address already in use" "$LOG_FILE" 2>/dev/null; then
+      echo
+      echo "NOTE: the runtime could not bind its port because something else already held it."
+      echo "      Two causes, and the process list above tells them apart:"
+      echo "        - an orphaned 'spiced' left by an earlier job on this runner; or"
+      echo "        - a concurrent job, since several runner instances share one machine"
+      echo "          and therefore one network namespace."
+      echo "      See .github/actions/stop-spice and #12058."
+    fi
+  else
+    echo "(no ${LOG_FILE} in $(pwd))"
+  fi
+
+  echo "::endgroup::"
+}
+
+echo "Waiting up to ${TIMEOUT}s for ${URL} to report ready…"
+
+start=$SECONDS
+last_body=""
+next_progress=$PROGRESS_EVERY
+
+while :; do
+  # `|| true`: curl exits non-zero while nothing is listening yet, which is the
+  # normal state early on and must not end the wait.
+  last_body="$(curl -fsS --max-time 5 "$URL" 2>/dev/null || true)"
+
+  if [ "$last_body" = "ready" ]; then
+    echo "Runtime ready after $((SECONDS - start))s."
+    exit 0
+  fi
+
+  elapsed=$((SECONDS - start))
+  if [ "$elapsed" -ge "$TIMEOUT" ]; then
+    echo "Runtime did not report ready within ${TIMEOUT}s."
+    diagnose "$last_body"
+    exit 1
+  fi
+
+  if [ "$elapsed" -ge "$next_progress" ]; then
+    # Echo what it actually said, not just that it is not "ready" — a runtime
+    # answering "initializing" is a very different problem from a dead socket.
+    echo "  ${elapsed}s — not ready yet (last response: '${last_body}')"
+    next_progress=$((elapsed + PROGRESS_EVERY))
+  fi
+
+  sleep "$INTERVAL"
+done

--- a/.github/actions/wait-for-spice-ready/wait_for_ready.sh
+++ b/.github/actions/wait-for-spice-ready/wait_for_ready.sh
@@ -36,6 +36,11 @@ port_from_url() {
   esac
 }
 
+# Runs only on the failure path, and is deliberately not itself time-bounded:
+# `lsof` can block on a wedged mount, and the job-level `timeout-minutes` is the
+# backstop for that. A step-level timeout is not an option — the inner steps of
+# a composite action do not honour one — and wrapping this in `timeout(1)` is
+# not portable to the macOS runners, which do not ship it.
 diagnose() {
   local last_body="$1" port
   port="$(port_from_url)"
@@ -100,11 +105,28 @@ last_body=""
 next_progress=$PROGRESS_EVERY
 
 while :; do
-  # `|| true`: curl exits non-zero while nothing is listening yet, which is the
-  # normal state early on and must not end the wait.
-  last_body="$(curl -fsS --max-time 5 "$URL" 2>/dev/null || true)"
+  # No `-f`. A runtime that is up but not ready answers 503 with a body saying
+  # so (crates/runtime/src/http/v1/ready.rs), and `-f` suppresses the body on an
+  # error status — which would leave every progress line and the timeout
+  # diagnosis reporting an empty response, the exact blindness being fixed here.
+  # The exact `= "ready"` comparison below is what guards against a false pass.
+  # `|| true`: curl still exits non-zero while nothing is listening yet, which
+  # is the normal state early on and must not end the wait.
+  last_body="$(curl -sS --max-time 5 "$URL" 2>/dev/null || true)"
 
   if [ "$last_body" = "ready" ]; then
+    # "Something on :8090 says ready" is not "our runtime is ready". Several
+    # runner instances share one machine and one network namespace, so if our
+    # `spiced` failed to bind, this poll can be answered by a *different job's*
+    # runtime — and every test step after this would then run against it.
+    # Failing to bind always leaves this line in our own log, so treat it as
+    # authoritative over whatever answered the socket.
+    if [ -f "$LOG_FILE" ] && grep -q "Address already in use" "$LOG_FILE" 2>/dev/null; then
+      echo "Something on ${URL} reports ready, but it is not this job's runtime:"
+      echo "${LOG_FILE} shows our own spiced failed to bind its port."
+      diagnose "$last_body"
+      exit 1
+    fi
     echo "Runtime ready after $((SECONDS - start))s."
     exit 0
   fi

--- a/.github/workflows/e2e_lifecycle_scripts_test.yml
+++ b/.github/workflows/e2e_lifecycle_scripts_test.yml
@@ -1,0 +1,64 @@
+---
+name: E2E Lifecycle Scripts Test
+
+# The E2E jobs share two scripts for starting and stopping the runtime, and
+# both are load-bearing for CI reliability rather than for any product
+# behaviour — which is exactly why they need their own tests. A stop that
+# misses the `spiced` child leaks a listener into the next job on a reused
+# self-hosted runner, and a readiness wait that cannot explain a timeout sends
+# whoever triages it back to a bare "the action has timed out" (#12058).
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - '.github/actions/stop-spice/**'
+      - '.github/actions/wait-for-spice-ready/**'
+      - 'scripts/test_e2e_spice_lifecycle.sh'
+      - '.github/workflows/e2e_lifecycle_scripts_test.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - '.github/actions/stop-spice/**'
+      - '.github/actions/wait-for-spice-ready/**'
+      - 'scripts/test_e2e_spice_lifecycle.sh'
+      - '.github/workflows/e2e_lifecycle_scripts_test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-e2e-lifecycle-scripts:
+    name: Unit tests for the E2E runtime lifecycle scripts (${{ matrix.os }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Both families the E2E jobs actually run on. macOS matters most —
+          # that is where the reused self-hosted runners are — and it ships an
+          # older bash, so it catches syntax the Linux runners would accept.
+          - os: linux-x64
+            runner: ubuntu-24.04
+          - os: macos-arm64
+            runner: macos-latest
+    # Stubbed processes and ports throughout: the tests read the repository and
+    # nothing else, so they need no write scope and no credentials.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run tests
+        # Invoked through `bash` so the job does not depend on the script's
+        # executable bit surviving a checkout on every platform.
+        run: bash scripts/test_e2e_spice_lifecycle.sh

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -239,9 +239,9 @@ jobs:
           spice run &> spice.log &
 
       - name: Wait for Spice runtime is ready
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          timeout: '60'
 
       - name: Install expect (linux)
         if: matrix.target.target_os == 'linux'
@@ -272,16 +272,7 @@ jobs:
 
       - name: Stop spice and check logs
         if: always()
-        run: |
-          if command -v pkill >/dev/null 2>&1; then
-            pkill -x spice || true
-          elif command -v killall >/dev/null 2>&1; then
-            killall spice || true
-          fi
-
-          if [ -f spice.log ]; then
-            cat spice.log
-          fi
+        uses: ./.github/actions/stop-spice
 
   test_hf_model:
     name: 'huggingface model (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
@@ -329,9 +320,9 @@ jobs:
           spice run &> spice.log &
 
       - name: Wait for Spice runtime is ready
-        timeout-minutes: 5
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          timeout: '300'
 
       - name: Install expect (linux)
         if: matrix.target.target_os == 'linux'
@@ -362,16 +353,7 @@ jobs:
 
       - name: Stop spice and check logs
         if: always()
-        run: |
-          if command -v pkill >/dev/null 2>&1; then
-            pkill -x spice || true
-          elif command -v killall >/dev/null 2>&1; then
-            killall spice || true
-          fi
-
-          if [ -f spice.log ]; then
-            cat spice.log
-          fi
+        uses: ./.github/actions/stop-spice
 
   test_quickstart_dremio:
     name: 'Test Dremio quickstart (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
@@ -432,10 +414,10 @@ jobs:
           cat spicepod.yaml
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -443,11 +425,10 @@ jobs:
           name: taxi_trips
 
       - name: Stop spice and check logs
-        working-directory: test_app
         if: always()
-        run: |
-          killall spice || true
-          cat spice.log
+        uses: ./.github/actions/stop-spice
+        with:
+          working-directory: test_app
 
   test_quickstart_spiceai:
     name: 'Test Spice.ai quickstart (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
@@ -498,10 +479,10 @@ jobs:
           sleep 10
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -509,11 +490,10 @@ jobs:
           name: taxi_trips
 
       - name: Stop spice and check logs
-        working-directory: test_app
         if: always()
-        run: |
-          killall spice || true
-          cat spice.log
+        uses: ./.github/actions/stop-spice
+        with:
+          working-directory: test_app
 
   test_quickstart_s3:
     name: 'Test S3 quickstart (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}; acceleration: ${{ matrix.acceleration.engine }})'
@@ -593,10 +573,10 @@ jobs:
           sleep 10
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -604,11 +584,10 @@ jobs:
           name: test_parquet_table
 
       - name: Stop spice and check logs
-        working-directory: test_app
         if: always()
-        run: |
-          killall spice || true
-          cat spice.log
+        uses: ./.github/actions/stop-spice
+        with:
+          working-directory: test_app
 
   test_quickstart_data_postgres:
     name: 'Test PostgreSQL quickstart (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }}; acceleration: ${{ matrix.acceleration.engine }})'
@@ -767,10 +746,10 @@ jobs:
           sleep 10
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Verify dataset1
         uses: ./.github/actions/verify-dataset
@@ -976,10 +955,10 @@ jobs:
           sleep 10
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Verify dataset1
         uses: ./.github/actions/verify-dataset
@@ -1089,10 +1068,10 @@ jobs:
           sleep 10
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -1100,11 +1079,10 @@ jobs:
           name: test_clickhouse_table
 
       - name: Stop spice and check logs
-        working-directory: test_app
         if: always()
-        run: |
-          killall spice || true
-          cat spice.log
+        uses: ./.github/actions/stop-spice
+        with:
+          working-directory: test_app
 
   test_quickstart_duckdb:
     env:
@@ -1174,10 +1152,10 @@ jobs:
           sleep 5
 
       - name: Wait for dataset to be ready
-        working-directory: duckdb-app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: duckdb-app
+          timeout: '60'
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -1186,10 +1164,9 @@ jobs:
 
       - name: Stop spice and check logs
         if: always()
-        working-directory: duckdb-app
-        run: |
-          killall spice || true
-          cat spice.log
+        uses: ./.github/actions/stop-spice
+        with:
+          working-directory: duckdb-app
 
   test_local_acceleration:
     name: 'Test acceleration on ${{ matrix.target.name }} using ${{ matrix.acceleration.engine }} (${{ matrix.acceleration.mode }})'
@@ -1290,10 +1267,10 @@ jobs:
           sleep 10
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Manually refresh dataset (no params)
         working-directory: test_app
@@ -1334,11 +1311,10 @@ jobs:
           expected-rows-count: 2
 
       - name: Stop spice and check logs
-        working-directory: test_app
         if: always()
-        run: |
-          killall spice || true
-          cat spice.log
+        uses: ./.github/actions/stop-spice
+        with:
+          working-directory: test_app
 
   test_results_caching:
     name: 'Test results caching on ${{ matrix.target.name }}'
@@ -1400,10 +1376,10 @@ jobs:
           sleep 10
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Run SQL query and check Miss cache header
         working-directory: test_app
@@ -1485,11 +1461,10 @@ jobs:
           fi
 
       - name: Stop spice and check logs
-        working-directory: test_app
         if: always()
-        run: |
-          killall spice || true
-          cat spice.log
+        uses: ./.github/actions/stop-spice
+        with:
+          working-directory: test_app
 
   gh_connector_quickstart:
     name: 'Test GitHub connector on ${{ matrix.target.name }}'
@@ -1583,10 +1558,10 @@ jobs:
           sleep 20
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Run test query (issues)
         env:
@@ -1629,11 +1604,10 @@ jobs:
           query: 'select * from spiceai.stargazers limit 10;'
 
       - name: Stop spice and check logs
-        working-directory: test_app
         if: always()
-        run: |
-          killall spice || true
-          cat spice.log
+        uses: ./.github/actions/stop-spice
+        with:
+          working-directory: test_app
 
   mssql_connector_quickstart:
     name: 'Test MS SQL connector on ${{ matrix.target.name }}'
@@ -1722,10 +1696,10 @@ jobs:
           sleep 20
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset
@@ -1809,10 +1783,10 @@ jobs:
           sleep 20
 
       - name: Wait for dataset to be ready
-        working-directory: test_app
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: test_app
+          timeout: '60'
 
       - name: Run test query (tpch)
         env:
@@ -1831,11 +1805,10 @@ jobs:
           query: 'select * from db_uc.tpcds.store limit 1;'
 
       - name: Stop spice and check logs
-        working-directory: test_app
         if: always()
-        run: |
-          killall spice || true
-          cat spice.log
+        uses: ./.github/actions/stop-spice
+        with:
+          working-directory: test_app
 
   graceful_shutdown_test_append:
     name: '${{ matrix.spicepod }} acceleration and graceful shutdown on ${{ matrix.target.name }}'
@@ -1947,10 +1920,10 @@ jobs:
           spice run &> spice.log &
 
       - name: Wait for Spice runtime to be ready
-        working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
+          timeout: '60'
 
       - name: Verify data_upsert dataset is queryable
         uses: ./.github/actions/verify-dataset
@@ -1993,8 +1966,16 @@ jobs:
         working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
         timeout-minutes: 2
         run: |
-          killall spice || true
-          while pgrep -x spice > /dev/null; do sleep 1; done
+          # `spice run` spawns `spiced`, and `spiced` is the process that holds the
+          # ports and the data — SIGTERM to the CLI alone left it running, so the
+          # graceful-shutdown path under test never ran (#12058). Reuse the shared
+          # stopper so this signals both, and only processes belonging to this
+          # runner instance: several instances share one machine.
+          #
+          # A grace longer than the step timeout on purpose. This step exists to
+          # verify the runtime exits cleanly on SIGTERM, so one that does not must
+          # trip the step timeout rather than be SIGKILLed into looking healthy.
+          SPICE_STOP_GRACE=600 bash "$GITHUB_WORKSPACE/.github/actions/stop-spice/stop_spice.sh"
           # Allow filesystem to sync after process exits
           sleep 2
 
@@ -2037,10 +2018,10 @@ jobs:
           spice run &> spice.log &
 
       - name: Wait for dataset to be ready
-        working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
-        timeout-minutes: 1
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
+          timeout: '60'
 
       - name: Verify data_upsert dataset
         uses: ./.github/actions/verify-dataset
@@ -2128,10 +2109,10 @@ jobs:
           spice run &> spice.log &
 
       - name: Wait for dataset to be ready
-        working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
-        timeout-minutes: 3
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
+          timeout: '180'
 
       - name: Run test workfload for 120s
         working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
@@ -2143,8 +2124,16 @@ jobs:
         working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
         timeout-minutes: 2
         run: |
-          killall spice || true
-          while pgrep -x spice > /dev/null; do sleep 1; done
+          # `spice run` spawns `spiced`, and `spiced` is the process that holds the
+          # ports and the data — SIGTERM to the CLI alone left it running, so the
+          # graceful-shutdown path under test never ran (#12058). Reuse the shared
+          # stopper so this signals both, and only processes belonging to this
+          # runner instance: several instances share one machine.
+          #
+          # A grace longer than the step timeout on purpose. This step exists to
+          # verify the runtime exits cleanly on SIGTERM, so one that does not must
+          # trip the step timeout rather than be SIGKILLed into looking healthy.
+          SPICE_STOP_GRACE=600 bash "$GITHUB_WORKSPACE/.github/actions/stop-spice/stop_spice.sh"
           sleep 2
 
       - name: Verify local DuckDB database
@@ -2182,10 +2171,10 @@ jobs:
           spice run &> spice.log &
 
       - name: Wait for dataset to be ready
-        working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
-        timeout-minutes: 3
-        run: |
-          while [[ "$(curl -s http://localhost:8090/v1/ready)" != "ready" ]]; do sleep 1; done
+        uses: ./.github/actions/wait-for-spice-ready
+        with:
+          working-directory: ./test/spicepods/tpch/sf1/accelerated/constraints
+          timeout: '180'
 
       - name: Verify dataset
         uses: ./.github/actions/verify-dataset

--- a/scripts/test_e2e_spice_lifecycle.sh
+++ b/scripts/test_e2e_spice_lifecycle.sh
@@ -116,6 +116,11 @@ STUB
 
 # Answers with STUB_READY_BODY. STUB_READY_AFTER makes it fail N times first,
 # modelling a runtime that comes up partway through the wait.
+#
+# STUB_READY_STATUS models the real endpoint: a runtime that is up but not ready
+# answers 503 *with a body* saying so. This stub reproduces curl's `-f`
+# behaviour of suppressing that body, which is why passing `-f` would blind the
+# diagnostics — the reason the subject must not use it.
 cat >"$stub_dir/curl" <<'STUB'
 #!/usr/bin/env bash
 set -uo pipefail
@@ -125,6 +130,13 @@ n=$((n + 1))
 echo "$n" > "${STATE_DIR}/curl_calls"
 if [[ -n "${STUB_READY_AFTER:-}" && "$n" -lt "${STUB_READY_AFTER}" ]]; then
   exit 7   # connection refused
+fi
+status="${STUB_READY_STATUS:-200}"
+if [[ "$status" -ge 400 ]]; then
+  # `-f`: no body, exit 22. Without it: body on stdout, exit 0.
+  [[ "$*" == *-f* ]] && exit 22
+  printf '%s' "${STUB_READY_BODY:-}"
+  exit 0
 fi
 printf '%s' "${STUB_READY_BODY:-}"
 exit 0
@@ -318,6 +330,17 @@ reset_state "101 spiced $OURS"
 result="$(run_subject "$wait_script" STUB_READY_BODY=ready STUB_READY_AFTER=3 SPICE_READY_TIMEOUT=20 SPICE_READY_INTERVAL=1)"
 assert_eq "waits through connection refused, then succeeds" "${result%%|*}" "0"
 
+# The real not-ready response is 503 *with* a body. Reporting that body is the
+# entire diagnostic value here, and `curl -f` would throw it away — so this is
+# the case that pins the absence of `-f`.
+reset_state "101 spiced $OURS"
+result="$(run_subject "$wait_script" STUB_READY_BODY="not ready" STUB_READY_STATUS=503 \
+  SPICE_READY_TIMEOUT=3 SPICE_READY_INTERVAL=1)"
+out="${result#*|}"
+assert_eq "a 503 keeps the wait going" "${result%%|*}" "1"
+assert_contains "reports the body of a 503, not an empty response" "$out" "not ready"
+assert_not_contains "does not report a 503 as an empty response" "$out" "(empty"
+
 # The whole point of #12058: a timeout must name its cause.
 reset_state
 printf 'ERROR spiced: Unable to start HTTP server: Unable to bind to address: Address already in use (os error 48)\n' \
@@ -350,6 +373,28 @@ assert_contains "says the log is missing" "${result#*|}" "no spice.log"
 reset_state
 result="$(run_subject "$wait_script" SPICE_READY_URL="http://localhost:9091/v1/ready" SPICE_READY_TIMEOUT=2 SPICE_READY_INTERVAL=1)"
 assert_contains "diagnoses the configured port" "${result#*|}" "listeners on :9091"
+
+# Ready answered by somebody else. Runner instances share a network namespace,
+# so if our spiced lost the bind, this poll can be satisfied by another job's
+# runtime and every later step would silently test *that* one. Our own log
+# saying we failed to bind has to outrank whatever answered the socket.
+reset_state "201 spiced $THEIRS"
+printf 'ERROR spiced: Unable to bind to address: Address already in use (os error 48)\n' \
+  > "$work_dir/spice.log"
+result="$(run_subject "$wait_script" STUB_READY_BODY=ready SPICE_READY_TIMEOUT=5 SPICE_READY_INTERVAL=1)"
+out="${result#*|}"
+assert_eq "refuses a ready answered by another job's runtime" "${result%%|*}" "1"
+assert_contains "says whose runtime it is not" "$out" "not this job's runtime"
+assert_not_contains "does not claim our runtime came up" "$out" "Runtime ready after"
+rm -f "$work_dir/spice.log"
+
+# ...but a genuine ready alongside an unrelated log must still pass, or the
+# guard above would fail every job whose log merely mentions the phrase.
+reset_state "101 spiced $OURS"
+printf 'INFO runtime: all good here\n' > "$work_dir/spice.log"
+result="$(run_subject "$wait_script" STUB_READY_BODY=ready SPICE_READY_TIMEOUT=5)"
+assert_eq "still accepts a genuine ready" "${result%%|*}" "0"
+rm -f "$work_dir/spice.log"
 
 echo
 if [ "$failures" -eq 0 ]; then

--- a/scripts/test_e2e_spice_lifecycle.sh
+++ b/scripts/test_e2e_spice_lifecycle.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the two scripts behind the E2E runtime lifecycle actions:
+# `.github/actions/stop-spice/stop_spice.sh` and
+# `.github/actions/wait-for-spice-ready/wait_for_ready.sh`.
+#
+# The bug they exist for (#12058) is not visible in the job that fails. A
+# cleanup that reaps `spice` but not the `spiced` child leaves a listener on
+# :8090, and the reused self-hosted runner hands that orphan to the *next* job,
+# whose runtime cannot bind and never reports ready.
+#
+# The correction has to stay narrow, though: several runner instances share one
+# physical machine (`<machine>-NN`, working out of `/opt/github-runner-NN/_work`)
+# and therefore one network namespace, so a name-wide kill would reap a
+# concurrent job's runtime on the same host. Hence three properties under test:
+# stop really stops both processes, stop touches nothing outside this runner's
+# workspace, and a wait that times out says why.
+#
+# No processes are started and no ports are bound: stub `pgrep`/`kill`/`lsof`/
+# `curl` on PATH model whatever state a case needs.
+#
+# Usage: scripts/test_e2e_spice_lifecycle.sh
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+stop_script="$repo_root/.github/actions/stop-spice/stop_spice.sh"
+wait_script="$repo_root/.github/actions/wait-for-spice-ready/wait_for_ready.sh"
+
+tests_run=0
+failures=0
+
+fail_test() {
+  failures=$((failures + 1))
+  echo "  FAIL: $1"
+}
+
+for required in "$stop_script" "$wait_script"; do
+  [ -f "$required" ] || { echo "missing subject: $required" >&2; exit 1; }
+done
+
+stub_dir="$(mktemp -d)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$stub_dir" "$work_dir"' EXIT
+
+# The two workspaces in play: ours, and a second runner instance on the same
+# machine whose processes must survive everything this script does.
+OURS="/opt/github-runner-02/_work/spiceai"
+THEIRS="/opt/github-runner-03/_work/spiceai"
+
+# ---------------------------------------------------------------------------
+# Stubs.
+#
+# Process state is $STATE_DIR/procs, one "pid name cwd" per line. `kill` removes
+# matching pids, so a test can assert exactly which PIDs were signalled and that
+# the other instance's were not. STUB_IGNORE_TERM models a runtime that declines
+# to die on SIGTERM, forcing the SIGKILL escalation. Signals are appended to
+# $STATE_DIR/signals.
+# ---------------------------------------------------------------------------
+
+cat >"$stub_dir/pgrep" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+name="${!#}"
+found=0
+while read -r pid pname _cwd; do
+  [ "$pname" = "$name" ] || continue
+  echo "$pid"; found=1
+done < "${STATE_DIR}/procs"
+[ "$found" = "1" ]
+STUB
+
+cat >"$stub_dir/kill" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+sig="${1#-}"; shift
+for pid in "$@"; do
+  echo "kill ${sig} ${pid}" >> "${STATE_DIR}/signals"
+  if [ "$sig" = "TERM" ] && [ -n "${STUB_IGNORE_TERM:-}" ]; then
+    continue   # signal delivered, process declines to die
+  fi
+  grep -v "^${pid} " "${STATE_DIR}/procs" > "${STATE_DIR}/procs.tmp" 2>/dev/null || true
+  mv "${STATE_DIR}/procs.tmp" "${STATE_DIR}/procs"
+done
+STUB
+
+# Serves two roles the subjects use: `-d cwd -Fn` reports a process's working
+# directory, and `-iTCP` reports port listeners (STUB_PORT_HOLDER, or nothing).
+cat >"$stub_dir/lsof" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+if [[ "$*" == *"-d cwd"* ]]; then
+  pid=""
+  while [ $# -gt 0 ]; do
+    [ "$1" = "-p" ] && { pid="$2"; break; }
+    shift
+  done
+  while read -r p _name cwd; do
+    if [ "$p" = "$pid" ]; then
+      [ "$cwd" = "UNKNOWN" ] && exit 1
+      echo "p${p}"; echo "n${cwd}"; exit 0
+    fi
+  done < "${STATE_DIR}/procs"
+  exit 1
+fi
+[[ -n "${STUB_PORT_HOLDER:-}" ]] || exit 1
+if [[ "$*" == *-t* ]]; then
+  echo "${STUB_PORT_HOLDER}"
+else
+  echo "COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME"
+  echo "spiced  ${STUB_PORT_HOLDER} runner  10u  IPv4 0x1234      0t0  TCP 127.0.0.1:8090 (LISTEN)"
+fi
+exit 0
+STUB
+
+# Answers with STUB_READY_BODY. STUB_READY_AFTER makes it fail N times first,
+# modelling a runtime that comes up partway through the wait.
+cat >"$stub_dir/curl" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+n=0
+[[ -f "${STATE_DIR}/curl_calls" ]] && n="$(cat "${STATE_DIR}/curl_calls")"
+n=$((n + 1))
+echo "$n" > "${STATE_DIR}/curl_calls"
+if [[ -n "${STUB_READY_AFTER:-}" && "$n" -lt "${STUB_READY_AFTER}" ]]; then
+  exit 7   # connection refused
+fi
+printf '%s' "${STUB_READY_BODY:-}"
+exit 0
+STUB
+
+chmod +x "$stub_dir"/*
+
+# reset_state "<pid> <name> <cwd>" ...
+reset_state() {
+  : > "$stub_dir/procs"
+  : > "$stub_dir/signals"
+  rm -f "$stub_dir/curl_calls"
+  local row
+  for row in "$@"; do echo "$row" >> "$stub_dir/procs"; done
+}
+
+# Surviving PIDs in file order (which is the order the case declared them).
+alive_pids() {
+  local pid rest out=""
+  while read -r pid rest; do
+    [ -n "$pid" ] && out="${out:+${out} }${pid}"
+  done < "$stub_dir/procs"
+  printf '%s' "$out"
+}
+
+# Runs a subject with the stubs first on PATH. Echoes "<rc>|<output>".
+#
+# `enable -n kill` then `source`: `kill` is a shell builtin, so a stub on PATH
+# would never be reached and the subject's signals would go to the real process
+# table. Disabling the builtin routes them to the stub, which is the only way to
+# assert *which* PIDs were signalled — the property this whole file exists for.
+run_subject() {
+  local subject="$1"
+  shift
+  local output rc
+  output="$(cd "$work_dir" && env "PATH=$stub_dir:$PATH" "STATE_DIR=$stub_dir" "$@" \
+    bash -c 'enable -n kill; source "$1"' _ "$subject" 2>&1)"
+  rc=$?
+  printf '%s|%s' "$rc" "$output"
+}
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  tests_run=$((tests_run + 1))
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  ok: $name"
+  else
+    fail_test "$name — expected output to contain '${needle}'; got: ${haystack}"
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  tests_run=$((tests_run + 1))
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  ok: $name"
+  else
+    fail_test "$name — expected output NOT to contain '${needle}'; got: ${haystack}"
+  fi
+}
+
+assert_eq() {
+  local name="$1" got="$2" want="$3"
+  tests_run=$((tests_run + 1))
+  if [[ "$got" == "$want" ]]; then
+    echo "  ok: $name"
+  else
+    fail_test "$name — expected '${want}', got '${got}'"
+  fi
+}
+
+stop_env=(SPICE_STOP_GRACE=2 SPICE_STOP_PORT_WAIT=2 "RUNNER_WORKSPACE=$OURS")
+
+# ---------------------------------------------------------------------------
+echo "stop_spice — reaping our own runtime"
+# ---------------------------------------------------------------------------
+
+# The regression itself: `spiced` holds the port, so a stop that only signals
+# `spice` is the bug. Assert both PIDs were signalled.
+reset_state "100 spice $OURS" "101 spiced $OURS"
+result="$(run_subject "$stop_script" "${stop_env[@]}")"
+signals="$(cat "$stub_dir/signals")"
+assert_contains "signals the spiced child, not just the CLI" "$signals" "kill TERM 101"
+assert_contains "signals the spice CLI too" "$signals" "kill TERM 100"
+assert_eq "leaves no process of ours alive" "$(alive_pids)" ""
+assert_eq "exits 0 on a clean stop" "${result%%|*}" "0"
+
+# A leaked `spiced` with no CLI parent is exactly what a previous job hands over.
+reset_state "101 spiced $OURS"
+run_subject "$stop_script" "${stop_env[@]}" >/dev/null
+assert_contains "reaps an orphaned spiced with no CLI parent" "$(cat "$stub_dir/signals")" "kill TERM 101"
+assert_eq "the orphan is gone" "$(alive_pids)" ""
+
+# Cleanup runs under `if: always()`; a job with nothing running must not fail.
+reset_state
+result="$(run_subject "$stop_script" "${stop_env[@]}")"
+assert_eq "exits 0 when nothing is running" "${result%%|*}" "0"
+assert_contains "says nothing of ours was running" "${result#*|}" "no spice/spiced process of ours"
+
+# A runtime that ignores SIGTERM must be escalated, or the port stays held.
+reset_state "100 spice $OURS" "101 spiced $OURS"
+result="$(run_subject "$stop_script" "${stop_env[@]}" STUB_IGNORE_TERM=1)"
+signals="$(cat "$stub_dir/signals")"
+assert_contains "escalates to SIGKILL when TERM is ignored" "$signals" "kill KILL 101"
+assert_contains "reports the escalation" "${result#*|}" "sending SIGKILL"
+assert_eq "still exits 0 after escalating" "${result%%|*}" "0"
+
+# ---------------------------------------------------------------------------
+echo "stop_spice — leaving other runner instances alone"
+# ---------------------------------------------------------------------------
+
+# The hazard that makes a name-wide killall unacceptable: another instance on
+# the same machine is mid-run. Its PIDs must not be touched.
+reset_state "100 spice $OURS" "101 spiced $OURS" "200 spice $THEIRS" "201 spiced $THEIRS"
+result="$(run_subject "$stop_script" "${stop_env[@]}")"
+signals="$(cat "$stub_dir/signals")"
+assert_contains "still stops our own spiced" "$signals" "kill TERM 101"
+assert_not_contains "does not signal the other instance's spiced" "$signals" "201"
+assert_not_contains "does not signal the other instance's CLI" "$signals" "200"
+assert_eq "the other instance survives intact" "$(alive_pids)" "200 201"
+assert_eq "exits 0 alongside a concurrent job" "${result%%|*}" "0"
+
+# Only the other instance is running: we must reap nothing at all.
+reset_state "200 spice $THEIRS" "201 spiced $THEIRS"
+result="$(run_subject "$stop_script" "${stop_env[@]}")"
+assert_eq "signals nothing when only another instance runs" "$(cat "$stub_dir/signals")" ""
+assert_eq "that instance is untouched" "$(alive_pids)" "200 201"
+# "running, but not ours" must read differently from "nothing running at all":
+# a scope that never matches would silently restore the leak, so it has to be
+# visible in the log rather than look like an idle runner.
+assert_contains "distinguishes out-of-scope from nothing-running" "${result#*|}" "none of it is under $OURS"
+assert_not_contains "does not claim nothing was running" "${result#*|}" "no spice/spiced process of ours"
+
+# An undeterminable cwd must not be killed — leaking costs a retry, killing a
+# concurrent job destroys in-flight work.
+reset_state "300 spiced UNKNOWN"
+result="$(run_subject "$stop_script" "${stop_env[@]}")"
+assert_eq "does not kill a process whose cwd is unknown" "$(cat "$stub_dir/signals")" ""
+assert_contains "says why it refused" "${result#*|}" "cannot determine cwd of PID 300"
+assert_eq "the unknown process survives" "$(alive_pids)" "300"
+
+# Run by hand with no RUNNER_WORKSPACE, "stop spice" means all of it.
+reset_state "100 spice $OURS" "201 spiced $THEIRS"
+result="$(run_subject "$stop_script" SPICE_STOP_GRACE=2 SPICE_STOP_PORT_WAIT=2)"
+assert_contains "unscoped run stops everything" "$(cat "$stub_dir/signals")" "kill TERM 201"
+assert_contains "announces it is unscoped" "${result#*|}" "no RUNNER_WORKSPACE"
+
+# ---------------------------------------------------------------------------
+echo "stop_spice — port reporting"
+# ---------------------------------------------------------------------------
+
+reset_state
+result="$(run_subject "$stop_script" "${stop_env[@]}")"
+assert_contains "confirms the http port is free" "${result#*|}" ":8090 is free"
+assert_contains "confirms the flight port is free" "${result#*|}" ":50051 is free"
+
+# A port still held once our processes are gone is the shared-machine
+# collision, and must be described as that rather than as a leak.
+reset_state
+result="$(run_subject "$stop_script" SPICE_STOP_GRACE=1 SPICE_STOP_PORT_WAIT=1 \
+  "RUNNER_WORKSPACE=$OURS" STUB_PORT_HOLDER=4321)"
+assert_contains "reports a port held by someone else" "${result#*|}" "none of them ours"
+assert_contains "names the holding pid" "${result#*|}" "4321"
+assert_contains "attributes it to another runner instance" "${result#*|}" "another runner instance's job, not a leak"
+assert_eq "a contended port still exits 0" "${result%%|*}" "0"
+
+reset_state
+result="$(run_subject "$stop_script" SPICE_STOP_GRACE=1 SPICE_STOP_PORT_WAIT=1 \
+  "RUNNER_WORKSPACE=$OURS" SPICE_STOP_PORTS="9999")"
+assert_contains "honours SPICE_STOP_PORTS" "${result#*|}" ":9999 is free"
+assert_not_contains "does not check unlisted ports" "${result#*|}" ":8090"
+
+# ---------------------------------------------------------------------------
+echo "wait_for_ready"
+# ---------------------------------------------------------------------------
+
+reset_state "101 spiced $OURS"
+result="$(run_subject "$wait_script" STUB_READY_BODY=ready SPICE_READY_TIMEOUT=5)"
+assert_eq "exits 0 once the runtime reports ready" "${result%%|*}" "0"
+assert_contains "reports how long it took" "${result#*|}" "Runtime ready after"
+
+# Not-ready must keep waiting rather than pass — the pre-#12057 expect bug was
+# exactly this shape, where an absent process read as success.
+reset_state "101 spiced $OURS"
+result="$(run_subject "$wait_script" STUB_READY_BODY=initializing SPICE_READY_TIMEOUT=3 SPICE_READY_INTERVAL=1)"
+assert_eq "fails when the runtime never becomes ready" "${result%%|*}" "1"
+assert_contains "quotes what the endpoint actually said" "${result#*|}" "initializing"
+
+# A runtime that comes up mid-wait must be caught, not timed out.
+reset_state "101 spiced $OURS"
+result="$(run_subject "$wait_script" STUB_READY_BODY=ready STUB_READY_AFTER=3 SPICE_READY_TIMEOUT=20 SPICE_READY_INTERVAL=1)"
+assert_eq "waits through connection refused, then succeeds" "${result%%|*}" "0"
+
+# The whole point of #12058: a timeout must name its cause.
+reset_state
+printf 'ERROR spiced: Unable to start HTTP server: Unable to bind to address: Address already in use (os error 48)\n' \
+  > "$work_dir/spice.log"
+result="$(run_subject "$wait_script" SPICE_READY_TIMEOUT=2 SPICE_READY_INTERVAL=1 STUB_PORT_HOLDER=7777)"
+out="${result#*|}"
+assert_eq "times out non-zero" "${result%%|*}" "1"
+assert_contains "dumps spice.log" "$out" "Address already in use"
+assert_contains "notices the runtime is not running" "$out" "the runtime is not running"
+assert_contains "names what holds the port" "$out" "7777"
+assert_contains "explains the contended-port case" "$out" "already held it"
+assert_contains "points at the tracking issue" "$out" "#12058"
+rm -f "$work_dir/spice.log"
+
+# A live-but-not-ready runtime is a different diagnosis from a dead one.
+reset_state "101 spiced $OURS"
+result="$(run_subject "$wait_script" STUB_READY_BODY= SPICE_READY_TIMEOUT=2 SPICE_READY_INTERVAL=1)"
+out="${result#*|}"
+assert_contains "lists the live spiced process" "$out" "101"
+assert_not_contains "does not claim a live runtime exited" "$out" "the runtime is not running"
+assert_contains "reports an empty response distinctly" "$out" "(empty"
+
+# A missing log must not crash the diagnosis.
+reset_state
+result="$(run_subject "$wait_script" SPICE_READY_TIMEOUT=2 SPICE_READY_INTERVAL=1)"
+assert_eq "still exits 1 with no log present" "${result%%|*}" "1"
+assert_contains "says the log is missing" "${result#*|}" "no spice.log"
+
+# A non-default endpoint must be diagnosed against its own port.
+reset_state
+result="$(run_subject "$wait_script" SPICE_READY_URL="http://localhost:9091/v1/ready" SPICE_READY_TIMEOUT=2 SPICE_READY_INTERVAL=1)"
+assert_contains "diagnoses the configured port" "${result#*|}" "listeners on :9091"
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "all ${tests_run} tests passed"
+  exit 0
+fi
+echo "${failures} of ${tests_run} tests failed"
+exit 1

--- a/scripts/test_e2e_spice_lifecycle.sh
+++ b/scripts/test_e2e_spice_lifecycle.sh
@@ -172,7 +172,12 @@ run_subject() {
   local subject="$1"
   shift
   local output rc
-  output="$(cd "$work_dir" && env "PATH=$stub_dir:$PATH" "STATE_DIR=$stub_dir" "$@" \
+  # `-u RUNNER_WORKSPACE -u SPICE_STOP_SCOPE` first: these are real variables on
+  # a GitHub runner, and inheriting them would silently scope a case that meant
+  # to run unscoped — passing locally and failing only in CI. Each case then
+  # sets whatever it needs through "$@".
+  output="$(cd "$work_dir" && env -u RUNNER_WORKSPACE -u SPICE_STOP_SCOPE \
+    "PATH=$stub_dir:$PATH" "STATE_DIR=$stub_dir" "$@" \
     bash -c 'enable -n kill; source "$1"' _ "$subject" 2>&1)"
   rc=$?
   printf '%s|%s' "$rc" "$output"


### PR DESCRIPTION
## Summary

`E2E Test CI` fails on roughly 1 in 7 runs, on a different sub-job each time, and each failure can strand an unrelated merge-queue entry. The randomness is because **the job that fails is not the job that caused it**.

Two facts combine:

1. **`spice run` is not the runtime.** The CLI spawns `spiced` as a child (`get_run_cmd` in [bin/spice/src/context.rs](bin/spice/src/context.rs) builds `Command::new(spiced_path)`), and `spiced` is what binds :8090 and :50051. Every cleanup in the workflow did `killall spice` / `pkill -x spice`. Both match exactly, so neither ever matched `spiced`: cleanup reaped the CLI and left the runtime holding the ports.

2. **The self-hosted runners are reused, and several instances share one machine.** A runner is named `<machine>-NN` and works out of `/opt/github-runner-NN/_work`, so `spiceai-macos-runner-04` hosts `-01`, `-02`, `-03`… concurrently, sharing one network namespace.

So an orphaned `spiced` is inherited by whatever runs next on that machine, and its `spice run` dies with:

```
ERROR spiced: Unable to start Spice Runtime servers: Unable to start HTTP server:
  Unable to bind to address: Address already in use (os error 48)
```

The runtime then never reports ready — and the readiness wait was
`while [[ "$(curl -s .../v1/ready)" != "ready" ]]; do sleep 1; done`, which prints nothing. So the entire diagnosis available to whoever triaged it was one line:

```
##[error]The action 'Wait for Spice runtime is ready' has timed out after 5 minutes.
```

That is the "no diagnosis" #12058 asked to fix before changing anything. Observed on run 30798700215 (`huggingface model (darwin-aarch64)`, machine `spiceai-macos-runner-04`).

## Changes

**`.github/actions/stop-spice`** (new) — stops the runtime this job started:

- signals **both** `spice` and `spiced`, SIGTERM then SIGKILL after a grace period;
- kills **by PID, filtered to processes whose cwd is under `$RUNNER_WORKSPACE`**. A name-wide `killall spiced` would have been worse than the leak — on a shared machine it would reap a *concurrent* job's runtime. When a PID's cwd cannot be determined it is left alone: leaking costs the next job a retry, killing a concurrent job destroys work in flight;
- waits for the ports, and distinguishes "free" from "held by someone who isn't us" — the latter being the shared-machine collision rather than a leak.

**`.github/actions/wait-for-spice-ready`** (new) — replaces the silent poll. Reports progress while waiting, and on timeout dumps the last response body, whether `spiced` is alive, what holds the port, and `spice.log`, calling out `Address already in use` explicitly with both of its causes.

**Applied across the class**, not just the reported job: 18 readiness waits and 11 cleanups in `e2e_test_ci.yml`, plus `.github/actions/check-spice-log`, which had the same `killall spice`. The two graceful-shutdown steps now use the shared stopper too — they were SIGTERMing the CLI, so the shutdown path under test never ran; they pass a grace longer than their step timeout so a runtime that does not exit cleanly still trips the timeout rather than being SIGKILLed into looking healthy.

## Test plan

- `scripts/test_e2e_spice_lifecycle.sh` — 49 unit tests, no processes started and no ports bound (stubbed `pgrep`/`kill`/`lsof`/`curl`). Run in CI by `.github/workflows/e2e_lifecycle_scripts_test.yml` on ubuntu-24.04 and macos-latest.
- Verified as genuine regression tests against both failure modes: reverting to `spice`-only fails 9 of them, and removing the workspace scoping fails 5 (including "the other instance survives intact").
- `make lint` and `make test` — no Rust, Cargo, or build inputs are touched, so this branch is outside `RUST_AFFECTING_PATH_PATTERN` and `Attestation` auto-passes.
- YAML validated for all changed workflow and action files.

## Not fixed here

The port collision *between concurrent runner instances on one machine* is real and separate: every E2E job hardcodes :8090, so two jobs on one machine contend by design regardless of leaks. That needs an infra decision (per-instance ports, or a concurrency group) rather than a workflow edit. This PR makes that case **self-identifying** instead of anonymous — `stop-spice` reports a port held by a PID that is not ours, and the readiness diagnosis names it.

Fixes #12058