### PR TITLE
fix(models): reject a pinned Model2Vec revision instead of 401ing on it (fixes #12445)

### DIFF
--- a/crates/llms/src/embeddings/mod.rs
+++ b/crates/llms/src/embeddings/mod.rs
@@ -115,6 +115,15 @@ pub enum Error {
     ))]
     ModelNotProvided { model_source: String },
 
+    #[snafu(display(
+        "The model '{model_id}' pins revision '{revision}', but source '{model_source}' cannot load a pinned revision. Remove ':{revision}' to load the repository's default revision, and try again."
+    ))]
+    RevisionPinningUnsupported {
+        model_source: String,
+        model_id: String,
+        revision: String,
+    },
+
     #[snafu(display("Embedding rate limit exceeded. Retry after a short delay: {source}"))]
     FailedToAcquireRateControllerPermit { source: runtime_rate_control::Error },
 

--- a/crates/runtime/src/model/embed.rs
+++ b/crates/runtime/src/model/embed.rs
@@ -45,6 +45,8 @@ use llms::openai::DEFAULT_EMBEDDING_MODEL;
 use llms::openai::embed::OpenaiEmbed;
 use secrecy::{ExposeSecret, SecretString};
 use snafu::ResultExt;
+#[cfg(feature = "models")]
+use spicepod::component::embeddings::pinned_revision;
 use spicepod::component::{embeddings::EmbeddingPrefix, model::ModelFileType};
 #[cfg(feature = "models")]
 use std::path::Path;
@@ -236,6 +238,33 @@ fn model2vec(
             model_source: "model2vec".to_string(),
         });
     };
+
+    // `model2vec:` has no revision plumbing: `EmbeddingPrefix::Model2Vec` is a bare
+    // `strip_prefix`, so a trailing `:rev` stays glued to the model id, and
+    // `StaticModel::from_pretrained` takes no revision argument to hand it to. The id
+    // therefore reaches the Hub as part of the *repository name*, which 401s — a bare
+    // auth error for what is really an unsupported-configuration mistake (#12445).
+    //
+    // Say so instead. `pinned_revision` defers to the same regex the `huggingface:`
+    // arm uses rather than splitting on the last ':', so the two agree about what a
+    // revision is: only an `org/model:rev` shape has one, and a local path — the other
+    // thing `from_pretrained` accepts, including a Windows `C:/…` — passes through.
+    //
+    // The `exists()` guard mirrors `from_pretrained`'s own precedence, which tries the
+    // id as a local path before treating it as a repo name. Without it, a directory
+    // that happened to match the `org/model:rev` shape would be rejected here even
+    // though the loader would have opened it — so this only ever rejects ids that
+    // really would have gone to the Hub and 401'd.
+    if let Some(revision) = pinned_revision(&model_id)
+        .filter(|_| !Path::new(&model_id).exists())
+        .map(ToString::to_string)
+    {
+        return Err(EmbedError::RevisionPinningUnsupported {
+            model_source: "model2vec".to_string(),
+            model_id,
+            revision,
+        });
+    }
 
     Model2Vec::from_params(
         &model_id,

--- a/crates/spicepod/src/component/embeddings.rs
+++ b/crates/spicepod/src/component/embeddings.rs
@@ -389,7 +389,7 @@ mod tests {
             "./relative/path/to/model",
             "C:/models/potion-base-8M",
             "C:/models",
-            "C:\models\potion-base-8M",
+            r"C:\models\potion-base-8M",
             "",
         ] {
             assert_eq!(pinned_revision(id), None, "{id} pins nothing");

--- a/crates/spicepod/src/component/embeddings.rs
+++ b/crates/spicepod/src/component/embeddings.rs
@@ -171,6 +171,25 @@ impl Embeddings {
     }
 }
 
+/// The revision a model id returned by [`Embeddings::get_model_id`] pins, if any.
+///
+/// Only an `org/model:rev` shape pins one — this defers to
+/// [`HUGGINGFACE_PATH_REGEX`], the same definition the `huggingface:` arm of
+/// `get_model_id` uses, so the two cannot disagree about what a revision is.
+/// Anything the regex does not match has none, which is what keeps a local
+/// filesystem path (including a Windows `C:/models/…`, whose colon is not a
+/// revision separator) out of this.
+///
+/// Callers whose loader cannot pass a revision downstream use this to reject the
+/// configuration with that as the stated reason, rather than sending the whole
+/// `org/model:rev` string to the Hub as a repository name and surfacing the 401
+/// that comes back (#12445).
+#[must_use]
+pub fn pinned_revision(model_id: &str) -> Option<&str> {
+    let caps = HUGGINGFACE_PATH_REGEX.captures(model_id)?;
+    caps.name("revision").map(|m| m.as_str())
+}
+
 pub enum EmbeddingPrefix {
     OpenAi,
     Azure,
@@ -327,4 +346,86 @@ pub struct ColumnEmbeddingConfig {
     /// are dropped with a warning log.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_elements_per_row: Option<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Embeddings, pinned_revision};
+
+    fn embedding(from: &str) -> Embeddings {
+        Embeddings::new(from, "test")
+    }
+
+    #[test]
+    fn pinned_revision_reads_the_revision_off_a_hub_id() {
+        for (id, want) in [
+            ("organization/model-name:v1", "v1"),
+            ("organization/model-name:latest", "latest"),
+            ("organization/model-name:my-branch", "my-branch"),
+            ("organization/model-name:v1.2-beta.3", "v1.2-beta.3"),
+            ("organization/my-model.v2:v1", "v1"),
+            // A commit SHA is just another revision as far as the id is concerned.
+            ("minishlab/potion-base-8M:9f1a2b3c4d5e", "9f1a2b3c4d5e"),
+        ] {
+            assert_eq!(
+                pinned_revision(id),
+                Some(want),
+                "expected {id} to pin revision {want}"
+            );
+        }
+    }
+
+    #[test]
+    fn pinned_revision_is_none_when_nothing_is_pinned() {
+        for id in [
+            "minishlab/potion-base-8M",
+            "organization/my-model.v2",
+            // Not a hub id at all: a bare name, and the local filesystem paths
+            // `StaticModel::from_pretrained` also accepts. The colon in a Windows
+            // path is a drive separator, not a revision separator — reading it as
+            // one would reject a working local model.
+            "potion-base-8M",
+            "/absolute/path/to/model",
+            "./relative/path/to/model",
+            "C:/models/potion-base-8M",
+            "C:/models",
+            "C:\models\potion-base-8M",
+            "",
+        ] {
+            assert_eq!(pinned_revision(id), None, "{id} pins nothing");
+        }
+    }
+
+    /// The shape of #12445: `get_model_id` hands the loader an id with the
+    /// revision still glued on, because the `model2vec:` arm is a bare
+    /// `strip_prefix`. The loader has no revision parameter to pass it to, so it
+    /// has to detect this and say so rather than send the whole string to the Hub
+    /// as a repository name and surface the 401 that comes back.
+    #[test]
+    fn a_pinned_model2vec_id_keeps_its_revision_through_get_model_id() {
+        let id = embedding("model2vec:minishlab/potion-base-8M:v1").get_model_id();
+        assert_eq!(id.as_deref(), Some("minishlab/potion-base-8M:v1"));
+        assert_eq!(id.as_deref().and_then(pinned_revision), Some("v1"));
+    }
+
+    #[test]
+    fn an_unpinned_model2vec_id_pins_nothing() {
+        let id = embedding("model2vec:minishlab/potion-base-8M").get_model_id();
+        assert_eq!(id.as_deref(), Some("minishlab/potion-base-8M"));
+        assert_eq!(id.as_deref().and_then(pinned_revision), None);
+    }
+
+    /// The `huggingface:` arm splits and rejoins the id, so a revision survives
+    /// there too — it just has somewhere to go downstream (#12430). Asserted here
+    /// so both arms are visibly held to one notion of a revision.
+    #[test]
+    fn the_huggingface_arm_agrees_about_what_a_revision_is() {
+        let from = "huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2:v1";
+        let id = embedding(from).get_model_id();
+        assert_eq!(
+            id.as_deref(),
+            Some("sentence-transformers/all-MiniLM-L6-v2:v1")
+        );
+        assert_eq!(id.as_deref().and_then(pinned_revision), Some("v1"));
+    }
 }


### PR DESCRIPTION
Fixes #12445

## Summary (root cause)

`model2vec:org/model:rev` cannot load the pinned revision, and reported that only as a bare `401`. Two gaps stack up:

1. **The prefix arm never splits a revision.** `EmbeddingPrefix::Model2Vec` in `crates/spicepod/src/component/embeddings.rs` is a plain `strip_prefix("model2vec:")`, so unlike the `huggingface:` arm it never applies `HUGGINGFACE_PATH_REGEX` — the trailing `:rev` stays glued to the model id.
2. **The loader has nowhere to put one.** `Model2Vec::from_params` calls `StaticModel::from_pretrained(&name, hf_token, normalize, subfolder)`, which has no revision parameter at all.

So the whole `org/model:rev` string reaches the Hub as a **repository name**. That repo does not exist, and the auth error that comes back reads as a credentials problem rather than as an unsupported configuration — the worst of the three outcomes the issue lists.

## Changes

The issue's stated acceptable outcome is either honouring the revision *or* rejecting it at load with a clear reason. This does the latter, because honouring it requires a revision parameter threaded through `StaticModel::from_pretrained` in `spiceai/model2vec-rs` (confirmed absent at the pinned rev `f1190f1f`) — a change in that repo plus a rev bump, which does not belong in this PR. See the note below.

- **`spicepod::component::embeddings::pinned_revision`** — a small pure function returning the revision an id pins. It defers to `HUGGINGFACE_PATH_REGEX`, the *same* definition the `huggingface:` arm of `get_model_id` uses, so the two cannot disagree about what a revision is. Placed in `spicepod` rather than beside the loader deliberately: `runtime`'s `models` feature is off by default, so a test next to the loader would never run under `cargo nextest run --all --lib`.
- **`model2vec()` in `crates/runtime/src/model/embed.rs`** rejects a pinned id with a new `EmbedError::RevisionPinningUnsupported` naming the model, the revision, and the remedy.

Two deliberate narrowings, both so this can only ever reject ids that really would have 401'd:

- Detection is regex-based, **not** "split on the last `:`". Only an `org/model:rev` shape pins a revision, so the local filesystem paths `from_pretrained` also accepts pass through — including a Windows `C:/models/x`, whose colon is a drive separator.
- An `exists()` guard mirrors `from_pretrained`'s own precedence, which tries the id as a local path *before* treating it as a repo name. Without it, a directory that happened to match the `org/model:rev` shape would be rejected here even though the loader would have opened it.

The error carries the model id and revision only — never `hf_token`.

## Test plan

- `make lint` and `make test` via `make signoff` on this branch.
- New tests in `crates/spicepod/src/component/embeddings.rs` (always compiled, so they run in the default `--lib` gate):
  - `pinned_revision` reads the revision off tags, branches, dotted/hyphenated versions, and commit-SHA-shaped revisions.
  - `pinned_revision` is `None` for a bare `org/model`, a dotted model name with no revision, a bare name, absolute and relative POSIX paths, `C:/models/x`, `C:/models`, a backslash Windows path, and the empty string — the pass-through cases a false positive would break.
  - **The regression test for this issue:** `a_pinned_model2vec_id_keeps_its_revision_through_get_model_id` asserts `model2vec:minishlab/potion-base-8M:v1` still yields the id `minishlab/potion-base-8M:v1` *and* that `pinned_revision` finds `v1` on it — i.e. the loader really is handed a revision it cannot use, which is the condition the new error keys on.
  - `an_unpinned_model2vec_id_pins_nothing` guards the common case against regression.
  - `the_huggingface_arm_agrees_about_what_a_revision_is` pins the invariant that both arms share one notion of a revision, so a future change to either is caught.

## Notes for reviewers

- **Scope, and why not the full fix.** Real revision support is a cross-repo change (`spiceai/model2vec-rs` gains a revision parameter → rev bump + `Cargo.lock` → wire through `from_params` and the prefix arm). I have kept that separate rather than opening a PR that has to wait on another repo. If you would rather have the capability than the clear error, say so and I will close this in favour of the fork PR.
- **Rejecting cannot break a working config.** Any `model2vec:` id this now rejects previously 401'd, so there is no configuration that worked before and stops working — it only replaces an opaque auth error with an actionable one.
- **Out of scope, per the issue:** `crates/runtime/src/model/rerank.rs` consumes the same `get_model_id()`, but its providers (Cohere, Voyage, Jina) are hosted APIs with no revision concept, so a `:rev` there is a malformed model name rather than a lost revision. The other embedding prefixes (`openai:`, `azure:`, `google:`, `databricks:`, `bedrock:`) are hosted APIs for the same reason.

## Checklist

- [x] Root cause identified; fix placed where it is testable in the default gate
- [x] Regression test that captures the reported condition
- [x] Pass-through cases (local paths, unpinned ids) covered against false positives
- [x] No credential material in the new error
- [x] No unrelated changes