### PR TITLE
fix(models): pass the pinned revision to a HuggingFace embedding model (fixes #12430)

### DIFF
--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -393,8 +393,14 @@ async fn huggingface(
     let hf_token = params.hf_token.as_ref().map(ExposeSecret::expose_secret);
     let pooling = params.pooling.map(embedding_params::Pooling::as_str);
     if let Some(id) = model_id {
+        // `get_model_id` joins a pinned revision onto the repo id as `org/model:revision`, so
+        // the two halves have to be recovered before the repo id reaches the Hub. Passing the
+        // joined string through requests a repo named `org/model:revision`, which does not
+        // exist, and leaves the revision defaulted to `main`. `chat` splits the same
+        // convention back out; this path did not.
+        let (repo_id, revision) = spicepod::component::model::split_hf_model_id(&id);
         Ok(Arc::new(
-            TeiEmbed::from_hf(&id, None, hf_token, pooling, params.max_seq_length)
+            TeiEmbed::from_hf(repo_id, revision, hf_token, pooling, params.max_seq_length)
                 .await?
                 .set_cache(embeddings_cache)
                 .set_cache_model_id(name),

--- a/crates/spicepod/src/component/embeddings.rs
+++ b/crates/spicepod/src/component/embeddings.rs
@@ -328,3 +328,77 @@ pub struct ColumnEmbeddingConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_elements_per_row: Option<usize>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component::model::split_hf_model_id;
+
+    /// A revision-pinned `HuggingFace` embedding must survive the round trip through
+    /// `get_model_id`. `get_model_id` re-joins the revision onto the repo id, so a loader has
+    /// to split it back out; the embeddings loader did not, and asked the Hub for a repo
+    /// literally named `org/model:revision`, which 401s (#12430).
+    #[test]
+    fn revision_pinned_embedding_model_id_round_trips() {
+        let sha = "a5beb1e3e68b9ab74eb54cfd186867f64f240e1a";
+
+        // The exact spicepod reported in #12430.
+        assert_splits_to(
+            &format!("huggingface:huggingface.co/BAAI/bge-base-en-v1.5:{sha}"),
+            "BAAI/bge-base-en-v1.5",
+            Some(sha),
+        );
+
+        // A branch name pins just as well as a sha.
+        assert_splits_to(
+            "hf:BAAI/bge-small-en-v1.5:v2-branch",
+            "BAAI/bge-small-en-v1.5",
+            Some("v2-branch"),
+        );
+
+        // Unpinned: every existing fixture takes this branch, which is why the defect
+        // stayed invisible.
+        assert_splits_to(
+            "hf:sentence-transformers/all-MiniLM-L6-v2",
+            "sentence-transformers/all-MiniLM-L6-v2",
+            None,
+        );
+    }
+
+    /// Asserts that the id `get_model_id` builds for `from` splits back into the repo and
+    /// revision a loader has to pass to the Hub separately.
+    fn assert_splits_to(from: &str, expected_repo: &str, expected_revision: Option<&str>) {
+        let Some(model_id) = Embeddings::new(from, "test").get_model_id() else {
+            panic!("expected a model id for {from}");
+        };
+
+        assert_eq!(
+            split_hf_model_id(&model_id),
+            (expected_repo, expected_revision),
+            "round trip lost the revision for {from}"
+        );
+    }
+
+    /// Guards the reason the bug was silent: the joined id is not itself a usable repo id, so
+    /// forwarding it unsplit cannot work. Without the split, the repo segment of the request
+    /// URL carries the revision and the revision segment falls back to `main`.
+    #[test]
+    fn joined_model_id_is_not_a_usable_repo_id() {
+        let from = "hf:BAAI/bge-base-en-v1.5:a5beb1e3";
+        let Some(model_id) = Embeddings::new(from, "test").get_model_id() else {
+            panic!("expected a model id for {from}");
+        };
+
+        assert!(
+            model_id.contains(':'),
+            "expected the joined id to carry the revision separator: {model_id}"
+        );
+
+        let (repo_id, revision) = split_hf_model_id(&model_id);
+        assert!(
+            !repo_id.contains(':'),
+            "repo id must not carry the revision: {repo_id}"
+        );
+        assert_eq!(revision, Some("a5beb1e3"));
+    }
+}

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -677,7 +677,10 @@ mod tests {
         assert_eq!(split_hf_model_id(&pinned), (repo, Some(sha)));
 
         // A model name containing dots must not be mistaken for a revision.
-        assert_eq!(split_hf_model_id("org/my-model.v2"), ("org/my-model.v2", None));
+        assert_eq!(
+            split_hf_model_id("org/my-model.v2"),
+            ("org/my-model.v2", None)
+        );
 
         // A revision carrying the dots, hyphens and digits the regex admits.
         assert_eq!(
@@ -688,7 +691,10 @@ mod tests {
         // An empty revision is reported absent, so the caller asks for the default branch
         // rather than for the empty revision. `HUGGINGFACE_PATH_REGEX` rejects a trailing
         // colon, so only a caller that built its id some other way reaches this.
-        assert_eq!(split_hf_model_id("org/model-name:"), ("org/model-name", None));
+        assert_eq!(
+            split_hf_model_id("org/model-name:"),
+            ("org/model-name", None)
+        );
     }
 
     /// The join in `ModelSource::parse_from` and the split in [`split_hf_model_id`] have to be
@@ -697,8 +703,16 @@ mod tests {
     #[test]
     fn hf_model_id_round_trips_through_split() {
         let cases = [
-            ("hf:BAAI/bge-base-en-v1.5:a5beb1e3", "BAAI/bge-base-en-v1.5", Some("a5beb1e3")),
-            ("hf:org/model-name:v1.2-beta.3", "org/model-name", Some("v1.2-beta.3")),
+            (
+                "hf:BAAI/bge-base-en-v1.5:a5beb1e3",
+                "BAAI/bge-base-en-v1.5",
+                Some("a5beb1e3"),
+            ),
+            (
+                "hf:org/model-name:v1.2-beta.3",
+                "org/model-name",
+                Some("v1.2-beta.3"),
+            ),
             ("huggingface.co/org/model-name", "org/model-name", None),
         ];
 

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -184,7 +184,11 @@ pub static HUGGINGFACE_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 pub fn split_hf_model_id(model_id: &str) -> (&str, Option<&str>) {
     match model_id.split_once(':') {
         Some((repo_id, revision)) if !revision.is_empty() => (repo_id, Some(revision)),
-        _ => (model_id, None),
+        // A trailing `:` still separates: the repo id is what precedes it. Folding this
+        // into the `None` arm below would hand the Hub `org/model:` as the repo name —
+        // the same "repo that does not exist" failure this function exists to prevent.
+        Some((repo_id, _)) => (repo_id, None),
+        None => (model_id, None),
     }
 }
 

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -162,6 +162,32 @@ pub static HUGGINGFACE_PATH_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     }
 });
 
+/// Splits a `HuggingFace` model id back into its repo id and optional revision.
+///
+/// Both joiners of this convention — [`ModelSource::parse_from`] for `models` and
+/// `Embedding::get_model_id` for `embeddings` — encode a pinned revision by appending it to
+/// the repo id as `org/model:revision`. A loader that forwards that joined string to the Hub
+/// as the repo name therefore asks for a repo that does not exist, and the revision defaults
+/// to `main`. This is the inverse of that join, so a loader can recover both halves.
+///
+/// The first colon is unambiguously the separator: [`HUGGINGFACE_PATH_REGEX`] matches `org`
+/// as `[\w\-]+` and `model` as `[\w\-\.]+`, neither of which admits a `:`.
+///
+/// An empty revision yields `None` rather than `Some("")`, because a caller would otherwise
+/// request the empty revision from the Hub instead of the default branch. The regex already
+/// rejects a trailing `:`, so this only guards a caller that did not build its id from it.
+///
+/// # Example
+/// - `BAAI/bge-base-en-v1.5` -> (`BAAI/bge-base-en-v1.5`, `None`)
+/// - `BAAI/bge-base-en-v1.5:a5beb1e` -> (`BAAI/bge-base-en-v1.5`, `Some("a5beb1e")`)
+#[must_use]
+pub fn split_hf_model_id(model_id: &str) -> (&str, Option<&str>) {
+    match model_id.split_once(':') {
+        Some((repo_id, revision)) if !revision.is_empty() => (repo_id, Some(revision)),
+        _ => (model_id, None),
+    }
+}
+
 /// Implement the [`TryFrom<&str>`] trait for [`ModelSource`]. Should be the inverse of [`ModelSource`]'s [`Display`].
 impl TryFrom<&str> for ModelSource {
     type Error = &'static str;
@@ -636,5 +662,56 @@ mod tests {
     fn spiceai_model_id_is_trimmed() {
         let model = Model::new("spice.ai: openai/gpt-4o ", "test");
         assert_eq!(model.get_model_id().as_deref(), Some("openai/gpt-4o"));
+    }
+
+    #[test]
+    fn split_hf_model_id_recovers_repo_and_revision() {
+        let repo = "BAAI/bge-base-en-v1.5";
+        let sha = "a5beb1e3e68b9ab74eb54cfd186867f64f240e1a";
+        let pinned = format!("{repo}:{sha}");
+
+        // No revision pinned: the whole id is the repo.
+        assert_eq!(split_hf_model_id(repo), (repo, None));
+
+        // A full commit sha, the form reported in #12430.
+        assert_eq!(split_hf_model_id(&pinned), (repo, Some(sha)));
+
+        // A model name containing dots must not be mistaken for a revision.
+        assert_eq!(split_hf_model_id("org/my-model.v2"), ("org/my-model.v2", None));
+
+        // A revision carrying the dots, hyphens and digits the regex admits.
+        assert_eq!(
+            split_hf_model_id("org/model-name:v1.2-beta.3"),
+            ("org/model-name", Some("v1.2-beta.3"))
+        );
+
+        // An empty revision is reported absent, so the caller asks for the default branch
+        // rather than for the empty revision. `HUGGINGFACE_PATH_REGEX` rejects a trailing
+        // colon, so only a caller that built its id some other way reaches this.
+        assert_eq!(split_hf_model_id("org/model-name:"), ("org/model-name", None));
+    }
+
+    /// The join in `ModelSource::parse_from` and the split in [`split_hf_model_id`] have to be
+    /// inverses. If they drift, a revision-pinned model is fetched from a repo id that has the
+    /// revision glued onto it, which is #12430.
+    #[test]
+    fn hf_model_id_round_trips_through_split() {
+        let cases = [
+            ("hf:BAAI/bge-base-en-v1.5:a5beb1e3", "BAAI/bge-base-en-v1.5", Some("a5beb1e3")),
+            ("hf:org/model-name:v1.2-beta.3", "org/model-name", Some("v1.2-beta.3")),
+            ("huggingface.co/org/model-name", "org/model-name", None),
+        ];
+
+        for (from, expected_repo, expected_revision) in cases {
+            let model = Model::new(from, "test");
+            let Some(model_id) = model.get_model_id() else {
+                panic!("expected a model id for {from}");
+            };
+            assert_eq!(
+                split_hf_model_id(&model_id),
+                (expected_repo, expected_revision),
+                "round trip lost the revision for {from}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #12430

## Why

`Embedding::get_model_id` encodes a pinned revision by joining it onto the repo id as
`org/model:revision`. The embeddings loader forwarded that joined string to the Hub as the
**repo name** and hardcoded the revision argument to `None`:

```rust
TeiEmbed::from_hf(&id, None, hf_token, pooling, params.max_seq_length)
```

So a revision-pinned embedding requested a repo that does not exist, and the revision segment
of the URL fell back to `main`:

```
https://huggingface.co/BAAI/bge-base-en-v1.5:a5beb1e.../resolve/main/config.json  ->  401
```

The knock-on effect is worse than a failed embedding: every dataset referencing that embedding
then fails configuration validation, so the runtime never reports ready.

Not a regression — the revision argument has been `None` since embedding support landed. It
stayed invisible because every HF embedding fixture is unpinned, and the existing revision
tests only assert the regex *captures* a revision, never that a loader splits it back out.

## Changes

- `split_hf_model_id` in `crates/spicepod/src/component/model.rs`, placed next to
  `HUGGINGFACE_PATH_REGEX` and the two joiners it inverts (`ModelSource::parse_from` for
  `models`, `Embedding::get_model_id` for `embeddings`), so the convention and its inverse sit
  together rather than being re-derived per caller.
- The HF embeddings loader splits the id and passes the tail as the revision. All the plumbing
  below it was already correct — `TeiEmbed::from_hf` accepts a revision and `get_api` already
  selects `Repo::with_revision` when one is supplied; no caller ever passed one.
- An empty revision yields `None` rather than `Some("")`, so a caller cannot request the empty
  revision instead of the default branch.

## Scope

The embeddings loader was the **only** consumer of the joined id that failed to split it. Every
`get_model_id()` caller was checked:

| Caller | Status |
| --- | --- |
| `model/chat.rs` -> `mistral.rs` | already splits on `:` — correct |
| `model/embed.rs` (HF) | **the defect, fixed here** |
| `model/responses.rs` | OpenAI/Azure/xAI only — never HF |
| `model/rerank.rs` | Cohere/Voyage/Jina hosted APIs — no revision concept |
| `model/rate_limit.rs` | uses the id as a rate-limit key, not a repo id |

Deliberately not included:

- **`mistral.rs` is not converted to the new helper.** It implements the same split inline and
  works; rewriting a correct path is a behaviour-neutral refactor, and the helper's doc names
  both joiners so the convention stays discoverable. Happy to fold it in if preferred.
- **Model2Vec** (`model2vec:org/model:rev`) fails for a *different* reason: its arm of
  `get_model_id` does not apply the HF regex, so nothing is re-joined, and
  `StaticModel::from_pretrained` has no revision parameter at all. Supporting a pinned
  Model2Vec revision needs an upstream change, not a split. Filed separately as #12445.

`revision` values reaching `Repo::with_revision` are constrained by `HUGGINGFACE_PATH_REGEX` to
`[\w\d\-\.]+`, so this does not widen what a Spicepod can express beyond what the `chat` and
`hf://` paths already accept.

## Test plan

- [x] Regression test that a revision-pinned embedding `from` round-trips: `get_model_id` then
      `split_hf_model_id` recovers `BAAI/bge-base-en-v1.5` + the sha from #12430. Fails on the
      old code path, which never split.
- [x] Test that the joined id is not itself a usable repo id, documenting why forwarding it
      unsplit cannot work
- [x] Unit tests for `split_hf_model_id`: unpinned, full sha, branch name, dotted revision, a
      dotted *model* name that must not be read as a revision, and the empty-revision guard
- [x] Round-trip test against the `models` joiner (`ModelSource::parse_from`) so the join and
      the split cannot drift
- [ ] `make lint` (workspace-wide `cargo fmt --all -- --check` + full clippy) — runs in the
      sign-off; no local Rust toolchain on this machine
- [ ] `make test` — same

## Checklist

- [x] Issue linked in title and body
- [x] Every `get_model_id()` consumer audited, not just the reported one
- [x] No behaviour change for unpinned models (the overwhelmingly common case)
