### PR TITLE
fix(cpu-budget): state a low CPU request plainly, and only below half the cores

### DIFF
--- a/crates/cpu-budget/src/lib.rs
+++ b/crates/cpu-budget/src/lib.rs
@@ -246,13 +246,14 @@ fn detect_request_millicores() -> Option<u64> {
 /// is shared between a countable number of plans.
 const QUERIES_PER_CORE: usize = 4;
 
-/// A CPU request at or above this fraction of the budget is close enough not to
-/// warn about. A quarter is loose enough to absorb cgroup quantization (a
+/// A CPU request at or above this fraction of the effective core count is close
+/// enough not to note. A half is loose enough to absorb cgroup quantization (a
 /// `requests.cpu: 1` lands at 974m under cgroup v2) while still catching a
-/// request that is a different order of magnitude from the budget.
-const REQUEST_SHORTFALL_NUM: u64 = 3;
+/// request that is a different order of magnitude from what the runtime sized
+/// itself for.
+const REQUEST_SHORTFALL_NUM: u64 = 1;
 /// Denominator of [`REQUEST_SHORTFALL_NUM`].
-const REQUEST_SHORTFALL_DEN: u64 = 4;
+const REQUEST_SHORTFALL_DEN: u64 = 2;
 
 /// The process-wide CPU entitlement and every sizing decision derived from it.
 #[derive(Debug, Clone)]
@@ -456,8 +457,11 @@ impl CpuBudget {
                 Some(setting) => setting,
                 None => CpuConfig::SPICEPOD_SETTING,
             },
-            CpuSource::CgroupQuota => "cgroup CPU quota",
-            CpuSource::Affinity => "detected CPUs",
+            CpuSource::CgroupQuota => "cgroup CPU limit",
+            // `available_parallelism`, which is the CPU affinity mask on Linux and
+            // the logical CPU count elsewhere — "host CPU count" is the one
+            // description true on every platform.
+            CpuSource::Affinity => "the host CPU count",
             CpuSource::Fallback => "fallback",
         }
     }
@@ -485,18 +489,24 @@ impl CpuBudget {
         )
     }
 
-    /// A warning when the CPU request sits well below the budget the runtime
-    /// chose, i.e. when sizing leans on CPU the scheduler does not guarantee.
+    /// A note when the CPU request sits well below the core count the runtime
+    /// sized itself for, i.e. when sizing leans on CPU the scheduler does not
+    /// guarantee.
+    ///
+    /// States the discrepancy and where the effective value came from, and stops
+    /// there: which of the two numbers is wrong is the operator's call, and both
+    /// answers (lower the setting, or raise the request) are legitimate.
     ///
     /// Fires for every source, and names the one responsible: a value read from
     /// an explicit `limits.cpu`, a value configured by hand, and — the case that
-    /// motivates this crate — a request with no limit at all, where the budget
+    /// motivates this crate — a request with no limit at all, where detection
     /// falls back to the node's cores. An over-large configured value is just as
-    /// wrong as an over-large inferred one, so the check is on the effective
-    /// budget rather than on any particular rung of the ladder.
+    /// wrong as an over-large inferred one, so the check is on the effective core
+    /// count rather than on any particular rung of the ladder.
     ///
     /// `None` when there is no request to compare against, or when the request is
-    /// within [`REQUEST_SHORTFALL_NUM`]/[`REQUEST_SHORTFALL_DEN`] of the budget.
+    /// at or above [`REQUEST_SHORTFALL_NUM`]/[`REQUEST_SHORTFALL_DEN`] of the
+    /// effective core count.
     #[must_use]
     pub fn request_shortfall_warning(&self) -> Option<String> {
         let request = self.request_millicores?;
@@ -505,27 +515,20 @@ impl CpuBudget {
         {
             return None;
         }
-        // Telling an operator to set the surface they already set is no advice at
-        // all, so the remedy depends on whether the value was chosen or detected.
-        let remedy = if matches!(self.source, CpuSource::Configured) {
-            format!(
-                "Lower {origin} to match the request, or raise the pod's CPU request to match it.",
-                origin = self.origin()
-            )
+        // Detection is reached only when nothing capped the process, and that is
+        // the fact behind this note: a request with no limit sizes for the node.
+        // `summary_line` reports the same thing as `cgroup limit unset`, so the
+        // qualifier belongs here rather than in `origin`.
+        let unlimited = if matches!(self.source, CpuSource::Affinity) {
+            ", no CPU limit set"
         } else {
-            format!(
-                "Set {spicepod} (or {env}, or {cli}) to size for the request instead.",
-                spicepod = CpuConfig::SPICEPOD_SETTING,
-                env = CpuConfig::ENV_SETTING,
-                cli = CpuConfig::CLI_SETTING,
-            )
+            ""
         };
         Some(format!(
-            "CPU request {request} is well below the CPU budget of {budget} taken from {origin}: \
-             the runtime is sized for CPU the scheduler does not guarantee, so every CPU-derived \
-             pool may be too large for what this process actually gets. {remedy}",
+            "Detected a cgroup CPU request of {request}, which is below the {effective} in effect \
+             (from {origin}{unlimited})",
             request = format_millicores(request),
-            budget = format_millicores(self.millicores),
+            effective = format_millicores(self.millicores),
             origin = self.origin(),
         ))
     }
@@ -845,17 +848,36 @@ mod tests {
     }
 
     #[test]
-    fn a_request_far_below_the_budget_warns() {
-        // The shape this crate exists for: a request, no limit, so the budget
+    fn a_request_far_below_the_effective_cores_warns() {
+        // The shape this crate exists for: a request, no limit, so detection
         // falls back to the node and dwarfs what the scheduler guarantees.
         let burstable = CpuBudget::resolve(&CpuConfig::default(), &request_only(64, 4000))
             .expect("detection cannot fail");
         let warning = burstable
             .request_shortfall_warning()
-            .expect("4 cores requested against a 64-core budget must warn");
+            .expect("4 cores requested against 64 effective cores must warn");
         assert!(warning.contains("4 cores"), "{warning}");
         assert!(warning.contains("64 cores"), "{warning}");
-        assert!(warning.contains(CpuConfig::SPICEPOD_SETTING), "{warning}");
+        // No configuration surface and no limit set this one — detection did, and
+        // the note names that rather than a setting the operator never touched,
+        // plus the absent limit that sent sizing to the node in the first place.
+        assert!(warning.contains("the host CPU count"), "{warning}");
+        assert!(warning.contains("no CPU limit set"), "{warning}");
+
+        // Under an explicit limit the value is capped, so the qualifier must not
+        // appear — it would contradict the limit the note just named.
+        let limited = CpuBudget::resolve(
+            &CpuConfig::default(),
+            &HostReadings {
+                affinity_cores: 64,
+                quota_millicores: Some(16_000),
+                request_millicores: Some(4000),
+            },
+        )
+        .expect("detection cannot fail")
+        .request_shortfall_warning()
+        .expect("must warn");
+        assert!(!limited.contains("no CPU limit set"), "{limited}");
 
         // A request under an explicit limit warns the same way.
         let capped = CpuBudget::resolve(
@@ -870,12 +892,28 @@ mod tests {
         let capped = capped
             .request_shortfall_warning()
             .expect("a request far under the limit must warn");
-        assert!(capped.contains("cgroup CPU quota"), "{capped}");
+        assert!(capped.contains("cgroup CPU limit"), "{capped}");
+    }
+
+    /// The note states the discrepancy and its source, and stops there — no
+    /// remedy, since which of the two numbers is wrong is the operator's call.
+    #[test]
+    fn the_note_carries_no_guidance() {
+        let warning = CpuBudget::resolve(&CpuConfig::default(), &request_only(64, 4000))
+            .expect("detection cannot fail")
+            .request_shortfall_warning()
+            .expect("must warn");
+
+        for advice in ["Lower", "Set ", "instead", "Raise", "raise"] {
+            assert!(
+                !warning.contains(advice),
+                "the note must not advise ({advice:?}): {warning}"
+            );
+        }
     }
 
     /// An over-large *configured* value is as wrong as an over-large inferred
-    /// one, so the warning fires there too — naming the surface that set it, and
-    /// advising something other than "set the setting you already set".
+    /// one, so the warning fires there too, naming the surface that set it.
     #[test]
     fn an_oversized_configured_value_warns_against_the_request() {
         let configured = CpuBudget::resolve(
@@ -889,7 +927,6 @@ mod tests {
             .expect("384 configured cores against a 4-core request must warn");
         assert!(warning.contains(CpuConfig::SPICEPOD_SETTING), "{warning}");
         assert!(warning.contains("384 cores"), "{warning}");
-        assert!(warning.contains("Lower"), "{warning}");
 
         // The CLI surface names itself rather than the spicepod field.
         let via_cli = CpuBudget::resolve(
@@ -903,8 +940,8 @@ mod tests {
     }
 
     #[test]
-    fn a_request_close_to_the_budget_is_quiet() {
-        // Within a quarter of the budget: no warning.
+    fn a_request_close_to_the_effective_cores_is_quiet() {
+        // Matching the effective core count: no warning.
         let matched = CpuBudget::resolve(&CpuConfig::default(), &request_only(4, 4000))
             .expect("detection cannot fail");
         assert_eq!(matched.request_shortfall_warning(), None);
@@ -916,6 +953,29 @@ mod tests {
 
         // Nothing to compare against.
         assert_eq!(budget(16).request_shortfall_warning(), None);
+    }
+
+    /// The threshold is *below* half, so exactly half stays quiet and a hair
+    /// under it notes. Pinning both sides keeps a later refactor from drifting
+    /// the comparison to `<=` and warning on every evenly-halved request.
+    #[test]
+    fn the_threshold_is_strictly_below_half_the_effective_cores() {
+        // 8 effective cores; a request of exactly 4 cores is half, so quiet.
+        let exactly_half = CpuBudget::resolve(&CpuConfig::default(), &request_only(8, 4000))
+            .expect("detection cannot fail");
+        assert_eq!(
+            exactly_half.request_shortfall_warning(),
+            None,
+            "a request at exactly half the effective cores must stay quiet"
+        );
+
+        // One millicore under half must note.
+        let just_under = CpuBudget::resolve(&CpuConfig::default(), &request_only(8, 3999))
+            .expect("detection cannot fail");
+        assert!(
+            just_under.request_shortfall_warning().is_some(),
+            "a request just under half the effective cores must be noted"
+        );
     }
 
     #[test]

--- a/crates/cpu-budget/src/lib.rs
+++ b/crates/cpu-budget/src/lib.rs
@@ -247,10 +247,10 @@ fn detect_request_millicores() -> Option<u64> {
 const QUERIES_PER_CORE: usize = 4;
 
 /// A CPU request at or above this fraction of the effective core count is close
-/// enough not to note. A half is loose enough to absorb cgroup quantization (a
-/// `requests.cpu: 1` lands at 974m under cgroup v2) while still catching a
-/// request that is a different order of magnitude from what the runtime sized
-/// itself for.
+/// enough not to warn about. A half is loose enough to absorb cgroup
+/// quantization (a `requests.cpu: 1` lands at 974m under cgroup v2), and tight
+/// enough that a warning means the runtime sized itself for at least twice the
+/// CPU the scheduler guarantees.
 const REQUEST_SHORTFALL_NUM: u64 = 1;
 /// Denominator of [`REQUEST_SHORTFALL_NUM`].
 const REQUEST_SHORTFALL_DEN: u64 = 2;
@@ -490,7 +490,7 @@ impl CpuBudget {
         )
     }
 
-    /// A note when the CPU request sits well below the core count the runtime
+    /// A warning when the CPU request sits well below the core count the runtime
     /// sized itself for, i.e. when sizing leans on CPU the scheduler does not
     /// guarantee.
     ///
@@ -501,7 +501,7 @@ impl CpuBudget {
     /// Fires for every source, and names the one responsible: a value read from
     /// an explicit `limits.cpu`, a value configured by hand, and — the case that
     /// motivates this crate — a request with no limit at all, where detection
-    /// falls back to the node's cores. An over-large configured value is just as
+    /// falls back to every CPU the process may use. An over-large configured value is just as
     /// wrong as an over-large inferred one, so the check is on the effective core
     /// count rather than on any particular rung of the ladder.
     ///
@@ -517,12 +517,12 @@ impl CpuBudget {
             return None;
         }
         // Detection is reached only when no limit was found, and that is the fact
-        // behind this note: a request with nothing capping it sizes for the whole
-        // machine. "detected" rather than "set" because a quota that exists but
-        // cannot be read degrades to the same `None` as one that was never set
-        // (see `detect_quota_millicores`), and the note must not claim the pod has
-        // no limit when it may only be unreadable. `summary_line` carries the same
-        // fact, so the qualifier belongs here rather than in `origin`.
+        // behind this warning: a request with nothing capping it sizes for every CPU
+        // the process may use. "detected" rather than "set" because a quota that
+        // exists but cannot be read degrades to the same `None` as one that was
+        // never set (see `detect_quota_millicores`), and the warning must not claim
+        // the pod has no limit when it may only be unreadable. `summary_line`
+        // carries the same fact, so the qualifier belongs here, not in `origin`.
         let unlimited = if matches!(self.source, CpuSource::Affinity) {
             ", no CPU limit detected"
         } else {
@@ -863,7 +863,7 @@ mod tests {
         assert!(warning.contains("4 cores"), "{warning}");
         assert!(warning.contains("64 cores"), "{warning}");
         // No configuration surface and no limit set this one — detection did, and
-        // the note names that rather than a setting the operator never touched,
+        // the warning names that rather than a setting the operator never touched,
         // plus the absent limit that sent sizing to the machine in the first place.
         assert!(
             warning.contains("the CPUs available to this process"),
@@ -877,7 +877,7 @@ mod tests {
         assert!(!warning.contains("no CPU limit set"), "{warning}");
 
         // Under an explicit limit the value is capped, so the qualifier must not
-        // appear — it would contradict the limit the note just named.
+        // appear — it would contradict the limit the warning just named.
         let limited = CpuBudget::resolve(
             &CpuConfig::default(),
             &HostReadings {
@@ -907,10 +907,10 @@ mod tests {
         assert!(capped.contains("cgroup CPU limit"), "{capped}");
     }
 
-    /// The note states the discrepancy and its source, and stops there — no
+    /// The warning states the discrepancy and its source, and stops there — no
     /// remedy, since which of the two numbers is wrong is the operator's call.
     #[test]
-    fn the_note_carries_no_guidance() {
+    fn the_warning_carries_no_guidance() {
         let warning = CpuBudget::resolve(&CpuConfig::default(), &request_only(64, 4000))
             .expect("detection cannot fail")
             .request_shortfall_warning()
@@ -919,7 +919,7 @@ mod tests {
         for advice in ["Lower", "Set ", "instead", "Raise", "raise"] {
             assert!(
                 !warning.contains(advice),
-                "the note must not advise ({advice:?}): {warning}"
+                "the warning must not advise ({advice:?}): {warning}"
             );
         }
     }
@@ -968,7 +968,7 @@ mod tests {
     }
 
     /// The threshold is *below* half, so exactly half stays quiet and a hair
-    /// under it notes. Pinning both sides keeps a later refactor from drifting
+    /// under it warns. Pinning both sides keeps a later refactor from drifting
     /// the comparison to `<=` and warning on every evenly-halved request.
     #[test]
     fn the_threshold_is_strictly_below_half_the_effective_cores() {
@@ -981,12 +981,12 @@ mod tests {
             "a request at exactly half the effective cores must stay quiet"
         );
 
-        // One millicore under half must note.
+        // One millicore under half must warn.
         let just_under = CpuBudget::resolve(&CpuConfig::default(), &request_only(8, 3999))
             .expect("detection cannot fail");
         assert!(
             just_under.request_shortfall_warning().is_some(),
-            "a request just under half the effective cores must be noted"
+            "a request just under half the effective cores must warn"
         );
     }
 

--- a/crates/cpu-budget/src/lib.rs
+++ b/crates/cpu-budget/src/lib.rs
@@ -458,10 +458,11 @@ impl CpuBudget {
                 None => CpuConfig::SPICEPOD_SETTING,
             },
             CpuSource::CgroupQuota => "cgroup CPU limit",
-            // `available_parallelism`, which is the CPU affinity mask on Linux and
-            // the logical CPU count elsewhere — "host CPU count" is the one
-            // description true on every platform.
-            CpuSource::Affinity => "the host CPU count",
+            // `available_parallelism`: the CPU affinity mask on Linux, the logical
+            // CPU count elsewhere. Not the host's total either way — a cpuset or
+            // `taskset` pins the process to a subset — so this names what the
+            // process may use rather than what the machine has.
+            CpuSource::Affinity => "the CPUs available to this process",
             CpuSource::Fallback => "fallback",
         }
     }
@@ -515,12 +516,15 @@ impl CpuBudget {
         {
             return None;
         }
-        // Detection is reached only when nothing capped the process, and that is
-        // the fact behind this note: a request with no limit sizes for the node.
-        // `summary_line` reports the same thing as `cgroup limit unset`, so the
-        // qualifier belongs here rather than in `origin`.
+        // Detection is reached only when no limit was found, and that is the fact
+        // behind this note: a request with nothing capping it sizes for the whole
+        // machine. "detected" rather than "set" because a quota that exists but
+        // cannot be read degrades to the same `None` as one that was never set
+        // (see `detect_quota_millicores`), and the note must not claim the pod has
+        // no limit when it may only be unreadable. `summary_line` carries the same
+        // fact, so the qualifier belongs here rather than in `origin`.
         let unlimited = if matches!(self.source, CpuSource::Affinity) {
-            ", no CPU limit set"
+            ", no CPU limit detected"
         } else {
             ""
         };
@@ -860,9 +864,17 @@ mod tests {
         assert!(warning.contains("64 cores"), "{warning}");
         // No configuration surface and no limit set this one — detection did, and
         // the note names that rather than a setting the operator never touched,
-        // plus the absent limit that sent sizing to the node in the first place.
-        assert!(warning.contains("the host CPU count"), "{warning}");
-        assert!(warning.contains("no CPU limit set"), "{warning}");
+        // plus the absent limit that sent sizing to the machine in the first place.
+        assert!(
+            warning.contains("the CPUs available to this process"),
+            "{warning}"
+        );
+        assert!(warning.contains("no CPU limit detected"), "{warning}");
+        // Never "the host CPU count": a cpuset can pin this process to a subset of
+        // the machine, and never "no CPU limit set": an unreadable quota degrades
+        // to the same `None` as an absent one, so neither claim is ours to make.
+        assert!(!warning.contains("host CPU count"), "{warning}");
+        assert!(!warning.contains("no CPU limit set"), "{warning}");
 
         // Under an explicit limit the value is capped, so the qualifier must not
         // appear — it would contradict the limit the note just named.
@@ -877,7 +889,7 @@ mod tests {
         .expect("detection cannot fail")
         .request_shortfall_warning()
         .expect("must warn");
-        assert!(!limited.contains("no CPU limit set"), "{limited}");
+        assert!(!limited.contains("no CPU limit detected"), "{limited}");
 
         // A request under an explicit limit warns the same way.
         let capped = CpuBudget::resolve(

--- a/crates/cpu-budget/src/snapshots/cpu_budget__tests__summary_affinity.snap
+++ b/crates/cpu-budget/src/snapshots/cpu_budget__tests__summary_affinity.snap
@@ -2,4 +2,4 @@
 source: crates/cpu-budget/src/lib.rs
 expression: "CpuBudget::resolve(&CpuConfig::default(),\n&host(18)).expect(\"valid\").summary_line()"
 ---
-CPU budget: 18 cores (source: the host CPU count; host reports 18, cgroup request unset, cgroup limit unset) → 18 main worker threads, 17 per dedicated runtime pool, 18 target partitions
+CPU budget: 18 cores (source: the CPUs available to this process; host reports 18, cgroup request unset, cgroup limit unset) → 18 main worker threads, 17 per dedicated runtime pool, 18 target partitions

--- a/crates/cpu-budget/src/snapshots/cpu_budget__tests__summary_affinity.snap
+++ b/crates/cpu-budget/src/snapshots/cpu_budget__tests__summary_affinity.snap
@@ -2,4 +2,4 @@
 source: crates/cpu-budget/src/lib.rs
 expression: "CpuBudget::resolve(&CpuConfig::default(),\n&host(18)).expect(\"valid\").summary_line()"
 ---
-CPU budget: 18 cores (source: detected CPUs; host reports 18, cgroup request unset, cgroup limit unset) → 18 main worker threads, 17 per dedicated runtime pool, 18 target partitions
+CPU budget: 18 cores (source: the host CPU count; host reports 18, cgroup request unset, cgroup limit unset) → 18 main worker threads, 17 per dedicated runtime pool, 18 target partitions

--- a/crates/cpu-budget/src/snapshots/cpu_budget__tests__summary_cgroup_quota.snap
+++ b/crates/cpu-budget/src/snapshots/cpu_budget__tests__summary_cgroup_quota.snap
@@ -2,4 +2,4 @@
 source: crates/cpu-budget/src/lib.rs
 expression: "CpuBudget::resolve(&CpuConfig::default(),\n&quota(18, 4000)).expect(\"valid\").summary_line()"
 ---
-CPU budget: 4 cores (source: cgroup CPU quota; host reports 18, cgroup request unset, cgroup limit 4 cores) → 4 main worker threads, 3 per dedicated runtime pool, 4 target partitions
+CPU budget: 4 cores (source: cgroup CPU limit; host reports 18, cgroup request unset, cgroup limit 4 cores) → 4 main worker threads, 3 per dedicated runtime pool, 4 target partitions


### PR DESCRIPTION
## What

The startup note about a CPU request that sits below the cores the runtime sized itself for now states the discrepancy and stops there, in the operator's vocabulary rather than the crate's, and fires only when the request is below **half** the cores in effect.

```
Detected a cgroup CPU request of 2.43 cores, which is below the 8 cores in effect (from the CPUs available to this process, no CPU limit detected)
```

## Why

The note used to prescribe a remedy, picking its advice from the source of the effective value:

- configured → `Lower runtime.cpu.cores to match the request, or raise the pod's CPU request to match it.`
- detected → `Set runtime.cpu.cores (or SPICE_CPU_CORES, or --cpu-cores) to size for the request instead.`

Which of the two numbers is wrong is the operator's call. Lowering the setting and raising the pod's request are both legitimate answers, and nothing in the process can tell which was intended — so the note reported a fact and then guessed at the intent behind it. It now reports the fact only.

The wording also spoke of a "CPU budget", which names a concept internal to this crate rather than anything an operator set. It now names quantities they recognize: the cgroup CPU request, the cores in effect, and the surface that chose them.

## Source names

Two got more precise, in `summary_line` as well as the note:

| Before | After | Why |
|---|---|---|
| `cgroup CPU quota` | `cgroup CPU limit` | Matches `limits.cpu`, and the `cgroup limit` the same summary line already printed. |
| `detected CPUs` | `the CPUs available to this process` | Names what the value measures. `available_parallelism` is the affinity mask on Linux, so a cpuset or `taskset` makes it a subset of the machine — it is not the host's total, and not an affinity concept at all on other platforms. |

Detection is reached only when no limit was found, which is the fact behind the warning, so it appends `no CPU limit detected` there. Only there: on the `cgroup CPU limit` rung that qualifier would contradict the limit the warning just named, and a test pins that it stays absent.

"detected" rather than "set" because a quota that exists but cannot be read degrades to the same `None` as one that was never set, so the stronger claim could be false. Modelling an explicit unknown/unset state would be the thorough fix, but that reaches into `HostReadings`/`limit_millicores` and the metrics that read them — wider than this wording change, and `summary_line` says `cgroup limit unset` for the same reason. Left for a separate change.

The qualifier lives in the warning rather than in the shared source name because `summary_line` already carries the same fact, and would otherwise state it twice in one line.

## Threshold

A request at or above half the cores in effect is now quiet, where the bar was previously three quarters. The comparison is strictly *below* half, so an evenly-halved request stays silent; a test pins both sides so a later refactor cannot drift it to `<=` and start warning on every such pod.

## Testing

`cargo test -p cpu-budget --lib` — 23 passed. Two `summary_line` snapshots regenerated for the renamed sources (single line each). New tests: the warning carries no guidance, the threshold is strictly below half, and neither `host CPU count` nor `no CPU limit set` can reappear.

Refs #12211
