### PR TITLE
fix(ci): stop Enforce Pulls with Spice racing itself, and let a Dependabot PR pass it (fixes #12377)

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -11,10 +11,20 @@ on:
 # runs of this workflow inside the same second. With nothing serialising them they race
 # on the same PR's labels — a PR was observed carrying `size/xl` and `size/l` at once —
 # and the verdict that sticks is whichever run happened to finish last rather than the
-# one that saw the final label set. Collapse the burst onto the newest run, which is the
-# only one that can see every label. The trigger list stays as it is: `labeled` is also
-# how a human clears a failed verdict after adding the missing `kind/`/`area/` label, so
-# dropping it would leave the check red with no way to re-run it short of a push.
+# one that saw the final label set. Queue the burst instead, so the runs execute one at a
+# time and the last one — which is the only one that can see every label — is the verdict
+# that sticks. The trigger list stays as it is: `labeled` is also how a human clears a
+# failed verdict after adding the missing `kind/`/`area/` label, so dropping it would
+# leave the check red with no way to re-run it short of a push.
+#
+# `cancel-in-progress` stays `false` deliberately, and this is the whole reason #12377
+# asks for a group rather than the one `pr.yml` used to carry. This is a *required*
+# check, branch protection and the merge queue count a cancelled required check as
+# not-passing, and these triggers fire without a new commit SHA — so a cancelled run
+# writes a not-passing conclusion onto the same SHA the surviving run is reporting on,
+# and can strand the PR with no failing check and no push available to re-trigger it.
+# Cancelling would collapse the burst marginally faster; the job is one `node24` API
+# call, so serialising four to seven of them costs seconds and risks nothing.
 #
 # `pull_request_target` evaluates in the base-branch context, so `github.ref` is `trunk`
 # for every PR and would serialise unrelated PRs against each other; the PR number is
@@ -22,7 +32,7 @@ on:
 # is the unique `gh-readonly-queue/...` branch, so it falls through to a group of its own.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   enforce-pull-with-spice:

--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -6,6 +6,24 @@ on:
     types:
       [labeled, unlabeled, opened, edited, synchronize, assigned, unassigned]
 
+# Opening a PR applies several labels and an assignee, and each of those is its own
+# `labeled`/`assigned` event, so a single `gh pr create` routinely starts four to seven
+# runs of this workflow inside the same second. With nothing serialising them they race
+# on the same PR's labels — a PR was observed carrying `size/xl` and `size/l` at once —
+# and the verdict that sticks is whichever run happened to finish last rather than the
+# one that saw the final label set. Collapse the burst onto the newest run, which is the
+# only one that can see every label. The trigger list stays as it is: `labeled` is also
+# how a human clears a failed verdict after adding the missing `kind/`/`area/` label, so
+# dropping it would leave the check red with no way to re-run it short of a push.
+#
+# `pull_request_target` evaluates in the base-branch context, so `github.ref` is `trunk`
+# for every PR and would serialise unrelated PRs against each other; the PR number is
+# the correct key. A `merge_group` event carries no `pull_request`, and its `github.ref`
+# is the unique `gh-readonly-queue/...` branch, so it falls through to a group of its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   enforce-pull-with-spice:
     # The only step is a `node24` JavaScript action that calls the GitHub API — it needs no
@@ -23,7 +41,15 @@ jobs:
           require_title_min_length: '10'
           required_label_prefixes: 'kind/,area/'
           banned_labels: 'invalid,wontfix,nomerge,duplicate'
-          require_assignee: 'true'
+          # GitHub's assignees API silently drops App accounts, so `auto_assign_author`
+          # below cannot satisfy `require_assignee` on a Dependabot PR — the required
+          # check is then red forever with nothing any author or reviewer can do about
+          # it. #12358 is the shape: every other gate green, blocked solely on
+          # `❌ At least one assignee is required`, until a maintainer hand-assigned
+          # themselves. `pr.yml` already fast-tracks Dependabot for the same reason.
+          # This exempts nothing else — the title-length, `kind/`/`area/` label and
+          # banned-label gates still apply to dependency bumps exactly as before.
+          require_assignee: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && 'false' || 'true' }}
           auto_label: 'true'
           # No auto_label_size: GitHub applies size labels natively now, and the
           # action's input defaults to false, so leaving it out is the whole


### PR DESCRIPTION
## Summary

`Enforce Pulls with Spice` is the **highest-blast-radius failing check in the repo** —
113 failed runs across 34 distinct branches in the three days to 2026-08-04. This fixes
two defects in the machinery around its verdicts and **changes no verdict**.

Fixes #12377.

## Evidence

Window: the 900 most recent failed runs, `2026-08-01T11:36Z → 2026-08-04T11:05Z`.

| Cluster | Runs | Branches | runs/branch |
|---|---:|---:|---:|
| `Enforce Pulls with Spice` → `##[error]Pull request checks failed. See PR comments for details.` | **113** | **34** | 3.3 |

`runs ≫ branches` is the signature the failure scanner flags as duplicate triggering
rather than a rule violated that often, and it is what is happening here.

Failing runs:
[30889352964](https://github.com/spiceai/spiceai/actions/runs/30889352964),
[30888479672](https://github.com/spiceai/spiceai/actions/runs/30888479672),
[30888445220](https://github.com/spiceai/spiceai/actions/runs/30888445220)

### Defect 1 — the workflow races itself, with nothing serialising the result

Opening a PR applies several labels and an assignee, and each of those is its own
`labeled`/`assigned` webhook event. One `gh pr create` therefore raises four runs inside
the same second. Verified on four unrelated branches:

```
4 runs at 08:39:32-33Z   fix/12462-dotted-index-key-requalification
4 runs at 08:37:25-29Z   phillip/12447-fixed-offset-timezone
3 runs at 08:28:59-29:00Z fix/12427-signoff-disk-guard-gaps
```

There is no `concurrency:` group, so they all execute at once and race on the same PR's
labels. Observed damage: a PR carrying `size/xl` and `size/l` simultaneously, and a
verdict decided by whichever run happened to finish last rather than the one that saw the
final label set. `pr.yml` and `e2e_test_ci.yml` both already have a group.

**The trigger list is deliberately unchanged.** `labeled` is also how a human clears a
failed verdict after adding the missing label — dropping it would leave the check red with
no way to re-run it short of a push. Serialising the burst fixes the race without
removing anyone's recovery path.

`pull_request_target` evaluates in the base-branch context, so `github.ref` is `trunk`
for every PR and would serialise unrelated PRs against each other; the PR number is the
correct key. A `merge_group` event carries no `pull_request` and its `github.ref` is the
unique `gh-readonly-queue/...` branch, so it falls into a group of its own.

**`cancel-in-progress` is `false`, deliberately.** #12377 asks for a group precisely
because cancelling is what made the old `pr.yml` group harmful: this is a *required*
check, branch protection and the merge queue count a cancelled required check as
not-passing, and these triggers fire without a new commit SHA — so a cancelled run
writes a not-passing conclusion onto the same SHA the surviving run is reporting on,
and can strand a PR with no failing check and no push available to re-trigger it.
Queueing fixes the race just as well: the runs execute one at a time and the last one,
the only one that can see every label, is the verdict that sticks. The job is a single
`node24` API call, so serialising four to seven of them costs seconds.

### Defect 2 — a Dependabot PR can never pass this check

`require_assignee: 'true'` together with `auto_assign_author: 'true'` is unsatisfiable for
an App account: GitHub's assignees API silently drops it, so auto-assign cannot satisfy
require-assignee. Current state of the repo:

```
PR #12358  assignees=[]  author=app/dependabot  (open since 2026-08-02)
PR #12356  assignees=[]  author=app/dependabot  (open since 2026-08-02)
PR #11969  assignees=[lukekim]  author=app/dependabot  (hand-assigned by a maintainer)
```

`gh pr checks 12358` shows every other check green, and the action's own comment on it
names the single failure:

```
### Passing checks:
- ✅ Title meets minimum length requirement (10 characters)
- ✅ No banned labels detected
- ✅ Has a label from required category `kind/`
- ✅ Has a label from required category `area/`

### Failed checks:
- ❌ At least one assignee is required for this pull request.
```

`pr.yml` already fast-tracks Dependabot for exactly this reason (`github.event.pull_request.user.login == 'dependabot[bot]'`); this workflow never got the equivalent. The gate here matches that idiom.

## What this does **not** weaken

- **No verdict changes for human PRs.** Title length, the required `kind/`/`area/` label
  prefixes, the banned-label list and `require_assignee` all still apply exactly as
  before. The ~86 human-branch failures in the window were correct and stay correct.
- **Dependency bumps still have to pass everything else** — title length, `kind/`,
  `area/`, banned labels. Only the requirement that no App account can satisfy is lifted,
  and only for `dependabot[bot]`.
- **The exemption cannot be spoofed.** `github.event.pull_request.user.login` is set by
  GitHub from the authenticated author, and `[`/`]` are not legal characters in a user
  login, so no user account can present itself as `dependabot[bot]`.
- **No check is removed from the required set**, no `continue-on-error`, no retry, no
  relaxed assertion, and no trigger removed.

## Test plan

- [x] `python .github/scripts/check_workflow_yaml.py` — `OK: 105 GitHub Actions definitions are well-formed` (this is the repo's own `Workflow YAML Check` gate, which runs on `.github/workflows/**`)
- [x] `python .github/scripts/test_check_workflow_yaml.py` — 24 tests, `OK`
- [x] Parsed the changed file with PyYAML and asserted the resulting trigger list, `concurrency` block and `require_assignee` expression
- [x] Verified the ternary's semantics against GitHub expression rules: a non-empty string is truthy, so `A && 'false' || 'true'` yields `'false'` when `A` holds and `'true'` otherwise
- [x] Verified the group key is distinct for `pull_request_target` (PR number) and `merge_group` (queue-branch `github.ref`), so a PR run and a queue run are never serialised behind one another
- [ ] `make lint` / `make test` — **not applicable and not run.** The diff is one workflow YAML file with no Rust; `signoff.yml` skips the Rust lint/build/test steps for a branch with no Rust-affecting files by design. Remote sign-off is dispatched for the `Attestation` gate.
