### PR TITLE
fix(ci): build the ADBC BigQuery driver with the Go version its go.mod requires

### DIFF
--- a/.github/actions/setup-adbc-bigquery/action.yml
+++ b/.github/actions/setup-adbc-bigquery/action.yml
@@ -7,15 +7,19 @@ inputs:
     required: false
     default: 'fe83ac26d43bffeaf28844bcf5fef303b1bdf345'
   go_version:
-    description: 'Go version to use for building'
+    description: >-
+      Go version to build the driver with. Must satisfy the `go` directive in the
+      pinned commit's go/go.mod — `actions/setup-go` v7 sets `GOTOOLCHAIN=local`,
+      so Go will not download a newer toolchain to cover a shortfall. The build
+      step below asserts the two agree.
     required: false
-    default: '1.24.1'
+    default: '1.26.1'
 
 runs:
   using: 'composite'
   steps:
     - name: Setup Go
-      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ inputs.go_version }}
         cache: false
@@ -30,15 +34,45 @@ runs:
 
     - name: Build ADBC BigQuery driver
       shell: bash
+      # Passed through the environment rather than interpolated into the script
+      # text: an input reaching `run:` as source is the shape review rejected on
+      # #12185, and a value the shell reads as data cannot end a quote.
+      env:
+        ADBC_BIGQUERY_COMMIT: ${{ inputs.adbc_bigquery_commit }}
       run: |
         set -eu
         DRIVER_DIR="/etc/adbc/drivers"
 
         git clone --depth=1 https://github.com/adbc-drivers/bigquery.git /tmp/adbc-bigquery
         cd /tmp/adbc-bigquery
-        git fetch --depth=1 origin "${{ inputs.adbc_bigquery_commit }}"
-        git checkout "${{ inputs.adbc_bigquery_commit }}"
+        git fetch --depth=1 origin "$ADBC_BIGQUERY_COMMIT"
+        git checkout "$ADBC_BIGQUERY_COMMIT"
         cd go
+
+        # `actions/setup-go` v7 sets GOTOOLCHAIN=local, so Go no longer downloads
+        # the toolchain go.mod asks for when the installed one is older — it just
+        # refuses. A drift between the pinned commit and `go_version` above is
+        # therefore a hard failure, and `go build`'s own report of it
+        # ("go: go.mod requires go >= X (running go Y; GOTOOLCHAIN=local)") is one
+        # line in the middle of a benchmark log that surfaces only as
+        # "Process completed with exit code 1". Say it up front instead, with both
+        # versions and the file to edit.
+        required_go=$(awk '$1 == "go" { print $2; exit }' go.mod)
+        installed_go=$(go env GOVERSION)
+        installed_go=${installed_go#go}
+        if [ -n "$required_go" ] && awk -v r="$required_go" -v i="$installed_go" 'BEGIN {
+              nr = split(r, R, "."); ni = split(i, I, ".");
+              n = (nr > ni ? nr : ni);
+              for (k = 1; k <= n; k++) {
+                x = (k <= ni ? I[k] + 0 : 0); y = (k <= nr ? R[k] + 0 : 0);
+                if (x < y) exit 0;
+                if (x > y) exit 1;
+              }
+              exit 1 }'; then
+          echo "::error::The pinned ADBC BigQuery driver (${ADBC_BIGQUERY_COMMIT}) needs Go >= ${required_go}, but this action installed ${installed_go}. Raise the go_version default in .github/actions/setup-adbc-bigquery/action.yml to ${required_go} or newer (or pin an older driver commit). This is not a failure of the branch under test."
+          exit 1
+        fi
+
         CGO_ENABLED=1 go build -tags driverlib -buildmode=c-shared \
           -o /tmp/libadbc_driver_bigquery.so ./pkg/
         rm -f /tmp/libadbc_driver_bigquery.h


### PR DESCRIPTION
## Summary

Every benchmark and throughput run for an `adbc[bigquery]` spicepod has failed at
`Install ADBC BigQuery Driver` since 2026-08-03, and the run summary says only
`##[error]Process completed with exit code 1`. The cause is a Go toolchain pin that a
grouped Actions bump quietly invalidated. Nothing about any branch under test is involved.

## Evidence

Window: the 900 most recent failed runs, `2026-08-01T11:36Z → 2026-08-04T11:05Z`.

| Cluster | Runs | Branches |
|---|---:|---:|
| `benchmark e2e tests` → `Run benchmark e2e tests` → `Install ADBC BigQuery Driver` | **7** | 2 |

Failing runs:
[30902740032](https://github.com/spiceai/spiceai/actions/runs/30902740032),
[30902243188](https://github.com/spiceai/spiceai/actions/runs/30902243188),
[30867576660](https://github.com/spiceai/spiceai/actions/runs/30867576660)

`gh run view 30902740032 --log-failed` — the step's last four lines, in full:

```
HEAD is now at fe83ac2 fix(go): process URI before other options to avoid nondeterminism (#143)
go: go.mod requires go >= 1.26.1 (running go 1.24.1; GOTOOLCHAIN=local)
##[error]Process completed with exit code 1.
```

## Mechanism

1. `actions/setup-go` was bumped **6.5.0 → 7.0.0** — a major — for this action in the
   grouped bump #12359 (`7b98c234`, 2026-08-03). That commit's entire diff to this file is
   the pinned SHA.
2. **v7 sets `GOTOOLCHAIN=local`.** `GOTOOLCHAIN` appears nowhere in this repository
   (`grep -rI GOTOOLCHAIN` finds nothing), yet it is in the failing step's env block — it
   comes from the action.
3. The pinned driver commit `fe83ac26` declares `go 1.26.1`
   (`repos/adbc-drivers/bigquery/contents/go/go.mod?ref=fe83ac26…` → `go 1.26.1`), while
   this action pinned `go_version: '1.24.1'`.

Until the bump, that three-minor gap was being papered over by an implicit toolchain
download; `GOTOOLCHAIN=local` turned it into a hard, 100%-reproducible failure. The pins
themselves have not changed since #10535 / #9960.

## The fix

**Raise `go_version` to `1.26.1`** — the version the pinned commit asks for. That keeps the
build hermetic (one declared toolchain, no download), matching every other pin in this
action. Keeping `GOTOOLCHAIN=local` is deliberate: the alternative re-enables a silent fetch
of an undeclared toolchain, which is exactly what kept this drift invisible.

**Assert the two pins agree, with a named cause.** The step now reads the `go` directive out
of the checked-out `go.mod` and compares it to the installed toolchain, so the next drift is
not another anonymous `exit 1`:

```
::error::The pinned ADBC BigQuery driver (fe83ac26…) needs Go >= 1.26.1, but this action
installed 1.24.1. Raise the go_version default in
.github/actions/setup-adbc-bigquery/action.yml to 1.26.1 or newer (or pin an older driver
commit). This is not a failure of the branch under test.
```

**Two smaller corrections in the same step:** the commit input moves from interpolated
`run:` text into `env:` (the finding review accepted on #12185 — read as data, it cannot end
a quote), and the `# v5` comment beside the `setup-go` pin, two majors stale, now reads
`# v7.0.0`.

## What this does **not** weaken

- **No test, query or assertion changes.** This step only builds and installs a driver.
- **Nothing is retried, skipped, or made `continue-on-error`.** A driver that genuinely
  fails to build still fails the job — the change is *which* Go builds it, plus a clearer
  message when the pins disagree.
- **Hermeticity is preserved, not traded away.** `GOTOOLCHAIN=local` stays, so no toolchain
  is fetched at build time; the requirement is satisfied by the declared pin instead.
- **The driver commit pin is untouched**, so the artifact being built is byte-for-byte the
  same source as before.

## Test plan

- [x] Confirmed the pinned commit's requirement directly from the upstream API:
      `go/go.mod` at `fe83ac26…` contains `go 1.26.1`, and the `awk '$1=="go"{print $2;exit}'`
      extraction the step uses returns exactly `1.26.1` from it
- [x] Confirmed `GOTOOLCHAIN` is set nowhere in this repository, so it is `setup-go` v7's
      default — and confirmed #12359's whole diff to this file is the `setup-go` SHA
- [x] Lifted the new assertion **verbatim** out of the `run:` block and ran it against a
      stub `go` and synthetic `go.mod` files. `go.mod`/installed → result:
      `1.26.1`/`1.24.1` → **error** (the live case), `1.26.1`/`1.26.1` → pass (the fix),
      `1.26.1`/`1.27.0` → pass, `1.24.0`/`1.26.1` → pass, `1.26`/`1.26.1` → pass,
      `1.27`/`1.26.1` → error, and a `go.mod` with no `go` directive → pass
- [x] Asserted programmatically that no `${{ }}` expression remains in the step's `run:` text
- [x] `python .github/scripts/check_workflow_yaml.py` — `OK: 105 GitHub Actions definitions are well-formed`
- [ ] `make lint` / `make test` — **not applicable and not run.** The diff is one composite
      action YAML file with no Rust. The real end-to-end check is an `adbc[bigquery]`
      benchmark dispatch, which needs the BigQuery credentials this workflow supplies; a
      maintainer dispatching `testoperator_run_bench.yml` with an `adbc[bigquery]` spicepod
      on this branch confirms it.
