### PR TITLE
fix(cli): bound the Spice.ai login poll instead of retrying forever (fixes #12506)

### DIFF
--- a/bin/spice/src/commands/login/mod.rs
+++ b/bin/spice/src/commands/login/mod.rs
@@ -226,44 +226,14 @@ async fn login_spiceai(
         .unwrap_or_default();
     let exchange_url = format!("{base_url}/auth/token/exchange");
 
-    let access_token = loop {
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-        let response = client
-            .post(&exchange_url)
-            .header("Content-Type", "application/json")
-            .json(&serde_json::json!({ "code": auth_code }))
-            .send()
-            .await;
-
-        let response = match response {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::error!("Error exchanging auth code with spice.ai: {e}");
-                continue;
-            }
-        };
-
-        let body: serde_json::Value = match response.json().await {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::error!("Error parsing exchange response: {e}");
-                continue;
-            }
-        };
-
-        if body["access_denied"].as_bool().unwrap_or(false) {
-            return Err(crate::error::Error::InvalidArgument {
-                message: "Access denied".to_string(),
-            });
-        }
-
-        if let Some(token) = body["access_token"].as_str()
-            && !token.is_empty()
-        {
-            break token.to_string();
-        }
-    };
+    let access_token = poll_for_access_token(
+        &client,
+        &exchange_url,
+        &auth_code,
+        LOGIN_POLL_TIMEOUT,
+        LOGIN_POLL_INTERVAL,
+    )
+    .await?;
 
     // Try to read the Spicepod manifest for preferred org/app.
     let (org_name, app_name) = read_spicepod_metadata();
@@ -309,6 +279,169 @@ async fn login_spiceai(
     }
 
     Ok(())
+}
+
+/// How long the Spice.ai browser flow waits for the user before giving up.
+///
+/// Matches the Spice Cloud device flow in [`crate::commands::cloud`]; the
+/// Microsoft device-code flow in [`providers`] bounds itself the same way, off
+/// the `expires_in` its authorization server returns.
+const LOGIN_POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// How long to wait between token-exchange attempts.
+const LOGIN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// What one token-exchange attempt tells the poll loop to do next.
+#[derive(PartialEq, Eq)]
+enum ExchangeOutcome {
+    /// The exchange carried a usable access token.
+    Token(String),
+    /// The authorization was refused. Waiting cannot change that.
+    Denied,
+    /// The user has not finished authorizing in the browser yet.
+    Pending,
+    /// Re-sending this identical request cannot succeed.
+    Permanent(String),
+    /// A blip that repeating may clear, until the deadline runs out.
+    Transient(String),
+}
+
+/// Redacts the token. This type carries a live credential, so it must not be
+/// the reason one reaches a log line or an assertion message.
+impl std::fmt::Debug for ExchangeOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Token(_) => f.write_str("Token(<redacted>)"),
+            Self::Denied => f.write_str("Denied"),
+            Self::Pending => f.write_str("Pending"),
+            Self::Permanent(message) => write!(f, "Permanent({message})"),
+            Self::Transient(message) => write!(f, "Transient({message})"),
+        }
+    }
+}
+
+/// Classify the HTTP status of a token-exchange attempt.
+///
+/// Returns `None` for a success status, meaning the body decides the outcome.
+fn classify_exchange_status(status: reqwest::StatusCode) -> Option<ExchangeOutcome> {
+    if status.is_success() {
+        return None;
+    }
+
+    // A server that is briefly unhappy, or is asking us to back off, can still
+    // become happy while the user is authorizing.
+    if status.is_server_error()
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+        || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+    {
+        return Some(ExchangeOutcome::Transient(format!(
+            "the exchange endpoint returned {status}"
+        )));
+    }
+
+    // Anything else is the endpoint rejecting this exact request: a 4xx, or a
+    // redirect the client declines to follow because it leaves the origin the
+    // credential was minted for. Neither is cleared by sending it again.
+    Some(ExchangeOutcome::Permanent(format!(
+        "the exchange endpoint returned {status}"
+    )))
+}
+
+/// Classify the body of a successful token-exchange response.
+fn classify_exchange_body(body: &serde_json::Value) -> ExchangeOutcome {
+    if body["access_denied"].as_bool().unwrap_or(false) {
+        return ExchangeOutcome::Denied;
+    }
+
+    match body["access_token"].as_str() {
+        Some(token) if !token.is_empty() => ExchangeOutcome::Token(token.to_string()),
+        // No token yet: the user has not finished in the browser.
+        _ => ExchangeOutcome::Pending,
+    }
+}
+
+/// Poll the Spice.ai token exchange until it yields a token, refuses, or
+/// `timeout` elapses.
+///
+/// # Errors
+///
+/// Returns an error if the authorization is refused, if the endpoint reports a
+/// failure that repeating cannot clear, or if `timeout` elapses first.
+async fn poll_for_access_token(
+    client: &reqwest::Client,
+    exchange_url: &str,
+    auth_code: &str,
+    timeout: std::time::Duration,
+    interval: std::time::Duration,
+) -> Result<String> {
+    let start = std::time::Instant::now();
+    // Kept so an endpoint that only ever fails reports *why* it timed out,
+    // rather than logging the same line once a second for the whole deadline.
+    let mut last_transient: Option<String> = None;
+
+    loop {
+        if start.elapsed() > timeout {
+            let detail = last_transient
+                .take()
+                .map(|message| format!(" Last error: {message}."))
+                .unwrap_or_default();
+            return Err(crate::error::Error::InvalidArgument {
+                message: format!("Authentication timed out. Please try again.{detail}"),
+            });
+        }
+
+        tokio::time::sleep(interval).await;
+
+        let response = client
+            .post(exchange_url)
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({ "code": auth_code }))
+            .send()
+            .await;
+
+        let outcome = match response {
+            Ok(response) => {
+                // Read the status out before the body: `json()` consumes the
+                // response, so it cannot borrow it in a match scrutinee.
+                let status = response.status();
+                match classify_exchange_status(status) {
+                    Some(outcome) => outcome,
+                    None => match response.json::<serde_json::Value>().await {
+                        Ok(body) => classify_exchange_body(&body),
+                        // A success status carrying a body we cannot read is
+                        // more likely an interposed proxy than a decided
+                        // answer, so it stays retriable and the deadline
+                        // bounds it.
+                        Err(e) => ExchangeOutcome::Transient(format!(
+                            "could not parse the exchange response: {e}"
+                        )),
+                    },
+                }
+            }
+            Err(e) => ExchangeOutcome::Transient(format!("could not reach the exchange: {e}")),
+        };
+
+        match outcome {
+            ExchangeOutcome::Token(token) => return Ok(token),
+            ExchangeOutcome::Denied => {
+                return Err(crate::error::Error::InvalidArgument {
+                    message: "Access denied".to_string(),
+                });
+            }
+            ExchangeOutcome::Permanent(message) => {
+                return Err(crate::error::Error::InvalidArgument {
+                    message: format!("Authentication failed: {message}."),
+                });
+            }
+            ExchangeOutcome::Transient(message) => {
+                tracing::debug!("Retrying the spice.ai token exchange: {message}");
+                last_transient = Some(message);
+            }
+            // A healthy "not yet" supersedes an earlier blip: if the deadline
+            // runs out from here, it is the user who did not finish.
+            ExchangeOutcome::Pending => last_transient = None,
+        }
+    }
 }
 
 /// Get the Spice.ai base URL.
@@ -437,4 +570,197 @@ async fn get_spice_auth_context(
         app_name: body["app"]["name"].as_str().map(String::from),
         app_api_key: body["app"]["api_key"].as_str().map(String::from),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ExchangeOutcome, classify_exchange_body, classify_exchange_status, poll_for_access_token,
+    };
+    use std::time::Duration;
+
+    /// Long enough that a bounded loop still polls several times, short enough
+    /// that an unbounded one is unmistakable.
+    const TEST_TIMEOUT_MS: u64 = 600;
+    const TEST_TIMEOUT: Duration = Duration::from_millis(TEST_TIMEOUT_MS);
+    const TEST_INTERVAL: Duration = Duration::from_millis(20);
+
+    fn status(code: u16) -> reqwest::StatusCode {
+        reqwest::StatusCode::from_u16(code).expect("code should be a valid HTTP status")
+    }
+
+    async fn exchange_against(
+        template: wiremock::ResponseTemplate,
+    ) -> (crate::error::Result<String>, u64) {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(template)
+            .mount(&server)
+            .await;
+
+        let url = format!("{}/auth/token/exchange", server.uri());
+        let client = reqwest::Client::new();
+        let started = std::time::Instant::now();
+        let result =
+            poll_for_access_token(&client, &url, "ABCD1234", TEST_TIMEOUT, TEST_INTERVAL).await;
+
+        let elapsed = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        (result, elapsed)
+    }
+
+    #[test]
+    fn a_success_status_defers_to_the_body() {
+        assert_eq!(classify_exchange_status(status(200)), None);
+        assert_eq!(classify_exchange_status(status(204)), None);
+    }
+
+    #[test]
+    fn a_server_error_or_backoff_status_is_retriable() {
+        for code in [408, 429, 500, 502, 503, 504] {
+            assert!(
+                matches!(
+                    classify_exchange_status(status(code)),
+                    Some(ExchangeOutcome::Transient(_))
+                ),
+                "{code} should be retriable"
+            );
+        }
+    }
+
+    #[test]
+    fn a_rejecting_status_is_permanent() {
+        // 302 is the cross-origin redirect the client declines to follow; the
+        // 4xx codes are the endpoint rejecting this exact request.
+        for code in [301, 302, 307, 400, 401, 403, 404, 410] {
+            assert!(
+                matches!(
+                    classify_exchange_status(status(code)),
+                    Some(ExchangeOutcome::Permanent(_))
+                ),
+                "{code} should be permanent"
+            );
+        }
+    }
+
+    #[test]
+    fn a_body_carrying_a_token_succeeds() {
+        let body = serde_json::json!({ "access_token": "tok_123" });
+        assert_eq!(
+            classify_exchange_body(&body),
+            ExchangeOutcome::Token("tok_123".to_string())
+        );
+    }
+
+    #[test]
+    fn an_access_denied_body_is_denied() {
+        let body = serde_json::json!({ "access_denied": true });
+        assert_eq!(classify_exchange_body(&body), ExchangeOutcome::Denied);
+    }
+
+    #[test]
+    fn a_body_without_a_usable_token_is_still_pending() {
+        for body in [
+            serde_json::json!({}),
+            serde_json::json!({ "access_token": "" }),
+            serde_json::json!({ "access_denied": false }),
+            serde_json::json!({ "access_token": null }),
+        ] {
+            assert_eq!(
+                classify_exchange_body(&body),
+                ExchangeOutcome::Pending,
+                "{body} should keep polling"
+            );
+        }
+    }
+
+    /// Regression test for #12506: before the deadline this spun at one request
+    /// per second forever, because a body with no token is indistinguishable
+    /// from "the user has not finished yet".
+    #[tokio::test]
+    async fn a_perpetually_pending_exchange_gives_up_at_the_deadline() {
+        let template = wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({}));
+        let (result, elapsed) = exchange_against(template).await;
+
+        let Err(err) = result else {
+            panic!("a never-completing exchange should not succeed");
+        };
+        assert!(
+            err.to_string().contains("Authentication timed out"),
+            "expected a timeout error, got: {err}"
+        );
+        assert!(
+            elapsed < TEST_TIMEOUT_MS * 10,
+            "the loop should stop near its deadline, took {elapsed}ms"
+        );
+    }
+
+    /// Regression test for #12506: a wrong `SPICE_BASE_URL` answers 404 to every
+    /// attempt, which the old loop retried forever.
+    #[tokio::test]
+    async fn a_rejecting_endpoint_fails_without_waiting_out_the_deadline() {
+        let (result, elapsed) = exchange_against(wiremock::ResponseTemplate::new(404)).await;
+
+        let Err(err) = result else {
+            panic!("a 404 exchange endpoint should not succeed");
+        };
+        assert!(
+            err.to_string().contains("404"),
+            "the error should name the status, got: {err}"
+        );
+        assert!(
+            elapsed < TEST_TIMEOUT_MS,
+            "a permanent failure should not wait out the deadline, took {elapsed}ms"
+        );
+    }
+
+    /// A 5xx stays retriable, so it is the deadline — not the first bad
+    /// response — that ends the loop, and the reason survives into the error.
+    #[tokio::test]
+    async fn a_failing_but_retriable_endpoint_reports_why_it_timed_out() {
+        let (result, _) = exchange_against(wiremock::ResponseTemplate::new(503)).await;
+
+        let Err(err) = result else {
+            panic!("a 503 exchange endpoint should not succeed");
+        };
+        let message = err.to_string();
+        assert!(
+            message.contains("Authentication timed out"),
+            "expected a timeout error, got: {message}"
+        );
+        assert!(
+            message.contains("503"),
+            "the timeout should carry the last error, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_token_response_completes_the_flow() {
+        let template = wiremock::ResponseTemplate::new(200)
+            .set_body_json(serde_json::json!({ "access_token": "tok_abc" }));
+        let (result, _) = exchange_against(template).await;
+
+        assert_eq!(
+            result.expect("a token response should succeed"),
+            "tok_abc".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn an_access_denied_response_stops_immediately() {
+        let template = wiremock::ResponseTemplate::new(200)
+            .set_body_json(serde_json::json!({ "access_denied": true }));
+        let (result, elapsed) = exchange_against(template).await;
+
+        let Err(err) = result else {
+            panic!("an access_denied response should not succeed");
+        };
+        assert!(
+            err.to_string().contains("Access denied"),
+            "expected an access-denied error, got: {err}"
+        );
+        assert!(
+            elapsed < TEST_TIMEOUT_MS,
+            "a denial should not wait out the deadline, took {elapsed}ms"
+        );
+    }
 }

--- a/bin/spice/src/commands/login/mod.rs
+++ b/bin/spice/src/commands/login/mod.rs
@@ -286,7 +286,7 @@ async fn login_spiceai(
 /// Matches the Spice Cloud device flow in [`crate::commands::cloud`]; the
 /// Microsoft device-code flow in [`providers`] bounds itself the same way, off
 /// the `expires_in` its authorization server returns.
-const LOGIN_POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+const LOGIN_POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(5);
 
 /// How long to wait between token-exchange attempts.
 const LOGIN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
@@ -322,8 +322,18 @@ impl std::fmt::Debug for ExchangeOutcome {
 
 /// Classify the HTTP status of a token-exchange attempt.
 ///
-/// Returns `None` for a success status, meaning the body decides the outcome.
+/// Returns `None` for a success status that can carry a body, meaning the body
+/// decides the outcome.
 fn classify_exchange_status(status: reqwest::StatusCode) -> Option<ExchangeOutcome> {
+    // A 204 promises no content, so there is no body to decide anything and no
+    // status a token could arrive under. Read it the same way as a 200 whose body
+    // carries no token -- the user has not finished authorizing yet -- rather than
+    // letting it reach `json()` and be reported as an unparseable success, which
+    // would put a parse error in the debug log and in the timeout's last error.
+    if status == reqwest::StatusCode::NO_CONTENT {
+        return Some(ExchangeOutcome::Pending);
+    }
+
     if status.is_success() {
         return None;
     }
@@ -609,9 +619,19 @@ mod tests {
     }
 
     #[test]
-    fn a_success_status_defers_to_the_body() {
+    fn a_success_status_with_a_body_defers_to_the_body() {
         assert_eq!(classify_exchange_status(status(200)), None);
-        assert_eq!(classify_exchange_status(status(204)), None);
+    }
+
+    /// A 204 carries no body, so deferring to one would classify every such
+    /// response as an unparseable success. It says the same thing a 200 with no
+    /// token says: keep polling.
+    #[test]
+    fn a_no_content_status_is_pending() {
+        assert_eq!(
+            classify_exchange_status(status(204)),
+            Some(ExchangeOutcome::Pending)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #12506

## Why

The Spice.ai browser-login poll loop in `login_spiceai` had **no deadline and no attempt
bound**, and treated every outcome that was not `access_denied` and not a non-empty
`access_token` as retryable. An unreachable or wrong `SPICE_BASE_URL`, a persistent 4xx, an
HTML error page, an empty body, or a `3xx` the client declines to follow all re-looped at one
request per second forever — printing an error line each time — and `spice login` never exited
on its own.

Both sibling flows in this binary already bound themselves, which is what makes this a gap
rather than a design choice:

- `execute_login_device_flow` (`commands/cloud/mod.rs`) polls the same auth-code exchange
  shape behind a 5-minute deadline, and logs its retryable failures at `debug`.
- `msal_device_code_flow` (`commands/login/providers.rs`) honours the `expires_in` its
  authorization server returns and fails with "Authentication timed out. Please try again."

The Spice.ai flow was the one of the three with neither.

## Changes

The loop moves into `poll_for_access_token`, which takes an explicit deadline and interval,
and each attempt is classified by two pure helpers:

| Outcome | Treated as | Why |
| --- | --- | --- |
| 2xx + non-empty `access_token` | success | unchanged |
| 2xx + `access_denied` | denied, stop | unchanged |
| 2xx + no token | pending, keep polling | unchanged — the user has not finished in the browser |
| 3xx, 4xx except 408/429 | **permanent, stop** | the endpoint is rejecting this exact request; re-sending it cannot succeed |
| 5xx, 408, 429, transport error | retryable, until the deadline | can still become healthy while the user authorizes |
| 2xx with an unparseable body | retryable, until the deadline | see below |

The one judgment call is the last row. The issue lists "an HTML error page, an empty body"
among the permanent outcomes, and in practice those arrive with a non-2xx status, which the
status rule above already stops on. A **2xx** carrying a body that will not parse is more
likely an interposed proxy or CDN interstitial than a decided answer, and killing a legitimate
login over one bad response during a 5-minute browser wait would be the worse failure — so it
stays retryable and the deadline bounds it. That keeps the load-bearing invariant intact: the
flow must keep polling for as long as the user is plausibly still completing login.

Also:

- Retryable failures log at `debug` rather than `error`, and the **last** one is carried into
  the timeout message. An endpoint that only ever fails now says why it gave up, instead of
  emitting one error line a second for the whole deadline. A healthy "not yet" clears it, so a
  genuine user timeout is not misattributed to an earlier blip.
- `ExchangeOutcome::Token` holds a live credential, so `Debug` is implemented by hand to
  redact it rather than derived — it must not be the reason a token reaches a log line or an
  assertion message.

The deadline is 300s, matching the closest sibling (the Cloud device flow), not the MSAL
default of 900s — that one is server-supplied for a different IdP.

## Test plan

`bin/spice` already has `wiremock` as a dev-dependency, so the loop is tested end-to-end over
HTTP rather than only through the helpers.

- Pure classification: success statuses defer to the body; 408/429/5xx are retryable; 301/302/307
  and 400/401/403/404/410 are permanent; bodies carrying a token, `access_denied`, an empty
  token, a null token, and `{}` each classify as expected.
- **Regression (the bug):** `a_perpetually_pending_exchange_gives_up_at_the_deadline` — a
  server that always answers `200 {}` made the old loop spin forever; it now returns a timeout
  error. `a_rejecting_endpoint_fails_without_waiting_out_the_deadline` — a server that always
  answers 404 (the wrong-`SPICE_BASE_URL` case) was retried forever; it now fails immediately
  and names the status.
- `a_failing_but_retriable_endpoint_reports_why_it_timed_out` — a 503 keeps polling to the
  deadline *and* the 503 survives into the error message.
- Happy path and denial are unchanged and covered: a token response completes, and
  `access_denied` stops without waiting out the deadline.

Verification:

- `make lint`
- `make test`

Both run via `make signoff` on this branch.

## Checklist

- [x] Bug reproduced and root-caused before fixing
- [x] Regression tests that fail on the old code and pass on the new
- [x] Happy path and denial paths covered, and unchanged in behaviour
- [x] No credential reaches a log, error, or assertion message
- [ ] `make signoff` green
