### PR TITLE
fix(runtime): compare an append high-water mark inclusively on a day-granular time column (fixes #12492)

### DIFF
--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -100,6 +100,7 @@ use tokio::{
 };
 use tracing::{Instrument, Span};
 use util::fibonacci_backoff::FibonacciBackoffBuilder;
+use util::timestamp_filter::is_day_granular;
 use util::{RetryError, retry};
 
 pub(crate) mod changes;
@@ -1138,7 +1139,11 @@ impl RefreshTask {
         let mut filters = vec![];
         if let Some(converter) = filter_converter.as_ref() {
             if let Some(timestamp) = overwrite_timestamp_in_nano {
-                filters.push(converter.convert(timestamp, Operator::Gt));
+                // A high-water mark read back out of the accelerator: compare
+                // inclusively on a day-granular time column, whose values all cast
+                // to midnight, and let `except_existing_records_from` drop the
+                // already-loaded rows it brings back (#12492).
+                filters.push(converter.convert_high_water_mark(timestamp));
             } else if let Some(period) = refresh.period {
                 filters.push(
                     converter.convert(get_timestamp(SystemTime::now() - period), Operator::Gt),
@@ -1181,7 +1186,12 @@ impl RefreshTask {
                     .get_full_or_incremental_append_update(refresh, timestamp)
                     .await
                 {
-                    Ok(data) => match self.except_existing_records_from(refresh, data).await {
+                    // Reuse `timestamp`: the dedupe must compare against the same mark the
+                    // source filter just used, not a freshly read one (#12492).
+                    Ok(data) => match self
+                        .except_existing_records_from(refresh, data, timestamp)
+                        .await
+                    {
                         Ok(data) => Ok(data),
                         Err(e) => Err(e),
                     },
@@ -1727,7 +1737,7 @@ impl RefreshTask {
 
     fn get_filter_converter(&self, refresh: &Refresh) -> Option<TimestampFilterConvert> {
         let schema = self.federated.schema();
-        Self::build_filter_converter(&schema, refresh)
+        self.build_high_water_converter(&schema, refresh)
     }
 
     fn get_accelerator_filter_converter(
@@ -1735,7 +1745,52 @@ impl RefreshTask {
         refresh: &Refresh,
     ) -> Option<TimestampFilterConvert> {
         let schema = self.accelerator.schema();
-        Self::build_filter_converter(&schema, refresh)
+        self.build_high_water_converter(&schema, refresh)
+    }
+
+    /// Build a converter for one side of the append high-water comparison.
+    ///
+    /// Both sides go through here so they cannot be given different day-granularity: the
+    /// flags come from [`Self::day_granular_high_water_columns`], which reads both schemas.
+    fn build_high_water_converter(
+        &self,
+        schema: &SchemaRef,
+        refresh: &Refresh,
+    ) -> Option<TimestampFilterConvert> {
+        let (time, partition) = self.day_granular_high_water_columns(refresh);
+        Self::build_filter_converter(schema, refresh)
+            .map(|converter| converter.with_day_granular_columns(time, partition))
+    }
+
+    /// Whether the time column and the partition column must be treated as day-granular
+    /// on the append high-water-mark path, as `(time_column, time_partition_column)`.
+    ///
+    /// Resolved across the federated *and* accelerator schemas together, and handed to
+    /// both converters, so the source filter and the dedupe filter cannot disagree about
+    /// the comparison. Deciding it from each converter's own schema is not safe: a
+    /// `refresh_sql` that casts the time column — say a `Date32` source projected to
+    /// `Timestamp` in the accelerator — would widen the source to `>=` while the dedupe
+    /// stayed on `>`. The already-loaded rows would then sit outside the dedupe's
+    /// comparison set and the re-fetched rows would be appended again on *every* refresh,
+    /// turning the stall this fixes into unbounded duplication (#12492).
+    ///
+    /// Either side being day-granular is enough. Widening the dedupe side only ever adds
+    /// rows to the comparison set, so it cannot cause duplication; leaving it narrow can.
+    fn day_granular_high_water_columns(&self, refresh: &Refresh) -> (bool, bool) {
+        let schemas = [self.federated.schema(), self.accelerator.schema()];
+        let any_day_granular = |column: Option<&str>| {
+            let Some(column) = column else { return false };
+            schemas.iter().any(|schema| {
+                schema
+                    .column_with_name(column)
+                    .is_some_and(|(_, field)| is_day_granular(field.data_type()))
+            })
+        };
+
+        (
+            any_day_granular(refresh.time_column.as_deref()),
+            any_day_granular(refresh.time_partition_column.as_deref()),
+        )
     }
 
     fn build_filter_converter(
@@ -1862,13 +1917,24 @@ impl RefreshTask {
         ctx
     }
 
+    /// `high_water_mark` is the mark the source filter was built from. Pass it whenever
+    /// the caller has it: recomputing it here reads `max(time_column)` a second time, and
+    /// a write that lands on the accelerator between the two reads gives this comparison a
+    /// *higher* mark than the source query used. The rows in between are then missing from
+    /// the comparison set and are appended again — the same duplication as widening one
+    /// side without the other (#12492). `None` falls back to deriving it.
     async fn except_existing_records_from(
         &self,
         refresh: &Refresh,
         mut update: StreamingDataUpdate,
+        high_water_mark: Option<u128>,
     ) -> Result<StreamingDataUpdate, RetryError<super::Error>> {
-        let Some(value) = self.timestamp_nanos_for_append_query(refresh).await? else {
-            return Ok(update);
+        let value = match high_water_mark {
+            Some(value) => value,
+            None => match self.timestamp_nanos_for_append_query(refresh).await? {
+                Some(value) => value,
+                None => return Ok(update),
+            },
         };
         let Some(filter_converter) = self.get_accelerator_filter_converter(refresh) else {
             return Ok(update);
@@ -1876,6 +1942,10 @@ impl RefreshTask {
 
         let federated_provider = self.federated.table_provider().await;
 
+        // The high-water filter below must widen in step with the source-side filter in
+        // `get_full_or_incremental_append_update`: on a day-granular time column, if the
+        // re-fetched same-day rows are not in this comparison set they pass the dedupe and
+        // get appended a second time, turning the skip into silent duplication (#12492).
         let mut existing_records = accelerator_df(
             &Arc::clone(&self.accelerator),
             &Self::create_refresh_df_context(
@@ -1889,7 +1959,7 @@ impl RefreshTask {
         )
         .map_err(find_datafusion_root)
         .context(super::UnableToScanTableProviderSnafu)?
-        .filter(filter_converter.convert(value, Operator::Gt))
+        .filter(filter_converter.convert_high_water_mark(value))
         .map_err(find_datafusion_root)
         .context(super::UnableToScanTableProviderSnafu)?
         .collect()
@@ -2780,8 +2850,8 @@ mod tests {
     use crate::dataupdate::{StreamingDataUpdate, UpdateType};
     use crate::federated_table::FederatedTable;
     use arrow::array::{
-        Float64Array, Int32Array, Int64Array, LargeStringArray, StringArray, StringViewArray,
-        TimestampNanosecondArray, UInt32Array, UInt64Array,
+        Date32Array, Float64Array, Int32Array, Int64Array, LargeStringArray, StringArray,
+        StringViewArray, TimestampNanosecondArray, UInt32Array, UInt64Array,
     };
     use arrow::datatypes::TimeUnit;
     use arrow_schema::{DataType, Field, Schema};
@@ -3580,7 +3650,7 @@ mod tests {
         let update = StreamingDataUpdate::new(update_stream, UpdateType::Append);
 
         let result = task
-            .except_existing_records_from(&refresh, update)
+            .except_existing_records_from(&refresh, update, None)
             .await
             .expect("except_existing_records_from should succeed with column subset");
 
@@ -3701,7 +3771,7 @@ mod tests {
         let update = StreamingDataUpdate::new(update_stream, UpdateType::Append);
 
         let result = task
-            .except_existing_records_from(&refresh, update)
+            .except_existing_records_from(&refresh, update, None)
             .await
             .expect("except_existing_records_from should succeed with nullable time column");
 
@@ -3739,6 +3809,180 @@ mod tests {
             id_col.value(0),
             2,
             "remaining row after fix should be the new id=2 (NULL dup was filtered)"
+        );
+    }
+
+    /// Regression test for the schema-mismatch half of #12492.
+    ///
+    /// `refresh_sql` can project the time column to another type, so the federated and
+    /// accelerator schemas disagree about day-granularity. Resolving the comparison from
+    /// each schema separately would widen the source filter to `>=` while leaving the
+    /// dedupe on `>`: the already-loaded rows would sit outside the dedupe's comparison
+    /// set, and the re-fetched rows would be appended again on *every* refresh — the
+    /// stall turned into unbounded duplication. Both sides must come out the same.
+    #[tokio::test]
+    async fn test_high_water_comparison_agrees_across_mismatched_schemas() {
+        let source_schema = Arc::new(Schema::new(vec![
+            Field::new("day", DataType::Date32, false),
+            Field::new("id", DataType::Int32, false),
+        ]));
+
+        // What `SELECT CAST(day AS TIMESTAMP) AS day, id FROM source` materialises.
+        let ts_type = DataType::Timestamp(TimeUnit::Nanosecond, None);
+        let accelerator_schema = Arc::new(Schema::new(vec![
+            Field::new("day", ts_type, false),
+            Field::new("id", DataType::Int32, false),
+        ]));
+
+        let federated_table = Arc::new(
+            MemTable::try_new(Arc::clone(&source_schema), vec![vec![]])
+                .expect("federated mem table"),
+        ) as Arc<dyn TableProvider>;
+        let accelerator = Arc::new(
+            MemTable::try_new(Arc::clone(&accelerator_schema), vec![vec![]])
+                .expect("accelerator mem table"),
+        ) as Arc<dyn TableProvider>;
+
+        let task = RefreshTaskBuilder::new(
+            crate::status::RuntimeStatus::new(),
+            TableReference::bare("test_mismatched_schemas"),
+            Arc::new(FederatedTable::new_unchecked(federated_table)),
+            None,
+            accelerator,
+            Handle::current(),
+            Arc::new(Mutex::new(())),
+        )
+        .build();
+
+        let refresh = Refresh::new(RefreshMode::Append).time_column("day".to_string());
+
+        assert_eq!(
+            task.day_granular_high_water_columns(&refresh),
+            (true, false),
+            "a Date32 on either side must make both converters day-granular"
+        );
+
+        let source = task
+            .get_filter_converter(&refresh)
+            .expect("source converter")
+            .convert_high_water_mark(1_620_000_000_000_000_000)
+            .to_string();
+        let dedupe = task
+            .get_accelerator_filter_converter(&refresh)
+            .expect("accelerator converter")
+            .convert_high_water_mark(1_620_000_000_000_000_000)
+            .to_string();
+
+        assert_eq!(
+            source, dedupe,
+            "the source filter and the dedupe filter must compare identically"
+        );
+        assert!(
+            source.contains(">="),
+            "both sides should be inclusive, got: {source}"
+        );
+    }
+
+    /// Regression test for #12492.
+    ///
+    /// With a `Date32` time column every value casts to midnight, so the append
+    /// high-water mark for a partly-loaded day *D* is *D*-midnight and the source
+    /// filter has to be inclusive to see the rest of that day. This dedupe has to
+    /// widen in step: with a strict `>` the already-loaded rows it exists to remove
+    /// are not in the comparison set at all, so the re-fetched rows pass through and
+    /// are appended a second time.
+    #[tokio::test]
+    async fn test_except_existing_records_from_date32_time_column_dedupes_same_day() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("day", DataType::Date32, false),
+            Field::new("id", DataType::Int32, false),
+        ]));
+
+        // Day 20_000 since the epoch. Both the loaded row and the incoming rows land on
+        // it, so the accelerator's max(day) is exactly this day's midnight.
+        let day: i32 = 20_000;
+
+        let existing_batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Date32Array::from(vec![day])),
+                Arc::new(Int32Array::from(vec![1])),
+            ],
+        )
+        .expect("existing batch");
+        let accelerator = Arc::new(
+            MemTable::try_new(Arc::clone(&schema), vec![vec![existing_batch]])
+                .expect("accelerator mem table"),
+        ) as Arc<dyn TableProvider>;
+
+        let federated_table = Arc::new(
+            MemTable::try_new(Arc::clone(&schema), vec![vec![]]).expect("federated mem table"),
+        ) as Arc<dyn TableProvider>;
+        let federated = Arc::new(FederatedTable::new_unchecked(Arc::clone(&federated_table)));
+
+        let task = RefreshTaskBuilder::new(
+            crate::status::RuntimeStatus::new(),
+            TableReference::bare("test_date32_append"),
+            federated,
+            None,
+            Arc::clone(&accelerator),
+            Handle::current(),
+            Arc::new(Mutex::new(())),
+        )
+        .build();
+
+        // No `append_overlap`: the overlap would push the high-water mark below midnight
+        // and mask the defect this test covers. `TimeFormat::Date` is what the runtime
+        // requires for a Date32 time column.
+        let refresh = Refresh::new(RefreshMode::Append)
+            .time_column("day".to_string())
+            .time_format(TimeFormat::Date);
+
+        // What the inclusive source filter returns for day D: the row already loaded
+        // into the accelerator, plus a genuinely new row for the same day.
+        let update_batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Date32Array::from(vec![day, day])),
+                Arc::new(Int32Array::from(vec![1, 2])),
+            ],
+        )
+        .expect("update batch");
+        let update_stream: SendableRecordBatchStream = Box::pin(
+            MemoryStream::try_new(vec![update_batch], Arc::clone(&schema), None)
+                .expect("update stream"),
+        );
+        let update = StreamingDataUpdate::new(update_stream, UpdateType::Append);
+
+        let collected = task
+            .except_existing_records_from(&refresh, update, None)
+            .await
+            .expect("except_existing_records_from should succeed for a Date32 time column")
+            .collect_data()
+            .await
+            .expect("collecting the deduped data should succeed");
+
+        let total_rows: usize = collected.data.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(
+            total_rows, 1,
+            "the already-loaded same-day row must be deduped, not appended again; \
+             a strict high-water comparison leaves the comparison set empty and lets both rows through"
+        );
+
+        let batch = collected
+            .data
+            .iter()
+            .find(|batch| batch.num_rows() > 0)
+            .expect("a non-empty batch should remain");
+        let id_col = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("id column should be Int32");
+        assert_eq!(
+            id_col.value(0),
+            2,
+            "the surviving row should be the new same-day row (id=2)"
         );
     }
 }

--- a/crates/runtime/src/accelerated_table/refresh_task.rs
+++ b/crates/runtime/src/accelerated_table/refresh_task.rs
@@ -3822,33 +3822,27 @@ mod tests {
     /// stall turned into unbounded duplication. Both sides must come out the same.
     #[tokio::test]
     async fn test_high_water_comparison_agrees_across_mismatched_schemas() {
-        let source_schema = Arc::new(Schema::new(vec![
+        let src = Arc::new(Schema::new(vec![
             Field::new("day", DataType::Date32, false),
             Field::new("id", DataType::Int32, false),
         ]));
 
         // What `SELECT CAST(day AS TIMESTAMP) AS day, id FROM source` materialises.
         let ts_type = DataType::Timestamp(TimeUnit::Nanosecond, None);
-        let accelerator_schema = Arc::new(Schema::new(vec![
+        let acc = Arc::new(Schema::new(vec![
             Field::new("day", ts_type, false),
             Field::new("id", DataType::Int32, false),
         ]));
 
-        let federated_table = Arc::new(
-            MemTable::try_new(Arc::clone(&source_schema), vec![vec![]])
-                .expect("federated mem table"),
-        ) as Arc<dyn TableProvider>;
-        let accelerator = Arc::new(
-            MemTable::try_new(Arc::clone(&accelerator_schema), vec![vec![]])
-                .expect("accelerator mem table"),
-        ) as Arc<dyn TableProvider>;
+        let federated = MemTable::try_new(Arc::clone(&src), vec![vec![]]).expect("src table");
+        let accelerator = MemTable::try_new(Arc::clone(&acc), vec![vec![]]).expect("acc table");
 
         let task = RefreshTaskBuilder::new(
             crate::status::RuntimeStatus::new(),
             TableReference::bare("test_mismatched_schemas"),
-            Arc::new(FederatedTable::new_unchecked(federated_table)),
+            Arc::new(FederatedTable::new_unchecked(Arc::new(federated))),
             None,
-            accelerator,
+            Arc::new(accelerator),
             Handle::current(),
             Arc::new(Mutex::new(())),
         )

--- a/crates/runtime/src/datafusion/filter_converter.rs
+++ b/crates/runtime/src/datafusion/filter_converter.rs
@@ -47,6 +47,12 @@ pub(crate) fn create_timestamp_filter_convert(
         data_type_to_timestamp_format(f.data_type(), partition_scale)
     });
 
+    // Day-granularity is deliberately NOT resolved here. It governs the append
+    // high-water comparison, whose two sides are filtered through two different
+    // converters (source schema and accelerator schema); deciding it from one schema
+    // at a time lets those two disagree and re-append the same rows every refresh.
+    // The caller resolves it across both schemas and applies
+    // `with_day_granular_columns` — see `RefreshTask::day_granular_high_water_columns`.
     Some(TimestampFilterConvert::new(
         time_column,
         format,
@@ -196,6 +202,33 @@ mod test {
         assert_eq!(
             result.to_string(),
             r#"CAST(timestamp AS Timestamp(ns, "UTC")) > TimestampNanosecond(1620000000000000000, Some("UTC"))"#
+        );
+    }
+
+    /// This factory deliberately does not resolve day-granularity: the append
+    /// high-water comparison is filtered through two converters (source schema and
+    /// accelerator schema) that must agree, so the caller resolves it across both and
+    /// applies `with_day_granular_columns`. A converter straight out of here must
+    /// therefore compare strictly, even for a `Date32` column — otherwise a caller that
+    /// forgot to resolve it would silently get half of the #12492 fix, which is the
+    /// duplication case rather than the stall.
+    #[test]
+    fn test_factory_leaves_the_high_water_comparison_strict() {
+        let converter = create_timestamp_filter_convert(
+            Some(Field::new("ts", DataType::Date32, false)),
+            Some("ts".to_string()),
+            Some(TimeFormat::Date),
+            None,
+            None,
+            None,
+        )
+        .expect("converter should be created");
+
+        assert_eq!(
+            converter
+                .convert_high_water_mark(1_620_000_000_000_000_000)
+                .to_string(),
+            "CAST(ts AS Timestamp(ns)) > TimestampNanosecond(1620000000000000000, None)",
         );
     }
 

--- a/crates/util/src/timestamp_filter.rs
+++ b/crates/util/src/timestamp_filter.rs
@@ -299,10 +299,15 @@ const NANOS_PER_DAY: i64 = 86_400_000_000_000;
 /// (`1969-12-31T23:00Z` floors to some instant late on the 30th), and the day's own
 /// partition would then fail its predicate. `rem_euclid` is never negative, so
 /// subtracting it always rounds toward negative infinity.
+/// `saturating_sub` because the plain subtraction underflows near `i64::MIN`: `rem_euclid`
+/// is non-negative, so subtracting it from a mark within one day of the floor of the range
+/// would panic in debug and wrap in release. Saturating clamps the bound to `i64::MIN`,
+/// which for an inclusive `>=` comparison simply admits everything — safe, and the mark
+/// would have to sit before 1678 to get there at all.
 #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn floor_to_day(timestamp_in_nanos: u128) -> u128 {
     let signed = timestamp_in_nanos as i64;
-    (signed - signed.rem_euclid(NANOS_PER_DAY)) as u128
+    signed.saturating_sub(signed.rem_euclid(NANOS_PER_DAY)) as u128
 }
 
 /// The comparison a high-water mark implies for one column.
@@ -660,6 +665,25 @@ mod tests {
         assert_eq!(
             converter.convert_high_water_mark(mark).to_string(),
             "CAST(ts AS Timestamp(ns)) >= TimestampNanosecond(-86400000000000, None)",
+        );
+    }
+
+    #[test]
+    fn test_high_water_mark_floors_an_extreme_negative_mark_without_underflowing() {
+        // The two's-complement wrap of i64::MIN, written without a signed cast: the floor of
+        // a mark this low is less than i64::MIN, so subtracting the remainder outright would
+        // panic in debug and wrap in release. It saturates instead, and an inclusive bound at
+        // the bottom of the range simply admits every row.
+        let mark = u128::MAX - (1u128 << 63) + 1;
+
+        let format =
+            data_type_to_timestamp_format(&DataType::Date32, None).expect("format resolves");
+        let converter = TimestampFilterConvert::new("ts".to_string(), format, None, None)
+            .with_day_granular_columns(true, false);
+
+        assert_eq!(
+            converter.convert_high_water_mark(mark).to_string(),
+            "CAST(ts AS Timestamp(ns)) >= TimestampNanosecond(-9223372036854775808, None)",
         );
     }
 

--- a/crates/util/src/timestamp_filter.rs
+++ b/crates/util/src/timestamp_filter.rs
@@ -93,6 +93,20 @@ fn convert_timestamp_expr(
     }
 }
 
+/// Whether an Arrow `DataType` can only represent whole days.
+///
+/// `Date32` counts days since the epoch, and Arrow requires every `Date64` value to
+/// be an exact multiple of `86_400_000` ms, so both cast to midnight. A value read out
+/// of such a column therefore carries no information about the time of day.
+///
+/// This is deliberately keyed on the `DataType` rather than on [`TimestampFormat`]:
+/// `Date64` shares the [`TimestampFormat::Timestamp`] arm with `Time32`/`Time64`,
+/// which are legitimately sub-day.
+#[must_use]
+pub fn is_day_granular(data_type: &DataType) -> bool {
+    matches!(data_type, DataType::Date32 | DataType::Date64)
+}
+
 /// Derive a [`TimestampFormat`] from an Arrow `DataType`.
 ///
 /// `unix_timestamp_scale` is used only for integer/float columns:
@@ -147,6 +161,12 @@ pub struct TimestampFilterConvert {
     /// but is used for partitioning.
     time_partition_column: Option<String>,
     time_partition_format: Option<TimestampFormat>,
+
+    /// Whether `time_column`'s Arrow type is day-granular ([`is_day_granular`]).
+    /// Only consulted by [`TimestampFilterConvert::convert_high_water_mark`].
+    time_is_day_granular: bool,
+    /// Whether `time_partition_column`'s Arrow type is day-granular.
+    time_partition_is_day_granular: bool,
 }
 
 impl TimestampFilterConvert {
@@ -166,7 +186,34 @@ impl TimestampFilterConvert {
             time_format,
             time_partition_column,
             time_partition_format,
+            time_is_day_granular: false,
+            time_partition_is_day_granular: false,
         }
+    }
+
+    /// Record whether each column's Arrow type is day-granular, as reported by
+    /// [`is_day_granular`].
+    ///
+    /// Both default to `false`, which keeps
+    /// [`convert_high_water_mark`](TimestampFilterConvert::convert_high_water_mark)
+    /// on strict `>` for every column; set them whenever the source Arrow
+    /// `DataType`s are available.
+    ///
+    /// When two converters are used against the two sides of one high-water
+    /// comparison — a source filter and a dedupe filter — they must be given the
+    /// *same* flags. Deriving them separately from each side's own schema lets the
+    /// two disagree, which widens one side only: the already-loaded rows then fall
+    /// outside the dedupe's comparison set and the re-fetched rows are appended
+    /// again on every refresh.
+    #[must_use]
+    pub fn with_day_granular_columns(
+        mut self,
+        time_is_day_granular: bool,
+        time_partition_is_day_granular: bool,
+    ) -> Self {
+        self.time_is_day_granular = time_is_day_granular;
+        self.time_partition_is_day_granular = time_partition_is_day_granular;
+        self
     }
 
     /// Build a filter expression for the given timestamp (in nanoseconds).
@@ -175,19 +222,104 @@ impl TimestampFilterConvert {
     /// `time_expr AND partition_expr`.
     #[must_use]
     pub fn convert(&self, timestamp_in_nanos: u128, op: Operator) -> Expr {
-        let time_expr =
-            convert_timestamp_expr(timestamp_in_nanos, &self.time_column, &self.time_format, op);
+        let bound = Bound {
+            timestamp_in_nanos,
+            op,
+        };
+        self.convert_with_bounds(bound, bound)
+    }
+
+    /// Build a filter expression selecting rows *after* an append high-water mark
+    /// that was itself read out of one of these columns.
+    ///
+    /// A day-granular column (`Date32`/`Date64`) is compared inclusively against the
+    /// **start of the mark's day**. Every one of its values casts to midnight, so
+    /// once any row of day *D* is loaded the mark is *D*-midnight and a strict `>`
+    /// excludes every other row of day *D* — they are skipped on each later refresh
+    /// and lost for good once the source advances past *D*. Callers must pair this
+    /// with an exact-row dedupe against the already-loaded rows, widened the same
+    /// way, so the rows that come back are dropped instead of appended twice.
+    ///
+    /// Flooring to the day is what makes a day-granular *partition* column work when
+    /// the time column itself is sub-day: the mark then carries a time of day, and
+    /// `CAST(day AS Timestamp) >= <midday>` is false for the very partition the new
+    /// rows live in. Flooring is a no-op when the mark came from a day-granular
+    /// column, since it is already midnight.
+    ///
+    /// Sub-day columns (`Time32`, `Time64`, `Timestamp`) keep the strict `>` against
+    /// the exact mark: they carry the precision that makes it correct.
+    #[must_use]
+    pub fn convert_high_water_mark(&self, timestamp_in_nanos: u128) -> Expr {
+        self.convert_with_bounds(
+            high_water_mark_bound(timestamp_in_nanos, self.time_is_day_granular),
+            high_water_mark_bound(timestamp_in_nanos, self.time_partition_is_day_granular),
+        )
+    }
+
+    /// Build the filter expression, applying a separate comparison to the time column
+    /// and to the partition column.
+    fn convert_with_bounds(&self, time: Bound, time_partition: Bound) -> Expr {
+        let time_expr = convert_timestamp_expr(
+            time.timestamp_in_nanos,
+            &self.time_column,
+            &self.time_format,
+            time.op,
+        );
         match (&self.time_partition_column, &self.time_partition_format) {
             (Some(time_partition_column), Some(time_partition_format)) => {
                 let time_partition_expr = convert_timestamp_expr(
-                    timestamp_in_nanos,
+                    time_partition.timestamp_in_nanos,
                     time_partition_column,
                     time_partition_format,
-                    op,
+                    time_partition.op,
                 );
                 and(time_expr, time_partition_expr)
             }
             _ => time_expr,
+        }
+    }
+}
+
+/// One column's half of a filter: the literal to compare against, and the operator.
+#[derive(Clone, Copy)]
+struct Bound {
+    timestamp_in_nanos: u128,
+    op: Operator,
+}
+
+/// Nanoseconds in a UTC day. Arrow dates carry no leap seconds, so this is exact.
+const NANOS_PER_DAY: i64 = 86_400_000_000_000;
+
+/// Round a mark down to midnight UTC of its own day.
+///
+/// Done in **signed** space. A mark taken from an Arrow timestamp arrives here as
+/// `i64 as u128`, so a pre-1970 value is a wrapped two's-complement number — it is only
+/// meaningful again after the `as i64` that builds the literal. Flooring the wrapped
+/// value with an unsigned modulo would produce a bound unrelated to the mark's day
+/// (`1969-12-31T23:00Z` floors to some instant late on the 30th), and the day's own
+/// partition would then fail its predicate. `rem_euclid` is never negative, so
+/// subtracting it always rounds toward negative infinity.
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn floor_to_day(timestamp_in_nanos: u128) -> u128 {
+    let signed = timestamp_in_nanos as i64;
+    (signed - signed.rem_euclid(NANOS_PER_DAY)) as u128
+}
+
+/// The comparison a high-water mark implies for one column.
+///
+/// Day-granular columns compare `>=` against midnight of the mark's day; everything
+/// else compares `>` against the mark itself. See
+/// [`convert_high_water_mark`](TimestampFilterConvert::convert_high_water_mark).
+fn high_water_mark_bound(timestamp_in_nanos: u128, is_day_granular: bool) -> Bound {
+    if is_day_granular {
+        Bound {
+            timestamp_in_nanos: floor_to_day(timestamp_in_nanos),
+            op: Operator::GtEq,
+        }
+    } else {
+        Bound {
+            timestamp_in_nanos,
+            op: Operator::Gt,
         }
     }
 }
@@ -391,6 +523,184 @@ mod tests {
         assert_eq!(
             result.to_string(),
             "timestamp > UInt64(1620000000000) AND CAST(partition_ts AS Timestamp(ns)) > TimestampNanosecond(1620000000000000000, None)",
+        );
+    }
+
+    /// 2021-05-03T00:00:00Z, the instant the other tests in this module use.
+    const TS_NANOS: u128 = 1_620_000_000_000_000_000;
+    /// 2021-05-03T12:00:00Z — the same day, but with a time of day.
+    const TS_MIDDAY_NANOS: u128 = 1_620_043_200_000_000_000;
+    /// Expected high-water-mark filter for a day-granular column named `ts`.
+    const TS_INCLUSIVE: &str =
+        "CAST(ts AS Timestamp(ns)) >= TimestampNanosecond(1620000000000000000, None)";
+    /// Expected high-water-mark filter for a sub-day column named `ts`.
+    const TS_STRICT: &str =
+        "CAST(ts AS Timestamp(ns)) > TimestampNanosecond(1620000000000000000, None)";
+
+    /// Build the high-water-mark filter for a single column of `data_type`.
+    fn high_water_mark_expr(data_type: &DataType) -> String {
+        let format = data_type_to_timestamp_format(data_type, None).expect("format resolves");
+        let converter = TimestampFilterConvert::new("ts".to_string(), format, None, None)
+            .with_day_granular_columns(is_day_granular(data_type), false);
+        converter.convert_high_water_mark(TS_NANOS).to_string()
+    }
+
+    #[test]
+    fn test_is_day_granular() {
+        assert!(is_day_granular(&DataType::Date32));
+        // Arrow requires Date64 values to be exact multiples of 86_400_000ms, so it is
+        // day-granular too — even though it shares a TimestampFormat with Time32/Time64.
+        assert!(is_day_granular(&DataType::Date64));
+
+        assert!(!is_day_granular(&DataType::Time32(TimeUnit::Second)));
+        assert!(!is_day_granular(&DataType::Time64(TimeUnit::Nanosecond)));
+        assert!(!is_day_granular(&DataType::Utf8));
+        assert!(!is_day_granular(&DataType::Int64));
+
+        let timestamp = DataType::Timestamp(TimeUnit::Nanosecond, None);
+        assert!(!is_day_granular(&timestamp));
+    }
+
+    #[test]
+    fn test_high_water_mark_is_inclusive_for_day_granular_types() {
+        // Every value casts to midnight, so a strict `>` against a high-water mark drawn
+        // from day D skips every other row of day D, permanently (#12492).
+        assert_eq!(high_water_mark_expr(&DataType::Date32), TS_INCLUSIVE);
+        assert_eq!(high_water_mark_expr(&DataType::Date64), TS_INCLUSIVE);
+    }
+
+    #[test]
+    fn test_high_water_mark_stays_strict_for_sub_day_types() {
+        // Time32/Time64 share TimestampFormat::Timestamp with Date64 but carry sub-day
+        // precision, so widening them would re-read rows that are already loaded.
+        let time32 = DataType::Time32(TimeUnit::Second);
+        let time64 = DataType::Time64(TimeUnit::Nanosecond);
+        let timestamp = DataType::Timestamp(TimeUnit::Nanosecond, None);
+
+        assert_eq!(high_water_mark_expr(&time32), TS_STRICT);
+        assert_eq!(high_water_mark_expr(&time64), TS_STRICT);
+        assert_eq!(high_water_mark_expr(&timestamp), TS_STRICT);
+        assert_eq!(
+            high_water_mark_expr(&DataType::Utf8),
+            r#"ts > Utf8("2021-05-03T00:00:00.000000000")"#,
+        );
+    }
+
+    #[test]
+    fn test_high_water_mark_defaults_to_strict() {
+        // Without day-granularity information the converter keeps the old behaviour.
+        let format = data_type_to_timestamp_format(&DataType::Date32, None).expect("resolves");
+        let converter = TimestampFilterConvert::new("ts".to_string(), format, None, None);
+        assert_eq!(
+            converter.convert_high_water_mark(TS_NANOS).to_string(),
+            TS_STRICT,
+        );
+    }
+
+    /// Build a converter for a sub-day `ts` column partitioned by a day-granular `day`.
+    fn sub_day_time_with_day_partition() -> TimestampFilterConvert {
+        let time_type = DataType::Timestamp(TimeUnit::Nanosecond, None);
+        let time_format =
+            data_type_to_timestamp_format(&time_type, None).expect("time format resolves");
+        let partition_format = data_type_to_timestamp_format(&DataType::Date32, None)
+            .expect("partition format resolves");
+
+        TimestampFilterConvert::new(
+            "ts".to_string(),
+            time_format,
+            Some("day".to_string()),
+            Some(partition_format),
+        )
+        .with_day_granular_columns(false, true)
+    }
+
+    #[test]
+    fn test_high_water_mark_widens_a_day_partition_independently() {
+        // A sub-day time column partitioned by day: the partition predicate is ANDed on,
+        // so leaving it strict would exclude the whole current-day partition and stall
+        // the append just as surely as a day-granular time column would.
+        assert_eq!(
+            sub_day_time_with_day_partition()
+                .convert_high_water_mark(TS_NANOS)
+                .to_string(),
+            "CAST(ts AS Timestamp(ns)) > TimestampNanosecond(1620000000000000000, None) AND CAST(day AS Timestamp(ns)) >= TimestampNanosecond(1620000000000000000, None)",
+        );
+    }
+
+    #[test]
+    fn test_high_water_mark_floors_a_day_partition_to_midnight() {
+        // The regression `>=` alone does not fix: with a sub-day time column the mark
+        // carries a time of day, and every `day` value casts to midnight — so
+        // `CAST(day) >= <midday>` is false for the partition the new rows are in and the
+        // whole current day stays excluded. The partition literal has to be floored to
+        // the start of the mark's day. Not `>=` at midday: 2021-05-03T12:00Z.
+        assert_eq!(
+            sub_day_time_with_day_partition()
+                .convert_high_water_mark(TS_MIDDAY_NANOS)
+                .to_string(),
+            "CAST(ts AS Timestamp(ns)) > TimestampNanosecond(1620043200000000000, None) AND CAST(day AS Timestamp(ns)) >= TimestampNanosecond(1620000000000000000, None)",
+        );
+    }
+
+    #[test]
+    fn test_high_water_mark_floors_a_pre_1970_mark_in_signed_space() {
+        // 1969-12-31T23:00:00Z as the runtime delivers it: the mark is an `i64` epoch
+        // value widened with `as u128`, so a negative one arrives two's-complement
+        // wrapped and only means anything again after the `as i64` that builds the
+        // literal. Flooring the wrapped value with an unsigned modulo would land on an
+        // unrelated instant, and the mark's own day would fail its partition predicate.
+        let mark = u128::MAX - 3_600_000_000_000 + 1;
+
+        let format =
+            data_type_to_timestamp_format(&DataType::Date32, None).expect("format resolves");
+        let converter = TimestampFilterConvert::new("ts".to_string(), format, None, None)
+            .with_day_granular_columns(true, false);
+
+        // Midnight on 1969-12-31 — not some instant on the 30th.
+        assert_eq!(
+            converter.convert_high_water_mark(mark).to_string(),
+            "CAST(ts AS Timestamp(ns)) >= TimestampNanosecond(-86400000000000, None)",
+        );
+    }
+
+    #[test]
+    fn test_high_water_mark_floors_a_day_granular_time_column_too() {
+        // A day-granular time column's own mark is already midnight, so flooring is
+        // normally a no-op — except with `append_overlap`, which subtracts a duration and
+        // can leave the mark mid-day. Flooring keeps the comparison on a day boundary
+        // there rather than excluding the day the mark now falls inside.
+        let format =
+            data_type_to_timestamp_format(&DataType::Date32, None).expect("format resolves");
+        let converter = TimestampFilterConvert::new("ts".to_string(), format, None, None)
+            .with_day_granular_columns(true, false);
+
+        assert_eq!(
+            converter
+                .convert_high_water_mark(TS_MIDDAY_NANOS)
+                .to_string(),
+            TS_INCLUSIVE,
+        );
+    }
+
+    #[test]
+    fn test_convert_still_applies_one_operator_to_every_column() {
+        // `convert` also builds the wall-clock refresh_data_window filter, which must
+        // keep taking its operator verbatim.
+        let time_format = data_type_to_timestamp_format(&DataType::Date32, None)
+            .expect("time format resolves");
+        let partition_format = data_type_to_timestamp_format(&DataType::Date32, None)
+            .expect("partition format resolves");
+        let converter = TimestampFilterConvert::new(
+            "ts".to_string(),
+            time_format,
+            Some("day".to_string()),
+            Some(partition_format),
+        )
+        .with_day_granular_columns(true, true);
+
+        assert_eq!(
+            converter.convert(TS_NANOS, Operator::Gt).to_string(),
+            "CAST(ts AS Timestamp(ns)) > TimestampNanosecond(1620000000000000000, None) AND CAST(day AS Timestamp(ns)) > TimestampNanosecond(1620000000000000000, None)",
         );
     }
 

--- a/crates/util/src/timestamp_filter.rs
+++ b/crates/util/src/timestamp_filter.rs
@@ -686,8 +686,8 @@ mod tests {
     fn test_convert_still_applies_one_operator_to_every_column() {
         // `convert` also builds the wall-clock refresh_data_window filter, which must
         // keep taking its operator verbatim.
-        let time_format = data_type_to_timestamp_format(&DataType::Date32, None)
-            .expect("time format resolves");
+        let time_format =
+            data_type_to_timestamp_format(&DataType::Date32, None).expect("time format resolves");
         let partition_format = data_type_to_timestamp_format(&DataType::Date32, None)
             .expect("partition format resolves");
         let converter = TimestampFilterConvert::new(


### PR DESCRIPTION
## Summary

`refresh_mode: append` silently loses data on any dataset whose `time_column` is a day-granular Arrow type. Rows arriving for the latest already-loaded day are never picked up, and are gone for good once the source advances to the next day.

**Root cause.** The append high-water mark is read back out of the *accelerator* — `timestamp_nanos_for_append_query` takes `max(time_column)` via `max_timestamp_df`, which `CAST`s to `Timestamp(ns)` — and the *source* is then filtered strictly greater than it. Every `Date32` value casts to **midnight**, so once any row of day *D* is loaded the mark is *D*-midnight, and every other row of day *D* casts to that same instant. `> D-midnight` excludes all of them, on that refresh and on every one after it.

The fix compares inclusively on a day-granular column and lets the existing exact-row dedupe in `except_existing_records_from` drop the rows that come back.

**Both high-water sites move together.** The dedupe builds its own comparison set with the same filter (`refresh_task.rs`, the `.filter(...)` in `except_existing_records_from`). Widening only the source side would leave the already-loaded same-day rows out of that set, so the re-fetched rows would pass the dedupe and be **appended a second time** — a stall turned into silent duplication, which is worse than the bug. Both are widened in this commit; a comment at each site points at the other.

The third `Gt` in that file is the `refresh_data_window` wall-clock window, not a high-water mark, and is deliberately left strict — it still goes through the unchanged `convert()`.

## Changes

- `crates/util/src/timestamp_filter.rs`
  - `is_day_granular(&DataType)` — `Date32 | Date64`.
  - `TimestampFilterConvert::convert_high_water_mark(ts)` — a day-granular column compares `>=` against **midnight of the mark's day**; everything else keeps `>` against the exact mark. Resolved **per column**, so the time column and `time_partition_column` each get their own literal and operator (`Bound`).
  - `with_day_granular_columns(bool, bool)`; both default `false`, so a converter built without this information keeps today's strict behaviour.
- `crates/runtime/src/datafusion/filter_converter.rs` — deliberately does *not* resolve day-granularity (see below).
- `crates/runtime/src/accelerated_table/refresh_task.rs` — `day_granular_high_water_columns` resolves it once across both schemas; both high-water-mark sites call `convert_high_water_mark`.

### Keyed on the Arrow type, not on `TimestampFormat`

`data_type_to_timestamp_format` maps only `Date32` to `TimestampFormat::Date`; `Date64` shares the `Timestamp` arm with `Time32`/`Time64`. Widening that arm would loosen two types that are legitimately sub-day, so the decision is made from the `DataType` and threaded to the call sites.

### One decision point, across both schemas

The source filter is built from the federated schema and the dedupe filter from the accelerator schema. Resolving day-granularity inside `create_timestamp_filter_convert` — i.e. per schema — is **not** safe: a `refresh_sql` that casts the time column (`Date32` source projected to `Timestamp` in the accelerator) would widen the source to `>=` while the dedupe stayed on `>`. The already-loaded rows would then sit outside the dedupe's comparison set and the re-fetched rows would be appended again on *every* refresh — the stall turned into unbounded duplication, which is worse than the bug.

So the factory returns a strict converter, and `RefreshTask::day_granular_high_water_columns` resolves the flags once by OR-ing `is_day_granular` across the federated *and* accelerator schemas, handing the same answer to both converters. Either side being day-granular is enough: widening the dedupe side only ever *adds* rows to the comparison set, so it cannot cause duplication, whereas leaving it narrow can.

### The partition predicate is floored, not just widened

`>=` alone does not fix a day-granular `time_partition_column`. The partition predicate is ANDed onto the time predicate, and with a sub-day time column the mark carries a time of day — so `CAST(day AS Timestamp) >= <midday>` is false for the very partition the new rows are in, and the current day stays excluded. The literal has to be floored to the start of the mark's day.

Flooring can never exclude a row the time predicate admits: a partition column tracks its time column, so `day = floor_to_day(ts)`, and `ts > mark` implies `day >= floor_to_day(mark)`. It is a no-op when the mark came from a day-granular column, since that mark is already midnight.

### `Date64` is defensive, not a live path

`validate_time_format` (`crates/runtime/src/accelerated_table/refresh.rs`) rejects a `Date64` time column for *every* `TimeFormat`, and requires `TimeFormat::Date` for `Date32`. So today only `Date32` can actually reach the append path and stall; the `Date64` handling is there so the behaviour is already correct if that validation is ever relaxed, and so the rule reads off the Arrow type rather than off a format that cannot express it.

## Performance impact

Both queries now re-read the latest already-loaded day instead of nothing on a day-granular time column — one extra day of source rows fetched and one extra day of accelerator rows materialised into the dedupe comparison set, per refresh. That is the minimum needed to see the day's new rows at all, and it applies **only** to `Date32`/`Date64` time or partition columns; every sub-day type is bit-for-bit unchanged (same operator, same expression). Datasets with a very large single day and no `append_overlap` pay the most, and can bound it as they can today by using a sub-day `time_column`.

## `append_overlap` interaction

`append_overlap` subtracts its duration from the mark, which is why it already worked around this bug: the mark lands before midnight *D*, so even a strict `>` sees day *D*. A dataset with no `append_overlap` — the default — is the one that stalls. With flooring, a day-granular column's window is quantised to the day boundary, so an overlap smaller than a day now re-reads the whole boundary day. That is extra work absorbed by the dedupe, not a correctness change.

## Known limitations — filed as #12499

The dedupe this fix leans on has two defects of its own, and both are pre-existing: `filter_records` is *set* subtraction rather than multiset subtraction (a legitimately duplicated row is dropped), and its comparison set is collected in full and compared row-by-row (an unbounded-memory window on a high-volume dataset). Both already apply to any dataset with a nonzero `append_overlap`, which is what makes the comparison set non-empty today.

This PR does make that path unconditional for a `Date32` time column, where the comparison set was previously empty — which is precisely the bug. The trade is deliberate and strictly less lossy: losing exact duplicates of already-loaded rows, instead of losing *every* row of the latest day. Fixing the dedupe design properly (counted multiset subtraction, or keyed dedupe) is #12499 and is a different change from the comparison operator.

## Test plan

- `make lint`
- `make test`
- New unit tests in `crates/util/src/timestamp_filter.rs`: `Date32`/`Date64` compare inclusively; `Time32`/`Time64`/`Timestamp`/`Utf8` stay strict; a converter without day-granularity information stays strict; a day partition of a sub-day time column widens independently **and is floored when the mark is at midday**; a day-granular time column is floored too; `convert()` still applies one operator and the unfloored literal to every column (the `refresh_data_window` contract).
- New unit test in `crates/runtime/src/datafusion/filter_converter.rs`: a converter straight out of the factory compares *strictly* even for `Date32`, so a caller that skips resolving day-granularity cannot silently get half the fix.
- New regression test in `crates/runtime/src/accelerated_table/refresh_task.rs`: `test_except_existing_records_from_date32_time_column_dedupes_same_day` loads one row for day *D*, feeds back that row plus a new same-day row, and asserts exactly one row survives and it is the new one. On the pre-change code the comparison set is empty, both rows survive, and the assertion fails — the duplication half of the bug.
- New regression test `test_high_water_comparison_agrees_across_mismatched_schemas`: a `Date32` federated column against a `Timestamp` accelerator column, asserting both converters render the *same* inclusive expression.

## Checklist

- [x] Both high-water-mark `Gt` sites widened in the same commit
- [x] The comparison resolved once, so the two sides cannot disagree
- [x] Day-granular partition literal floored to the day (correct off-midnight, not just at midnight)
- [x] `refresh_data_window` left on strict `Gt` with an unfloored literal
- [x] Sub-day types unchanged
- [x] Regression tests fail on the old code
- [x] Deferred dedupe defects filed as #12499 and documented above
- [ ] `make signoff` green / `Attestation` re-run

Fixes #12492
