### PR TITLE
fix(runtime): report a dataset connector load failure once, not once per site (fixes #12365)

### DIFF
--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -355,6 +355,12 @@ impl Runtime {
             .await
         {
             Ok(data_connector) => data_connector,
+            // This is the only failure this function can raise, and reporting it is
+            // owned here: the component status, the `LOAD_ERROR` count, and one log
+            // line at the level the failure's permanence warrants. Both callers --
+            // `try_load_dataset_once` and the hot-reload path in `update_dataset` --
+            // used to report the error again on receiving it, which counted one
+            // failure twice and wrote the same status twice. See #12365.
             Err(err) => {
                 let ds_name = &ds.name;
                 self.status.update_dataset(
@@ -505,18 +511,15 @@ impl Runtime {
                 tracing::debug!(dataset = %ds.name, duration_ms = connector_start.elapsed().as_millis(), "Dataset connector created");
                 connector
             }
-            Err(err) => {
-                if !self.status.is_shutdown() {
-                    let ds_name = &ds.name;
-                    self.status.update_dataset(
-                        ds_name,
-                        status::ComponentStatus::error_with_message(err.to_string()),
-                    );
-                    metrics::datasets::LOAD_ERROR.add(1, &[]);
-                    warn_spaced!(spaced_tracer, "{} {err}", ds_name.table());
-                }
-                return Err(err);
-            }
+            // `load_dataset_connector` has already written the status, counted
+            // `LOAD_ERROR`, and logged at the level this failure's permanence
+            // warrants -- repeating any of it here reported one failure twice
+            // (#12365). It raises no other error, so nothing goes unreported.
+            //
+            // The `is_shutdown()` guard went with that block. It only ever
+            // suppressed this duplicate, never the callee's report, so a failure
+            // during teardown counted once before this change and still does.
+            Err(err) => return Err(err),
         };
 
         // Check shutdown between connector load and registration.
@@ -1095,11 +1098,9 @@ impl Runtime {
                 }
             }
             Err(e) => {
+                // `load_dataset_connector` set the error status for this failure.
+                // Only the hot-reload context it cannot know is added here (#12365).
                 tracing::error!("Unable to update dataset {}: {e}", ds.name);
-                self.status.update_dataset(
-                    &ds.name,
-                    status::ComponentStatus::error_with_message(e.to_string()),
-                );
             }
         }
     }
@@ -2171,6 +2172,113 @@ mod tests {
         assert!(
             DfError::UnableToLockDataWriters {}.is_retriable(),
             "contention on an internal lock is transient"
+        );
+    }
+
+    /// Installs a `MeterProvider` backed by a scrapable Prometheus registry, so the
+    /// `datasets::LOAD_ERROR` counter this module writes can be read back.
+    ///
+    /// The metric statics are `LazyLock`s that bind to whichever provider is global
+    /// when they are first touched, and that binding survives a later
+    /// `set_meter_provider`. So this rewires the meter for the whole process and only
+    /// the first caller in it wins -- keep it to a single test, as
+    /// `tests/query_failure_err_code.rs` does.
+    fn install_prometheus_meter_provider() -> prometheus::Registry {
+        let registry = prometheus::Registry::new();
+
+        let exporter = opentelemetry_prometheus::exporter()
+            .with_registry(registry.clone())
+            .without_scope_info()
+            .without_units()
+            .without_counter_suffixes()
+            .without_target_info()
+            .build()
+            .expect("to build the prometheus exporter");
+
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            .with_resource(opentelemetry_sdk::Resource::builder().build())
+            .with_reader(exporter)
+            .build();
+        opentelemetry::global::set_meter_provider(provider);
+
+        registry
+    }
+
+    /// Reads a counter's current value, treating "never incremented" as zero -- a
+    /// counter that was never written does not appear among the gathered families.
+    fn counter_value(registry: &prometheus::Registry, name: &str) -> f64 {
+        registry
+            .gather()
+            .iter()
+            .find(|family| {
+                family.name() == name
+                    && family.get_field_type() == prometheus::proto::MetricType::COUNTER
+            })
+            .and_then(|family| family.get_metric().first())
+            .map_or(0.0, |metric| metric.get_counter().value())
+    }
+
+    /// A dataset whose `from:` names no registered connector, so building its
+    /// connector always fails.
+    fn unloadable_dataset(runtime: &Arc<crate::Runtime>) -> Arc<Dataset> {
+        let spec = spicepod::component::dataset::Dataset::new(
+            "not_a_real_connector:any",
+            "reported_once",
+        );
+        let app = app::AppBuilder::new("single_load_error_report")
+            .with_dataset(spec.clone())
+            .build();
+
+        Arc::new(
+            DatasetBuilder::try_from(spec)
+                .expect("valid dataset builder")
+                .with_app(Arc::new(app))
+                .with_runtime(Arc::clone(runtime))
+                .build()
+                .expect("valid runtime dataset"),
+        )
+    }
+
+    /// Regression test for #12365: `load_dataset_connector` reports a connector
+    /// failure -- component status, `LOAD_ERROR`, and a log line -- and its caller
+    /// then reported the very same error again, so one unloadable dataset advanced
+    /// `dataset_load_errors` by 2 per attempt instead of 1.
+    ///
+    /// The teardown half is asserted in the same test on purpose: installing the
+    /// meter provider rewires the process, so only one test per binary can do it.
+    /// Deleting the caller's block also deleted the `is_shutdown()` guard around it,
+    /// and that guard only ever suppressed the duplicate -- the callee counted
+    /// regardless -- so a failure during teardown counted exactly one before this
+    /// change and must still count exactly one.
+    #[tokio::test]
+    async fn a_dataset_connector_failure_counts_one_load_error() {
+        let registry = install_prometheus_meter_provider();
+        let runtime = Arc::new(crate::Runtime::builder().build().await);
+
+        let before = counter_value(&registry, "dataset_load_errors");
+        runtime
+            .try_load_dataset_once(unloadable_dataset(&runtime), BootstrapStatus::None, None)
+            .await
+            .expect_err("a connector that cannot be created must fail the load");
+        let counted = counter_value(&registry, "dataset_load_errors") - before;
+
+        assert!(
+            (counted - 1.0).abs() < f64::EPSILON,
+            "one failure must be counted once, not once per reporting site; counted {counted}"
+        );
+
+        runtime.status.mark_shutdown();
+
+        let before = counter_value(&registry, "dataset_load_errors");
+        runtime
+            .try_load_dataset_once(unloadable_dataset(&runtime), BootstrapStatus::None, None)
+            .await
+            .expect_err("a connector that cannot be created must fail the load");
+        let counted = counter_value(&registry, "dataset_load_errors") - before;
+
+        assert!(
+            (counted - 1.0).abs() < f64::EPSILON,
+            "teardown counted one load error before this change; counted {counted}"
         );
     }
 }

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -355,12 +355,12 @@ impl Runtime {
             .await
         {
             Ok(data_connector) => data_connector,
-            // This is the only failure this function can raise, and reporting it is
+            // This is the only failure this function raises, and reporting it is
             // owned here: the component status, the `LOAD_ERROR` count, and one log
-            // line at the level the failure's permanence warrants. Both callers --
+            // line at the level the failure's permanence warrants. Callers -- both
             // `try_load_dataset_once` and the hot-reload path in `update_dataset` --
-            // used to report the error again on receiving it, which counted one
-            // failure twice and wrote the same status twice. See #12365.
+            // propagate it without reporting it again, so one failure is counted
+            // once and writes one status. See #12365.
             Err(err) => {
                 let ds_name = &ds.name;
                 self.status.update_dataset(
@@ -511,14 +511,12 @@ impl Runtime {
                 tracing::debug!(dataset = %ds.name, duration_ms = connector_start.elapsed().as_millis(), "Dataset connector created");
                 connector
             }
-            // `load_dataset_connector` has already written the status, counted
-            // `LOAD_ERROR`, and logged at the level this failure's permanence
-            // warrants -- repeating any of it here reported one failure twice
-            // (#12365). It raises no other error, so nothing goes unreported.
-            //
-            // The `is_shutdown()` guard went with that block. It only ever
-            // suppressed this duplicate, never the callee's report, so a failure
-            // during teardown counted once before this change and still does.
+            // `load_dataset_connector` owns reporting for this failure -- the
+            // status, the `LOAD_ERROR` count, and a log line at the level its
+            // permanence warrants -- and raises no other error, so propagating it
+            // unreported leaves nothing unreported (#12365). Its reporting is
+            // unconditional, including during teardown, so this arm needs no
+            // `is_shutdown()` guard of its own to keep the count at one.
             Err(err) => return Err(err),
         };
 
@@ -2221,10 +2219,8 @@ mod tests {
     /// A dataset whose `from:` names no registered connector, so building its
     /// connector always fails.
     fn unloadable_dataset(runtime: &Arc<crate::Runtime>) -> Arc<Dataset> {
-        let spec = spicepod::component::dataset::Dataset::new(
-            "not_a_real_connector:any",
-            "reported_once",
-        );
+        let spec =
+            spicepod::component::dataset::Dataset::new("not_a_real_connector:any", "reported_once");
         let app = app::AppBuilder::new("single_load_error_report")
             .with_dataset(spec.clone())
             .build();


### PR DESCRIPTION
## Summary

**Root cause.** `Runtime::load_dataset_connector` fully reports the one failure it can
raise -- it writes the component status, counts `datasets::LOAD_ERROR`, and logs at the
level the failure's permanence warrants (ERROR for permanent, WARN otherwise) -- and then
returns the error. Both of its callers reported that same error again on receiving it:

- `try_load_dataset_once` wrote the status, counted `LOAD_ERROR`, and logged a second time;
- `update_dataset` (the hot-reload path) wrote the status a second time.

So one unloadable dataset advanced `dataset_load_errors` by 2 per attempt rather than 1,
and wrote the same error status twice for a single failure.

## Changes

Reporting is now owned by the callee alone, which is where it has to live: the function
raises exactly one error, and it is the only site that knows whether that error is
permanent, so the ERROR-vs-WARN level cannot be reproduced correctly by a caller.

- `try_load_dataset_once` returns the error unchanged.
- `update_dataset` keeps only its `tracing::error!`, which carries the hot-reload context
  the callee cannot know, and drops the duplicate status write.
- `load_dataset_connector` is unchanged apart from a comment recording that it owns the
  reporting.

The `is_shutdown()` guard is deleted with the caller block it wrapped. It only ever
suppressed the duplicate report -- the callee counted regardless -- so a failure during
teardown counted exactly one before this change and still counts exactly one. This is
asserted, not assumed (see the test plan).

**Scope.** #12442 tracks the same shape on the catalog path. It is already fixed by
#12469, which removes the reporting from `load_catalog_connector` and declares
`Fixes #12442`, so this PR deliberately leaves `init/catalog.rs` alone rather than
opening a second, conflicting change to the same lines.

**Performance impact.** None. This removes work (one counter add, one status write, one
formatted log line per failed dataset load); no query or plan path is touched.

## Test plan

- `a_dataset_connector_failure_counts_one_load_error` (new, `crates/runtime/src/init/dataset.rs`):
  installs a Prometheus-backed `MeterProvider`, drives `try_load_dataset_once` with a
  dataset whose `from:` names no registered connector, and asserts `dataset_load_errors`
  advances by exactly 1. It advances by 2 on the code before this change. The same test
  then marks the runtime shut down and repeats the load, asserting the count still
  advances by exactly 1 -- pinning the behaviour the deleted guard did not actually
  change. Both halves live in one test on purpose: installing the meter provider rewires
  the process, so only the first caller in a test binary wins, which is why
  `tests/query_failure_err_code.rs` carries the same "keep it to a single test" note.
- `make lint`
- `make test`

## Checklist

- [x] Root cause identified and stated
- [x] Regression test that fails on the old code and passes on the new
- [x] No behaviour change outside the reported defect (teardown counting asserted unchanged)
- [x] Checked the sibling catalog path -- already covered by #12469, left untouched
- [ ] `make signoff` green / `Attestation` re-run

Fixes #12365
