### PR TITLE
fix(runtime): keep the leading slash on an inferred local Iceberg warehouse root (fixes #12533)

### DIFF
--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -786,10 +786,10 @@ pub fn parse_hadoop_table_url(
         // nodes includes the inferred namespace, which needs to be excluded from the inferred base URI.
         //
         // `warehouse_leaves` never carries a leading `/`, so a host-less URL needs the third
-        // slash written back explicitly. Emitting `file://{leaves}` instead re-parses with the
-        // first path segment as the authority, which then silently vanishes from the path:
-        // `file:///home/u/wh/db/t` came back as `file://home/u/wh`, and every consumer that
-        // reads `.path()` off it saw `/u/wh`.
+        // slash written back explicitly. With only two, the result re-parses with the first
+        // path segment as the authority and that segment then disappears from the path:
+        // `file:///home/u/wh/db/t` would yield `file://home/u/wh`, leaving every consumer
+        // that reads `.path()` off it with `/u/wh`.
         format!("{}:///{warehouse_leaves}", parsed.scheme())
     };
 

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -783,8 +783,14 @@ pub fn parse_hadoop_table_url(
     let mut base_uri = if let Some(host) = parsed.host_str() {
         format!("{}://{host}/{warehouse_leaves}", parsed.scheme())
     } else {
-        // nodes includes the inferred namespace, which needs to be excluded from the inferred base URI
-        format!("{}://{warehouse_leaves}", parsed.scheme())
+        // nodes includes the inferred namespace, which needs to be excluded from the inferred base URI.
+        //
+        // `warehouse_leaves` never carries a leading `/`, so a host-less URL needs the third
+        // slash written back explicitly. Emitting `file://{leaves}` instead re-parses with the
+        // first path segment as the authority, which then silently vanishes from the path:
+        // `file:///home/u/wh/db/t` came back as `file://home/u/wh`, and every consumer that
+        // reads `.path()` off it saw `/u/wh`.
+        format!("{}:///{warehouse_leaves}", parsed.scheme())
     };
 
     let mut namespace = Namespace::new(namespace_ident);
@@ -948,6 +954,59 @@ mod tests {
         let url = "s3a://my-bucket/my-prefix/warehouse/spiceai_sandbox/my_table";
         let result = parse_hadoop_table_url(url, Some("file:///my/local/path/to/warehouse"));
         result.expect_err("should error parsing url");
+    }
+
+    /// Regression test for #12533. Every previously covered host-less case passed a
+    /// `warehouse_uri`, which overwrites `base_uri` outright and hid the inferred form.
+    #[test]
+    fn test_parse_hadoop_table_url_infers_local_warehouse_root() {
+        let url = "file:///var/lib/spice/warehouse/db/events";
+        let (base_uri, namespace, table_name) =
+            parse_hadoop_table_url(url, None).expect("local warehouse path should parse");
+        assert_eq!(base_uri, "file:///var/lib/spice/warehouse");
+        assert_eq!(namespace.name().to_url_string().as_str(), "db");
+        assert_eq!(table_name, "events");
+
+        // The defect was only visible once something re-parsed the result, which both
+        // consumers do: `build_opendal_operator` reads `.path()` into `FsConfig.root`, and
+        // `HadoopCatalogBuilder::with_warehouse_root` checks the root exists. Written with
+        // two slashes, this URI re-parsed as host `var` with path `/lib/spice/warehouse`.
+        let reparsed = Url::parse(&base_uri).expect("inferred base URI should re-parse");
+        assert!(
+            reparsed.host_str().is_none(),
+            "a local warehouse path must not re-parse with an authority"
+        );
+        assert_eq!(reparsed.path(), "/var/lib/spice/warehouse");
+    }
+
+    #[test]
+    fn test_parse_hadoop_table_url_infers_local_warehouse_root_edges() {
+        // Deeper than the namespace/table pair: only the two trailing segments are stripped.
+        let url = "file:///a/b/c/d/e/ns/tbl";
+        let (base_uri, namespace, table_name) =
+            parse_hadoop_table_url(url, None).expect("deep path should parse");
+        assert_eq!(base_uri, "file:///a/b/c/d/e");
+        assert_eq!(namespace.name().to_url_string().as_str(), "ns");
+        assert_eq!(table_name, "tbl");
+
+        // Shortest path that still names a namespace and a table: the warehouse is the
+        // filesystem root, which stays a valid absolute path rather than becoming `file://`.
+        let url = "file:///ns/tbl";
+        let (base_uri, namespace, table_name) =
+            parse_hadoop_table_url(url, None).expect("root warehouse should parse");
+        assert_eq!(base_uri, "file:///");
+        assert_eq!(namespace.name().to_url_string().as_str(), "ns");
+        assert_eq!(table_name, "tbl");
+        let reparsed = Url::parse(&base_uri).expect("root base URI should re-parse");
+        assert_eq!(reparsed.path(), "/");
+
+        // An explicit warehouse still wins over the inferred one, unchanged by this fix.
+        let url = "file:///var/lib/spice/warehouse/db/events";
+        let warehouse = "file:///var/lib/spice/warehouse";
+        let (base_uri, namespace, _) =
+            parse_hadoop_table_url(url, Some(warehouse)).expect("explicit warehouse parses");
+        assert_eq!(base_uri, "file:///var/lib/spice/warehouse");
+        assert_eq!(namespace.name().to_url_string().as_str(), "db");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

An Iceberg dataset or catalog on a local `file://` warehouse could never load: the first path
segment was silently dropped from the warehouse root, so the runtime looked one directory too
shallow and reported either a permission error at the filesystem root or a missing warehouse
root.

**Root cause.** `parse_hadoop_table_url` rebuilds the warehouse root from the URL's path
segments. `warehouse_leaves` is those segments joined with `/` and never carries a leading
slash, so the host-less branch emitted two slashes where an absolute path needs three:

```rust
format!("{}://{warehouse_leaves}", parsed.scheme())   // file://home/u/wh
```

Re-parsing that reads `home` as the URL authority, leaving `path = /u/wh`. Both consumers
read the result back through `Url`, so both were wrong:

- `build_opendal_operator` assigns `parsed.path()` to `FsConfig.root` → `/u/wh`, which does
  not exist (the reported symptom is `create root dir failed: Permission denied` when the
  truncation lands at the filesystem root).
- `HadoopCatalogBuilder::with_warehouse_root` gets the malformed URI and reports the warehouse
  root as missing.

The `s3a://` and `file://host/...` forms have an authority and take the other branch, which
already writes the slash, so only host-less URLs were affected.

## Changes

- `crates/runtime/src/catalogconnector/iceberg.rs`: write the third slash in the host-less
  branch (`{scheme}:///{warehouse_leaves}`), with a comment recording the failure mode.
- Two tests. Every pre-existing host-less case passed an explicit `warehouse_uri`, which
  overwrites `base_uri` outright — that is why the inferred form had no coverage.
  - `test_parse_hadoop_table_url_infers_local_warehouse_root` — the regression: asserts the
    inferred root, and then re-parses it to assert no authority and the full path, which is
    exactly what the two consumers do and the only place the defect was observable.
  - `..._edges` — a deeper path, the shortest path that still names a namespace and a table
    (warehouse at the filesystem root, which must stay `file:///` rather than `file://`), and
    an explicit `warehouse_uri` to confirm that path is unchanged.

Scope is the single reconstruction site. `file://host/path` keeps its current handling.

## Follow-up filed, not fixed here

#12539 — the same function computes the namespace segment with an unchecked `count - 2`, which
underflows for a one-segment path. It panics in debug builds and degrades to the correct
`MissingNamespace` error in release only because no release profile enables `overflow-checks`.
Fixing it changes which inputs are rejected, so it needs its own tests rather than riding
along here.

## Test plan

- `make lint`
- `make test`

## Checklist

- [x] Root cause identified and stated
- [x] Regression test that fails before the change and passes after
- [x] Edge cases covered (deep path, filesystem-root warehouse, explicit warehouse URI)
- [x] Existing `s3a://` and host-bearing `file://` behaviour unchanged
- [x] Out-of-scope defect filed rather than folded in (#12539)

Fixes #12533
