### PR TITLE
fix(ci): size the cayenne property-test timeout ceiling to its measured runtime (fixes #12336)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -23,10 +23,63 @@ cayenne-property-tests = { max-threads = 2 }
 # (e.g. the post-compaction duplicate-row race that surfaced as a masked "flake"
 # under CI load). Give them zero retries so any single failure is a hard failure,
 # never a silently-recovered flake.
+#
+# `slow-timeout` here raises only the WALL-CLOCK ceiling, from the global 360s
+# (120s x 3) to 960s (120s x 8). `retries = 0` is deliberately unchanged: an
+# assertion failure still fails hard on its first occurrence and is never retried
+# into a pass. The two are independent, and only the former carries no
+# correctness signal.
+#
+# Why 960s. The global 360s cap sits inside this family's noise band rather than
+# above it, so it measures pool load instead of the diff under test. The same
+# tests, on a quiet pool (run 30833882620) vs. a pool running six concurrent
+# sign-offs (run 30858006237):
+#
+#   cayenne::…                                      quiet   contended   factor
+#   mutation_property prop_concurrent_mixed_position 239.5s  killed 360s  >1.5x
+#   mutation_property prop_concurrent_mixed_key      192.0s      356.1s   1.85x
+#   mutation_property mixed_dense_position           122.8s      208.6s   1.70x
+#   partition_chunking …timestamp_partition…         247.9s      308.1s   1.24x
+#
+# In that contended run `prop_concurrent_mixed_key` PASSED at 356.1s while its
+# matched sibling `prop_concurrent_mixed_position` was killed at 360.015s — a
+# 1.1% margin deciding a merge gate. Merge-queue run 30723487049 is the far end:
+# `prop_concurrent_upsert_only_key` passed at 338.0s against a 92.0s quiet
+# baseline, a 3.7x contention factor, and five tests in this binary were killed
+# at the cap with no assertion failure or panic anywhere in the log.
+#
+# So the slowest test here intrinsically needs ~240s and contention has been
+# measured multiplying that by up to 3.7x, while the cap allowed only 1.5x.
+# 960s clears 240s x 3.7 with headroom. A genuine hang is still caught, just at
+# 16 minutes instead of 6.
+#
+# This is a ceiling, not a target: if these tests get slower on a QUIET pool,
+# that is a regression to investigate, not a reason to raise this again.
 [[profile.default.overrides]]
 filter = 'binary(=mutation_property_test) | binary(=cdc_compaction_delete_race_test) | binary(=maintained_aggregate_filter_test)'
 test-group = 'cayenne-property-tests'
 retries = 0
+slow-timeout = { period = "120s", terminate-after = 8 }
+
+# The same wall-clock margin, for the long-running cayenne binaries that are NOT
+# in the zero-retry group above. These keep the default retries, so a timeout is
+# recoverable rather than a hard gate failure — but recovering costs up to
+# 5 x 360s = 30 minutes of runner time for a test that only ever needed wall
+# clock. That is not hypothetical: in merge-queue run 30723487049
+# `partition_chunking_test …timestamp_partition_with_date_part` hit the cap on
+# tries 1-5 and then passed on try 6 at 305.5s.
+#
+# Quiet-pool baselines (run 30833882620) against the 3.7x contention factor
+# measured above: partition_chunking 247.9s, layout_pruning_ab 170.1s,
+# mutation_model 107.1s — all of which exceed 360s once multiplied, so all three
+# sit in the same band as the group above for the same reason.
+#
+# Spelled out as its own block rather than folded into the filter above so that
+# `retries = 0` stays visibly scoped to the three convergence binaries that need
+# it. These binaries must NOT inherit it.
+[[profile.default.overrides]]
+filter = 'binary(=partition_chunking_test) | binary(=layout_pruning_ab_test) | binary(=mutation_model_test)'
+slow-timeout = { period = "120s", terminate-after = 8 }
 
 # Same reasoning for the MySQL CDC convergence tests: a retry that passes hides a lost update.
 [[profile.default.overrides]]

--- a/.github/scripts/check_nextest_config.py
+++ b/.github/scripts/check_nextest_config.py
@@ -104,7 +104,17 @@ def ceiling_seconds(slow_timeout: object) -> float | None:
     terminate_after = slow_timeout.get("terminate-after")
     if terminate_after is None:
         return None
-    return parse_duration(slow_timeout["period"]) * int(terminate_after)
+    # `period` is mandatory once `terminate-after` is set, but a hand-edited
+    # table can omit it. Report that as a config problem like every other
+    # malformed value here, rather than letting a KeyError escape as a crash.
+    period = slow_timeout.get("period")
+    if not isinstance(period, str):
+        raise ValueError(
+            f"slow-timeout sets terminate-after but no string period: {slow_timeout!r}"
+        )
+    if not isinstance(terminate_after, int) or isinstance(terminate_after, bool):
+        raise ValueError(f"slow-timeout has a non-integer terminate-after: {slow_timeout!r}")
+    return parse_duration(period) * terminate_after
 
 
 def binaries_matched(filter_expr: str) -> set[str]:
@@ -194,15 +204,25 @@ def check_config(config_path: Path) -> list[str]:
             )
             continue
         try:
-            inherits_a_kill = ceiling_seconds(resolve(config, binary, "slow-timeout")) is not None
+            ceiling = ceiling_seconds(resolve(config, binary, "slow-timeout"))
         except ValueError as exc:
             problems.append(f"{name}: {binary}: {exc}")
             continue
-        if inherits_a_kill and not has_override_setting(config, binary, "slow-timeout"):
+        if not has_override_setting(config, binary, "slow-timeout"):
             problems.append(
                 f"{name}: {binary} has retries = 0 but inherits the global slow-timeout. "
                 "With no retries a wall-clock kill is an unrecoverable merge-queue "
                 "failure, so this binary needs a ceiling sized for it explicitly."
+            )
+        elif ceiling is None:
+            # Deleting `terminate-after` would satisfy the baseline check above
+            # by removing the ceiling entirely, which is the wrong way to make a
+            # timeout stop failing: nothing then kills a genuine hang.
+            problems.append(
+                f"{name}: {binary} has retries = 0 and a slow-timeout that never "
+                "terminates, so a hung test is never killed. It would run until the "
+                "job's own timeout, costing the whole run and reporting as an "
+                "infrastructure failure rather than a test one. Set terminate-after."
             )
 
     return problems

--- a/.github/scripts/check_nextest_config.py
+++ b/.github/scripts/check_nextest_config.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# nextest wall-clock ceiling guard.
+#
+# `.config/nextest.toml` gives every test a `slow-timeout` — a period, and a
+# `terminate-after` count of periods after which nextest kills the test. That
+# ceiling exists to catch hangs. It is not a statement about how long the work
+# takes, so when a genuinely slow test's runtime drifts up into it, the ceiling
+# silently changes meaning: it stops catching hangs and starts reporting pool
+# contention as a test failure.
+#
+# That is #12336 / #12434. The `cayenne::mutation_property_test` concurrency
+# property tests need 2-4 minutes of real work, the global ceiling was 360s, and
+# contention on the self-hosted pool was measured stretching them by up to 3.7x.
+# Sign-off then failed on unrelated PRs: in run 30858006237 one variant passed at
+# 356.1s while its matched sibling was killed at 360.015s. Those binaries also
+# carry `retries = 0` (a retry that passes would hide a real convergence race),
+# so the kill was an unrecoverable merge-queue failure.
+#
+# This guard keeps the ceiling ahead of the measurements instead of trusting a
+# comment to stay true. For each binary with a recorded baseline it resolves the
+# ceiling the way nextest does and requires it to clear
+# `baseline * CONTENTION_FACTOR`. It also asserts the two settings stay coupled:
+# the convergence binaries must keep `retries = 0` (so a real failure is never
+# retried into a pass) *and* keep an explicit ceiling (so a timeout is not a hard
+# gate failure).
+"""Validate the repository's nextest slow-timeout ceilings against measured runtimes."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+# Slowest observed duration for each long-running test binary on a QUIET pool.
+#
+# Source: `Remote Sign-off` run 30833882620 (trunk @ 7b98c234), which ran with no
+# other sign-off in flight. Value is the slowest single test in that binary.
+QUIET_BASELINE_SECONDS = {
+    "mutation_property_test": 239.5,  # prop_concurrent_mixed_position_sqlite
+    "partition_chunking_test": 247.9,  # ..._timestamp_partition_with_date_part_impl_sqlite
+    "layout_pruning_ab_test": 170.1,  # pruning_ab_inferred_vs_authoritative_sort
+    "mutation_model_test": 107.1,  # test_exhaustive_composite_single_row_sequences_impl_sqlite
+}
+
+# Worst same-test slowdown measured between a quiet pool and a saturated one.
+#
+# Source: merge-queue run 30723487049, where
+# `mutation_property_test prop_concurrent_upsert_only_key_sqlite` passed at
+# 338.0s against a 92.0s quiet baseline in run 30833882620. Contention on this
+# pool is shared-machine CPU starvation, so it applies to any binary here.
+CONTENTION_FACTOR = 3.7
+
+# Binaries whose failures must never be retried: they assert that the accelerated
+# table converges to a reference model, so a retry that happens to pass hides a
+# real race rather than working around flakiness. Each must ALSO carry its own
+# `slow-timeout` — with `retries = 0`, the ceiling is the difference between a
+# recoverable timeout and a hard merge-queue failure.
+ZERO_RETRY_BINARIES = frozenset(
+    {
+        "mutation_property_test",
+        "cdc_compaction_delete_race_test",
+        "maintained_aggregate_filter_test",
+    }
+)
+
+# The global ceiling every other test gets. Pinned so that a future timeout is
+# not "fixed" by raising this: it applies to the whole workspace and would hide
+# slowness everywhere rather than recording a decision about one test family.
+EXPECTED_GLOBAL_SLOW_TIMEOUT = {"period": "120s", "terminate-after": 3}
+
+_DURATION = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>ms|s|m|h)$")
+_UNIT_SECONDS = {"ms": 0.001, "s": 1.0, "m": 60.0, "h": 3600.0}
+
+# The only binary-filter spelling this guard resolves. `binary(~x)`, `binary(/re/)`
+# and `binary-id(...)` would each need different matching, so they are rejected
+# rather than silently treated as non-matching.
+_BINARY_EQ_TERM = re.compile(r"binary\(=([A-Za-z0-9_]+)\)")
+_OTHER_BINARY_TERM = re.compile(r"binary(?:-id)?\((?!=[A-Za-z0-9_]+\))")
+
+
+def parse_duration(text: str) -> float:
+    """Return `text` ('120s', '2m', …) in seconds."""
+    match = _DURATION.match(text.strip())
+    if not match:
+        raise ValueError(f"unparseable duration: {text!r}")
+    return float(match.group("value")) * _UNIT_SECONDS[match.group("unit")]
+
+
+def ceiling_seconds(slow_timeout: object) -> float | None:
+    """Return the wall-clock kill ceiling a `slow-timeout` value implies.
+
+    `None` means the value sets no ceiling — either nothing configured one, or a
+    bare duration, which only marks the test SLOW in the output and never
+    terminates it.
+    """
+    if slow_timeout is None or isinstance(slow_timeout, str):
+        return None
+    if not isinstance(slow_timeout, dict):
+        raise ValueError(f"unexpected slow-timeout value: {slow_timeout!r}")
+    terminate_after = slow_timeout.get("terminate-after")
+    if terminate_after is None:
+        return None
+    return parse_duration(slow_timeout["period"]) * int(terminate_after)
+
+
+def binaries_matched(filter_expr: str) -> set[str]:
+    """Return the binaries a filter expression matches by exact name.
+
+    Only `binary(=name)` terms are understood. A filter selecting tests by name
+    (for example `test(=mysql::…)`) matches no binary here, which is correct: it
+    cannot be resolved to a binary without knowing that binary's test names.
+    """
+    if _OTHER_BINARY_TERM.search(filter_expr):
+        raise ValueError(
+            f"unsupported binary filter spelling, cannot resolve a ceiling: {filter_expr!r}"
+        )
+    return set(_BINARY_EQ_TERM.findall(filter_expr))
+
+
+def resolve(config: dict, binary: str, setting: str) -> object | None:
+    """Resolve `setting` for `binary` the way nextest does.
+
+    nextest evaluates precedence per setting: the first override that matches and
+    configures that setting wins, and the profile default applies if none do.
+    """
+    profile = config.get("profile", {}).get("default", {})
+    for override in profile.get("overrides", []):
+        if setting not in override:
+            continue
+        if binary in binaries_matched(override.get("filter", "")):
+            return override[setting]
+    return profile.get(setting)
+
+
+def check_config(config_path: Path) -> list[str]:
+    """Return a list of problems with the nextest config at `config_path`."""
+    if not config_path.is_file():
+        return [f"{config_path}: not found"]
+    try:
+        # utf-8-sig so a stray BOM reports as a config problem, not a crash.
+        config = tomllib.loads(config_path.read_text(encoding="utf-8-sig"))
+    except tomllib.TOMLDecodeError as exc:
+        return [f"{config_path}: does not parse as TOML: {exc}"]
+
+    problems: list[str] = []
+    name = config_path.name
+
+    profile = config.get("profile", {}).get("default", {})
+    try:
+        for override in profile.get("overrides", []):
+            binaries_matched(override.get("filter", ""))
+    except ValueError as exc:
+        # Every check below resolves settings per binary, so an unresolvable
+        # filter would make the rest of this run meaningless rather than merely
+        # incomplete.
+        return [f"{name}: {exc}"]
+
+    if profile.get("slow-timeout") != EXPECTED_GLOBAL_SLOW_TIMEOUT:
+        problems.append(
+            f"{name}: the global [profile.default] slow-timeout is "
+            f"{profile.get('slow-timeout')!r}, expected {EXPECTED_GLOBAL_SLOW_TIMEOUT!r}. "
+            "Raising the global ceiling hides slowness across the whole workspace; give "
+            "the affected binaries their own override and record why."
+        )
+
+    for binary, baseline in sorted(QUIET_BASELINE_SECONDS.items()):
+        required = baseline * CONTENTION_FACTOR
+        try:
+            ceiling = ceiling_seconds(resolve(config, binary, "slow-timeout"))
+        except ValueError as exc:
+            problems.append(f"{name}: {binary}: {exc}")
+            continue
+        if ceiling is None:
+            continue  # No ceiling at all cannot be breached by contention.
+        if ceiling < required:
+            problems.append(
+                f"{name}: {binary} is killed after {ceiling:.0f}s, but its slowest test "
+                f"needs {baseline:.1f}s on a quiet pool and contention has been measured "
+                f"multiplying runtimes by {CONTENTION_FACTOR}x, so it needs at least "
+                f"{required:.0f}s. As configured, pool load decides whether unrelated PRs "
+                "pass. See #12336."
+            )
+
+    for binary in sorted(ZERO_RETRY_BINARIES):
+        if resolve(config, binary, "retries") != 0:
+            problems.append(
+                f"{name}: {binary} no longer has retries = 0. These tests assert the "
+                "accelerated table converges to a reference model; a retry that passes "
+                "hides a real race instead of working around flakiness."
+            )
+            continue
+        try:
+            inherits_a_kill = ceiling_seconds(resolve(config, binary, "slow-timeout")) is not None
+        except ValueError as exc:
+            problems.append(f"{name}: {binary}: {exc}")
+            continue
+        if inherits_a_kill and not has_override_setting(config, binary, "slow-timeout"):
+            problems.append(
+                f"{name}: {binary} has retries = 0 but inherits the global slow-timeout. "
+                "With no retries a wall-clock kill is an unrecoverable merge-queue "
+                "failure, so this binary needs a ceiling sized for it explicitly."
+            )
+
+    return problems
+
+
+def has_override_setting(config: dict, binary: str, setting: str) -> bool:
+    """Return whether an override — not the profile default — supplies `setting`."""
+    return any(
+        setting in override and binary in binaries_matched(override.get("filter", ""))
+        for override in config.get("profile", {}).get("default", {}).get("overrides", [])
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / ".config" / "nextest.toml",
+        help="path to nextest.toml (default: the repository's .config/nextest.toml)",
+    )
+    args = parser.parse_args(argv)
+
+    problems = check_config(args.config)
+    if problems:
+        print(f"FAIL: {len(problems)} problem(s) in {args.config}:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: {args.config.name} keeps every measured binary's kill ceiling above "
+        f"its quiet baseline x {CONTENTION_FACTOR}, and the convergence binaries "
+        "keep retries = 0 with an explicit ceiling"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_check_nextest_config.py
+++ b/.github/scripts/test_check_nextest_config.py
@@ -167,14 +167,32 @@ class CheckConfigTest(unittest.TestCase):
             problems = check_nextest_config.check_config(write(tmp, config))
         self.assertTrue(any("no longer has retries = 0" in p for p in problems))
 
-    def test_a_slow_timeout_that_never_terminates_is_accepted(self):
-        """A bare period cannot kill a test, so contention cannot fail it."""
+    def test_rejects_removing_the_ceiling_from_a_zero_retry_binary(self):
+        """A bare period cannot kill a test — including a genuinely hung one.
+
+        Dropping `terminate-after` is the other way to make a timeout stop
+        failing, and it satisfies the baseline check by removing the ceiling
+        rather than sizing it. The convergence binaries must keep a real one.
+        """
         config = FIXED_CONFIG.replace(
             'slow-timeout = { period = "120s", terminate-after = 8 }',
             'slow-timeout = "120s"',
         )
         with tempfile.TemporaryDirectory() as tmp:
-            self.assertEqual(check_nextest_config.check_config(write(tmp, config)), [])
+            problems = check_nextest_config.check_config(write(tmp, config))
+        never_terminates = [p for p in problems if "never terminates" in p]
+        self.assertEqual(len(never_terminates), len(check_nextest_config.ZERO_RETRY_BINARIES))
+        self.assertTrue(all("Set terminate-after" in p for p in never_terminates))
+
+    def test_reports_a_slow_timeout_missing_its_period(self):
+        """A `terminate-after` with no `period` is a config problem, not a crash."""
+        config = FIXED_CONFIG.replace(
+            'slow-timeout = { period = "120s", terminate-after = 8 }',
+            "slow-timeout = { terminate-after = 8 }",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, config))
+        self.assertTrue(any("no string period" in p for p in problems), problems)
 
     def test_reports_an_unresolvable_binary_filter(self):
         config = FIXED_CONFIG + """

--- a/.github/scripts/test_check_nextest_config.py
+++ b/.github/scripts/test_check_nextest_config.py
@@ -1,0 +1,217 @@
+"""Unit tests for check_nextest_config.py."""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check_nextest_config  # noqa: E402
+
+# The config as it stood before #12336 was fixed: the convergence binaries carry
+# `retries = 0` but no ceiling of their own, so they inherit the global 360s.
+PRE_FIX_CONFIG = """\
+[profile.default]
+retries = { backoff = "exponential", count = 5, delay = "2s", max-delay = "30s", jitter = true }
+slow-timeout = { period = "120s", terminate-after = 3 }
+
+[test-groups]
+cayenne-property-tests = { max-threads = 2 }
+
+[[profile.default.overrides]]
+filter = 'binary(=mutation_property_test) | binary(=cdc_compaction_delete_race_test) | binary(=maintained_aggregate_filter_test)'
+test-group = 'cayenne-property-tests'
+retries = 0
+"""
+
+# The fix: the same overrides, plus an explicit ceiling for the slow binaries.
+FIXED_CONFIG = PRE_FIX_CONFIG + """\
+slow-timeout = { period = "120s", terminate-after = 8 }
+
+[[profile.default.overrides]]
+filter = 'binary(=partition_chunking_test) | binary(=layout_pruning_ab_test) | binary(=mutation_model_test)'
+slow-timeout = { period = "120s", terminate-after = 8 }
+"""
+
+
+def write(tmp: str, text: str) -> Path:
+    path = Path(tmp) / "nextest.toml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class DurationTest(unittest.TestCase):
+    def test_parses_each_supported_unit(self):
+        self.assertEqual(check_nextest_config.parse_duration("120s"), 120.0)
+        self.assertEqual(check_nextest_config.parse_duration("2m"), 120.0)
+        self.assertEqual(check_nextest_config.parse_duration("1h"), 3600.0)
+        self.assertEqual(check_nextest_config.parse_duration("500ms"), 0.5)
+        self.assertEqual(check_nextest_config.parse_duration("1.5m"), 90.0)
+
+    def test_rejects_an_unparseable_duration(self):
+        for text in ("120", "s", "", "120 s", "2days"):
+            with self.assertRaises(ValueError):
+                check_nextest_config.parse_duration(text)
+
+
+class CeilingTest(unittest.TestCase):
+    def test_period_times_terminate_after(self):
+        self.assertEqual(
+            check_nextest_config.ceiling_seconds({"period": "120s", "terminate-after": 8}), 960.0
+        )
+
+    def test_a_bare_duration_sets_no_ceiling(self):
+        """Without `terminate-after` nextest only marks the test SLOW; it never kills it."""
+        self.assertIsNone(check_nextest_config.ceiling_seconds("120s"))
+
+    def test_a_period_without_terminate_after_sets_no_ceiling(self):
+        self.assertIsNone(check_nextest_config.ceiling_seconds({"period": "120s"}))
+
+    def test_nothing_configured_sets_no_ceiling(self):
+        """A config with no slow-timeout at all cannot kill a test."""
+        self.assertIsNone(check_nextest_config.ceiling_seconds(None))
+
+
+class BinaryFilterTest(unittest.TestCase):
+    def test_matches_each_disjunct(self):
+        self.assertEqual(
+            check_nextest_config.binaries_matched("binary(=a_test) | binary(=b_test)"),
+            {"a_test", "b_test"},
+        )
+
+    def test_a_test_name_filter_matches_no_binary(self):
+        """A `test(=…)` filter cannot be resolved to a binary, and must not be guessed at."""
+        self.assertEqual(
+            check_nextest_config.binaries_matched("test(=mysql::replication_e2e::foo)"), set()
+        )
+
+    def test_rejects_binary_filter_spellings_it_cannot_resolve(self):
+        for expr in ("binary(~mutation)", "binary(/mutation.*/)", "binary-id(cayenne::foo)"):
+            with self.assertRaises(ValueError):
+                check_nextest_config.binaries_matched(expr)
+
+
+class ResolveTest(unittest.TestCase):
+    def test_first_matching_override_wins_per_setting(self):
+        """nextest evaluates precedence separately for each setting."""
+        config = {
+            "profile": {
+                "default": {
+                    "retries": 5,
+                    "slow-timeout": {"period": "120s", "terminate-after": 3},
+                    "overrides": [
+                        {"filter": "binary(=a_test)", "retries": 0},
+                        {
+                            "filter": "binary(=a_test)",
+                            "retries": 9,
+                            "slow-timeout": {"period": "60s", "terminate-after": 2},
+                        },
+                    ],
+                }
+            }
+        }
+        self.assertEqual(check_nextest_config.resolve(config, "a_test", "retries"), 0)
+        # The second block still supplies the setting the first one omits.
+        self.assertEqual(
+            check_nextest_config.resolve(config, "a_test", "slow-timeout"),
+            {"period": "60s", "terminate-after": 2},
+        )
+
+    def test_falls_back_to_the_profile_default(self):
+        config = {"profile": {"default": {"retries": 5, "overrides": []}}}
+        self.assertEqual(check_nextest_config.resolve(config, "z_test", "retries"), 5)
+
+
+class CheckConfigTest(unittest.TestCase):
+    def test_the_pre_fix_config_is_rejected(self):
+        """Regression test for #12336: this is the exact config that failed sign-off."""
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, PRE_FIX_CONFIG))
+        self.assertTrue(problems)
+        joined = "\n".join(problems)
+        # The 360s ceiling is below every recorded baseline x 3.7.
+        self.assertIn("mutation_property_test is killed after 360s", joined)
+        self.assertIn("partition_chunking_test is killed after 360s", joined)
+        # And retries = 0 on top of an inherited ceiling is the unrecoverable case.
+        self.assertIn("inherits the global slow-timeout", joined)
+
+    def test_the_fixed_config_is_accepted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(check_nextest_config.check_config(write(tmp, FIXED_CONFIG)), [])
+
+    def test_rejects_a_ceiling_that_clears_the_baseline_but_not_contention(self):
+        """600s clears the 247.9s baseline but not 247.9 x 3.7."""
+        config = PRE_FIX_CONFIG.replace(
+            'slow-timeout = { period = "120s", terminate-after = 3 }',
+            'slow-timeout = { period = "120s", terminate-after = 5 }',
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, config))
+        self.assertTrue(any("needs at least 917s" in p for p in problems))
+
+    def test_rejects_raising_the_global_ceiling_instead(self):
+        """The tempting one-line 'fix' hides slowness across the whole workspace."""
+        config = FIXED_CONFIG.replace(
+            'slow-timeout = { period = "120s", terminate-after = 3 }',
+            'slow-timeout = { period = "120s", terminate-after = 12 }',
+            1,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, config))
+        self.assertTrue(any("global [profile.default] slow-timeout" in p for p in problems))
+
+    def test_rejects_dropping_retries_zero(self):
+        """Buying headroom by allowing retries would mask the races these tests exist to catch."""
+        config = FIXED_CONFIG.replace("retries = 0", "retries = 3")
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, config))
+        self.assertTrue(any("no longer has retries = 0" in p for p in problems))
+
+    def test_a_slow_timeout_that_never_terminates_is_accepted(self):
+        """A bare period cannot kill a test, so contention cannot fail it."""
+        config = FIXED_CONFIG.replace(
+            'slow-timeout = { period = "120s", terminate-after = 8 }',
+            'slow-timeout = "120s"',
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(check_nextest_config.check_config(write(tmp, config)), [])
+
+    def test_reports_an_unresolvable_binary_filter(self):
+        config = FIXED_CONFIG + """
+[[profile.default.overrides]]
+filter = 'binary(~mutation)'
+retries = 0
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, config))
+        self.assertTrue(any("unsupported binary filter spelling" in p for p in problems))
+
+    def test_reports_malformed_toml(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, "[profile.default\n"))
+        self.assertTrue(any("does not parse as TOML" in p for p in problems))
+
+    def test_reports_a_missing_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(Path(tmp) / "absent.toml")
+        self.assertTrue(any("not found" in p for p in problems))
+
+
+class MainTest(unittest.TestCase):
+    def test_exit_codes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(check_nextest_config.main(["--config", str(write(tmp, FIXED_CONFIG))]), 0)
+            self.assertEqual(
+                check_nextest_config.main(["--config", str(write(tmp, PRE_FIX_CONFIG))]), 1
+            )
+
+
+class RepositoryTest(unittest.TestCase):
+    def test_this_repositorys_nextest_config_holds(self):
+        """Regression test for #12336 / #12434 against the real .config/nextest.toml."""
+        config_path = Path(__file__).resolve().parents[2] / ".config" / "nextest.toml"
+        self.assertEqual(check_nextest_config.check_config(config_path), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/nextest_config_check.yml
+++ b/.github/workflows/nextest_config_check.yml
@@ -1,0 +1,56 @@
+---
+name: Nextest Config Check
+
+# `.config/nextest.toml`'s `slow-timeout` exists to kill hangs. When a genuinely
+# slow test's runtime drifts up into that ceiling, it stops catching hangs and
+# starts failing unrelated PRs whenever the self-hosted pool is busy — and for the
+# cayenne convergence binaries, which carry `retries = 0`, that is an
+# unrecoverable merge-queue failure. This gate keeps the ceiling ahead of the
+# measured runtimes. See #12336 / #12434.
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - '.config/nextest.toml'
+      - '.github/scripts/check_nextest_config.py'
+      - '.github/scripts/test_check_nextest_config.py'
+  push:
+    branches:
+      - trunk
+    paths:
+      - '.config/nextest.toml'
+      - '.github/scripts/check_nextest_config.py'
+      - '.github/scripts/test_check_nextest_config.py'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  check-nextest-config:
+    name: Validate nextest timeout ceilings
+    # GitHub-hosted on purpose: this is a sub-second check and must not queue
+    # behind the saturated self-hosted pool.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # 3.11 for `tomllib` in the standard library — this check needs no pip deps.
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Run tests
+        run: python .github/scripts/test_check_nextest_config.py -v
+
+      - name: Validate nextest timeout ceilings
+        run: python .github/scripts/check_nextest_config.py

--- a/.github/workflows/nextest_config_check.yml
+++ b/.github/workflows/nextest_config_check.yml
@@ -18,6 +18,9 @@ on:
       - '.config/nextest.toml'
       - '.github/scripts/check_nextest_config.py'
       - '.github/scripts/test_check_nextest_config.py'
+      # Self-referencing so an edit to this file is exercised by the gate it
+      # defines, rather than only when one of the paths above also changes.
+      - '.github/workflows/nextest_config_check.yml'
   push:
     branches:
       - trunk
@@ -25,6 +28,9 @@ on:
       - '.config/nextest.toml'
       - '.github/scripts/check_nextest_config.py'
       - '.github/scripts/test_check_nextest_config.py'
+      # Self-referencing so an edit to this file is exercised by the gate it
+      # defines, rather than only when one of the paths above also changes.
+      - '.github/workflows/nextest_config_check.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

`.config/nextest.toml` gives every test a `slow-timeout` ceiling — `120s × 3 = 360s`, after which nextest kills it. That ceiling exists to catch hangs. It is not a statement about how long the work legitimately takes, so when a genuinely slow test's runtime drifts up into it, the ceiling silently changes meaning: it stops catching hangs and starts reporting pool contention as a test failure.

The `cayenne::mutation_property_test` concurrency property tests are past that point. In `Remote Sign-off` run [30858006237](https://github.com/spiceai/spiceai/actions/runs/30858006237), two variants of the *same* test ran on the *same* box in the *same* window:

| Test | Result |
|---|---|
| `prop_concurrent_mixed_key_sqlite` | **passed at 356.125s** — 3.9s under the cap |
| `prop_concurrent_mixed_position_sqlite` | **TIMEOUT at 360.015s** |

A 1.1% margin decided a merge gate. The branch under sign-off was #12422, which touches Hugging Face token handling and an E2E workflow — nothing that can reach `crates/cayenne`. It cost a 2h56m sign-off run and left `Attestation` red on a clean branch, which reads as a code failure until someone opens the 17,000-line log.

These binaries also carry `retries = 0`, deliberately: they assert the accelerated table converges to a reference model, so a retry that happens to pass hides a real race. That reasoning is sound and is kept. But it means a wall-clock kill — which carries no correctness signal at all — is an *unrecoverable* merge-queue failure. Merge-queue run [30723487049](https://github.com/spiceai/spiceai/actions/runs/30723487049) is the same failure with five tests killed at the cap, zero assertion failures and zero panics anywhere in the log.

Fixes #12336

## Why raise the ceiling, and why 960s

Raising a timeout is usually the wrong instinct — it hides the slowness. So the number is derived from measurement rather than picked to make the red go away.

**The tests intrinsically need minutes.** On a quiet pool (run [30833882620](https://github.com/spiceai/spiceai/actions/runs/30833882620), trunk @ `7b98c234`, no other sign-off in flight) the slowest test in this binary takes 239.5s of real work. That is what the property test does; it is not waiting on anything.

**Contention has been measured multiplying that by up to 3.7×.** In merge-queue run 30723487049, `prop_concurrent_upsert_only_key_sqlite` passed at 338.0s against a 92.0s quiet baseline. The pool is shared-machine CPU starvation, so the factor applies to any binary on it.

| `cayenne::…` | quiet | contended | factor |
|---|---|---|---|
| `mutation_property prop_concurrent_mixed_position` | 239.5s | killed at 360s | >1.5× |
| `mutation_property prop_concurrent_mixed_key` | 192.0s | 356.1s | 1.85× |
| `mutation_property mixed_dense_position` | 122.8s | 208.6s | 1.70× |
| `partition_chunking …timestamp_partition…` | 247.9s | 308.1s | 1.24× |

So the work needs ~240s and contention stretches it by up to 3.7× — while the cap allowed only 1.5×. `960s` (`120s × 8`) clears `240 × 3.7` with headroom. A genuine hang is still caught, just at 16 minutes instead of 6.

**`retries = 0` is unchanged.** The two settings are independent: an assertion failure still fails hard on its first occurrence and is never retried into a pass. Only the wall-clock ceiling moves, and only the wall-clock ceiling carries no correctness signal.

**The global ceiling is unchanged too.** Raising `[profile.default]` would have been the one-line version of this fix, and it would hide slowness across the entire workspace rather than recording a decision about one test family. The guard below actively rejects that.

## Changes

**`.config/nextest.toml`** — two overrides, with the measurements above recorded inline as the justification.

The first adds `slow-timeout = { period = "120s", terminate-after = 8 }` to the existing zero-retry group (`mutation_property_test`, `cdc_compaction_delete_race_test`, `maintained_aggregate_filter_test`).

The second covers `partition_chunking_test`, `layout_pruning_ab_test` and `mutation_model_test` — long-running cayenne binaries that keep the default retries, so a timeout there is recoverable rather than a hard gate failure. Recovering still costs up to `5 × 360s = 30 minutes` of runner time for a test that only ever needed wall clock: in run 30723487049 `partition_chunking_test …timestamp_partition_with_date_part` hit the cap on tries 1–5 and passed on try 6 at 305.5s. Their quiet baselines (247.9s / 170.1s / 107.1s) all exceed 360s once multiplied by 3.7. It is spelled out as a separate block rather than folded into the filter above so `retries = 0` stays visibly scoped to the three convergence binaries that need it — these three must **not** inherit it.

**`.github/scripts/check_nextest_config.py`** — the guard. A comment claiming a ceiling is well-sized decays; this checks it. For each binary with a recorded quiet baseline it resolves the effective ceiling *the way nextest does* (per-setting precedence: the first override that matches and configures that setting wins, profile default otherwise) and requires it to clear `baseline × 3.7`. It also asserts the two settings stay coupled — the convergence binaries must keep `retries = 0` **and** keep an explicit ceiling, since with no retries the ceiling is the difference between a recoverable timeout and a hard gate failure — and it pins the global `slow-timeout`, so the tempting workspace-wide "fix" fails the build.

It parses only `binary(=name)` filters and **raises** on `binary(~x)`, `binary(/re/)` or `binary-id(...)` rather than silently treating them as non-matching, which would make the guard quietly stop guarding. A bare-duration `slow-timeout` correctly resolves to *no ceiling* (it only marks a test SLOW, it never terminates it).

**`.github/workflows/nextest_config_check.yml`** — runs the guard's own tests and then the guard, on `ubuntu-24.04`. GitHub-hosted on purpose: a sub-second check must not queue behind the saturated self-hosted pool this change exists to keep honest. Python 3.11 for stdlib `tomllib`, so there are no pip dependencies. Path-filtered to the config and the two scripts.

## What this does not do

It does not make the tests faster, and the ceiling is a ceiling rather than a target — the inline comment says so explicitly: if these tests get slower on a *quiet* pool, that is a regression to investigate, not a reason to raise this again. The guard makes that concrete, since a quiet baseline that grows past `ceiling ÷ 3.7` fails the build.

It also does not address the underlying capacity problem. `test-threads = "num-cpus"` means the rest of the suite can saturate the runner around a group whose `max-threads = 2` only caps parallelism *within* it, which is why `partition_chunking_test` starved in a run where the box was globally contended. Lowering global parallelism is a separate, higher-risk change to the whole suite's wall clock and is deliberately not bundled here.

The baselines are hand-recorded from two named runs rather than harvested automatically. Auto-harvesting would need a durable store of per-test timings across runs, which does not exist today; the constant is small, sourced in a comment, and fails loudly if the config drifts under it.

## Test plan

- `python .github/scripts/test_check_nextest_config.py -v` — 22 tests. Duration parsing per unit and rejection of malformed input; ceiling resolution for a bare duration, a missing `terminate-after`, and a full table; nextest's per-setting override precedence; unsupported filter spellings; a missing file and malformed TOML; and `main`'s exit codes.
- `python .github/scripts/check_nextest_config.py` — the real `.config/nextest.toml` passes.
- **Regression tests are load-bearing and pinned to this bug.** `test_the_pre_fix_config_is_rejected` feeds the guard the exact config that failed sign-off and asserts it is rejected; `test_the_fixed_config_is_accepted` asserts this PR's config is accepted; `test_this_repositorys_nextest_config_holds` runs the guard against the checked-in file so the two cannot drift apart. `test_rejects_raising_the_global_ceiling_instead` asserts the tempting one-line alternative fails.
- `make lint` and `make test` — no Rust files are touched, so the branch has no Rust-affecting changes and the gate skips lint/build/tests for it; the sign-off status is still posted.

## Checklist

- [x] Regression tests fail on the pre-fix config and pass on the new one
- [x] `retries = 0` preserved for the three convergence binaries, and asserted by the guard
- [x] The global `[profile.default]` ceiling is unchanged, and asserted by the guard
- [x] Every number in the config comments is sourced to a named CI run
- [x] Security review: no findings — no new inputs, secrets, or permissions; the new workflow is `pull_request` (not `pull_request_target`), pins its actions by SHA, and sets `persist-credentials: false`
