### PR TITLE
fix(ci): publish a CUDA image for every compute capability, not just 80 (fixes #10622)

### DIFF
--- a/.github/scripts/check_cuda_compute_caps.py
+++ b/.github/scripts/check_cuda_compute_caps.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# CUDA compute-capability drift guard.
+#
+# Two workflows have to agree on which CUDA compute capabilities exist:
+#
+#   build_and_release_cuda.yml  builds one `spiced_cuda_<cap>_linux_x86_64.tar.gz`
+#                               release asset per capability
+#   spiced_docker.yml           packages each of those assets into an image
+#
+# They agree by convention, in three hand-maintained lists (a JS matrix, a shell
+# string, and two `choice` input option lists). Nothing connected them, so
+# spiced_docker.yml sat at a single hardcoded capability while the release
+# workflow grew to five — the CUDA image shipped sm_80 only and was unusable on
+# anything newer than an A100, with the binaries sitting in the release the
+# whole time. That is #10622.
+#
+# The failure mode is silence: adding a capability to the release workflow and
+# forgetting the packaging side produces no error, just an image that quietly
+# does not exist. This guard makes the lists disagree loudly instead.
+"""Validate that the CUDA compute-capability lists in the workflows agree."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+RELEASE_WORKFLOW = "build_and_release_cuda.yml"
+DOCKER_WORKFLOW = "spiced_docker.yml"
+
+# `build_and_release_cuda.yml` declares its matrix inside an inline
+# `actions/github-script` body, so it is JavaScript rather than YAML and has to
+# be read as text.
+_JS_COMPUTE_CAP = re.compile(r'compute_cap:\s*"(\d+)"')
+
+# `spiced_docker.yml` declares its list as a shell word list in the `resolve`
+# step. Matched on the assignment rather than on any digit sequence so an
+# unrelated number in that step cannot be mistaken for a capability.
+_SHELL_COMPUTE_CAPS = re.compile(r"^\s*all_compute_caps='([^']*)'", re.MULTILINE)
+
+
+def load_workflow(path: Path) -> dict:
+    """Parse a workflow file, or raise ValueError describing why it could not be."""
+    if not path.is_file():
+        raise ValueError(f"{path}: not found")
+    try:
+        # utf-8-sig so a stray BOM reports as a config problem, not a crash.
+        document = yaml.safe_load(path.read_text(encoding="utf-8-sig"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path.name}: does not parse as YAML: {exc}") from exc
+    if not isinstance(document, dict):
+        raise ValueError(f"{path.name}: is not a YAML mapping")
+    return document
+
+
+def dispatch_choices(workflow: dict, input_name: str) -> list[str]:
+    """Return the `choice` options of a `workflow_dispatch` input.
+
+    PyYAML resolves the unquoted `on:` key to the boolean True (YAML 1.1), so it
+    is looked up under both spellings rather than assuming either one.
+    """
+    triggers = workflow.get("on", workflow.get(True))
+    if not isinstance(triggers, dict):
+        raise ValueError("has no `on:` mapping")
+    dispatch = triggers.get("workflow_dispatch")
+    if not isinstance(dispatch, dict):
+        raise ValueError("has no `workflow_dispatch:` mapping")
+    inputs = dispatch.get("inputs")
+    if not isinstance(inputs, dict) or input_name not in inputs:
+        raise ValueError(f"has no `{input_name}` workflow_dispatch input")
+    options = inputs[input_name].get("options")
+    if not isinstance(options, list):
+        raise ValueError(f"`{input_name}` input has no `options` list")
+    # YAML resolves an unquoted 80 to an int; compare as text either way.
+    return [str(option) for option in options]
+
+
+def release_matrix_caps(text: str) -> list[str]:
+    """Return the compute capabilities in the release workflow's JS matrix."""
+    caps = _JS_COMPUTE_CAP.findall(text)
+    if not caps:
+        raise ValueError(f"{RELEASE_WORKFLOW}: found no `compute_cap: \"<n>\"` matrix entries")
+    return caps
+
+
+def docker_shell_caps(text: str) -> list[str]:
+    """Return the compute capabilities in the docker workflow's shell list."""
+    match = _SHELL_COMPUTE_CAPS.search(text)
+    if match is None:
+        raise ValueError(f"{DOCKER_WORKFLOW}: found no `all_compute_caps='...'` assignment")
+    caps = match.group(1).split()
+    if not caps:
+        raise ValueError(f"{DOCKER_WORKFLOW}: `all_compute_caps` is empty")
+    return caps
+
+
+def default_cap(workflow: dict) -> str:
+    """Return the docker workflow's DEFAULT_CUDA_COMPUTE_CAP."""
+    env = workflow.get("env")
+    if not isinstance(env, dict) or "DEFAULT_CUDA_COMPUTE_CAP" not in env:
+        raise ValueError(f"{DOCKER_WORKFLOW}: has no top-level DEFAULT_CUDA_COMPUTE_CAP env")
+    return str(env["DEFAULT_CUDA_COMPUTE_CAP"])
+
+
+def _duplicates(caps: list[str]) -> list[str]:
+    return sorted({cap for cap in caps if caps.count(cap) > 1})
+
+
+def check(workflows_dir: Path) -> list[str]:
+    """Return a list of problems with the CUDA capability lists."""
+    release_path = workflows_dir / RELEASE_WORKFLOW
+    docker_path = workflows_dir / DOCKER_WORKFLOW
+
+    problems: list[str] = []
+    try:
+        release_text = release_path.read_text(encoding="utf-8-sig")
+        docker_text = docker_path.read_text(encoding="utf-8-sig")
+        release_workflow = load_workflow(release_path)
+        docker_workflow = load_workflow(docker_path)
+        release_caps = release_matrix_caps(release_text)
+        docker_caps = docker_shell_caps(docker_text)
+        release_choices = dispatch_choices(release_workflow, "compute_cap")
+        docker_choices = dispatch_choices(docker_workflow, "compute_cap")
+        default = default_cap(docker_workflow)
+    except (OSError, ValueError) as exc:
+        # Every check below compares two lists, so failing to read one of them
+        # makes the rest meaningless rather than merely incomplete.
+        return [str(exc)]
+
+    for name, caps in ((RELEASE_WORKFLOW, release_caps), (DOCKER_WORKFLOW, docker_caps)):
+        repeated = _duplicates(caps)
+        if repeated:
+            problems.append(
+                f"{name}: compute capabilities {repeated} are listed more than once. "
+                "A duplicate builds the same image twice and makes the two lists "
+                "compare unequal for a reason that is not a real difference."
+            )
+
+    if set(release_caps) != set(docker_caps):
+        only_release = sorted(set(release_caps) - set(docker_caps))
+        only_docker = sorted(set(docker_caps) - set(release_caps))
+        detail = []
+        if only_release:
+            detail.append(
+                f"{only_release} have release binaries but are never packaged into an image"
+            )
+        if only_docker:
+            detail.append(
+                f"{only_docker} would be packaged but have no release asset to download, "
+                "so the image build fails at the curl"
+            )
+        problems.append(
+            f"{RELEASE_WORKFLOW}'s matrix and {DOCKER_WORKFLOW}'s `all_compute_caps` "
+            f"disagree: {'; '.join(detail)}. See #10622."
+        )
+
+    # Derived from the release matrix, not from either choice list: that matrix
+    # is what decides which binaries exist, so it is the one list the other three
+    # have to follow.
+    expected_choices = ["all", *release_caps]
+    for name, choices in (
+        (RELEASE_WORKFLOW, release_choices),
+        (DOCKER_WORKFLOW, docker_choices),
+    ):
+        if choices != expected_choices:
+            problems.append(
+                f"{name}: the `compute_cap` input options are {choices}, expected "
+                f"{expected_choices}. A capability that is built but cannot be "
+                "selected is unreachable from a manual dispatch."
+            )
+
+    if default not in docker_caps:
+        problems.append(
+            f"{DOCKER_WORKFLOW}: DEFAULT_CUDA_COMPUTE_CAP is {default!r}, which is not "
+            f"one of {docker_caps}. The unsuffixed `-cuda` tags alias that capability, "
+            "so they would never be published."
+        )
+
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workflows-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "workflows",
+        help="path to .github/workflows (default: this repository's)",
+    )
+    args = parser.parse_args(argv)
+
+    problems = check(args.workflows_dir)
+    if problems:
+        print(f"FAIL: {len(problems)} problem(s) in {args.workflows_dir}:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: {RELEASE_WORKFLOW} and {DOCKER_WORKFLOW} agree on the CUDA compute "
+        "capabilities, every capability is selectable, and the default is one of them"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_cuda_compute_caps.py
+++ b/.github/scripts/test_cuda_compute_caps.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Tests for check_cuda_compute_caps.py — the CUDA compute-capability drift guard.
+"""Unit tests for the CUDA compute-capability drift guard."""
+
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_cuda_compute_caps import (  # noqa: E402
+    DOCKER_WORKFLOW,
+    RELEASE_WORKFLOW,
+    check,
+    default_cap,
+    dispatch_choices,
+    docker_shell_caps,
+    load_workflow,
+    main,
+    release_matrix_caps,
+)
+
+# Minimal stand-ins for the two real workflows: only the parts this guard reads.
+
+
+def release_workflow(caps: list[str], choices: list[str] | None = None) -> str:
+    entries = ",\n".join(
+        f"""              {{
+                compute_cap: "{cap}",
+                runner: runner,
+                target_os: "linux",
+                target_arch: "x86_64"
+              }}"""
+        for cap in caps
+    )
+    options = "\n".join(f"          - '{choice}'" for choice in (choices or ["all", *caps]))
+    return f"""---
+name: build_and_release_cuda
+
+on:
+  workflow_dispatch:
+    inputs:
+      compute_cap:
+        description: 'Which CUDA compute capability to build for?'
+        required: false
+        type: choice
+        options:
+{options}
+        default: 'all'
+
+jobs:
+  setup-matrix:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const matrix = [
+{entries}
+            ];
+            if (context.eventName === 'pull_request') {{
+              return matrix.filter(m => m.compute_cap === "90");
+            }}
+            return matrix;
+"""
+
+
+def docker_workflow(
+    caps: list[str],
+    choices: list[str] | None = None,
+    default: str = "80",
+) -> str:
+    options = "\n".join(f"          - '{choice}'" for choice in (choices or ["all", *caps]))
+    return f"""---
+name: spiced_docker
+
+on:
+  workflow_dispatch:
+    inputs:
+      compute_cap:
+        description: Which CUDA compute capability to package
+        required: false
+        type: choice
+        options:
+{options}
+        default: all
+
+env:
+  DEFAULT_CUDA_COMPUTE_CAP: '{default}'
+
+jobs:
+  setup:
+    runs-on: ubuntu-24.04
+    steps:
+      - id: resolve
+        run: |
+          all_compute_caps='{" ".join(caps)}'
+          echo "cuda_compute_caps=${{cuda_compute_caps}}" >> "$GITHUB_OUTPUT"
+"""
+
+
+class WorkflowsDir:
+    """A temporary .github/workflows holding the two workflows under test."""
+
+    def __init__(self, release: str | None, docker: str | None):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self._tmp.name)
+        if release is not None:
+            (self.path / RELEASE_WORKFLOW).write_text(release, encoding="utf-8")
+        if docker is not None:
+            (self.path / DOCKER_WORKFLOW).write_text(docker, encoding="utf-8")
+
+    def __enter__(self) -> Path:
+        return self.path
+
+    def __exit__(self, *exc) -> None:
+        self._tmp.cleanup()
+
+
+CAPS = ["80", "86", "87", "89", "90"]
+
+
+class CheckTest(unittest.TestCase):
+    def test_matching_lists_are_accepted(self):
+        with WorkflowsDir(release_workflow(CAPS), docker_workflow(CAPS)) as workflows:
+            self.assertEqual(check(workflows), [])
+
+    def test_the_pre_fix_docker_workflow_is_rejected(self):
+        """Regression test for #10622: the release workflow built five capabilities
+        and the docker workflow packaged one.
+
+        Two problems, because the pre-fix workflow had two: the four capabilities
+        were neither packaged nor selectable.
+        """
+        with WorkflowsDir(release_workflow(CAPS), docker_workflow(["80"])) as workflows:
+            problems = check(workflows)
+        self.assertEqual(len(problems), 2)
+        joined = "\n".join(problems)
+        self.assertIn("['86', '87', '89', '90']", joined)
+        self.assertIn("never packaged into an image", joined)
+        self.assertIn("unreachable from a manual dispatch", joined)
+        self.assertIn("#10622", joined)
+
+    def test_a_capability_with_no_release_asset_is_rejected(self):
+        """The inverse drift: packaging a capability nothing builds a binary for."""
+        with WorkflowsDir(release_workflow(CAPS), docker_workflow([*CAPS, "120"])) as workflows:
+            problems = check(workflows)
+        self.assertEqual(len(problems), 2)  # the mismatch, and the unreachable choice
+        self.assertIn("no release asset to download", problems[0])
+        self.assertIn("['120']", problems[0])
+
+    def test_an_unselectable_capability_is_rejected(self):
+        """A capability that is built but missing from the dispatch choice list."""
+        with WorkflowsDir(
+            release_workflow(CAPS),
+            docker_workflow(CAPS, choices=["all", "80", "86", "87", "89"]),
+        ) as workflows:
+            problems = check(workflows)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("`compute_cap` input options", problems[0])
+        self.assertIn("unreachable from a manual dispatch", problems[0])
+
+    def test_the_release_workflows_choices_are_checked_too(self):
+        with WorkflowsDir(
+            release_workflow(CAPS, choices=["all", "80"]),
+            docker_workflow(CAPS),
+        ) as workflows:
+            problems = check(workflows)
+        self.assertEqual(len(problems), 1)
+        self.assertIn(RELEASE_WORKFLOW, problems[0])
+
+    def test_a_default_outside_the_list_is_rejected(self):
+        """The unsuffixed `-cuda` tags alias the default, so it has to be built."""
+        with WorkflowsDir(
+            release_workflow(CAPS), docker_workflow(CAPS, default="75")
+        ) as workflows:
+            problems = check(workflows)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("DEFAULT_CUDA_COMPUTE_CAP", problems[0])
+        self.assertIn("would never be published", problems[0])
+
+    def test_a_duplicate_capability_is_rejected(self):
+        with WorkflowsDir(
+            release_workflow(CAPS),
+            docker_workflow([*CAPS, "90"], choices=["all", *CAPS]),
+        ) as workflows:
+            problems = check(workflows)
+        self.assertTrue(any("listed more than once" in problem for problem in problems))
+
+    def test_a_missing_workflow_is_reported(self):
+        with WorkflowsDir(None, docker_workflow(CAPS)) as workflows:
+            problems = check(workflows)
+        self.assertEqual(len(problems), 1)
+        self.assertIn(RELEASE_WORKFLOW, problems[0])
+
+    def test_malformed_yaml_is_reported(self):
+        with WorkflowsDir(release_workflow(CAPS), "name: [unclosed\n") as workflows:
+            problems = check(workflows)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("does not parse as YAML", problems[0])
+
+    def test_a_missing_matrix_is_reported(self):
+        with WorkflowsDir("name: nothing-here\n", docker_workflow(CAPS)) as workflows:
+            problems = check(workflows)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("found no", problems[0])
+
+
+class ParsingTest(unittest.TestCase):
+    def test_release_matrix_caps_ignores_js_comparisons(self):
+        """`m.compute_cap === "90"` is a filter, not a matrix entry."""
+        self.assertEqual(release_matrix_caps(release_workflow(CAPS)), CAPS)
+
+    def test_docker_shell_caps_reads_the_assignment(self):
+        self.assertEqual(docker_shell_caps(docker_workflow(CAPS)), CAPS)
+
+    def test_docker_shell_caps_rejects_an_empty_list(self):
+        with self.assertRaises(ValueError):
+            docker_shell_caps("          all_compute_caps=''\n")
+
+    def test_dispatch_choices_handles_the_yaml_on_key(self):
+        """PyYAML resolves an unquoted `on:` to the boolean True."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / DOCKER_WORKFLOW
+            path.write_text(docker_workflow(CAPS), encoding="utf-8")
+            workflow = load_workflow(path)
+        self.assertEqual(dispatch_choices(workflow, "compute_cap"), ["all", *CAPS])
+
+    def test_dispatch_choices_reports_a_missing_input(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / DOCKER_WORKFLOW
+            path.write_text(docker_workflow(CAPS), encoding="utf-8")
+            workflow = load_workflow(path)
+        with self.assertRaises(ValueError):
+            dispatch_choices(workflow, "not_an_input")
+
+    def test_default_cap_is_read_as_text(self):
+        """An unquoted 80 parses as an int; it still has to compare to the caps."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / DOCKER_WORKFLOW
+            path.write_text(
+                docker_workflow(CAPS).replace("'80'", "80"), encoding="utf-8"
+            )
+            workflow = load_workflow(path)
+        self.assertEqual(default_cap(workflow), "80")
+
+
+class RepositoryTest(unittest.TestCase):
+    def test_this_repositorys_workflows_agree(self):
+        """Regression test for #10622 against the real .github/workflows."""
+        workflows = Path(__file__).resolve().parents[1] / "workflows"
+        self.assertEqual(check(workflows), [])
+
+
+class MainTest(unittest.TestCase):
+    def test_exit_codes(self):
+        with WorkflowsDir(release_workflow(CAPS), docker_workflow(CAPS)) as workflows:
+            out = io.StringIO()
+            with redirect_stdout(out):
+                self.assertEqual(main(["--workflows-dir", str(workflows)]), 0)
+            self.assertIn("OK:", out.getvalue())
+
+        with WorkflowsDir(release_workflow(CAPS), docker_workflow(["80"])) as workflows:
+            err = io.StringIO()
+            with redirect_stderr(err):
+                self.assertEqual(main(["--workflows-dir", str(workflows)]), 1)
+            self.assertIn("FAIL:", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_spiced_docker_cuda_publish.py
+++ b/.github/scripts/test_spiced_docker_cuda_publish.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -67,6 +68,7 @@ def run_publish(
     rel_version: str = "9.9.9",
     default_cap: str = "80",
     extra_files: list[str] | None = None,
+    expected_caps: list[str] | None = None,
 ) -> tuple[int, list[str], str]:
     """Run the publish step over fake artifacts for `caps`.
 
@@ -107,6 +109,10 @@ def run_publish(
             "REL_VERSION": rel_version,
             "SHOULD_TAG_LATEST": should_tag_latest,
             "DEFAULT_CUDA_COMPUTE_CAP": default_cap,
+            # The setup job hands this to the publish job as a JSON array.
+            "CUDA_COMPUTE_CAPS": json.dumps(
+                expected_caps if expected_caps is not None else caps
+            ),
         }
         completed = subprocess.run(
             ["bash", "-c", script], env=env, capture_output=True, text=True
@@ -184,10 +190,24 @@ class PublishTest(unittest.TestCase):
         self.assertEqual(calls, [])
 
     def test_a_stray_tarball_is_refused(self):
-        """The capability is parsed from a filename, so it is re-validated."""
+        """The capability is parsed from a filename, so its shape is re-validated."""
         code, _, stderr = run_publish(["80"], extra_files=["images-amd64-cuda-evil.tar"])
         self.assertEqual(code, 1)
         self.assertIn("is not a compute capability", stderr)
+
+    def test_a_capability_this_run_did_not_build_is_refused(self):
+        """A well-formed but unexpected number must not reach a published tag."""
+        code, _, stderr = run_publish(
+            ["80"], extra_files=["images-amd64-cuda-120.tar"], expected_caps=["80"]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("capability 120 is not one of", stderr)
+
+    def test_an_empty_capability_list_with_artifacts_present_is_refused(self):
+        """Artifacts but no resolved capabilities means the two disagree."""
+        code, _, stderr = run_publish(["80"], expected_caps=[])
+        self.assertEqual(code, 1)
+        self.assertIn("No compute capabilities resolved", stderr)
 
     def test_each_capability_is_loaded_from_its_own_tarball(self):
         code, calls, stderr = run_publish(CAPS)

--- a/.github/scripts/test_spiced_docker_cuda_publish.py
+++ b/.github/scripts/test_spiced_docker_cuda_publish.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Tests for the CUDA publish step in .github/workflows/spiced_docker.yml.
+#
+# That step decides which Docker tags a release publishes. It only ever runs
+# during a release dispatch, on a self-hosted runner, against real registries —
+# so a mistake in it is expensive to discover and cannot be reproduced locally.
+#
+# These tests extract the step's script straight out of the workflow and run it
+# with a stub `docker` on PATH, so the assertions are against the same text CI
+# executes rather than a copy that can drift. Nothing is pulled or pushed: the
+# stub records its arguments and exits 0.
+"""Execute the spiced_docker CUDA publish step against a stub docker."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[1] / "workflows" / "spiced_docker.yml"
+STEP_NAME = "Import images and create manifests"
+JOB_NAME = "publish-cuda"
+
+# The stub stands in for every `docker` call the step makes. It appends its
+# arguments to $DOCKER_LOG so the test can assert on what would have run.
+DOCKER_STUB = """#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$DOCKER_LOG"
+exit 0
+"""
+
+
+def bash_path(path: Path) -> str:
+    """Return `path` as the shell sees it.
+
+    On CI this is the identity. It exists so the suite is also runnable on a
+    Windows dev machine, where bash is present but `C:\\x` is not a path it can
+    glob.
+    """
+    if sys.platform != "win32":
+        return str(path)
+    drive, rest = os.path.splitdrive(path)
+    return f"/{drive[0].lower()}{rest.replace(os.sep, '/')}"
+
+
+def publish_script() -> str:
+    """Return the CUDA publish step's `run:` script, read from the workflow."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"][JOB_NAME]["steps"]
+    for step in steps:
+        if step.get("name") == STEP_NAME:
+            return step["run"]
+    raise AssertionError(f"{JOB_NAME} has no step named {STEP_NAME!r}")
+
+
+def run_publish(
+    caps: list[str],
+    *,
+    publish: str = "true",
+    should_tag_latest: str = "true",
+    rel_version: str = "9.9.9",
+    default_cap: str = "80",
+    extra_files: list[str] | None = None,
+) -> tuple[int, list[str], str]:
+    """Run the publish step over fake artifacts for `caps`.
+
+    Returns (exit code, the stub's recorded docker invocations, stderr).
+
+    The only edit made to the script is repointing /tmp at a scratch directory,
+    so the test cannot collide with a real /tmp or with a parallel run.
+    """
+    script = publish_script()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        artifacts = tmpdir / "artifacts"
+        artifacts.mkdir()
+        script = script.replace(
+            "/tmp/images-amd64-cuda-", f"{bash_path(artifacts)}/images-amd64-cuda-"
+        )
+
+        for cap in caps:
+            (artifacts / f"images-amd64-cuda-{cap}.tar").write_text("fake", encoding="utf-8")
+        for name in extra_files or []:
+            (artifacts / name).write_text("fake", encoding="utf-8")
+
+        bin_dir = tmpdir / "bin"
+        bin_dir.mkdir()
+        stub = bin_dir / "docker"
+        stub.write_text(DOCKER_STUB, encoding="utf-8", newline="\n")
+        stub.chmod(0o755)
+
+        log = tmpdir / "docker.log"
+        log.touch()
+
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "DOCKER_LOG": str(log),
+            "PUBLISH": publish,
+            "REL_VERSION": rel_version,
+            "SHOULD_TAG_LATEST": should_tag_latest,
+            "DEFAULT_CUDA_COMPUTE_CAP": default_cap,
+        }
+        completed = subprocess.run(
+            ["bash", "-c", script], env=env, capture_output=True, text=True
+        )
+        calls = [line for line in log.read_text(encoding="utf-8").splitlines() if line]
+        return completed.returncode, calls, completed.stderr
+
+
+def tags_in(calls: list[str]) -> set[str]:
+    """Return every `-t <ref>` argument across the recorded docker calls."""
+    tags: set[str] = set()
+    for call in calls:
+        parts = call.split()
+        for index, part in enumerate(parts):
+            if part == "-t" and index + 1 < len(parts):
+                tags.add(parts[index + 1])
+    return tags
+
+
+CAPS = ["80", "86", "87", "89", "90"]
+
+
+class PublishTest(unittest.TestCase):
+    def test_every_capability_gets_its_own_tag(self):
+        """Regression test for #10622: five capabilities in, five tag pairs out."""
+        code, calls, stderr = run_publish(CAPS)
+        self.assertEqual(code, 0, stderr)
+        tags = tags_in(calls)
+        for cap in CAPS:
+            self.assertIn(f"ghcr.io/spiceai/spiceai:9.9.9-cuda-{cap}", tags)
+            self.assertIn(f"spiceai/spiceai:9.9.9-cuda-{cap}", tags)
+            self.assertIn(f"ghcr.io/spiceai/spiceai:latest-cuda-{cap}", tags)
+            self.assertIn(f"spiceai/spiceai:latest-cuda-{cap}", tags)
+
+    def test_the_unsuffixed_tags_alias_the_default_capability(self):
+        """`latest-cuda` has always been an sm_80 image and has to stay one."""
+        code, calls, stderr = run_publish(CAPS)
+        self.assertEqual(code, 0, stderr)
+        tags = tags_in(calls)
+        self.assertIn("ghcr.io/spiceai/spiceai:latest-cuda", tags)
+        self.assertIn("ghcr.io/spiceai/spiceai:9.9.9-cuda", tags)
+
+        # ...and it is created from the 80 image, not from whichever ran last.
+        aliasing = [call for call in calls if " -t ghcr.io/spiceai/spiceai:latest-cuda " in f" {call} "]
+        self.assertEqual(len(aliasing), 1)
+        self.assertTrue(aliasing[0].endswith("localhost:5000/spiceai:cuda-80-amd64"))
+
+    def test_a_non_default_capability_gets_no_unsuffixed_tag(self):
+        code, calls, stderr = run_publish(["89"])
+        self.assertEqual(code, 0, stderr)
+        tags = tags_in(calls)
+        self.assertIn("ghcr.io/spiceai/spiceai:latest-cuda-89", tags)
+        self.assertNotIn("ghcr.io/spiceai/spiceai:latest-cuda", tags)
+        self.assertNotIn("ghcr.io/spiceai/spiceai:9.9.9-cuda", tags)
+
+    def test_a_pre_release_skips_the_latest_tags(self):
+        code, calls, stderr = run_publish(CAPS, should_tag_latest="false")
+        self.assertEqual(code, 0, stderr)
+        tags = tags_in(calls)
+        self.assertIn("ghcr.io/spiceai/spiceai:9.9.9-cuda-90", tags)
+        self.assertFalse({tag for tag in tags if ":latest" in tag})
+
+    def test_a_non_publish_run_touches_no_registry(self):
+        code, calls, stderr = run_publish(CAPS, publish="false")
+        self.assertEqual(code, 0, stderr)
+        tags = tags_in(calls)
+        self.assertTrue(all(tag.startswith("localhost:5000/") for tag in tags), tags)
+        self.assertIn("localhost:5000/spiceai:latest-cuda-90", tags)
+        self.assertIn("localhost:5000/spiceai:latest-cuda", tags)
+
+    def test_no_artifacts_is_not_a_failure(self):
+        """A run with CUDA disabled must no-op rather than fail the workflow."""
+        code, calls, stderr = run_publish([])
+        self.assertEqual(code, 0, stderr)
+        self.assertEqual(calls, [])
+
+    def test_a_stray_tarball_is_refused(self):
+        """The capability is parsed from a filename, so it is re-validated."""
+        code, _, stderr = run_publish(["80"], extra_files=["images-amd64-cuda-evil.tar"])
+        self.assertEqual(code, 1)
+        self.assertIn("is not a compute capability", stderr)
+
+    def test_each_capability_is_loaded_from_its_own_tarball(self):
+        code, calls, stderr = run_publish(CAPS)
+        self.assertEqual(code, 0, stderr)
+        loads = [call for call in calls if call.startswith("load -i ")]
+        self.assertEqual(len(loads), len(CAPS))
+        for cap in CAPS:
+            self.assertTrue(
+                any(call.endswith(f"images-amd64-cuda-{cap}.tar") for call in loads),
+                f"no load for capability {cap}: {loads}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -647,6 +647,10 @@ jobs:
     if: ${{ needs.setup.outputs.run_cuda == 'true' }}
     runs-on: ubuntu-24.04
     env:
+      # The capabilities `setup` resolved, so the publish step can check what it
+      # parsed out of an artifact filename against what this run actually built
+      # rather than trusting the filename's shape alone.
+      CUDA_COMPUTE_CAPS: ${{ needs.setup.outputs.cuda_compute_caps }}
       REL_VERSION: ${{ needs.setup.outputs.rel_version }}
       PUBLISH: ${{ needs.setup.outputs.publish }}
       SHOULD_TAG_LATEST: ${{ needs.setup.outputs.should_tag_latest }}
@@ -708,6 +712,15 @@ jobs:
             exit 0
           fi
 
+          # The capabilities this run built, as a word list. Every non-digit in
+          # the JSON array becomes a separator, so `["80","86"]` reads as `80 86`
+          # without needing jq on the runner.
+          read -r -a expected_caps <<< "${CUDA_COMPUTE_CAPS//[^0-9]/ }"
+          if [ ${#expected_caps[@]} -eq 0 ]; then
+            echo "No compute capabilities resolved, but artifacts are present." >&2
+            exit 1
+          fi
+
           # Each capability is published under its own tag suffix. The
           # unsuffixed `-cuda` tags are kept as an alias of
           # DEFAULT_CUDA_COMPUTE_CAP so existing pulls keep resolving to the
@@ -716,12 +729,25 @@ jobs:
             cap="${tarball##*/images-amd64-cuda-}"
             cap="${cap%.tar}"
 
-            # The capability comes from a filename rather than from the
-            # validated list, so re-check it here: it is about to become part of
-            # a published image tag, and any other tarball that happened to match
-            # the glob would otherwise be published under a nonsense one.
+            # The capability comes from a filename rather than from the resolved
+            # list, so re-check it here: it is about to become part of a
+            # published image tag. Shape first, for a clear message on a stray
+            # file, then membership — a well-formed but unexpected number like
+            # `120` would otherwise be published under a tag this run never
+            # built.
             if ! [[ "${cap}" =~ ^[0-9]+$ ]]; then
               echo "Refusing to publish ${tarball}: '${cap}' is not a compute capability" >&2
+              exit 1
+            fi
+            matched=false
+            for expected in "${expected_caps[@]}"; do
+              if [ "${cap}" = "${expected}" ]; then
+                matched=true
+              fi
+            done
+            if [ "${matched}" != "true" ]; then
+              echo "Refusing to publish ${tarball}: capability ${cap} is not one of" \
+                   "${expected_caps[*]}, which is what this run built" >&2
               exit 1
             fi
 

--- a/.github/workflows/spiced_docker.yml
+++ b/.github/workflows/spiced_docker.yml
@@ -41,6 +41,29 @@ on:
           - arm64
           - cuda
         default: all
+      compute_cap:
+        # Must stay in sync with the matrix in build_and_release_cuda.yml — that
+        # workflow produces the release assets this one packages, so a capability
+        # missing there cannot be built here. Enforced by
+        # .github/scripts/check_cuda_compute_caps.py.
+        description: Which CUDA compute capability to package (only applies when CUDA is built)
+        required: false
+        type: choice
+        options:
+          - all
+          - '80'
+          - '86'
+          - '87'
+          - '89'
+          - '90'
+        default: all
+
+env:
+  # The capability the unsuffixed `:<version>-cuda` / `:latest-cuda` tags point
+  # at. It stays 80 because those tags have always shipped an sm_80 binary, and
+  # an image whose contents silently changed capability would break the pulls
+  # that already depend on them. Per-capability tags are additive.
+  DEFAULT_CUDA_COMPUTE_CAP: '80'
 
 jobs:
   setup:
@@ -81,12 +104,19 @@ jobs:
       run_amd64: ${{ steps.resolve.outputs.run_amd64 }}
       run_arm64: ${{ steps.resolve.outputs.run_arm64 }}
       run_cuda: ${{ steps.resolve.outputs.run_cuda }}
+      cuda_compute_caps: ${{ steps.resolve.outputs.cuda_compute_caps }}
     steps:
       - name: Resolve release metadata
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          # Passed through the environment rather than interpolated into the
+          # script body, so the value can never be parsed as shell. It is a
+          # `choice` input, so GitHub already constrains it, but a dispatch input
+          # reaching `run:` via `${{ }}` is the shape of a script injection and
+          # is not worth reproducing for a new input.
+          COMPUTE_CAP_INPUT: ${{ github.event.inputs.compute_cap }}
         run: |
           set -euo pipefail
 
@@ -95,12 +125,14 @@ jobs:
             target_input="${{ github.event.inputs.target }}"
             publish_flag="${{ github.event.inputs.publish || 'false' }}"
             release_tag_input="${{ github.event.inputs.release_tag }}"
+            compute_cap_input="${COMPUTE_CAP_INPUT:-all}"
             allow_cuda=true
           else
             # For release events, CUDA is not built (nightly-only)
             target_input="all"
             publish_flag="true"
             release_tag_input="${{ github.event.release.tag_name }}"
+            compute_cap_input="all"
             allow_cuda=false
           fi
 
@@ -165,6 +197,55 @@ jobs:
               ;;
           esac
 
+          # CUDA compute capabilities to package. `build_and_release_cuda.yml`
+          # publishes one `spiced_cuda_<cap>_linux_x86_64.tar.gz` release asset
+          # per capability, and this workflow turns each into an image. Building
+          # only 80 is what left the CUDA image unusable on anything newer than
+          # an A100 even though the binaries existed (#10622).
+          #
+          # Kept in sync with that workflow's matrix — and with the choice list
+          # on this workflow's `compute_cap` input — by
+          # .github/scripts/check_cuda_compute_caps.py.
+          all_compute_caps='80 86 87 89 90'
+
+          compute_cap_input="${compute_cap_input:-all}"
+          if [ "$compute_cap_input" = "all" ]; then
+            selected_caps="$all_compute_caps"
+          else
+            selected_caps=""
+            for cap in $all_compute_caps; do
+              if [ "$cap" = "$compute_cap_input" ]; then
+                selected_caps="$cap"
+              fi
+            done
+            if [ -z "$selected_caps" ]; then
+              echo "Unknown CUDA compute capability: $compute_cap_input" >&2
+              echo "Known capabilities: $all_compute_caps" >&2
+              exit 1
+            fi
+          fi
+
+          # The matrix must never be empty. `build-cuda` is deliberately always
+          # scheduled — it no-ops through per-step `if`s rather than a job-level
+          # one, so that `publish-cuda`'s `needs` can still be satisfied — and an
+          # empty matrix would skip the job rather than run it as a no-op. When
+          # CUDA is not being built, collapse to the single default capability so
+          # exactly one no-op job runs, exactly as before this change.
+          if [ "$run_cuda" != "true" ]; then
+            selected_caps="${DEFAULT_CUDA_COMPUTE_CAP}"
+          fi
+
+          # Built by hand rather than with `jq` so this step keeps working on any
+          # runner image, hosted or self-hosted, without a tool check.
+          cuda_compute_caps="["
+          cap_sep=""
+          for cap in $selected_caps; do
+            cuda_compute_caps="${cuda_compute_caps}${cap_sep}\"${cap}\""
+            cap_sep=","
+          done
+          cuda_compute_caps="${cuda_compute_caps}]"
+          echo "CUDA compute capabilities: ${cuda_compute_caps}"
+
           # Determine if this release should be tagged as 'latest'.
           #
           # Rule: ONLY apply the ':latest' Docker tag when the GitHub release
@@ -217,6 +298,7 @@ jobs:
           echo "run_amd64=${run_amd64}" >> "$GITHUB_OUTPUT"
           echo "run_arm64=${run_arm64}" >> "$GITHUB_OUTPUT"
           echo "run_cuda=${run_cuda}" >> "$GITHUB_OUTPUT"
+          echo "cuda_compute_caps=${cuda_compute_caps}" >> "$GITHUB_OUTPUT"
 
   build-amd64:
     needs: setup
@@ -360,10 +442,20 @@ jobs:
         if: ${{ needs.setup.outputs.run_arm64 == 'true' }}
 
   build-cuda:
+    name: Build CUDA ${{ matrix.compute_cap }} image
     needs: setup
     runs-on: 'spiceai-dev-runners'
+    strategy:
+      # One capability's failure should not cancel the others mid-build, so a
+      # broken run reports every capability that failed instead of only the
+      # first. `publish-cuda` still needs the whole job green, so a partial set
+      # is never published — a release missing some CUDA tags with no failure
+      # anywhere is harder to notice than one that failed outright.
+      fail-fast: false
+      matrix:
+        compute_cap: ${{ fromJson(needs.setup.outputs.cuda_compute_caps) }}
     env:
-      CUDA_COMPUTE_CAP: 80
+      CUDA_COMPUTE_CAP: ${{ matrix.compute_cap }}
     steps:
       - name: Skip CUDA build
         if: ${{ needs.setup.outputs.run_cuda != 'true' }}
@@ -387,7 +479,7 @@ jobs:
 
       - name: Configure CUDA build
         run: |
-          echo "IMAGE_TAG=cuda" >> $GITHUB_ENV
+          echo "IMAGE_TAG=cuda-${CUDA_COMPUTE_CAP}" >> $GITHUB_ENV
           echo "BINARY_VARIANT=cuda" >> $GITHUB_ENV
           echo "CARGO_FEATURES=release,models,cuda" >> $GITHUB_ENV
         if: ${{ needs.setup.outputs.run_cuda == 'true' }}
@@ -398,9 +490,12 @@ jobs:
           context: .
           file: Dockerfile-cuda-release
           platforms: linux/amd64
-          outputs: type=docker,name=localhost:5000/spiceai:${{ env.IMAGE_TAG }}-amd64,dest=/tmp/images-amd64-cuda.tar
-          cache-from: type=gha,scope=build-cuda
-          cache-to: type=gha,scope=build-cuda,mode=max
+          outputs: type=docker,name=localhost:5000/spiceai:${{ env.IMAGE_TAG }}-amd64,dest=/tmp/images-amd64-cuda-${{ matrix.compute_cap }}.tar
+          # Scoped per capability: the layers differ only in the release asset
+          # each one downloads, so a shared scope would have the capabilities
+          # evicting each other's cache on every run.
+          cache-from: type=gha,scope=build-cuda-${{ matrix.compute_cap }}
+          cache-to: type=gha,scope=build-cuda-${{ matrix.compute_cap }},mode=max
           build-args: |
             REL_VERSION=${{ needs.setup.outputs.rel_version }}
             CARGO_FEATURES=${{ env.CARGO_FEATURES }}
@@ -410,15 +505,15 @@ jobs:
 
       - name: Validate CUDA image
         run: |
-          docker load -i /tmp/images-amd64-cuda.tar
+          docker load -i /tmp/images-amd64-cuda-${{ matrix.compute_cap }}.tar
           docker run --rm localhost:5000/spiceai:${{ env.IMAGE_TAG }}-amd64 --version
         if: ${{ needs.setup.outputs.run_cuda == 'true' }}
 
       - name: Upload CUDA artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: images-amd64-cuda
-          path: /tmp/images-amd64-cuda.tar
+          name: images-amd64-cuda-${{ matrix.compute_cap }}
+          path: /tmp/images-amd64-cuda-${{ matrix.compute_cap }}.tar
         if: ${{ needs.setup.outputs.run_cuda == 'true' }}
 
   publish:
@@ -559,7 +654,11 @@ jobs:
       - name: Download CUDA artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: images-amd64-cuda
+          # One artifact per compute capability. `merge-multiple` flattens them
+          # into /tmp rather than one directory per artifact, so the tarballs
+          # land at the paths the publish step globs for.
+          pattern: images-amd64-cuda-*
+          merge-multiple: true
           path: /tmp
 
       - name: Verify artifacts
@@ -600,43 +699,77 @@ jobs:
 
       - name: Import images and create manifests
         run: |
-          if [ ! -f /tmp/images-amd64-cuda.tar ]; then
+          set -euo pipefail
+
+          shopt -s nullglob
+          tarballs=(/tmp/images-amd64-cuda-*.tar)
+          if [ ${#tarballs[@]} -eq 0 ]; then
             echo "No CUDA artifacts to publish."
             exit 0
           fi
 
-          echo "Handling CUDA..."
-          docker load -i /tmp/images-amd64-cuda.tar
-          docker push localhost:5000/spiceai:cuda-amd64
+          # Each capability is published under its own tag suffix. The
+          # unsuffixed `-cuda` tags are kept as an alias of
+          # DEFAULT_CUDA_COMPUTE_CAP so existing pulls keep resolving to the
+          # same binary they always have. See #10622.
+          for tarball in "${tarballs[@]}"; do
+            cap="${tarball##*/images-amd64-cuda-}"
+            cap="${cap%.tar}"
 
-          if [[ "${PUBLISH}" == "true" ]]; then
-            echo "Pushing CUDA to GHCR and DockerHub"
-
-            # Build tag arguments - always include version tag
-            ghcr_tags="-t ghcr.io/spiceai/spiceai:${REL_VERSION}-cuda"
-            dockerhub_tags="-t spiceai/spiceai:${REL_VERSION}-cuda"
-
-            # Add optionally 'latest-cuda' tags
-            if [[ "${SHOULD_TAG_LATEST}" == "true" ]]; then
-              echo "Adding 'latest-cuda' tag"
-              ghcr_tags="${ghcr_tags} -t ghcr.io/spiceai/spiceai:latest-cuda"
-              dockerhub_tags="${dockerhub_tags} -t spiceai/spiceai:latest-cuda"
-            else
-              echo "Skipping 'latest-cuda' tag (pre-release or explicitly disabled)"
+            # The capability comes from a filename rather than from the
+            # validated list, so re-check it here: it is about to become part of
+            # a published image tag, and any other tarball that happened to match
+            # the glob would otherwise be published under a nonsense one.
+            if ! [[ "${cap}" =~ ^[0-9]+$ ]]; then
+              echo "Refusing to publish ${tarball}: '${cap}' is not a compute capability" >&2
+              exit 1
             fi
 
-            docker buildx imagetools create ${ghcr_tags} ${dockerhub_tags} localhost:5000/spiceai:cuda-amd64
+            echo "Handling CUDA ${cap}..."
+            docker load -i "${tarball}"
+            docker push "localhost:5000/spiceai:cuda-${cap}-amd64"
 
-            echo "Verifying CUDA GHCR image:"
-            docker buildx imagetools inspect ghcr.io/spiceai/spiceai:${REL_VERSION}-cuda
+            suffixes=("-cuda-${cap}")
+            if [ "${cap}" = "${DEFAULT_CUDA_COMPUTE_CAP}" ]; then
+              echo "Compute capability ${cap} is the default; also tagging it unsuffixed"
+              suffixes+=("-cuda")
+            fi
 
-            echo "Verifying CUDA DockerHub image:"
-            docker buildx imagetools inspect spiceai/spiceai:${REL_VERSION}-cuda
-          else
-            echo "Skipping push for non-publish CUDA build"
-            docker buildx imagetools create \
-              -t localhost:5000/spiceai:latest-cuda \
-              localhost:5000/spiceai:cuda-amd64
+            if [[ "${PUBLISH}" == "true" ]]; then
+              echo "Pushing CUDA ${cap} to GHCR and DockerHub"
 
-            docker buildx imagetools inspect localhost:5000/spiceai:latest-cuda
-          fi
+              tags=()
+              for suffix in "${suffixes[@]}"; do
+                # Always include the version tag.
+                tags+=(-t "ghcr.io/spiceai/spiceai:${REL_VERSION}${suffix}")
+                tags+=(-t "spiceai/spiceai:${REL_VERSION}${suffix}")
+
+                # Optionally add the 'latest' tags.
+                if [[ "${SHOULD_TAG_LATEST}" == "true" ]]; then
+                  echo "Adding 'latest${suffix}' tag"
+                  tags+=(-t "ghcr.io/spiceai/spiceai:latest${suffix}")
+                  tags+=(-t "spiceai/spiceai:latest${suffix}")
+                else
+                  echo "Skipping 'latest${suffix}' tag (pre-release or explicitly disabled)"
+                fi
+              done
+
+              docker buildx imagetools create "${tags[@]}" "localhost:5000/spiceai:cuda-${cap}-amd64"
+
+              echo "Verifying CUDA ${cap} GHCR image:"
+              docker buildx imagetools inspect "ghcr.io/spiceai/spiceai:${REL_VERSION}-cuda-${cap}"
+
+              echo "Verifying CUDA ${cap} DockerHub image:"
+              docker buildx imagetools inspect "spiceai/spiceai:${REL_VERSION}-cuda-${cap}"
+            else
+              echo "Skipping push for non-publish CUDA ${cap} build"
+
+              tags=()
+              for suffix in "${suffixes[@]}"; do
+                tags+=(-t "localhost:5000/spiceai:latest${suffix}")
+              done
+
+              docker buildx imagetools create "${tags[@]}" "localhost:5000/spiceai:cuda-${cap}-amd64"
+              docker buildx imagetools inspect "localhost:5000/spiceai:latest-cuda-${cap}"
+            fi
+          done

--- a/.github/workflows/workflow_yaml_check.yml
+++ b/.github/workflows/workflow_yaml_check.yml
@@ -16,6 +16,9 @@ on:
       - '.github/actions/**'
       - '.github/scripts/check_workflow_yaml.py'
       - '.github/scripts/test_check_workflow_yaml.py'
+      - '.github/scripts/check_cuda_compute_caps.py'
+      - '.github/scripts/test_cuda_compute_caps.py'
+      - '.github/scripts/test_spiced_docker_cuda_publish.py'
   push:
     branches:
       - trunk
@@ -24,6 +27,9 @@ on:
       - '.github/actions/**'
       - '.github/scripts/check_workflow_yaml.py'
       - '.github/scripts/test_check_workflow_yaml.py'
+      - '.github/scripts/check_cuda_compute_caps.py'
+      - '.github/scripts/test_cuda_compute_caps.py'
+      - '.github/scripts/test_spiced_docker_cuda_publish.py'
   workflow_dispatch:
 
 concurrency:
@@ -55,3 +61,20 @@ jobs:
 
       - name: Validate GitHub Actions definitions
         run: python .github/scripts/check_workflow_yaml.py
+
+      # Two workflows have to agree on which CUDA compute capabilities exist —
+      # one builds the release binaries, the other packages them into images.
+      # Drift between them is silent: the image for a capability simply never
+      # gets published. See #10622.
+      - name: Run CUDA compute-capability tests
+        run: python .github/scripts/test_cuda_compute_caps.py -v
+
+      - name: Validate CUDA compute capabilities
+        run: python .github/scripts/check_cuda_compute_caps.py
+
+      # The CUDA publish step decides which Docker tags a release ships, and only
+      # ever runs during a release dispatch against real registries. This runs
+      # the step's own script with a stub `docker` so a tagging mistake is caught
+      # here instead of in a release.
+      - name: Test the spiced_docker CUDA publish step
+        run: python .github/scripts/test_spiced_docker_cuda_publish.py -v

--- a/docs/DISTRIBUTIONS.md
+++ b/docs/DISTRIBUTIONS.md
@@ -137,9 +137,21 @@ For Linux systems with NVIDIA GPUs, CUDA distributions enable GPU-accelerated AI
 
 **Docker (Nightly):**
 
+One image is published per compute capability. Pull the tag matching your GPU —
+`nvidia-smi --query-gpu=compute_cap --format=csv,noheader` reports it as `8.9`
+for capability `89`:
+
 ```bash
-docker pull ghcr.io/spiceai/spiceai-nightly:latest-cuda
+docker pull ghcr.io/spiceai/spiceai:latest-cuda-89
 ```
+
+The unsuffixed `latest-cuda` tag is an alias for `latest-cuda-80`, so it only
+runs on capability 80 hardware (A100, A30). Prefer the explicit tag.
+
+CUDA images are published to `ghcr.io/spiceai/spiceai` (and `spiceai/spiceai` on
+Docker Hub) by a manual dispatch of the `spiced_docker` workflow; they are not
+part of the automated nightly image build, so `spiceai-nightly` carries no CUDA
+tags.
 
 **Local Build:**
 

--- a/docs/DISTRIBUTIONS.md
+++ b/docs/DISTRIBUTIONS.md
@@ -135,7 +135,7 @@ For Linux systems with NVIDIA GPUs, CUDA distributions enable GPU-accelerated AI
 - 89 (RTX 40xx, L40, L4)
 - 90 (H100, H200)
 
-**Docker (Nightly):**
+**Docker:**
 
 One image is published per compute capability. Pull the tag matching your GPU —
 `nvidia-smi --query-gpu=compute_cap --format=csv,noheader` reports it as `8.9`


### PR DESCRIPTION
## Summary

`build_and_release_cuda.yml` builds a `spiced` binary for five CUDA compute capabilities and publishes one release asset each:

```
spiced_cuda_80_linux_x86_64.tar.gz   spiced_cuda_86_…   spiced_cuda_87_…   spiced_cuda_89_…   spiced_cuda_90_…
```

`spiced_docker.yml` packaged exactly one of them:

```yaml
  build-cuda:
    env:
      CUDA_COMPUTE_CAP: 80
```

So the CUDA image has always contained an sm_80 binary and is unusable on anything newer than an A100 — as reported for a Blackwell-class card on driver 580 / CUDA 13. The other four binaries were built, published to the release, and then never packaged. `docs/DISTRIBUTIONS.md` has listed all five capabilities as supported the whole time, which is true of the binaries and was not true of the image.

Fixes #10622

## Changes

**`.github/workflows/spiced_docker.yml`** — `build-cuda` becomes a matrix over the capabilities the release workflow publishes, and each is published under its own tag suffix:

```
ghcr.io/spiceai/spiceai:<version>-cuda-89     spiceai/spiceai:<version>-cuda-89
ghcr.io/spiceai/spiceai:latest-cuda-89        spiceai/spiceai:latest-cuda-89
```

Supporting changes: per-capability artifact names and buildx cache scopes (a shared `type=gha` scope would have the five capabilities evicting each other every run); `publish-cuda` collects the artifacts with `pattern:` + `merge-multiple: true` — the same spelling and the same action SHA already used in `build_and_release_cuda.yml`; and a `compute_cap` dispatch input to build a single capability instead of all five.

**`.github/scripts/check_cuda_compute_caps.py`** — the drift guard, with `.github/scripts/test_cuda_compute_caps.py` (18 tests). Four hand-maintained lists have to agree on which capabilities exist: the release workflow's JS matrix, this workflow's shell list, and both workflows' `compute_cap` choice options. Nothing connected them, which is how they came to disagree in the first place, and the failure is silent — adding a capability to the release workflow and forgetting the packaging side produces no error, just an image that quietly does not exist. The guard treats the release matrix as the source of truth and fails the build on any disagreement.

**`.github/scripts/test_spiced_docker_cuda_publish.py`** — 8 tests that extract the publish step's script straight out of the workflow and run it with a stub `docker` on `PATH`. That step only ever runs during a release dispatch against real registries, so this is the only way to assert on the tags it produces before a release does it for us.

**`.github/workflows/workflow_yaml_check.yml`** — runs all three. It already triggers on `.github/workflows/**` and is GitHub-hosted, so this adds no self-hosted pool load.

**`docs/DISTRIBUTIONS.md`** — documents the per-capability tags, and corrects the registry: the documented pull was `ghcr.io/spiceai/spiceai-nightly:latest-cuda`, and `spiceai-nightly` has **no** CUDA tags at all (checked against the GHCR tag list — 0 of its tags contain `cuda`). CUDA images are published to `ghcr.io/spiceai/spiceai`, where `latest-cuda` and `<version>-cuda` do exist. Corrected here rather than left, since this PR rewrites that same code block.

## Backwards compatibility

`latest-cuda` and `<version>-cuda` keep pointing at capability 80 — the binary they have always contained. The alias is driven by a single `DEFAULT_CUDA_COMPUTE_CAP` workflow env, the guard asserts that value is one of the built capabilities, and a test asserts the alias is created from the 80 image specifically rather than from whichever matrix leg finished last. Per-capability tags are purely additive; nothing that pulls today resolves to a different image after this.

## Trade-offs

**A release now needs all five capabilities to build.** `publish-cuda` still requires the whole `build-cuda` job green, so a partial CUDA tag set is never published. This does couple the release to five builds where it used to depend on one. It is deliberate: a release that quietly ships three of five CUDA tags with no failure anywhere is materially harder to notice than one that fails outright — that asymmetry is the bug being fixed. `fail-fast: false` means a broken run names every failing capability at once rather than one per re-run.

**Five parallel image builds instead of one**, on `spiceai-dev-runners`. Each downloads a release asset and assembles a runtime image; there is no Rust compilation in this path. The `compute_cap` dispatch input exists so a targeted rebuild does not have to pay for all five.

**The capability list is still duplicated**, now across four places rather than three. Deriving it from one source would mean generating the JS matrix or the `choice` options, neither of which GitHub Actions supports — `workflow_dispatch` options must be literals. The guard is the alternative: the lists stay hand-written but can no longer disagree silently.

## Test plan

- `python .github/scripts/test_cuda_compute_caps.py -v` — 18 tests: matching lists accepted; the pre-fix state rejected; the inverse drift (packaging a capability with no release asset) rejected; unselectable capabilities; a default outside the list; duplicates; missing file; malformed YAML; and the parsing edge cases (`m.compute_cap === "90"` is a JS filter and not a matrix entry, PyYAML resolving the `on:` key to `True`, an unquoted `80` parsing as an int).
- `python .github/scripts/test_spiced_docker_cuda_publish.py -v` — 8 tests against the real workflow script: every capability gets its four tags; the unsuffixed tags alias 80 and are built from the 80 image; a non-default capability gets no unsuffixed tag; a pre-release skips all `latest` tags; a non-publish run touches no registry; no artifacts is a no-op rather than a failure; a stray tarball is refused; each capability loads from its own tarball.
- `python .github/scripts/check_cuda_compute_caps.py` and `python .github/scripts/check_workflow_yaml.py` — the real repo passes both; 101 Actions definitions well-formed.
- Every `run:` block in `spiced_docker.yml` checked with `bash -n`.
- `make lint` and `make test` — no Rust files are touched, so the branch has no Rust-affecting changes and the gate skips lint/build/tests for it; the sign-off status is still posted.

**Neutered to prove the tests are load-bearing**, each against the real workflow file:

| Mutation | Result |
|---|---|
| `all_compute_caps='80'` (the pre-fix state) | `check_cuda_compute_caps` fails: `['86', '87', '89', '90'] have release binaries but are never packaged into an image` |
| add `compute_cap: "120"` to the release matrix only | fails on all three lists: the packaging gap plus both unreachable `compute_cap` choice lists |
| `DEFAULT_CUDA_COMPUTE_CAP: '75'` | fails: `not one of ['80', '86', '87', '89', '90'] … they would never be published` |
| remove the default-capability alias | 2 publish tests fail — the unsuffixed tags disappear |
| remove the capability re-validation | `test_a_stray_tarball_is_refused` fails |

## Checklist

- [x] Regression tests fail on the pre-fix workflow and pass on the new one
- [x] `latest-cuda` / `<version>-cuda` still resolve to capability 80, asserted by a test and by the guard
- [x] The `compute_cap` dispatch input reaches the script through `env:`, not `${{ }}` interpolation into `run:`
- [x] The capability parsed from the artifact filename is re-validated before it becomes a published tag
- [x] New workflow steps are GitHub-hosted and add no self-hosted pool load
- [x] Security review: no findings. No new secrets, permissions, or network inputs. The one new dispatch input is passed via `env:` rather than interpolated into a shell body, and the one value derived from a filename is regex-validated before use in a tag.
- [ ] Adversarial (cross-model) review: **not run** — the review engine is unavailable in this environment (the plugin companion needs Node.js, which is not installed; the `codex` CLI produced no output). Compensated for with the neuter table above and by executing the publish step's real script under test.
