### PR TITLE
fix(runtime): reject a Hadoop table URL too short to name a namespace (fixes #12539)

### DIFF
--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -752,6 +752,15 @@ pub fn parse_hadoop_table_url(
         .map(std::iter::Iterator::count)
         .context(UrlParseNoSourceSnafu)?;
 
+    // A Hadoop table URL has to name both a namespace and a table, so the three `count - 2` /
+    // `count - 1` offsets below are only in range from two segments up. Reject a shorter path
+    // here rather than letting the subtraction decide: in debug builds it panics with
+    // `attempt to subtract with overflow`, and in release it only produces this same error by
+    // wrapping to `usize::MAX` and relying on no iterator being able to satisfy that index.
+    if count < 2 {
+        return MissingNamespaceSnafu.fail();
+    }
+
     let table_name = parsed
         .path_segments()
         .and_then(std::iter::Iterator::last)
@@ -1212,5 +1221,43 @@ mod tests {
         let props = HashMap::new();
         let op = build_opendal_operator("ftp://my-host/path", &props);
         assert!(op.is_err(), "Unsupported scheme should fail");
+    }
+
+    /// Regression test for #12539. Each of these URLs has too few path segments to name both a
+    /// namespace and a table, so each reaches the `count - 2` offsets with `count < 2`. Before
+    /// the guard that subtraction panicked with `attempt to subtract with overflow` under
+    /// `debug_assertions` — which is every `cargo test` / `cargo nextest` run — and reached
+    /// `MissingNamespace` in release only by wrapping to `usize::MAX`, an index no iterator can
+    /// satisfy.
+    #[test]
+    fn test_parse_hadoop_table_url_rejects_short_paths() {
+        // A warehouse mounted at the filesystem root, or a namespace simply left out.
+        for url in [
+            "file:///events",
+            "file:///",
+            "s3a://my-bucket/table-with-no-namespace",
+            "s3a://my-bucket/",
+        ] {
+            let Err(err) = parse_hadoop_table_url(url, None) else {
+                panic!("{url} names no namespace and must be rejected");
+            };
+            assert!(
+                matches!(err, Error::MissingNamespace),
+                "{url} should be rejected as MissingNamespace, got: {err}"
+            );
+        }
+
+        // Supplying a warehouse URI does not rescue a short table URL: the namespace is read
+        // from the table URL before the warehouse is consulted at all.
+        let Err(err) = parse_hadoop_table_url("file:///events", Some("file:///")) else {
+            panic!("an explicit warehouse does not supply the missing namespace");
+        };
+        assert!(matches!(err, Error::MissingNamespace), "got: {err}");
+
+        // The shortest path that does name both still parses, so the guard is not off by one.
+        let (_, namespace, table_name) =
+            parse_hadoop_table_url("s3a://my-bucket/ns/tbl", None).expect("two segments parse");
+        assert_eq!(namespace.name().to_url_string().as_str(), "ns");
+        assert_eq!(table_name, "tbl");
     }
 }

--- a/crates/runtime/src/catalogconnector/iceberg.rs
+++ b/crates/runtime/src/catalogconnector/iceberg.rs
@@ -752,11 +752,10 @@ pub fn parse_hadoop_table_url(
         .map(std::iter::Iterator::count)
         .context(UrlParseNoSourceSnafu)?;
 
-    // A Hadoop table URL has to name both a namespace and a table, so the three `count - 2` /
-    // `count - 1` offsets below are only in range from two segments up. Reject a shorter path
-    // here rather than letting the subtraction decide: in debug builds it panics with
-    // `attempt to subtract with overflow`, and in release it only produces this same error by
-    // wrapping to `usize::MAX` and relying on no iterator being able to satisfy that index.
+    // The segment offsets below — `count - 2` for the namespace and the warehouse leaves,
+    // `count - 1` for the nodes — require a path naming both a namespace and a table. Reject a
+    // shorter one explicitly: left to `usize` arithmetic the subtraction decides it instead,
+    // which aborts a debug build and elsewhere depends on the wrap landing out of range.
     if count < 2 {
         return MissingNamespaceSnafu.fail();
     }
@@ -1223,12 +1222,8 @@ mod tests {
         assert!(op.is_err(), "Unsupported scheme should fail");
     }
 
-    /// Regression test for #12539. Each of these URLs has too few path segments to name both a
-    /// namespace and a table, so each reaches the `count - 2` offsets with `count < 2`. Before
-    /// the guard that subtraction panicked with `attempt to subtract with overflow` under
-    /// `debug_assertions` — which is every `cargo test` / `cargo nextest` run — and reached
-    /// `MissingNamespace` in release only by wrapping to `usize::MAX`, an index no iterator can
-    /// satisfy.
+    /// A Hadoop table URL must name both a namespace and a table. Anything shorter is rejected
+    /// as `MissingNamespace`, identically in every build profile. Regression test for #12539.
     #[test]
     fn test_parse_hadoop_table_url_rejects_short_paths() {
         // A warehouse mounted at the filesystem root, or a namespace simply left out.


### PR DESCRIPTION
Fixes #12539

## Summary

`parse_hadoop_table_url` reads a namespace and a table out of the path segments of a
Hadoop table URL using three offsets derived from the segment count — `nth(count - 2)`
for the namespace, `take(count - 1)` for the nodes, `take(count - 2)` for the warehouse
leaves — without checking that the URL actually has the two segments those offsets
assume.

A one-segment path underflows `count - 2`. That is a plausible input: it is what you get
from omitting the namespace, or from a warehouse mounted at the filesystem root.

```yaml
catalogs:
  - from: iceberg:file:///events
    name: ice
```

**Root cause.** The rejection of short URLs was never written; it was an accident of
unsigned wraparound. In debug builds — which includes every `cargo test` / `cargo nextest`
run, so any test reaching this path — the subtraction panics with `attempt to subtract
with overflow`. No release profile sets `overflow-checks`, so in release it wraps to
`usize::MAX`, `nth` returns `None`, and the caller gets `MissingNamespace`. That outcome
is correct, which is why this has gone unnoticed.

## Changes

- Reject `count < 2` up front with the existing `MissingNamespace` error, before any of
  the three offsets are computed. Release behaviour is unchanged; debug builds get the
  same error instead of a panic.

## Test plan

- New `test_parse_hadoop_table_url_rejects_short_paths` covers the zero- and one-segment
  cases across both accepted schemes (`file:///events`, `file:///`,
  `s3a://my-bucket/table-with-no-namespace`, `s3a://my-bucket/`), asserts the error is
  `MissingNamespace` rather than any other failure, and checks that passing an explicit
  `warehouse_uri` does not paper over the missing namespace. It fails on the old code with
  `attempt to subtract with overflow` under `debug_assertions` and passes on the new.
- The same test pins the two-segment boundary (`s3a://my-bucket/ns/tbl`) so the guard is
  not off by one.
- `make lint`
- `make test`

## Notes

Found while fixing #12533 (PR #12540), which changes the `base_uri` reconstruction further
down the same function. Kept separate as the issue requests, because this one changes which
inputs are rejected and needs its own coverage. The two touch different hunks; whichever
lands second may need a trivial merge.

## Checklist

- [x] Regression test fails before the fix and passes after
- [x] Release-profile behaviour unchanged (same error, no longer via wraparound)
- [x] No new error variant or message — reuses `MissingNamespace`
- [ ] `make signoff` green
