### PR TITLE
fix(runtime): name a UTC timestamp column's zone in a spelling DuckDB knows (fixes #12528)

### DIFF
--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -46,6 +46,7 @@ pub mod time;
 pub mod time_format;
 #[cfg(feature = "datafusion")]
 pub mod timestamp_filter;
+pub mod timezone;
 
 pub const DATAFUSION_BUG_REPORT_MESSAGE: &str = "This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues";
 

--- a/crates/util/src/timestamp_filter.rs
+++ b/crates/util/src/timestamp_filter.rs
@@ -86,8 +86,9 @@ fn convert_timestamp_expr(
             // DuckDB unparser renders `CAST(col AS Timestamp(ns, tz))` as
             // `col AT TIME ZONE '<tz>'`, which DuckDB resolves through ICU — named
             // zones only. Iceberg spells every `timestamptz` as the fixed offset
-            // `+00:00`, so the pushed-down filter was rejected outright with
-            // `Unknown TimeZone '+00:00'` and the dataset never became ready (#12528).
+            // `+00:00`, so carrying that spelling through unchanged gets the whole
+            // filter rejected with `Unknown TimeZone '+00:00'`, leaving the dataset
+            // stuck retrying a refresh that can never bind (#12528).
             //
             // Naming the same zone in a spelling every engine knows leaves the
             // comparison unchanged. A non-UTC offset is left alone: it denotes a
@@ -386,10 +387,10 @@ mod tests {
             .to_string()
     }
 
-    /// The #12528 regression: Iceberg maps every `timestamptz` to the fixed offset
-    /// `+00:00`, which the `DuckDB` unparser renders as `AT TIME ZONE '+00:00'` —
-    /// rejected by `DuckDB`'s ICU resolver, so the dataset never became ready. The
-    /// zone is named in a spelling every engine knows instead.
+    /// Regression test for #12528. Iceberg maps every `timestamptz` to the fixed
+    /// offset `+00:00`, which the `DuckDB` unparser renders as
+    /// `AT TIME ZONE '+00:00'` — a spelling `DuckDB`'s ICU resolver rejects, so the
+    /// filter has to name the zone in a form every engine accepts.
     #[test]
     fn a_fixed_offset_utc_column_is_named_utc() {
         let expected = r#"CAST(timestamp AS Timestamp(ns, "UTC")) > TimestampNanosecond(1620000000000000000, Some("UTC"))"#;

--- a/crates/util/src/timestamp_filter.rs
+++ b/crates/util/src/timestamp_filter.rs
@@ -387,8 +387,8 @@ mod tests {
     }
 
     /// The #12528 regression: Iceberg maps every `timestamptz` to the fixed offset
-    /// `+00:00`, which the DuckDB unparser renders as `AT TIME ZONE '+00:00'` —
-    /// rejected by DuckDB's ICU resolver, so the dataset never became ready. The
+    /// `+00:00`, which the `DuckDB` unparser renders as `AT TIME ZONE '+00:00'` —
+    /// rejected by `DuckDB`'s ICU resolver, so the dataset never became ready. The
     /// zone is named in a spelling every engine knows instead.
     #[test]
     fn a_fixed_offset_utc_column_is_named_utc() {

--- a/crates/util/src/timestamp_filter.rs
+++ b/crates/util/src/timestamp_filter.rs
@@ -25,6 +25,8 @@ use datafusion::{
 };
 use std::sync::Arc;
 
+use crate::timezone;
+
 /// Timestamp format for a column — determines how target filter expressions
 /// are constructed.
 #[derive(Debug, Clone)]
@@ -79,17 +81,37 @@ fn convert_timestamp_expr(
                 None,
             ),
         ),
-        TimestampFormat::Timestamptz(tz) => binary_expr(
-            cast(
-                ident(time_column),
-                DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, tz.clone()),
-            ),
-            op,
-            Expr::Literal(
-                ScalarValue::TimestampNanosecond(Some(timestamp_in_nanos as i64), tz.to_owned()),
-                None,
-            ),
-        ),
+        TimestampFormat::Timestamptz(tz) => {
+            // The cast carries the accelerator schema's timezone spelling, and the
+            // DuckDB unparser renders `CAST(col AS Timestamp(ns, tz))` as
+            // `col AT TIME ZONE '<tz>'`, which DuckDB resolves through ICU — named
+            // zones only. Iceberg spells every `timestamptz` as the fixed offset
+            // `+00:00`, so the pushed-down filter was rejected outright with
+            // `Unknown TimeZone '+00:00'` and the dataset never became ready (#12528).
+            //
+            // Naming the same zone in a spelling every engine knows leaves the
+            // comparison unchanged. A non-UTC offset is left alone: it denotes a
+            // different zone, so rewriting it would move the comparison.
+            let tz = tz.as_ref().map(|tz| {
+                if timezone::is_utc(tz) {
+                    Arc::from(timezone::CANONICAL_UTC)
+                } else {
+                    Arc::clone(tz)
+                }
+            });
+
+            binary_expr(
+                cast(
+                    ident(time_column),
+                    DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, tz.clone()),
+                ),
+                op,
+                Expr::Literal(
+                    ScalarValue::TimestampNanosecond(Some(timestamp_in_nanos as i64), tz),
+                    None,
+                ),
+            )
+        }
     }
 }
 
@@ -348,6 +370,49 @@ mod tests {
         assert_eq!(
             result.to_string(),
             r#"CAST(timestamp AS Timestamp(ns, "UTC")) > TimestampNanosecond(1620000000000000000, Some("UTC"))"#,
+        );
+    }
+
+    /// Builds the filter for a `Timestamp(ns, tz)` column and returns it rendered.
+    fn convert_with_timezone(tz: &str) -> String {
+        let format = data_type_to_timestamp_format(
+            &DataType::Timestamp(TimeUnit::Nanosecond, Some(tz.into())),
+            None,
+        )
+        .expect("should resolve");
+        let converter = TimestampFilterConvert::new("timestamp".to_string(), format, None, None);
+        converter
+            .convert(1_620_000_000_000_000_000, Operator::Gt)
+            .to_string()
+    }
+
+    /// The #12528 regression: Iceberg maps every `timestamptz` to the fixed offset
+    /// `+00:00`, which the DuckDB unparser renders as `AT TIME ZONE '+00:00'` —
+    /// rejected by DuckDB's ICU resolver, so the dataset never became ready. The
+    /// zone is named in a spelling every engine knows instead.
+    #[test]
+    fn a_fixed_offset_utc_column_is_named_utc() {
+        let expected = r#"CAST(timestamp AS Timestamp(ns, "UTC")) > TimestampNanosecond(1620000000000000000, Some("UTC"))"#;
+
+        for tz in ["+00:00", "-00:00", "+0000", "+00"] {
+            assert_eq!(convert_with_timezone(tz), expected, "{tz} denotes UTC");
+        }
+        for tz in ["Z", "GMT", "Etc/UTC", "utc"] {
+            assert_eq!(convert_with_timezone(tz), expected, "{tz} denotes UTC");
+        }
+    }
+
+    /// A non-UTC zone must survive untouched — rewriting it would move the
+    /// comparison to a different instant.
+    #[test]
+    fn a_non_utc_timezone_is_left_alone() {
+        assert_eq!(
+            convert_with_timezone("America/New_York"),
+            r#"CAST(timestamp AS Timestamp(ns, "America/New_York")) > TimestampNanosecond(1620000000000000000, Some("America/New_York"))"#,
+        );
+        assert_eq!(
+            convert_with_timezone("-05:00"),
+            r#"CAST(timestamp AS Timestamp(ns, "-05:00")) > TimestampNanosecond(1620000000000000000, Some("-05:00"))"#,
         );
     }
 

--- a/crates/util/src/timezone.rs
+++ b/crates/util/src/timezone.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Spice.ai OSS Authors
+Copyright 2026 The Spice.ai OSS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crates/util/src/timezone.rs
+++ b/crates/util/src/timezone.rs
@@ -1,0 +1,142 @@
+/*
+Copyright 2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Recognising the many spellings an Arrow schema uses for UTC.
+//!
+//! Arrow timezone metadata is a free-form string that is never canonicalised, so
+//! the same zone arrives spelled differently depending on the source: Iceberg
+//! maps every `timestamptz` to the fixed offset `+00:00`, most connectors emit
+//! `UTC`, and RFC 3339 parsing yields `Z`. Engines disagree over which of those
+//! they accept, so code that hands a zone to an engine has to recognise the
+//! equivalent spellings rather than compare against a single one.
+
+/// The spelling to use when a UTC-equivalent zone has to be named for an engine.
+pub const CANONICAL_UTC: &str = "UTC";
+
+/// Returns `true` when `tz` denotes UTC, in any spelling an Arrow schema carries.
+///
+/// Covers the named zones (`UTC`, `Z`, `GMT`, `Etc/UTC`, …) and every zero
+/// fixed-offset spelling (`+00:00`, `-00:00`, `+0000`, `+00`). A non-zero offset
+/// such as `-05:00` denotes a different zone and returns `false`.
+#[must_use]
+pub fn is_utc(tz: &str) -> bool {
+    let tz = tz.trim();
+
+    if is_zero_offset(tz) {
+        return true;
+    }
+
+    matches!(
+        tz.to_ascii_lowercase().as_str(),
+        "utc" | "uct" | "gmt" | "z" | "zulu" | "universal" | "etc/utc" | "etc/gmt"
+    )
+}
+
+/// Returns `true` for a fixed-offset spelling whose offset is zero.
+///
+/// Accepts the forms Arrow producers actually emit — `+00:00`, `-00:00`, `+0000`,
+/// `+00`, `+0:00` — and requires both halves to be present and zero, so a
+/// malformed `+00:` or `+:00` is rejected rather than read as UTC. Any non-zero
+/// digit makes it a different zone.
+fn is_zero_offset(tz: &str) -> bool {
+    let Some(offset) = tz.strip_prefix(['+', '-']) else {
+        return false;
+    };
+
+    let (hours, minutes) = match offset.split_once(':') {
+        Some((hours, minutes)) => (hours, minutes),
+        // `+0000` packs both halves; the `is_ascii` guard keeps the split on a
+        // character boundary, since a 4-byte offset may be one multi-byte char.
+        None if offset.len() == 4 && offset.is_ascii() => (&offset[..2], &offset[2..]),
+        // `+00` names only the hours, so the minutes are an implicit zero.
+        None => (offset, "0"),
+    };
+
+    is_all_zeros(hours) && is_all_zeros(minutes)
+}
+
+/// Returns `true` for a non-empty run of ASCII `0`s.
+fn is_all_zeros(part: &str) -> bool {
+    !part.is_empty() && part.bytes().all(|byte| byte == b'0')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_utc, is_zero_offset};
+
+    #[test]
+    fn named_utc_zones_are_utc() {
+        for tz in ["UTC", "utc", "uTc", "GMT", "gmt", "Z", "z", "UCT"] {
+            assert!(is_utc(tz), "{tz} names UTC");
+        }
+        for tz in ["Zulu", "Universal", "Etc/UTC", "etc/utc", "Etc/GMT"] {
+            assert!(is_utc(tz), "{tz} names UTC");
+        }
+    }
+
+    /// Surrounding whitespace is metadata noise, not a different zone.
+    #[test]
+    fn a_padded_zone_name_is_still_utc() {
+        assert!(is_utc(" UTC "), "the zone name should be trimmed");
+    }
+
+    /// The #12528 case: Iceberg spells every `timestamptz` as `+00:00`, and the
+    /// other zero-offset forms denote that same zone.
+    #[test]
+    fn zero_fixed_offsets_are_utc() {
+        for tz in ["+00:00", "-00:00", "+0000", "-0000"] {
+            assert!(is_utc(tz), "{tz} is a zero offset, so it is UTC");
+        }
+        for tz in ["+00", "-00", "+0:00", "+0"] {
+            assert!(is_utc(tz), "{tz} is a zero offset, so it is UTC");
+        }
+    }
+
+    /// A non-zero offset is a different zone and must never be rewritten to UTC.
+    #[test]
+    fn non_zero_offsets_are_not_utc() {
+        for tz in ["-05:00", "+05:30", "+01:00", "-0500"] {
+            assert!(!is_utc(tz), "{tz} is not UTC");
+        }
+        for tz in ["+10", "+00:30", "-00:01"] {
+            assert!(!is_utc(tz), "{tz} is not UTC");
+        }
+    }
+
+    #[test]
+    fn named_non_utc_zones_are_not_utc() {
+        for tz in ["America/New_York", "Asia/Tokyo", "Europe/London"] {
+            assert!(!is_utc(tz), "{tz} is not UTC");
+        }
+        // `Etc/GMT+5` is a real, non-zero zone despite reading like a zero offset.
+        for tz in ["Etc/GMT+5", "EST", ""] {
+            assert!(!is_utc(tz), "{tz} is not UTC");
+        }
+    }
+
+    /// Guards the byte scan against inputs that are not offsets at all — it must
+    /// reject them rather than panic or read them as zero. `+°0` is multi-byte, so
+    /// a scan that indexed by byte position instead of matching would split a char.
+    #[test]
+    fn malformed_offsets_are_rejected() {
+        for tz in ["+", "-", "+00:", "+:00", "+0:0:0", "+0a"] {
+            assert!(!is_zero_offset(tz), "{tz} is not a zero offset");
+        }
+        for tz in ["00:00", "+°0", "+0 0"] {
+            assert!(!is_zero_offset(tz), "{tz} is not a zero offset");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A dataset accelerated with `engine: duckdb` failed to load and stayed permanently unhealthy when its refresh time column carried an Arrow **fixed-offset** timezone:

```
Not implemented Error: Unknown TimeZone '+00:00'!
```

**Root cause.** Arrow timezone metadata is a free-form string that is never canonicalised, so the same zone arrives spelled differently per source — Iceberg maps *every* `timestamptz` to the fixed offset `+00:00`. `TimestampFilterConvert` (`crates/util/src/timestamp_filter.rs`) carries that spelling verbatim into the `CAST(col AS Timestamp(ns, tz))` it builds for the append-refresh dedup filter. The DuckDB unparser renders that cast as `col AT TIME ZONE '<tz>'`, which DuckDB resolves through its ICU extension — **named zones only**. Every fixed-offset spelling is rejected, so the filter never binds, the refresh retries with unbounded backoff, and the dataset never becomes ready (`6/7 ready, 1 unhealthy`).

Verified against DuckDB v1.5.2: `+00:00`, `+0000`, `+00`, `-05:00` all raise `Unknown TimeZone`, while `UTC`, `Etc/UTC`, `GMT`, `America/New_York` are accepted. So the fix has to key on *UTC-equivalence*, not on the literal string `+00:00`.

## Changes

- **`crates/util/src/timezone.rs` (new)** — a shared recogniser for the spellings an Arrow schema uses for UTC: the named zones (`UTC`, `Z`, `GMT`, `Etc/UTC`, …, case-insensitive) and every zero fixed offset (`+00:00`, `-00:00`, `+0000`, `+00`, `+0:00`). A non-zero offset such as `-05:00` is deliberately **not** UTC.

  This is shared rather than another ad-hoc match because four sites in the tree already each accept a different subset — `connector-mysql/src/replication.rs`, `data_components/src/turso.rs`, `runtime-table-partition/src/provider/pruning.rs`, `test-framework/src/queries/validation/mod.rs` — and none of them covers `+0000` or `+00`. Converting those callers is deliberately left out of scope: each does something different with the answer, so they need their own reasoning and tests.

- **`crates/util/src/timestamp_filter.rs`** — when building the `Timestamptz` filter, name a UTC-equivalent zone as `UTC` on both the cast and the literal.

**Why this is behaviour-preserving.** An Arrow timestamp is a UTC instant and its timezone is display metadata; both operands of the comparison carry the same zone, so naming that zone differently cannot move the comparison. `+00:00` and `UTC` denote the same zone, so this is a spelling change, not a conversion — for every engine, not just DuckDB. A non-UTC zone is left exactly as it was, so no engine's existing behaviour changes for it.

## Scope — what this deliberately does not fix

A **non-zero** fixed offset (`-05:00`) still fails on DuckDB. Rewriting it to UTC would silently move the comparison, so failing loudly stays the correct outcome until the DuckDB dialect renders an internally-constructed cast as a cast rather than as an `AT TIME ZONE` conversion. That dialect gap — which also makes a *named* non-UTC zone silently shift the comparison instead of erroring — lives in `datafusion-table-providers`/the DataFusion unparser, not this repo, and is tracked separately in the issue discussion.

## Test plan

- `make lint`
- `make test`
- New unit tests in `crates/util/src/timezone.rs`: named UTC zones, whitespace padding, every zero-offset spelling, non-zero offsets, named non-UTC zones (including `Etc/GMT+5`, which reads like a zero offset but is not), and malformed inputs — the last covering multi-byte input (`+°0`) so the offset split cannot panic on a non-character boundary.
- New regression tests in `crates/util/src/timestamp_filter.rs`: `a_fixed_offset_utc_column_is_named_utc` fails on the old code (it emitted `Timestamp(ns, "+00:00")`) and passes on the new; `a_non_utc_timezone_is_left_alone` pins that `America/New_York` and `-05:00` are untouched.

## Checklist

- [x] Root cause identified and stated
- [x] Regression test fails on old code, passes on new
- [x] Non-UTC zones proven untouched
- [x] Multi-byte input cannot panic
- [ ] `make signoff` green
- [ ] Copilot review addressed

Fixes #12528
