### PR TITLE
docs: update v2.1.3 release notes for the Iceberg timestamptz fix (trunk sync)

### DIFF
--- a/docs/release_notes/v2.1.3.md
+++ b/docs/release_notes/v2.1.3.md
@@ -1,6 +1,6 @@
-# Spice v2.1.3 (August 3, 2026)
+# Spice v2.1.3 (August 4, 2026)
 
-Spice v2.1.3 is a patch release focused on resource efficiency: explicit CPU sizing with the new `runtime.cpu.cores` setting, more query memory for Cayenne deployments, and improved memory and crash diagnostics.
+Spice v2.1.3 is a patch release focused on resource efficiency: explicit CPU sizing with the new `runtime.cpu.cores` setting, more query memory for Cayenne deployments, and improved memory and crash diagnostics. It also fixes Cayenne acceleration of Iceberg datasets with `timestamptz` columns.
 
 ## What's New in v2.1.3
 
@@ -35,6 +35,10 @@ Memory pool refusals now return `ResourcesExhausted` and HTTP `503`, distinguish
 Fatal native signals (`SIGSEGV`, `SIGBUS`, `SIGILL`, `SIGFPE`) report the signal, faulting address, and thread before exit, so a crash can be diagnosed from logs.
 
 Fixed a bug where setting `runtime.task_history.enabled: false` also disabled every query metric — `query_duration_ms`, `query_execution_duration_ms`, `query_executions`, `query_failures`, `query_returned_rows`, and `query_returned_bytes`. These are now reported regardless of the task history setting.
+
+### Cayenne Acceleration of Iceberg `timestamptz` Columns
+
+Accelerating an Iceberg dataset with a `timestamptz` column using the [Cayenne](https://spiceai.org/docs/components/data-accelerators/cayenne) engine previously failed during the refresh write with an error resolving the time zone `+00:00`. Iceberg maps every `timestamptz` column to the fixed-offset Arrow time zone `+00:00`, which the file writer could not resolve when building column statistics. Fixed-offset time zones (`±HH:MM`, `±HHMM`, and `±HH`) are now resolved wherever time zones are handled, so these datasets accelerate correctly.
 
 ## Contributors
 
@@ -103,5 +107,6 @@ Spice is available in the [AWS Marketplace](https://aws.amazon.com/marketplace/p
 - fix(cayenne): the write-concurrency raise must respect the memory brake by [@lukekim](https://github.com/lukekim) in [#12317](https://github.com/spiceai/spiceai/pull/12317)
 - feat(spiced): report fatal signals before exit by [@sgrebnov](https://github.com/sgrebnov) in [#12334](https://github.com/spiceai/spiceai/pull/12334)
 - fix: report query metrics when task history is disabled by [@sgrebnov](https://github.com/sgrebnov) in [#12227](https://github.com/spiceai/spiceai/pull/12227)
+- chore(deps): repoint vortex at the 2.1 fixed-offset timezone fix by [@phillipleblanc](https://github.com/phillipleblanc) in [#12455](https://github.com/spiceai/spiceai/pull/12455)
 
 **Full Changelog**: <https://github.com/spiceai/spiceai/compare/v2.1.2...v2.1.3>

--- a/docs/release_notes/v2.1.3.md
+++ b/docs/release_notes/v2.1.3.md
@@ -1,6 +1,6 @@
 # Spice v2.1.3 (August 4, 2026)
 
-Spice v2.1.3 is a patch release focused on resource efficiency: explicit CPU sizing with the new `runtime.cpu.cores` setting, more query memory for Cayenne deployments, and improved memory and crash diagnostics. It also fixes Cayenne acceleration of Iceberg datasets with `timestamptz` columns.
+Spice v2.1.3 is a patch release focused on resource efficiency: explicit CPU sizing with the new `runtime.cpu.cores` setting, more query memory for Cayenne deployments, and improved memory and crash diagnostics. It also fixes Cayenne acceleration of Iceberg datasets with `timestamptz` columns and restores `WHERE` filters on federated `LEFT`/`RIGHT JOIN` queries.
 
 ## What's New in v2.1.3
 
@@ -40,12 +40,17 @@ Fixed a bug where setting `runtime.task_history.enabled: false` also disabled ev
 
 Accelerating an Iceberg dataset with a `timestamptz` column using the [Cayenne](https://spiceai.org/docs/components/data-accelerators/cayenne) engine previously failed during the refresh write with an error resolving the time zone `+00:00`. Iceberg maps every `timestamptz` column to the fixed-offset Arrow time zone `+00:00`, which the file writer could not resolve when building column statistics. Fixed-offset time zones (`±HH:MM`, `±HHMM`, and `±HH`) are now resolved wherever time zones are handled, so these datasets accelerate correctly.
 
+### Federated Outer Join Filters
+
+A federated query combining a `LEFT JOIN` with a `WHERE` filter on the left table previously returned all rows instead of the filtered rows: when the query was pushed down to the data source or accelerator, the filter was folded into the `JOIN ON` clause, where it no longer filters the left side (`RIGHT JOIN` was affected symmetrically). Filters now stay on the side of the join they came from, so these queries return the correct rows.
+
 ## Contributors
 
 - [@lukekim](https://github.com/lukekim)
 - [@sgrebnov](https://github.com/sgrebnov)
 - [@phillipleblanc](https://github.com/phillipleblanc)
 - [@bjchambers](https://github.com/bjchambers)
+- [@Jeadie](https://github.com/Jeadie)
 
 ## Breaking Changes
 
@@ -108,5 +113,6 @@ Spice is available in the [AWS Marketplace](https://aws.amazon.com/marketplace/p
 - feat(spiced): report fatal signals before exit by [@sgrebnov](https://github.com/sgrebnov) in [#12334](https://github.com/spiceai/spiceai/pull/12334)
 - fix: report query metrics when task history is disabled by [@sgrebnov](https://github.com/sgrebnov) in [#12227](https://github.com/spiceai/spiceai/pull/12227)
 - chore(deps): repoint vortex at the 2.1 fixed-offset timezone fix by [@phillipleblanc](https://github.com/phillipleblanc) in [#12455](https://github.com/spiceai/spiceai/pull/12455)
+- chore(deps): bump datafusion rev for outer-join unparser fix by [@Jeadie](https://github.com/Jeadie) in [#12460](https://github.com/spiceai/spiceai/pull/12460)
 
 **Full Changelog**: <https://github.com/spiceai/spiceai/compare/v2.1.2...v2.1.3>


### PR DESCRIPTION
Trunk copy of the v2.1.3 release-notes update in #12458 — the two files were identical before this edit and stay identical after it.

Covers both late additions to the release: the Cayenne Iceberg `timestamptz` fix (#12455, fixes #12447) and the federated outer join filter fix (#12460, fixes #12403), plus changelog entries, @Jeadie in contributors, an intro mention, and the August 4 release date.

Part of the v2.1.3 endgame (#12379).