### PR TITLE
fix(ci): report cache health on the build failures it explains (refs #12420)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,8 +81,13 @@ jobs:
       #   make release
 
       - name: Show sccache stats
-        if: env.HAS_TEST_MINIO_SECRET == 'true'
-        run: sccache --show-stats
+        if: always() && (env.HAS_TEST_MINIO_SECRET == 'true')
+        # `always()`: this is the one step that reports cache health, and without it
+        # it is skipped on exactly the failures it would explain (#12420). The `||`
+        # keeps a diagnostic from ever deciding a verdict — when the cache backend is
+        # gone `--show-stats` cannot answer either, and that is itself the finding.
+        run: |
+          sccache --show-stats || echo "::warning::sccache --show-stats failed, so the cache server is not answering either. Read a build failure in this job as a possible cache-backend outage rather than a code failure."
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -131,8 +131,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_MINIO_SECRET_KEY }}
 
       - name: Show sccache stats
-        if: runner.os == 'macOS' && env.SCCACHE_SETUP == 'true' && steps.setup-spiceio.outputs.endpoint != ''
-        run: sccache --show-stats
+        if: always() && (runner.os == 'macOS' && env.SCCACHE_SETUP == 'true' && steps.setup-spiceio.outputs.endpoint != '')
+        # `always()`: this is the one step that reports cache health, and without it
+        # it is skipped on exactly the failures it would explain (#12420). The `||`
+        # keeps a diagnostic from ever deciding a verdict — when the cache backend is
+        # gone `--show-stats` cannot answer either, and that is itself the finding.
+        run: |
+          sccache --show-stats || echo "::warning::sccache --show-stats failed, so the cache server is not answering either. Read a build failure in this job as a possible cache-backend outage rather than a code failure."
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''

--- a/.github/workflows/pr-develop.yml
+++ b/.github/workflows/pr-develop.yml
@@ -93,8 +93,13 @@ jobs:
           BRANCH: spiceai-54
 
       - name: Show sccache stats
-        if: runner.os == 'macOS' && steps.setup-spiceio.outputs.endpoint != ''
-        run: sccache --show-stats
+        if: always() && (runner.os == 'macOS' && steps.setup-spiceio.outputs.endpoint != '')
+        # `always()`: this is the one step that reports cache health, and without it
+        # it is skipped on exactly the failures it would explain (#12420). The `||`
+        # keeps a diagnostic from ever deciding a verdict — when the cache backend is
+        # gone `--show-stats` cannot answer either, and that is itself the finding.
+        run: |
+          sccache --show-stats || echo "::warning::sccache --show-stats failed, so the cache server is not answering either. Read a build failure in this job as a possible cache-backend outage rather than a code failure."
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
@@ -166,8 +171,13 @@ jobs:
         run: cargo build -p testoperator --all-features --locked
 
       - name: Show sccache stats
-        if: runner.os == 'macOS' && steps.setup-spiceio.outputs.endpoint != ''
-        run: sccache --show-stats
+        if: always() && (runner.os == 'macOS' && steps.setup-spiceio.outputs.endpoint != '')
+        # `always()`: this is the one step that reports cache health, and without it
+        # it is skipped on exactly the failures it would explain (#12420). The `||`
+        # keeps a diagnostic from ever deciding a verdict — when the cache backend is
+        # gone `--show-stats` cannot answer either, and that is itself the finding.
+        run: |
+          sccache --show-stats || echo "::warning::sccache --show-stats failed, so the cache server is not answering either. Read a build failure in this job as a possible cache-backend outage rather than a code failure."
 
       - name: Check if Cargo.lock is updated
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -692,8 +692,13 @@ jobs:
           RUST_PROFILE: ${{ env.RUST_PROFILE }}
 
       - name: Show sccache stats
-        if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true' }}
-        run: sccache --show-stats
+        if: ${{ always() && (needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true') }}
+        # `always()`: this is the one step that reports cache health, and without it
+        # it is skipped on exactly the failures it would explain (#12420). The `||`
+        # keeps a diagnostic from ever deciding a verdict — when the cache backend is
+        # gone `--show-stats` cannot answer either, and that is itself the finding.
+        run: |
+          sccache --show-stats || echo "::warning::sccache --show-stats failed, so the cache server is not answering either. Read a build failure in this job as a possible cache-backend outage rather than a code failure."
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''
@@ -803,8 +808,13 @@ jobs:
         run: cargo build -p testoperator --all-features --locked
 
       - name: Show sccache stats
-        if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true' }}
-        run: sccache --show-stats
+        if: ${{ always() && (needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true') }}
+        # `always()`: this is the one step that reports cache health, and without it
+        # it is skipped on exactly the failures it would explain (#12420). The `||`
+        # keeps a diagnostic from ever deciding a verdict — when the cache backend is
+        # gone `--show-stats` cannot answer either, and that is itself the finding.
+        run: |
+          sccache --show-stats || echo "::warning::sccache --show-stats failed, so the cache server is not answering either. Read a build failure in this job as a possible cache-backend outage rather than a code failure."
 
       - name: Check if Cargo.lock is updated
         if: needs.check_changes.outputs.relevant_changes == 'true'
@@ -911,8 +921,13 @@ jobs:
         run: make install-spiced
 
       - name: Show sccache stats
-        if: ${{ needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true' }}
-        run: sccache --show-stats
+        if: ${{ always() && (needs.check_changes.outputs.relevant_changes == 'true' && env.SCCACHE_SETUP == 'true') }}
+        # `always()`: this is the one step that reports cache health, and without it
+        # it is skipped on exactly the failures it would explain (#12420). The `||`
+        # keeps a diagnostic from ever deciding a verdict — when the cache backend is
+        # gone `--show-stats` cannot answer either, and that is itself the finding.
+        run: |
+          sccache --show-stats || echo "::warning::sccache --show-stats failed, so the cache server is not answering either. Read a build failure in this job as a possible cache-backend outage rather than a code failure."
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''

--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -342,8 +342,13 @@ jobs:
             "Remote sign-off ended without posting a verdict — sign off again"
 
       - name: Show sccache stats
-        if: env.SCCACHE_SETUP == 'true'
-        run: sccache --show-stats
+        if: always() && (env.SCCACHE_SETUP == 'true')
+        # `always()`: this is the one step that reports cache health, and without it
+        # it is skipped on exactly the failures it would explain (#12420). The `||`
+        # keeps a diagnostic from ever deciding a verdict — when the cache backend is
+        # gone `--show-stats` cannot answer either, and that is itself the finding.
+        run: |
+          sccache --show-stats || echo "::warning::sccache --show-stats failed, so the cache server is not answering either. Read a build failure in this job as a possible cache-backend outage rather than a code failure."
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''


### PR DESCRIPTION
## Summary

All **eight** `Show sccache stats` steps in this repository are gated on a condition without
`always()`, so each is **skipped whenever its job fails** — that is, on exactly the failures
whose cause it would name.

This makes them run regardless of the job's result. It is the **observability half of #12420
only**: it does not stop an sccache backend outage from failing a build, it stops that
failure from reading as a compile error in the branch under test.

Refs #12420.

## Evidence

`error: Server startup failed: cache storage failed to read` is a live cluster — **10 failed
runs across 10 distinct branches** in the 900 most recent failed runs
(`2026-08-01T11:36Z → 2026-08-04T11:05Z`), on `pr` → `Build and Test` → `Build CLI and run
nextest`, across both `pull_request` and `merge_group`:
[30881366426](https://github.com/spiceai/spiceai/actions/runs/30881366426),
[30854424648](https://github.com/spiceai/spiceai/actions/runs/30854424648),
[30759877882](https://github.com/spiceai/spiceai/actions/runs/30759877882).

The timeline from the sign-off run analysed on #12420
([30791412731](https://github.com/spiceai/spiceai/actions/runs/30791412731)):

```
06:52:11Z → 07:22:08Z   30 minutes of successful compilation — the cache was working
07:41:43Z               first `sccache: error: Server startup failed … Connection refused`,
                        and all 68 remaining units fail in the same second
07:41:44Z               `Show sccache stats` — SKIPPED
```

In four of the nine runs examined there, the count of `sccache: Server startup failed` lines
**equalled** the count of `could not compile` lines (68/68, 35/35, 4/4, 4/4) with zero
`error[E….]` and zero `-->` source pointers. Every "compile failure" was a cache failure —
and the one step that would have said so did not run.

All eight sites, none of which had `always()`:

| Workflow | Job |
|---|---|
| `signoff.yml` | `sign-off` |
| `pr.yml` | `lint-rust`, `build-test`, `build-install-release` |
| `pr-develop.yml` | `check`, `build-and-test` |
| `features.yml` | `build` |
| `codeql-analysis.yml` | `analyze` |

## Why `--show-stats` cannot simply be run as-is

It queries the same server that just died, so it would fail on precisely the runs this
change adds it to. A diagnostic must never decide a verdict, so its failure becomes a
`::warning::` naming the likely cause instead:

```
::warning::sccache --show-stats failed, so the cache server is not answering either. Read a
build failure in this job as a possible cache-backend outage rather than a code failure.
```

## What this does **not** weaken

- **It cannot change any job's result, in either direction.** The step's own exit status is
  now always 0; before this change it could (in principle) have failed a passing job.
- **Every gating condition is otherwise preserved** — a job that never set the cache up
  still does not run the step. Only `always() && (…)` was added around the existing
  expression.
- **No check, test, retry, timeout or assertion is touched**, and no `continue-on-error` is
  introduced.
- **It does not fix #12420.** An sccache backend that dies mid-build still fails the build.
  Preventing that — a wrapper that falls back to uncached compilation, or a supervised
  sidecar — remains open on the issue, and is deliberately not attempted here because it
  cannot be verified without a full Rust build.

## Test plan

- [x] `python .github/scripts/check_workflow_yaml.py` — `OK: 105 GitHub Actions definitions are well-formed`
- [x] `python .github/scripts/test_check_workflow_yaml.py` — 24 tests, `OK`
- [x] Enumerated every `sccache --show-stats` step by parsing all workflows and asserted
      `always()` is present in each of the 8 — no site missed, none added
- [x] Ran the resulting `run:` block against a stub `sccache` **both ways**: healthy
      (`exit 0`) → prints stats, `rc=0`; dead (`exit 2` with `Server startup failed` on
      stderr) → prints the `::warning::`, `rc=0`. The step cannot fail either way.
- [x] The first attempt at this diff used a plain (unquoted) `run:` scalar containing `: `,
      and the repo's own `Workflow YAML Check` rejected it
      (`mapping values are not allowed here at line 700 column 82`) — refactored to a block
      scalar, which is also the surrounding style
- [ ] `make lint` / `make test` — **not applicable and not run.** The diff is five workflow
      YAML files with no Rust.
