### PR TITLE
fix(ci): key the sign-off concurrency group on the commit, not the dispatch input (fixes #12472)

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -75,6 +75,18 @@ on:
         type: boolean
         default: false
 
+# Coarse, pre-resolution guard: it only collapses re-dispatches that used the
+# *same* input form, because `concurrency` is evaluated before any step runs and
+# so cannot see which branch a `pr_number` actually names. That still earns its
+# keep — a `branch=X` re-dispatch after X's tip moved lands here, and the two
+# runs target different commits, so the SHA group below would not pair them.
+#
+# The authoritative guard is the `concurrency` block on `sign-off`, keyed on the
+# commit `resolve` pins. Without it, `-f branch=X` and `-f pr_number=N` for the
+# same branch sat in different groups (`signoff-X` vs `signoff-N`), so neither
+# cancelled the other: two 1-4h runs held two slots of the shared self-hosted
+# pool for one commit and both posted the `signoff` status on it, last write
+# winning regardless of which run was authoritative (#12472).
 concurrency:
   group: signoff-${{ inputs.pr_number || inputs.branch }}
   cancel-in-progress: true
@@ -87,8 +99,157 @@ env:
   CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
+  # Its own job purely so `sign-off` can key `concurrency` on the commit this
+  # resolves to: a job-level `concurrency` group can read `needs`, but a
+  # workflow-level one cannot read a step output, so the canonical key is not
+  # available where the workflow-level group above is declared (#12472).
+  #
+  # GitHub-hosted on purpose. It is two API calls and must not queue behind the
+  # saturated self-hosted pool — every sign-off now waits on it.
+  resolve:
+    name: "Resolve sign-off target"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      # Reading the PR to pin its head commit.
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      checkout_repo: ${{ steps.resolve.outputs.checkout_repo }}
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
+      is_fork: ${{ steps.resolve.outputs.is_fork }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+    steps:
+      - name: Resolve branch/PR input
+        id: resolve
+        env:
+          BRANCH: ${{ inputs.branch }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${BRANCH// }" && -n "${PR_NUMBER// }" ]]; then
+            echo "::error::specify either 'branch' or 'pr_number', not both"
+            exit 1
+          fi
+
+          if [[ -n "${PR_NUMBER// }" ]]; then
+            if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+              echo "::error::pr_number must be a positive integer, got '${PR_NUMBER}'"
+              exit 1
+            fi
+            pr_json=$(gh pr view "$PR_NUMBER" --repo "$BASE_REPO" \
+              --json state,isCrossRepository,headRepositoryOwner,headRepository,headRefName,headRefOid) \
+              || { echo "::error::could not look up PR #${PR_NUMBER} on ${BASE_REPO}"; exit 1; }
+
+            state=$(jq -r '.state' <<<"$pr_json")
+            is_fork=$(jq -r '.isCrossRepository' <<<"$pr_json")
+            head_ref=$(jq -r '.headRefName' <<<"$pr_json")
+            head_sha=$(jq -r '.headRefOid' <<<"$pr_json")
+            owner=$(jq -r '.headRepositoryOwner.login' <<<"$pr_json")
+            name=$(jq -r '.headRepository.name' <<<"$pr_json")
+
+            # Same shape check the branch arm applies below. `jq -r` renders a
+            # missing field as the string "null", which a PR whose head repo has
+            # been deleted really does return — and an unvalidated "null" here
+            # would become both the checkout ref and the concurrency key, so two
+            # such PRs would share a group and cancel each other.
+            if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::PR #${PR_NUMBER} resolved to head commit '${head_sha}', which is not a commit SHA — is its head repository still present?"
+              exit 1
+            fi
+
+            if [[ "$state" != "OPEN" ]]; then
+              echo "::warning::PR #${PR_NUMBER} is ${state}, not OPEN — signing off its last-known head anyway"
+            fi
+
+            checkout_repo="${owner}/${name}"
+            # Pin to the exact commit resolved right now, not the mutable
+            # branch — the PR author (fork owner or collaborator) can push
+            # new commits between this dispatch and when the runner actually
+            # checks it out, and this job runs that code with full secrets.
+            checkout_ref="$head_sha"
+
+            if [[ "$is_fork" == "true" ]]; then
+              echo "::warning::Signing off PR #${PR_NUMBER} from FORK ${checkout_repo}@${head_ref}, pinned to ${head_sha}. This runs fork-authored code (build scripts, tests, Makefiles) on a self-hosted runner with full access to this job's secrets — only dispatch this for a fork PR you've reviewed and trust."
+            fi
+            echo "Signing off PR #${PR_NUMBER}: ${checkout_repo}@${checkout_ref}"
+          elif [[ -n "${BRANCH// }" ]]; then
+            # Mirror scripts/signoff remote: allow feature/foo, reject whitespace,
+            # quotes, $, `, leading dashes, absolute paths, `..`, and any char
+            # outside [A-Za-z0-9._/-] so dispatch/checkout cannot be broken by the name.
+            if [[ "$BRANCH" =~ [[:space:]] || "$BRANCH" == -* || "$BRANCH" == /* || "$BRANCH" == *..* \
+                || "$BRANCH" == *\"* || "$BRANCH" == *\'* || "$BRANCH" == *\$* || "$BRANCH" == *\`* ]]; then
+              echo "::error::invalid branch name: '${BRANCH}'"
+              exit 1
+            fi
+            if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+              echo "::error::invalid branch name: '${BRANCH}'"
+              exit 1
+            fi
+            checkout_repo="$BASE_REPO"
+            checkout_ref="$BRANCH"
+            # The concurrency key needs a commit, and this form only names a
+            # branch, so resolve its tip. `checkout_ref` deliberately stays the
+            # branch name: pinning it here would change what a `branch=`
+            # sign-off attests, which is not this fix's business. A push between
+            # this lookup and the checkout therefore signs a commit the SHA
+            # group did not pair on — that race is why the coarse branch-keyed
+            # workflow-level group above is still worth having.
+            head_sha=$(gh api "repos/${BASE_REPO}/commits/${BRANCH}" --jq '.sha') \
+              || { echo "::error::could not resolve branch '${BRANCH}' on ${BASE_REPO} — is it pushed?"; exit 1; }
+            if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::resolved branch '${BRANCH}' to '${head_sha}', which is not a commit SHA"
+              exit 1
+            fi
+            echo "Signing off branch: ${BRANCH} (${head_sha})"
+          else
+            echo "::error::one of 'branch' or 'pr_number' is required"
+            exit 1
+          fi
+
+          if [[ "$checkout_repo" == "$BASE_REPO" ]]; then
+            is_fork=false
+          else
+            is_fork=true
+          fi
+
+          echo "checkout_repo=${checkout_repo}" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=${checkout_ref}" >> "$GITHUB_OUTPUT"
+          echo "is_fork=${is_fork}" >> "$GITHUB_OUTPUT"
+          # Keys the sign-off job's concurrency group — see its comment.
+          echo "head_sha=${head_sha}" >> "$GITHUB_OUTPUT"
+          echo "Triggered by: ${{ github.actor }}"
+          echo "Targeted pre-lint base: trunk (fixed)"
+
   sign-off:
     name: "Sign off on ${{ inputs.pr_number && format('PR #{0}', inputs.pr_number) || github.event.inputs.branch }}"
+    needs: resolve
+    # The authoritative one-run-per-commit guard. Both dispatch forms reduce to
+    # the same commit here, so a second dispatch for a commit already being
+    # signed off evicts the first instead of duplicating 1-4h of identical work
+    # and racing it for the `signoff` status (#12472). Two open PRs sharing a
+    # head commit collapse into one group too, which is the same desirable
+    # dedupe: the status they would post is for that one commit.
+    #
+    # The evicted run is cancelled mid-flight, which is the case
+    # `scripts/signoff correct-cancelled` covers — it repairs only the
+    # `signoff=failure` a dying run posted and leaves a genuine `success`
+    # alone (#12424, #12428).
+    #
+    # The `||` fallback matters more than it looks. `needs` is a documented
+    # context for a job-level `concurrency` (unlike a workflow-level one, which
+    # is why the group above cannot do this), but if `head_sha` ever arrived
+    # empty the key would collapse to the constant `signoff-commit-` for every
+    # run — and with `cancel-in-progress` that means every dispatch evicting
+    # every other branch's sign-off, a far worse failure than the duplicate runs
+    # this fixes. Falling back to the raw inputs degrades to the old
+    # per-input behaviour instead.
+    concurrency:
+      group: signoff-commit-${{ needs.resolve.outputs.head_sha || format('input-{0}-{1}', inputs.pr_number, inputs.branch) }}
+      cancel-in-progress: true
     runs-on: spiceai-macos
     # The spiceai-macos pool terminates a job at ~360 minutes, and that arrives
     # as `cancelled` with no failed step — the same shape as the
@@ -121,83 +282,6 @@ jobs:
       SIGNOFF_DEBUG: '1'
 
     steps:
-      - name: Resolve branch/PR input
-        id: resolve
-        env:
-          BRANCH: ${{ inputs.branch }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          BASE_REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          if [[ -n "${BRANCH// }" && -n "${PR_NUMBER// }" ]]; then
-            echo "::error::specify either 'branch' or 'pr_number', not both"
-            exit 1
-          fi
-
-          if [[ -n "${PR_NUMBER// }" ]]; then
-            if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-              echo "::error::pr_number must be a positive integer, got '${PR_NUMBER}'"
-              exit 1
-            fi
-            pr_json=$(gh pr view "$PR_NUMBER" --repo "$BASE_REPO" \
-              --json state,isCrossRepository,headRepositoryOwner,headRepository,headRefName,headRefOid) \
-              || { echo "::error::could not look up PR #${PR_NUMBER} on ${BASE_REPO}"; exit 1; }
-
-            state=$(jq -r '.state' <<<"$pr_json")
-            is_fork=$(jq -r '.isCrossRepository' <<<"$pr_json")
-            head_ref=$(jq -r '.headRefName' <<<"$pr_json")
-            head_sha=$(jq -r '.headRefOid' <<<"$pr_json")
-            owner=$(jq -r '.headRepositoryOwner.login' <<<"$pr_json")
-            name=$(jq -r '.headRepository.name' <<<"$pr_json")
-
-            if [[ "$state" != "OPEN" ]]; then
-              echo "::warning::PR #${PR_NUMBER} is ${state}, not OPEN — signing off its last-known head anyway"
-            fi
-
-            checkout_repo="${owner}/${name}"
-            # Pin to the exact commit resolved right now, not the mutable
-            # branch — the PR author (fork owner or collaborator) can push
-            # new commits between this dispatch and when the runner actually
-            # checks it out, and this job runs that code with full secrets.
-            checkout_ref="$head_sha"
-
-            if [[ "$is_fork" == "true" ]]; then
-              echo "::warning::Signing off PR #${PR_NUMBER} from FORK ${checkout_repo}@${head_ref}, pinned to ${head_sha}. This runs fork-authored code (build scripts, tests, Makefiles) on a self-hosted runner with full access to this job's secrets — only dispatch this for a fork PR you've reviewed and trust."
-            fi
-            echo "Signing off PR #${PR_NUMBER}: ${checkout_repo}@${checkout_ref}"
-          elif [[ -n "${BRANCH// }" ]]; then
-            # Mirror scripts/signoff remote: allow feature/foo, reject whitespace,
-            # quotes, $, `, leading dashes, absolute paths, `..`, and any char
-            # outside [A-Za-z0-9._/-] so dispatch/checkout cannot be broken by the name.
-            if [[ "$BRANCH" =~ [[:space:]] || "$BRANCH" == -* || "$BRANCH" == /* || "$BRANCH" == *..* \
-                || "$BRANCH" == *\"* || "$BRANCH" == *\'* || "$BRANCH" == *\$* || "$BRANCH" == *\`* ]]; then
-              echo "::error::invalid branch name: '${BRANCH}'"
-              exit 1
-            fi
-            if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-              echo "::error::invalid branch name: '${BRANCH}'"
-              exit 1
-            fi
-            checkout_repo="$BASE_REPO"
-            checkout_ref="$BRANCH"
-            echo "Signing off branch: ${BRANCH}"
-          else
-            echo "::error::one of 'branch' or 'pr_number' is required"
-            exit 1
-          fi
-
-          if [[ "$checkout_repo" == "$BASE_REPO" ]]; then
-            is_fork=false
-          else
-            is_fork=true
-          fi
-
-          echo "checkout_repo=${checkout_repo}" >> "$GITHUB_OUTPUT"
-          echo "checkout_ref=${checkout_ref}" >> "$GITHUB_OUTPUT"
-          echo "is_fork=${is_fork}" >> "$GITHUB_OUTPUT"
-          echo "Triggered by: ${{ github.actor }}"
-          echo "Targeted pre-lint base: trunk (fixed)"
-
       - name: Check out branch/PR
         # Same-repo case only — never pass a `repository:` override here. Doing
         # so would repoint the local "origin" remote at whatever repo we pass,
@@ -206,10 +290,10 @@ jobs:
         # that other repo instead of this one. The fork case below keeps
         # "origin" pointed at this repo and fetches the fork as a second,
         # separate remote instead.
-        if: steps.resolve.outputs.is_fork != 'true'
+        if: needs.resolve.outputs.is_fork != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ steps.resolve.outputs.checkout_ref }}
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
           # Full history so local merge-base with trunk works when trunk is present.
           # scripts/signoff still falls back to the GitHub compare API if needed.
           fetch-depth: 0
@@ -219,7 +303,7 @@ jobs:
         # step above. The actual PR content is fetched from the fork and
         # checked out over this in the next step; ref is left at whatever
         # triggered this workflow_dispatch since it's immediately replaced.
-        if: steps.resolve.outputs.is_fork == 'true'
+        if: needs.resolve.outputs.is_fork == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -254,10 +338,10 @@ jobs:
           echo "Saved trusted CI helpers from $(git rev-parse --short HEAD) to .trusted-ci/"
 
       - name: Fetch and check out fork head commit
-        if: steps.resolve.outputs.is_fork == 'true'
+        if: needs.resolve.outputs.is_fork == 'true'
         env:
-          FORK_REPO: ${{ steps.resolve.outputs.checkout_repo }}
-          FORK_SHA: ${{ steps.resolve.outputs.checkout_ref }}
+          FORK_REPO: ${{ needs.resolve.outputs.checkout_repo }}
+          FORK_SHA: ${{ needs.resolve.outputs.checkout_ref }}
         run: |
           set -euo pipefail
           echo "Fetching ${FORK_SHA} from fork ${FORK_REPO} ('origin' stays $(git remote get-url origin))…"

--- a/.github/workflows/signoff_resolve_target_test.yml
+++ b/.github/workflows/signoff_resolve_target_test.yml
@@ -57,7 +57,11 @@ jobs:
       - name: Install dependencies
         # The test extracts the step under test from signoff.yml rather than
         # keeping a copy, so it needs a YAML parser.
-        run: pip install pyyaml
+        #
+        # `python -m pip`, not a bare `pip`: it installs into the interpreter
+        # setup-python just put on PATH, rather than whichever `pip` the runner
+        # image happens to resolve first.
+        run: python -m pip install pyyaml
 
       - name: Run tests
         # Invoked through `bash` rather than as `./…` so the job does not depend

--- a/.github/workflows/signoff_resolve_target_test.yml
+++ b/.github/workflows/signoff_resolve_target_test.yml
@@ -1,0 +1,65 @@
+---
+name: Sign-off Resolve Target Tests
+
+# `signoff.yml`'s `resolve` job exists so the `sign-off` job can key its
+# `concurrency` group on the commit being signed off rather than on the raw
+# dispatch input. That key is what stops `-f branch=X` and `-f pr_number=N` for
+# the same branch from occupying two slots of the shared self-hosted pool for
+# 1-4 hours each and then racing to post the `signoff` status on one commit
+# (#12472). Nothing else exercises the step: a change that stops it emitting
+# `head_sha`, or that makes the two input forms disagree, silently restores the
+# duplicate runs — the workflow still passes, it just does the work twice.
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - '.github/workflows/signoff.yml'
+      - 'scripts/test_signoff_resolve_target.sh'
+      - '.github/workflows/signoff_resolve_target_test.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - '.github/workflows/signoff.yml'
+      - 'scripts/test_signoff_resolve_target.sh'
+      - '.github/workflows/signoff_resolve_target_test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-signoff-resolve-target:
+    name: Unit tests for the sign-off target resolution
+    # GitHub-hosted on purpose: this is a sub-second check and must not queue
+    # behind the saturated self-hosted pool this fix exists to stop wasting.
+    runs-on: ubuntu-24.04
+    # A checkout plus a local bash script against a stub `gh` — the job reads
+    # the repository and nothing else, so it needs no write scope.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        # The test extracts the step under test from signoff.yml rather than
+        # keeping a copy, so it needs a YAML parser.
+        run: pip install pyyaml
+
+      - name: Run tests
+        # Invoked through `bash` rather than as `./…` so the job does not depend
+        # on the script's executable bit surviving a checkout on every platform.
+        run: bash scripts/test_signoff_resolve_target.sh

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -254,6 +254,8 @@ corrupts the measurement.
 
 The Actions workflow:
 
+0. Resolves the dispatch input to a commit, in a small GitHub-hosted `resolve`
+   job, so the sign-off job can key its concurrency group on that commit
 1. Checks out your branch (full history) and fetches `trunk`
 2. Target-lints crates touched by the branch vs `trunk` (GitHub compare API as a
    fallback when merge-base isn't available), or skips Rust checks when the
@@ -270,6 +272,15 @@ expired, evicted by a re-dispatch, cancelled — replaces its own `pending` stat
 with a failure; otherwise `scripts/signoff status` and `scripts/signoff mine`
 would keep showing a sign-off in progress for a run that is long gone.
 Re-dispatch against the same HEAD to try again.
+
+Only one sign-off runs per commit. Both dispatch forms — `-f branch=<branch>` and
+`-f pr_number=<N>` — resolve to the same commit before the sign-off job starts,
+and its concurrency group is keyed on that commit, so a second dispatch for a
+commit already being signed off evicts the first rather than duplicating 1-4
+hours of identical work and racing it for the `signoff` status (#12472). Two open
+PRs that happen to share a head commit collapse into one run for the same reason.
+Dispatching after the branch tip has *moved* is a different commit, so it starts
+a fresh run (and the branch-keyed group evicts the run on the stale commit).
 
 Re-dispatching against a HEAD that is *already* signed off leaves that success in
 place: the run skips the in-progress `pending` and only replaces the status once

--- a/scripts/test_signoff_resolve_target.sh
+++ b/scripts/test_signoff_resolve_target.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the `Resolve sign-off target` step of
+# `.github/workflows/signoff.yml` — the step whose `head_sha` output keys the
+# `sign-off` job's concurrency group.
+#
+# That key is the whole point. `concurrency` is evaluated before any step runs,
+# so a workflow-level group can only see the raw dispatch input: `-f branch=X`
+# and `-f pr_number=N` for the same branch produced `signoff-X` and `signoff-N`,
+# two different groups, so neither cancelled the other. Two 1-4h runs then held
+# two slots of the shared self-hosted pool for one commit and both posted the
+# `signoff` status on it, last write winning (#12472). Resolving in its own job
+# lets the group key on the commit instead, which both input forms reduce to —
+# so the load-bearing assertion here is that the two forms agree on `head_sha`
+# for the same branch.
+#
+# The step is inline YAML rather than a function in scripts/signoff, so this
+# extracts the real `run:` block from the workflow and executes it. Extracting
+# (rather than copying it here) is what makes the test bind to the shipping
+# definition: a change to the step that breaks resolution fails this test.
+#
+# No network and no credentials: a stub `gh` on PATH answers the two lookups.
+#
+# Usage: scripts/test_signoff_resolve_target.sh
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+workflow="$repo_root/.github/workflows/signoff.yml"
+
+tests_run=0
+failures=0
+
+fail_test() {
+  failures=$((failures + 1))
+  echo "  FAIL: $1"
+}
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 not found — required to extract the step"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "jq not found — the step under test uses it"; exit 1; }
+
+stub_dir="$(mktemp -d)"
+trap 'rm -rf "$stub_dir"' EXIT
+
+subject="$stub_dir/resolve_step.sh"
+
+# Pull the step's `run:` script out of the workflow by name, and with it the
+# `env:` keys it declares — asserting those are exactly the three this test
+# supplies, so a new input added to the step cannot be silently untested.
+#
+# The script embeds `${{ github.actor }}`, which bash cannot expand, so the two
+# recognised expressions are substituted with fixed values. Any *other* `${{ }}`
+# left in the body is a hard error: it would mean the step grew a template this
+# test does not model, and letting it through would exercise a script that is
+# not the one CI runs.
+python3 - "$workflow" "$subject" <<'PY' || exit 1
+import io, re, sys
+import yaml
+
+workflow_path, out_path = sys.argv[1], sys.argv[2]
+doc = yaml.safe_load(io.open(workflow_path, encoding="utf-8"))
+
+steps = doc["jobs"]["resolve"]["steps"]
+matches = [s for s in steps if s.get("name") == "Resolve branch/PR input"]
+if len(matches) != 1:
+    sys.exit(f"expected exactly 1 'Resolve branch/PR input' step in the resolve job, found {len(matches)}")
+step = matches[0]
+
+declared = sorted(step.get("env", {}))
+expected = ["BASE_REPO", "BRANCH", "PR_NUMBER"]
+if declared != expected:
+    sys.exit(f"step env keys changed: expected {expected}, found {declared} — update this test")
+
+body = step["run"]
+body = body.replace("${{ github.actor }}", "test-actor")
+leftover = re.findall(r"\$\{\{.*?\}\}", body)
+if leftover:
+    sys.exit(f"step body has unmodelled template expressions: {leftover} — update this test")
+
+io.open(out_path, "w", encoding="utf-8", newline="\n").write("#!/usr/bin/env bash\n" + body)
+PY
+chmod +x "$subject"
+
+# A `gh` covering exactly the two calls the step makes:
+#
+#   pr view <N> --repo <repo> --json …   -> STUB_PR_JSON, or exit STUB_PR_RC
+#   api repos/<repo>/commits/<ref> --jq .sha -> STUB_BRANCH_SHA, or exit STUB_API_RC
+#
+# Any other invocation is a hard error: several cases assert the step rejects an
+# input *before* reaching the network, and a stub that quietly served an
+# unexpected call would let a regression pass.
+cat >"$stub_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+  [[ "${STUB_PR_RC:-0}" == "0" ]] || exit "${STUB_PR_RC}"
+  printf '%s' "${STUB_PR_JSON:-}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == repos/*/commits/* ]]; then
+  [[ "${STUB_API_RC:-0}" == "0" ]] || exit "${STUB_API_RC}"
+  printf '%s\n' "${STUB_BRANCH_SHA:-}"
+  exit 0
+fi
+
+echo "stub gh: unexpected invocation: $*" >&2
+exit 99
+STUB
+chmod +x "$stub_dir/gh"
+
+PR_SHA="1111111111111111111111111111111111111111"
+BRANCH_SHA="2222222222222222222222222222222222222222"
+
+# A `gh pr view --json …` payload for the fields the step reads.
+pr_json() {
+  local state="$1" cross="$2" owner="$3" name="$4" ref="$5" oid="$6"
+  jq -nc --arg s "$state" --argjson x "$cross" --arg o "$owner" \
+    --arg n "$name" --arg r "$ref" --arg oid "$oid" \
+    '{state:$s, isCrossRepository:$x, headRepositoryOwner:{login:$o},
+      headRepository:{name:$n}, headRefName:$r, headRefOid:$oid}'
+}
+
+# Run the extracted step with the given dispatch inputs, capturing its exit
+# status, its combined output, and the step outputs it wrote to $GITHUB_OUTPUT.
+# Sets: rc, out, and out_<name> for each resolved output.
+run_step() {
+  local branch="$1" pr_number="$2"
+  local outfile="$stub_dir/github_output"
+  : >"$outfile"
+
+  out=$(
+    PATH="$stub_dir:$PATH" \
+    BRANCH="$branch" \
+    PR_NUMBER="$pr_number" \
+    BASE_REPO="spiceai/spiceai" \
+    GITHUB_OUTPUT="$outfile" \
+    STUB_PR_JSON="${STUB_PR_JSON:-}" \
+    STUB_PR_RC="${STUB_PR_RC:-0}" \
+    STUB_BRANCH_SHA="${STUB_BRANCH_SHA:-}" \
+    STUB_API_RC="${STUB_API_RC:-0}" \
+    bash "$subject" 2>&1
+  )
+  rc=$?
+
+  local key
+  for key in checkout_repo checkout_ref is_fork head_sha; do
+    printf -v "out_$key" '%s' "$(sed -n "s/^${key}=//p" "$outfile" | tail -1)"
+  done
+}
+
+# `printf -v` is a bashism for indirect assignment; keep a portable fallback for
+# shells that reject it so a failure here is loud rather than a silent empty.
+if ! printf -v _probe '%s' ok 2>/dev/null || [[ "${_probe:-}" != "ok" ]]; then
+  echo "this test needs a bash whose printf supports -v"; exit 1
+fi
+
+assert_eq() {
+  local label="$1" want="$2" got="$3"
+  [[ "$got" == "$want" ]] || fail_test "$label: expected '$want', got '$got'"
+}
+
+echo "Testing the sign-off target resolution step"
+echo
+
+# --- the regression test for #12472 -----------------------------------------
+# Both dispatch forms for the same branch must land on one commit, because that
+# commit is the concurrency key. If these two disagree, the two forms sit in
+# different groups again and neither cancels the other.
+tests_run=$((tests_run + 1))
+echo "both dispatch forms resolve the same branch to the same commit"
+STUB_PR_JSON="$(pr_json OPEN false spiceai spiceai fix/my-branch "$BRANCH_SHA")" \
+  STUB_PR_RC=0 STUB_BRANCH_SHA="$BRANCH_SHA" STUB_API_RC=0 \
+  run_step "" "1234"
+via_pr="$out_head_sha"
+[[ $rc -eq 0 ]] || fail_test "pr_number form exited $rc: $out"
+
+STUB_PR_JSON="" STUB_PR_RC=0 STUB_BRANCH_SHA="$BRANCH_SHA" STUB_API_RC=0 \
+  run_step "fix/my-branch" ""
+via_branch="$out_head_sha"
+[[ $rc -eq 0 ]] || fail_test "branch form exited $rc: $out"
+
+assert_eq "head_sha via pr_number" "$BRANCH_SHA" "$via_pr"
+assert_eq "head_sha via branch" "$BRANCH_SHA" "$via_branch"
+assert_eq "the two forms agree" "$via_pr" "$via_branch"
+
+# --- the pr_number form ------------------------------------------------------
+tests_run=$((tests_run + 1))
+echo "a same-repo PR pins checkout_ref to the head commit"
+STUB_PR_JSON="$(pr_json OPEN false spiceai spiceai fix/branch "$PR_SHA")" \
+  run_step "" "99"
+[[ $rc -eq 0 ]] || fail_test "exited $rc: $out"
+assert_eq "checkout_repo" "spiceai/spiceai" "$out_checkout_repo"
+assert_eq "checkout_ref" "$PR_SHA" "$out_checkout_ref"
+assert_eq "is_fork" "false" "$out_is_fork"
+assert_eq "head_sha" "$PR_SHA" "$out_head_sha"
+
+tests_run=$((tests_run + 1))
+echo "a fork PR reports is_fork and still pins the commit"
+STUB_PR_JSON="$(pr_json OPEN true contributor spiceai fix/theirs "$PR_SHA")" \
+  run_step "" "99"
+[[ $rc -eq 0 ]] || fail_test "exited $rc: $out"
+assert_eq "checkout_repo" "contributor/spiceai" "$out_checkout_repo"
+assert_eq "checkout_ref" "$PR_SHA" "$out_checkout_ref"
+assert_eq "is_fork" "true" "$out_is_fork"
+assert_eq "head_sha" "$PR_SHA" "$out_head_sha"
+grep -q "FORK" <<<"$out" || fail_test "expected a fork warning in: $out"
+
+tests_run=$((tests_run + 1))
+echo "a closed PR warns but still resolves"
+STUB_PR_JSON="$(pr_json CLOSED false spiceai spiceai fix/old "$PR_SHA")" \
+  run_step "" "99"
+[[ $rc -eq 0 ]] || fail_test "exited $rc: $out"
+assert_eq "head_sha" "$PR_SHA" "$out_head_sha"
+grep -q "not OPEN" <<<"$out" || fail_test "expected a state warning in: $out"
+
+tests_run=$((tests_run + 1))
+echo "a failed PR lookup fails the step"
+STUB_PR_RC=1 run_step "" "99"
+[[ $rc -ne 0 ]] || fail_test "expected a non-zero exit, got 0: $out"
+grep -q "could not look up PR" <<<"$out" || fail_test "expected a lookup error in: $out"
+
+# `jq -r` renders a missing field as "null", which is what a PR whose head
+# repository has been deleted actually returns. Unvalidated, that string becomes
+# the concurrency key, so every such PR would share one group.
+tests_run=$((tests_run + 1))
+echo "a PR whose head commit does not resolve is rejected, not keyed on 'null'"
+STUB_PR_JSON='{"state":"OPEN","isCrossRepository":true,"headRepositoryOwner":null,"headRepository":null,"headRefName":null,"headRefOid":null}' \
+  run_step "" "99"
+[[ $rc -ne 0 ]] || fail_test "expected a non-zero exit, got 0: $out"
+grep -q "not a commit SHA" <<<"$out" || fail_test "expected a SHA-shape error in: $out"
+
+tests_run=$((tests_run + 1))
+echo "a non-numeric pr_number is rejected before any lookup"
+run_step "" "12; rm -rf /"
+[[ $rc -ne 0 ]] || fail_test "expected a non-zero exit, got 0: $out"
+grep -q "positive integer" <<<"$out" || fail_test "expected a validation error in: $out"
+
+# --- the branch form ---------------------------------------------------------
+tests_run=$((tests_run + 1))
+echo "a branch keeps checkout_ref as the branch name, and resolves head_sha"
+STUB_BRANCH_SHA="$BRANCH_SHA" run_step "feature/foo.bar-1" ""
+[[ $rc -eq 0 ]] || fail_test "exited $rc: $out"
+assert_eq "checkout_repo" "spiceai/spiceai" "$out_checkout_repo"
+assert_eq "checkout_ref" "feature/foo.bar-1" "$out_checkout_ref"
+assert_eq "is_fork" "false" "$out_is_fork"
+assert_eq "head_sha" "$BRANCH_SHA" "$out_head_sha"
+
+tests_run=$((tests_run + 1))
+echo "an unpushed branch fails with a legible error, not a late checkout failure"
+STUB_API_RC=1 run_step "fix/never-pushed" ""
+[[ $rc -ne 0 ]] || fail_test "expected a non-zero exit, got 0: $out"
+grep -q "could not resolve branch" <<<"$out" || fail_test "expected a resolve error in: $out"
+
+tests_run=$((tests_run + 1))
+echo "a lookup that answers with something other than a commit SHA fails"
+STUB_BRANCH_SHA="not-a-sha" run_step "fix/weird" ""
+[[ $rc -ne 0 ]] || fail_test "expected a non-zero exit, got 0: $out"
+grep -q "not a commit SHA" <<<"$out" || fail_test "expected a SHA-shape error in: $out"
+
+# A branch name that would break the dispatch or the checkout must be rejected
+# by the step's own validation, before the stub `gh` is ever reached — the stub
+# hard-errors on an unexpected call, so reaching it shows up as a failure here.
+for bad in "fix/../etc" "fix/\$(id)" 'fix/`id`' "-fix/leading-dash" "/abs/path" "fix/with space" "fix/quote'x" 'fix/dquote"x' "fix/semi;x"; do
+  tests_run=$((tests_run + 1))
+  echo "rejects the branch name '$bad'"
+  run_step "$bad" ""
+  [[ $rc -ne 0 ]] || fail_test "expected a non-zero exit, got 0: $out"
+  grep -q "invalid branch name" <<<"$out" || fail_test "expected a validation error in: $out"
+done
+
+# --- mutually exclusive inputs ----------------------------------------------
+tests_run=$((tests_run + 1))
+echo "both inputs at once is rejected"
+run_step "fix/branch" "99"
+[[ $rc -ne 0 ]] || fail_test "expected a non-zero exit, got 0: $out"
+grep -q "not both" <<<"$out" || fail_test "expected an exclusivity error in: $out"
+
+tests_run=$((tests_run + 1))
+echo "neither input is rejected"
+run_step "" ""
+[[ $rc -ne 0 ]] || fail_test "expected a non-zero exit, got 0: $out"
+grep -q "is required" <<<"$out" || fail_test "expected a missing-input error in: $out"
+
+# Whitespace-only inputs are the same as absent: the step tests "${VAR// }".
+tests_run=$((tests_run + 1))
+echo "whitespace-only inputs count as absent"
+run_step "   " "  "
+[[ $rc -ne 0 ]] || fail_test "expected a non-zero exit, got 0: $out"
+grep -q "is required" <<<"$out" || fail_test "expected a missing-input error in: $out"
+
+echo
+if [[ $failures -eq 0 ]]; then
+  echo "All $tests_run test group(s) passed."
+  exit 0
+fi
+echo "$failures assertion(s) failed across $tests_run test group(s)."
+exit 1

--- a/scripts/test_signoff_resolve_target.sh
+++ b/scripts/test_signoff_resolve_target.sh
@@ -39,6 +39,11 @@ fail_test() {
 
 command -v python3 >/dev/null 2>&1 || { echo "python3 not found — required to extract the step"; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "jq not found — the step under test uses it"; exit 1; }
+# Checked separately from python3 itself: without this the extraction below fails
+# as an ImportError traceback, which reads like a bug in the test rather than a
+# missing dependency.
+python3 -c 'import yaml' 2>/dev/null \
+  || { echo "python3 cannot import yaml — required to extract the step (pip install pyyaml)"; exit 1; }
 
 stub_dir="$(mktemp -d)"
 trap 'rm -rf "$stub_dir"' EXIT


### PR DESCRIPTION
Fixes #12472

## Summary (root cause)

`signoff.yml` accepts either dispatch form for the same target — `-f branch=<branch>` or `-f pr_number=<N>` — and resolves both to one branch in its `Resolve branch/PR input` step. But `concurrency` is evaluated *before* any step runs, so the group keyed on the raw input placed the two forms in **different groups** (`signoff-X` vs `signoff-N`), and `cancel-in-progress` never applied between them.

Two consequences, both observed live on 2026-08-04 (two independent pairs alive simultaneously, each pair targeting the same head commit):

1. Two 1–4 hour runs held two slots of the shared self-hosted macOS pool for the same commit.
2. Both runs posted the `signoff` commit status on that commit, so the later write won regardless of which run was authoritative — the same failure shape as #12428 arriving from a different direction.

## Changes

A workflow-level `concurrency` group cannot read a step output, so the canonical key is not available where it is declared. Resolution therefore moves into its own job:

- **New `resolve` job** (`ubuntu-24.04`) holding the existing resolve step verbatim plus a new `head_sha` output. GitHub-hosted on purpose: two API calls that must not queue behind the saturated self-hosted pool.
- **`sign-off` gains `needs: resolve` and a job-level `concurrency`** keyed on `needs.resolve.outputs.head_sha` — the commit both input forms reduce to. Two open PRs sharing a head commit collapse into one run too, which is the same desirable dedupe.
- **The workflow-level group stays.** It is cheaper for a same-form re-dispatch, and it covers the one case the SHA group cannot pair: a `branch=` re-dispatch *after* the branch tip moved is a different commit, so only the branch-keyed group evicts the run on the stale commit.
- **`branch=` now resolves its tip** via `gh api repos/<repo>/commits/<branch>`, which also turns an unpushed branch into a legible error instead of a late checkout failure. `checkout_ref` deliberately stays the branch name — pinning it would change what a `branch=` sign-off attests, which is out of scope here.
- **Both arms now validate the resolved SHA's shape.** `jq -r` renders a missing field as the string `"null"`, which a PR whose head repository has been deleted really returns; unvalidated, that would become both the checkout ref and the concurrency key, so two such PRs would share a group and cancel each other.

Two deliberate safety properties worth calling out for review:

- The group carries a `|| format('input-{0}-{1}', …)` fallback. `needs` is a documented context for a job-level `concurrency`, but if `head_sha` ever arrived empty the key would collapse to the constant `signoff-commit-` for *every* run — with `cancel-in-progress`, every dispatch evicting every other branch's sign-off, far worse than the duplicate runs this fixes. The fallback degrades to the old per-input behaviour instead.
- Resolution no longer runs in a job holding `statuses: write`, `actions: write` and the pool's secrets; the `resolve` job checks out nothing and needs only `contents: read` + `pull-requests: read`. The `.trusted-ci/` fork trust boundary in `sign-off` is untouched (step order preserved; only the `steps.resolve.*` → `needs.resolve.*` references changed).

## Test plan

- New `scripts/test_signoff_resolve_target.sh` (22 groups) + `.github/workflows/signoff_resolve_target_test.yml` to run it. The test **extracts the real `run:` block from `signoff.yml`** rather than keeping a copy, so it binds to the shipping definition; it asserts the step's `env:` keys are exactly the three it models and hard-errors on any unmodelled `${{ }}`, so a step that grows an input cannot be silently untested.
- The load-bearing regression assertion: **both dispatch forms resolve the same branch to the same `head_sha`.** Against the pre-fix step body this fails with `expected '2222…', got ''` (no `head_sha` output at all) — verified locally before applying the fix.
- Also covered: same-repo and fork PR pinning, closed-PR warning, failed PR lookup, non-numeric `pr_number`, unpushed branch, non-SHA lookup result, deleted head repo (`null`), the nine rejected branch-name shapes, both-inputs, neither-input, whitespace-only inputs.
- `python .github/scripts/check_workflow_yaml.py` — OK, 106 definitions well-formed.
- The three existing sign-off suites still pass unchanged: `test_signoff_status.sh` (27), `test_signoff_attestation_refresh.sh` (15), `test_signoff_disk_guard.sh` (31).
- `make lint` and `make test` via `make signoff` on this branch.

## Notes for reviewers

- **No overlap with the other open sign-off PRs.** #12471, #12461, #12432 and #12425 all touch `signoff.yml` only at lines 281–400 (the status-posting / disk-guard region); this touches 78–260 (the concurrency declaration and the resolve/checkout region). #12392 changes only `scripts/signoff`, which this does not touch.
- **This narrows one justification in #12432**, which documents the two-input group split as known-and-handled and relies on it for its "another run signed the same commit off" case. That case stays reachable after this lands (two PRs sharing a head commit; the branch-tip-moved race), so the guard there is still correct — but whichever of the two merges second should update that comment to stop citing the group split as the primary example. Flagging rather than editing, since the two PRs branch independently off trunk.
- `scripts/signoff`'s `cmd_mine` matches in-flight runs on `displayTitle`, which `run-name:` still populates from the inputs — unaffected by the job split.

## Checklist

- [x] Root cause identified and fixed at the right layer
- [x] Regression test that fails on the old code and passes on the new
- [x] Existing sign-off test suites still pass
- [x] Workflow definitions validate
- [x] No unrelated changes