### PR TITLE
chore(deps): bump datafusion rev for outer-join unparser fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5584,7 +5584,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5636,7 +5636,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5660,7 +5660,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5684,7 +5684,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5709,7 +5709,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "futures",
  "log",
@@ -5719,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5801,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5823,7 +5823,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5872,12 +5872,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5898,7 +5898,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5920,7 +5920,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5972,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6003,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6047,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6071,7 +6071,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6086,7 +6086,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6102,7 +6102,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6111,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "chrono",
@@ -6172,7 +6172,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6193,7 +6193,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6207,7 +6207,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "chrono",
@@ -6223,7 +6223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6243,7 +6243,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6275,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "chrono",
@@ -6304,7 +6304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6316,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6372,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6390,7 +6390,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
+source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,7 +2630,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2650,7 +2650,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2670,7 +2670,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -5584,7 +5584,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5636,7 +5636,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5660,7 +5660,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5684,7 +5684,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5709,7 +5709,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "futures",
  "log",
@@ -5719,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5801,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5823,7 +5823,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5872,12 +5872,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5898,7 +5898,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5920,7 +5920,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5972,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6003,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6047,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6071,7 +6071,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6086,7 +6086,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6102,7 +6102,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6111,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "chrono",
@@ -6172,7 +6172,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6193,7 +6193,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6207,7 +6207,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "chrono",
@@ -6223,7 +6223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6243,7 +6243,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6275,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "chrono",
@@ -6304,7 +6304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6316,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6372,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6390,7 +6390,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=3c74952f141055c29140bf50d210bbd90278880e#3c74952f141055c29140bf50d210bbd90278880e"
+source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -8337,8 +8337,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -9444,7 +9444,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -9479,7 +9479,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -14527,8 +14527,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -14562,7 +14562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14890,7 +14890,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14928,7 +14928,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -18148,7 +18148,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -19705,7 +19705,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark 0.12.2",
@@ -22837,7 +22837,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5584,7 +5584,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5636,7 +5636,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5660,7 +5660,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5684,7 +5684,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5709,7 +5709,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "futures",
  "log",
@@ -5719,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5801,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5823,7 +5823,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5872,12 +5872,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5898,7 +5898,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5920,7 +5920,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5972,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6003,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6047,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6071,7 +6071,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6086,7 +6086,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6102,7 +6102,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6111,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "chrono",
@@ -6172,7 +6172,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6193,7 +6193,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6207,7 +6207,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "chrono",
@@ -6223,7 +6223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6243,7 +6243,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6275,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "chrono",
@@ -6304,7 +6304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6316,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6372,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6390,7 +6390,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=c307db628bcbd49414bdd6e17bc4a1b28b900c24#c307db628bcbd49414bdd6e17bc4a1b28b900c24"
+source = "git+https://github.com/spiceai/datafusion.git?rev=297181d1a6e13e3233d5fdcb2fc114841e731b30#297181d1a6e13e3233d5fdcb2fc114841e731b30"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,41 +391,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,41 +391,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "3c74952f141055c29140bf50d210bbd90278880e" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,41 +391,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "c307db628bcbd49414bdd6e17bc4a1b28b900c24" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "297181d1a6e13e3233d5fdcb2fc114841e731b30" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).


### PR DESCRIPTION
## 📝 Summary

Bump the `spiceai/datafusion.git` dependencies from `3c74952f` to `c307db628`. The new rev adds the outer join table-scan filter routing fix on top of the previously pinned commit. This fix corrects a case where an outer join folded a preserved-side filter into the `JOIN ON` clause, which stopped the filter from removing rows.

All 35 `datafusion-*` crate revs in `Cargo.toml` and `Cargo.lock` move together. The `datafusion-ballista`, `datafusion-federation`, and `datafusion-table-providers` revs do not change.

## 🔗 Related

- Datafusion fix PR: spiceai/datafusion#194 (duplicate of spiceai/datafusion#193, retargeted onto the pinned commit)
- Downstream report: #12403

## 🚨 Breaking Changes

None.

## 📚 Docs

None.

## 👀 Notes for Reviewers

The new rev `c307db628` is the head of the datafusion PR #194 feature branch. It is not merged into `spiceai-54-3c74952f` yet. Merge or re-pin before this leaves draft.
