### PR TITLE
fix(ci): make integration tests (models) able to start on the release/2.1 line (refs #12396)

### DIFF
--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -191,6 +191,11 @@ jobs:
     runs-on: spiceai-macos
     env:
       HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
+      HAS_OPENAI_SECRET: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY != '' }}
+      HAS_ANTHROPIC_SECRET: ${{ secrets.SPICE_SECRET_ANTHROPIC_API_KEY != '' }}
+      HAS_XAI_SECRET: ${{ secrets.SPICE_SECRET_XAI_API_KEY != '' }}
+      HAS_HF_SECRET: ${{ secrets.SPICE_SECRET_HF_TOKEN != '' }}
+      HAS_S3_VECTORS_SECRET: ${{ secrets.AWS_S3_VECTORS_KEY != '' && secrets.AWS_S3_VECTORS_SECRET != '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -239,7 +244,7 @@ jobs:
 
       # OpenAI tests
       - name: Run OpenAI integration test
-        if: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY != '' }}
+        if: env.HAS_OPENAI_SECRET == 'true'
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
@@ -251,7 +256,7 @@ jobs:
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --archive-file ./integration_test/integration.tar.zst -- openai_test
 
       - name: Run OpenAI Beta functionality embeddings test
-        if: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY != '' }}
+        if: env.HAS_OPENAI_SECRET == 'true'
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
@@ -264,7 +269,7 @@ jobs:
 
       # AI UDF tests
       - name: Run AI UDF basic test
-        if: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY != '' && secrets.SPICE_SECRET_ANTHROPIC_API_KEY != '' }}
+        if: env.HAS_OPENAI_SECRET == 'true' && env.HAS_ANTHROPIC_SECRET == 'true'
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
@@ -281,7 +286,7 @@ jobs:
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --archive-file ./integration_test/integration.tar.zst -- test_ai_udf_basic
 
       - name: Run AI UDF with dataset test
-        if: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY != '' && secrets.SPICE_SECRET_ANTHROPIC_API_KEY != '' && secrets.SPICE_SECRET_XAI_API_KEY != '' }}
+        if: env.HAS_OPENAI_SECRET == 'true' && env.HAS_ANTHROPIC_SECRET == 'true' && env.HAS_XAI_SECRET == 'true'
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
@@ -304,7 +309,7 @@ jobs:
 
       # NOTE: Step-level `if:` conditionals on secret-requiring AI test steps (OpenAI, workers, search, xAI/HF UDFs, etc.) cause the step to report "skipped" (neutral, job succeeds) on PRs where secrets are intentionally unavailable for security (forks/external PRs). When a step *does* execute (schedule/workflow_dispatch with secrets present), an explicit fast-fail guard at the start of `run:` errors immediately if a required key is missing, preserving the original intent. This is intentional and confirmed for schedule + workflow_dispatch (incl. `run_all_tests`). See Copilot review threads for context; prevents spurious reds unrelated to code.
       - name: Run AI UDF LEFT truncate test
-        if: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY != '' && secrets.SPICE_SECRET_ANTHROPIC_API_KEY != '' && secrets.SPICE_SECRET_XAI_API_KEY != '' }}
+        if: env.HAS_OPENAI_SECRET == 'true' && env.HAS_ANTHROPIC_SECRET == 'true' && env.HAS_XAI_SECRET == 'true'
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
@@ -325,7 +330,7 @@ jobs:
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --archive-file ./integration_test/integration.tar.zst -- local_embeddings_beta_requirements
 
       - name: Run AI UDF with local model test
-        if: ${{ secrets.SPICE_SECRET_HF_TOKEN != '' }}
+        if: env.HAS_HF_SECRET == 'true'
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_HF_TOKEN: ${{ secrets.SPICE_SECRET_HF_TOKEN }}
@@ -334,7 +339,7 @@ jobs:
 
       # Workers tests
       - name: Run workers integration test
-        if: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY != '' }}
+        if: env.HAS_OPENAI_SECRET == 'true'
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
@@ -347,7 +352,7 @@ jobs:
 
       # Search tests
       - name: Run search integration test
-        if: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY != '' && secrets.AWS_S3_VECTORS_KEY != '' && secrets.AWS_S3_VECTORS_SECRET != '' }}
+        if: env.HAS_OPENAI_SECRET == 'true' && env.HAS_S3_VECTORS_SECRET == 'true'
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
@@ -377,6 +382,7 @@ jobs:
     runs-on: spiceai-macos
     env:
       HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
+      HAS_HF_SECRET: ${{ secrets.SPICE_SECRET_HF_TOKEN != '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -418,7 +424,7 @@ jobs:
           path: ./integration_test
 
       - name: Run integration test
-        if: ${{ secrets.SPICE_SECRET_HF_TOKEN != '' }}
+        if: env.HAS_HF_SECRET == 'true'
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_HF_TOKEN: ${{ secrets.SPICE_SECRET_HF_TOKEN }}
@@ -430,7 +436,7 @@ jobs:
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --archive-file ./integration_test/integration.tar.zst -- huggingface_test
 
       - name: Run Beta functionality embedding tests
-        if: ${{ secrets.SPICE_SECRET_HF_TOKEN != '' }}
+        if: env.HAS_HF_SECRET == 'true'
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_HF_TOKEN: ${{ secrets.SPICE_SECRET_HF_TOKEN }}


### PR DESCRIPTION
## Summary

`integration tests (models)` has **never succeeded** on the `release/2.1` line. Every run
is a *startup* failure: zero jobs, no downloadable log, and the run named after the
workflow **file path** rather than `integration tests (models)`, because GitHub never got
far enough to read the `name:` key.

`secrets` is not an available context in an `if:` conditional, so a workflow that uses one
there cannot be scheduled at all. This file has ten of them. Trunk fixed exactly this in
#11781 (`520bc8bb`, 2026-07-13) by hoisting each secret test into a job-level `env: HAS_*`
and testing that; `release/2.1` was cut without that commit. This applies the same change.

Base is `release/2.1` — **not** trunk — because trunk is already correct.

Refs #12396.

## Evidence

Window: the 900 most recent failed runs, `2026-08-01T11:36Z → 2026-08-04T11:05Z`.

**25 failed runs across 6 branches, all on the release/2.1 line, and it is the only
workflow definition in the repository producing startup failures:**

```
4  release/2.1
3  sgrebnov/2.1.3-prep
2  update-datafusion-rev-pr194
2  phillip/vortex-pin-2.1-fixed-offset-timezone
1  phillip/v2.1.3-notes-timestamptz
1  schema/2.1.3
```

Every other workflow on those same branches runs fine (`ADBC integration tests`,
`Check for forbidden licenses`, `Enforce Pulls with Spice`, `integration tests`, the bench
matrices), which isolates the cause to this file's contents rather than the branches.

A representative run —
[30900174211](https://github.com/spiceai/spiceai/actions/runs/30900174211):

```
name:        .github/workflows/integration_models.yml     <- the path, not the name
event:       push
head_branch: update-datafusion-rev-pr194
conclusion:  failure
jobs:        0
```

```
$ gh run view 30900174211
X This run likely failed because of a workflow file issue.
$ gh run view 30900174211 --log
failed to get run log: log not found
```

### Why it lands on every push here but not on trunk

Trunk's copy triggers only on `schedule` and `workflow_dispatch`. `release/2.1`'s copy also
subscribes to `push:` on `trunk`/`release/*` and `pull_request:`/`merge_group:` on
`release/*`, so the unschedulable definition is reached by **every push and every PR to the
release line** — which is why this reads as a recurring per-branch failure that no author's
diff can account for.

### Why the diagnosis is the `if:` conditionals

- The commit that changed them on trunk is titled *"Fix secrets in
  `.github/workflows/integration_models.yml`"* (#11781), and
  `git merge-base --is-ancestor 520bc8bba origin/release/2.1` → **not an ancestor**.
- `git grep -E "if:.*secrets\." origin/trunk -- .github/` returns **nothing**: the pattern
  was eradicated from trunk and exists nowhere else in the repo.
- It is the only difference between the two copies that affects schedulability. The others
  are pinned action SHAs (`actions/checkout` v7.0.0 vs v7.0.1, `spiceio` v0.5.8 vs v0.5.9)
  and the extra triggers above, all of which are intentional release-line state and are
  left untouched here.

A startup-failed run exposes neither logs nor a check-run annotation, so GitHub's exact
message is not retrievable after the fact — the evidence above is what establishes it.

## What this does **not** change

- **No test is enabled, disabled, relaxed, retried or skipped.** `env.HAS_X == 'true'` is
  true on exactly the runs where `secrets.X != ''` was intended to be.
- **Every step keeps its explicit fast-fail guard** at the top of its `run:` that errors
  when a required key is missing, so a step that *does* execute without its secret still
  fails loudly rather than passing vacuously.
- **The release line's own pins and triggers are untouched** — no action-SHA bumps, no
  trigger changes, nothing else backported from trunk.

## Test plan

- [x] The `if:` conditionals in this file are now **character-for-character identical** to
      trunk's: 47 `if:` lines on each side, symmetric-difference empty in both directions
- [x] Every `env.HAS_*` referenced by a step `if:` is declared in that step's own job `env:`
      — checked programmatically across all five jobs, 0 problems
- [x] No `if:` in the file references `secrets.` any more (was 10, now 0), and no job-level
      `if:` references `env.` (which is also unavailable there)
- [x] Trunk's `.github/scripts/check_workflow_yaml.py --github-dir <this tree>/.github` —
      `OK: 93 GitHub Actions definitions are well-formed`. (That guard does not exist on
      `release/2.1`; it was added to trunk for #12181, and it does not yet catch this
      class — a follow-up extends it.)
- [ ] `make lint` / `make test` — **not applicable and not run.** The diff is one workflow
      YAML file with no Rust.
