### PR TITLE
fix(cli): treat a blank --api-key as no key at all (fixes #12498)

### DIFF
--- a/bin/spice/src/context.rs
+++ b/bin/spice/src/context.rs
@@ -33,6 +33,16 @@ const SPICED_FILENAME: &str = "spiced";
 const SPICEPODS_DIR: &str = "spicepods";
 const WSL_ENV_KEYS: [&str; 2] = ["WSL_DISTRO_NAME", "WSL_INTEROP"];
 
+/// Treat a blank credential as absent.
+///
+/// A credential that is empty or whitespace-only cannot authenticate anything, so
+/// carrying it as `Some` only means an empty header goes out on the wire and any
+/// fallback that keys off `is_none` is suppressed. The value is otherwise kept
+/// verbatim -- only the all-blank case is discarded.
+fn normalize_credential(value: Option<String>) -> Option<String> {
+    value.filter(|key| !key.trim().is_empty())
+}
+
 /// Runtime context holding paths and configuration for CLI operations.
 #[derive(Debug, Clone)]
 pub struct RuntimeContext {
@@ -127,7 +137,7 @@ impl RuntimeContext {
             ctx.cloud_region = Some(region.to_string());
         }
 
-        ctx.api_key = api_key;
+        ctx.api_key = normalize_credential(api_key);
         ctx.tls_root_certificate_file = tls_root_certificate_file;
 
         // Load API key from .env if not provided
@@ -148,8 +158,26 @@ impl RuntimeContext {
         )
     }
 
-    /// Load API key from .env or .env.local file.
+    /// Load API key from the environment or a .env / .env.local file.
+    ///
+    /// `SPICE_API_KEY` is checked before the files because `--api-key` is declared
+    /// with `env = "SPICE_API_KEY"`: clap resolves that variable itself whenever the
+    /// flag is omitted, so consulting it first here is what makes a blank
+    /// `--api-key` resolve to the same key that omitting the flag would.
     fn load_api_key_from_env(&self) -> Option<String> {
+        normalize_credential(std::env::var("SPICE_API_KEY").ok())
+            .or_else(|| self.load_api_key_from_env_files())
+            .or_else(|| normalize_credential(std::env::var("SPICE_SPICEAI_API_KEY").ok()))
+    }
+
+    /// Load API key from the app's .env.local or .env file.
+    ///
+    /// The first matching entry wins, exactly as before -- .env.local outranks .env,
+    /// and within a file the earlier line wins. A blank value is authoritative but is
+    /// never a credential: `spice login` writes `SPICE_SPICEAI_API_KEY=` for an app
+    /// that has no key, so a blank resolves to `None` rather than falling through to
+    /// an older key in a lower-precedence file.
+    fn load_api_key_from_env_files(&self) -> Option<String> {
         // Try .env.local first, then .env
         let env_files = [".env.local", ".env"];
 
@@ -160,16 +188,13 @@ impl RuntimeContext {
             {
                 for item in env_map.flatten() {
                     if item.0 == "SPICE_SPICEAI_API_KEY" || item.0 == "SPICE_API_KEY" {
-                        return Some(item.1);
+                        return normalize_credential(Some(item.1));
                     }
                 }
             }
         }
 
-        // Also check environment variables
-        std::env::var("SPICE_API_KEY")
-            .or_else(|_| std::env::var("SPICE_SPICEAI_API_KEY"))
-            .ok()
+        None
     }
 
     /// Get the Spice runtime directory (~/.spice).
@@ -892,6 +917,107 @@ mod tests {
             .expect("with_args should succeed");
 
         assert_eq!(ctx.api_key(), Some("test-key"));
+    }
+
+    #[test]
+    fn test_normalize_credential_discards_blank_values() {
+        assert_eq!(normalize_credential(None), None);
+        assert_eq!(normalize_credential(Some(String::new())), None);
+        assert_eq!(normalize_credential(Some("   ".to_string())), None);
+        assert_eq!(normalize_credential(Some("\t\r\n".to_string())), None);
+    }
+
+    #[test]
+    fn test_normalize_credential_keeps_a_real_key_verbatim() {
+        assert_eq!(
+            normalize_credential(Some("real-key".to_string())),
+            Some("real-key".to_string())
+        );
+        // Surrounding whitespace decides only whether the value is blank; a key that
+        // has any content is passed through exactly as supplied.
+        assert_eq!(
+            normalize_credential(Some(" real-key ".to_string())),
+            Some(" real-key ".to_string())
+        );
+    }
+
+    #[test]
+    fn test_with_args_treats_an_empty_api_key_as_absent() {
+        // Regression: `--api-key ""` used to be carried as Some("") -- it suppressed the
+        // .env fallback and every authenticated request went out with a blank credential.
+        // The resolved key may legitimately come from the environment here, so what is
+        // asserted is that the blank flag itself is never what gets carried.
+        for blank in ["", "   ", "\t"] {
+            let ctx = RuntimeContext::with_args(None, Some(blank.to_string()), None, None)
+                .expect("with_args should succeed");
+
+            assert_ne!(
+                ctx.api_key(),
+                Some(blank),
+                "an explicitly blank --api-key must not be carried verbatim"
+            );
+            assert!(
+                ctx.api_key().is_none_or(|key| !key.trim().is_empty()),
+                "a blank --api-key must never resolve to a blank credential"
+            );
+        }
+    }
+
+    /// A context whose app dir is an isolated temp dir, for the .env lookup tests.
+    /// The `TempDir` must be kept alive for the test.
+    fn create_test_context_with_app_dir() -> (RuntimeContext, TempDir) {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let mut ctx = create_test_context();
+        ctx.app_dir = temp_dir.path().to_path_buf();
+
+        (ctx, temp_dir)
+    }
+
+    /// Write one of the app dir's env files for a .env lookup test.
+    fn write_env_file(dir: &TempDir, name: &str, contents: &str) {
+        std::fs::write(dir.path().join(name), contents).expect("write env file");
+    }
+
+    #[test]
+    fn test_load_api_key_from_env_files_returns_a_stored_key() {
+        let (ctx, temp_dir) = create_test_context_with_app_dir();
+        write_env_file(&temp_dir, ".env", "SPICE_API_KEY=real-key\n");
+
+        assert_eq!(
+            ctx.load_api_key_from_env_files(),
+            Some("real-key".to_string())
+        );
+    }
+
+    #[test]
+    fn test_load_api_key_from_env_files_prefers_env_local() {
+        let (ctx, temp_dir) = create_test_context_with_app_dir();
+        write_env_file(&temp_dir, ".env.local", "SPICE_API_KEY=local-key\n");
+        write_env_file(&temp_dir, ".env", "SPICE_API_KEY=plain-key\n");
+
+        assert_eq!(
+            ctx.load_api_key_from_env_files(),
+            Some("local-key".to_string())
+        );
+    }
+
+    #[test]
+    fn test_load_api_key_from_env_files_treats_a_stored_blank_as_no_key() {
+        let (ctx, temp_dir) = create_test_context_with_app_dir();
+        // `spice login` writes SPICE_SPICEAI_API_KEY= for an app that has no key, so a
+        // blank is a deliberate "no key" -- it must resolve to None rather than either
+        // becoming a blank credential or resurrecting an older key from .env.
+        write_env_file(&temp_dir, ".env.local", "SPICE_SPICEAI_API_KEY=\n");
+        write_env_file(&temp_dir, ".env", "SPICE_API_KEY=older-key\n");
+
+        assert_eq!(ctx.load_api_key_from_env_files(), None);
+    }
+
+    #[test]
+    fn test_load_api_key_from_env_files_without_any_env_file() {
+        let (ctx, _temp_dir) = create_test_context_with_app_dir();
+
+        assert_eq!(ctx.load_api_key_from_env_files(), None);
     }
 
     #[test]

--- a/bin/spice/src/context.rs
+++ b/bin/spice/src/context.rs
@@ -165,9 +165,25 @@ impl RuntimeContext {
     /// flag is omitted, so consulting it first here is what makes a blank
     /// `--api-key` resolve to the same key that omitting the flag would.
     fn load_api_key_from_env(&self) -> Option<String> {
-        normalize_credential(std::env::var("SPICE_API_KEY").ok())
-            .or_else(|| self.load_api_key_from_env_files())
-            .or_else(|| normalize_credential(std::env::var("SPICE_SPICEAI_API_KEY").ok()))
+        self.resolve_api_key(|key| std::env::var(key).ok())
+    }
+
+    /// `load_api_key_from_env` with the environment lookup injected, so the precedence
+    /// between the process environment and the app's .env files is testable without
+    /// mutating this process's environment.
+    fn resolve_api_key<F>(&self, mut get_env: F) -> Option<String>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        if let Some(api_key) = normalize_credential(get_env("SPICE_API_KEY")) {
+            return Some(api_key);
+        }
+
+        if let Some(api_key) = self.load_api_key_from_env_files() {
+            return Some(api_key);
+        }
+
+        normalize_credential(get_env("SPICE_SPICEAI_API_KEY"))
     }
 
     /// Load API key from the app's .env.local or .env file.
@@ -1018,6 +1034,51 @@ mod tests {
         let (ctx, _temp_dir) = create_test_context_with_app_dir();
 
         assert_eq!(ctx.load_api_key_from_env_files(), None);
+    }
+
+    /// An env lookup for the resolve tests: `name` is set to `value`, nothing else is.
+    fn only_env(name: &'static str, value: &'static str) -> impl FnMut(&str) -> Option<String> {
+        move |key| (key == name).then(|| value.to_string())
+    }
+
+    #[test]
+    fn test_resolve_api_key_prefers_the_process_environment() {
+        // --api-key is declared `env = "SPICE_API_KEY"`, so clap resolves that variable
+        // itself when the flag is omitted. This fallback has to agree with clap:
+        // otherwise a blank --api-key would resolve to the .env key while omitting the
+        // flag resolved to the environment's, silently selecting a different credential.
+        let (ctx, temp_dir) = create_test_context_with_app_dir();
+        write_env_file(&temp_dir, ".env.local", "SPICE_API_KEY=file-key\n");
+
+        let api_key = ctx.resolve_api_key(only_env("SPICE_API_KEY", "env-key"));
+
+        assert_eq!(api_key, Some("env-key".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_api_key_prefers_files_over_the_legacy_variable() {
+        let (ctx, temp_dir) = create_test_context_with_app_dir();
+        write_env_file(&temp_dir, ".env", "SPICE_API_KEY=file-key\n");
+
+        // A blank primary variable falls through to the files, and a stored key outranks
+        // the legacy variable -- together with the two tests either side of this one,
+        // that pins the whole order: SPICE_API_KEY > .env files > SPICE_SPICEAI_API_KEY.
+        let api_key = ctx.resolve_api_key(|key| match key {
+            "SPICE_API_KEY" => Some("   ".to_string()),
+            "SPICE_SPICEAI_API_KEY" => Some("legacy-key".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(api_key, Some("file-key".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_api_key_uses_the_legacy_variable_last() {
+        let (ctx, _temp_dir) = create_test_context_with_app_dir();
+
+        let api_key = ctx.resolve_api_key(only_env("SPICE_SPICEAI_API_KEY", "legacy-key"));
+
+        assert_eq!(api_key, Some("legacy-key".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary (root cause)

`Context::with_args` assigned the `--api-key` flag verbatim, so an explicitly empty
`--api-key ""` became `Some("")`. Two things followed:

1. `Some("")` is not `None`, so the `.env` / `.env.local` fallback was skipped — a user
   with a working `SPICE_API_KEY` in `.env` silently lost it by passing a blank flag.
2. Both REPL transports then sent the blank value, because neither checks for it: Flight
   (all SQL) sent `Bearer ` with no token (`crates/repl/src/lib.rs:954`), and HTTP (`nql`)
   sent an empty `X-API-Key`. The resulting authentication failure pointed at the
   credential rather than at the flag that caused it.

## Changes

Normalize a blank credential to `None` once, where the credential is resolved
(`bin/spice/src/context.rs`), rather than at each call site. `with_args` is the only path
that populates `RuntimeContext::api_key` (verified: `new()` sets `None`, the field is
private, and `main.rs:867` is the sole caller), so every consumer is covered — Flight,
HTTP, `get_headers`, and the `SPICE_API_KEY` handed to `spiced` — and SQL and `nql` keep
sending identical credentials for any given session.

Two details are what make "a blank flag behaves as if it were omitted" actually hold:

- **`--api-key` is declared `env = "SPICE_API_KEY"`** (`main.rs:126`), so clap merges the
  flag and that variable into one value and the provenance is gone before the CLI sees it.
  The fallback therefore checks `SPICE_API_KEY` **before** the `.env` files, which is what
  clap itself resolves when the flag is omitted. Without that ordering, `--api-key ""` with
  `SPICE_API_KEY` set could resolve to a `.env` key while omitting the flag resolved to the
  environment's — silently selecting a different credential. This is a no-op for every
  pre-existing path, because when the flag is omitted and that variable is set, clap
  supplies it and the fallback never runs.
- **A blank value stored in a `.env` file stays authoritative.** `spice login` writes
  `SPICE_SPICEAI_API_KEY=` for an app that has no key
  (`commands/login/mod.rs:280`), so falling through to the next file would resurrect an
  older credential. A stored blank resolves to `None` instead: never a blank credential,
  never a stale one.

File precedence is otherwise untouched — `.env.local` still outranks `.env`, and the
earlier line in a file still wins. A key with any content is preserved verbatim; only the
all-blank case is discarded.

Behaviour note: per the issue's acceptance criteria, `--api-key ""` now behaves as if the
flag were omitted, which includes the `.env` fallback. A blank flag is not a way to
suppress authentication — it never was, since the previous behaviour was to send a blank
credential rather than none.

## Test plan

- `make lint`
- `make test`

New tests in `bin/spice/src/context.rs`:

- `test_normalize_credential_discards_blank_values` / `..._keeps_a_real_key_verbatim` —
  empty, spaces and tabs/newlines normalize to `None`; any non-blank key is passed through
  unchanged, including surrounding whitespace.
- `test_with_args_treats_an_empty_api_key_as_absent` — regression test over `""`, `"   "`
  and `"\t"`: the blank flag is never carried verbatim and never resolves to a blank
  credential. Fails on the old code, which returned `Some("")`.
- `test_load_api_key_from_env_files_returns_a_stored_key` / `..._prefers_env_local` — the
  fallback resolves a real stored key, and `.env.local` still outranks `.env`.
- `test_load_api_key_from_env_files_treats_a_stored_blank_as_no_key` — a blank written by
  `spice login` yields `None` rather than resurrecting the older key in `.env`.
- `test_load_api_key_from_env_files_without_any_env_file` — no env file yields `None`.

The `.env` lookup is split into `load_api_key_from_env_files` so these assert against a
temp app dir and never depend on the ambient environment. Coverage limit worth stating:
the resolver is tested directly, not through a spawned `spice` process, so the exact
outgoing header is not asserted end-to-end.

## Checklist

- [x] A blank `--api-key` behaves as if the flag were omitted, including the `.env` fallback
- [x] No request carries an empty `Authorization` or `X-API-Key` header
- [x] SQL and `nql` remain identical in what they send for a given session
- [x] A blank flag and an omitted flag resolve to the same credential
- [x] Tests added, including a regression test that fails on the old code
- [x] `make signoff` green and `Attestation` re-run

Fixes #12498

