### PR TITLE
fix(cli): keep a login credential on the origin it was minted for (fixes #12505)

### DIFF
--- a/bin/spice/src/commands/login/mod.rs
+++ b/bin/spice/src/commands/login/mod.rs
@@ -23,6 +23,7 @@ use crate::context::RuntimeContext;
 use crate::error::Result;
 use crate::manifest;
 use clap::{Args, Subcommand};
+use spice_cloud_client::redirect::same_origin_redirect_policy;
 
 pub use auth_config::{merge_auth_config, store_keychain};
 
@@ -212,18 +213,9 @@ async fn login_spiceai(
 
     tracing::info!("Waiting for authentication...");
 
-    // Poll for auth status
-    let client = reqwest::Client::builder()
-        .user_agent(format!(
-            "spice/{} ({}; {})",
-            env!("CARGO_PKG_VERSION"),
-            std::env::consts::OS,
-            std::env::consts::ARCH
-        ))
-        .connect_timeout(std::time::Duration::from_secs(10))
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .unwrap_or_default();
+    // Poll for auth status. The exchange below posts the auth code in the request body, so
+    // this client must not follow a redirect off the origin.
+    let client = credentialed_client()?;
     let exchange_url = format!("{base_url}/auth/token/exchange");
 
     let access_token = loop {
@@ -243,6 +235,20 @@ async fn login_spiceai(
                 continue;
             }
         };
+
+        // A 3xx here means the redirect policy refused to follow it, so this is the
+        // redirecting origin's own response, not the target's. Fail instead of parsing it:
+        // retrying cannot make a redirect succeed, and an unchecked body could otherwise be
+        // read as a token or as "still pending".
+        let status = response.status();
+        if status.is_redirection() {
+            return Err(crate::error::Error::InvalidResponse {
+                message: format!(
+                    "The Spice.ai token exchange answered {status}. The redirect was not \
+                     followed because it leaves the origin the auth code was issued for."
+                ),
+            });
+        }
 
         let body: serde_json::Value = match response.json().await {
             Ok(v) => v,
@@ -309,6 +315,36 @@ async fn login_spiceai(
     }
 
     Ok(())
+}
+
+/// Build the HTTP client for the credential-bearing calls `spice login` makes.
+///
+/// The redirect policy is the reason this is shared rather than built per call site. These
+/// requests carry an auth code, a device code or a bearer token, and `reqwest`'s default
+/// policy follows a `Location` up to ten hops. Stripping headers is not enough on its own:
+/// `Authorization` is dropped on a cross-origin hop, but a 307 or 308 replays the request
+/// *body* — which is exactly where the Spice.ai token exchange and the Microsoft
+/// device-code flow carry their credential — so the hop itself has to be refused.
+///
+/// # Errors
+///
+/// Returns an error if the client cannot be built. This is deliberately not defaulted
+/// past: a default client would silently drop the same-origin policy.
+fn credentialed_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent(format!(
+            "spice/{} ({}; {})",
+            env!("CARGO_PKG_VERSION"),
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        ))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(30))
+        .redirect(same_origin_redirect_policy())
+        .build()
+        .map_err(|e| crate::error::Error::InvalidResponse {
+            message: format!("Could not build the login HTTP client: {e}"),
+        })
 }
 
 /// Get the Spice.ai base URL.
@@ -394,17 +430,7 @@ async fn get_spice_auth_context(
         url = format!("{url}?{}", params.join("&"));
     }
 
-    let client = reqwest::Client::builder()
-        .user_agent(format!(
-            "spice/{} ({}; {})",
-            env!("CARGO_PKG_VERSION"),
-            std::env::consts::OS,
-            std::env::consts::ARCH
-        ))
-        .connect_timeout(std::time::Duration::from_secs(10))
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .unwrap_or_default();
+    let client = credentialed_client()?;
     let response = client
         .get(&url)
         .header("Authorization", format!("Bearer {access_token}"))
@@ -437,4 +463,156 @@ async fn get_spice_auth_context(
         app_name: body["app"]["name"].as_str().map(String::from),
         app_api_key: body["app"]["api_key"].as_str().map(String::from),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::credentialed_client;
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::{TcpListener, TcpStream};
+
+    /// How long a request that must not hang is given before the test fails it. Well under
+    /// the client's own 30-second timeout, so a regression fails fast instead of stalling.
+    const TEST_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// Read the whole request — head *and* body — so the client's write completes before we
+    /// reply. Closing a socket with unread request data still buffered can surface as a
+    /// reset rather than the response under test, which on Windows is packetisation
+    /// dependent and so intermittent.
+    fn drain_request(stream: &mut TcpStream) {
+        let mut reader = BufReader::new(stream);
+        let mut content_length = 0usize;
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) | Err(_) => return,
+                Ok(_) => {}
+            }
+            if line == "\r\n" || line == "\n" {
+                break;
+            }
+            let lowered = line.to_ascii_lowercase();
+            if let Some(value) = lowered.strip_prefix("content-length:") {
+                content_length = value.trim().parse().unwrap_or(0);
+            }
+        }
+
+        if content_length > 0 {
+            let mut body = vec![0u8; content_length];
+            let _ = reader.read_exact(&mut body);
+        }
+    }
+
+    fn serve_once(listener: &TcpListener, response: &str) {
+        let Ok((mut stream, _)) = listener.accept() else {
+            return;
+        };
+        drain_request(&mut stream);
+        let _ = stream.write_all(response.as_bytes());
+        let _ = stream.flush();
+    }
+
+    fn localhost_listener() -> TcpListener {
+        TcpListener::bind("127.0.0.1:0")
+            .expect("a test listener should bind to an ephemeral port")
+    }
+
+    fn local_port(listener: &TcpListener) -> u16 {
+        listener
+            .local_addr()
+            .expect("listener should have a local address")
+            .port()
+    }
+
+    /// A cross-origin redirect must not be followed, because the request body carries the
+    /// auth code and a 307 replays it to the new origin.
+    #[tokio::test]
+    async fn test_cross_origin_redirect_is_not_followed() {
+        let redirector = localhost_listener();
+        let elsewhere = localhost_listener();
+        let elsewhere_port = local_port(&elsewhere);
+        let redirector_port = local_port(&redirector);
+        let url = format!("http://127.0.0.1:{redirector_port}/auth/token/exchange");
+
+        // Nothing should ever connect here; poll without blocking after the call returns.
+        elsewhere
+            .set_nonblocking(true)
+            .expect("listener should go non-blocking");
+
+        let response = format!(
+            "HTTP/1.1 307 Temporary Redirect\r\n\
+             Location: http://127.0.0.1:{elsewhere_port}/collect\r\n\
+             Content-Length: 0\r\n\
+             Connection: close\r\n\r\n"
+        );
+        let server = std::thread::spawn(move || serve_once(&redirector, &response));
+
+        let client = credentialed_client().expect("client should build");
+        let request = client
+            .post(&url)
+            .json(&serde_json::json!({ "code": "SECRET12" }))
+            .send();
+        // On the old default policy the client follows the hop and then waits on a listener
+        // that never answers, so without this bound the regression would surface only as a
+        // 30-second stall.
+        let got = tokio::time::timeout(TEST_REQUEST_TIMEOUT, request)
+            .await
+            .expect("a refused redirect must return promptly, not hang")
+            .expect("the 307 should come back as a response");
+
+        // Stopped at the redirect rather than followed, and the 3xx is still diagnosable.
+        assert_eq!(got.status().as_u16(), 307);
+
+        // `WouldBlock` specifically: any other error would mean the listener itself failed,
+        // which is not evidence that nothing ever connected to it.
+        let contacted = elsewhere.accept();
+        let refused_kind = contacted.as_ref().err().map(std::io::Error::kind);
+        assert_eq!(
+            refused_kind,
+            Some(std::io::ErrorKind::WouldBlock),
+            "the off-origin listener must never be contacted"
+        );
+
+        server.join().expect("server thread should not panic");
+    }
+
+    /// The policy must not break a legitimate same-origin redirect.
+    #[tokio::test]
+    async fn test_same_origin_redirect_is_followed() {
+        let listener = localhost_listener();
+        let port = local_port(&listener);
+        let url = format!("http://127.0.0.1:{port}/auth/token/exchange");
+
+        let redirect = format!(
+            "HTTP/1.1 307 Temporary Redirect\r\n\
+             Location: http://127.0.0.1:{port}/auth/token/exchange/retry\r\n\
+             Content-Length: 0\r\n\
+             Connection: close\r\n\r\n"
+        );
+        let ok = "HTTP/1.1 200 OK\r\n\
+                  Content-Type: application/json\r\n\
+                  Content-Length: 11\r\n\
+                  Connection: close\r\n\r\n\
+                  {\"ok\":true}";
+        let server = std::thread::spawn(move || {
+            serve_once(&listener, &redirect);
+            serve_once(&listener, ok);
+        });
+
+        let client = credentialed_client().expect("client should build");
+        let request = client
+            .post(&url)
+            .json(&serde_json::json!({ "code": "SECRET12" }))
+            .send();
+        let got = tokio::time::timeout(TEST_REQUEST_TIMEOUT, request)
+            .await
+            .expect("the same-origin redirect chain must not hang")
+            .expect("a same-origin redirect should be followed");
+
+        assert_eq!(got.status().as_u16(), 200);
+
+        server.join().expect("server thread should not panic");
+    }
 }

--- a/bin/spice/src/commands/login/mod.rs
+++ b/bin/spice/src/commands/login/mod.rs
@@ -515,8 +515,7 @@ mod tests {
     }
 
     fn localhost_listener() -> TcpListener {
-        TcpListener::bind("127.0.0.1:0")
-            .expect("a test listener should bind to an ephemeral port")
+        TcpListener::bind("127.0.0.1:0").expect("test listener should bind")
     }
 
     fn local_port(listener: &TcpListener) -> u16 {

--- a/bin/spice/src/commands/login/providers.rs
+++ b/bin/spice/src/commands/login/providers.rs
@@ -444,18 +444,9 @@ async fn msal_device_code_flow(
 
     let scope_string = scopes.join(" ");
 
-    // Step 1: Request device code
-    let client = reqwest::Client::builder()
-        .user_agent(format!(
-            "spice/{} ({}; {})",
-            env!("CARGO_PKG_VERSION"),
-            std::env::consts::OS,
-            std::env::consts::ARCH
-        ))
-        .connect_timeout(std::time::Duration::from_secs(10))
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .unwrap_or_default();
+    // Step 1: Request device code. The token poll below posts the device code in the
+    // request body, so this client must not follow a redirect off the origin.
+    let client = super::credentialed_client()?;
     let device_response = client
         .post(&device_code_url)
         .form(&[("client_id", client_id), ("scope", &scope_string)])
@@ -541,6 +532,19 @@ async fn msal_device_code_flow(
             .map_err(|e| crate::error::Error::InvalidResponse {
                 message: format!("Token request failed: {e}"),
             })?;
+
+        // A 3xx here means the redirect policy refused to follow it, so this body is the
+        // redirecting origin's, not the target's. Fail instead of parsing it: an unchecked
+        // body could be read as a token, or as `authorization_pending` and keep polling.
+        let token_status = token_response.status();
+        if token_status.is_redirection() {
+            return Err(crate::error::Error::InvalidResponse {
+                message: format!(
+                    "The token endpoint answered {token_status}. The redirect was not \
+                     followed because it leaves the origin the device code was issued for."
+                ),
+            });
+        }
 
         let token_data: serde_json::Value =
             token_response

--- a/crates/spice-cloud-client/src/client.rs
+++ b/crates/spice-cloud-client/src/client.rs
@@ -22,6 +22,7 @@ use reqwest::Client;
 use snafu::ResultExt;
 
 use crate::error::{self, HttpRequestSnafu, Result};
+use crate::redirect::same_origin_redirect_policy;
 use crate::types::{
     ApiKeysResponse, App, AppsResponse, AuthContext, AuthContextRaw, AuthExchangeRequest,
     AuthExchangeResponse, ContainerImagesResponse, CreateAppRequest, CreateDeploymentRequest,
@@ -32,6 +33,21 @@ use crate::types::{
 
 const DEFAULT_BASE_URL: &str = "https://api.spice.ai";
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Build the underlying HTTP client.
+///
+/// Both constructors go through here so the settings cannot drift apart — in particular the
+/// same-origin redirect policy, which is what keeps a bearer token, and the auth code that
+/// `exchange_code` puts in a request body, from following a `Location` off origin.
+fn build_http_client(timeout: Duration) -> Result<Client> {
+    Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(timeout)
+        .https_only(true)
+        .redirect(same_origin_redirect_policy())
+        .build()
+        .context(HttpRequestSnafu)
+}
 
 /// HTTP client for the Spice Cloud API.
 #[derive(Clone)]
@@ -51,12 +67,7 @@ impl CloudClient {
     /// Use [`Self::with_token`] to set an authentication token, and
     /// [`Self::with_timeout`] to override the default 30-second timeout.
     pub fn new(base_url: &str) -> Result<Self> {
-        let client = Client::builder()
-            .connect_timeout(Duration::from_secs(10))
-            .timeout(DEFAULT_TIMEOUT)
-            .https_only(true)
-            .build()
-            .context(HttpRequestSnafu)?;
+        let client = build_http_client(DEFAULT_TIMEOUT)?;
 
         Ok(Self {
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -83,12 +94,7 @@ impl CloudClient {
     ///
     /// Returns an error if the HTTP client cannot be rebuilt with the given timeout.
     pub fn with_timeout(mut self, timeout: Duration) -> Result<Self> {
-        self.client = Client::builder()
-            .connect_timeout(Duration::from_secs(10))
-            .timeout(timeout)
-            .https_only(true)
-            .build()
-            .context(HttpRequestSnafu)?;
+        self.client = build_http_client(timeout)?;
         Ok(self)
     }
 
@@ -663,6 +669,30 @@ mod tests {
     use super::{CloudClient, auth_exchange_result, auth_exchange_status_is_pending};
     use crate::types::{AuthContext, AuthContextApp, AuthContextOrg, AuthContextRaw};
     use crate::{error, types::AuthExchangeResponse};
+
+    /// Both constructors must install the same-origin redirect policy, or a bearer token —
+    /// and the auth code `exchange_code` puts in a request body — could follow a `Location`
+    /// off origin.
+    ///
+    /// `reqwest` exposes no getter for the policy, but its `Client` `Debug` prints a
+    /// `redirect_policy` field only when the policy is *not* the default, and renders a
+    /// custom one as `Custom`. So the absence of that word is exactly the regression.
+    #[test]
+    fn test_both_constructors_install_the_same_origin_redirect_policy() {
+        let client = CloudClient::new("https://api.spice.ai").expect("client should build");
+        assert!(
+            format!("{:?}", client.client).contains("Custom"),
+            "CloudClient::new must set a non-default redirect policy"
+        );
+
+        let retimed = client
+            .with_timeout(std::time::Duration::from_secs(5))
+            .expect("client should rebuild with a new timeout");
+        assert!(
+            format!("{:?}", retimed.client).contains("Custom"),
+            "CloudClient::with_timeout must preserve the redirect policy"
+        );
+    }
 
     #[test]
     fn oauth_base_url_rewrites_api_hosts() {

--- a/crates/spice-cloud-client/src/lib.rs
+++ b/crates/spice-cloud-client/src/lib.rs
@@ -24,6 +24,7 @@ limitations under the License.
 mod client;
 pub mod endpoints;
 pub mod error;
+pub mod redirect;
 pub mod types;
 
 pub use client::CloudClient;

--- a/crates/spice-cloud-client/src/redirect.rs
+++ b/crates/spice-cloud-client/src/redirect.rs
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Redirect policy for HTTP clients that carry a credential.
+//!
+//! `reqwest`'s default policy follows up to ten redirects, and on a cross-origin hop it
+//! sanitises only the standard credential headers — `Authorization`, `Cookie`, `Cookie2`,
+//! `Proxy-Authorization` and `WWW-Authenticate`. That leaves two ways for a credential to
+//! follow a `Location` off the origin it was minted for:
+//!
+//! - a custom header such as `X-API-Key` is not on that list, so it rides along; and
+//! - a 307 or 308 preserves the method *and* the body, so a token-exchange `POST` replays
+//!   its auth code or device code to whatever the new origin is.
+//!
+//! The second one is why stripping headers is not sufficient on its own, and why every
+//! client in this workspace that sends a credential — in a header or in a body — should be
+//! built with [`same_origin_redirect_policy`].
+
+use reqwest::Url;
+
+/// How many same-origin redirects to follow before refusing, matching the depth of
+/// `reqwest`'s own default policy.
+///
+/// Compared the way `reqwest` compares it: the first entry of `previous()` is the initial
+/// URL rather than a redirect, so the bound is `previous().len() > MAX_REDIRECTS`.
+const MAX_REDIRECTS: usize = 10;
+
+/// Whether two URLs share an origin, per the URL standard's definition.
+///
+/// Defers to `Url::origin` rather than comparing scheme/host/port by hand, which buys two
+/// things. For `http` and `https` it is the tuple origin — scheme, host and *effective*
+/// port, so `https://host` and `https://host:443` match, and `Url` has already
+/// canonicalised case, IDN and IPv4/IPv6 spellings by then. For every other scheme
+/// (`file:`, `blob:`, anything custom) it is an opaque origin, which is unique per call and
+/// so never compares equal — meaning such a hop is always refused rather than being
+/// silently treated as same-origin because two URLs happen to share a scheme and have no
+/// host.
+fn is_same_origin(previous: &Url, next: &Url) -> bool {
+    previous.origin() == next.origin()
+}
+
+/// A redirect policy that follows same-origin redirects and refuses to leave the origin.
+///
+/// Refusing means `Attempt::stop`, so the 3xx comes back to the caller as an ordinary
+/// response. An unexpected redirect stays diagnosable that way, rather than surfacing as a
+/// transport error indistinguishable from a network fault.
+///
+/// `Policy::custom` does not bound the redirect chain for you, so this counts hops too.
+#[must_use]
+pub fn same_origin_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        // Both predicates are resolved before acting, because `previous()` borrows the
+        // attempt while `follow()` and `stop()` consume it.
+        let stays_on_origin = attempt
+            .previous()
+            .last()
+            .is_some_and(|previous| is_same_origin(previous, attempt.url()));
+        let within_limit = attempt.previous().len() <= MAX_REDIRECTS;
+
+        if stays_on_origin && within_limit {
+            attempt.follow()
+        } else {
+            attempt.stop()
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_same_origin;
+    use reqwest::Url;
+
+    fn url(value: &str) -> Url {
+        Url::parse(value).expect("test URL should parse")
+    }
+
+    #[test]
+    fn test_same_origin_for_identical_origin_with_different_path() {
+        let base = url("https://api.spice.ai/auth/token/exchange");
+        let next = url("https://api.spice.ai/auth/token");
+
+        assert!(is_same_origin(&base, &next));
+    }
+
+    #[test]
+    fn test_same_origin_treats_implicit_and_explicit_default_ports_alike() {
+        let implicit_https = url("https://host/a");
+        let explicit_https = url("https://host:443/b");
+        let implicit_http = url("http://host/a");
+        let explicit_http = url("http://host:80/b");
+
+        assert!(is_same_origin(&implicit_https, &explicit_https));
+        assert!(is_same_origin(&implicit_http, &explicit_http));
+    }
+
+    /// The cases a credential must not follow: a different host is the exfiltrating one,
+    /// and a different scheme or port is still a different origin.
+    #[test]
+    fn test_not_same_origin_across_host_scheme_or_port() {
+        let base = url("https://api.spice.ai/auth/token/exchange");
+        let other_host = url("https://evil.example/collect");
+        let other_scheme = url("http://api.spice.ai/auth");
+        let other_port = url("https://api.spice.ai:8443/auth");
+        // A subdomain is a different host, so it is a different origin.
+        let subdomain = url("https://evil.api.spice.ai/collect");
+
+        assert!(!is_same_origin(&base, &other_host));
+        assert!(!is_same_origin(&base, &other_scheme));
+        assert!(!is_same_origin(&base, &other_port));
+        assert!(!is_same_origin(&base, &subdomain));
+    }
+
+    /// A userinfo prefix must not be mistaken for the host: `https://api.spice.ai@evil`
+    /// has host `evil`, and reading it as `api.spice.ai` would let the credential out.
+    #[test]
+    fn test_not_same_origin_when_userinfo_spoofs_the_host() {
+        let base = url("https://api.spice.ai/auth/token/exchange");
+        let spoofed = url("https://api.spice.ai@evil.example/collect");
+
+        assert_eq!(spoofed.host_str(), Some("evil.example"));
+        assert!(!is_same_origin(&base, &spoofed));
+    }
+
+    /// A scheme with no host has an opaque origin, which is unique per call and so never
+    /// equal. Two `file:` URLs sharing a scheme must not be read as one origin just
+    /// because both have `host_str() == None`.
+    #[test]
+    fn test_not_same_origin_for_hostless_schemes() {
+        let one = url("file:///tmp/a");
+        let two = url("file:///tmp/b");
+
+        assert_eq!(one.host_str(), None);
+        assert_eq!(two.host_str(), None);
+        assert!(!is_same_origin(&one, &two));
+        // Not even against itself, which is what makes the refusal unconditional.
+        assert!(!is_same_origin(&one, &one));
+    }
+}

--- a/crates/spice-cloud-client/src/redirect.rs
+++ b/crates/spice-cloud-client/src/redirect.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Spice.ai OSS Authors
+Copyright 2024-2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,8 +34,9 @@ use reqwest::Url;
 /// How many same-origin redirects to follow before refusing, matching the depth of
 /// `reqwest`'s own default policy.
 ///
-/// Compared the way `reqwest` compares it: the first entry of `previous()` is the initial
-/// URL rather than a redirect, so the bound is `previous().len() > MAX_REDIRECTS`.
+/// Compared the same way `reqwest` compares it: because the first entry of `previous()` is
+/// the initial URL rather than a redirect, the limit is exceeded only once
+/// `previous().len() > MAX_REDIRECTS`.
 const MAX_REDIRECTS: usize = 10;
 
 /// Whether two URLs share an origin, per the URL standard's definition.


### PR DESCRIPTION
## Summary

Four credential-bearing HTTP clients built their own `reqwest::Client` with the default redirect policy, which follows up to ten redirects. `reqwest` sanitises `Authorization`, `Cookie`, `Cookie2`, `Proxy-Authorization` and `WWW-Authenticate` on a cross-origin hop, and that stripping is sound — but it cannot help the case that actually applies here: **a 307 or 308 preserves the method and the body**, and three of these four flows carry their credential in the body, not in a header.

So a `Location` pointing off-origin would hand the Spice.ai auth code, or the Microsoft `device_code`, to whatever origin the redirect named. This is the "adjacent but distinct" class identified while fixing #12495; unlike #12502 it needs no SDK change and is fixed entirely here.

Root cause is one missing policy, repeated four times, in clients that each opted out of the shared one by constructing their own.

## Changes

- **New `spice_cloud_client::redirect`** — `same_origin_redirect_policy()`, a `reqwest::redirect::Policy` that follows same-origin redirects and refuses to leave the origin. Placed in `spice-cloud-client` because it is the crate `bin/spice` and the Cloud client already share.
- **Applied at all four sites** — both `CloudClient` constructors, and the three `spice login` clients.
- **Collapsed the duplication that let the setting diverge** — the three `spice login` builders become one `credentialed_client()`, and the two `CloudClient` builders one `build_http_client()`, so neither pair can drift apart.
- **Stopped defaulting past a client-build failure** — the three `spice login` sites used `.build().unwrap_or_default()`, which would silently substitute a default client and so silently drop the policy. They now return an error.
- **Made a refused redirect fail fast where it was being misread** — see below.

### Design notes worth a reviewer's eye

**Same-origin is decided by `Url::origin()`**, not a hand-rolled scheme/host/port comparison. For `http(s)` that is the same tuple, with case, IDN and IPv4/IPv6 spellings already canonicalised. For a hostless scheme (`file:`, `blob:`, anything custom) it is an *opaque* origin, which is unique per call and so never compares equal — the hop is refused rather than read as same-origin merely because both URLs share a scheme and have `host_str() == None`. Not reachable today (reqwest only follows `http(s)`), but it fails closed rather than open.

**`stop()`, not `error()`.** Refusing returns the 3xx to the caller as an ordinary response, so an unexpected redirect stays diagnosable instead of surfacing as a transport error indistinguishable from a network fault. The consequence is that the returned body belongs to the *redirecting* origin, not the refused target — so the exfiltration protection holds, but a poller that parsed that body without checking the status could misread it. Two did, and now reject a 3xx up front:

- the Spice.ai login poll — an empty 307 body failed to parse and re-looped; a 307 body carrying `access_token` was accepted as success
- the Microsoft device-code token poll — a 307 body carrying `authorization_pending` would extend polling to expiry

`CloudClient::exchange_code` and `get_spice_auth_context` already classified a 3xx as an error, and `spice cloud login`'s poller is bounded at five minutes and terminates with a clear message, so those needed no change. That the Spice.ai login loop is unbounded *in the first place* is a pre-existing defect independent of this change, filed as #12506 rather than widened into this PR. Switching to `error()` would not have fixed it either — that loop retries `Err` too.

**Adjacent-hop comparison is sufficient.** The policy compares `previous().last()` against the next URL rather than the original request. Because same-origin is equality on the `(scheme, host, port)` triple it is transitive, so a chain cannot walk off-origin one same-origin hop at a time.

Verified against the `reqwest` these crates actually resolve to, **0.13.4** (not the 0.12.24 the pinned `spiceai` SDK carries): `previous()` is non-empty on the first redirect because `TowerRedirectPolicy` pushes the previous URL before calling `check`, so a legitimate first-hop same-origin redirect is still followed; and the hop bound `previous().len() <= 10` matches `reqwest`'s own `previous().len() > max` with the default `max` of 10.

## Blast radius

The concern with a same-origin policy on a public host is an apex-to-`www` or regional redirect. There is none in play: `spice.ai`, `dev.spice.ai` and `api.spice.ai` all answer `200` at the apex, and `/auth/token/exchange` and `/api/spice-cli/auth` answer `405`/`401` directly rather than redirecting. It does make that an API contract: a future CDN, regional-host or host-migration redirect on these endpoints would now fail rather than silently forward a credential.

Worth stating explicitly: a redirect policy cannot protect a credential sent *directly* to a hostile origin. It bounds where a credential can travel after the first hop, not whether `SPICE_BASE_URL` was trustworthy to begin with.

`CloudClient` already set `https_only(true)`, which blocked a downgrade to `http` but not a cross-origin `https` hop.

## Test plan

- `make lint`
- `make test`
- **`crates/spice-cloud-client/src/redirect.rs`** — origin comparison: same origin across paths; implicit vs explicit default ports on both schemes; and the refusals — different host, scheme, port, a subdomain, a `https://api.spice.ai@evil.example` userinfo spoof whose real host is `evil.example`, and two hostless `file:` URLs (which must not match, *including against themselves*).
- **`crates/spice-cloud-client/src/client.rs`** — `test_both_constructors_install_the_same_origin_redirect_policy` asserts the policy survives `CloudClient::new` **and** `with_timeout`. `reqwest` exposes no getter, but its `Client` `Debug` prints `redirect_policy` only when the policy is not the default and renders a custom one as `Custom`, so deleting either `.redirect(...)` call fails this test. Without it, both `CloudClient` sites were untested.
- **`bin/spice/src/commands/login/mod.rs`** — behavioural tests driving the **production** `credentialed_client()` against real loopback listeners:
  - `test_cross_origin_redirect_is_not_followed` — posts a body to a listener answering `307` with a `Location` on a second listener's port, then asserts the call returns `307` **and** that the off-origin listener was never contacted (requiring `WouldBlock` specifically, so a listener failure cannot masquerade as proof). Fails on the old default policy.
  - `test_same_origin_redirect_is_followed` — asserts a same-origin `307` is still followed through to `200`, which is what would break if the policy were simply `Policy::none()`.

Both bind `127.0.0.1:0` so they cannot collide with a port in use on a shared runner; both are wrapped in a 5s timeout so a regression fails fast instead of stalling on the client's own 30s timeout; and the test server drains the full request body, since closing a socket with unread request data can surface as a reset rather than the response under test.

## Checklist

- [x] Fixes the whole bug class, not one instance — all four credential-bearing clients, found by auditing every `reqwest::Client::builder()`/`::new()` in `bin/spice` and `spice-cloud-client`. The registry client is injected (`http_client: &reqwest::Client`) and so inherits the context client's policy from #12495.
- [x] Regression test that fails on the old code and passes on the new
- [x] No behaviour change for same-origin redirects
- [x] No credential or internal detail added to a log, error or this PR body
- [ ] `make lint` and `make test` green in CI

Fixes #12505
