### PR TITLE
fix(monitoring): correct p99 queries in the Datadog dashboard

### DIFF
--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -198,7 +198,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "p99:spice.query_duration_ms{$service.instance.id} by {protocol}"
+                      "query": "max:spice.query_duration_ms_summary.quantile{$service.instance.id,quantile:0.99} by {protocol}.rollup(max)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -228,7 +228,7 @@
           {
             "id": 202,
             "definition": {
-              "title": "Query Throughput",
+              "title": "Query Count by Protocol",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
@@ -394,7 +394,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "p99:spice.query_returned_rows{$service.instance.id} by {protocol}"
+                      "query": "max:spice.query_returned_rows_summary.quantile{$service.instance.id,quantile:0.99} by {protocol}.rollup(max)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -652,7 +652,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "p99:spice.dataset_acceleration_refresh_duration_ms{$service.instance.id,!dataset:runtime.*} by {dataset}"
+                      "query": "max:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$service.instance.id,!dataset:runtime.*,quantile:0.99} by {dataset}.rollup(max)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1392,7 +1392,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "p99:spice.http_requests_duration_ms{$service.instance.id} by {method,path}"
+                      "query": "max:spice.http_requests_duration_ms_summary.quantile{$service.instance.id,quantile:0.99} by {method,path}.rollup(max)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1512,7 +1512,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "p99:spice.flight_request_duration_ms{$service.instance.id,method:do_get} by {command}"
+                      "query": "max:spice.flight_request_duration_ms_summary.quantile{$service.instance.id,method:do_get,quantile:0.99} by {command}.rollup(max)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1567,7 +1567,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "p99:spice.flight_request_duration_ms{$service.instance.id,method:do_put} by {command}"
+                      "query": "max:spice.flight_request_duration_ms_summary.quantile{$service.instance.id,method:do_put,quantile:0.99} by {command}.rollup(max)"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1622,7 +1622,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "p99:spice.flight_request_duration_ms{$service.instance.id,method:get_flight_info} by {command}"
+                      "query": "max:spice.flight_request_duration_ms_summary.quantile{$service.instance.id,method:get_flight_info,quantile:0.99} by {command}.rollup(max)"
                     }
                   ],
                   "response_format": "timeseries",


### PR DESCRIPTION
## Problem

Seven panels in `monitoring/datadog-dashboard.json` query percentiles with the `p99:` aggregator, e.g.:

>p99:spice.query_duration_ms{$service.instance.id} by {protocol}

`p99:` is only valid on a Datadog *distribution* metric. With the OpenMetrics check configured as documented, Prometheus histograms are submitted as `.count` / `.sum` / `.bucket` — no distribution is created, so these panels
render empty.

## Fix

Query the derived `<metric>_summary.quantile` series instead, which the runtime's Prometheus exporter emits for every histogram, filtered to `quantile:0.99`:

>max:spice.query_duration_ms_summary.quantile{$service.instance.id,quantile:0.99} by {protocol}.rollup(max)

Two aggregator choices worth noting:

- `max:` rather than `avg:` — averaging pre-computed per-instance quantiles is not a percentile of anything, and hides single-instance degradation across a multi-replica deployment.
- `.rollup(max)` — the underlying series is a gauge, so Datadog's default `avg` time rollup would flatten tail spikes when zooming out.

Panels fixed: Query Duration, Rows Returned per Query, Refresh Duration, HTTP Request Duration, and the three Arrow Flight duration panels. Scope filters and group-bys are preserved; no other queries change.

Also renames the "Query Throughput" panel to "Query Count by Protocol", which describes what it plots.

## Verification

Confirmed against a live 2.1.3 `/metrics` endpoint that all five underlying metrics expose a `_summary` companion carrying the labels each panel groups by with `quantile` values 0.5 / 0.9 / 0.95 / 0.99 available.
