### PR TITLE
fix(ci): reject an `if:` naming a context GitHub does not provide there (refs #12396)

### DIFF
--- a/.github/scripts/check_workflow_yaml.py
+++ b/.github/scripts/check_workflow_yaml.py
@@ -17,11 +17,16 @@
 # It also rejects a step budget its own job's budget pre-empts, which is dead
 # config with the same symptom — the job is terminated as `cancelled` with no
 # failed step to explain it (#12340).
+#
+# And it rejects an `if:` naming a context GitHub does not make available there,
+# which fails the same way for a different reason: GitHub rejects the definition
+# rather than the expression, so the workflow never schedules (#12396).
 """Validate the repository's GitHub Actions workflow and composite action YAML."""
 
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -31,6 +36,48 @@ import yaml
 # is also how it reaches GitHub's parser, so a trigger block is present under
 # either spelling.
 TRIGGER_KEYS = ("on", True)
+
+# Every context GitHub defines. Only these names are reported when they appear
+# somewhere they are not available — an unrecognised `word.` is left alone, so an
+# incidental dotted string inside a condition cannot fail the build.
+KNOWN_CONTEXTS = frozenset(
+    {
+        "env",
+        "github",
+        "inputs",
+        "job",
+        "jobs",
+        "matrix",
+        "needs",
+        "runner",
+        "secrets",
+        "steps",
+        "strategy",
+        "vars",
+    }
+)
+
+# What each kind of `if:` may name. A job-level `if:` is evaluated before the job
+# has an environment, a matrix row, or any completed step, so it sees far less
+# than a step's does.
+JOB_IF_CONTEXTS = frozenset({"github", "inputs", "needs", "vars"})
+STEP_IF_CONTEXTS = JOB_IF_CONTEXTS | frozenset(
+    {"env", "job", "matrix", "runner", "steps", "strategy"}
+)
+
+# A context reference is `name.` — but only when `name` starts the token. The
+# lookbehind is what keeps `needs.setup-model-matrix.outputs.matrix` from reading
+# as a use of the `matrix` context (`e2e_test_ci.yml` has exactly that).
+CONTEXT_REFERENCE = re.compile(r"(?<![\w.-])([a-z]+)\s*\.")
+
+# `secrets` is the case that has actually bitten, so its diagnosis names the fix
+# trunk already uses rather than leaving the reader to find it.
+CONTEXT_REMEDIES = {
+    "secrets": (
+        "hoist the test into a job-level `env:` "
+        "(`HAS_X: ${{ secrets.X != '' }}`) and test `env.HAS_X == 'true'`"
+    ),
+}
 
 
 def workflow_files(github_dir: Path) -> list[Path]:
@@ -78,7 +125,98 @@ def check_workflow(text: str) -> list[str]:
         problems.append("has a `jobs:` block that is not a non-empty mapping")
     else:
         problems.extend(check_step_budgets(jobs))
+        problems.extend(check_workflow_conditions(jobs))
 
+    return problems
+
+
+def unavailable_contexts(condition: object, available: frozenset[str]) -> list[str]:
+    """Return the contexts `condition` names that are not available to it.
+
+    Order follows first appearance in the condition so the message reads in the
+    same order as the line it is about, and each context is reported once.
+    """
+    found = []
+    for name in CONTEXT_REFERENCE.findall(str(condition)):
+        if name in KNOWN_CONTEXTS and name not in available and name not in found:
+            found.append(name)
+    return found
+
+
+def _condition_problem(where: str, condition: object, available: frozenset[str]) -> str | None:
+    """Describe one `if:` that names an unavailable context, or None if it is fine."""
+    unavailable = unavailable_contexts(condition, available)
+    if not unavailable:
+        return None
+    named = ", ".join(f"`{name}`" for name in unavailable)
+    problem = (
+        f"{where} has an `if:` naming {named}, which GitHub does not make available "
+        f"there, so it cannot schedule this definition at all"
+    )
+    remedies = [CONTEXT_REMEDIES[name] for name in unavailable if name in CONTEXT_REMEDIES]
+    return f"{problem} — {'; '.join(remedies)}" if remedies else problem
+
+
+def check_workflow_conditions(jobs: dict) -> list[str]:
+    """Report `if:` conditions naming a context GitHub does not provide there.
+
+    GitHub validates an `if:` expression's contexts when it reads the file, not
+    when it evaluates the condition, so naming an unavailable one does not fail
+    the step — it makes the whole workflow unschedulable. The run that appears is
+    a startup failure: zero jobs, no downloadable log, and a run named after the
+    file path because `name:` was never reached, which reads as a mystery rather
+    than as a definition error.
+
+    #12396 is the shape: ten `if: ${{ secrets.X != '' }}` conditionals left
+    `integration tests (models)` unable to start on any push or PR to the
+    release/2.1 line. `secrets` is available in `env:` and `with:`, just not in an
+    `if:`, so the fix is an indirection through the job's environment rather than
+    dropping the condition.
+    """
+    problems = []
+    for name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        if "if" in job:
+            problem = _condition_problem(f"job `{name}`", job["if"], JOB_IF_CONTEXTS)
+            if problem:
+                problems.append(problem)
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for position, step in enumerate(steps, start=1):
+            if not isinstance(step, dict) or "if" not in step:
+                continue
+            label = step.get("name") or f"step {position}"
+            problem = _condition_problem(
+                f"job `{name}` step `{label}`", step["if"], STEP_IF_CONTEXTS
+            )
+            if problem:
+                problems.append(problem)
+    return problems
+
+
+def check_action_conditions(runs: object) -> list[str]:
+    """Report the same unavailable-context problem in a composite action's steps.
+
+    Reuses the workflow step set, which is deliberately the permissive choice: a
+    composite step sees a little less than a workflow step (no `needs`, no matrix),
+    so allowing those cannot produce a false positive — and `secrets`, the one that
+    has actually broken a definition here, is excluded either way.
+    """
+    if not isinstance(runs, dict):
+        return []
+    steps = runs.get("steps")
+    if not isinstance(steps, list):
+        return []
+    problems = []
+    for position, step in enumerate(steps, start=1):
+        if not isinstance(step, dict) or "if" not in step:
+            continue
+        label = step.get("name") or f"step {position}"
+        problem = _condition_problem(f"step `{label}`", step["if"], STEP_IF_CONTEXTS)
+        if problem:
+            problems.append(problem)
     return problems
 
 
@@ -127,7 +265,10 @@ def check_action(text: str) -> list[str]:
     if document is None:
         return problems
 
-    return [] if "runs" in document else ["has no `runs:` block"]
+    if "runs" not in document:
+        return ["has no `runs:` block"]
+
+    return check_action_conditions(document["runs"])
 
 
 def _format_yaml_error(error: yaml.YAMLError) -> str:
@@ -178,8 +319,8 @@ def main(argv: list[str] | None = None) -> int:
     if failures:
         print(
             f"{len(failures)} GitHub Actions definition problem(s) found. A definition "
-            "GitHub cannot parse is silently disabled, and a budget it pre-empts never "
-            "fires, so this fails the build:",
+            "GitHub cannot parse or schedule is silently disabled, and a budget it "
+            "pre-empts never fires, so this fails the build:",
             file=sys.stderr,
         )
         for failure in failures:

--- a/.github/scripts/check_workflow_yaml.py
+++ b/.github/scripts/check_workflow_yaml.py
@@ -38,8 +38,10 @@ import yaml
 TRIGGER_KEYS = ("on", True)
 
 # Every context GitHub defines. Only these names are reported when they appear
-# somewhere they are not available — an unrecognised `word.` is left alone, so an
-# incidental dotted string inside a condition cannot fail the build.
+# somewhere they are not available, so an unrecognised `word.` / `word[` is left
+# alone. String literals are removed before the scan (see `unavailable_contexts`),
+# so an incidental dotted or bracketed string inside a condition cannot fail the
+# build even when it leads with a real context name.
 KNOWN_CONTEXTS = frozenset(
     {
         "env",
@@ -65,10 +67,18 @@ STEP_IF_CONTEXTS = JOB_IF_CONTEXTS | frozenset(
     {"env", "job", "matrix", "runner", "steps", "strategy"}
 )
 
-# A context reference is `name.` — but only when `name` starts the token. The
-# lookbehind is what keeps `needs.setup-model-matrix.outputs.matrix` from reading
-# as a use of the `matrix` context (`e2e_test_ci.yml` has exactly that).
-CONTEXT_REFERENCE = re.compile(r"(?<![\w.-])([a-z]+)\s*\.")
+# A context reference is `name.` or `name[` — GitHub expressions accept property
+# access in either form, and `secrets['TOKEN']` makes a definition unschedulable
+# exactly as `secrets.TOKEN` does. The match holds only when `name` starts the
+# token: the lookbehind is what keeps `needs.setup-model-matrix.outputs.matrix`
+# from reading as a use of the `matrix` context (`e2e_test_ci.yml` has that).
+CONTEXT_REFERENCE = re.compile(r"(?<![\w.-])([a-z]+)\s*[.\[]")
+
+# A GitHub expression quotes string literals with `'`, doubling the quote to
+# escape it. Literals are dropped before the scan so that a condition comparing
+# against text that happens to lead with a context name — `== 'env.FOO'` — is not
+# read as a use of that context.
+STRING_LITERAL = re.compile(r"'[^']*'")
 
 # `secrets` is the case that has actually bitten, so its diagnosis names the fix
 # trunk already uses rather than leaving the reader to find it.
@@ -133,11 +143,16 @@ def check_workflow(text: str) -> list[str]:
 def unavailable_contexts(condition: object, available: frozenset[str]) -> list[str]:
     """Return the contexts `condition` names that are not available to it.
 
+    Property access counts in either of the forms GitHub accepts, `name.KEY` and
+    `name['KEY']`. Quoted string literals are removed first, so text that merely
+    reads like a context reference is not mistaken for one.
+
     Order follows first appearance in the condition so the message reads in the
     same order as the line it is about, and each context is reported once.
     """
+    scanned = STRING_LITERAL.sub("''", str(condition))
     found = []
-    for name in CONTEXT_REFERENCE.findall(str(condition)):
+    for name in CONTEXT_REFERENCE.findall(scanned):
         if name in KNOWN_CONTEXTS and name not in available and name not in found:
             found.append(name)
     return found

--- a/.github/scripts/test_check_workflow_yaml.py
+++ b/.github/scripts/test_check_workflow_yaml.py
@@ -183,6 +183,149 @@ class CheckStepBudgetTest(unittest.TestCase):
         )
 
 
+def _workflow_with_conditions(job_if: str = "", step_if: str = "") -> str:
+    """A one-step workflow, with each `if:` line omitted when passed empty."""
+    return "".join(
+        [
+            "---\non:\n  workflow_dispatch:\n\njobs:\n  gate:\n    runs-on: ubuntu-24.04\n",
+            f"    if: {job_if}\n" if job_if else "",
+            "    steps:\n      - name: Run the checks\n        run: echo hello\n",
+            f"        if: {step_if}\n" if step_if else "",
+        ]
+    )
+
+
+class CheckConditionContextTest(unittest.TestCase):
+    """#12396: an `if:` naming an unavailable context makes the file unschedulable."""
+
+    def test_secrets_in_a_step_condition_is_reported_with_the_remedy(self):
+        problems = check_workflow_yaml.check_workflow(
+            _workflow_with_conditions(step_if="${{ secrets.SPICE_SECRET_HF_TOKEN != '' }}")
+        )
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("job `gate` step `Run the checks`", problems[0])
+        self.assertIn("naming `secrets`", problems[0])
+        self.assertIn("hoist the test into a job-level `env:`", problems[0])
+
+    def test_secrets_in_a_job_condition_is_reported(self):
+        problems = check_workflow_yaml.check_workflow(
+            _workflow_with_conditions(job_if="${{ secrets.A != '' }}")
+        )
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("job `gate` has an `if:`", problems[0])
+
+    def test_the_env_indirection_trunk_uses_is_accepted(self):
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_with_conditions(step_if="env.HAS_HF_SECRET == 'true'")
+            ),
+            [],
+        )
+
+    def test_env_is_rejected_in_a_job_condition_but_allowed_in_a_step_condition(self):
+        """A job's `if:` is evaluated before the job has an environment."""
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_with_conditions(step_if="env.READY == 'true'")
+            ),
+            [],
+        )
+        problems = check_workflow_yaml.check_workflow(
+            _workflow_with_conditions(job_if="env.READY == 'true'")
+        )
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("naming `env`", problems[0])
+
+    def test_steps_matrix_and_runner_are_rejected_in_a_job_condition(self):
+        for context, condition in (
+            ("steps", "steps.probe.outputs.ok == 'true'"),
+            ("matrix", "matrix.target == 'linux'"),
+            ("runner", "runner.os == 'macOS'"),
+        ):
+            with self.subTest(context=context):
+                problems = check_workflow_yaml.check_workflow(
+                    _workflow_with_conditions(job_if=condition)
+                )
+                self.assertEqual(len(problems), 1, problems)
+                self.assertIn(f"naming `{context}`", problems[0])
+
+    def test_contexts_every_condition_may_name_are_accepted(self):
+        for condition in (
+            "github.event_name == 'push'",
+            "needs.build.result == 'success'",
+            "inputs.run_all_tests == 'true'",
+            "vars.FLAG == '1'",
+        ):
+            with self.subTest(condition=condition):
+                self.assertEqual(
+                    check_workflow_yaml.check_workflow(
+                        _workflow_with_conditions(job_if=condition, step_if=condition)
+                    ),
+                    [],
+                )
+
+    def test_a_hyphenated_job_name_is_not_read_as_a_context(self):
+        """`e2e_test_ci.yml` has exactly this: `needs.setup-model-matrix.outputs.matrix`."""
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_with_conditions(
+                    job_if="${{ needs.setup-model-matrix.outputs.matrix != '[]' }}"
+                )
+            ),
+            [],
+        )
+
+    def test_a_dotted_path_after_an_allowed_context_is_not_read_as_a_context(self):
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_with_conditions(
+                    step_if="github.event.pull_request.user.login == 'dependabot[bot]'"
+                )
+            ),
+            [],
+        )
+
+    def test_every_unavailable_context_in_one_condition_is_named_once(self):
+        problems = check_workflow_yaml.check_workflow(
+            _workflow_with_conditions(job_if="env.A == 'x' && secrets.B != '' && env.C == 'y'")
+        )
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("naming `env`, `secrets`", problems[0])
+
+    def test_an_unknown_dotted_word_is_left_alone(self):
+        """Only real GitHub context names are reported, so a stray string cannot fail CI."""
+        self.assertEqual(
+            check_workflow_yaml.unavailable_contexts(
+                "contains(github.ref, 'refs/heads/release.candidate')",
+                check_workflow_yaml.JOB_IF_CONTEXTS,
+            ),
+            [],
+        )
+
+    def test_a_condition_without_any_if_key_is_not_invented(self):
+        self.assertEqual(check_workflow_yaml.check_workflow(_workflow_with_conditions()), [])
+
+    def test_secrets_in_a_composite_action_step_condition_is_reported(self):
+        action = (
+            "name: Set up thing\ndescription: d\n\nruns:\n  using: composite\n  steps:\n"
+            "    - name: Configure\n      shell: bash\n      if: secrets.TOKEN != ''\n"
+            "      run: echo hello\n"
+        )
+        problems = check_workflow_yaml.check_action(action)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("step `Configure`", problems[0])
+        self.assertIn("naming `secrets`", problems[0])
+
+    def test_a_composite_action_step_may_name_inputs_steps_and_runner(self):
+        action = (
+            "name: Set up thing\ndescription: d\n\nruns:\n  using: composite\n  steps:\n"
+            "    - name: Configure\n      shell: bash\n"
+            "      if: runner.os == 'macOS' && inputs.enabled == 'true' && "
+            "steps.probe.outputs.ok == '1'\n      run: echo hello\n"
+        )
+        self.assertEqual(check_workflow_yaml.check_action(action), [])
+
+
 class CheckActionTest(unittest.TestCase):
     def test_valid_action_has_no_problems(self):
         self.assertEqual(check_workflow_yaml.check_action(VALID_ACTION), [])

--- a/.github/scripts/test_check_workflow_yaml.py
+++ b/.github/scripts/test_check_workflow_yaml.py
@@ -214,6 +214,57 @@ class CheckConditionContextTest(unittest.TestCase):
         self.assertEqual(len(problems), 1, problems)
         self.assertIn("job `gate` has an `if:`", problems[0])
 
+    def test_bracket_property_access_is_reported_like_dotted_access(self):
+        """`secrets['A']` is the same unschedulable definition as `secrets.A`."""
+        problems = check_workflow_yaml.check_workflow(
+            _workflow_with_conditions(job_if="${{ secrets['A'] != '' }}")
+        )
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("naming `secrets`", problems[0])
+
+    def test_bracket_access_in_a_step_condition_is_reported_with_the_remedy(self):
+        problems = check_workflow_yaml.check_workflow(
+            _workflow_with_conditions(step_if="${{ secrets['SPICE_SECRET_HF_TOKEN'] != '' }}")
+        )
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("job `gate` step `Run the checks`", problems[0])
+        self.assertIn("hoist the test into a job-level `env:`", problems[0])
+
+    def test_bracket_access_on_an_available_context_is_accepted(self):
+        """The lookbehind must still keep `needs['x'].outputs` from reading as a use."""
+        self.assertEqual(
+            check_workflow_yaml.unavailable_contexts(
+                "needs['setup'].outputs.matrix != ''",
+                check_workflow_yaml.JOB_IF_CONTEXTS,
+            ),
+            [],
+        )
+
+    def test_a_context_name_inside_a_quoted_literal_is_not_a_reference(self):
+        """A literal compared against is text, not property access on a context."""
+        for condition in (
+            "github.event.head_commit.message == 'env.READY'",
+            "contains(github.ref, 'secrets.A')",
+            "github.ref == 'matrix[0]'",
+        ):
+            with self.subTest(condition=condition):
+                self.assertEqual(
+                    check_workflow_yaml.unavailable_contexts(
+                        condition, check_workflow_yaml.JOB_IF_CONTEXTS
+                    ),
+                    [],
+                )
+
+    def test_a_real_reference_beside_a_quoted_literal_is_still_reported(self):
+        """Dropping literals must not swallow the reference next to them."""
+        self.assertEqual(
+            check_workflow_yaml.unavailable_contexts(
+                "github.ref == 'env.READY' && secrets.A != ''",
+                check_workflow_yaml.JOB_IF_CONTEXTS,
+            ),
+            ["secrets"],
+        )
+
     def test_the_env_indirection_trunk_uses_is_accepted(self):
         self.assertEqual(
             check_workflow_yaml.check_workflow(


### PR DESCRIPTION
## Summary

`Workflow YAML Check` exists because **a definition GitHub cannot read is silently
disabled** — no jobs, `on:`/`paths:` filters never evaluated, not a required check, and a
failed run nobody is obliged to look at (#12181). An `if:` naming a context GitHub does not
make available there fails in exactly that way, and the guard did not catch it.

This extends it to that class, with the remedy named in the message.

Refs #12396. The companion #12467 un-breaks the live instance on `release/2.1`; this stops
the next one.

## Evidence — the gap is live today

`integration tests (models)` has **never once started** on the `release/2.1` line: **25
failed runs across 6 branches** in the 900 most recent failed runs
(`2026-08-01T11:36Z → 2026-08-04T11:05Z`), every one a startup failure.

[Run 30900174211](https://github.com/spiceai/spiceai/actions/runs/30900174211):

```
name:       .github/workflows/integration_models.yml   <- the path, because `name:` was never read
conclusion: failure
jobs:       0
$ gh run view 30900174211 --log
failed to get run log: log not found
```

The cause is ten `if: ${{ secrets.X != '' }}` conditionals. `secrets` is available in
`env:` and `with:`, just not in an `if:`, and GitHub validates an `if:`'s contexts **when
it reads the file**, not when it evaluates the condition — so the mistake takes out the
whole definition rather than the step. Trunk fixed its own copy in #11781 by hoisting each
test into a job-level `env: HAS_X` and testing that. Nothing stopped it being made again,
here or in any other file.

## What the check does

| `if:` position | May name |
|---|---|
| `jobs.<id>.if` | `github`, `needs`, `vars`, `inputs` |
| `jobs.<id>.steps[*].if` | the above plus `env`, `job`, `matrix`, `runner`, `steps`, `strategy` |
| composite action `runs.steps[*].if` | same as a workflow step (deliberately permissive — see below) |

Anything else that is a real GitHub context name is reported, e.g.:

```
integration_models.yml: job `test-models` step `Run OpenAI integration test` has an `if:`
naming `secrets`, which GitHub does not make available there, so it cannot schedule this
definition at all — hoist the test into a job-level `env:` (`HAS_X: ${{ secrets.X != '' }}`)
and test `env.HAS_X == 'true'`
```

Two deliberate limits keep it from becoming a nuisance:

- **Only real context names are reported.** An unrecognised `word.` is left alone, so a
  dotted string literal inside a condition cannot fail the build.
- **A reference must start its token.** `e2e_test_ci.yml`'s
  `needs.setup-model-matrix.outputs.matrix` is not a use of the `matrix` context, and the
  lookbehind is what makes that true. There is a test for it.
- The composite-action set reuses the workflow-step set, which is the *permissive*
  direction: a composite step sees slightly less, so allowing `needs`/`matrix`/`strategy`
  there cannot produce a false positive, and `secrets` is excluded either way.

## What this does **not** weaken

- **It adds no failure to trunk.** Run against the tree it guards: `OK: 105 GitHub Actions
  definitions are well-formed` — unchanged from before this commit. Every existing `if:` in
  the repo already names only available contexts (job-level `if:` uses `github`, `needs`,
  `inputs`; step-level adds `env`, `matrix`, `runner`, `steps`).
- **No workflow behaviour changes.** This is a lint on the definitions, not a change to any
  of them.
- **No check is relaxed, retried, skipped or removed**, and nothing new is allowed through
  — the guard only rejects more.

## Test plan

- [x] `python .github/scripts/test_check_workflow_yaml.py` — **37 tests, `OK`** (was 24; 13 new)
- [x] New cases cover: `secrets` in a step `if:` and in a job `if:`; the `env:` indirection
      trunk uses being accepted; `env` rejected in a job `if:` but accepted in a step `if:`;
      `steps`/`matrix`/`runner` rejected in a job `if:`; `github`/`needs`/`inputs`/`vars`
      accepted in both; the hyphenated-job-name non-match; a dotted path after an allowed
      context; several unavailable contexts in one condition named once each; an unknown
      dotted word left alone; a composite-action step both ways
- [x] `python .github/scripts/check_workflow_yaml.py` against this repo —
      `OK: 105 GitHub Actions definitions are well-formed` (zero false positives)
- [x] Negative test against `origin/release/2.1`'s unpatched `integration_models.yml` —
      reports **exactly the 10** real conditionals and nothing else, each with the remedy
- [ ] `make lint` / `make test` — **not applicable and not run.** The diff is two Python
      files under `.github/scripts/` with no Rust; the script's own unit suite above is the
      gate that `Workflow YAML Check` runs.
