### PR TITLE
fix(ci): make the out-of-disk sign-off verdict survive being out of disk (fixes #12427)

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -281,6 +281,19 @@ jobs:
           echo "HEAD: $(git rev-parse --short HEAD)"
           echo "merge-base with origin/trunk: $(git merge-base HEAD origin/trunk 2>/dev/null | cut -c1-12 || echo 'n/a (API fallback)')"
 
+      # Before the toolchain setup, not after. The same floor is checked inside
+      # the sign-off run, but that check sits behind Rust, Nextest, spiceio,
+      # sccache, protoc, cc and make setup — so an already-full runner spent all
+      # of that before being told, and a volume that filled *during* those steps
+      # failed the job with no indication that the volume, not the branch, was at
+      # fault (#12427). Checking here stops the already-full case at once, with an
+      # annotation and a step summary that name it as infrastructure.
+      #
+      # `.trusted-ci/signoff`, not the working tree's copy: this runs before any
+      # of the branch's code, and a fork PR must not choose its own floor.
+      - name: Check the work volume before setting up the toolchain
+        run: .trusted-ci/signoff preflight-disk
+
       - name: Set up Rust
         uses: ./.trusted-ci/actions/setup-rust
 

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -346,16 +346,28 @@ read correctly: the linker dies with `errno=28` thousands of lines after nextest
 has already reported every test passing, on a crate the branch never touched,
 with no `-->` source pointer anywhere in the log.
 
+The floor is checked twice: once as the job's first step after checkout
+(`scripts/signoff preflight-disk`), so an already-full runner is turned away
+before the toolchain setup rather than after it, and again inside the run. A stop
+at the early step has no commit status to explain itself — the `pending` status is
+posted later — so it annotates the run instead.
+
 A remote run watches its own build output for that error, and a watched run's
 verdict is final **in both directions**. It has to be: by the time anything
 measures free space again, cargo has unlinked the partial binaries it was
 writing and the volume can look healthy — and conversely, on a shared pool
 another run can drag the volume under any threshold while your branch is failing
 for its own reasons. Measured free space is consulted only when nothing watched,
-which is how a local run gets a classification at all. The marker is truncated
-per build step, so only the step that actually failed speaks.
+which is how a local run gets a classification at all. The verdict resets per
+build step, so only the step that actually failed speaks.
 
-Set `SIGNOFF_MIN_FREE_GIB` to change the floor. Locally the check only warns and
+The watch keeps its answer in a shell variable, not a file. Recording it on disk
+needed an allocation at the one moment allocation is failing — and on macOS
+`$TMPDIR` and the workspace are usually the same APFS container, so there was no
+reliably writable place to put it. An unwritable marker read as "not a disk
+failure", which blamed the branch for the volume.
+
+Set `SIGNOFF_MIN_FREE_GIB` to change the floor. Locally both checks only warn and
 the output is not watched — your own disk is yours to manage.
 
 ### External contributors (forks)

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -361,6 +361,14 @@ for its own reasons. Measured free space is consulted only when nothing watched,
 which is how a local run gets a classification at all. The verdict resets per
 build step, so only the step that actually failed speaks.
 
+"Final in both directions" applies only to a watcher that actually reported. The
+watcher exits with a reserved status to say it saw the error, so a watcher that
+exits any *other* non-zero way — no `awk` on the runner, a signal — is a watcher
+that reached no verdict rather than one that saw nothing. That disarms the watch
+and hands classification back to the free-space backstop; treating its silence as
+"not disk" would blame the branch for the volume just as surely as the unwritable
+marker did.
+
 The watch keeps its answer in a shell variable, not a file. Recording it on disk
 needed an allocation at the one moment allocation is failing — and on macOS
 `$TMPDIR` and the workspace are usually the same APFS container, so there was no

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -754,7 +754,9 @@ SIGNOFF_DISK_HIT="${SIGNOFF_DISK_HIT:-}"
 
 # The status the watcher exits with to report an out-of-disk line. Deliberately
 # not 1 or 2: awk uses those for its own errors, and a watcher that itself died
-# must not be read as a volume that filled.
+# must not be read as a volume that filled. Reserving a distinct status is also
+# what lets run_make_step tell "ran, saw nothing" (0) from "never reached a
+# verdict" (anything else), which it must not conflate — see run_make_step.
 readonly DISK_WATCH_HIT_STATUS=3
 
 # Run one `make` step, recording whether it died for want of disk. Returns
@@ -789,12 +791,24 @@ run_make_step() {
   watch_status="${pipe_status[1]:-0}"
   if [[ "$watch_status" -eq "$DISK_WATCH_HIT_STATUS" ]]; then
     SIGNOFF_DISK_HIT=1
+  elif [[ "$watch_status" -ne 0 ]]; then
+    # The watcher died instead of reaching a verdict: no awk on the runner, a
+    # syntax error, a signal. Its silence is then not "no out-of-disk line went
+    # past" — nothing reliably read the output at all — so leaving the watch
+    # armed would let failure_kind assert "not disk" on the authority of a
+    # watcher that never ran, which is the same mislabelling in the other
+    # direction from #12427. Disarm it so classification falls back to the
+    # free-space backstop, exactly as on an unwatched local run.
+    info "warning: the out-of-disk watcher exited ${watch_status} rather than reporting a verdict — falling back to free-space classification"
+    SIGNOFF_DISK_WATCH=""
   fi
   return "$status"
 }
 
 # True when this run watched its build output at all, i.e. the watch's verdict —
-# including its "no ENOSPC line went past" — is worth something.
+# including its "no ENOSPC line went past" — is worth something. run_make_step
+# clears the flag if the watcher itself failed, so this stays false for a run
+# whose watch was requested but never actually delivered a reading.
 disk_watch_armed() {
   [[ -n "$SIGNOFF_DISK_WATCH" ]]
 }
@@ -839,7 +853,8 @@ disk_is_critical() {
 # else, which is the branch. Three ways to reach "disk", in falling order of
 # authority: the preflight refused to start, the build said so itself, or the
 # volume is at ~0 now. The last is a backstop for a build whose output we did
-# not record (a local run), which is why it is not the only signal.
+# not record — a local run, or a remote one whose watcher died before it could
+# read anything — which is why it is not the only signal.
 failure_kind() {
   local check_status="$1"
 

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -26,6 +26,8 @@
 #   scripts/signoff status          Show the sign-off status of HEAD
 #   scripts/signoff mine            Show attestation status for all your open PRs
 #   scripts/signoff clear-pending   Turn a left-behind pending status into a failure
+#   scripts/signoff preflight-disk  Check the work volume's free space (CI: run
+#                                   before the toolchain setup steps)
 #   scripts/signoff check           Show whether trunk requires sign-off
 #   scripts/signoff install         Configure the trunk ruleset (maintainers)
 #   scripts/signoff install --yes   Apply the ruleset change (default is a dry-run)
@@ -42,9 +44,11 @@
 #   SIGNOFF_SKIP_TARGETED_TESTS Set to any value to skip the branch-scoped unit
 #                     tests that run after the pre-lint
 #   SIGNOFF_MIN_FREE_GIB  Free space (GiB) the work volume must have before a
-#                     remote run starts its Rust checks (default: 25). Below it
-#                     a remote run stops immediately as an infrastructure
-#                     failure; a local run only warns.
+#                     remote run starts its Rust checks (default: 25). Checked
+#                     twice: by the `preflight-disk` step before the toolchain
+#                     setup, and again inside the run. Below it a remote run
+#                     stops immediately as an infrastructure failure; a local
+#                     run only warns.
 #
 # Targeted pre-lint always diffs against trunk (not configurable).
 # When the branch has no Rust-affecting changes vs trunk (.rs, Cargo.toml,
@@ -728,53 +732,80 @@ readonly EXIT_DISK_EXHAUSTED=70
 # enough; matching both survives a toolchain that words one of them differently.
 readonly DISK_FULL_PATTERN='No space left on device|errno=28'
 
-# Set on remote runs to a file collecting any out-of-disk line the build emits.
-# Only matching lines are kept — writing a full three-hour transcript to a
-# volume that is already out of space would make the very problem worse.
-SIGNOFF_DISK_MARKER="${SIGNOFF_DISK_MARKER:-}"
+# Set to 1 on remote runs, where run_make_step watches build output for the
+# out-of-disk signature. Separates "watched, and it was not disk" from "nothing
+# watched at all", which failure_kind answers differently.
+SIGNOFF_DISK_WATCH="${SIGNOFF_DISK_WATCH:-}"
+
+# Set to 1 by run_make_step when the step it ran reported running out of disk.
+#
+# A shell variable rather than a file, because the signal has to survive the
+# condition it reports. Recording the line by appending to a marker file needed
+# an allocation at exactly the moment allocation is failing — and on macOS
+# $TMPDIR and the workspace are usually the same APFS container, so there was
+# nowhere to put that file that was reliably writable. An empty marker read as
+# "not a disk failure", so the branch was blamed for the volume (#12427). The
+# watcher's exit status needs no disk at all.
+#
+# Seeded from the environment so the unit tests can set up a classification
+# without running a build; run_make_step resets it per step, so an inherited
+# value cannot outlive a run that watched anything.
+SIGNOFF_DISK_HIT="${SIGNOFF_DISK_HIT:-}"
+
+# The status the watcher exits with to report an out-of-disk line. Deliberately
+# not 1 or 2: awk uses those for its own errors, and a watcher that itself died
+# must not be read as a volume that filled.
+readonly DISK_WATCH_HIT_STATUS=3
 
 # Run one `make` step, recording whether it died for want of disk. Returns
-# make's own status, never the recorder's. With no marker set — every local run
-# — make is invoked exactly as before, so local output is untouched.
+# make's own status, never the watcher's. With the watch off — every local run —
+# make is invoked exactly as before, so local output is untouched.
 run_make_step() {
-  if [[ -z "$SIGNOFF_DISK_MARKER" ]]; then
+  if [[ -z "$SIGNOFF_DISK_WATCH" ]]; then
     make "$@"
     return $?
   fi
-  local status
-  # Truncate per step, so the marker describes the step that actually failed.
-  # Left to accumulate, a step that merely *mentioned* running out of disk and
-  # then succeeded would still be blaming the volume for a genuine test failure
-  # two steps later.
-  : >"$SIGNOFF_DISK_MARKER" 2>/dev/null || true
-  # awk rather than `tee` to a full log: it passes every line straight through
-  # while copying only the out-of-disk lines to the marker, so the recorder
-  # costs a few hundred bytes instead of tens of megabytes. fflush keeps the
-  # output streaming to the Actions log line by line, as it does untee'd.
-  make "$@" 2>&1 | awk -v marker="$SIGNOFF_DISK_MARKER" -v pat="$DISK_FULL_PATTERN" '
-    $0 ~ pat { print >> marker; close(marker) }
+  local status watch_status
+  local -a pipe_status
+  # Reset per step, so the verdict describes the step that actually failed. Left
+  # to accumulate, a step that merely *mentioned* running out of disk and then
+  # succeeded would still be blaming the volume for a genuine test failure two
+  # steps later.
+  SIGNOFF_DISK_HIT=""
+  # awk rather than a captured log: it passes every line straight through and
+  # keeps one bit of state, so watching costs nothing on a volume that is
+  # already short of space. fflush keeps the output streaming to the Actions log
+  # line by line, as it does unwatched.
+  make "$@" 2>&1 | awk -v pat="$DISK_FULL_PATTERN" -v hit_status="$DISK_WATCH_HIT_STATUS" '
+    $0 ~ pat { hit = 1 }
     { print; fflush() }
+    END { if (hit) exit (hit_status + 0) }
   '
-  status="${PIPESTATUS[0]}"
+  # Copy the whole array in one statement: reading PIPESTATUS is itself a command,
+  # so a second `x="${PIPESTATUS[1]}"` would be reading the *assignment's* status
+  # and, under `set -u`, abort on the now-absent index.
+  pipe_status=("${PIPESTATUS[@]}")
+  status="${pipe_status[0]:-0}"
+  watch_status="${pipe_status[1]:-0}"
+  if [[ "$watch_status" -eq "$DISK_WATCH_HIT_STATUS" ]]; then
+    SIGNOFF_DISK_HIT=1
+  fi
   return "$status"
 }
 
-# True when this run watched its build output at all, i.e. the marker's verdict
-# — including an empty marker's "not disk" — is worth something.
-marker_is_armed() {
-  [[ -n "$SIGNOFF_DISK_MARKER" && -f "$SIGNOFF_DISK_MARKER" ]]
+# True when this run watched its build output at all, i.e. the watch's verdict —
+# including its "no ENOSPC line went past" — is worth something.
+disk_watch_armed() {
+  [[ -n "$SIGNOFF_DISK_WATCH" ]]
 }
 
 # True when this run's build actually reported running out of disk. This is the
 # authoritative signal — unlike a free-space reading taken after the fact, it
-# cannot be washed out by the partial artifacts cargo unlinks on its way out.
-#
-# Known gap: at true ENOSPC the append that records the line can itself fail,
-# leaving the marker empty and the failure read as the branch's. That is the
-# behavior this whole guard replaced, so it is no worse than not watching — but
-# it is why the marker lives in $TMPDIR rather than beside the build output.
+# cannot be washed out by the partial artifacts cargo unlinks on its way out,
+# and unlike a marker file it costs no allocation at the moment allocation is
+# what is failing.
 build_hit_disk_full() {
-  [[ -n "$SIGNOFF_DISK_MARKER" && -s "$SIGNOFF_DISK_MARKER" ]]
+  [[ -n "$SIGNOFF_DISK_HIT" ]]
 }
 
 # Free space in GiB on the volume holding "$1" (default: the working tree).
@@ -818,13 +849,13 @@ failure_kind() {
     return
   fi
 
-  # If we watched the build, the watch decides — both ways. An empty marker
-  # means the build ran out of many things but not disk, and a free-space
-  # reading must not overrule that: on a shared pool another run can drag the
-  # volume under any threshold while *this* branch fails for its own reasons,
-  # and calling that "infrastructure" tells the author to re-dispatch a branch
-  # that will fail again. Free space is consulted only when nothing watched.
-  if marker_is_armed; then
+  # If we watched the build, the watch decides — both ways. No ENOSPC line means
+  # the build ran out of many things but not disk, and a free-space reading must
+  # not overrule that: on a shared pool another run can drag the volume under any
+  # threshold while *this* branch fails for its own reasons, and calling that
+  # "infrastructure" tells the author to re-dispatch a branch that will fail
+  # again. Free space is consulted only when nothing watched.
+  if disk_watch_armed; then
     if build_hit_disk_full; then echo "disk"; else echo "checks"; fi
     return
   fi
@@ -865,6 +896,11 @@ preflight_disk() {
 
   info "${NO} Only ${free} GiB free on the work volume; a sign-off needs ${min} GiB."
   info "  The branch was not evaluated. Reclaim space on this runner and re-dispatch."
+  # An Actions annotation as well as the step summary. Reached from the standalone
+  # `preflight-disk` step there is no commit status yet to carry the distinction —
+  # the pending status is posted later, inside the sign-off run — so the run page
+  # is the only place an operator can learn this was the volume and not the diff.
+  echo "::error title=Runner out of disk::Only ${free} GiB free on the work volume, below the ${min} GiB floor. The branch was not evaluated: reclaim space on this runner and re-dispatch."
   append_step_summary "### Preflight: not enough disk"$'\n'"Only **${free} GiB** free on the runner work volume, below the **${min} GiB** floor, so the Rust checks did not run and **the branch was not evaluated**. This is an infrastructure failure, not a code failure: reclaim space on this runner (\`target/\` is shared across branches) and re-dispatch. Adjust the floor with \`SIGNOFF_MIN_FREE_GIB\`."$'\n'
   return "$EXIT_DISK_EXHAUSTED"
 }
@@ -1174,14 +1210,11 @@ cmd_signoff() {
     start=$(date +%s)
     if is_remote_run; then
       post_pending_status "$repo" "$sha" "$user"
-      # Record out-of-disk lines from here on, so a failure can say whether the
-      # volume or the branch was at fault. Remote only: a local run's output
-      # then stays byte-for-byte what it is today. A marker we cannot create is
-      # not fatal — failure_kind falls back to reading free space.
-      SIGNOFF_DISK_MARKER=$(mktemp "${TMPDIR:-/tmp}/signoff-disk.XXXXXX" 2>/dev/null) \
-        || SIGNOFF_DISK_MARKER=""
-      [[ -z "$SIGNOFF_DISK_MARKER" ]] \
-        || trap 'rm -f "$SIGNOFF_DISK_MARKER"' EXIT
+      # Watch for out-of-disk lines from here on, so a failure can say whether
+      # the volume or the branch was at fault. Remote only: a local run's output
+      # then stays byte-for-byte what it is today. Arming cannot fail — there is
+      # no file to create and so nothing to clean up on exit.
+      SIGNOFF_DISK_WATCH=1
     fi
     # Capture status without wrapping in `if`/`||` (those also disable set -e
     # for the LHS). run_checks uses explicit `|| return` so make failures still
@@ -1226,6 +1259,23 @@ cmd_signoff() {
 
   echo "${OK} Signed off on ${sha:0:12} — ${description}"
   refresh_attestation_check "$sha" "$repo"
+}
+
+# Run the disk preflight on its own, for the workflow to call *before* the
+# toolchain setup steps.
+#
+# The guard reached through `run_checks` sits behind Rust, Nextest, sccache,
+# protoc, cc and spiceio setup, so a volume that was already below the floor
+# spent all of that first, and a volume that filled during those steps produced
+# an ordinary red job with none of the labelling (#12427). Running the same floor
+# check as the first step after checkout stops the already-full case immediately
+# and says why. It cannot catch a volume that fills mid-setup — that would need
+# the setup actions to report it — so this narrows the gap rather than closing it.
+#
+# Same floor, same `SIGNOFF_MIN_FREE_GIB` override, same remote-only fatality as
+# the in-run preflight, because it is the same function.
+cmd_preflight_disk() {
+  preflight_disk
 }
 
 cmd_status() {
@@ -1572,6 +1622,12 @@ Developers:
                                Replace a left-behind '${STATUS_CONTEXT}' pending status
                                on HEAD with a failure (no-op for any other state)
 
+CI (.github/workflows/signoff.yml):
+  scripts/signoff preflight-disk
+                               Check the work volume against the ${DEFAULT_MIN_FREE_GIB} GiB floor
+                               before the toolchain setup steps run; fatal only
+                               on a remote run (override: SIGNOFF_MIN_FREE_GIB)
+
 Maintainers:
   scripts/signoff check        Show whether '${TARGET_BRANCH}' requires sign-off
   scripts/signoff install      Preview the required-checks change (dry run)
@@ -1616,6 +1672,7 @@ main() {
     status)   shift; cmd_status "$@" ;;
     mine)     shift; cmd_mine "$@" ;;
     clear-pending) shift; cmd_clear_pending "$@" ;;
+    preflight-disk) shift; cmd_preflight_disk "$@" ;;
     check)    shift; cmd_check "$@" ;;
     install)  shift; cmd_install "$@" ;;
     version|--version) echo "signoff ${VERSION}" ;;

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -255,6 +255,59 @@ else
 fi
 rm -f "$stub_dir/make"
 
+echo "run_make_step when the watcher itself fails"
+# A watcher that exits for its own reasons — no awk on the runner, a syntax error
+# in its program, a signal — has not reported "no out-of-disk line went past". It
+# has reported nothing. Leaving the watch armed on that would let failure_kind
+# assert "not disk" on the authority of a reading nobody took, mislabelling a
+# genuine ENOSPC death as the branch's fault: #12427 in the other direction.
+#
+# The stub fails *only* the watcher invocation and delegates everything else to
+# the real awk, so this isolates a dead watcher from a host with no awk at all —
+# and lets the same shell go on to check that the free-space backstop takes over.
+tests_run=$((tests_run + 1))
+broken_dir="$stub_dir/broken-watcher"
+mkdir -p "$broken_dir"
+real_awk="$(command -v awk)"
+cat >"$broken_dir/awk" <<STUB
+#!/usr/bin/env bash
+set -uo pipefail
+# The watcher is the only awk call carrying \`-v pat=…\`; free_disk_gib's df
+# parsing has no such argument and must keep working.
+for arg in "\$@"; do
+  # Exit 2, awk's own error status — deliberately not the hit status 3.
+  [[ "\$arg" == pat=* ]] && exit 2
+done
+exec "${real_awk}" "\$@"
+STUB
+chmod +x "$broken_dir/awk"
+printf '#!/usr/bin/env bash\necho "ld: write() failed, errno=28"; exit 101\n' >"$broken_dir/make"
+chmod +x "$broken_dir/make"
+
+broken_output="$(env "PATH=$broken_dir:$stub_dir:$PATH" SIGNOFF_DISK_WATCH=1 \
+  STUB_FREE_KB="$(gib_to_kb 1)" \
+  bash -c 'source "$1"
+    if run_make_step some-target; then step_rc=0; else step_rc=$?; fi
+    echo "RC=${step_rc}"
+    echo "VERDICT=${SIGNOFF_DISK_HIT:+yes}"
+    echo "ARMED=${SIGNOFF_DISK_WATCH:+yes}"
+    echo "KIND=$(failure_kind "$step_rc")"' _ "$subject" 2>&1)"
+
+if [[ "$broken_output" != *"RC=101"* ]]; then
+  fail_test "a dead watcher still reports make's own status: expected RC=101, got '${broken_output}'"
+elif [[ "$broken_output" == *"VERDICT=yes"* ]]; then
+  fail_test "a dead watcher must not be read as an out-of-disk hit: '${broken_output}'"
+elif [[ "$broken_output" == *"ARMED=yes"* ]]; then
+  fail_test "a dead watcher must disarm the watch, not leave it asserting 'not disk': '${broken_output}'"
+elif [[ "$broken_output" != *"watcher exited 2"* ]]; then
+  fail_test "a dead watcher is reported, not silent: expected 'watcher exited 2', got '${broken_output}'"
+elif [[ "$broken_output" != *"KIND=disk"* ]]; then
+  fail_test "with the watch disarmed, a near-empty volume must classify as disk: '${broken_output}'"
+else
+  echo "  ok: a watcher that died disarms the watch and lets free space classify"
+fi
+rm -rf "$broken_dir"
+
 echo "failure_kind"
 # The regression: run 30831204417 passed 8809 tests, then died at the linker
 # with errno=28 and reported as a plain check failure. run_checks exits non-zero

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -166,24 +166,33 @@ assert_preflight "proceeds when free space is unknown" 0 "" \
   SIGNOFF_REMOTE_RUN=1 STUB_DF_RC=1
 
 echo "run_make_step + build_hit_disk_full"
-# The recorder has to notice the linker's death without swallowing make's own
+# The watcher has to notice the linker's death without swallowing make's own
 # exit status, and without eating the output the Actions log shows the reader.
+#
+# The verdict is read back out of `SIGNOFF_DISK_HIT` in the same shell that ran
+# the step, which is exactly how failure_kind reads it in production. It has to
+# be: a file could not be written at true ENOSPC, which is the whole point of
+# #12427, so there is nothing on disk for a later shell to inspect.
 assert_recorder() {
   local name="$1" make_body="$2" want_rc="$3" want_marked="$4" want_passthrough="${5:-}"
   tests_run=$((tests_run + 1))
 
-  local marker="$stub_dir/marker" fake_make="$stub_dir/make"
-  : >"$marker"
+  local fake_make="$stub_dir/make"
   printf '#!/usr/bin/env bash\n%s\n' "$make_body" >"$fake_make"
   chmod +x "$fake_make"
 
   local output rc
-  output="$(env "PATH=$stub_dir:$PATH" SIGNOFF_DISK_MARKER="$marker" \
-    bash -c 'source "$1"; run_make_step some-target' _ "$subject" 2>&1)"
+  # `if run_make_step` rather than a bare call: sourcing the subject turns on
+  # `set -e`, which would abort before the verdict could be reported.
+  output="$(env "PATH=$stub_dir:$PATH" SIGNOFF_DISK_WATCH=1 \
+    bash -c 'source "$1"
+      if run_make_step some-target; then step_rc=0; else step_rc=$?; fi
+      echo "VERDICT=${SIGNOFF_DISK_HIT:+yes}"
+      exit "$step_rc"' _ "$subject" 2>&1)"
   rc=$?
 
   if [[ "$rc" -ne "$want_rc" ]]; then
-    fail_test "$name: expected make's status ${want_rc} to survive the recorder, got ${rc}"
+    fail_test "$name: expected make's status ${want_rc} to survive the watcher, got ${rc}"
     rm -f "$fake_make"
     return
   fi
@@ -194,9 +203,14 @@ assert_recorder() {
   fi
 
   local marked="no"
-  [[ -s "$marker" ]] && marked="yes"
+  [[ "$output" == *"VERDICT=yes"* ]] && marked="yes"
+  if [[ "$output" != *"VERDICT="* ]]; then
+    fail_test "$name: the step never reported a verdict — output: '${output}'"
+    rm -f "$fake_make"
+    return
+  fi
   if [[ "$marked" != "$want_marked" ]]; then
-    fail_test "$name: expected marked=${want_marked}, got ${marked} (marker: '$(cat "$marker")')"
+    fail_test "$name: expected marked=${want_marked}, got ${marked} (output: '${output}')"
     rm -f "$fake_make"
     return
   fi
@@ -226,18 +240,18 @@ assert_recorder "reports make's failure, not the recorder's success" \
   42 no "some output"
 
 # Stickiness: a step that merely mentions running out of disk and then succeeds
-# must not leave the marker blaming the volume for a later, genuine failure.
+# must not leave the verdict blaming the volume for a later, genuine failure.
 tests_run=$((tests_run + 1))
-sticky_marker="$stub_dir/marker-sticky"
-printf 'ld: write() failed, errno=28 (No space left on device)\n' >"$sticky_marker"
 printf '#!/usr/bin/env bash\necho "error[E0308]: mismatched types"; exit 101\n' >"$stub_dir/make"
 chmod +x "$stub_dir/make"
-env "PATH=$stub_dir:$PATH" SIGNOFF_DISK_MARKER="$sticky_marker" \
-  bash -c 'source "$1"; run_make_step some-target' _ "$subject" >/dev/null 2>&1
-if [[ -s "$sticky_marker" ]]; then
-  fail_test "each step truncates the marker: a previous step's ENOSPC still marks a later compile failure ('$(cat "$sticky_marker")')"
+sticky_output="$(env "PATH=$stub_dir:$PATH" SIGNOFF_DISK_WATCH=1 SIGNOFF_DISK_HIT=1 \
+  bash -c 'source "$1"
+    if run_make_step some-target; then :; fi
+    echo "VERDICT=${SIGNOFF_DISK_HIT:+yes}"' _ "$subject" 2>&1)"
+if [[ "$sticky_output" == *"VERDICT=yes"* ]]; then
+  fail_test "each step resets the verdict: a previous step's ENOSPC still marks a later compile failure"
 else
-  echo "  ok: each step truncates the marker, so only the failing step speaks"
+  echo "  ok: each step resets the verdict, so only the failing step speaks"
 fi
 rm -f "$stub_dir/make"
 
@@ -251,27 +265,24 @@ assert_failure_kind "calls a failure on a near-empty volume a disk failure" 101 
 # The authoritative signal, and the one that matters most: the volume can look
 # healthy again by the time we measure it, because cargo unlinks the partial
 # binaries it was writing on its way out. What the build *said* still stands.
-marker_with_disk_error="$stub_dir/marker-disk"
-echo "ld: write() failed, errno=28 (No space left on device)" >"$marker_with_disk_error"
 assert_failure_kind "trusts what the build said over free space measured after it" 101 "disk" \
-  SIGNOFF_DISK_MARKER="$marker_with_disk_error" STUB_FREE_KB="$(gib_to_kb 200)"
-marker_empty="$stub_dir/marker-empty"
-: >"$marker_empty"
-assert_failure_kind "an empty marker does not itself imply a disk failure" 101 "checks" \
-  SIGNOFF_DISK_MARKER="$marker_empty" STUB_FREE_KB="$(gib_to_kb 200)"
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_DISK_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+assert_failure_kind "a watch that saw no ENOSPC does not itself imply a disk failure" 101 "checks" \
+  SIGNOFF_DISK_WATCH=1 STUB_FREE_KB="$(gib_to_kb 200)"
 # A watched run's verdict is final in BOTH directions. On a shared pool another
 # run can drag the volume under any threshold while this branch fails for its
 # own reasons; calling that "infrastructure" tells the author to re-dispatch a
 # branch that will just fail again.
 assert_failure_kind "a watched build that did not hit ENOSPC stays a check failure on an empty volume" 101 "checks" \
-  SIGNOFF_DISK_MARKER="$marker_empty" STUB_FREE_KB="$(gib_to_kb 1)"
+  SIGNOFF_DISK_WATCH=1 STUB_FREE_KB="$(gib_to_kb 1)"
 # ...and free space is still consulted when nothing watched, which is how a
 # local run gets any classification at all.
-assert_failure_kind "falls back to free space when no marker is armed" 101 "disk" \
+assert_failure_kind "falls back to free space when nothing watched the build" 101 "disk" \
   STUB_FREE_KB="$(gib_to_kb 1)"
-# A marker path that was never created is not an armed watch.
-assert_failure_kind "an uncreated marker path does not count as a watch" 101 "disk" \
-  SIGNOFF_DISK_MARKER="$stub_dir/marker-never-made" STUB_FREE_KB="$(gib_to_kb 1)"
+# A hit with no armed watch is not a watch: only a run that armed the watch can
+# have produced the flag, so an inherited one must not classify on its own.
+assert_failure_kind "a hit without an armed watch falls back to free space" 101 "checks" \
+  SIGNOFF_DISK_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 assert_failure_kind "calls the preflight's own refusal a disk failure" 70 "disk" \
   STUB_FREE_KB="$(gib_to_kb 60)"
 # The other direction matters just as much: a real defect on a tight disk must
@@ -290,6 +301,45 @@ assert_preflight "reads a leading-zero floor as base 10, not octal" 0 "" \
   SIGNOFF_REMOTE_RUN=1 SIGNOFF_MIN_FREE_GIB=08 STUB_FREE_KB="$(gib_to_kb 9)"
 assert_preflight "still stops below a leading-zero floor" 70 "not evaluated" \
   SIGNOFF_REMOTE_RUN=1 SIGNOFF_MIN_FREE_GIB=08 STUB_FREE_KB="$(gib_to_kb 7)"
+
+echo
+echo "preflight-disk subcommand"
+# The workflow runs this as its own step, before the toolchain setup, so it has
+# to be reachable through the dispatcher and not just as an internal function —
+# and it has to carry the same verdict, since that step's exit status is the
+# only thing the job sees.
+assert_preflight_cmd() {
+  local name="$1" want_rc="$2" want_out="$3"
+  shift 3
+  tests_run=$((tests_run + 1))
+
+  local output rc
+  output="$(env "PATH=$stub_dir:$PATH" "$@" \
+    bash "$subject" preflight-disk 2>&1)"
+  rc=$?
+
+  if [[ "$rc" -ne "$want_rc" ]]; then
+    fail_test "$name: expected exit ${want_rc}, got ${rc} (output: '${output}')"
+  elif [[ -n "$want_out" && "$output" != *"$want_out"* ]]; then
+    fail_test "$name: expected '${want_out}' in the output, got '${output}'"
+  else
+    echo "  ok: $name"
+  fi
+}
+assert_preflight_cmd "proceeds when the volume has room" 0 "" \
+  SIGNOFF_REMOTE_RUN=1 STUB_FREE_KB="$(gib_to_kb 200)"
+assert_preflight_cmd "stops a remote run below the floor" 70 "not evaluated" \
+  SIGNOFF_REMOTE_RUN=1 STUB_FREE_KB="$(gib_to_kb 5)"
+# The step summary is not visible on the run page when the step itself is what
+# failed, so the annotation is what an operator actually reads.
+assert_preflight_cmd "annotates the stop as a runner problem" 70 "::error title=Runner out of disk::" \
+  SIGNOFF_REMOTE_RUN=1 STUB_FREE_KB="$(gib_to_kb 5)"
+# Locally it must stay advisory: a developer's own disk is theirs to manage, and
+# this subcommand is reachable by hand.
+assert_preflight_cmd "only warns locally below the floor" 0 "warning" \
+  STUB_FREE_KB="$(gib_to_kb 5)"
+assert_preflight_cmd "proceeds when free space is unknown" 0 "" \
+  SIGNOFF_REMOTE_RUN=1 STUB_DF_RC=1
 
 echo
 if [[ "$failures" -gt 0 ]]; then


### PR DESCRIPTION
Follow-up to #12426, which added the sign-off disk guard and recorded three gaps it deliberately did not close. Two are closed here; the third is left, with a reason.

## Root cause

**1. The verdict needed disk in order to record that there was no disk.** `run_make_step` recorded the out-of-disk line by appending to a marker file under `$TMPDIR`. At true ENOSPC that append can itself fail — and on macOS `$TMPDIR` and the workspace are usually the same APFS container, so there was no reliably writable place to put it. `build_hit_disk_full` tested `-s` on the marker, so an unwritable marker read as *"the build did not run out of disk"*, and the run was reported as the branch's failure. That is the exact misclassification the guard exists to prevent, in the one case where it matters most.

**2. The floor was checked only after the expensive setup.** The guard lives in `scripts/signoff`, which the workflow reaches only after Rust, Nextest, spiceio, sccache, protoc, make and cc setup. An already-full runner paid for all of that before being turned away, and a volume that filled *during* those steps produced an ordinary red job with none of the new labelling.

## Changes

- **The signal is the watcher's exit status, not a file.** `run_make_step`'s `awk` exits `3` when an out-of-disk line went past, and the shell records that in `SIGNOFF_DISK_HIT`. An exit status needs no allocation, so it cannot be lost to the condition it reports. `3` and not `1`/`2`, which `awk` uses for its own errors — a watcher that itself died must not read as a volume that filled.
- Deletes the `mktemp`, its `trap … EXIT` (which clobbered any other EXIT trap), and the "marker we could not create" fallback path.
- `PIPESTATUS` is copied in **one** statement. Reading the array is itself a command, so a second `x="${PIPESTATUS[1]}"` reads the *assignment's* status and, under `set -u`, aborts on the now-absent index. This was caught by the unit tests, not by review.
- **A `preflight-disk` subcommand, run as the job's first step after checkout**, so the already-full case is refused before the toolchain setup instead of after it. Same function, same floor, same `SIGNOFF_MIN_FREE_GIB` override, same remote-only fatality. It runs `.trusted-ci/signoff`, not the working tree's copy, so a fork PR cannot choose its own floor.
- `preflight_disk` now also emits an `::error title=Runner out of disk::` annotation. Reached from the early step there is no commit status to carry the distinction — the `pending` status is posted later, inside the run — so the run page is the only place an operator can learn this was the volume and not the diff.
- `docs/dev/ci_signoff.md` updated for both.

**Deliberately not addressed — gap 2 of the issue.** The preflight is a check, not a reservation: nothing serializes sign-off runs across branches, so several can each pass the floor and then collectively exhaust the volume. Fixing that needs cross-run serialization on the pool, not a change to this script. The early step also cannot catch a volume that fills *mid-setup* — that needs the setup actions themselves to report it — so it narrows gap 3 rather than closing it.

## Test plan

- [x] `bash scripts/test_signoff_disk_guard.sh` — **36 assertions pass** (was 31). The recorder cases now read the verdict back out of `SIGNOFF_DISK_HIT` in the same shell that ran the step, which is how `failure_kind` reads it in production; there is deliberately nothing on disk for a later shell to inspect.
- [x] New coverage: a hit with no armed watch falls back to free space; the per-step verdict reset; and five cases for the `preflight-disk` subcommand (room / below the floor / the annotation / local warn-only / unknown free space).
- [x] `bash scripts/test_signoff_status.sh` and `bash scripts/test_signoff_attestation_refresh.sh` still pass — both source the same script.
- [x] `bash -n scripts/signoff`, `bash -n scripts/test_signoff_disk_guard.sh`, and `signoff.yml` parsed as YAML.
- [x] `make lint` — the branch touches no Rust, so sign-off reports "no Rust changes (lint/test skipped)"; the workspace lint gate has nothing to run on this diff.
- [x] `make test` — same: no Rust-affecting changes, so the workspace test gate has nothing to run on this diff.
- [x] `make signoff` run after the final push (`Attestation` green)

**Neutered to prove the new assertions are load-bearing**, each against the real script:

| Mutation | Result |
|---|---|
| drop the per-step `SIGNOFF_DISK_HIT=""` reset | `each step resets the verdict` fails — a previous step's ENOSPC marks a later compile failure |
| never record the watcher's hit | both `records the linker's out-of-disk death` cases fail (`marked=yes`, got `no`) |
| let a hit classify without an armed watch | 3 fail, including `a hit without an armed watch falls back to free space` |
| drop the `::error` annotation | `annotates the stop as a runner problem` fails |
| keep `watch_status="${PIPESTATUS[1]}"` as its own statement | all 5 recorder cases fail with `PIPESTATUS[1]: unbound variable` |

## Checklist

- [x] The out-of-disk verdict no longer requires a successful write to be recorded
- [x] A watched run's verdict stays final in both directions (a full volume does not excuse a real defect)
- [x] The early step uses `.trusted-ci/signoff`, so a fork PR cannot supply the floor check
- [x] The new step is a sub-second `df` read and adds no self-hosted pool load beyond the job it already runs in
- [x] Local behaviour unchanged: with the watch off, `make` is invoked exactly as before

Fixes #12427
