### PR TITLE
fix(ci): install protoc before building the spice CLI in the E2E CLI workflow

### DIFF
--- a/.github/workflows/e2e_test_spice_cli.yml
+++ b/.github/workflows/e2e_test_spice_cli.yml
@@ -106,6 +106,10 @@ jobs:
         if: matrix.target.target_os == 'linux' && github.event.inputs.build_cli == 'true'
         uses: ./.github/actions/setup-cc
 
+      - name: Install protoc
+        if: github.event.inputs.build_cli == 'true'
+        uses: ./.github/actions/install-protoc
+
       - name: Build spice
         if: github.event.inputs.build_cli == 'true'
         run: cargo build --release -p spice


### PR DESCRIPTION
## Summary

The [E2E Test CLI workflow run](https://github.com/spiceai/spiceai/actions/runs/30883632110) dispatched for the v2.1.3 endgame (#12379) fails in the **Build spice** step:

```
error: failed to run custom build command for `runtime-cloud-connect v2.2.0-unstable`
Error: Custom { kind: NotFound, error: "Could not find `protoc`. ..." }
```

The `spice` CLI build now reaches `runtime-cloud-connect` (via the `spice connect` work), whose build script invokes `protoc` since #12153 — but `e2e_test_spice_cli.yml` never installs it. The last green trunk run (Jul 30) predates #12153.

## Fix

Add the same `./.github/actions/install-protoc` composite action that `build_and_release.yml` already uses, in the CLI build job for every matrix platform (Linux/macOS/Windows), gated on `build_cli == 'true'` like the surrounding steps.

## Validation

Dispatched the workflow on this branch to confirm the build passes; will link the run below.