### PR TITLE
fix(cli): authenticate the SQL REPL's nql line like the session's SQL (fixes #12491)

### DIFF
--- a/crates/repl/src/lib.rs
+++ b/crates/repl/src/lib.rs
@@ -1052,7 +1052,7 @@ fn display_records(
     Ok(pretty_batches)
 }
 
-/// Use the `POST v1/nsql` HTTP endpoint to send an NSQL query and display the resulting records.
+/// Use the `POST /v1/nsql` HTTP endpoint to send an NSQL query and display the resulting records.
 ///
 /// `api_key` is the session's key — the same one every Flight query authenticates with. See
 /// #12491.
@@ -1419,6 +1419,46 @@ mod tests {
         );
     }
 
+    /// How long a stub server waits to be contacted, and then to be spoken to, before giving up.
+    const STUB_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+    /// Accept one connection, giving up after `STUB_TIMEOUT` rather than parking forever.
+    ///
+    /// Each stub below is joined only *after* the client call has returned, so a regression that
+    /// makes `get_and_display_nql_records` fail before it connects would leave a plain blocking
+    /// `accept()` waiting for a client that is never coming. The deadline turns that into a
+    /// prompt, named failure, and the matching read timeout does the same for a client that
+    /// connects but never finishes its request.
+    fn accept_one(listener: &std::net::TcpListener) -> std::net::TcpStream {
+        listener
+            .set_nonblocking(true)
+            .expect("set stub listener non-blocking");
+
+        let deadline = Instant::now() + STUB_TIMEOUT;
+        loop {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    // Back to blocking reads, but bounded, so `read_http_request` cannot stall.
+                    stream
+                        .set_nonblocking(false)
+                        .expect("restore blocking stub stream");
+                    stream
+                        .set_read_timeout(Some(STUB_TIMEOUT))
+                        .expect("set stub read timeout");
+                    return stream;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "no client connected to the stub server within {STUB_TIMEOUT:?}"
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                Err(e) => panic!("accept on the stub server failed: {e}"),
+            }
+        }
+    }
+
     /// Serve exactly one HTTP request on an ephemeral port from a plain-std thread, answering
     /// with a one-row JSON array, and hand back the raw request text.
     ///
@@ -1432,7 +1472,7 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind capture listener");
         let addr = listener.local_addr().expect("capture listener addr");
         let handle = std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("accept nsql request");
+            let mut stream = accept_one(&listener);
             let request = read_http_request(&mut stream);
 
             // A real row, so the response parses through schema inference the way a runtime's
@@ -1455,13 +1495,18 @@ mod tests {
     /// Read one whole HTTP request — headers plus the body its `Content-Length` declares — and
     /// return it as text, so a stub answers only once the client has finished sending and the
     /// captured text is complete.
+    ///
+    /// Bounded by the read timeout `accept_one` installs: a client that connects and then goes
+    /// quiet fails here instead of stalling the thread.
     fn read_http_request(stream: &mut std::net::TcpStream) -> String {
         use std::io::Read as _;
 
         let mut buf = Vec::new();
         let mut chunk = [0_u8; 4096];
         loop {
-            let read = stream.read(&mut chunk).expect("read request");
+            let read = stream
+                .read(&mut chunk)
+                .expect("read request from the stub server's client within the read timeout");
             if read == 0 {
                 break;
             }
@@ -1539,7 +1584,7 @@ mod tests {
         let addr = listener.local_addr().expect("redirect listener addr");
         let location = location.to_string();
         let handle = std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("accept redirected request");
+            let mut stream = accept_one(&listener);
             // Drained but not inspected: the response below is what this stub is for.
             let _ = read_http_request(&mut stream);
             let response = format!(

--- a/crates/repl/src/lib.rs
+++ b/crates/repl/src/lib.rs
@@ -148,6 +148,12 @@ pub struct ReplConfig {
 
 const NQL_LINE_PREFIX: &str = "nql ";
 
+/// The header the runtime's HTTP API reads an API key from.
+///
+/// The runtime accepts either this or `Authorization: Bearer`; this is the one every other
+/// CLI HTTP call site sends (`RuntimeContext::get_headers`), so `nql` sends it too.
+const API_KEY_HEADER: &str = "X-API-Key";
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum LlmRuntime {
@@ -162,19 +168,26 @@ async fn send_nsql_request(
     query: String,
     runtime: LlmRuntime,
     user_agent: &str,
+    api_key: Option<&str>,
 ) -> Result<String, reqwest::Error> {
-    client
+    let mut request = client
         .post(format!("{base_url}/v1/nsql"))
         .header("Content-Type", "application/json")
         .header("User-Agent", user_agent)
         .json(&json!({
             "query": query,
             "model": runtime,
-        }))
-        .send()
-        .await?
-        .text()
-        .await
+        }));
+
+    // `nql` is the one REPL feature that goes over the runtime's HTTP API rather than Flight.
+    // Every Flight query in the same session authenticates with `ReplConfig::api_key`, so this
+    // request has to as well — otherwise it is refused wherever the session's SQL succeeds.
+    // See #12491.
+    if let Some(api_key) = api_key {
+        request = request.header(API_KEY_HEADER, api_key);
+    }
+
+    request.send().await?.text().await
 }
 
 const SPECIAL_COMMANDS: [&str; 12] = [
@@ -624,6 +637,7 @@ pub async fn run(repl_config: ReplConfig) -> Result<(), Box<dyn std::error::Erro
                     repl_config.http_endpoint.clone(),
                     question,
                     &user_agent,
+                    repl_config.api_key.as_deref(),
                     expanded,
                 )
                 .await
@@ -1039,23 +1053,40 @@ fn display_records(
 }
 
 /// Use the `POST v1/nsql` HTTP endpoint to send an NSQL query and display the resulting records.
+///
+/// `api_key` is the session's key — the same one every Flight query authenticates with. See
+/// #12491.
 async fn get_and_display_nql_records(
     endpoint: String,
     query: String,
     user_agent: &str,
+    api_key: Option<&str>,
     expanded: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let start_time = Instant::now();
 
+    let mut client = Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(30));
+
+    // A request carrying the session's key must not follow a redirect. `reqwest` follows up to
+    // ten by default, and the sanitisation it applies when the origin changes drops
+    // `Authorization` and cookies but *not* custom headers — so a runtime or proxy answering
+    // `/v1/nsql` with a cross-origin `Location` would hand `X-API-Key` to whatever that names.
+    //
+    // Only the keyed request is constrained: without a key there is nothing to disclose, and
+    // leaving that case on the default policy means no setup that works today stops working.
+    if api_key.is_some() {
+        client = client.redirect(reqwest::redirect::Policy::none());
+    }
+
     let resp = send_nsql_request(
-        &Client::builder()
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(30))
-            .build()?,
+        &client.build()?,
         endpoint,
         query,
         LlmRuntime::Openai,
         user_agent,
+        api_key,
     )
     .await
     .map_err(|e| {
@@ -1385,6 +1416,203 @@ mod tests {
         assert_ne!(
             cache_control::CacheControl::Cache,
             cache_control::CacheControl::NoCache
+        );
+    }
+
+    /// Serve exactly one HTTP request on an ephemeral port from a plain-std thread, answering
+    /// with a one-row JSON array, and hand back the raw request text.
+    ///
+    /// Asserting on the bytes `nql` actually puts on the wire is the point: the defect in
+    /// #12491 was a header that never left the client, which no assertion on `ReplConfig`
+    /// would have caught. A std-thread listener keeps it hermetic — the workspace `tokio` has
+    /// no `net` feature and the crate has no HTTP-mock dev-dependency.
+    fn spawn_nsql_request_capture() -> (String, std::thread::JoinHandle<String>) {
+        use std::io::Write as _;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind capture listener");
+        let addr = listener.local_addr().expect("capture listener addr");
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept nsql request");
+            let request = read_http_request(&mut stream);
+
+            // A real row, so the response parses through schema inference the way a runtime's
+            // answer would rather than exercising an empty-result path.
+            let body = r#"[{"count":1}]"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write nsql response");
+
+            request
+        });
+
+        (format!("http://{addr}"), handle)
+    }
+
+    /// Read one whole HTTP request — headers plus the body its `Content-Length` declares — and
+    /// return it as text, so a stub answers only once the client has finished sending and the
+    /// captured text is complete.
+    fn read_http_request(stream: &mut std::net::TcpStream) -> String {
+        use std::io::Read as _;
+
+        let mut buf = Vec::new();
+        let mut chunk = [0_u8; 4096];
+        loop {
+            let read = stream.read(&mut chunk).expect("read request");
+            if read == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..read]);
+            let text = String::from_utf8_lossy(&buf);
+            if let Some(header_end) = text.find("\r\n\r\n") {
+                let content_length = text[..header_end]
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        if name.eq_ignore_ascii_case("content-length") {
+                            value.trim().parse::<usize>().ok()
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(0);
+                if buf.len() >= header_end + 4 + content_length {
+                    break;
+                }
+            }
+        }
+
+        String::from_utf8_lossy(&buf).into_owned()
+    }
+
+    /// #12491: `nql` is the one REPL feature that goes over the runtime's HTTP API, and it sent
+    /// no credentials — so against any runtime that requires authentication it was refused while
+    /// plain SQL in the same session, which does send the key over Flight, worked.
+    #[tokio::test]
+    async fn the_nql_request_carries_the_session_api_key() {
+        let (endpoint, captured) = spawn_nsql_request_capture();
+
+        get_and_display_nql_records(
+            endpoint,
+            "how many rows are in taxi_trips".to_string(),
+            "spice/test",
+            Some("session-api-key"),
+            false,
+        )
+        .await
+        .expect("nql request against the capture server should succeed");
+
+        let request = captured.join().expect("capture thread should not panic");
+
+        // The header name is compared case-insensitively because reqwest lowercases names on the
+        // wire; the *value* is compared exactly, since an API key is case-sensitive and a
+        // regression that mangled its casing would otherwise pass. The literal is spelled out
+        // rather than read from `API_KEY_HEADER` so the test pins the wire format independently
+        // of the constant.
+        let sent_key = request.lines().find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.trim().eq_ignore_ascii_case("X-API-Key") {
+                Some(value.trim())
+            } else {
+                None
+            }
+        });
+
+        assert_eq!(
+            sent_key,
+            Some("session-api-key"),
+            "the request should carry the session's API key verbatim: {request}"
+        );
+        // The header the fix adds must not displace the ones the path already sent.
+        assert!(request.contains("spice/test"), "{request}");
+        assert!(request.contains("/v1/nsql"), "{request}");
+    }
+
+    /// Serve one HTTP request answering with a cross-origin redirect to `location`.
+    fn spawn_redirect_to(location: &str) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::Write as _;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind redirect listener");
+        let addr = listener.local_addr().expect("redirect listener addr");
+        let location = location.to_string();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept redirected request");
+            // Drained but not inspected: the response below is what this stub is for.
+            let _ = read_http_request(&mut stream);
+            let response = format!(
+                "HTTP/1.1 302 Found\r\nlocation: {location}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write redirect response");
+        });
+
+        (format!("http://{addr}"), handle)
+    }
+
+    /// A request carrying the session's key must not follow a redirect: `reqwest`'s cross-origin
+    /// sanitisation drops `Authorization` and cookies but not custom headers, so following one
+    /// would hand `X-API-Key` to whatever the `Location` names.
+    ///
+    /// The redirect target is a port nothing listens on, which is what makes the two behaviours
+    /// distinguishable without a second capture server: not following returns the 302 itself and
+    /// fails in the response parser, while following would fail to connect. So the *parse* error
+    /// is the evidence that the key stayed put.
+    #[tokio::test]
+    async fn a_keyed_nql_request_does_not_follow_a_redirect() {
+        let unreachable_target = {
+            let listener =
+                std::net::TcpListener::bind("127.0.0.1:0").expect("bind throwaway listener");
+            let addr = listener.local_addr().expect("throwaway listener addr");
+            drop(listener);
+            format!("http://{addr}/v1/nsql")
+        };
+        let (endpoint, redirector) = spawn_redirect_to(&unreachable_target);
+
+        let error = get_and_display_nql_records(
+            endpoint,
+            "how many rows are in taxi_trips".to_string(),
+            "spice/test",
+            Some("session-api-key"),
+            false,
+        )
+        .await
+        .expect_err("a redirect that is not followed cannot produce records");
+
+        redirector.join().expect("redirect thread should not panic");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("Response may be malformed"),
+            "the redirect should have been left unfollowed and failed in the parser, not \
+             chased to its target: {message}"
+        );
+    }
+
+    /// A session with no API key keeps sending no key — an unauthenticated runtime must not
+    /// start seeing an empty credential it then has to reject.
+    #[tokio::test]
+    async fn the_nql_request_omits_the_api_key_header_when_the_session_has_none() {
+        let (endpoint, captured) = spawn_nsql_request_capture();
+
+        get_and_display_nql_records(
+            endpoint,
+            "how many rows are in taxi_trips".to_string(),
+            "spice/test",
+            None,
+            false,
+        )
+        .await
+        .expect("nql request against the capture server should succeed");
+
+        let request = captured.join().expect("capture thread should not panic");
+
+        assert!(
+            !request.to_ascii_lowercase().contains("x-api-key"),
+            "a keyless session should send no API-key header: {request}"
         );
     }
 }


### PR DESCRIPTION
## Summary

The SQL REPL's `nql <question>` line is the one REPL feature that goes over the runtime's
**HTTP** API (`POST /v1/nsql`) rather than Arrow Flight, and it sent no credentials.
`send_nsql_request` set `Content-Type` and `User-Agent` and nothing else, and
`get_and_display_nql_records` was never given the key to send — while every Flight query in
the same session authenticates with `ReplConfig::api_key`.

So against any runtime that requires authentication, `nql` was refused while plain SQL in the
same REPL worked. The clearest case is Spice.ai Cloud: `spice --cloud --api-key <key> sql`
resolves the Cloud Flight and data endpoints together, so `nql` reached the right host and was
then rejected for having no credentials.

Fixes #12491

## Changes

- `send_nsql_request` takes `api_key: Option<&str>` and sends it as `X-API-Key` when present.
- `get_and_display_nql_records` threads it through; the REPL passes `repl_config.api_key`.
- The header name is a named constant with the reason it is that name.
- A request that carries the key does not follow redirects (see below).

`X-API-Key` rather than `Authorization: Bearer`: the runtime's `ApiKeyAuth` accepts either
(`crates/runtime-auth/src/api_key/mod.rs`), and `X-API-Key` is what every other CLI HTTP call
site already sends via `RuntimeContext::get_headers` — `spice nsql`, `spice search`,
`spice chat`, `spice trace`, and the `/v1/*` GETs. This makes the REPL's `nql` consistent with
them instead of introducing a second convention.

### Scope: the API key only, not `--headers`

`--headers` is also dropped on this path, and it stays dropped. The REPL already warns that
custom headers are unsupported for its Flight connection, so forwarding them on `nql` alone
would make one flag half-work within a single session. The API key is not in that category —
it is supported everywhere else in the session — which is why it is the defect being fixed
here. If `--headers` should work end-to-end, that is its own change covering both transports.

### The credential does not follow redirects

`reqwest` follows up to ten redirects by default, and the sanitisation it applies when the
origin changes drops `Authorization` and cookies but **not** custom headers — so a runtime or
proxy answering `/v1/nsql` with a cross-origin `Location` would have handed `X-API-Key` to
whatever that named. Since this PR is what newly puts a credential on this request, it also
constrains it: the client disables redirects **when a key is present**.

Gating on the key rather than disabling redirects outright is deliberate — a keyless session
has nothing to disclose and keeps `reqwest`'s default behaviour, so no setup that works today
stops working.

This is systemic beyond `nql`: every other CLI HTTP call site sends `X-API-Key` on a client
with the default policy. That is filed as #12495 rather than fixed here, since it belongs in
`RuntimeContext::http_client` and a shared builder, not in one call site. #12495 also notes the
rough edge this PR inherits — with redirects off, a 3xx surfaces as "Response may be malformed"
rather than as "the endpoint redirected".

### Bug-class audit

Every other CLI HTTP call site was checked and already applies `ctx.get_headers()`:
`commands/nsql/mod.rs`, `commands/nsql/analyze.rs`, `commands/search.rs`, `commands/chat.rs`,
`commands/trace.rs`, and the `RuntimeContext::get`/`post`/`post_json` helpers. Within
`crates/repl` itself, the `util.rs` helpers (`get_available_models`, `validate_model`,
`select_model`, `get_or_select_model`) already take a headers slice and are passed one.
`send_nsql_request` was the only site with no way to carry credentials at all, so this is a
one-site fix rather than the first of a chain.

## Test plan

- `make lint`
- `make test`

Two tests in `crates/repl/src/lib.rs` drive the production `get_and_display_nql_records`
against a one-shot `std::net` stub server that captures the raw request text:

- `the_nql_request_carries_the_session_api_key` — the #12491 regression. Asserts
  `X-API-Key: session-api-key` is on the wire, and that the `User-Agent` and path the request
  already carried are still there.
- `the_nql_request_omits_the_api_key_header_when_the_session_has_none` — a keyless session
  sends no key header, so an unauthenticated runtime does not start receiving an empty
  credential to reject.
- `a_keyed_nql_request_does_not_follow_a_redirect` — pins the credential boundary. The stub
  answers `302` with a `Location` on a port nothing listens on, which makes the two behaviours
  distinguishable without a second server: not following returns the 302 and fails in the
  response parser, while following would fail to connect. The parse error is the evidence the
  key stayed put.

Asserting on the bytes rather than on `ReplConfig` is deliberate: the defect was a header that
never left the client, which no assertion on config state would have caught. The stub is a
plain `std::thread` + `std::net::TcpListener` because the workspace `tokio` has no `net`
feature and the crate has no HTTP-mock dev-dependency — the same pattern already used in
`bin/spice/tests/cli_integration.rs`.

## Notes for review

**Where the key is sent.** The request goes to `repl_config.http_endpoint`. #12493 (PR #12494)
covers the case where that endpoint is one nothing pointed at the runtime this session's SQL
goes to — `spice sql --endpoint` moves only the Flight endpoint. That PR makes `nql` refuse
outright in exactly that case, so the two compose: where the endpoints are a trusted pair
(both defaulted, both chosen, or derived together from a cloud region) `nql` now authenticates,
and where they are not, #12494's guard stops the request before it is built. The two PRs touch
adjacent lines in `crates/repl/src/lib.rs` but different functions; whichever lands second
takes a small textual merge.

The key is only ever placed in a request header. It is not logged, and no error path on this
route formats the request or its headers — the `reqwest` error surfaced by
`"Network error during NQL request: {e}"` carries the URL, not headers.

**Verification.** This branch was written on a host with no Rust toolchain, so `make lint` and
`make test` run remotely via `make signoff` rather than locally; the `Attestation` check is the
gate. The diff additionally went through a cross-model adversarial review (Codex) covering
signature/call-site agreement, the pedantic clippy set, and hang/flake risk in the stub server.
Two of its findings are applied here — the redirect exposure above, and an assertion that
compared the key value case-insensitively where an API key is case-sensitive — and its
systemic redirect finding is #12495.
