### PR TITLE
fix(workers): give the weighted-router test a noise margin it can survive (fixes #12537)

### DIFF
--- a/crates/workers/src/router.rs
+++ b/crates/workers/src/router.rs
@@ -373,9 +373,34 @@ mod tests {
             assert!(count_2 > count_1);
             assert!(count_4 > count_2);
 
-            // An integer approximation to check that weights are approximately correct.
-            assert!(count_2 - 2 * count_1 < n / 10);
-            assert!(count_4 - 2 * count_2 < n / 10);
+            // The draw is random and unseeded, so these bounds are noise margins
+            // rather than accuracy targets. Each count is binomial over `draws`
+            // trials, so a two-sided five-standard-deviation band fails by chance
+            // about once in 580,000 runs while still catching any real
+            // mis-weighting: the band is ±14% of the mean on the heaviest arm,
+            // widening to ±39% on the lightest, which is the one whose count is
+            // smallest and so proportionally noisiest.
+            //
+            // The bounds this replaces were one-sided (`count_4 - 2 * count_2 <
+            // n / 10` constrained the heaviest arm being over-selected but never
+            // under-selected) and, on that arm, only 2.4 standard deviations wide,
+            // so they failed roughly one run in 128 and took unrelated PRs'
+            // sign-offs down with them. See #12537.
+            let draws = f64::from(n - 1);
+            let total_weight = 7.0;
+
+            for (count, weight) in [(count_1, 1.0), (count_2, 2.0), (count_4, 4.0)] {
+                let share = weight / total_weight;
+                let expected = draws * share;
+                let deviation = (f64::from(count) - expected).abs();
+                let tolerance = 5.0 * (draws * share * (1.0 - share)).sqrt();
+
+                assert!(
+                    deviation < tolerance,
+                    "weight {weight} selected {count} times, {deviation:.1} away from the \
+                     expected {expected:.1} (tolerance {tolerance:.1})"
+                );
+            }
         }
     }
 

--- a/crates/workers/src/router.rs
+++ b/crates/workers/src/router.rs
@@ -354,24 +354,58 @@ mod tests {
                     weight: 4,
                 },
             ];
-            let mut count_1 = 0;
-            let mut count_2 = 0;
-            let mut count_4 = 0;
+            // Every expectation below is derived from `cfg` rather than
+            // restating its weights, so editing the fixture above cannot leave
+            // the assertions silently describing the old weighting.
+            let mut arms: Vec<(String, f64, u32)> = cfg
+                .iter()
+                .filter_map(|c| {
+                    if let worker::RouterConfig::Weighted { from, weight } = c {
+                        Some((from.clone(), f64::from(*weight), 0))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            assert_eq!(
+                arms.len(),
+                cfg.len(),
+                "every arm of the fixture must be Weighted for these bounds to hold"
+            );
+            let total_weight: f64 = arms.iter().map(|(_, weight, _)| weight).sum();
+
             let n = 1000;
             for _ in 1..n {
                 let Some(v) = select_from_weighted(&cfg) else {
                     continue;
                 };
-                match v.as_str() {
-                    "example1.com" => count_1 += 1,
-                    "example2.com" => count_2 += 1,
-                    "example3.com" => count_4 += 1,
-                    _ => {}
+                if let Some((_, _, count)) = arms.iter_mut().find(|(from, _, _)| *from == v) {
+                    *count += 1;
                 }
             }
 
-            assert!(count_2 > count_1);
-            assert!(count_4 > count_2);
+            // A heavier arm must be selected more often than a lighter one. The
+            // fixture ascends by weight, so comparing consecutive pairs covers
+            // every arm; the weight assertion is what keeps that true if the
+            // fixture is reordered.
+            for pair in arms.windows(2) {
+                let [lighter, heavier] = pair else {
+                    continue;
+                };
+                let (lighter, light_weight, light_count) = lighter;
+                let (heavier, heavy_weight, heavy_count) = heavier;
+                assert!(
+                    heavy_weight > light_weight,
+                    "the fixture's arms must ascend by weight, but '{heavier}' \
+                     ({heavy_weight}) does not outweigh '{lighter}' ({light_weight})"
+                );
+                assert!(
+                    heavy_count > light_count,
+                    "'{heavier}' (weight {heavy_weight}) was selected {heavy_count} times, \
+                     no more often than the lighter '{lighter}' (weight {light_weight}, \
+                     {light_count} times)"
+                );
+            }
 
             // The draw is random and unseeded, so these bounds are noise margins
             // rather than accuracy targets. Each count is binomial over `draws`
@@ -387,18 +421,17 @@ mod tests {
             // so they failed roughly one run in 128 and took unrelated PRs'
             // sign-offs down with them. See #12537.
             let draws = f64::from(n - 1);
-            let total_weight = 7.0;
 
-            for (count, weight) in [(count_1, 1.0), (count_2, 2.0), (count_4, 4.0)] {
+            for (from, weight, count) in &arms {
                 let share = weight / total_weight;
                 let expected = draws * share;
-                let deviation = (f64::from(count) - expected).abs();
+                let deviation = (f64::from(*count) - expected).abs();
                 let tolerance = 5.0 * (draws * share * (1.0 - share)).sqrt();
 
                 assert!(
                     deviation < tolerance,
-                    "weight {weight} selected {count} times, {deviation:.1} away from the \
-                     expected {expected:.1} (tolerance {tolerance:.1})"
+                    "'{from}' (weight {weight}) selected {count} times, {deviation:.1} away \
+                     from the expected {expected:.1} (tolerance {tolerance:.1})"
                 );
             }
         }

--- a/crates/workers/src/router.rs
+++ b/crates/workers/src/router.rs
@@ -407,19 +407,21 @@ mod tests {
                 );
             }
 
-            // The draw is random and unseeded, so these bounds are noise margins
-            // rather than accuracy targets. Each count is binomial over `draws`
-            // trials, so a two-sided five-standard-deviation band fails by chance
-            // about once in 580,000 runs while still catching any real
-            // mis-weighting: the band is ±14% of the mean on the heaviest arm,
-            // widening to ±39% on the lightest, which is the one whose count is
-            // smallest and so proportionally noisiest.
+            // Regression test for #12537. The draw is random and unseeded, so
+            // these bounds are noise margins rather than accuracy targets, and a
+            // margin sized by eye is a flaky test: this suite runs on every
+            // sign-off, so a bound only a couple of standard deviations wide reds
+            // out PRs that touch nothing in this crate.
             //
-            // The bounds this replaces were one-sided (`count_4 - 2 * count_2 <
-            // n / 10` constrained the heaviest arm being over-selected but never
-            // under-selected) and, on that arm, only 2.4 standard deviations wide,
-            // so they failed roughly one run in 128 and took unrelated PRs'
-            // sign-offs down with them. See #12537.
+            // Each count is binomial over `draws` trials, so the tolerance is
+            // derived from the weights rather than hardcoded — five standard
+            // deviations, two-sided, which fails by chance about once in 580,000
+            // runs. That is still tight enough to catch a real mis-weighting: the
+            // band is ±14% of the mean on the heaviest arm, widening to ±39% on
+            // the lightest, whose count is smallest and so proportionally
+            // noisiest. Two-sided matters as much as the width — an arm selected
+            // far too *rarely* is as much a weighting bug as one selected too
+            // often.
             let draws = f64::from(n - 1);
 
             for (from, weight, count) in &arms {

--- a/crates/workers/src/router.rs
+++ b/crates/workers/src/router.rs
@@ -375,13 +375,24 @@ mod tests {
             let total_weight: f64 = arms.iter().map(|(_, weight, _)| weight).sum();
 
             let n = 1000;
-            for _ in 1..n {
+            // Every draw must land on a known arm. Skipping the ones that don't
+            // would let a draw vanish from the tally, and the bounds below are
+            // noise margins wide enough to absorb a fair number of vanished
+            // draws without noticing — so a `select_from_weighted` that started
+            // returning `None`, or a name outside the fixture, would leave every
+            // count uniformly low and the test still passing. Neither is
+            // reachable for this fixture (`WeightedIndex` accepts these weights,
+            // and it only ever samples an index into them), which is exactly why
+            // a draw that isn't one of them should fail loudly rather than be
+            // dropped.
+            for draw in 1..n {
                 let Some(v) = select_from_weighted(&cfg) else {
-                    continue;
+                    panic!("draw {draw} selected nothing from the fixture");
                 };
-                if let Some((_, _, count)) = arms.iter_mut().find(|(from, _, _)| *from == v) {
-                    *count += 1;
-                }
+                let Some((_, _, count)) = arms.iter_mut().find(|(from, _, _)| *from == v) else {
+                    panic!("draw {draw} selected '{v}', not an arm of the fixture");
+                };
+                *count += 1;
             }
 
             // A heavier arm must be selected more often than a lighter one. The


### PR DESCRIPTION
## Summary

`router::tests::weighted::test_select_from_weighted` draws 999 samples from an **unseeded** RNG over weights 1:2:4 and asserted:

```rust
assert!(count_2 - 2 * count_1 < n / 10);
assert!(count_4 - 2 * count_2 < n / 10);
```

Both differences are centred on zero, so `n / 10 = 100` is a pure noise margin, not an accuracy target. Under the multinomial with `p = 1/7, 2/7, 4/7` over 999 draws:

| assertion | SD | threshold | z | P(fail) |
|---|---|---|---|---|
| `count_4 - 2*count_2 < 100` | 41.4 | 100 | 2.42 | **0.78%** (~1 in 128) |
| `count_2 - 2*count_1 < 100` | 29.3 | 100 | 3.42 | 0.03% (~1 in 3163) |

The heavy arm dominates: the `2×` multiplier scales `count_2`'s variance fourfold, and the negative multinomial covariance *adds* to the total rather than cancelling.

Because it runs in the full `nextest` suite, it fails sign-off for PRs that touch nothing in `crates/workers`. The observation that prompted this took down PR #12513 (an append-dedup change) after a **3.8-hour** sign-off cycle — 9650 tests passed, this one failed.

There was a second, quieter defect: both bounds were **one-sided**. `count_4 - 2 * count_2 < 100` constrained the heaviest arm being selected too *often* but never too *rarely* — so a regression that under-weights it passed, which is at least as plausible a weighting bug as the one the test did catch.

## Changes

Assert that each count lies within five standard deviations of its own binomial mean, two-sided. Tolerance is computed from the weights rather than hardcoded, so it stays correct if the fixture's weights change.

| arm | expected | 5 SD tolerance | band |
|---|---|---|---|
| weight 1 | 142.7 | ±55.3 | ±39% |
| weight 2 | 285.4 | ±71.4 | ±25% |
| weight 4 | 570.9 | ±78.2 | ±14% |

Chance failure drops to roughly **1 in 580,000** runs across all three assertions, and every arm is now constrained in both directions. The existing `count_2 > count_1` / `count_4 > count_2` ordering checks are kept.

## Why not seed the RNG

Seeding is the stronger fix and the issue proposes it. It is deliberately **not** done here: choosing a seed requires running the suite to confirm that particular seed passes, and a seed that does not converts a rare flake into a permanent, 100%-reproducible break. That trade is only worth making from a change that can be verified against a real test run. Noted as a follow-up on the issue.

No production code changes — this is a test-only change.

## Test plan

- `make lint`
- `make test`
- The bounds are derived analytically rather than tuned, so the change is verifiable by inspection: each `tolerance` is `5 * sqrt(draws * share * (1 - share))`, the standard deviation of a binomial with that share.

## Checklist

- [x] Root cause identified and quantified
- [x] Both defects addressed (flake rate and one-sidedness)
- [x] No production code touched
- [ ] `make signoff` green

Fixes #12537
