### PR TITLE
fix(cli): stop the SQL REPL asking a runtime its queries never went to (fixes #12493)

### DIFF
--- a/bin/spice/src/commands/sql.rs
+++ b/bin/spice/src/commands/sql.rs
@@ -16,12 +16,11 @@ limitations under the License.
 
 //! SQL command implementation - starts an interactive SQL REPL or runs one query.
 
-use crate::context::{DEFAULT_HTTP_ENDPOINT, RuntimeContext};
+use crate::context::RuntimeContext;
 use crate::error::Result;
 use crate::output::OutputFormat;
 use clap::Args;
 use spice_cloud_client::endpoints::flight_endpoint as spice_cloud_flight_endpoint;
-use std::net::IpAddr;
 
 /// Arguments for the sql command.
 #[derive(Args, Debug)]
@@ -163,7 +162,8 @@ fn build_repl_config(ctx: &RuntimeContext, args: &SqlArgs) -> repl::ReplConfig {
         _ => repl::cache_control::CacheControl::Cache,
     };
 
-    let another_runtime = may_be_another_runtime(&http_endpoint, &flight_endpoint);
+    let flight_chosen = flight_endpoint_chosen(args);
+    let another_runtime = repl::http_endpoint_unpaired(flight_chosen, ctx.http_endpoint_chosen());
 
     repl::ReplConfig {
         repl_flight_endpoint: flight_endpoint,
@@ -180,113 +180,54 @@ fn build_repl_config(ctx: &RuntimeContext, args: &SqlArgs) -> repl::ReplConfig {
     }
 }
 
-/// Whether the REPL's HTTP endpoint addresses a different runtime than its SQL queries do.
+/// Whether this session's Flight endpoint was chosen on the command line.
 ///
-/// `--endpoint` moves only the Flight endpoint; the HTTP endpoint comes from the global
-/// `--http-endpoint`, whose default is this machine. Point the REPL at a remote runtime and the
-/// two disagree — SQL goes to the remote, `nql` to whatever is listening locally.
-///
-/// A non-default HTTP endpoint is taken at its word: the user set it, and cloud mode derives it
-/// from the region alongside the Flight endpoint (so `data.` vs `flight.` hosts are not a
-/// mismatch). Only the untouched local default paired with a non-loopback Flight target is one.
-fn may_be_another_runtime(http_endpoint: &str, flight_endpoint: &str) -> bool {
-    if http_endpoint != DEFAULT_HTTP_ENDPOINT {
-        return false;
-    }
-
-    !is_loopback_endpoint(flight_endpoint)
-}
-
-/// Whether `endpoint`'s host is this machine, for endpoints in `scheme://host:port/…` form.
-fn is_loopback_endpoint(endpoint: &str) -> bool {
-    let mut authority = endpoint;
-    if let Some((_scheme, rest)) = authority.split_once("://") {
-        authority = rest;
-    }
-    if let Some(path_start) = authority.find(['/', '?', '#']) {
-        authority = &authority[..path_start];
-    }
-    if let Some((_userinfo, host)) = authority.rsplit_once('@') {
-        authority = host;
-    }
-
-    // An IPv6 literal is bracketed, so its own colons are not port separators.
-    let host = if let Some(rest) = authority.strip_prefix('[') {
-        rest.split_once(']').map_or(rest, |(host, _rest)| host)
-    } else {
-        let split = authority.split_once(':');
-        split.map_or(authority, |(host, _port)| host)
-    };
-
-    if host.eq_ignore_ascii_case("localhost") {
-        return true;
-    }
-
-    host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+/// `--flight-endpoint` is the deprecated spelling of `--endpoint`; either one moves the SQL
+/// target away from the default.
+fn flight_endpoint_chosen(args: &SqlArgs) -> bool {
+    args.endpoint.is_some() || args.flight_endpoint.is_some()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        sql: SqlArgs,
+    }
+
+    fn sql_args(argv: &[&str]) -> SqlArgs {
+        TestCli::parse_from(argv.iter().copied()).sql
+    }
 
     /// #11005: `spice sql --endpoint <remote>` moves only the Flight endpoint, so the REPL's
-    /// HTTP-backed `nql` kept asking the local runtime — silently answering from a different
-    /// instance than the one every SQL query in the same session went to.
+    /// HTTP-backed `nql` kept asking the local runtime - silently answering from a different
+    /// instance than the one every SQL query in the same session went to. Reporting that starts
+    /// with knowing the SQL target was moved.
     #[test]
-    fn a_remote_flight_endpoint_with_the_default_http_endpoint_is_another_runtime() {
-        assert!(may_be_another_runtime(
-            DEFAULT_HTTP_ENDPOINT,
-            "http://spice-test.127.0.0.1.nip.io:50051"
-        ));
-        assert!(may_be_another_runtime(
-            DEFAULT_HTTP_ENDPOINT,
-            "https://spiced.internal:50051"
-        ));
+    fn the_endpoint_flag_counts_as_a_chosen_flight_endpoint() {
+        let args = sql_args(&["sql", "--endpoint", "grpc://spiced.internal:50051"]);
+
+        assert!(flight_endpoint_chosen(&args));
     }
 
-    /// The default local session, and an explicitly named local Flight endpoint, both reach the
-    /// same runtime the default HTTP endpoint does — `nql` must keep working untouched.
+    /// The deprecated spelling moves the SQL target just as far.
     #[test]
-    fn a_loopback_flight_endpoint_is_the_same_runtime() {
-        for flight_endpoint in [
-            "http://localhost:50051",
-            "http://LOCALHOST:50051",
-            "http://127.0.0.1:50051",
-            "http://127.7.7.7:50051",
-            "https://[::1]:50051",
-        ] {
-            assert!(
-                !may_be_another_runtime(DEFAULT_HTTP_ENDPOINT, flight_endpoint),
-                "{flight_endpoint} is this machine"
-            );
-        }
+    fn the_deprecated_flight_endpoint_flag_counts_as_chosen() {
+        let args = sql_args(&["sql", "--flight-endpoint", "grpc://spiced.internal:50051"]);
+
+        assert!(flight_endpoint_chosen(&args));
     }
 
-    /// An HTTP endpoint the user (or cloud mode) chose is taken at its word, even when its host
-    /// differs from the Flight host — Cloud serves the two APIs from `data.` and `flight.`.
+    /// A local session chose neither endpoint, and cloud mode derives both from the region, so
+    /// `nql` keeps working untouched in each.
     #[test]
-    fn a_chosen_http_endpoint_is_never_reported_as_another_runtime() {
-        assert!(!may_be_another_runtime(
-            "http://spiced.internal:8090",
-            "http://spiced.internal:50051"
-        ));
-        assert!(!may_be_another_runtime(
-            "https://us-east-1.data.spiceai.io",
-            "https://us-east-1.flight.spiceai.io"
-        ));
-        // Same host as the default but a different port: still chosen, still trusted.
-        assert!(!may_be_another_runtime(
-            "http://127.0.0.1:9090",
-            "http://spiced.internal:50051"
-        ));
-    }
+    fn endpoints_nobody_moved_are_the_same_runtime() {
+        let args = sql_args(&["sql"]);
 
-    #[test]
-    fn a_host_without_a_port_or_scheme_is_still_classified() {
-        assert!(is_loopback_endpoint("http://localhost"));
-        assert!(is_loopback_endpoint("localhost:50051"));
-        assert!(is_loopback_endpoint("http://user@127.0.0.1:50051/path"));
-        assert!(!is_loopback_endpoint("spice-test.127.0.0.1.nip.io"));
-        assert!(!is_loopback_endpoint("http://192.168.1.10:50051"));
+        assert!(!flight_endpoint_chosen(&args));
     }
 }

--- a/bin/spice/src/commands/sql.rs
+++ b/bin/spice/src/commands/sql.rs
@@ -16,11 +16,12 @@ limitations under the License.
 
 //! SQL command implementation - starts an interactive SQL REPL or runs one query.
 
-use crate::context::RuntimeContext;
+use crate::context::{DEFAULT_HTTP_ENDPOINT, RuntimeContext};
 use crate::error::Result;
 use crate::output::OutputFormat;
 use clap::Args;
 use spice_cloud_client::endpoints::flight_endpoint as spice_cloud_flight_endpoint;
+use std::net::IpAddr;
 
 /// Arguments for the sql command.
 #[derive(Args, Debug)]
@@ -53,9 +54,12 @@ pub struct SqlArgs {
     #[arg(long, value_name = "SQL")]
     pub query: Option<String>,
 
-    /// Specifies the remote Spice instance endpoint.
-    /// Supports http://, https://, grpc://, or grpc+tls:// schemes.
+    /// Specifies the remote Spice instance's Arrow Flight (gRPC) endpoint — the runtime's
+    /// flight port, 50051 by default, not its HTTP API.
+    /// Supports http://, https://, grpc://, or grpc+tls:// schemes (http:// being plaintext
+    /// gRPC); behind a proxy or ingress it needs a gRPC-capable route.
     /// If not provided, uses local spiced runtime.
+    /// `nql` additionally needs --http-endpoint pointed at the same runtime.
     #[arg(long)]
     endpoint: Option<String>,
 
@@ -159,9 +163,12 @@ fn build_repl_config(ctx: &RuntimeContext, args: &SqlArgs) -> repl::ReplConfig {
         _ => repl::cache_control::CacheControl::Cache,
     };
 
+    let another_runtime = may_be_another_runtime(&http_endpoint, &flight_endpoint);
+
     repl::ReplConfig {
         repl_flight_endpoint: flight_endpoint,
         http_endpoint,
+        http_endpoint_may_be_another_runtime: another_runtime,
         tls_root_certificate_file: args.tls_root_certificate_file.clone(),
         client_tls_certificate_file: args.client_tls_certificate_file.clone(),
         client_tls_key_file: args.client_tls_key_file.clone(),
@@ -170,5 +177,116 @@ fn build_repl_config(ctx: &RuntimeContext, args: &SqlArgs) -> repl::ReplConfig {
         cache_control,
         custom_headers: args.custom_headers.clone(),
         expanded: args.expanded,
+    }
+}
+
+/// Whether the REPL's HTTP endpoint addresses a different runtime than its SQL queries do.
+///
+/// `--endpoint` moves only the Flight endpoint; the HTTP endpoint comes from the global
+/// `--http-endpoint`, whose default is this machine. Point the REPL at a remote runtime and the
+/// two disagree — SQL goes to the remote, `nql` to whatever is listening locally.
+///
+/// A non-default HTTP endpoint is taken at its word: the user set it, and cloud mode derives it
+/// from the region alongside the Flight endpoint (so `data.` vs `flight.` hosts are not a
+/// mismatch). Only the untouched local default paired with a non-loopback Flight target is one.
+fn may_be_another_runtime(http_endpoint: &str, flight_endpoint: &str) -> bool {
+    if http_endpoint != DEFAULT_HTTP_ENDPOINT {
+        return false;
+    }
+
+    !is_loopback_endpoint(flight_endpoint)
+}
+
+/// Whether `endpoint`'s host is this machine, for endpoints in `scheme://host:port/…` form.
+fn is_loopback_endpoint(endpoint: &str) -> bool {
+    let mut authority = endpoint;
+    if let Some((_scheme, rest)) = authority.split_once("://") {
+        authority = rest;
+    }
+    if let Some(path_start) = authority.find(['/', '?', '#']) {
+        authority = &authority[..path_start];
+    }
+    if let Some((_userinfo, host)) = authority.rsplit_once('@') {
+        authority = host;
+    }
+
+    // An IPv6 literal is bracketed, so its own colons are not port separators.
+    let host = if let Some(rest) = authority.strip_prefix('[') {
+        rest.split_once(']').map_or(rest, |(host, _rest)| host)
+    } else {
+        let split = authority.split_once(':');
+        split.map_or(authority, |(host, _port)| host)
+    };
+
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #11005: `spice sql --endpoint <remote>` moves only the Flight endpoint, so the REPL's
+    /// HTTP-backed `nql` kept asking the local runtime — silently answering from a different
+    /// instance than the one every SQL query in the same session went to.
+    #[test]
+    fn a_remote_flight_endpoint_with_the_default_http_endpoint_is_another_runtime() {
+        assert!(may_be_another_runtime(
+            DEFAULT_HTTP_ENDPOINT,
+            "http://spice-test.127.0.0.1.nip.io:50051"
+        ));
+        assert!(may_be_another_runtime(
+            DEFAULT_HTTP_ENDPOINT,
+            "https://spiced.internal:50051"
+        ));
+    }
+
+    /// The default local session, and an explicitly named local Flight endpoint, both reach the
+    /// same runtime the default HTTP endpoint does — `nql` must keep working untouched.
+    #[test]
+    fn a_loopback_flight_endpoint_is_the_same_runtime() {
+        for flight_endpoint in [
+            "http://localhost:50051",
+            "http://LOCALHOST:50051",
+            "http://127.0.0.1:50051",
+            "http://127.7.7.7:50051",
+            "https://[::1]:50051",
+        ] {
+            assert!(
+                !may_be_another_runtime(DEFAULT_HTTP_ENDPOINT, flight_endpoint),
+                "{flight_endpoint} is this machine"
+            );
+        }
+    }
+
+    /// An HTTP endpoint the user (or cloud mode) chose is taken at its word, even when its host
+    /// differs from the Flight host — Cloud serves the two APIs from `data.` and `flight.`.
+    #[test]
+    fn a_chosen_http_endpoint_is_never_reported_as_another_runtime() {
+        assert!(!may_be_another_runtime(
+            "http://spiced.internal:8090",
+            "http://spiced.internal:50051"
+        ));
+        assert!(!may_be_another_runtime(
+            "https://us-east-1.data.spiceai.io",
+            "https://us-east-1.flight.spiceai.io"
+        ));
+        // Same host as the default but a different port: still chosen, still trusted.
+        assert!(!may_be_another_runtime(
+            "http://127.0.0.1:9090",
+            "http://spiced.internal:50051"
+        ));
+    }
+
+    #[test]
+    fn a_host_without_a_port_or_scheme_is_still_classified() {
+        assert!(is_loopback_endpoint("http://localhost"));
+        assert!(is_loopback_endpoint("localhost:50051"));
+        assert!(is_loopback_endpoint("http://user@127.0.0.1:50051/path"));
+        assert!(!is_loopback_endpoint("spice-test.127.0.0.1.nip.io"));
+        assert!(!is_loopback_endpoint("http://192.168.1.10:50051"));
     }
 }

--- a/bin/spice/src/context.rs
+++ b/bin/spice/src/context.rs
@@ -29,8 +29,8 @@ use std::time::Duration;
 
 /// The runtime HTTP endpoint the CLI talks to when `--http-endpoint` is not given.
 ///
-/// Shared with the `--http-endpoint` flag's `default_value` so a command can tell an
-/// explicitly chosen endpoint from the built-in local one.
+/// The default lives here rather than on the flag so that not passing the flag is
+/// distinguishable from passing this exact value — see [`RuntimeContext::http_endpoint_chosen`].
 pub const DEFAULT_HTTP_ENDPOINT: &str = "http://127.0.0.1:8090";
 
 /// Constants for Spice paths and filenames
@@ -56,6 +56,11 @@ pub struct RuntimeContext {
 
     /// HTTP endpoint for runtime API
     http_endpoint: String,
+
+    /// Whether `http_endpoint` came from `--http-endpoint`, rather than the built-in default
+    /// or the cloud region. `spice sql` needs the provenance and not the value: it moves only
+    /// the Flight endpoint, so an HTTP endpoint nobody pointed at that runtime is not it.
+    http_endpoint_chosen: bool,
 
     /// API key for authentication
     api_key: Option<String>,
@@ -103,6 +108,7 @@ impl RuntimeContext {
             app_dir,
             pods_dir,
             http_endpoint: DEFAULT_HTTP_ENDPOINT.to_string(),
+            http_endpoint_chosen: false,
             api_key: None,
             cloud_region: None,
             user_agent: Self::default_user_agent(),
@@ -126,10 +132,15 @@ impl RuntimeContext {
 
         if let Some(endpoint) = http_endpoint {
             ctx.http_endpoint = endpoint;
+            ctx.http_endpoint_chosen = true;
         }
 
         if let Some(region) = cloud {
+            // The region replaces whatever `--http-endpoint` asked for, so the endpoint in use
+            // is derived from the region rather than chosen. It is derived alongside the Cloud
+            // Flight endpoint, which is what makes the pair trustworthy.
             ctx.http_endpoint = spice_cloud_data_endpoint(region);
+            ctx.http_endpoint_chosen = false;
             ctx.cloud_region = Some(region.to_string());
         }
 
@@ -211,6 +222,13 @@ impl RuntimeContext {
     #[must_use]
     pub fn http_endpoint(&self) -> &str {
         &self.http_endpoint
+    }
+
+    /// Whether the HTTP endpoint came from `--http-endpoint`, rather than the built-in default
+    /// or the cloud region.
+    #[must_use]
+    pub fn http_endpoint_chosen(&self) -> bool {
+        self.http_endpoint_chosen
     }
 
     /// Get the API key if set.
@@ -501,6 +519,7 @@ mod tests {
             app_dir: PathBuf::from("/test/app"),
             pods_dir: PathBuf::from("/test/app/spicepods"),
             http_endpoint: "http://127.0.0.1:8090".to_string(),
+            http_endpoint_chosen: false,
             api_key: None,
             cloud_region: None,
             user_agent: "spice/test (test; test)".to_string(),
@@ -525,6 +544,7 @@ mod tests {
             app_dir: PathBuf::from("/test/app"),
             pods_dir: PathBuf::from("/test/app/spicepods"),
             http_endpoint: "http://127.0.0.1:8090".to_string(),
+            http_endpoint_chosen: false,
             api_key: None,
             cloud_region: None,
             user_agent: "spice/test (test; test)".to_string(),
@@ -890,6 +910,40 @@ mod tests {
                 .expect("with_args should succeed");
 
         assert_eq!(ctx.http_endpoint(), "http://custom:9999");
+    }
+
+    /// #11005: `spice sql` moves only the Flight endpoint, so it needs to tell an HTTP endpoint
+    /// somebody chose from the default one nobody pointed anywhere.
+    #[test]
+    fn test_with_args_records_whether_the_http_endpoint_was_chosen() {
+        let chosen =
+            RuntimeContext::with_args(Some("http://custom:9999".to_string()), None, None, None)
+                .expect("with_args should succeed");
+
+        assert!(chosen.http_endpoint_chosen());
+
+        let omitted =
+            RuntimeContext::with_args(None, None, None, None).expect("with_args should succeed");
+
+        assert!(!omitted.http_endpoint_chosen());
+        assert_eq!(omitted.http_endpoint(), DEFAULT_HTTP_ENDPOINT);
+    }
+
+    /// A cloud region replaces the flag's value, so the endpoint in use was derived rather than
+    /// chosen — and it is derived alongside the Cloud Flight endpoint, which is what makes the
+    /// pair trustworthy without either being chosen.
+    #[test]
+    fn test_with_args_treats_a_cloud_endpoint_as_derived() {
+        let ctx = RuntimeContext::with_args(
+            Some("http://custom:9999".to_string()),
+            None,
+            Some("us-east-1"),
+            None,
+        )
+        .expect("with_args should succeed");
+
+        assert!(!ctx.http_endpoint_chosen());
+        assert_ne!(ctx.http_endpoint(), "http://custom:9999");
     }
 
     #[test]

--- a/bin/spice/src/context.rs
+++ b/bin/spice/src/context.rs
@@ -27,6 +27,12 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
 
+/// The runtime HTTP endpoint the CLI talks to when `--http-endpoint` is not given.
+///
+/// Shared with the `--http-endpoint` flag's `default_value` so a command can tell an
+/// explicitly chosen endpoint from the built-in local one.
+pub const DEFAULT_HTTP_ENDPOINT: &str = "http://127.0.0.1:8090";
+
 /// Constants for Spice paths and filenames
 const DOT_SPICE: &str = ".spice";
 const SPICED_FILENAME: &str = "spiced";
@@ -96,7 +102,7 @@ impl RuntimeContext {
             spice_bin_dir,
             app_dir,
             pods_dir,
-            http_endpoint: "http://127.0.0.1:8090".to_string(),
+            http_endpoint: DEFAULT_HTTP_ENDPOINT.to_string(),
             api_key: None,
             cloud_region: None,
             user_agent: Self::default_user_agent(),

--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -134,7 +134,7 @@ struct Cli {
     #[arg(long, global = true, value_parser = parse_cloud_region, default_value = DEFAULT_CLOUD_REGION, requires = "cloud")]
     cloud_region: String,
 
-    /// HTTP endpoint of the Spice runtime to talk to [default: http://127.0.0.1:8090].
+    /// HTTP endpoint of the Spice runtime to talk to (default `http://127.0.0.1:8090`).
     ///
     /// The default is applied by the runtime context rather than by clap, so that omitting
     /// this flag stays distinguishable from passing the default value: `spice sql` refuses to

--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -24,7 +24,6 @@ use spice::commands::{
     datasets, feedback, init, install, login, models, nsql, pods, query, refresh, run, search, sql,
     status, trace, upgrade, validate, version, workers,
 };
-use spice::context::DEFAULT_HTTP_ENDPOINT;
 use spice::output::OutputFormat;
 use spice::{Result, RuntimeContext};
 use spice_cloud_client::endpoints::{
@@ -135,9 +134,13 @@ struct Cli {
     #[arg(long, global = true, value_parser = parse_cloud_region, default_value = DEFAULT_CLOUD_REGION, requires = "cloud")]
     cloud_region: String,
 
-    /// HTTP endpoint of the Spice runtime to talk to.
-    #[arg(long, global = true, default_value = DEFAULT_HTTP_ENDPOINT)]
-    http_endpoint: String,
+    /// HTTP endpoint of the Spice runtime to talk to [default: http://127.0.0.1:8090].
+    ///
+    /// The default is applied by the runtime context rather than by clap, so that omitting
+    /// this flag stays distinguishable from passing the default value: `spice sql` refuses to
+    /// send a natural-language query to an HTTP endpoint nobody chose. See #11005.
+    #[arg(long, global = true)]
+    http_endpoint: Option<String>,
 
     /// Path to a PEM root certificate used to verify the runtime's TLS server certificate.
     #[arg(long, global = true)]
@@ -866,7 +869,7 @@ fn run_cli(cli: Cli) -> Result<()> {
     // Create runtime context from CLI args
     let cloud_region = cli.cloud.then_some(cli.cloud_region.as_str());
     let ctx = RuntimeContext::with_args(
-        Some(cli.http_endpoint),
+        cli.http_endpoint,
         cli.api_key,
         cloud_region,
         cli.tls_root_certificate_file,
@@ -1062,6 +1065,16 @@ mod tests {
     fn parse_normalized(args: &[&str]) -> Cli {
         let args = normalize_direct_command_args(args.iter().map(OsString::from));
         Cli::try_parse_from(args).expect("failed to parse CLI args")
+    }
+
+    /// #11005: the guard that keeps the SQL REPL's `nql` from answering out of an unrelated
+    /// runtime reads whether `--http-endpoint` was *given*, so the flag must carry no clap
+    /// `default_value` — with one, omitting it is indistinguishable from passing it.
+    #[test]
+    fn an_omitted_http_endpoint_stays_unset() {
+        let cli = parse_normalized(&["spice", "-sql", "show tables"]);
+
+        assert!(cli.http_endpoint.is_none());
     }
 
     fn try_parse_normalized(args: &[&str]) -> std::result::Result<Cli, clap::Error> {
@@ -1280,7 +1293,8 @@ mod tests {
             "-sql",
             "show tables",
         ]);
-        assert_eq!(cli.http_endpoint, "http://127.0.0.1:8090");
+        let endpoint = cli.http_endpoint.as_deref();
+        assert_eq!(endpoint, Some("http://127.0.0.1:8090"));
         let Commands::Sql(args) = cli.command else {
             panic!("expected sql command");
         };
@@ -1450,7 +1464,8 @@ mod tests {
             "--http-endpoint",
             "http://127.0.0.1:8090",
         ]);
-        assert_eq!(cli.http_endpoint, "http://127.0.0.1:8090");
+        let endpoint = cli.http_endpoint.as_deref();
+        assert_eq!(endpoint, Some("http://127.0.0.1:8090"));
         let Commands::Sql(args) = cli.command else {
             panic!("expected sql command");
         };

--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -24,6 +24,7 @@ use spice::commands::{
     datasets, feedback, init, install, login, models, nsql, pods, query, refresh, run, search, sql,
     status, trace, upgrade, validate, version, workers,
 };
+use spice::context::DEFAULT_HTTP_ENDPOINT;
 use spice::output::OutputFormat;
 use spice::{Result, RuntimeContext};
 use spice_cloud_client::endpoints::{
@@ -135,7 +136,7 @@ struct Cli {
     cloud_region: String,
 
     /// HTTP endpoint of the Spice runtime to talk to.
-    #[arg(long, global = true, default_value = "http://127.0.0.1:8090")]
+    #[arg(long, global = true, default_value = DEFAULT_HTTP_ENDPOINT)]
     http_endpoint: String,
 
     /// Path to a PEM root certificate used to verify the runtime's TLS server certificate.

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -82,10 +82,10 @@ fn main() {
     let matches = spiced::Args::command().get_matches();
     let open_telemetry_deprecated =
         matches.value_source("open_telemetry_bind_address") == Some(ValueSource::CommandLine);
-    // `--repl-flight-endpoint` moves only the REPL's SQL target; its HTTP endpoint, which is
-    // what `nql` uses, keeps its own default. Choosing one without the other leaves nothing
-    // pointing the HTTP endpoint at that runtime, so `nql` says so instead of answering from
-    // whatever the default reaches. See #11005.
+    // `--repl-flight-endpoint` moves only the REPL's SQL target, leaving the HTTP endpoint that
+    // `nql` uses wherever it already was. Choosing one without the other leaves nothing pointing
+    // the HTTP endpoint at that runtime, so `nql` says so instead of answering from whatever
+    // that endpoint reaches. See #11005.
     let flight_chosen = chosen_on_command_line(&matches, "repl_flight_endpoint");
     let http_chosen = chosen_on_command_line(&matches, "http_endpoint");
     let mut args = spiced::Args::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -69,6 +69,11 @@ const fn get_allocator_name() -> Option<&'static str> {
     }
 }
 
+/// Whether `id` was given on the command line, rather than falling back to its default.
+fn chosen_on_command_line(matches: &clap::ArgMatches, id: &str) -> bool {
+    matches.value_source(id) == Some(ValueSource::CommandLine)
+}
+
 fn main() {
     // Before anything else, so a fault during startup is still reported. A native
     // crash is not a panic: without this the process dies silently with exit 139.
@@ -77,8 +82,16 @@ fn main() {
     let matches = spiced::Args::command().get_matches();
     let open_telemetry_deprecated =
         matches.value_source("open_telemetry_bind_address") == Some(ValueSource::CommandLine);
+    // `--repl-flight-endpoint` moves only the REPL's SQL target; its HTTP endpoint, which is
+    // what `nql` uses, keeps its own default. Choosing one without the other leaves nothing
+    // pointing the HTTP endpoint at that runtime, so `nql` says so instead of answering from
+    // whatever the default reaches. See #11005.
+    let flight_chosen = chosen_on_command_line(&matches, "repl_flight_endpoint");
+    let http_chosen = chosen_on_command_line(&matches, "http_endpoint");
     let mut args = spiced::Args::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
     args.open_telemetry_deprecated = open_telemetry_deprecated;
+    args.repl_config.http_endpoint_may_be_another_runtime =
+        repl::http_endpoint_unpaired(flight_chosen, http_chosen);
 
     if args.version {
         println!("{}", get_version_string());

--- a/crates/repl/src/lib.rs
+++ b/crates/repl/src/lib.rs
@@ -145,10 +145,11 @@ pub struct ReplConfig {
     #[arg(long, short = 'x', help_heading = "SQL REPL")]
     pub expanded: bool,
 
-    /// Set when the Flight endpoint was chosen on the command line and `http_endpoint` was
-    /// left to its default, so nothing pointed the HTTP endpoint at the runtime the SQL
-    /// queries go to. `nql` — the one REPL feature that speaks HTTP rather than Flight — then
-    /// says so instead of answering from whatever the default reaches. See #11005.
+    /// Set when the Flight endpoint was chosen on the command line and `http_endpoint` was not,
+    /// so nothing pointed the HTTP endpoint at the runtime the SQL queries go to — whether it
+    /// then holds a built-in default or a value derived from something else, such as a cloud
+    /// region. `nql` — the one REPL feature that speaks HTTP rather than Flight — says so
+    /// instead of answering from whatever that endpoint reaches. See #11005.
     ///
     /// Not a flag: only the caller that resolved both endpoints knows where each came from.
     #[arg(skip)]
@@ -159,10 +160,10 @@ pub struct ReplConfig {
 /// given whether each endpoint was chosen on the command line.
 ///
 /// This is a question about provenance, not about hosts. The Flight endpoint can be moved on
-/// its own — by `spice sql --endpoint` or `spiced --repl-flight-endpoint` — while the HTTP
-/// endpoint keeps its own default, and comparing the two cannot settle whether they agree: a
-/// host and port say nothing about which runtime answers there. Two runtimes can both be on
-/// loopback, and one runtime can be reached at unrelated addresses through a tunnel or ingress.
+/// its own — by `spice sql --endpoint` or `spiced --repl-flight-endpoint` — leaving the HTTP
+/// endpoint at whatever it already held, and comparing the two cannot settle whether they
+/// agree: a host and port say nothing about which runtime answers there. Two runtimes can both
+/// be on loopback, and one runtime can be reached at unrelated addresses through a tunnel.
 ///
 /// So only endpoints that were chosen, or defaulted as a pair, are trusted:
 ///
@@ -843,9 +844,9 @@ fn nql_endpoint_mismatch_message(repl_config: &ReplConfig) -> String {
     let flight_endpoint = &repl_config.repl_flight_endpoint;
 
     format!(
-        "`nql` uses the runtime's HTTP API, which is still at its default \
-         '{http_endpoint}' while this session's SQL queries go to '{flight_endpoint}'. \
-         Pass `--http-endpoint` for the runtime `nql` should ask — repeating the default \
+        "`nql` uses the runtime's HTTP API at '{http_endpoint}', which nothing pointed at \
+         the runtime this session's SQL queries go to ('{flight_endpoint}'). Pass \
+         `--http-endpoint` for the runtime `nql` should ask — repeating the endpoint above \
          is accepted, and confirms that is the one you mean."
     )
 }

--- a/crates/repl/src/lib.rs
+++ b/crates/repl/src/lib.rs
@@ -144,6 +144,15 @@ pub struct ReplConfig {
     /// line per record (useful for wide tables). Toggle at runtime with `.expanded`.
     #[arg(long, short = 'x', help_heading = "SQL REPL")]
     pub expanded: bool,
+
+    /// Set when `http_endpoint` was left at its local default while SQL queries go to an
+    /// explicitly chosen remote Flight endpoint. The two then address different runtimes, so
+    /// `nql` — the one REPL feature that speaks HTTP rather than Flight — must say so instead
+    /// of answering from whatever happens to be listening locally. See #11005.
+    ///
+    /// Not a flag: the caller that resolved both endpoints is the only thing that can know.
+    #[arg(skip)]
+    pub http_endpoint_may_be_another_runtime: bool,
 }
 
 const NQL_LINE_PREFIX: &str = "nql ";
@@ -616,6 +625,15 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
             }
             _ if lower.starts_with(NQL_LINE_PREFIX) => {
                 let _ = rl.add_history_entry(line);
+                if repl_config.http_endpoint_may_be_another_runtime {
+                    println!(
+                        "{} {}",
+                        Color::Red.paint("Error:"),
+                        nql_endpoint_mismatch_message(&repl_config)
+                    );
+                    let _ = std::io::stdout().flush();
+                    continue;
+                }
                 // `lower` and `line` have the same byte length, so slicing
                 // off the prefix on the original line yields the user's
                 // original-case question.
@@ -793,6 +811,38 @@ fn format_flight_sql_status(status: &Status) -> String {
     )
 }
 
+/// Why `nql` will not run when the HTTP endpoint and the SQL target are different runtimes.
+///
+/// `nql` is the one REPL feature that goes over the runtime's HTTP API; everything else uses
+/// Flight. Answering it from the local default while this session's SQL goes to a remote would
+/// silently mix results from two runtimes, so name both endpoints and the flag that fixes it.
+fn nql_endpoint_mismatch_message(repl_config: &ReplConfig) -> String {
+    let http_endpoint = &repl_config.http_endpoint;
+    let flight_endpoint = &repl_config.repl_flight_endpoint;
+
+    format!(
+        "`nql` uses the runtime's HTTP API at '{http_endpoint}', but this session's SQL \
+         queries go to '{flight_endpoint}' — a different runtime. Re-run with \
+         `--http-endpoint <http url of that runtime>` to ask it instead."
+    )
+}
+
+/// Why the REPL could not open its Flight connection.
+///
+/// The endpoint is the runtime's **Arrow Flight (gRPC)** address, not its HTTP API, and the
+/// scheme (`http://`) hides that: pointing the REPL at an HTTP ingress, or at the HTTP port,
+/// fails here with a bare transport error. Say what the endpoint has to serve. See #11005.
+fn flight_connection_failed(flight_endpoint: &str, cause: &str) -> Box<dyn Error> {
+    Box::<dyn Error>::from(format!(
+        "Connection failed to spiced at '{flight_endpoint}': {cause}. This endpoint must \
+         serve the runtime's Arrow Flight (gRPC) API — its flight port, 50051 by default, \
+         reached through a gRPC-capable route if it is behind a proxy or ingress; the \
+         runtime's HTTP port will not answer here. Check that the Spice runtime is running, \
+         that the endpoint including port is correct, and that the TLS config (if used) is \
+         valid."
+    ))
+}
+
 async fn connect_flight_client(
     repl_config: &ReplConfig,
     user_agent: &str,
@@ -841,11 +891,7 @@ async fn connect_flight_client(
 
     let channel = connect_channel(repl_flight_endpoint.clone(), user_agent, client_tls_config)
         .await
-        .map_err(|e| {
-        Box::<dyn Error>::from(format!(
-            "Connection failed to spiced at '{repl_flight_endpoint}': {e}. Check if the Spice runtime is running, endpoint including port is correct, and TLS config (if used) is valid."
-        ))
-    })?;
+        .map_err(|e| flight_connection_failed(&repl_flight_endpoint, &e.to_string()))?;
 
     Ok(FlightServiceClient::new(channel)
         .max_encoding_message_size(MAX_ENCODING_MESSAGE_SIZE)
@@ -1370,6 +1416,47 @@ mod tests {
     fn test_cache_control_default() {
         let default = cache_control::CacheControl::default();
         assert_eq!(default, cache_control::CacheControl::Cache);
+    }
+
+    /// #11005: refusing `nql` is only useful if the message names both endpoints and the flag
+    /// that reconciles them — otherwise it reads as `nql` being broken.
+    #[test]
+    fn the_nql_mismatch_message_names_both_endpoints_and_the_flag() {
+        let config = ReplConfig::parse_from([
+            "repl",
+            "--http-endpoint",
+            "http://127.0.0.1:8090",
+            "--repl-flight-endpoint",
+            "http://spiced.internal:50051",
+        ]);
+
+        let message = nql_endpoint_mismatch_message(&config);
+
+        assert!(message.contains("http://127.0.0.1:8090"), "{message}");
+        assert!(message.contains("http://spiced.internal:50051"), "{message}");
+        assert!(message.contains("--http-endpoint"), "{message}");
+    }
+
+    /// #11005: the reporter pointed `--endpoint` at an HTTP ingress and got a bare transport
+    /// error, so the message has to say the endpoint serves Flight/gRPC on its own port.
+    #[test]
+    fn the_flight_connection_failure_says_the_endpoint_serves_grpc() {
+        let endpoint = "http://spice-test.127.0.0.1.nip.io";
+        let message = flight_connection_failed(endpoint, "transport error").to_string();
+
+        assert!(message.contains(endpoint), "{message}");
+        assert!(message.contains("transport error"), "{message}");
+        assert!(message.contains("gRPC"), "{message}");
+        assert!(message.contains("50051"), "{message}");
+    }
+
+    /// The `nql` guard is off unless a caller sets it, so parsing the REPL's own flags — what
+    /// `spiced` does — never turns it on.
+    #[test]
+    fn the_nql_guard_defaults_off_when_parsed_from_flags() {
+        let config = ReplConfig::parse_from(["repl"]);
+
+        assert!(!config.http_endpoint_may_be_another_runtime);
     }
 
     #[test]

--- a/crates/repl/src/lib.rs
+++ b/crates/repl/src/lib.rs
@@ -145,14 +145,35 @@ pub struct ReplConfig {
     #[arg(long, short = 'x', help_heading = "SQL REPL")]
     pub expanded: bool,
 
-    /// Set when `http_endpoint` was left at its local default while SQL queries go to an
-    /// explicitly chosen remote Flight endpoint. The two then address different runtimes, so
-    /// `nql` — the one REPL feature that speaks HTTP rather than Flight — must say so instead
-    /// of answering from whatever happens to be listening locally. See #11005.
+    /// Set when the Flight endpoint was chosen on the command line and `http_endpoint` was
+    /// left to its default, so nothing pointed the HTTP endpoint at the runtime the SQL
+    /// queries go to. `nql` — the one REPL feature that speaks HTTP rather than Flight — then
+    /// says so instead of answering from whatever the default reaches. See #11005.
     ///
-    /// Not a flag: the caller that resolved both endpoints is the only thing that can know.
+    /// Not a flag: only the caller that resolved both endpoints knows where each came from.
     #[arg(skip)]
     pub http_endpoint_may_be_another_runtime: bool,
+}
+
+/// Whether the REPL's HTTP endpoint may address a runtime other than the one SQL queries go to,
+/// given whether each endpoint was chosen on the command line.
+///
+/// This is a question about provenance, not about hosts. The Flight endpoint can be moved on
+/// its own — by `spice sql --endpoint` or `spiced --repl-flight-endpoint` — while the HTTP
+/// endpoint keeps its own default, and comparing the two cannot settle whether they agree: a
+/// host and port say nothing about which runtime answers there. Two runtimes can both be on
+/// loopback, and one runtime can be reached at unrelated addresses through a tunnel or ingress.
+///
+/// So only endpoints that were chosen, or defaulted as a pair, are trusted:
+///
+/// - neither chosen — the built-in defaults, or a pair derived from a cloud region: trusted;
+/// - both chosen — the caller paired them, even if the HTTP one repeats the default: trusted;
+/// - Flight chosen alone — nothing pointed the HTTP endpoint at that runtime: not trusted.
+///
+/// Callers pass the result to [`ReplConfig::http_endpoint_may_be_another_runtime`]. See #11005.
+#[must_use]
+pub fn http_endpoint_unpaired(flight_chosen: bool, http_chosen: bool) -> bool {
+    flight_chosen && !http_chosen
 }
 
 const NQL_LINE_PREFIX: &str = "nql ";
@@ -811,19 +832,21 @@ fn format_flight_sql_status(status: &Status) -> String {
     )
 }
 
-/// Why `nql` will not run when the HTTP endpoint and the SQL target are different runtimes.
+/// Why `nql` will not run when nothing pointed the HTTP endpoint at the SQL target.
 ///
 /// `nql` is the one REPL feature that goes over the runtime's HTTP API; everything else uses
-/// Flight. Answering it from the local default while this session's SQL goes to a remote would
-/// silently mix results from two runtimes, so name both endpoints and the flag that fixes it.
+/// Flight. Answering it from an endpoint nobody chose, while this session's SQL goes somewhere
+/// chosen, would silently mix results from two runtimes — so state both endpoints, and the flag
+/// that settles which runtime `nql` should ask, without claiming to know what answers where.
 fn nql_endpoint_mismatch_message(repl_config: &ReplConfig) -> String {
     let http_endpoint = &repl_config.http_endpoint;
     let flight_endpoint = &repl_config.repl_flight_endpoint;
 
     format!(
-        "`nql` uses the runtime's HTTP API at '{http_endpoint}', but this session's SQL \
-         queries go to '{flight_endpoint}' — a different runtime. Re-run with \
-         `--http-endpoint <http url of that runtime>` to ask it instead."
+        "`nql` uses the runtime's HTTP API, which is still at its default \
+         '{http_endpoint}' while this session's SQL queries go to '{flight_endpoint}'. \
+         Pass `--http-endpoint` for the runtime `nql` should ask — repeating the default \
+         is accepted, and confirms that is the one you mean."
     )
 }
 
@@ -1427,13 +1450,13 @@ mod tests {
             "--http-endpoint",
             "http://127.0.0.1:8090",
             "--repl-flight-endpoint",
-            "http://spiced.internal:50051",
+            "http://remote:50051",
         ]);
 
         let message = nql_endpoint_mismatch_message(&config);
 
         assert!(message.contains("http://127.0.0.1:8090"), "{message}");
-        assert!(message.contains("http://spiced.internal:50051"), "{message}");
+        assert!(message.contains("http://remote:50051"), "{message}");
         assert!(message.contains("--http-endpoint"), "{message}");
     }
 
@@ -1442,7 +1465,8 @@ mod tests {
     #[test]
     fn the_flight_connection_failure_says_the_endpoint_serves_grpc() {
         let endpoint = "http://spice-test.127.0.0.1.nip.io";
-        let message = flight_connection_failed(endpoint, "transport error").to_string();
+        let error = flight_connection_failed(endpoint, "transport error");
+        let message = error.to_string();
 
         assert!(message.contains(endpoint), "{message}");
         assert!(message.contains("transport error"), "{message}");
@@ -1450,13 +1474,27 @@ mod tests {
         assert!(message.contains("50051"), "{message}");
     }
 
-    /// The `nql` guard is off unless a caller sets it, so parsing the REPL's own flags — what
-    /// `spiced` does — never turns it on.
+    /// The guard is not a flag, and defaults off: a caller that does not resolve endpoint
+    /// provenance gets the previous behaviour rather than a REPL that refuses `nql`.
     #[test]
     fn the_nql_guard_defaults_off_when_parsed_from_flags() {
         let config = ReplConfig::parse_from(["repl"]);
 
         assert!(!config.http_endpoint_may_be_another_runtime);
+    }
+
+    /// #11005: moving the SQL target without saying where `nql` should go is the one case
+    /// nothing can vouch for. Defaulted pairs and chosen pairs both can.
+    #[test]
+    fn only_a_flight_endpoint_chosen_alone_is_unpaired() {
+        assert!(http_endpoint_unpaired(true, false));
+
+        // Both defaulted: the local pair, or a pair derived from a cloud region.
+        assert!(!http_endpoint_unpaired(false, false));
+        // Both chosen: the caller paired them, even if the HTTP one repeats its default.
+        assert!(!http_endpoint_unpaired(true, true));
+        // Only the HTTP endpoint moved, so SQL still goes to the default it belongs to.
+        assert!(!http_endpoint_unpaired(false, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary (root cause)

`spice sql --endpoint <remote>` moves **only** the Arrow Flight endpoint. The REPL's HTTP
endpoint comes from the global `--http-endpoint`, whose default is this machine, and
`build_repl_config` copied it in unconditionally:

```rust
let http_endpoint = ctx.http_endpoint().to_string();
```

`nql <question>` is the one REPL feature that goes over HTTP (`POST /v1/nsql`) rather than
Flight, so pointing the REPL at a remote runtime split the session in two: every SQL query went
to the remote, while `nql` asked whatever was listening on `http://127.0.0.1:8090`. If a local
`spiced` happened to be running, it answered — from a different dataset, with no warning.
`spiced --repl --repl-flight-endpoint` splits the same way.

The reported symptom in #11005 is the other half of the same confusion. `--endpoint` is the
runtime's **Flight (gRPC)** address, but its help text just listed the `http://` and `https://`
schemes it accepts, so an HTTP ingress looks like a valid value; it then fails with a bare
`transport error` naming neither gRPC nor the flight port.

## Changes

- `nql` now reports the split instead of answering across it, naming both endpoints and the
  `--http-endpoint` that settles which runtime it should ask.
- **The verdict is about provenance, not hosts.** Comparing the two endpoints cannot decide
  whether they reach one runtime: a host and port say nothing about what answers there. Two
  runtimes can both be on loopback, and one runtime can be reached at unrelated addresses
  through a tunnel or an ingress. So only a Flight endpoint chosen *without* an HTTP endpoint
  is unvouched-for; a defaulted pair (local, or derived from a cloud region) and a chosen pair
  are both trusted — which makes repeating the default a real way to confirm it.
- `--http-endpoint` therefore carries no clap `default_value` any more. The default moves to
  `DEFAULT_HTTP_ENDPOINT`, applied by `RuntimeContext`, so omitting the flag stays
  distinguishable from passing the same value; `RuntimeContext` records which happened. A cloud
  region replaces the flag's value, so that endpoint counts as derived, not chosen.
- The rule lives in `repl::http_endpoint_unpaired` so `spiced --repl` applies the same policy
  rather than a copy of it. `spiced` already reads argument provenance this way for
  `--open-telemetry-bind-address`.
- The Flight connection failure, and `--endpoint`'s help, now say the endpoint must serve Arrow
  Flight over gRPC on the runtime's flight port (50051 by default), through a gRPC-capable route
  if it is behind a proxy or ingress — the ingress case from the issue.

Nothing changes for a session that did not move an endpoint, or that moved both: the guard is
off unless the Flight endpoint alone was chosen. `ReplConfig`'s new field is `#[arg(skip)]`, so
it is not a flag and defaults off — a caller that does not resolve provenance keeps today's
behaviour.

The trade-off, stated plainly: `spice sql --endpoint <remote>` with no `--http-endpoint` now
refuses `nql` even where the two happen to agree (a locally forwarded HTTP port, say). One flag
re-enables it, and repeating the default value is accepted precisely so that case has an answer.
Split targeting was never expressible on purpose — it was what the bug did by accident.

## Test plan

- `make lint`
- `make test`
- New regression tests. Each fails on the old code, where the mismatch was unrepresentable and
  the messages said none of this:
  - `only_a_flight_endpoint_chosen_alone_is_unpaired` (`repl`) — the four provenance
    combinations, including that a chosen pair repeating the default is trusted.
  - `the_nql_mismatch_message_names_both_endpoints_and_the_flag` (`repl`) — the refusal is
    actionable rather than a bare "no".
  - `the_flight_connection_failure_says_the_endpoint_serves_grpc` (`repl`) — the connect failure
    names gRPC and the flight port, which is what the reported ingress case needed.
  - `the_nql_guard_defaults_off_when_parsed_from_flags` (`repl`) — the guard is not a flag.
  - `the_endpoint_flag_counts_as_a_chosen_flight_endpoint`,
    `the_deprecated_flight_endpoint_flag_counts_as_chosen`,
    `endpoints_nobody_moved_are_the_same_runtime` (`spice sql`) — both spellings of the flag
    count, and a bare `spice sql` moves nothing.
  - `test_with_args_records_whether_the_http_endpoint_was_chosen`,
    `test_with_args_treats_a_cloud_endpoint_as_derived` (`RuntimeContext`) — provenance is
    recorded, and a cloud region counts as derived.
  - `an_omitted_http_endpoint_stays_unset` (`spice` CLI) — guards the whole mechanism: with a
    clap `default_value` back on the flag, omitting it would be indistinguishable from passing
    it and the check would silently pass everything.

## Follow-up filed, not fixed here

#12491 — the same `nql` path sends no API key, so it is refused wherever the session's Flight
queries are authenticated (most visibly `spice --cloud sql`). Which runtime a request is
addressed to is orthogonal to whether it may ask, so it is tracked separately rather than
widened into this fix.

## Checklist

- [x] Root cause identified and fixed at the source, not the symptom
- [x] Regression tests that fail on the old code
- [x] Whole bug class covered — both REPL entry points (`spice sql`, `spiced --repl`) share one
      rule; `chat` and `search` apply their `--endpoint` to the HTTP client they actually use,
      and `query`, `nsql` and `trace` have no per-command endpoint flag, so `spice sql` was the
      only place one transport could move without the other
- [x] No behaviour change for a session that moved neither endpoint or both, including cloud mode
- [ ] `make signoff` green + `Attestation` re-run

Fixes #12493
Refs #11005
