### PR TITLE
chore(deps): repoint vortex at the 2.1 fixed-offset timezone fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21638,7 +21638,7 @@ dependencies = [
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "vortex-alp",
  "vortex-array",
@@ -21672,7 +21672,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -21690,7 +21690,7 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "arc-swap",
  "arcref",
@@ -21741,7 +21741,7 @@ dependencies = [
 [[package]]
 name = "vortex-array-macros"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -21751,7 +21751,7 @@ dependencies = [
 [[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -21778,7 +21778,7 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "arrow-buffer",
  "bitvec",
@@ -21791,7 +21791,7 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "num-traits",
  "vortex-array",
@@ -21804,7 +21804,7 @@ dependencies = [
 [[package]]
 name = "vortex-compressor"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -21860,7 +21860,7 @@ dependencies = [
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -21874,7 +21874,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -21888,7 +21888,7 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -21901,7 +21901,7 @@ dependencies = [
 [[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "fastlanes",
  "itertools 0.14.0",
@@ -21918,7 +21918,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -21962,7 +21962,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -21972,7 +21972,7 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "fsst-rs",
  "prost 0.14.3",
@@ -21986,7 +21986,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "async-fs",
  "async-stream",
@@ -22016,7 +22016,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -22033,7 +22033,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "arcref",
  "arrow-array",
@@ -22075,7 +22075,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer",
@@ -22085,7 +22085,7 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "parking_lot",
  "sketches-ddsketch",
@@ -22094,7 +22094,7 @@ dependencies = [
 [[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "pco",
  "prost 0.14.3",
@@ -22108,7 +22108,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "prost 0.14.3",
  "prost-types",
@@ -22117,7 +22117,7 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "arrow-array",
  "itertools 0.14.0",
@@ -22133,7 +22133,7 @@ dependencies = [
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "async-trait",
  "futures",
@@ -22149,7 +22149,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -22165,7 +22165,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "dashmap",
  "lasso",
@@ -22177,7 +22177,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -22192,7 +22192,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "dashmap",
  "hashbrown 0.17.1",
@@ -22202,7 +22202,7 @@ dependencies = [
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "vortex-array",
  "vortex-buffer",
@@ -22215,7 +22215,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=ab4f0b177527df49b1b886a37cf636151e672ac7#ab4f0b177527df49b1b886a37cf636151e672ac7"
+source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
 dependencies = [
  "itertools 0.14.0",
  "prost 0.14.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,13 +360,13 @@ flatbuffers = "25.2.10"
 # Vortex tagged releases publish version 0.1.0 in their Cargo.toml, not the actual release version,
 # so we specify git deps here directly. The [patch.crates-io] entries below exist to override
 # transitive vortex dependencies pulled in by other patched crates.
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
-vortex-btrblocks = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex-btrblocks = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
 vortex-datafusion = { path = "crates/vortex" }
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
 
 x509-certificate = "0.25.0"
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "93b75c3c7d1a812b23d00b45adf537d7a2415496" } # spiceai/spice-rs#77
@@ -490,9 +490,9 @@ arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a4037
 arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a40370d014a0f8eed12ee0d5a914e8cb2070d8" } # branch: lukim/spiceai-58.3.0
 parquet = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a40370d014a0f8eed12ee0d5a914e8cb2070d8" }      # branch: lukim/spiceai-58.3.0
 
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
 vortex-datafusion = { path = "crates/vortex" }
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "ab4f0b177527df49b1b886a37cf636151e672ac7" } # spiceai-54
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54


### PR DESCRIPTION
Repoints the vortex pin at `spiceai-2.1-54`, picking up the fixed-offset timezone fix from spiceai/vortex#77.

Fixes #12447.

## Problem

Arrow allows the timezone of a timestamp to be either an IANA name or a fixed UTC offset such as `+00:00`. Iceberg maps every `timestamptz` column to `+00:00`, and vortex resolved timezones through a lookup that accepts only IANA names.

Accelerating an Iceberg dataset with a `timestamptz` column therefore panics during the refresh write with `failed to find time zone '+00:00' in time zone database`, which kills the vortex writer task.

## Change

Both workspace stanzas move from `ab4f0b177527df49b1b886a37cf636151e672ac7` to `70b2429e31e9f122774200047c6aec3dc8f8136f`, and `Cargo.lock` is refreshed to match. The pin comment changes from `# spiceai-54` to `# spiceai-2.1-54` to name the branch it now tracks.

The vortex-side change resolves an IANA name first and otherwise parses the offset forms Arrow permits — `±HH:MM`, `±HHMM` and `±HH` — into a fixed offset. Timestamps are stored as epoch-based `i64`, so ordering and zone-map pruning are unchanged. A timezone that does not resolve now returns an error or renders as the underlying UTC timestamp rather than aborting the process.

## Verification

`cargo check -p vortex-datafusion` compiles against the new pin. The vortex-side APIs are additive, so no call sites in this repository change.
