### PR TITLE
fix(monitoring): align Datadog dashboard with OTel service instance identity

### DIFF
--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -1,6 +1,6 @@
 {
   "title": "Spice.ai Dashboard",
-  "description": "Monitoring dashboard for Spice.ai runtime - covers system health, query performance, data acceleration, caching, AI/ML operations, and Flight protocol metrics.",
+  "description": "Base Datadog dashboard for Spice.ai scraped by the Datadog Agent OpenMetrics check (Kubernetes Autodiscovery). Expected check shape: openmetrics_endpoint on the Spice metrics port (default 9090), namespace \"spice\", metrics [.*]. Filter with standard Agent Kubernetes tags (kube_namespace, kube_app_instance, pod_name); leave unused filters as *. Counter panels use OpenMetrics V2 *.count names; latency panels use Spice *_summary.quantile gauges (quantile:0.99).",
   "widgets": [
     {
       "id": 1,
@@ -28,7 +28,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_active_count{$instance}",
+                      "query": "sum:spice.dataset_active_count{$kube_namespace,$kube_app_instance,$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -63,7 +63,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.model_active_count{$instance}",
+                      "query": "sum:spice.model_active_count{$kube_namespace,$kube_app_instance,$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -98,7 +98,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.embeddings_active_count{$instance}",
+                      "query": "sum:spice.embeddings_active_count{$kube_namespace,$kube_app_instance,$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -133,7 +133,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.tool_active_count{$instance}",
+                      "query": "sum:spice.tool_active_count{$kube_namespace,$kube_app_instance,$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -198,7 +198,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_duration_ms_summary.quantile{$instance,quantile:0.99} by {protocol}"
+                      "query": "avg:spice.query_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,quantile:0.99} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -249,7 +249,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_executions.count{$instance} by {protocol}.as_count()"
+                      "query": "sum:spice.query_executions.count{$kube_namespace,$kube_app_instance,$pod_name} by {protocol}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -298,7 +298,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_active_count{$instance} by {protocol}"
+                      "query": "sum:spice.query_active_count{$kube_namespace,$kube_app_instance,$pod_name} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -346,7 +346,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_failures.count{$instance} by {err_code}.as_count()"
+                      "query": "sum:spice.query_failures.count{$kube_namespace,$kube_app_instance,$pod_name} by {err_code}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -394,7 +394,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_returned_rows_summary.quantile{$instance,quantile:0.99} by {protocol}"
+                      "query": "avg:spice.query_returned_rows_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,quantile:0.99} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -465,12 +465,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_processed_bytes.count{$instance}"
+                      "query": "sum:spice.query_processed_bytes.count{$kube_namespace,$kube_app_instance,$pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.query_returned_bytes.count{$instance}"
+                      "query": "sum:spice.query_returned_bytes.count{$kube_namespace,$kube_app_instance,$pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -520,7 +520,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_spilled_bytes.count{$instance}.as_count()"
+                      "query": "sum:spice.query_spilled_bytes.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -574,7 +574,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$instance,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$kube_namespace,$kube_app_instance,$pod_name,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -658,7 +658,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$instance,!dataset:runtime.*,quantile:0.99} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,!dataset:runtime.*,quantile:0.99} by {dataset}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -706,7 +706,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$instance} by {dataset}.as_count()"
+                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$kube_namespace,$kube_app_instance,$pod_name} by {dataset}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -744,7 +744,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$instance,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$kube_namespace,$kube_app_instance,$pod_name,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -812,7 +812,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$instance,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$kube_namespace,$kube_app_instance,$pod_name,!dataset:runtime.*} by {dataset}",
                       "aggregator": "avg"
                     }
                   ],
@@ -894,7 +894,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.results_cache_hit_ratio{$instance}",
+                      "query": "avg:spice.results_cache_hit_ratio{$kube_namespace,$kube_app_instance,$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -959,12 +959,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_hits.count{$instance}.as_count()"
+                      "query": "sum:spice.results_cache_hits.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_requests.count{$instance}.as_count()"
+                      "query": "sum:spice.results_cache_requests.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1021,12 +1021,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_size_bytes{$instance}"
+                      "query": "sum:spice.results_cache_size_bytes{$kube_namespace,$kube_app_instance,$pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_max_size_bytes{$instance}"
+                      "query": "sum:spice.results_cache_max_size_bytes{$kube_namespace,$kube_app_instance,$pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1070,7 +1070,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_items_count{$instance}"
+                      "query": "sum:spice.results_cache_items_count{$kube_namespace,$kube_app_instance,$pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1114,7 +1114,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_evictions.count{$instance}.as_count()"
+                      "query": "sum:spice.results_cache_evictions.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1158,7 +1158,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_swr_background_query_count.count{$instance}.as_count()"
+                      "query": "sum:spice.results_cache_swr_background_query_count.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1223,7 +1223,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$instance,quantile:0.99} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,quantile:0.99} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1277,7 +1277,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$instance} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$kube_namespace,$kube_app_instance,$pod_name} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1331,7 +1331,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$instance} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$kube_namespace,$kube_app_instance,$pod_name} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1410,7 +1410,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$instance,quantile:0.99} by {method,path}"
+                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,quantile:0.99} by {method,path}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1458,7 +1458,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.http_requests.count{$instance} by {method,path,status}.as_count()"
+                      "query": "sum:spice.http_requests.count{$kube_namespace,$kube_app_instance,$pod_name} by {method,path,status}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1530,7 +1530,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:do_get,quantile:0.99} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,method:do_get,quantile:0.99} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1585,7 +1585,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:do_put,quantile:0.99} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,method:do_put,quantile:0.99} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1640,7 +1640,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:get_flight_info,quantile:0.99} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,method:get_flight_info,quantile:0.99} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1688,7 +1688,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_requests.count{$instance} by {method}.as_count()"
+                      "query": "sum:spice.flight_requests.count{$kube_namespace,$kube_app_instance,$pod_name} by {method}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1737,7 +1737,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$instance}.as_count()"
+                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1802,7 +1802,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_kafka_records_lag{$instance} by {name}"
+                      "query": "avg:spice.dataset_kafka_records_lag{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1849,7 +1849,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$instance} by {name}"
+                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1915,7 +1915,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_lag_ms{$instance} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_lag_ms{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1963,7 +1963,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$instance} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2011,7 +2011,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_shards_active{$instance} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_shards_active{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2059,7 +2059,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$instance} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2126,7 +2126,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_cores{$instance} by {pod_name,source}"
+                      "query": "avg:spice.spiced_cpu_budget_cores{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name,source}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2184,17 +2184,17 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_millicores{$instance} by {pod_name,source}"
+                      "query": "avg:spice.spiced_cpu_budget_millicores{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name,source}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.spiced_cpu_limit_millicores{$instance} by {pod_name}"
+                      "query": "avg:spice.spiced_cpu_limit_millicores{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query3",
-                      "query": "avg:spice.spiced_cpu_request_millicores{$instance} by {pod_name}"
+                      "query": "avg:spice.spiced_cpu_request_millicores{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2243,7 +2243,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_workers{$instance} by {pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_workers{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2292,7 +2292,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_alive_tasks{$instance} by {pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_alive_tasks{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2341,7 +2341,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_global_queue_depth{$instance} by {pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_global_queue_depth{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2396,7 +2396,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.process_resident_memory_bytes{$instance} by {pod_name}"
+                      "query": "avg:spice.process_resident_memory_bytes{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2451,7 +2451,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_memory_pool_used_bytes{$instance} by {pod_name}"
+                      "query": "avg:spice.query_memory_pool_used_bytes{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2517,12 +2517,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$instance} by {pod_name}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$instance} by {pod_name}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2589,7 +2589,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.cpu.usage{$instance} by {pod_name}"
+                      "query": "avg:k8s.pod.cpu.usage{$kube_namespace,$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2638,7 +2638,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.memory.working_set{$instance} by {pod_name}"
+                      "query": "avg:k8s.pod.memory.working_set{$kube_namespace,$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2686,12 +2686,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{$instance,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{$kube_namespace,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{$instance,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{$kube_namespace,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2739,12 +2739,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{$instance,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{$kube_namespace,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{$instance,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{$kube_namespace,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2781,7 +2781,19 @@
   ],
   "template_variables": [
     {
-      "name": "instance",
+      "name": "kube_namespace",
+      "prefix": "kube_namespace",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "kube_app_instance",
+      "prefix": "kube_app_instance",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "pod_name",
       "prefix": "pod_name",
       "available_values": [],
       "default": "*"

--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -28,7 +28,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_active_count{$pod_name}",
+                      "query": "sum:spice.dataset_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -63,7 +63,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.model_active_count{$pod_name}",
+                      "query": "sum:spice.model_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -98,7 +98,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.embeddings_active_count{$pod_name}",
+                      "query": "sum:spice.embeddings_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -133,7 +133,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.tool_active_count{$pod_name}",
+                      "query": "sum:spice.tool_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -198,7 +198,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_duration_ms_summary.quantile{$pod_name,$percentile} by {protocol}"
+                      "query": "avg:spice.query_duration_ms_summary.quantile{$instance,$percentile} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -249,7 +249,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_executions.count{$pod_name} by {protocol}.as_count()"
+                      "query": "sum:spice.query_executions.count{$instance} by {protocol}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -298,7 +298,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_active_count{$pod_name} by {protocol}"
+                      "query": "sum:spice.query_active_count{$instance} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -346,7 +346,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_failures.count{$pod_name} by {err_code}.as_count()"
+                      "query": "sum:spice.query_failures.count{$instance} by {err_code}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -394,7 +394,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_returned_rows_summary.quantile{$pod_name,$percentile} by {protocol}"
+                      "query": "avg:spice.query_returned_rows_summary.quantile{$instance,$percentile} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -465,12 +465,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_processed_bytes.count{$pod_name}"
+                      "query": "sum:spice.query_processed_bytes.count{$instance}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.query_returned_bytes.count{$pod_name}"
+                      "query": "sum:spice.query_returned_bytes.count{$instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -520,7 +520,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_spilled_bytes.count{$pod_name}.as_count()"
+                      "query": "sum:spice.query_spilled_bytes.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -574,7 +574,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$pod_name,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$instance,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -658,7 +658,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$pod_name,!dataset:runtime.*,$percentile} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$instance,!dataset:runtime.*,$percentile} by {dataset}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -706,7 +706,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$pod_name} by {dataset}.as_count()"
+                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$instance} by {dataset}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -744,7 +744,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$pod_name,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$instance,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -812,7 +812,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$pod_name,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$instance,!dataset:runtime.*} by {dataset}",
                       "aggregator": "avg"
                     }
                   ],
@@ -894,7 +894,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.results_cache_hit_ratio{$pod_name}",
+                      "query": "avg:spice.results_cache_hit_ratio{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -959,12 +959,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_hits.count{$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_hits.count{$instance}.as_count()"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_requests.count{$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_requests.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1021,12 +1021,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_size_bytes{$pod_name}"
+                      "query": "sum:spice.results_cache_size_bytes{$instance}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_max_size_bytes{$pod_name}"
+                      "query": "sum:spice.results_cache_max_size_bytes{$instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1070,7 +1070,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_items_count{$pod_name}"
+                      "query": "sum:spice.results_cache_items_count{$instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1114,7 +1114,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_evictions.count{$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_evictions.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1158,7 +1158,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_swr_background_query_count.count{$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_swr_background_query_count.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1223,7 +1223,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$pod_name,$percentile} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$instance,$percentile} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1277,7 +1277,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$pod_name} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$instance} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1331,7 +1331,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$pod_name} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$instance} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1410,7 +1410,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$pod_name,$percentile} by {method,path}"
+                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$instance,$percentile} by {method,path}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1458,7 +1458,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.http_requests.count{$pod_name} by {method,path,status}.as_count()"
+                      "query": "sum:spice.http_requests.count{$instance} by {method,path,status}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1530,7 +1530,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$pod_name,method:do_get,$percentile} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:do_get,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1585,7 +1585,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$pod_name,method:do_put,$percentile} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:do_put,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1640,7 +1640,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$pod_name,method:get_flight_info,$percentile} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:get_flight_info,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1688,7 +1688,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_requests.count{$pod_name} by {method}.as_count()"
+                      "query": "sum:spice.flight_requests.count{$instance} by {method}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1737,7 +1737,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$pod_name}.as_count()"
+                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1802,7 +1802,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_kafka_records_lag{$pod_name} by {name}"
+                      "query": "avg:spice.dataset_kafka_records_lag{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1849,7 +1849,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$pod_name} by {name}"
+                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1915,7 +1915,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_lag_ms{$pod_name} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_lag_ms{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1963,7 +1963,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$pod_name} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2011,7 +2011,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_shards_active{$pod_name} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_shards_active{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2059,7 +2059,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$pod_name} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2126,7 +2126,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_cores{$pod_name} by {pod_name,source}"
+                      "query": "avg:spice.spiced_cpu_budget_cores{$instance} by {instance,source}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2184,17 +2184,17 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_millicores{$pod_name} by {pod_name,source}"
+                      "query": "avg:spice.spiced_cpu_budget_millicores{$instance} by {instance,source}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.spiced_cpu_limit_millicores{$pod_name} by {pod_name}"
+                      "query": "avg:spice.spiced_cpu_limit_millicores{$instance} by {instance}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query3",
-                      "query": "avg:spice.spiced_cpu_request_millicores{$pod_name} by {pod_name}"
+                      "query": "avg:spice.spiced_cpu_request_millicores{$instance} by {instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2243,7 +2243,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_workers{$pod_name} by {pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_workers{$instance} by {instance,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2292,7 +2292,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_alive_tasks{$pod_name} by {pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_alive_tasks{$instance} by {instance,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2341,7 +2341,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_global_queue_depth{$pod_name} by {pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_global_queue_depth{$instance} by {instance,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2396,7 +2396,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.process_resident_memory_bytes{$pod_name} by {pod_name}"
+                      "query": "avg:spice.process_resident_memory_bytes{$instance} by {instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2451,7 +2451,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_memory_pool_used_bytes{$pod_name} by {pod_name}"
+                      "query": "avg:spice.query_memory_pool_used_bytes{$instance} by {instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2517,12 +2517,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$pod_name} by {pod_name}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$instance} by {instance}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$pod_name} by {pod_name}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$instance} by {instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2589,7 +2589,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.cpu.usage{$pod_name} by {pod_name}"
+                      "query": "avg:k8s.pod.cpu.usage{pod_name:$instance.value} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2638,7 +2638,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.memory.working_set{$pod_name} by {pod_name}"
+                      "query": "avg:k8s.pod.memory.working_set{pod_name:$instance.value} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2686,12 +2686,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2739,12 +2739,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2781,8 +2781,8 @@
   ],
   "template_variables": [
     {
-      "name": "pod_name",
-      "prefix": "pod_name",
+      "name": "instance",
+      "prefix": "instance",
       "available_values": [],
       "default": "*"
     },

--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -28,7 +28,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_active_count{$service.instance.id}",
+                      "query": "sum:spice.dataset_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -63,7 +63,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.model_active_count{$service.instance.id}",
+                      "query": "sum:spice.model_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -98,7 +98,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.embeddings_active_count{$service.instance.id}",
+                      "query": "sum:spice.embeddings_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -133,7 +133,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.tool_active_count{$service.instance.id}",
+                      "query": "sum:spice.tool_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -170,7 +170,7 @@
           {
             "id": 201,
             "definition": {
-              "title": "Query Duration by Protocol (p99)",
+              "title": "Query Duration by Protocol",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
@@ -198,7 +198,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "max:spice.query_duration_ms_summary.quantile{$service.instance.id,quantile:0.99} by {protocol}.rollup(max)"
+                      "query": "avg:spice.query_duration_ms_summary.quantile{$instance,quantile:0.99} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -228,7 +228,7 @@
           {
             "id": 202,
             "definition": {
-              "title": "Query Count by Protocol",
+              "title": "Query Throughput",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
@@ -249,7 +249,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_executions{*} by {protocol}.as_count()"
+                      "query": "sum:spice.query_executions.count{$instance} by {protocol}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -298,7 +298,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_active_count{$service.instance.id} by {protocol}"
+                      "query": "sum:spice.query_active_count{$instance} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -346,7 +346,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_failures{$service.instance.id} by {err_code}.as_count()"
+                      "query": "sum:spice.query_failures.count{$instance} by {err_code}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -373,7 +373,7 @@
           {
             "id": 205,
             "definition": {
-              "title": "Rows Returned per Query (p99)",
+              "title": "Rows Returned per Query",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
@@ -394,7 +394,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "max:spice.query_returned_rows_summary.quantile{$service.instance.id,quantile:0.99} by {protocol}.rollup(max)"
+                      "query": "avg:spice.query_returned_rows_summary.quantile{$instance,quantile:0.99} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -465,12 +465,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_processed_bytes{$service.instance.id}"
+                      "query": "sum:spice.query_processed_bytes.count{$instance}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.query_returned_bytes{$service.instance.id}"
+                      "query": "sum:spice.query_returned_bytes.count{$instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -520,7 +520,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_spilled_bytes{$service.instance.id}.as_count()"
+                      "query": "sum:spice.query_spilled_bytes.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -574,7 +574,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration.time_since_last_refresh_ms{$service.instance.id,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$instance,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -598,7 +598,13 @@
                   ],
                   "formulas": [
                     {
-                      "formula": "query1"
+                      "formula": "time() * 1000 - query1",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "millisecond"
+                        }
+                      }
                     }
                   ],
                   "sort": {
@@ -652,7 +658,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "max:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$service.instance.id,!dataset:runtime.*,quantile:0.99} by {dataset}.rollup(max)"
+                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$instance,!dataset:runtime.*,quantile:0.99} by {dataset}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -700,7 +706,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_acceleration_refresh_errors{$service.instance.id} by {dataset}.as_count()"
+                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$instance} by {dataset}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -738,7 +744,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$service.instance.id,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$instance,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -806,7 +812,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$service.instance.id,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$instance,!dataset:runtime.*} by {dataset}",
                       "aggregator": "avg"
                     }
                   ],
@@ -888,7 +894,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.results_cache_hit_ratio{$service.instance.id}",
+                      "query": "avg:spice.results_cache_hit_ratio{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -953,12 +959,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_hits{$service.instance.id}.as_count()"
+                      "query": "sum:spice.results_cache_hits.count{$instance}.as_count()"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_requests{$service.instance.id}.as_count()"
+                      "query": "sum:spice.results_cache_requests.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1015,12 +1021,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_size_bytes{$service.instance.id}"
+                      "query": "sum:spice.results_cache_size_bytes{$instance}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_max_size_bytes{$service.instance.id}"
+                      "query": "sum:spice.results_cache_max_size_bytes{$instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1064,7 +1070,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_items_count{$service.instance.id}"
+                      "query": "sum:spice.results_cache_items_count{$instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1108,7 +1114,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_evictions{$service.instance.id}.as_count()"
+                      "query": "sum:spice.results_cache_evictions.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1152,7 +1158,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_swr_background_query_count{$service.instance.id}.as_count()"
+                      "query": "sum:spice.results_cache_swr_background_query_count.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1217,7 +1223,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "spice.dataset_acceleration_snapshot_write_duration_ms{$service.instance.id} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$instance,quantile:0.99} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1271,12 +1277,18 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "spice.dataset_acceleration_snapshot_write_bytes{$service.instance.id} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$instance} by {dataset}"
                     }
                   ],
                   "formulas": [
                     {
-                      "formula": "query1"
+                      "formula": "query1",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "byte"
+                        }
+                      }
                     }
                   ],
                   "style": {
@@ -1319,7 +1331,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "spice.dataset_acceleration_snapshot_bootstrap_duration_ms{$service.instance.id} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$instance} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1385,14 +1397,20 @@
                 {
                   "formulas": [
                     {
-                      "formula": "query1"
+                      "formula": "query1",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "millisecond"
+                        }
+                      }
                     }
                   ],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "max:spice.http_requests_duration_ms_summary.quantile{$service.instance.id,quantile:0.99} by {method,path}.rollup(max)"
+                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$instance,quantile:0.99} by {method,path}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1440,7 +1458,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.http_requests{$service.instance.id} by {method,path,status}.as_count()"
+                      "query": "sum:spice.http_requests.count{$instance} by {method,path,status}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1512,7 +1530,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "max:spice.flight_request_duration_ms_summary.quantile{$service.instance.id,method:do_get,quantile:0.99} by {command}.rollup(max)"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:do_get,quantile:0.99} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1567,7 +1585,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "max:spice.flight_request_duration_ms_summary.quantile{$service.instance.id,method:do_put,quantile:0.99} by {command}.rollup(max)"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:do_put,quantile:0.99} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1622,7 +1640,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "max:spice.flight_request_duration_ms_summary.quantile{$service.instance.id,method:get_flight_info,quantile:0.99} by {command}.rollup(max)"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:get_flight_info,quantile:0.99} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1670,7 +1688,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_requests{$service.instance.id} by {method}.as_count()"
+                      "query": "sum:spice.flight_requests.count{$instance} by {method}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1719,7 +1737,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_do_exchange_data_updates_sent{$service.instance.id}.as_count()"
+                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1784,7 +1802,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_kafka_records_lag{$service.instance.id} by {name}"
+                      "query": "avg:spice.dataset_kafka_records_lag{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1831,7 +1849,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_kafka_records_consumed_total{$service.instance.id} by {name}"
+                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1897,7 +1915,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_lag_ms{$service.instance.id} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_lag_ms{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1945,7 +1963,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_records_consumed_total{$service.instance.id} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1993,7 +2011,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_shards_active{$service.instance.id} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_shards_active{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2041,7 +2059,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_errors_transient_total{$service.instance.id} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2072,6 +2090,469 @@
         "y": 34,
         "width": 12,
         "height": 1
+      }
+    },
+    {
+      "id": 11,
+      "definition": {
+        "title": "⚙️ Runtime Resources",
+        "background_color": "vivid_yellow",
+        "show_title": true,
+        "type": "group",
+        "layout_type": "ordered",
+        "widgets": [
+          {
+            "id": 1001,
+            "definition": {
+              "title": "CPU Cores",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "max",
+                "value"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:spice.spiced_cpu_budget_cores{$instance} by {pod_name,source}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear"
+              }
+            },
+            "layout": {
+              "x": 0,
+              "y": 0,
+              "width": 6,
+              "height": 3
+            }
+          },
+          {
+            "id": 1002,
+            "definition": {
+              "title": "CPU Entitlement",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "max",
+                "value"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "budget"
+                    },
+                    {
+                      "formula": "query2",
+                      "alias": "limit"
+                    },
+                    {
+                      "formula": "query3",
+                      "alias": "request"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:spice.spiced_cpu_budget_millicores{$instance} by {pod_name,source}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "avg:spice.spiced_cpu_limit_millicores{$instance} by {pod_name}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query3",
+                      "query": "avg:spice.spiced_cpu_request_millicores{$instance} by {pod_name}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear"
+              }
+            },
+            "layout": {
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 3
+            }
+          },
+          {
+            "id": 1003,
+            "definition": {
+              "title": "Worker Threads",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "max",
+                "value"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:spice.tokio_runtime_workers{$instance} by {pod_name,runtime}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear"
+              }
+            },
+            "layout": {
+              "x": 0,
+              "y": 3,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "id": 1004,
+            "definition": {
+              "title": "Active Tasks",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "max",
+                "value"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:spice.tokio_runtime_alive_tasks{$instance} by {pod_name,runtime}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear"
+              }
+            },
+            "layout": {
+              "x": 4,
+              "y": 3,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "id": 1005,
+            "definition": {
+              "title": "Queued Tasks",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "max",
+                "value"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:spice.tokio_runtime_global_queue_depth{$instance} by {pod_name,runtime}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear"
+              }
+            },
+            "layout": {
+              "x": 8,
+              "y": 3,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "id": 1006,
+            "definition": {
+              "title": "Process Memory",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "max",
+                "value"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "byte"
+                        }
+                      }
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:spice.process_resident_memory_bytes{$instance} by {pod_name}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear"
+              }
+            },
+            "layout": {
+              "x": 0,
+              "y": 6,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "id": 1007,
+            "definition": {
+              "title": "Query Memory",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "max",
+                "value"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "byte"
+                        }
+                      }
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:spice.query_memory_pool_used_bytes{$instance} by {pod_name}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear"
+              }
+            },
+            "layout": {
+              "x": 4,
+              "y": 6,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "id": 1008,
+            "definition": {
+              "title": "Compaction Memory",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "avg",
+                "max",
+                "value"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "formula": "query1",
+                      "alias": "used",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "byte"
+                        }
+                      }
+                    },
+                    {
+                      "formula": "query2",
+                      "alias": "budget",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "byte"
+                        }
+                      }
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$instance} by {pod_name}"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$instance} by {pod_name}"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "dog_classic",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
+                  "display_type": "line"
+                }
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear"
+              }
+            },
+            "layout": {
+              "x": 8,
+              "y": 6,
+              "width": 4,
+              "height": 3
+            }
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 35,
+        "width": 12,
+        "height": 10
       }
     },
     {
@@ -2108,7 +2589,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.cpu.usage{*} by {pod_name}"
+                      "query": "avg:k8s.pod.cpu.usage{$instance} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2157,7 +2638,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.memory.working_set{*} by {pod_name}"
+                      "query": "avg:k8s.pod.memory.working_set{$instance} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2205,12 +2686,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{$instance,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{$instance,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2258,12 +2739,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{$instance,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{$instance,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2292,7 +2773,7 @@
       },
       "layout": {
         "x": 0,
-        "y": 35,
+        "y": 45,
         "width": 12,
         "height": 1
       }
@@ -2300,8 +2781,8 @@
   ],
   "template_variables": [
     {
-      "name": "service.instance.id",
-      "prefix": "service.instance.id",
+      "name": "instance",
+      "prefix": "pod_name",
       "available_values": [],
       "default": "*"
     }

--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -28,7 +28,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_active_count{$host,$pod_name}",
+                      "query": "sum:spice.dataset_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -63,7 +63,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.model_active_count{$host,$pod_name}",
+                      "query": "sum:spice.model_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -98,7 +98,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.embeddings_active_count{$host,$pod_name}",
+                      "query": "sum:spice.embeddings_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -133,7 +133,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.tool_active_count{$host,$pod_name}",
+                      "query": "sum:spice.tool_active_count{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -198,7 +198,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_duration_ms_summary.quantile{$host,$pod_name,$percentile} by {protocol}"
+                      "query": "avg:spice.query_duration_ms_summary.quantile{$instance,$percentile} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -249,7 +249,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_executions.count{$host,$pod_name} by {protocol}.as_count()"
+                      "query": "sum:spice.query_executions.count{$instance} by {protocol}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -298,7 +298,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_active_count{$host,$pod_name} by {protocol}"
+                      "query": "sum:spice.query_active_count{$instance} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -346,7 +346,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_failures.count{$host,$pod_name} by {err_code}.as_count()"
+                      "query": "sum:spice.query_failures.count{$instance} by {err_code}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -394,7 +394,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_returned_rows_summary.quantile{$host,$pod_name,$percentile} by {protocol}"
+                      "query": "avg:spice.query_returned_rows_summary.quantile{$instance,$percentile} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -465,12 +465,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_processed_bytes.count{$host,$pod_name}"
+                      "query": "sum:spice.query_processed_bytes.count{$instance}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.query_returned_bytes.count{$host,$pod_name}"
+                      "query": "sum:spice.query_returned_bytes.count{$instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -520,7 +520,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_spilled_bytes.count{$host,$pod_name}.as_count()"
+                      "query": "sum:spice.query_spilled_bytes.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -574,7 +574,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$host,$pod_name,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$instance,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -658,7 +658,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$host,$pod_name,!dataset:runtime.*,$percentile} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$instance,!dataset:runtime.*,$percentile} by {dataset}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -706,7 +706,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$host,$pod_name} by {dataset}.as_count()"
+                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$instance} by {dataset}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -744,7 +744,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$host,$pod_name,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$instance,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -812,7 +812,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$host,$pod_name,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$instance,!dataset:runtime.*} by {dataset}",
                       "aggregator": "avg"
                     }
                   ],
@@ -894,7 +894,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.results_cache_hit_ratio{$host,$pod_name}",
+                      "query": "avg:spice.results_cache_hit_ratio{$instance}",
                       "aggregator": "last"
                     }
                   ],
@@ -959,12 +959,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_hits.count{$host,$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_hits.count{$instance}.as_count()"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_requests.count{$host,$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_requests.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1021,12 +1021,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_size_bytes{$host,$pod_name}"
+                      "query": "sum:spice.results_cache_size_bytes{$instance}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_max_size_bytes{$host,$pod_name}"
+                      "query": "sum:spice.results_cache_max_size_bytes{$instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1070,7 +1070,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_items_count{$host,$pod_name}"
+                      "query": "sum:spice.results_cache_items_count{$instance}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1114,7 +1114,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_evictions.count{$host,$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_evictions.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1158,7 +1158,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_swr_background_query_count.count{$host,$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_swr_background_query_count.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1223,7 +1223,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$host,$pod_name,$percentile} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$instance,$percentile} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1277,7 +1277,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$host,$pod_name} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$instance} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1331,7 +1331,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$host,$pod_name} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$instance} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1410,7 +1410,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$host,$pod_name,$percentile} by {method,path}"
+                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$instance,$percentile} by {method,path}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1458,7 +1458,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.http_requests.count{$host,$pod_name} by {method,path,status}.as_count()"
+                      "query": "sum:spice.http_requests.count{$instance} by {method,path,status}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1530,7 +1530,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$host,$pod_name,method:do_get,$percentile} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:do_get,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1585,7 +1585,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$host,$pod_name,method:do_put,$percentile} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:do_put,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1640,7 +1640,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$host,$pod_name,method:get_flight_info,$percentile} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:get_flight_info,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1688,7 +1688,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_requests.count{$host,$pod_name} by {method}.as_count()"
+                      "query": "sum:spice.flight_requests.count{$instance} by {method}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1737,7 +1737,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$host,$pod_name}.as_count()"
+                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$instance}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1802,7 +1802,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_kafka_records_lag{$host,$pod_name} by {name}"
+                      "query": "avg:spice.dataset_kafka_records_lag{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1849,7 +1849,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$host,$pod_name} by {name}"
+                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1915,7 +1915,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_lag_ms{$host,$pod_name} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_lag_ms{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1963,7 +1963,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$host,$pod_name} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2011,7 +2011,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_shards_active{$host,$pod_name} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_shards_active{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2059,7 +2059,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$host,$pod_name} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$instance} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2126,7 +2126,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_cores{$host,$pod_name} by {host,pod_name,source}"
+                      "query": "avg:spice.spiced_cpu_budget_cores{$instance} by {service.instance.id,source}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2184,17 +2184,17 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_millicores{$host,$pod_name} by {host,pod_name,source}"
+                      "query": "avg:spice.spiced_cpu_budget_millicores{$instance} by {service.instance.id,source}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.spiced_cpu_limit_millicores{$host,$pod_name} by {host,pod_name}"
+                      "query": "avg:spice.spiced_cpu_limit_millicores{$instance} by {service.instance.id}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query3",
-                      "query": "avg:spice.spiced_cpu_request_millicores{$host,$pod_name} by {host,pod_name}"
+                      "query": "avg:spice.spiced_cpu_request_millicores{$instance} by {service.instance.id}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2243,7 +2243,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_workers{$host,$pod_name} by {host,pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_workers{$instance} by {service.instance.id,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2292,7 +2292,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_alive_tasks{$host,$pod_name} by {host,pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_alive_tasks{$instance} by {service.instance.id,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2341,7 +2341,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_global_queue_depth{$host,$pod_name} by {host,pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_global_queue_depth{$instance} by {service.instance.id,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2396,7 +2396,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.process_resident_memory_bytes{$host,$pod_name} by {host,pod_name}"
+                      "query": "avg:spice.process_resident_memory_bytes{$instance} by {service.instance.id}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2451,7 +2451,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_memory_pool_used_bytes{$host,$pod_name} by {host,pod_name}"
+                      "query": "avg:spice.query_memory_pool_used_bytes{$instance} by {service.instance.id}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2517,12 +2517,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$host,$pod_name} by {host,pod_name}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$instance} by {service.instance.id}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$host,$pod_name} by {host,pod_name}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$instance} by {service.instance.id}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2589,7 +2589,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.cpu.usage{$host,$pod_name} by {pod_name}"
+                      "query": "avg:k8s.pod.cpu.usage{pod_name:$instance.value} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2638,7 +2638,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.memory.working_set{$host,$pod_name} by {pod_name}"
+                      "query": "avg:k8s.pod.memory.working_set{pod_name:$instance.value} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2686,12 +2686,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{$host,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{$host,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2739,12 +2739,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{$host,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{$host,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2781,14 +2781,8 @@
   ],
   "template_variables": [
     {
-      "name": "host",
-      "prefix": "host",
-      "available_values": [],
-      "default": "*"
-    },
-    {
-      "name": "pod_name",
-      "prefix": "pod_name",
+      "name": "instance",
+      "prefix": "service.instance.id",
       "available_values": [],
       "default": "*"
     },

--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -5,7 +5,7 @@
     {
       "id": 1,
       "definition": {
-        "title": "🏠 System Overview",
+        "title": "\ud83c\udfe0 System Overview",
         "background_color": "vivid_blue",
         "type": "group",
         "layout_type": "ordered",
@@ -162,7 +162,7 @@
     {
       "id": 2,
       "definition": {
-        "title": "📊 Query Performance",
+        "title": "\ud83d\udcca Query Performance",
         "background_color": "vivid_green",
         "type": "group",
         "layout_type": "ordered",
@@ -430,7 +430,7 @@
     {
       "id": 3,
       "definition": {
-        "title": "📈 Data Throughput",
+        "title": "\ud83d\udcc8 Data Throughput",
         "background_color": "vivid_purple",
         "type": "group",
         "layout_type": "ordered",
@@ -556,7 +556,7 @@
     {
       "id": 4,
       "definition": {
-        "title": "⚡ Accelerated Datasets",
+        "title": "\u26a1 Accelerated Datasets",
         "background_color": "vivid_orange",
         "type": "group",
         "layout_type": "ordered",
@@ -865,7 +865,7 @@
     {
       "id": 5,
       "definition": {
-        "title": "💾 Results Cache",
+        "title": "\ud83d\udcbe Results Cache",
         "background_color": "vivid_pink",
         "type": "group",
         "layout_type": "ordered",
@@ -1194,7 +1194,7 @@
     {
       "id": 6025761671556420,
       "definition": {
-        "title": "📦 Acceleration Snapshots",
+        "title": "\ud83d\udce6 Acceleration Snapshots",
         "background_color": "vivid_orange",
         "show_title": true,
         "type": "group",
@@ -1374,7 +1374,7 @@
     {
       "id": 6,
       "definition": {
-        "title": "🌐 HTTP API",
+        "title": "\ud83c\udf10 HTTP API",
         "background_color": "vivid_yellow",
         "type": "group",
         "layout_type": "ordered",
@@ -1494,7 +1494,7 @@
     {
       "id": 7,
       "definition": {
-        "title": "✈️ Arrow Flight Operations",
+        "title": "\u2708\ufe0f Arrow Flight Operations",
         "background_color": "gray",
         "type": "group",
         "layout_type": "ordered",
@@ -1773,7 +1773,7 @@
     {
       "id": 8,
       "definition": {
-        "title": "⏩ Debezium Ingestion",
+        "title": "\u23e9 Debezium Ingestion",
         "background_color": "white",
         "show_title": true,
         "type": "group",
@@ -1885,7 +1885,7 @@
     {
       "id": 9,
       "definition": {
-        "title": "⏩ DynamoDB Streams Ingestion",
+        "title": "\u23e9 DynamoDB Streams Ingestion",
         "background_color": "blue",
         "show_title": true,
         "type": "group",
@@ -2095,7 +2095,7 @@
     {
       "id": 11,
       "definition": {
-        "title": "⚙️ Runtime Resources",
+        "title": "\u2699\ufe0f Runtime Resources",
         "background_color": "vivid_yellow",
         "show_title": true,
         "type": "group",
@@ -2126,7 +2126,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_cores{$instance} by {service.instance.id,source}"
+                      "query": "avg:spice.spiced_cpu_budget_cores{$instance} by {service_instance_id,source}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2184,17 +2184,17 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_millicores{$instance} by {service.instance.id,source}"
+                      "query": "avg:spice.spiced_cpu_budget_millicores{$instance} by {service_instance_id,source}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.spiced_cpu_limit_millicores{$instance} by {service.instance.id}"
+                      "query": "avg:spice.spiced_cpu_limit_millicores{$instance} by {service_instance_id}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query3",
-                      "query": "avg:spice.spiced_cpu_request_millicores{$instance} by {service.instance.id}"
+                      "query": "avg:spice.spiced_cpu_request_millicores{$instance} by {service_instance_id}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2243,7 +2243,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_workers{$instance} by {service.instance.id,runtime}"
+                      "query": "avg:spice.tokio_runtime_workers{$instance} by {service_instance_id,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2292,7 +2292,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_alive_tasks{$instance} by {service.instance.id,runtime}"
+                      "query": "avg:spice.tokio_runtime_alive_tasks{$instance} by {service_instance_id,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2341,7 +2341,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_global_queue_depth{$instance} by {service.instance.id,runtime}"
+                      "query": "avg:spice.tokio_runtime_global_queue_depth{$instance} by {service_instance_id,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2396,7 +2396,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.process_resident_memory_bytes{$instance} by {service.instance.id}"
+                      "query": "avg:spice.process_resident_memory_bytes{$instance} by {service_instance_id}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2451,7 +2451,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_memory_pool_used_bytes{$instance} by {service.instance.id}"
+                      "query": "avg:spice.query_memory_pool_used_bytes{$instance} by {service_instance_id}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2517,12 +2517,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$instance} by {service.instance.id}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$instance} by {service_instance_id}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$instance} by {service.instance.id}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$instance} by {service_instance_id}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2558,7 +2558,7 @@
     {
       "id": 10,
       "definition": {
-        "title": "🔧 Kubernetes Resource Utilization",
+        "title": "\ud83d\udd27 Kubernetes Resource Utilization",
         "background_color": "vivid_green",
         "show_title": true,
         "type": "group",
@@ -2782,8 +2782,7 @@
   "template_variables": [
     {
       "name": "instance",
-      "prefix": "service.instance.id",
-      "available_values": [],
+      "prefix": "service_instance_id",
       "default": "*"
     },
     {

--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -1,6 +1,6 @@
 {
   "title": "Spice.ai Dashboard",
-  "description": "Base Datadog dashboard for Spice.ai scraped by the Datadog Agent OpenMetrics check (Kubernetes Autodiscovery). Expected check shape: openmetrics_endpoint on the Spice metrics port (default 9090), namespace \"spice\", metrics [.*]. Filter pods with pod_name (Agent Kubernetes tag; leave * for all). Percentile selects the quantile tag on *_summary.quantile panels (default 0.99). Counter panels use OpenMetrics V2 *.count names.",
+  "description": "Monitoring dashboard for Spice.ai runtime - covers system health, query performance, data acceleration, caching, AI/ML operations, and Flight protocol metrics.",
   "widgets": [
     {
       "id": 1,

--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -28,7 +28,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_active_count{$instance}",
+                      "query": "sum:spice.dataset_active_count{$host,$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -63,7 +63,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.model_active_count{$instance}",
+                      "query": "sum:spice.model_active_count{$host,$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -98,7 +98,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.embeddings_active_count{$instance}",
+                      "query": "sum:spice.embeddings_active_count{$host,$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -133,7 +133,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.tool_active_count{$instance}",
+                      "query": "sum:spice.tool_active_count{$host,$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -198,7 +198,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_duration_ms_summary.quantile{$instance,$percentile} by {protocol}"
+                      "query": "avg:spice.query_duration_ms_summary.quantile{$host,$pod_name,$percentile} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -249,7 +249,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_executions.count{$instance} by {protocol}.as_count()"
+                      "query": "sum:spice.query_executions.count{$host,$pod_name} by {protocol}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -298,7 +298,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_active_count{$instance} by {protocol}"
+                      "query": "sum:spice.query_active_count{$host,$pod_name} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -346,7 +346,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_failures.count{$instance} by {err_code}.as_count()"
+                      "query": "sum:spice.query_failures.count{$host,$pod_name} by {err_code}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -394,7 +394,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_returned_rows_summary.quantile{$instance,$percentile} by {protocol}"
+                      "query": "avg:spice.query_returned_rows_summary.quantile{$host,$pod_name,$percentile} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -465,12 +465,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_processed_bytes.count{$instance}"
+                      "query": "sum:spice.query_processed_bytes.count{$host,$pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.query_returned_bytes.count{$instance}"
+                      "query": "sum:spice.query_returned_bytes.count{$host,$pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -520,7 +520,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_spilled_bytes.count{$instance}.as_count()"
+                      "query": "sum:spice.query_spilled_bytes.count{$host,$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -574,7 +574,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$instance,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$host,$pod_name,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -658,7 +658,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$instance,!dataset:runtime.*,$percentile} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$host,$pod_name,!dataset:runtime.*,$percentile} by {dataset}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -706,7 +706,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$instance} by {dataset}.as_count()"
+                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$host,$pod_name} by {dataset}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -744,7 +744,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$instance,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$host,$pod_name,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -812,7 +812,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$instance,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$host,$pod_name,!dataset:runtime.*} by {dataset}",
                       "aggregator": "avg"
                     }
                   ],
@@ -894,7 +894,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.results_cache_hit_ratio{$instance}",
+                      "query": "avg:spice.results_cache_hit_ratio{$host,$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -959,12 +959,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_hits.count{$instance}.as_count()"
+                      "query": "sum:spice.results_cache_hits.count{$host,$pod_name}.as_count()"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_requests.count{$instance}.as_count()"
+                      "query": "sum:spice.results_cache_requests.count{$host,$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1021,12 +1021,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_size_bytes{$instance}"
+                      "query": "sum:spice.results_cache_size_bytes{$host,$pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_max_size_bytes{$instance}"
+                      "query": "sum:spice.results_cache_max_size_bytes{$host,$pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1070,7 +1070,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_items_count{$instance}"
+                      "query": "sum:spice.results_cache_items_count{$host,$pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1114,7 +1114,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_evictions.count{$instance}.as_count()"
+                      "query": "sum:spice.results_cache_evictions.count{$host,$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1158,7 +1158,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_swr_background_query_count.count{$instance}.as_count()"
+                      "query": "sum:spice.results_cache_swr_background_query_count.count{$host,$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1223,7 +1223,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$instance,$percentile} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$host,$pod_name,$percentile} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1277,7 +1277,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$instance} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$host,$pod_name} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1331,7 +1331,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$instance} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$host,$pod_name} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1410,7 +1410,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$instance,$percentile} by {method,path}"
+                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$host,$pod_name,$percentile} by {method,path}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1458,7 +1458,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.http_requests.count{$instance} by {method,path,status}.as_count()"
+                      "query": "sum:spice.http_requests.count{$host,$pod_name} by {method,path,status}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1530,7 +1530,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:do_get,$percentile} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$host,$pod_name,method:do_get,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1585,7 +1585,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:do_put,$percentile} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$host,$pod_name,method:do_put,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1640,7 +1640,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$instance,method:get_flight_info,$percentile} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$host,$pod_name,method:get_flight_info,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1688,7 +1688,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_requests.count{$instance} by {method}.as_count()"
+                      "query": "sum:spice.flight_requests.count{$host,$pod_name} by {method}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1737,7 +1737,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$instance}.as_count()"
+                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$host,$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1802,7 +1802,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_kafka_records_lag{$instance} by {name}"
+                      "query": "avg:spice.dataset_kafka_records_lag{$host,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1849,7 +1849,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$instance} by {name}"
+                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$host,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1915,7 +1915,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_lag_ms{$instance} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_lag_ms{$host,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1963,7 +1963,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$instance} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$host,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2011,7 +2011,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_shards_active{$instance} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_shards_active{$host,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2059,7 +2059,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$instance} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$host,$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2126,7 +2126,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_cores{$instance} by {instance,source}"
+                      "query": "avg:spice.spiced_cpu_budget_cores{$host,$pod_name} by {host,pod_name,source}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2184,17 +2184,17 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_millicores{$instance} by {instance,source}"
+                      "query": "avg:spice.spiced_cpu_budget_millicores{$host,$pod_name} by {host,pod_name,source}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.spiced_cpu_limit_millicores{$instance} by {instance}"
+                      "query": "avg:spice.spiced_cpu_limit_millicores{$host,$pod_name} by {host,pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query3",
-                      "query": "avg:spice.spiced_cpu_request_millicores{$instance} by {instance}"
+                      "query": "avg:spice.spiced_cpu_request_millicores{$host,$pod_name} by {host,pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2243,7 +2243,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_workers{$instance} by {instance,runtime}"
+                      "query": "avg:spice.tokio_runtime_workers{$host,$pod_name} by {host,pod_name,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2292,7 +2292,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_alive_tasks{$instance} by {instance,runtime}"
+                      "query": "avg:spice.tokio_runtime_alive_tasks{$host,$pod_name} by {host,pod_name,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2341,7 +2341,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_global_queue_depth{$instance} by {instance,runtime}"
+                      "query": "avg:spice.tokio_runtime_global_queue_depth{$host,$pod_name} by {host,pod_name,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2396,7 +2396,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.process_resident_memory_bytes{$instance} by {instance}"
+                      "query": "avg:spice.process_resident_memory_bytes{$host,$pod_name} by {host,pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2451,7 +2451,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_memory_pool_used_bytes{$instance} by {instance}"
+                      "query": "avg:spice.query_memory_pool_used_bytes{$host,$pod_name} by {host,pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2517,12 +2517,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$instance} by {instance}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$host,$pod_name} by {host,pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$instance} by {instance}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$host,$pod_name} by {host,pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2589,7 +2589,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.cpu.usage{pod_name:$instance.value} by {pod_name}"
+                      "query": "avg:k8s.pod.cpu.usage{$host,$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2638,7 +2638,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.memory.working_set{pod_name:$instance.value} by {pod_name}"
+                      "query": "avg:k8s.pod.memory.working_set{$host,$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2686,12 +2686,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{$host,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{$host,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2739,12 +2739,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{$host,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{pod_name:$instance.value,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{$host,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2781,8 +2781,14 @@
   ],
   "template_variables": [
     {
-      "name": "instance",
-      "prefix": "instance",
+      "name": "host",
+      "prefix": "host",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "pod_name",
+      "prefix": "pod_name",
       "available_values": [],
       "default": "*"
     },

--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -1,6 +1,6 @@
 {
   "title": "Spice.ai Dashboard",
-  "description": "Base Datadog dashboard for Spice.ai scraped by the Datadog Agent OpenMetrics check (Kubernetes Autodiscovery). Expected check shape: openmetrics_endpoint on the Spice metrics port (default 9090), namespace \"spice\", metrics [.*]. Filter with standard Agent Kubernetes tags (kube_namespace, kube_app_instance, pod_name); leave unused filters as *. Counter panels use OpenMetrics V2 *.count names; latency panels use Spice *_summary.quantile gauges (quantile:0.99).",
+  "description": "Base Datadog dashboard for Spice.ai scraped by the Datadog Agent OpenMetrics check (Kubernetes Autodiscovery). Expected check shape: openmetrics_endpoint on the Spice metrics port (default 9090), namespace \"spice\", metrics [.*]. Filter pods with pod_name (Agent Kubernetes tag; leave * for all). Percentile selects the quantile tag on *_summary.quantile panels (default 0.99). Counter panels use OpenMetrics V2 *.count names.",
   "widgets": [
     {
       "id": 1,
@@ -28,7 +28,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_active_count{$kube_namespace,$kube_app_instance,$pod_name}",
+                      "query": "sum:spice.dataset_active_count{$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -63,7 +63,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.model_active_count{$kube_namespace,$kube_app_instance,$pod_name}",
+                      "query": "sum:spice.model_active_count{$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -98,7 +98,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.embeddings_active_count{$kube_namespace,$kube_app_instance,$pod_name}",
+                      "query": "sum:spice.embeddings_active_count{$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -133,7 +133,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.tool_active_count{$kube_namespace,$kube_app_instance,$pod_name}",
+                      "query": "sum:spice.tool_active_count{$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -198,7 +198,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,quantile:0.99} by {protocol}"
+                      "query": "avg:spice.query_duration_ms_summary.quantile{$pod_name,$percentile} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -249,7 +249,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_executions.count{$kube_namespace,$kube_app_instance,$pod_name} by {protocol}.as_count()"
+                      "query": "sum:spice.query_executions.count{$pod_name} by {protocol}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -298,7 +298,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_active_count{$kube_namespace,$kube_app_instance,$pod_name} by {protocol}"
+                      "query": "sum:spice.query_active_count{$pod_name} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -346,7 +346,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_failures.count{$kube_namespace,$kube_app_instance,$pod_name} by {err_code}.as_count()"
+                      "query": "sum:spice.query_failures.count{$pod_name} by {err_code}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -394,7 +394,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_returned_rows_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,quantile:0.99} by {protocol}"
+                      "query": "avg:spice.query_returned_rows_summary.quantile{$pod_name,$percentile} by {protocol}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -465,12 +465,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_processed_bytes.count{$kube_namespace,$kube_app_instance,$pod_name}"
+                      "query": "sum:spice.query_processed_bytes.count{$pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.query_returned_bytes.count{$kube_namespace,$kube_app_instance,$pod_name}"
+                      "query": "sum:spice.query_returned_bytes.count{$pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -520,7 +520,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.query_spilled_bytes.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
+                      "query": "sum:spice.query_spilled_bytes.count{$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -574,7 +574,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$kube_namespace,$kube_app_instance,$pod_name,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_last_refresh_unix_time_ms{$pod_name,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -630,7 +630,7 @@
           {
             "id": 304,
             "definition": {
-              "title": "Refresh Duration (p99)",
+              "title": "Refresh Duration",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
@@ -658,7 +658,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,!dataset:runtime.*,quantile:0.99} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_refresh_duration_ms_summary.quantile{$pod_name,!dataset:runtime.*,$percentile} by {dataset}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -706,7 +706,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$kube_namespace,$kube_app_instance,$pod_name} by {dataset}.as_count()"
+                      "query": "sum:spice.dataset_acceleration_refresh_errors.count{$pod_name} by {dataset}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -744,7 +744,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$kube_namespace,$kube_app_instance,$pod_name,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_ingestion_lag_ms{$pod_name,!dataset:runtime.*} by {dataset}",
                       "aggregator": "last"
                     }
                   ],
@@ -812,7 +812,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$kube_namespace,$kube_app_instance,$pod_name,!dataset:runtime.*} by {dataset}",
+                      "query": "avg:spice.dataset_acceleration_refresh_lag_ms{$pod_name,!dataset:runtime.*} by {dataset}",
                       "aggregator": "avg"
                     }
                   ],
@@ -894,7 +894,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.results_cache_hit_ratio{$kube_namespace,$kube_app_instance,$pod_name}",
+                      "query": "avg:spice.results_cache_hit_ratio{$pod_name}",
                       "aggregator": "last"
                     }
                   ],
@@ -959,12 +959,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_hits.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_hits.count{$pod_name}.as_count()"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_requests.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_requests.count{$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1021,12 +1021,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_size_bytes{$kube_namespace,$kube_app_instance,$pod_name}"
+                      "query": "sum:spice.results_cache_size_bytes{$pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:spice.results_cache_max_size_bytes{$kube_namespace,$kube_app_instance,$pod_name}"
+                      "query": "sum:spice.results_cache_max_size_bytes{$pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1070,7 +1070,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_items_count{$kube_namespace,$kube_app_instance,$pod_name}"
+                      "query": "sum:spice.results_cache_items_count{$pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1114,7 +1114,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_evictions.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_evictions.count{$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1158,7 +1158,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.results_cache_swr_background_query_count.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
+                      "query": "sum:spice.results_cache_swr_background_query_count.count{$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1223,7 +1223,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,quantile:0.99} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_duration_ms_summary.quantile{$pod_name,$percentile} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1277,7 +1277,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$kube_namespace,$kube_app_instance,$pod_name} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_write_bytes{$pod_name} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1331,7 +1331,7 @@
                     {
                       "name": "query1",
                       "data_source": "metrics",
-                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$kube_namespace,$kube_app_instance,$pod_name} by {dataset}"
+                      "query": "avg:spice.dataset_acceleration_snapshot_bootstrap_duration_ms.count{$pod_name} by {dataset}"
                     }
                   ],
                   "formulas": [
@@ -1382,7 +1382,7 @@
           {
             "id": 601,
             "definition": {
-              "title": "HTTP Request Duration (p99)",
+              "title": "HTTP Request Duration",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
@@ -1410,7 +1410,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,quantile:0.99} by {method,path}"
+                      "query": "avg:spice.http_requests_duration_ms_summary.quantile{$pod_name,$percentile} by {method,path}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1458,7 +1458,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.http_requests.count{$kube_namespace,$kube_app_instance,$pod_name} by {method,path,status}.as_count()"
+                      "query": "sum:spice.http_requests.count{$pod_name} by {method,path,status}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1502,7 +1502,7 @@
           {
             "id": 701,
             "definition": {
-              "title": "do_get Duration (p99)",
+              "title": "do_get Duration",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
@@ -1530,7 +1530,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,method:do_get,quantile:0.99} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$pod_name,method:do_get,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1557,7 +1557,7 @@
           {
             "id": 702,
             "definition": {
-              "title": "do_put Duration (p99)",
+              "title": "do_put Duration",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
@@ -1585,7 +1585,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,method:do_put,quantile:0.99} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$pod_name,method:do_put,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1612,7 +1612,7 @@
           {
             "id": 703,
             "definition": {
-              "title": "get_flight_info Duration (p99)",
+              "title": "get_flight_info Duration",
               "title_size": "16",
               "title_align": "left",
               "show_legend": true,
@@ -1640,7 +1640,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$kube_namespace,$kube_app_instance,$pod_name,method:get_flight_info,quantile:0.99} by {command}"
+                      "query": "avg:spice.flight_request_duration_ms_summary.quantile{$pod_name,method:get_flight_info,$percentile} by {command}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1688,7 +1688,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_requests.count{$kube_namespace,$kube_app_instance,$pod_name} by {method}.as_count()"
+                      "query": "sum:spice.flight_requests.count{$pod_name} by {method}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1737,7 +1737,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$kube_namespace,$kube_app_instance,$pod_name}.as_count()"
+                      "query": "sum:spice.flight_do_exchange_data_updates_sent.count{$pod_name}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1802,7 +1802,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_kafka_records_lag{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
+                      "query": "avg:spice.dataset_kafka_records_lag{$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1849,7 +1849,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
+                      "query": "sum:spice.dataset_kafka_records_consumed_total.count{$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1915,7 +1915,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_lag_ms{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_lag_ms{$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -1963,7 +1963,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_records_consumed_total.count{$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2011,7 +2011,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.dataset_dynamodb_shards_active{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
+                      "query": "avg:spice.dataset_dynamodb_shards_active{$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2059,7 +2059,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$kube_namespace,$kube_app_instance,$pod_name} by {name}"
+                      "query": "sum:spice.dataset_dynamodb_errors_transient_total.count{$pod_name} by {name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2126,7 +2126,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_cores{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name,source}"
+                      "query": "avg:spice.spiced_cpu_budget_cores{$pod_name} by {pod_name,source}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2184,17 +2184,17 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.spiced_cpu_budget_millicores{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name,source}"
+                      "query": "avg:spice.spiced_cpu_budget_millicores{$pod_name} by {pod_name,source}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.spiced_cpu_limit_millicores{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
+                      "query": "avg:spice.spiced_cpu_limit_millicores{$pod_name} by {pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query3",
-                      "query": "avg:spice.spiced_cpu_request_millicores{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
+                      "query": "avg:spice.spiced_cpu_request_millicores{$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2243,7 +2243,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_workers{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_workers{$pod_name} by {pod_name,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2292,7 +2292,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_alive_tasks{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_alive_tasks{$pod_name} by {pod_name,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2341,7 +2341,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.tokio_runtime_global_queue_depth{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name,runtime}"
+                      "query": "avg:spice.tokio_runtime_global_queue_depth{$pod_name} by {pod_name,runtime}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2396,7 +2396,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.process_resident_memory_bytes{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
+                      "query": "avg:spice.process_resident_memory_bytes{$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2451,7 +2451,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.query_memory_pool_used_bytes{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
+                      "query": "avg:spice.query_memory_pool_used_bytes{$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2517,12 +2517,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_used_bytes{$pod_name} by {pod_name}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$kube_namespace,$kube_app_instance,$pod_name} by {pod_name}"
+                      "query": "avg:spice.cayenne_compaction_memory_pool_bytes{$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2589,7 +2589,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.cpu.usage{$kube_namespace,$pod_name} by {pod_name}"
+                      "query": "avg:k8s.pod.cpu.usage{$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2638,7 +2638,7 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.pod.memory.working_set{$kube_namespace,$pod_name} by {pod_name}"
+                      "query": "avg:k8s.pod.memory.working_set{$pod_name} by {pod_name}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2686,12 +2686,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{$kube_namespace,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{$kube_namespace,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2739,12 +2739,12 @@
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "avg:k8s.volume.capacity{$kube_namespace,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.capacity{$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     },
                     {
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "avg:k8s.volume.available{$kube_namespace,$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
+                      "query": "avg:k8s.volume.available{$pod_name,!persistentvolumeclaim:kube-api-access-*,!persistentvolumeclaim:default-token-*} by {pod_name,persistentvolumeclaim}"
                     }
                   ],
                   "response_format": "timeseries",
@@ -2781,22 +2781,20 @@
   ],
   "template_variables": [
     {
-      "name": "kube_namespace",
-      "prefix": "kube_namespace",
-      "available_values": [],
-      "default": "*"
-    },
-    {
-      "name": "kube_app_instance",
-      "prefix": "kube_app_instance",
-      "available_values": [],
-      "default": "*"
-    },
-    {
       "name": "pod_name",
       "prefix": "pod_name",
       "available_values": [],
       "default": "*"
+    },
+    {
+      "name": "percentile",
+      "prefix": "quantile",
+      "available_values": [
+        "0.9",
+        "0.95",
+        "0.99"
+      ],
+      "default": "0.99"
     }
   ],
   "layout_type": "ordered",


### PR DESCRIPTION
## Summary

Base Datadog dashboard for Spice metrics, filtered by **`service_instance_id`** (OpenTelemetry [`service.instance.id`](https://opentelemetry.io/docs/specs/semconv/resource/#service) in undotted form).

The template variable is named `instance` (not `service.instance.id`) because Datadog treats `$name.key` / `$name.value` as TV syntax — see [Template variables](https://docs.datadoghq.com/dashboards/template_variables/#widgets).

### Template variables
| Variable | Tag prefix | Role |
|---|---|---|
| `instance` | `service_instance_id` | Service instance identity |
| `percentile` | `quantile` | 0.9 / 0.95 / 0.99 (default 0.99) |

### Agent setup (OpenMetrics)
```json
"tags": ["service_instance_id:%%kube_pod_name%%"]
```

### Other fixes vs trunk
- OpenMetrics V2 counters (`.count`) and summary percentile queries
- Time Since Last Refresh, snapshot / rate panels
- Runtime Resources section before Kubernetes

<img width="1346" height="779" alt="Screenshot 2026-08-04 at 22 17 30" src="https://github.com/user-attachments/assets/a6d4d8de-c8cf-4c80-83ae-0b4a3cbeb33a" />

<img width="1346" height="886" alt="Screenshot 2026-08-04 at 21 14 53" src="https://github.com/user-attachments/assets/872c7118-0529-4f3d-acb5-61396783b566" />
