### PR TITLE
test(cayenne): cover the selective PK join and the inline/file tier boundary

### DIFF
--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -151,6 +151,10 @@ loom = { workspace = true }
 
 [[bench]]
 harness = false
+name = "selective_join_pk_probe"
+
+[[bench]]
+harness = false
 name = "zorder_clustering"
 
 [[bench]]

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -151,10 +151,6 @@ loom = { workspace = true }
 
 [[bench]]
 harness = false
-name = "selective_join_pk_probe"
-
-[[bench]]
-harness = false
 name = "zorder_clustering"
 
 [[bench]]
@@ -400,6 +396,11 @@ name = "apply_partial_filter_empty_alloc"
 [[bench]]
 harness = false
 name = "pk_lookup_file_group_fanout"
+required-features = ["duckdb-bench"]
+
+[[bench]]
+harness = false
+name = "selective_join_pk_probe"
 required-features = ["duckdb-bench"]
 
 [[bench]]

--- a/crates/cayenne/benches/selective_join_pk_probe.rs
+++ b/crates/cayenne/benches/selective_join_pk_probe.rs
@@ -1,0 +1,311 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! A selective join whose key IS the probe table's primary key.
+//!
+//! ## The shape
+//!
+//! ```sql
+//! SELECT ... FROM parent p INNER JOIN child c ON p.id = c.parent_id
+//! WHERE c.sel = <one value>          -- matches exactly one child row
+//! ```
+//!
+//! Both tables are large, the filter is on the CHILD and returns one row, the
+//! join key on the PARENT side is its declared primary key, and the answer is
+//! one row. This is the serving shape behind a high-QPS lookup API: a wide
+//! record fetched by a secondary attribute, via its own key.
+//!
+//! ## What is already good, and must stay good
+//!
+//! Sideways information passing works end to end: the one-row build side's key
+//! reaches the probe scan as a dynamic filter, the min/max conjuncts of that
+//! filter push into Vortex, and the probe emits ONE row rather than materialising
+//! the wide parent. Only the `InList` membership conjunct is declined — Vortex
+//! evaluates it with an O(N×M) `list_contains` kernel
+//! (`crates/vortex/src/persistent/opener.rs`) — and declining it costs nothing
+//! here because the bounds already collapse to a point range.
+//!
+//! `selective_join_probe_emits_one_row` in
+//! `crates/cayenne/tests/selective_join_pk_probe_test.rs` pins that property.
+//! This bench measures what it COSTS.
+//!
+//! ## What this bench exists to expose
+//!
+//! The probe still pays file-group fan-out that the equivalent literal lookup
+//! does not, because the two reach `scan()` differently:
+//!
+//!   - `WHERE id = K` arrives as a literal filter, so `is_pk_selective_scan`
+//!     (`crates/cayenne/src/provider/table.rs`) recognises point equality on the
+//!     PK and suppresses byte-range fan-out.
+//!   - A join key is NOT a literal at `scan()` time — it arrives later, as a
+//!     dynamic filter. `pk_column_equals_literal` requires `is_literal_like`, so
+//!     the suppression never engages and the probe opens every file group.
+//!
+//! Two lanes measure the same single row through both paths, so the ratio
+//! between them is the cost of that gap alone:
+//!
+//!   - `literal_pk`  — `WHERE p.id = K`, the suppressed-fan-out path.
+//!   - `join_pk`     — the join above, resolving to the same `K`.
+//!
+//! Sizing is deliberate: DataFusion only byte-range splits when each resulting
+//! group would still clear `repartition_file_min_size` (10 MB), so the `wide`
+//! lane (~131k rows x 2.7 KB ≈ 350 MB) splits at 16 partitions while `narrow`
+//! does not. A smaller table shows no fan-out at all and would measure nothing —
+//! which is exactly why the companion test can only assert parity.
+//!
+//! `target_partitions` is swept because fan-out is what is under test; at 1 the
+//! two lanes should converge, and the gap at 16 is the cost being paid today.
+//!
+//! `probe_width` is swept because the production table this models carries two
+//! JSON blobs (~2.7 KB/row against a ~197 B/row child, a ~14× width ratio).
+//! Width is what makes an unnecessary file open expensive rather than merely
+//! wasteful, so a narrow-only bench would understate the gap.
+//!
+//! A second axis, `file_count`, exists because PK **hash**-sharding on the write
+//! path gives every file a `min/max` spanning the whole key domain
+//! (`resolved_shard_key_columns`), so listing-time min/max pruning can never
+//! drop a file no matter how selective the predicate. Growing the file count at
+//! a fixed row count therefore grows the work for a one-row answer — which is
+//! the signature of that gap, and what a range-sharded write path would flatten.
+//!
+//! `cargo bench --bench selective_join_pk_probe -p cayenne --features duckdb-bench`
+//! (the shared fixture helper lives under `vs_duckdb_helpers`, hence the feature).
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+
+#[path = "vs_duckdb_helpers/common.rs"]
+mod common;
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use cayenne::CayenneTableProvider;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use datafusion::datasource::TableProvider;
+use datafusion::execution::config::SessionConfig;
+use datafusion::prelude::SessionContext;
+use tokio::runtime::Runtime;
+
+use common::{CayenneFixture, Metastore, cayenne_insert, setup_cayenne_custom};
+
+/// Parent rows. Large enough that a full scan is obviously wrong for a one-row
+/// answer, small enough that the bench stays interactive.
+const PARENT_ROWS: usize = 131_072;
+/// Child rows, roughly one per parent — the production ratio is ~1.01:1.
+const CHILD_ROWS: usize = 131_072;
+
+/// Payload widths for the parent. `narrow` isolates the file-open cost;
+/// `wide` reproduces the JSON-blob width that makes a redundant open expensive.
+const PROBE_WIDTHS: &[(&str, usize)] = &[("narrow", 0), ("wide", 2_700)];
+
+const TARGET_PARTITIONS: &[usize] = &[1, 4, 16];
+
+fn parent_schema(payload: bool) -> Arc<Schema> {
+    let mut fields = vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ];
+    if payload {
+        // Stands in for `ConfigurationJSON` + `ModuleTypeConfigurationJSON`.
+        fields.push(Field::new("payload", DataType::Utf8, false));
+    }
+    Arc::new(Schema::new(fields))
+}
+
+fn child_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("child_id", DataType::Int64, false),
+        Field::new("parent_id", DataType::Int64, false),
+        // The selective attribute the API looks a record up by.
+        Field::new("sel", DataType::Utf8, false),
+    ]))
+}
+
+#[expect(
+    dead_code,
+    reason = "kept alongside child_batch for symmetry when adding lanes"
+)]
+fn parent_batch(schema: Arc<Schema>, rows: usize, payload_bytes: usize) -> RecordBatch {
+    let ids: Vec<i64> = (0..rows as i64).collect();
+    let values: Vec<i64> = ids.iter().map(|id| id * 7).collect();
+    let mut cols: Vec<arrow::array::ArrayRef> = vec![
+        Arc::new(Int64Array::from(ids.clone())),
+        Arc::new(Int64Array::from(values)),
+    ];
+    if payload_bytes > 0 {
+        // Per-row unique so it cannot dictionary-compress to nothing — the
+        // production blobs are distinct per row.
+        let payloads: Vec<String> = ids
+            .iter()
+            .map(|id| format!("{id:0width$}", width = payload_bytes))
+            .collect();
+        cols.push(Arc::new(StringArray::from(payloads)));
+    }
+    RecordBatch::try_new(schema, cols).expect("parent batch")
+}
+
+fn child_batch(schema: Arc<Schema>, rows: usize) -> RecordBatch {
+    let ids: Vec<i64> = (0..rows as i64).collect();
+    let parent_ids: Vec<i64> = ids.clone();
+    // Unique per row, so `sel = 'sel_K'` matches exactly one child — the
+    // unique-ish `(DeveloperAccountSid, RemoteEntityId)` pair in production.
+    let sels: Vec<String> = ids.iter().map(|id| format!("sel_{id}")).collect();
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(ids)),
+            Arc::new(Int64Array::from(parent_ids)),
+            Arc::new(StringArray::from(sels)),
+        ],
+    )
+    .expect("child batch")
+}
+
+/// Load the pair. `file_count` writes the parent in that many separate inserts,
+/// each producing its own Vortex file, so the sweep can show what an extra file
+/// costs a one-row answer when min/max pruning cannot drop it.
+async fn load_pair(payload_bytes: usize, file_count: usize) -> (CayenneFixture, CayenneFixture) {
+    let p_schema = parent_schema(payload_bytes > 0);
+    let parent = setup_cayenne_custom(
+        "sjp_parent",
+        Metastore::Sqlite,
+        vec!["id".to_string()],
+        None,
+        Arc::clone(&p_schema),
+        cayenne::metadata::VortexConfig::default(),
+        Arc::new(datafusion::execution::runtime_env::RuntimeEnv::default()),
+    )
+    .await;
+
+    let per = PARENT_ROWS / file_count;
+    for f in 0..file_count {
+        let start = (f * per) as i64;
+        let ids: Vec<i64> = (0..per as i64).map(|i| start + i).collect();
+        let values: Vec<i64> = ids.iter().map(|id| id * 7).collect();
+        let mut cols: Vec<arrow::array::ArrayRef> = vec![
+            Arc::new(Int64Array::from(ids.clone())),
+            Arc::new(Int64Array::from(values)),
+        ];
+        if payload_bytes > 0 {
+            let payloads: Vec<String> = ids
+                .iter()
+                .map(|id| format!("{id:0width$}", width = payload_bytes))
+                .collect();
+            cols.push(Arc::new(StringArray::from(payloads)));
+        }
+        let batch = RecordBatch::try_new(Arc::clone(&p_schema), cols).expect("parent chunk");
+        let _ = cayenne_insert(&parent.table, batch).await;
+    }
+
+    let child = setup_cayenne_custom(
+        "sjp_child",
+        Metastore::Sqlite,
+        vec!["child_id".to_string()],
+        None,
+        child_schema(),
+        cayenne::metadata::VortexConfig::default(),
+        Arc::new(datafusion::execution::runtime_env::RuntimeEnv::default()),
+    )
+    .await;
+    let _ = cayenne_insert(&child.table, child_batch(child_schema(), CHILD_ROWS)).await;
+
+    (parent, child)
+}
+
+async fn query(
+    parent: &Arc<CayenneTableProvider>,
+    child: &Arc<CayenneTableProvider>,
+    sql: &str,
+    target_partitions: usize,
+) -> Vec<RecordBatch> {
+    let config = SessionConfig::new().with_target_partitions(target_partitions);
+    let ctx = SessionContext::new_with_config(config);
+    ctx.register_table("p", Arc::clone(parent) as Arc<dyn TableProvider>)
+        .expect("register parent");
+    ctx.register_table("c", Arc::clone(child) as Arc<dyn TableProvider>)
+        .expect("register child");
+    ctx.sql(sql)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect")
+}
+
+/// `literal_pk` vs `join_pk` across `target_partitions` and probe width.
+///
+/// Both lanes resolve the SAME single row, so their ratio is the cost of
+/// reaching the probe through a dynamic filter instead of a literal.
+fn bench_literal_vs_join(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    // A key in the middle, so no lane wins by landing in the first file.
+    let key = (PARENT_ROWS / 2) as i64;
+
+    for (width_label, payload) in PROBE_WIDTHS {
+        let (parent, child) = rt.block_on(load_pair(*payload, 4));
+        let mut group = c.benchmark_group(format!("selective_join_pk_probe/{width_label}"));
+
+        for &tp in TARGET_PARTITIONS {
+            group.bench_with_input(BenchmarkId::new("literal_pk", tp), &tp, |b, &tp| {
+                let sql = format!("SELECT p.id, p.value FROM p WHERE p.id = {key}");
+                b.to_async(&rt).iter(|| async {
+                    black_box(query(&parent.table, &child.table, &sql, tp).await)
+                });
+            });
+            group.bench_with_input(BenchmarkId::new("join_pk", tp), &tp, |b, &tp| {
+                let sql = format!(
+                    "SELECT p.id, p.value FROM p INNER JOIN c ON p.id = c.parent_id \
+                     WHERE c.sel = 'sel_{key}'"
+                );
+                b.to_async(&rt).iter(|| async {
+                    black_box(query(&parent.table, &child.table, &sql, tp).await)
+                });
+            });
+        }
+        group.finish();
+    }
+}
+
+/// Cost of the same one-row answer as the parent is split across more files.
+///
+/// Flat is the goal. A rising curve is PK hash-sharding denying listing-time
+/// min/max pruning: every file's key range spans the domain, so none can be
+/// dropped and each new file is another open on the way to one row.
+fn bench_file_count_scaling(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let key = (PARENT_ROWS / 2) as i64;
+    let mut group = c.benchmark_group("selective_join_pk_probe/file_count");
+
+    for &files in &[1_usize, 4, 16] {
+        let (parent, child) = rt.block_on(load_pair(0, files));
+        group.bench_with_input(BenchmarkId::new("join_pk", files), &files, |b, _| {
+            let sql = format!(
+                "SELECT p.id, p.value FROM p INNER JOIN c ON p.id = c.parent_id \
+                 WHERE c.sel = 'sel_{key}'"
+            );
+            b.to_async(&rt)
+                .iter(|| async { black_box(query(&parent.table, &child.table, &sql, 16).await) });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_literal_vs_join, bench_file_count_scaling);
+criterion_main!(benches);

--- a/crates/cayenne/benches/selective_join_pk_probe.rs
+++ b/crates/cayenne/benches/selective_join_pk_probe.rs
@@ -233,7 +233,15 @@ async fn load_pair(payload_bytes: usize, file_count: usize) -> (CayenneFixture, 
             cols.push(Arc::new(StringArray::from(payloads)));
         }
         let batch = RecordBatch::try_new(Arc::clone(&p_schema), cols).expect("parent chunk");
-        let _ = cayenne_insert(&parent.table, batch).await;
+        // Assert the acknowledged count: the lanes are sized against an exact
+        // row count (the `wide` lane splits at 16 partitions only because it
+        // clears 10 MB), so an insert that lands short would still benchmark,
+        // just against a table this file's reasoning no longer describes.
+        let acked = cayenne_insert(&parent.table, batch).await;
+        assert_eq!(
+            acked, per as u64,
+            "parent chunk {f} acknowledged {acked} of {per} rows"
+        );
     }
 
     let child = setup_cayenne_custom(
@@ -246,7 +254,13 @@ async fn load_pair(payload_bytes: usize, file_count: usize) -> (CayenneFixture, 
         Arc::new(datafusion::execution::runtime_env::RuntimeEnv::default()),
     )
     .await;
-    let _ = cayenne_insert(&child.table, child_batch(child_schema(), CHILD_ROWS)).await;
+    // A short child would break the premise that `sel = 'sel_K'` matches
+    // exactly one row, which is what makes the build side one row.
+    let acked = cayenne_insert(&child.table, child_batch(child_schema(), CHILD_ROWS)).await;
+    assert_eq!(
+        acked, CHILD_ROWS as u64,
+        "child acknowledged {acked} of {CHILD_ROWS} rows"
+    );
 
     (parent, child)
 }
@@ -345,7 +359,7 @@ async fn load_fact_and_dim(inline: bool) -> (CayenneFixture, CayenneFixture) {
     let ids: Vec<i64> = (0..PARENT_ROWS as i64).collect();
     let dim_ids: Vec<i64> = ids.iter().map(|i| i % DIM_ROWS as i64).collect();
     let values: Vec<i64> = ids.iter().map(|i| i * 7).collect();
-    let _ = cayenne_insert(
+    let acked = cayenne_insert(
         &fact.table,
         RecordBatch::try_new(
             f_schema,
@@ -358,6 +372,10 @@ async fn load_fact_and_dim(inline: bool) -> (CayenneFixture, CayenneFixture) {
         .expect("fact batch"),
     )
     .await;
+    assert_eq!(
+        acked, PARENT_ROWS as u64,
+        "fact acknowledged {acked} of {PARENT_ROWS} rows"
+    );
 
     // The ONLY difference between the lanes. `0` bars admission, so the same
     // rows are written as a Vortex file instead of a metastore row.
@@ -379,7 +397,10 @@ async fn load_fact_and_dim(inline: bool) -> (CayenneFixture, CayenneFixture) {
     .await;
     let d_ids: Vec<i64> = (0..DIM_ROWS as i64).collect();
     let labels: Vec<String> = d_ids.iter().map(|i| format!("label_{i}")).collect();
-    let _ = cayenne_insert(
+    // Both lanes must hold the SAME dimension content — that is the whole point
+    // of the pair — so a short insert on either would make the comparison
+    // measure the row count instead of the tier.
+    let acked = cayenne_insert(
         &dim.table,
         RecordBatch::try_new(
             dim_join_schema(),
@@ -391,6 +412,10 @@ async fn load_fact_and_dim(inline: bool) -> (CayenneFixture, CayenneFixture) {
         .expect("dim batch"),
     )
     .await;
+    assert_eq!(
+        acked, DIM_ROWS as u64,
+        "dimension acknowledged {acked} of {DIM_ROWS} rows (inline={inline})"
+    );
 
     (fact, dim)
 }

--- a/crates/cayenne/benches/selective_join_pk_probe.rs
+++ b/crates/cayenne/benches/selective_join_pk_probe.rs
@@ -74,6 +74,28 @@ limitations under the License.
 //! Width is what makes an unnecessary file open expensive rather than merely
 //! wasteful, so a narrow-only bench would understate the gap.
 //!
+//! ## Mixed-tier joins
+//!
+//! `bench_mixed_tier_dim_join` covers the case the two lanes above cannot: a
+//! join across a table small enough to live in the metastore inline tier and one
+//! that does not. That is the customer's real shape — `integration_points` (13
+//! rows) and `module_specifications` (117) inline while the 2M-row tables do
+//! not — and it is where inlining changes the PLAN rather than just the storage.
+//!
+//! An inlined table is served as a single-partition in-memory source; the same
+//! table on Vortex is a file scan the optimizer may repartition. When the two
+//! sides disagree on partitioning, `EnforceDistribution` resolves it by
+//! COALESCING the other side rather than fanning this one out, which costs the
+//! join its parallelism. That is the mechanism measured at +11% on TPC-DS q64
+//! (611 -> 720 ms at SF-10), so it needs a bench that isolates it.
+//!
+//! The two lanes hold the dimension's CONTENT and the query constant and vary
+//! only the tier: `dim_inlined` leaves the inline-admission caps at their
+//! defaults so the small dimension is admitted, `dim_file` sets
+//! `inline_max_rows = 0` so the identical rows land in Vortex instead. Any
+//! difference is therefore the tier and nothing else — the same isolation the
+//! `cayenne_inline_max_rows: 0` arm gives at benchmark scale.
+//!
 //! A second axis, `file_count`, exists because PK **hash**-sharding on the write
 //! path gives every file a `min/max` spanning the whole key domain
 //! (`resolved_shard_key_columns`), so listing-time min/max pruning can never
@@ -237,10 +259,16 @@ async fn query(
 ) -> Vec<RecordBatch> {
     let config = SessionConfig::new().with_target_partitions(target_partitions);
     let ctx = SessionContext::new_with_config(config);
+    // Registered under both name pairs so one helper serves the probe lanes
+    // (`p`/`c`) and the mixed-tier lane (`f`/`d`).
     ctx.register_table("p", Arc::clone(parent) as Arc<dyn TableProvider>)
         .expect("register parent");
     ctx.register_table("c", Arc::clone(child) as Arc<dyn TableProvider>)
         .expect("register child");
+    ctx.register_table("f", Arc::clone(parent) as Arc<dyn TableProvider>)
+        .expect("register fact");
+    ctx.register_table("d", Arc::clone(child) as Arc<dyn TableProvider>)
+        .expect("register dim");
     ctx.sql(sql)
         .await
         .expect("sql")
@@ -283,6 +311,116 @@ fn bench_literal_vs_join(c: &mut Criterion) {
     }
 }
 
+/// Rows for the small dimension the fact table joins against. Comfortably under
+/// `DEFAULT_INLINE_MAX_ROWS` (1024) so the default-config lane is admitted to the
+/// inline tier, and matching the scale of the dimensions that inline in
+/// production (13 and 117 rows).
+const DIM_ROWS: usize = 64;
+
+fn dim_join_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("dim_id", DataType::Int64, false),
+        Field::new("label", DataType::Utf8, false),
+    ]))
+}
+
+/// Build a fact table plus a small dimension, with the dimension's storage tier
+/// chosen by `inline`. Everything else — rows, schema, query — is identical.
+async fn load_fact_and_dim(inline: bool) -> (CayenneFixture, CayenneFixture) {
+    let f_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("dim_id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+    let fact = setup_cayenne_custom(
+        "mt_fact",
+        Metastore::Sqlite,
+        vec!["id".to_string()],
+        None,
+        Arc::clone(&f_schema),
+        cayenne::metadata::VortexConfig::default(),
+        Arc::new(datafusion::execution::runtime_env::RuntimeEnv::default()),
+    )
+    .await;
+    let ids: Vec<i64> = (0..PARENT_ROWS as i64).collect();
+    let dim_ids: Vec<i64> = ids.iter().map(|i| i % DIM_ROWS as i64).collect();
+    let values: Vec<i64> = ids.iter().map(|i| i * 7).collect();
+    let _ = cayenne_insert(
+        &fact.table,
+        RecordBatch::try_new(
+            f_schema,
+            vec![
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(Int64Array::from(dim_ids)),
+                Arc::new(Int64Array::from(values)),
+            ],
+        )
+        .expect("fact batch"),
+    )
+    .await;
+
+    // The ONLY difference between the lanes. `0` bars admission, so the same
+    // rows are written as a Vortex file instead of a metastore row.
+    let mut dim_config = cayenne::metadata::VortexConfig::default();
+    if !inline {
+        dim_config.inline_max_rows = 0;
+        dim_config.inline_max_bytes = 0;
+        dim_config.inline_max_buffer_bytes = 0;
+    }
+    let dim = setup_cayenne_custom(
+        "mt_dim",
+        Metastore::Sqlite,
+        vec!["dim_id".to_string()],
+        None,
+        dim_join_schema(),
+        dim_config,
+        Arc::new(datafusion::execution::runtime_env::RuntimeEnv::default()),
+    )
+    .await;
+    let d_ids: Vec<i64> = (0..DIM_ROWS as i64).collect();
+    let labels: Vec<String> = d_ids.iter().map(|i| format!("label_{i}")).collect();
+    let _ = cayenne_insert(
+        &dim.table,
+        RecordBatch::try_new(
+            dim_join_schema(),
+            vec![
+                Arc::new(Int64Array::from(d_ids)),
+                Arc::new(StringArray::from(labels)),
+            ],
+        )
+        .expect("dim batch"),
+    )
+    .await;
+
+    (fact, dim)
+}
+
+/// A fact table joined to a small dimension, with the dimension inlined vs
+/// file-backed. Same rows, same query — only the tier differs.
+///
+/// Swept over `target_partitions` because the cost is a partitioning mismatch:
+/// at 1 there is nothing to coalesce and the lanes should converge, and any gap
+/// at 16 is the parallelism the join gives up to accommodate a single-partition
+/// side.
+fn bench_mixed_tier_dim_join(c: &mut Criterion) {
+    let rt = Runtime::new().expect("runtime");
+    let mut group = c.benchmark_group("selective_join_pk_probe/mixed_tier");
+
+    for (label, inline) in [("dim_inlined", true), ("dim_file", false)] {
+        let (fact, dim) = rt.block_on(load_fact_and_dim(inline));
+        for &tp in TARGET_PARTITIONS {
+            // An aggregate, not a point lookup: the coalesce penalty is paid by
+            // the pipeline ABOVE the join, so a one-row answer would hide it.
+            let sql = "SELECT d.label, count(*) AS n, sum(f.value) AS s                        FROM f INNER JOIN d ON f.dim_id = d.dim_id                        GROUP BY d.label";
+            group.bench_with_input(BenchmarkId::new(label, tp), &tp, |b, &tp| {
+                b.to_async(&rt)
+                    .iter(|| async { black_box(query(&fact.table, &dim.table, sql, tp).await) });
+            });
+        }
+    }
+    group.finish();
+}
+
 /// Cost of the same one-row answer as the parent is split across more files.
 ///
 /// Flat is the goal. A rising curve is PK hash-sharding denying listing-time
@@ -307,5 +445,10 @@ fn bench_file_count_scaling(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_literal_vs_join, bench_file_count_scaling);
+criterion_group!(
+    benches,
+    bench_literal_vs_join,
+    bench_mixed_tier_dim_join,
+    bench_file_count_scaling
+);
 criterion_main!(benches);

--- a/crates/cayenne/tests/selective_join_pk_probe_test.rs
+++ b/crates/cayenne/tests/selective_join_pk_probe_test.rs
@@ -297,22 +297,30 @@ async fn join_driven_lookup_costs_the_same_as_a_literal_lookup() -> TestResult {
     // The join plan contains TWO scans (parent and child). Compare only the
     // parent's, identified by its projection — counting both would measure the
     // child's scan, not the fan-out under test.
-    let probe_groups = |plan: &str| -> usize {
+    //
+    // `None` rather than a fallback count when the plan cannot be read: a
+    // defaulted number would let the comparison below pass against something
+    // the plan never said, so a change to the EXPLAIN format would silently
+    // stop this test from measuring anything.
+    let probe_groups = |plan: &str| -> Option<usize> {
         plan.split("DataSourceExec")
             .find(|frag| frag.contains("projection=[id, value"))
-            .map_or(0, |frag| {
+            .and_then(|frag| {
                 frag.split_once("file_groups={")
                     .and_then(|(_, tail)| tail.split_once(" group"))
                     .and_then(|(n, _)| n.trim().parse::<usize>().ok())
-                    .unwrap_or(1)
             })
     };
-    let literal_groups = probe_groups(&literal_plan);
-    let join_groups = probe_groups(&join_plan);
-    assert!(
-        literal_groups > 0 && join_groups > 0,
-        "could not locate the probe scan in one of the plans.\n\nliteral:\n{literal_plan}\n\njoin:\n{join_plan}"
-    );
+    let (Some(literal_groups), Some(join_groups)) =
+        (probe_groups(&literal_plan), probe_groups(&join_plan))
+    else {
+        panic!(
+            "could not read the probe scan's file-group count from one of the plans — \
+             it is located by its `projection=[id, value` and its `file_groups={{N group`, \
+             so either the scan is gone or EXPLAIN no longer renders it that way.\
+             \n\nliteral:\n{literal_plan}\n\njoin:\n{join_plan}"
+        )
+    };
 
     assert!(
         join_groups <= literal_groups,

--- a/crates/cayenne/tests/selective_join_pk_probe_test.rs
+++ b/crates/cayenne/tests/selective_join_pk_probe_test.rs
@@ -257,7 +257,7 @@ async fn selective_join_pushes_a_dynamic_filter_to_the_probe_impl(
 /// a literal — so the suppression cannot engage on the join path.
 ///
 /// At THIS scale both paths yield one group and the test passes, because
-/// DataFusion only byte-range splits when each resulting group would still clear
+/// `DataFusion` only byte-range splits when each resulting group would still clear
 /// `repartition_file_min_size` (10 MB): a ~12 MB parent is never split into 16.
 /// The divergence therefore needs a parent in the hundreds of MB, which belongs
 /// in `benches/selective_join_pk_probe.rs` rather than here — it was measured at
@@ -437,7 +437,8 @@ async fn mixed_tier_join_keeps_the_inlined_side_in_the_metastore_impl(
         .await?;
     let groups: usize = rows.iter().map(RecordBatch::num_rows).sum();
     assert_eq!(
-        groups, DIM_ROWS as usize,
+        groups,
+        usize::try_from(DIM_ROWS).expect("DIM_ROWS fits usize"),
         "a join across the inline/file tier boundary must not drop or duplicate groups"
     );
     let total: i64 = rows

--- a/crates/cayenne/tests/selective_join_pk_probe_test.rs
+++ b/crates/cayenne/tests/selective_join_pk_probe_test.rs
@@ -1,0 +1,323 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! A selective join whose key is the probe table's primary key.
+//!
+//! ```sql
+//! SELECT ... FROM parent p INNER JOIN child c ON p.id = c.parent_id
+//! WHERE c.sel = <one value>
+//! ```
+//!
+//! Both sides are large, the filter is on the CHILD and matches one row, and the
+//! join key on the PARENT side is its primary key. The whole query is worth one
+//! row, and the parent is the wide table — so the property that matters is that
+//! the parent is never materialised to answer it.
+//!
+//! These tests pin the plan-level behaviour. `benches/selective_join_pk_probe.rs`
+//! measures what it costs.
+
+#![allow(clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use arrow::array::{Int64Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use cayenne::CayenneTableProvider;
+use cayenne::metadata::{CreateTableOptions, VortexConfig};
+use datafusion::datasource::TableProvider;
+use datafusion::prelude::*;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+test_with_backends!(selective_join_probe_emits_one_row_impl);
+test_with_backends!(selective_join_pushes_a_dynamic_filter_to_the_probe_impl);
+
+const PARENT_ROWS: i64 = 20_000;
+
+fn parent_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+        // Padding, not decoration: byte-range fan-out only happens once a file
+        // clears DataFusion's `repartition_file_min_size` (10 MB). A narrow
+        // table yields one group either way and the gap under test cannot
+        // appear at all.
+        Field::new("payload", DataType::Utf8, false),
+    ]))
+}
+
+fn child_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("child_id", DataType::Int64, false),
+        Field::new("parent_id", DataType::Int64, false),
+        Field::new("sel", DataType::Utf8, false),
+    ]))
+}
+
+async fn make_table(
+    fixture: &common::TestFixture,
+    name: &str,
+    schema: Arc<Schema>,
+    pk: Vec<String>,
+) -> CayenneTableProvider {
+    let ctx = SessionContext::new();
+    CayenneTableProvider::create_table(
+        Arc::clone(&fixture.catalog) as Arc<dyn cayenne::MetadataCatalog>,
+        CreateTableOptions {
+            table_name: name.to_string(),
+            schema,
+            primary_key: pk,
+            on_conflict: None,
+            base_path: fixture.data_path.to_string_lossy().to_string(),
+            partition_column: None,
+            vortex_config: VortexConfig::default(),
+        },
+        ctx.runtime_env(),
+    )
+    .await
+    .expect("create table")
+}
+
+/// Register both tables in one context and return the `EXPLAIN ANALYZE` text
+/// alongside the rows the query actually produced.
+async fn explain_and_run(
+    parent: &Arc<CayenneTableProvider>,
+    child: &Arc<CayenneTableProvider>,
+    sql: &str,
+) -> (String, usize) {
+    let ctx = SessionContext::new();
+    ctx.register_table("p", Arc::clone(parent) as Arc<dyn TableProvider>)
+        .expect("register p");
+    ctx.register_table("c", Arc::clone(child) as Arc<dyn TableProvider>)
+        .expect("register c");
+
+    let rows: usize = ctx
+        .sql(sql)
+        .await
+        .expect("sql")
+        .collect()
+        .await
+        .expect("collect")
+        .iter()
+        .map(RecordBatch::num_rows)
+        .sum();
+
+    let explain = ctx
+        .sql(&format!("EXPLAIN ANALYZE {sql}"))
+        .await
+        .expect("explain")
+        .collect()
+        .await
+        .expect("explain run");
+    let text = arrow::util::pretty::pretty_format_batches(&explain)
+        .expect("format")
+        .to_string();
+    (text, rows)
+}
+
+/// Every `output_rows=N` the plan reports, in plan order.
+fn output_rows(plan: &str) -> Vec<usize> {
+    plan.split("output_rows=")
+        .skip(1)
+        .filter_map(|tail| {
+            tail.chars()
+                .take_while(char::is_ascii_digit)
+                .collect::<String>()
+                .parse::<usize>()
+                .ok()
+        })
+        .collect()
+}
+
+async fn seed(
+    fixture: &common::TestFixture,
+) -> (Arc<CayenneTableProvider>, Arc<CayenneTableProvider>) {
+    let parent = Arc::new(make_table(fixture, "p", parent_schema(), vec!["id".to_string()]).await);
+    let child =
+        Arc::new(make_table(fixture, "c", child_schema(), vec!["child_id".to_string()]).await);
+
+    let ids: Vec<i64> = (0..PARENT_ROWS).collect();
+    let values: Vec<i64> = ids.iter().map(|i| i * 7).collect();
+    // ~600 B/row over 20k rows ≈ 12 MB, comfortably past the split threshold.
+    let payloads: Vec<String> = ids.iter().map(|i| format!("{i:0600}")).collect();
+    common::insert_batch(
+        &parent,
+        RecordBatch::try_new(
+            parent_schema(),
+            vec![
+                Arc::new(Int64Array::from(ids.clone())),
+                Arc::new(Int64Array::from(values)),
+                Arc::new(StringArray::from(payloads)),
+            ],
+        )
+        .expect("parent batch"),
+    )
+    .await
+    .expect("insert parent");
+
+    let sels: Vec<String> = ids.iter().map(|i| format!("sel_{i}")).collect();
+    common::insert_batch(
+        &child,
+        RecordBatch::try_new(
+            child_schema(),
+            vec![
+                Arc::new(Int64Array::from(ids.clone())),
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(StringArray::from(sels)),
+            ],
+        )
+        .expect("child batch"),
+    )
+    .await
+    .expect("insert child");
+
+    (parent, child)
+}
+
+/// The load-bearing property: the one-row build side's key reaches the probe
+/// scan, so the WIDE parent yields one row instead of being materialised.
+///
+/// If this regresses, the plan still returns the right answer — it just reads
+/// the whole parent to do it, which is invisible in a correctness test and
+/// ruinous at serving QPS. That is exactly why it is asserted on the plan.
+async fn selective_join_probe_emits_one_row_impl(fixture: common::TestFixture) -> TestResult {
+    let (parent, child) = seed(&fixture).await;
+
+    let key = PARENT_ROWS / 2;
+    let sql = format!(
+        "SELECT p.id, p.value FROM p INNER JOIN c ON p.id = c.parent_id WHERE c.sel = 'sel_{key}'"
+    );
+    let (plan, rows) = explain_and_run(&parent, &child, &sql).await;
+
+    assert_eq!(rows, 1, "the join must resolve to exactly one row");
+
+    let seen = output_rows(&plan);
+    assert!(
+        !seen.is_empty(),
+        "EXPLAIN ANALYZE reported no output_rows; plan:\n{plan}"
+    );
+    // No operator may emit more than a handful of rows. A probe that scanned the
+    // parent would report ~PARENT_ROWS here.
+    let worst = seen.iter().copied().max().unwrap_or(usize::MAX);
+    assert!(
+        worst <= 16,
+        "an operator emitted {worst} rows for a one-row join — the selective key \
+         did not reach the probe scan, so the parent was materialised. \
+         Expected every operator at or near 1. Plan:\n{plan}"
+    );
+    Ok(())
+}
+
+/// The dynamic filter must actually be present on the probe side.
+///
+/// This is the mechanism behind the test above, asserted separately so a failure
+/// says WHICH half broke: `output_rows` regressing means the filter stopped
+/// pruning, this one failing means it stopped being generated at all.
+async fn selective_join_pushes_a_dynamic_filter_to_the_probe_impl(
+    fixture: common::TestFixture,
+) -> TestResult {
+    let (parent, child) = seed(&fixture).await;
+
+    let key = PARENT_ROWS / 3;
+    let sql = format!(
+        "SELECT p.id, p.value FROM p INNER JOIN c ON p.id = c.parent_id WHERE c.sel = 'sel_{key}'"
+    );
+    let (plan, _) = explain_and_run(&parent, &child, &sql).await;
+
+    assert!(
+        plan.contains("DynamicFilter") || plan.contains("dynamic_filter"),
+        "no dynamic filter reached the probe scan — sideways information passing \
+         is off, and every such join now reads its whole probe table. Plan:\n{plan}"
+    );
+    Ok(())
+}
+
+/// The same row fetched two ways must cost the probe the same number of file
+/// groups.
+///
+/// A literal `WHERE id = K` reaches `scan()` as a literal, so
+/// `is_pk_selective_scan` suppresses byte-range fan-out. A join key does not —
+/// it arrives later as a dynamic filter, and `pk_column_equals_literal` requires
+/// a literal — so the suppression cannot engage on the join path.
+///
+/// At THIS scale both paths yield one group and the test passes, because
+/// DataFusion only byte-range splits when each resulting group would still clear
+/// `repartition_file_min_size` (10 MB): a ~12 MB parent is never split into 16.
+/// The divergence therefore needs a parent in the hundreds of MB, which belongs
+/// in `benches/selective_join_pk_probe.rs` rather than here — it was measured at
+/// 17 groups versus 2 on a 415 MiB parent.
+///
+/// Keeping it as a parity assertion is still worth it: it catches a regression
+/// that made the join path fan out even at small scale, and it will start
+/// failing if the split threshold or the suppression heuristic moves — at which
+/// point this comment is the record of why the number is what it is.
+///
+/// Sqlite only: this is a plan-shape assertion, and the metastore backend does
+/// not participate in file-group fan-out.
+#[tokio::test]
+async fn join_driven_lookup_costs_the_same_as_a_literal_lookup() -> TestResult {
+    let fixture = common::TestFixture::new(common::BackendType::Sqlite).await?;
+    let (parent, child) = seed(&fixture).await;
+    let key = PARENT_ROWS / 2;
+
+    let (literal_plan, literal_rows) = explain_and_run(
+        &parent,
+        &child,
+        &format!("SELECT p.id, p.value FROM p WHERE p.id = {key}"),
+    )
+    .await;
+    let (join_plan, join_rows) = explain_and_run(
+        &parent,
+        &child,
+        &format!(
+            "SELECT p.id, p.value FROM p INNER JOIN c ON p.id = c.parent_id \
+             WHERE c.sel = 'sel_{key}'"
+        ),
+    )
+    .await;
+    assert_eq!(literal_rows, 1);
+    assert_eq!(join_rows, 1);
+
+    // The join plan contains TWO scans (parent and child). Compare only the
+    // parent's, identified by its projection — counting both would measure the
+    // child's scan, not the fan-out under test.
+    let probe_groups = |plan: &str| -> usize {
+        plan.split("DataSourceExec")
+            .find(|frag| frag.contains("projection=[id, value"))
+            .map_or(0, |frag| {
+                frag.split_once("file_groups={")
+                    .and_then(|(_, tail)| tail.split_once(" group"))
+                    .and_then(|(n, _)| n.trim().parse::<usize>().ok())
+                    .unwrap_or(1)
+            })
+    };
+    let literal_groups = probe_groups(&literal_plan);
+    let join_groups = probe_groups(&join_plan);
+    assert!(
+        literal_groups > 0 && join_groups > 0,
+        "could not locate the probe scan in one of the plans.\n\nliteral:\n{literal_plan}\n\njoin:\n{join_plan}"
+    );
+
+    assert!(
+        join_groups <= literal_groups,
+        "the join path opened {join_groups} file groups against the literal path's \
+         {literal_groups} for the SAME single row — the PK-selective fan-out \
+         suppression did not engage for a dynamic filter.\n\nliteral:\n{literal_plan}\n\njoin:\n{join_plan}"
+    );
+    Ok(())
+}

--- a/crates/cayenne/tests/selective_join_pk_probe_test.rs
+++ b/crates/cayenne/tests/selective_join_pk_probe_test.rs
@@ -37,8 +37,8 @@ use std::sync::Arc;
 
 use arrow::array::{Int64Array, RecordBatch, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
-use cayenne::CayenneTableProvider;
 use cayenne::metadata::{CreateTableOptions, VortexConfig};
+use cayenne::{CayenneTableProvider, MetadataCatalog};
 use datafusion::datasource::TableProvider;
 use datafusion::prelude::*;
 
@@ -46,6 +46,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 test_with_backends!(selective_join_probe_emits_one_row_impl);
 test_with_backends!(selective_join_pushes_a_dynamic_filter_to_the_probe_impl);
+test_with_backends!(mixed_tier_join_keeps_the_inlined_side_in_the_metastore_impl);
 
 const PARENT_ROWS: i64 = 20_000;
 
@@ -77,7 +78,7 @@ async fn make_table(
 ) -> CayenneTableProvider {
     let ctx = SessionContext::new();
     CayenneTableProvider::create_table(
-        Arc::clone(&fixture.catalog) as Arc<dyn cayenne::MetadataCatalog>,
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>,
         CreateTableOptions {
             table_name: name.to_string(),
             schema,
@@ -318,6 +319,131 @@ async fn join_driven_lookup_costs_the_same_as_a_literal_lookup() -> TestResult {
         "the join path opened {join_groups} file groups against the literal path's \
          {literal_groups} for the SAME single row — the PK-selective fan-out \
          suppression did not engage for a dynamic filter.\n\nliteral:\n{literal_plan}\n\njoin:\n{join_plan}"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Mixed-tier joins: one side small enough to inline, the other file-backed.
+// ---------------------------------------------------------------------------
+
+/// Under `DEFAULT_INLINE_MAX_ROWS` (1024), matching the production dimensions
+/// that inline (`integration_points` 13 rows, `module_specifications` 117).
+const DIM_ROWS: i64 = 64;
+
+fn dim_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("dim_id", DataType::Int64, false),
+        Field::new("label", DataType::Utf8, false),
+    ]))
+}
+
+/// A join across the tier boundary: a fact table on Vortex against a dimension
+/// small enough to live in the metastore.
+///
+/// This is the customer's real shape, and the case where inlining changes the
+/// PLAN rather than only the storage: an inlined table is a single-partition
+/// in-memory source, so when it meets a repartitionable file scan
+/// `EnforceDistribution` resolves the mismatch by coalescing the other side.
+/// That is the mechanism behind the +11% measured on TPC-DS q64.
+///
+/// What is asserted here is the precondition the bench depends on — that the
+/// dimension really is in the inline tier and the join is still correct across
+/// it. The COST is measured by `bench_mixed_tier_dim_join`, because a
+/// partitioning penalty is a timing property and asserting a coalesce count
+/// would pin today's plan shape and fight every future optimiser change.
+async fn mixed_tier_join_keeps_the_inlined_side_in_the_metastore_impl(
+    fixture: common::TestFixture,
+) -> TestResult {
+    let fact_schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("dim_id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+    let fact = Arc::new(
+        make_table(
+            &fixture,
+            "f",
+            Arc::clone(&fact_schema),
+            vec!["id".to_string()],
+        )
+        .await,
+    );
+    let dim = Arc::new(make_table(&fixture, "d", dim_schema(), vec!["dim_id".to_string()]).await);
+
+    let ids: Vec<i64> = (0..PARENT_ROWS).collect();
+    let dim_ids: Vec<i64> = ids.iter().map(|i| i % DIM_ROWS).collect();
+    let values: Vec<i64> = ids.iter().map(|i| i * 7).collect();
+    common::insert_batch(
+        &fact,
+        RecordBatch::try_new(
+            fact_schema,
+            vec![
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(Int64Array::from(dim_ids)),
+                Arc::new(Int64Array::from(values)),
+            ],
+        )
+        .expect("fact batch"),
+    )
+    .await
+    .expect("insert fact");
+
+    let d_ids: Vec<i64> = (0..DIM_ROWS).collect();
+    let labels: Vec<String> = d_ids.iter().map(|i| format!("label_{i}")).collect();
+    common::insert_batch(
+        &dim,
+        RecordBatch::try_new(
+            dim_schema(),
+            vec![
+                Arc::new(Int64Array::from(d_ids)),
+                Arc::new(StringArray::from(labels)),
+            ],
+        )
+        .expect("dim batch"),
+    )
+    .await
+    .expect("insert dim");
+
+    // The precondition: a 64-row write clears the admission caps, so the
+    // dimension is a metastore row rather than a Vortex file. If this ever stops
+    // holding, the mixed-tier bench is silently comparing two file-backed
+    // tables and measuring nothing.
+    let dim_id = fixture.catalog.get_table("d").await?.table_id;
+    let inlined_rows = fixture.catalog.get_inlined_data_count(&dim_id).await?;
+    assert_eq!(
+        inlined_rows, DIM_ROWS,
+        "the {DIM_ROWS}-row dimension should be admitted to the inline tier \
+         (get_inlined_data_count sums record_count, so this counts ROWS)"
+    );
+
+    // And the join across the tier boundary is correct: every fact row finds its
+    // dimension, and the group count is the dimension's cardinality.
+    let ctx = SessionContext::new();
+    ctx.register_table("f", Arc::clone(&fact) as Arc<dyn TableProvider>)?;
+    ctx.register_table("d", Arc::clone(&dim) as Arc<dyn TableProvider>)?;
+    let rows = ctx
+        .sql("SELECT d.label, count(*) AS n FROM f INNER JOIN d ON f.dim_id = d.dim_id GROUP BY d.label")
+        .await?
+        .collect()
+        .await?;
+    let groups: usize = rows.iter().map(RecordBatch::num_rows).sum();
+    assert_eq!(
+        groups, DIM_ROWS as usize,
+        "a join across the inline/file tier boundary must not drop or duplicate groups"
+    );
+    let total: i64 = rows
+        .iter()
+        .flat_map(|b| {
+            b.column_by_name("n")
+                .and_then(|c| c.as_any().downcast_ref::<Int64Array>())
+                .map(|a| a.values().to_vec())
+                .unwrap_or_default()
+        })
+        .sum();
+    assert_eq!(
+        total, PARENT_ROWS,
+        "every fact row must join to exactly one dimension row"
     );
     Ok(())
 }


### PR DESCRIPTION
Adds coverage for two join shapes the tree did not exercise. Tests and benches
only — no product code changes.

## The shapes

**A selective join whose key is the probe's primary key.**

```sql
SELECT ... FROM parent p INNER JOIN child c ON p.id = c.parent_id
WHERE c.sel = <one value>
```

Both sides large, the filter on the CHILD matching one row, the join key on the
PARENT side being its primary key, and one row of answer. It is the serving
shape behind a high-QPS lookup API — a wide record fetched by a secondary
attribute, via its own key — and it is what a real customer's canonical query
does against two 2M-row tables to return a single row.

**A join across the inline/file tier boundary.** A table small enough to live in
the metastore, joined against one that is not. That is the same customer's real
layout (two of their eight datasets clear the inline caps at 13 and 117 rows
while the rest do not), and it is where inlining changes the PLAN rather than
just the storage: an inlined table is a single-partition in-memory source, so
when it meets a repartitionable file scan `EnforceDistribution` resolves the
mismatch by COALESCING the other side, and the join gives up its parallelism.

## Tests

Two pin what is already right, split so a failure says which half broke:

- `selective_join_probe_emits_one_row` — the one-row build side's key reaches
  the probe, so the wide parent emits ONE row instead of being materialised.
  Asserted on the plan deliberately: a regression here still returns the correct
  answer, just by reading the whole table, which no correctness test would catch
  and which is ruinous at serving QPS.
- `selective_join_pushes_a_dynamic_filter_to_the_probe` — the mechanism behind
  it, so `output_rows` regressing means the filter stopped pruning while this one
  failing means it stopped being generated at all.

`join_driven_lookup_costs_the_same_as_a_literal_lookup` asserts the two paths
cost the probe the same number of file groups. It passes today and is NOT marked
as a known gap: at this scale there is none, because DataFusion only byte-range
splits when each resulting group would still clear `repartition_file_min_size`
(10 MB), so a ~12 MB parent is never split into 16 and both paths yield one
group. The divergence — measured at 17 groups versus 2 — needs a parent in the
hundreds of MB, which is the bench's job. Keeping the assertion is still worth
it: it catches a regression that fanned out even at small scale, and it starts
failing if the split threshold moves, at which point the comment is the record
of why the number is what it is.

`mixed_tier_join_keeps_the_inlined_side_in_the_metastore` asserts the
precondition the mixed-tier bench depends on — that the dimension is genuinely
in the inline tier. Without it, a future change to the admission caps would
leave that bench comparing two file-backed tables and measuring nothing,
silently. It also checks the cross-tier join is correct: every fact row joins
exactly once, and the group count is the dimension's cardinality.

## Bench

`literal_pk` vs `join_pk` resolve the SAME single row, so their ratio isolates
one variable: a literal `WHERE id = K` reaches `scan()` as a literal and
`is_pk_selective_scan` suppresses byte-range fan-out, while a join key arrives
later as a dynamic filter and `pk_column_equals_literal` requires a literal, so
the suppression cannot engage.

`dim_inlined` vs `dim_file` hold the dimension's content and the query constant
and vary ONLY the tier, so any difference is the tier and nothing else. It runs
an aggregate rather than a point lookup because the coalesce penalty is paid by
the pipeline ABOVE the join, which a one-row answer would hide.

Swept axes are chosen, not incidental: `target_partitions` because the cost IS a
partitioning mismatch and the lanes should converge at 1; probe width because the
production table carries two JSON blobs at a ~14x width ratio to its child, and
width is what makes a redundant file open expensive rather than merely wasteful;
`file_count` because PK hash-sharding gives every file a min/max spanning the
whole key domain, so listing-time pruning can never drop one — a rising curve
there is that gap, and range-sharding would flatten it.

Sizing is deliberate for the same reason the test can only assert parity: the
`wide` lane is ~131k rows x 2.7 KB so it splits at 16 partitions while `narrow`
does not.

The bench needs `--features duckdb-bench`, because the shared Cayenne fixture
helper lives under `vs_duckdb_helpers` — same as its sibling
`pk_lookup_file_group_fanout`.

Context for the shapes and the measured numbers: #12429.