### PR TITLE
fix(search): stop re-parsing a dotted index key as relation.column (fixes #12462)

### DIFF
--- a/crates/runtime-datafusion-index/src/delete.rs
+++ b/crates/runtime-datafusion-index/src/delete.rs
@@ -23,7 +23,7 @@ use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::ScalarValue;
 use datafusion::datasource::DefaultTableSource;
 use datafusion::error::Result;
-use datafusion::logical_expr::{Expr, LogicalPlanBuilder, col};
+use datafusion::logical_expr::{Expr, LogicalPlanBuilder, ident};
 use datafusion::physical_plan::collect;
 
 /// Resolves the rows of `table` that currently match `filters`, projected down to
@@ -71,7 +71,7 @@ pub async fn resolve_keys_matching_predicate(
     for filter in filters {
         builder = builder.filter(filter)?;
     }
-    let projection: Vec<Expr> = key_columns.iter().map(|name| col(name.as_str())).collect();
+    let projection: Vec<Expr> = key_columns.iter().map(|name| ident(name.as_str())).collect();
     let plan = builder.project(projection)?.build()?;
 
     let physical_plan = session.create_physical_plan(&plan).await?;
@@ -114,7 +114,7 @@ pub fn build_key_match_predicate(
         let mut eq_exprs = Vec::with_capacity(key_columns.len());
         for (name, array) in key_columns.iter().zip(&arrays) {
             let value = ScalarValue::try_from_array(array.as_ref(), row)?;
-            eq_exprs.push(col(name.as_str()).eq(Expr::Literal(value, None)));
+            eq_exprs.push(ident(name.as_str()).eq(Expr::Literal(value, None)));
         }
         if let Some(row_condition) = balanced_binary(eq_exprs, Expr::and) {
             row_conditions.push(row_condition);
@@ -151,6 +151,9 @@ mod tests {
     use datafusion::arrow::array::{Int64Array, StringArray};
     use datafusion::arrow::datatypes::DataType;
     use datafusion::datasource::MemTable;
+    // The dot-splitting constructor, kept here rather than at module scope: the tests use
+    // it deliberately for undotted filter columns, while the code under test must not.
+    use datafusion::logical_expr::col;
     use datafusion::prelude::SessionContext;
 
     fn id_name_batch(ids: &[i64], names: &[&str]) -> RecordBatch {
@@ -293,5 +296,86 @@ mod tests {
             .expect("resolve should succeed");
 
         assert_eq!(keys.num_rows(), 0);
+    }
+
+    /// A chunked index's primary keys include `_spice.chunk_id`, and a flattened `JSON`
+    /// column is named like `message.body`. Both are single columns whose *name*
+    /// contains a dot — not a `relation.column` reference.
+    fn dotted_key_batch(chunk_ids: &[&str], ids: &[i64]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("_spice.chunk_id", DataType::Utf8, false),
+            Field::new("id", DataType::Int64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(chunk_ids.to_vec())),
+                Arc::new(Int64Array::from(ids.to_vec())),
+            ],
+        )
+        .expect("valid batch")
+    }
+
+    /// Regression test: `col(name)` routes through `Column::from_qualified_name`, which
+    /// splits on `.`, so projecting a dotted key asked for column `chunk_id` of relation
+    /// `_spice`. The scan is built as relation `t`, so planning failed with
+    /// `No field named _spice.chunk_id` and a delete on a chunked index could resolve no
+    /// rows at all.
+    #[tokio::test]
+    async fn resolve_keys_matching_predicate_projects_a_dotted_key_column() {
+        let batch = dotted_key_batch(&["c1", "c2", "c3"], &[1, 2, 3]);
+        let schema = batch.schema();
+        let table: Arc<dyn TableProvider> =
+            Arc::new(MemTable::try_new(schema, vec![vec![batch]]).expect("mem table"));
+
+        let ctx = SessionContext::new();
+        let filters = vec![col("id").gt(datafusion::logical_expr::lit(1_i64))];
+        let key_columns = vec!["_spice.chunk_id".to_string()];
+
+        let keys = resolve_keys_matching_predicate(&table, &ctx.state(), filters, &key_columns)
+            .await
+            .expect("a dotted key column must resolve, not be read as relation.column");
+
+        assert_eq!(keys.num_columns(), 1);
+        assert_eq!(
+            keys.schema().field(0).name(),
+            "_spice.chunk_id",
+            "the projected field keeps its whole name"
+        );
+        let chunk_ids = keys
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("chunk id column is Utf8");
+        let mut values: Vec<&str> = chunk_ids.iter().flatten().collect();
+        values.sort_unstable();
+        assert_eq!(values, vec!["c2", "c3"]);
+    }
+
+    /// The same split in `build_key_match_predicate`. Asserted by *planning* the predicate
+    /// rather than by rendering it: `Expr`'s display is `_spice.chunk_id` either way, so
+    /// only resolution against a real schema tells the two apart.
+    #[tokio::test]
+    async fn build_key_match_predicate_keeps_a_dotted_key_name_whole() {
+        let keys = dotted_key_batch(&["c1", "c2"], &[1, 2]);
+        let key_columns = vec!["_spice.chunk_id".to_string()];
+        let predicate = build_key_match_predicate(&keys, &key_columns)
+            .expect("should not error")
+            .expect("non-empty batch produces a predicate");
+
+        let mem = MemTable::try_new(keys.schema(), vec![vec![keys.clone()]]).expect("mem table");
+        let table: Arc<dyn TableProvider> = Arc::new(mem);
+        let table_source = Arc::new(DefaultTableSource::new(table));
+        let plan = LogicalPlanBuilder::scan("t", table_source, None)
+            .expect("scan builds")
+            .filter(predicate)
+            .expect("the predicate must resolve against the scanned relation")
+            .build()
+            .expect("plan builds");
+
+        assert!(
+            format!("{plan:?}").contains("_spice.chunk_id"),
+            "the filter must reference the whole dotted name: {plan:?}"
+        );
     }
 }

--- a/crates/runtime-datafusion-index/src/delete.rs
+++ b/crates/runtime-datafusion-index/src/delete.rs
@@ -366,7 +366,8 @@ mod tests {
             .expect("should not error")
             .expect("non-empty batch produces a predicate");
 
-        let mem = MemTable::try_new(keys.schema(), vec![vec![keys.clone()]]).expect("mem table");
+        let schema = keys.schema();
+        let mem = MemTable::try_new(schema, vec![vec![keys]]).expect("mem table");
         let table: Arc<dyn TableProvider> = Arc::new(mem);
         let table_source = Arc::new(DefaultTableSource::new(table));
         let plan = LogicalPlanBuilder::scan("t", table_source, None)

--- a/crates/runtime-datafusion-index/src/delete.rs
+++ b/crates/runtime-datafusion-index/src/delete.rs
@@ -71,7 +71,10 @@ pub async fn resolve_keys_matching_predicate(
     for filter in filters {
         builder = builder.filter(filter)?;
     }
-    let projection: Vec<Expr> = key_columns.iter().map(|name| ident(name.as_str())).collect();
+    let projection: Vec<Expr> = key_columns
+        .iter()
+        .map(|name| ident(name.as_str()))
+        .collect();
     let plan = builder.project(projection)?.build()?;
 
     let physical_plan = session.create_physical_plan(&plan).await?;

--- a/crates/runtime-search/src/candidate/vector.rs
+++ b/crates/runtime-search/src/candidate/vector.rs
@@ -665,7 +665,7 @@ impl ChunkedNonIndexVectorGeneration {
         // Step 1: per (pk, q_idx) — MAX cosine (best stored element for
         // this query) and FIRST_VALUE(match element ordered by score).
         let step1_group: Vec<LogicalExpr> =
-            [pks.iter().map(col).collect(), vec![col("q_idx")]].concat();
+            [pks.iter().map(ident).collect(), vec![col("q_idx")]].concat();
         let per_query_best_col = "per_query_best";
         let per_query_match_col = "per_query_match";
 
@@ -683,7 +683,7 @@ impl ChunkedNonIndexVectorGeneration {
 
         // Step 2: per pk — SUM per-query bests (late-interaction total);
         // pick the match element from whichever query scored highest.
-        let step2_group: Vec<LogicalExpr> = pks.iter().map(col).collect();
+        let step2_group: Vec<LogicalExpr> = pks.iter().map(ident).collect();
         let match_sort = vec![col(per_query_best_col).sort(false, false)];
         let aggregated = step1
             .aggregate(

--- a/crates/runtime-search/src/candidate/vector.rs
+++ b/crates/runtime-search/src/candidate/vector.rs
@@ -347,7 +347,7 @@ impl ChunkedNonIndexVectorGeneration {
     /// partitioned by pk, so a sibling `row_number() = 1` filter selects
     /// the best-matching element in the same step.
     fn aggregate_score_expr(&self, pks: &[String]) -> Result<LogicalExpr, DataFusionError> {
-        let partition: Vec<LogicalExpr> = pks.iter().map(col).collect();
+        let partition: Vec<LogicalExpr> = pks.iter().map(ident).collect();
         let score_arg = col(SEARCH_SCORE_COLUMN_NAME);
 
         let aggregation = match &self.mode {
@@ -460,7 +460,7 @@ impl ChunkedNonIndexVectorGeneration {
 
         // Then apply the window function in a separate step
         let window_expr = row_number()
-            .partition_by(pks.iter().map(col).collect())
+            .partition_by(pks.iter().map(ident).collect())
             .order_by(vec![col(SEARCH_SCORE_COLUMN_NAME).sort(false, false)])
             .build()?
             .alias("chunk_rank");
@@ -562,7 +562,7 @@ impl ChunkedNonIndexVectorGeneration {
         // Two sibling window functions: one to pick the argmax element
         // (`chunk_rank = 1`), one to compute the aggregated per-pk score.
         let rank_window = row_number()
-            .partition_by(pks.iter().map(col).collect())
+            .partition_by(pks.iter().map(ident).collect())
             .order_by(vec![col(SEARCH_SCORE_COLUMN_NAME).sort(false, false)])
             .build()?
             .alias("chunk_rank");

--- a/crates/runtime-search/src/candidate/vector.rs
+++ b/crates/runtime-search/src/candidate/vector.rs
@@ -822,6 +822,31 @@ mod tests {
         );
     }
 
+    /// Regression test: the per-pk window partition went through `col()`, which routes
+    /// through `Column::from_qualified_name` and splits on `.`, so a chunked index's
+    /// `_spice.chunk_id` key partitioned by column `chunk_id` of relation `_spice`
+    /// instead of by the one column actually named `_spice.chunk_id`. Asserted on the
+    /// resolved column refs, not on the rendered expression: a `Column`'s display is
+    /// `_spice.chunk_id` either way, so only the `relation`/`name` split tells them apart.
+    #[test]
+    fn aggregate_score_expr_partitions_by_a_dotted_primary_key_whole() {
+        let candidate = make_list_multi_gen(EmbeddingAggregation::Max);
+        let expr = candidate
+            .aggregate_score_expr(&["_spice.chunk_id".to_string()])
+            .expect("should not error");
+
+        let refs = expr.column_refs();
+        assert!(
+            refs.iter()
+                .any(|c| c.relation.is_none() && c.name == "_spice.chunk_id"),
+            "the partition key must stay one unqualified column named `_spice.chunk_id`: {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|c| c.name == "chunk_id"),
+            "the dotted key was split into relation `_spice` + column `chunk_id`: {refs:?}"
+        );
+    }
+
     #[test]
     fn test_quoting_embedding_columns() {
         // lowercase


### PR DESCRIPTION
Completes the dot-safe-column class that #12389 started, in the two crates that PR does not touch.

## Root cause

`datafusion_expr::col` converts a `&str`/`String` through `Column::from_qualified_name`, which **splits on `.`** — so `col("_spice.chunk_id")` is a reference to column `chunk_id` of relation `_spice`, not to the column literally named `_spice.chunk_id`. Index primary keys can contain a dot: chunking injects `_spice.chunk_id` (`crates/search/src/index/chunking.rs`), and `flatten_json: true` produces names like `message.body`.

**`crates/runtime-datafusion-index/src/delete.rs`** built both of its expression sets from raw key-name strings:

- `resolve_keys_matching_predicate` projects off a plan scanned as relation `t`, so the schema field is `t."_spice.chunk_id"`. With a dotted key the projection resolved against a relation `_spice` that does not exist, and planning failed with `No field named _spice.chunk_id` — the error whose "valid fields" list contains the field it claims is missing. **A delete on a chunked index could resolve none of the rows it meant to remove.**
- `build_key_match_predicate` had the same split. This one is harder to spot because an `Expr` renders as `_spice.chunk_id` whichever way it was built, so only resolution against a real schema tells the two apart.

**`crates/runtime-search/src/candidate/vector.rs`** had it in `search_late_interaction`'s two group-by lists (`:668`, `:686`), while line 638 of the *same function* already used the dot-safe `ident` for its projection — so the function projected dotted primary keys correctly and then grouped by them incorrectly.

## Changes

- `delete.rs`: `col(name)` → `ident(name)` at both sites; `col` moves into the test module, where the tests still legitimately want the splitting constructor for their undotted filter columns.
- `vector.rs`: `pks.iter().map(col)` → `pks.iter().map(ident)` in both group-by lists, matching line 638. `col("q_idx")` alongside it is left as-is — the name has no dot, so `col` and `ident` are identical there and changing it would be pure noise.

**Left alone deliberately:** `Column::from_qualified_name_ignore_case` at `crates/runtime-search/src/request.rs:310` and the `col_qualified!` macro in `rrf.rs:153` split on `.` on purpose.

**No overlap with the open search PRs.** #12389 touches `index/memory/provider.rs`, `index/elasticsearch/mod.rs`, `provider.rs` and `index/compound/tests.rs`; #12411 touches `index/chunking.rs`, `index/compound/vector_index.rs` and `index/mod.rs`; #12410 touches `index/elasticsearch/write.rs`. None of them touches either file here.

## Test plan

- [x] Added regression test `resolve_keys_matching_predicate_projects_a_dotted_key_column` — a `MemTable` with a field literally named `_spice.chunk_id`, resolved with that as the key column. On the old code the plan fails to build; on the new code it returns the right keys and the projected field keeps its whole name.
- [x] Added regression test `build_key_match_predicate_keeps_a_dotted_key_name_whole` — asserts by **planning** the predicate against a scanned relation rather than by rendering it, because the rendered form is identical either way.
- [x] Both new tests are `#[tokio::test]` over an in-process `MemTable` + `SessionContext` — no network, no credentials, no secret-gated fixtures.
- [x] `make lint` passes (workspace-wide `cargo fmt --all -- --check` + full clippy — not a per-crate invocation)
- [x] `make test` passes
- [x] `make signoff` run after the final push (`Attestation` check is green)

## Checklist

- [x] Whole bug class in these two crates, not just the reported call site
- [x] Deliberate dot-splitting call sites (`request.rs`, `col_qualified!`) left untouched
- [x] No behaviour change for undotted names — `col` and `ident` are equivalent there
- [x] No file overlap with #12389 / #12411 / #12410

## Notes for the reviewer

The integration-level symptom is `models::s3_vectors::search::with_chunking_metadata` in the secret-gated `Test Models, AI & Search` suite (see the re-triage on #11112). I could not run that suite, so the unit tests above are what proves this change; they fail on the pre-fix code for the same reason the integration test does.

Fixes #12462
