### PR TITLE
fix(ci): publish no sign-off verdict when the run was signalled (fixes #12518)

### DIFF
--- a/.github/workflows/signoff_disk_guard_test.yml
+++ b/.github/workflows/signoff_disk_guard_test.yml
@@ -7,6 +7,11 @@ name: Sign-off Disk Guard Tests
 # else: a guard that under-reports leaves an out-of-disk run looking like a code
 # failure (the bug it was written for, #12412), and one that over-reports
 # excuses a genuinely broken branch as "infrastructure, just re-dispatch".
+#
+# The same classification also decides whether a run reached a verdict at all, so
+# these tests cover the signalled case too — a budget expiry publishing "checks
+# failed" about a suite that was still passing (#12518). The workflow keeps its
+# name: it is a required check, and renaming one costs a branch-protection edit.
 on:
   pull_request:
     branches:

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -277,6 +277,19 @@ with a failure; otherwise `scripts/signoff status` and `scripts/signoff mine`
 would keep showing a sign-off in progress for a run that is long gone.
 Re-dispatch against the same HEAD to try again.
 
+That replacement is the workflow's job, not the dying script's. Being signalled is
+how a run learns its budget expired: `run_checks` returns `make`'s status and bash
+reports a killed child as 128+N, so the script classifies that as reaching **no
+verdict** and publishes nothing at all, saying why in its step summary. Treating it
+as a check result instead would assert a code failure nothing established — on a
+suite the log shows still passing, and over a `signoff=success` an earlier run may
+already have earned ([#12518](https://github.com/spiceai/spiceai/issues/12518),
+[#12520](https://github.com/spiceai/spiceai/issues/12520)). Declining to write is
+what leaves the `pending` for `Resolve an incomplete sign-off` to describe honestly,
+and leaves an existing success alone. The correction handlers cannot cover this case
+after the fact: both are gated on `cancelled()`, and a budget expiry is a *failed*
+step by the design above.
+
 Only one sign-off runs per commit. Both dispatch forms — `-f branch=<branch>` and
 `-f pr_number=<N>` — resolve to the same commit before the sign-off job starts,
 and its concurrency group is keyed on that commit, so a second dispatch for a
@@ -383,6 +396,12 @@ that reached no verdict rather than one that saw nothing. That disarms the watch
 and hands classification back to the free-space backstop; treating its silence as
 "not disk" would blame the branch for the volume just as surely as the unwritable
 marker did.
+
+Classification has a third answer, ranked above both disk signals: a run that was
+*signalled* judged nothing at all, where the two disk cases both describe a `make`
+that returned. That ordering matters when a budget expires on a tight volume —
+calling it disk would send you to reclaim space that was never the problem. See
+the budget paragraph above for what a signalled run publishes.
 
 The watch keeps its answer in a shell variable, not a file. Recording it on disk
 needed an allocation at the one moment allocation is failing — and on macOS

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -727,6 +727,12 @@ readonly DEFAULT_MIN_FREE_GIB=25
 readonly DISK_CRITICAL_GIB=2
 # run_checks returns this when the preflight refuses to start.
 readonly EXIT_DISK_EXHAUSTED=70
+# Bash reports a foreground child killed by signal N as 128+N, and run_make_step
+# returns make's own status untouched. So a status at or above this means `make`
+# never reached a verdict of its own — the process tree was signalled. That is
+# how a `Sign off` step reads when its `timeout-minutes` budget expires (#12518)
+# and how a cancelled job reads (#12424); a recipe that genuinely fails exits 2.
+readonly EXIT_SIGNAL_BASE=128
 # How the linker's out-of-disk death actually reads in the run log:
 # `ld: write() failed, errno=28 (No space left on device)`. Either spelling is
 # enough; matching both survives a toolchain that words one of them differently.
@@ -849,14 +855,25 @@ disk_is_critical() {
 }
 
 # Names what broke in a check run that did not pass, given run_checks' exit
-# status: "disk" when the work volume is the cause, "checks" for everything
-# else, which is the branch. Three ways to reach "disk", in falling order of
-# authority: the preflight refused to start, the build said so itself, or the
-# volume is at ~0 now. The last is a backstop for a build whose output we did
-# not record — a local run, or a remote one whose watcher died before it could
-# read anything — which is why it is not the only signal.
+# status: "signalled" when nothing judged the branch at all, "disk" when the work
+# volume is the cause, "checks" for everything else, which is the branch. Three
+# ways to reach "disk", in falling order of authority: the preflight refused to
+# start, the build said so itself, or the volume is at ~0 now. The last is a
+# backstop for a build whose output we did not record — a local run, or a remote
+# one whose watcher died before it could read anything — which is why it is not
+# the only signal.
 failure_kind() {
   local check_status="$1"
+
+  # First, because it is the one kind that says the checks reached no verdict
+  # rather than which verdict they reached. The two disk signals below both
+  # describe a `make` that *returned*: the preflight refusing to start (70) and
+  # a build that printed ENOSPC and died. Neither can coexist with a status that
+  # says make itself was killed.
+  if [[ "$check_status" -ge "$EXIT_SIGNAL_BASE" ]]; then
+    echo "signalled"
+    return
+  fi
 
   # The preflight's own refusal needs no corroboration.
   if [[ "$check_status" -eq "$EXIT_DISK_EXHAUSTED" ]]; then
@@ -876,6 +893,57 @@ failure_kind() {
   fi
 
   if disk_is_critical; then echo "disk"; else echo "checks"; fi
+}
+
+# What to publish about a check run that did not pass, given run_checks' exit
+# status, how long it ran, and who dispatched it. Sets three globals rather than
+# returning a packed string, the way run_make_step reports through
+# SIGNOFF_DISK_HIT:
+#
+#   SIGNOFF_FAILURE_STATUS_DESC  the commit-status description, or "" to publish
+#                                no verdict at all
+#   SIGNOFF_FAILURE_SUMMARY      the step summary
+#   SIGNOFF_FAILURE_MESSAGE      what `fail` says on the way out
+#
+# An empty description is the whole point of the "signalled" case and is not an
+# error path: see below.
+SIGNOFF_FAILURE_STATUS_DESC=""
+SIGNOFF_FAILURE_SUMMARY=""
+SIGNOFF_FAILURE_MESSAGE=""
+describe_check_failure() {
+  local check_status="$1" elapsed="$2" user="$3"
+
+  case "$(failure_kind "$check_status")" in
+    signalled)
+      # Publish nothing. Nothing judged this branch — the process tree was
+      # signalled — so the `pending` this run posted before it started is still
+      # the truthful status, and it is already what the workflow's "Resolve an
+      # incomplete sign-off" step is there to describe.
+      #
+      # Any verdict written here would assert something nothing established:
+      # "checks failed" about a suite the log shows still passing when the
+      # 353-minute budget expired (#12518), on a commit that may already carry a
+      # `signoff=success` an earlier run earned (#12520). Neither correction
+      # handler can take it back — both are gated on `cancelled()`, and a budget
+      # expiry is a *failed* step by #12343's design — so the only safe moment to
+      # decline is here.
+      SIGNOFF_FAILURE_STATUS_DESC=""
+      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Did not complete** after ${elapsed}s — the run was signalled (its step budget expired, or the job was stopped), so **the checks reached no verdict**. This is not a code failure and the diff is not implicated. The \`${STATUS_CONTEXT}\` status is left as this run found it; sign off again."$'\n'
+      SIGNOFF_FAILURE_MESSAGE="sign-off did not complete: the run was signalled after ${elapsed}s, so the checks reached no verdict — sign off again"
+      ;;
+    disk)
+      # An out-of-disk run says nothing useful by default — the commit status is
+      # all most readers see, so it has to carry the distinction itself.
+      SIGNOFF_FAILURE_STATUS_DESC="Runner out of disk after ${elapsed}s — checks did not complete, re-dispatch (triggered by ${user})"
+      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — the build ran out of disk on the runner work volume, so **the checks did not complete**. Re-dispatch once the runner has space. Only if this recurs for one branch alone is the diff worth suspecting: a build script or dependency change can consume the volume by itself."$'\n'
+      SIGNOFF_FAILURE_MESSAGE="sign-off aborted: the runner ran out of disk (the checks did not complete)"
+      ;;
+    *)
+      SIGNOFF_FAILURE_STATUS_DESC="Sign-off checks failed after ${elapsed}s (triggered by ${user})"
+      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Failed** after ${elapsed}s."$'\n'
+      SIGNOFF_FAILURE_MESSAGE="sign-off checks failed"
+      ;;
+  esac
 }
 
 # Stop before the Rust checks when the work volume cannot hold them. Fatal only
@@ -1240,26 +1308,18 @@ cmd_signoff() {
     set -e
     if [[ "$check_status" -ne 0 ]]; then
       elapsed=$(( $(date +%s) - start ))
-      local status_desc summary_text fail_message
-      # An out-of-disk run says nothing useful by default — the commit status is
-      # all most readers see, so it has to carry the distinction itself.
-      case "$(failure_kind "$check_status")" in
-        disk)
-          status_desc="Runner out of disk after ${elapsed}s — checks did not complete, re-dispatch (triggered by ${user})"
-          summary_text="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — the build ran out of disk on the runner work volume, so **the checks did not complete**. Re-dispatch once the runner has space. Only if this recurs for one branch alone is the diff worth suspecting: a build script or dependency change can consume the volume by itself."$'\n'
-          fail_message="sign-off aborted: the runner ran out of disk (the checks did not complete)"
-          ;;
-        *)
-          status_desc="Sign-off checks failed after ${elapsed}s (triggered by ${user})"
-          summary_text="### Sign-off"$'\n'"**Failed** after ${elapsed}s."$'\n'
-          fail_message="sign-off checks failed"
-          ;;
-      esac
+      describe_check_failure "$check_status" "$elapsed" "$user"
       if is_remote_run; then
-        post_failure_status "$repo" "$sha" "$status_desc"
-        append_step_summary "$summary_text"
+        # An empty description means this run reached no verdict, so it has none
+        # to publish — leaving the status it posted at the start untouched. The
+        # summary still goes out: it is where an operator reads *why* the run
+        # ended without one.
+        if [[ -n "$SIGNOFF_FAILURE_STATUS_DESC" ]]; then
+          post_failure_status "$repo" "$sha" "$SIGNOFF_FAILURE_STATUS_DESC"
+        fi
+        append_step_summary "$SIGNOFF_FAILURE_SUMMARY"
       fi
-      fail "$fail_message"
+      fail "$SIGNOFF_FAILURE_MESSAGE"
     fi
     elapsed=$(( $(date +%s) - start ))
     description="Signed off by ${user}${via} — ${SIGNOFF_CHECK_SUMMARY} in ${elapsed}s"

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -916,9 +916,11 @@ describe_check_failure() {
   case "$(failure_kind "$check_status")" in
     signalled)
       # Publish nothing. Nothing judged this branch — the process tree was
-      # signalled — so the `pending` this run posted before it started is still
-      # the truthful status, and it is already what the workflow's "Resolve an
-      # incomplete sign-off" step is there to describe.
+      # signalled — so the status this run left on its way in is still the most
+      # this run can honestly claim: the `pending` it posted before starting, or
+      # an earlier `success` post_pending_status declined to overwrite. A leftover
+      # `pending` is already what the workflow's "Resolve an incomplete sign-off"
+      # step is there to describe.
       #
       # Any verdict written here would assert something nothing established:
       # "checks failed" about a suite the log shows still passing when the
@@ -928,7 +930,7 @@ describe_check_failure() {
       # expiry is a *failed* step by #12343's design — so the only safe moment to
       # decline is here.
       SIGNOFF_FAILURE_STATUS_DESC=""
-      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Did not complete** after ${elapsed}s — the run was signalled (its step budget expired, or the job was stopped), so **the checks reached no verdict**. This is not a code failure and the diff is not implicated. The \`${STATUS_CONTEXT}\` status is left as this run found it; sign off again."$'\n'
+      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Did not complete** after ${elapsed}s — the run was signalled (its step budget expired, or the job was stopped), so **the checks reached no verdict** and no failure status is published. Nothing reported a failure; equally, nothing cleared the branch. The \`${STATUS_CONTEXT}\` status stands as this run left it — the \`pending\` posted at the start, or an earlier \`success\` this run declined to overwrite. Sign off again: a branch that repeatedly exhausts the budget is either contending for the pool or has lengthened the build itself."$'\n'
       SIGNOFF_FAILURE_MESSAGE="sign-off did not complete: the run was signalled after ${elapsed}s, so the checks reached no verdict — sign off again"
       ;;
     disk)

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -9,6 +9,11 @@
 # direction is the bug. No network and no credentials: a stub `df` on PATH
 # reports whatever free space a case needs.
 #
+# `failure_kind` names a third cause with the same consequence — a run that was
+# signalled and so judged nothing at all — so its cases live here too, alongside
+# `describe_check_failure`, which turns any of the three into what the run
+# publishes.
+#
 # Usage: scripts/test_signoff_disk_guard.sh
 
 set -uo pipefail
@@ -347,6 +352,86 @@ assert_failure_kind "calls a failure on a roomy volume a check failure" 101 "che
   STUB_FREE_KB="$(gib_to_kb 200)"
 assert_failure_kind "calls a failure with unknown free space a check failure" 101 "checks" \
   STUB_DF_RC=1
+
+# A signalled run reached no verdict at all, which is a different statement from
+# either disk kind: both of those describe a `make` that returned. The statuses
+# here are what bash reports for a killed foreground child — 128+N — which is how
+# a `Sign off` step whose 353-minute budget expires reads (#12518).
+assert_failure_kind "calls a SIGTERM'd run signalled, not a check failure" 143 "signalled" \
+  STUB_FREE_KB="$(gib_to_kb 200)"
+assert_failure_kind "calls an interrupted run signalled" 130 "signalled" \
+  STUB_FREE_KB="$(gib_to_kb 200)"
+assert_failure_kind "calls a SIGKILL'd run signalled" 137 "signalled" \
+  STUB_FREE_KB="$(gib_to_kb 200)"
+assert_failure_kind "treats 128 itself as signalled" 128 "signalled" \
+  STUB_FREE_KB="$(gib_to_kb 200)"
+# "Signalled" must win over the disk backstop. A budget that expires while the
+# volume happens to be tight is still a run that judged nothing, and telling the
+# author it was disk sends them to reclaim space that was never the problem.
+assert_failure_kind "keeps a signalled run signalled on a near-empty volume" 143 "signalled" \
+  STUB_FREE_KB="$(gib_to_kb 1)"
+# The boundary in the other direction is the one that protects real verdicts: 2
+# is what make exits when a recipe fails, and 101 is cargo's own. Neither may be
+# excused as "nothing ran".
+assert_failure_kind "leaves make's own recipe failure a check failure" 2 "checks" \
+  STUB_FREE_KB="$(gib_to_kb 200)"
+assert_failure_kind "leaves status 127 a check failure" 127 "checks" \
+  STUB_FREE_KB="$(gib_to_kb 200)"
+
+echo
+echo "describe_check_failure"
+# Asserts what a failed run publishes. An empty SIGNOFF_FAILURE_STATUS_DESC is
+# the contract for "publish no verdict", so it is checked as a value, not as an
+# accident of an unset variable.
+assert_describe() {
+  local name="$1" check_status="$2" want_desc="$3" want_message="$4"
+  shift 4
+  tests_run=$((tests_run + 1))
+
+  # The status is interpolated into the snippet, as assert_failure_kind does:
+  # call_subject's trailing arguments are environment assignments for `env`, so
+  # there is no positional left to pass it through.
+  local result rc output
+  result="$(call_subject \
+    "describe_check_failure ${check_status} 21195 someone
+     printf 'DESC[%s]\nMSG[%s]\nSUM[%s]\n' \
+       \"\$SIGNOFF_FAILURE_STATUS_DESC\" \"\$SIGNOFF_FAILURE_MESSAGE\" \"\$SIGNOFF_FAILURE_SUMMARY\"" \
+    "$@")"
+  rc="${result%%|*}"
+  output="${result#*|}"
+
+  if [[ "$rc" -ne 0 ]]; then
+    fail_test "$name: expected exit 0, got ${rc} (output: ${output})"
+    return
+  fi
+  if [[ "$output" != *"DESC[${want_desc}]"* ]]; then
+    fail_test "$name: expected description '${want_desc}', got: ${output}"
+    return
+  fi
+  if [[ "$output" != *"${want_message}"* ]]; then
+    fail_test "$name: expected '${want_message}' in the output, got: ${output}"
+    return
+  fi
+  echo "  ok: $name"
+}
+
+# The regression, stated as the contract: run 30942941645 on PR #12448 timed out
+# with the suite still passing, and published "Sign-off checks failed after
+# 21195s" — a code failure that had not happened, on top of a `signoff=success`
+# posted seven hours earlier. Publishing nothing is what makes both impossible.
+assert_describe "publishes no verdict for a signalled run" 143 "" \
+  "the checks reached no verdict" STUB_FREE_KB="$(gib_to_kb 200)"
+assert_describe "says the run was signalled rather than that checks failed" 143 "" \
+  "was signalled after 21195s" STUB_FREE_KB="$(gib_to_kb 200)"
+# The two kinds that *did* reach a verdict still publish one. Without these, the
+# guard above could silence every failure and the tests would not notice.
+assert_describe "still publishes the out-of-disk verdict" 101 \
+  "Runner out of disk after 21195s — checks did not complete, re-dispatch (triggered by someone)" \
+  "ran out of disk" SIGNOFF_DISK_WATCH=1 SIGNOFF_DISK_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+assert_describe "still publishes a genuine check failure" 101 \
+  "Sign-off checks failed after 21195s (triggered by someone)" \
+  "sign-off checks failed" STUB_FREE_KB="$(gib_to_kb 200)"
+echo
 
 # `08` passes the digit regex, but bash arithmetic reads a leading zero as
 # octal — untreated, the floor becomes an arithmetic error rather than 8.


### PR DESCRIPTION
## Summary

A Remote Sign-off whose `Sign off` step exhausts its `timeout-minutes: 353` budget
is killed by signal. `run_checks` returns non-zero under the `set +e` that captures
its status, so the script took its ordinary failure branch and published

```
failure  Sign-off checks failed after 21195s (triggered by grokspice)
```

`21195s` is 353.25 minutes — the budget exactly. Nothing failed: run
[30942941645](https://github.com/spiceai/spiceai/actions/runs/30942941645) on
PR #12448 shows `PASS` up to `(1452/1858)` with no `error[E….]`, no `error:` and no
failing test in the 1.1 MB log. The run simply never reached a verdict.

Two consequences, both observed on `b1fc7141e`:

1. **Attestation reports a code failure that did not happen**, and the only way to
   tell it from a real defect is to download the whole log.
2. **A `signoff=success` posted seven hours earlier was destroyed**, forcing another
   multi-hour re-dispatch of a commit that had already passed.

Neither correction handler can take it back. `correct-cancelled` and the cancellation
step are gated on `cancelled()`, and a budget expiry lands as a *failed step* by
#12343's deliberate choice of `353` inside a `358`-minute job budget; `clear-pending`
only ever rewrites a left-behind `pending` and correctly leaves a `failure` alone. So
the misleading verdict outlives the run that wrote it.

## Changes

- **`failure_kind` gains a `signalled` kind**, ranked above both disk signals. Bash
  reports a foreground child killed by signal N as `128+N` and `run_make_step`
  returns make's status untouched, so a status `>= 128` means make never reached a
  verdict of its own. A recipe that genuinely fails exits `2`; cargo exits `101`.
  The ordering matters: a budget that expires on a tight volume must not be reported
  as disk, which would send the author to reclaim space that was never the problem.
- **A signalled run publishes no verdict at all** — no commit status is written. The
  `pending` the run posted at the start survives for the workflow's existing
  `Resolve an incomplete sign-off` step to describe ("ended without posting a
  verdict — sign off again"), which is both honest and already wired up. Because
  `post_pending_status` leaves an existing `success` in place, a commit that was
  already signed off now comes through a timed-out re-dispatch with that success
  intact. The step summary still explains why the run ended without a verdict.
- **The classification-to-message mapping moves into `describe_check_failure`**, out
  of the middle of `cmd_signoff`, so it is directly testable. It reports through
  `SIGNOFF_FAILURE_*` globals the way `run_make_step` reports through
  `SIGNOFF_DISK_HIT`; an empty description is the contract for "publish nothing".
- Docs and the test workflow's header note the third classification.

This is #12520's stated alternative rather than its preferred option. Widening the
correction handler to `steps.sign_off.outcome == 'failure'` would fire on *genuine*
check failures too, and `correct-cancelled` rewrites any `failure` it finds — so it
would erase legitimate verdicts. Declining to write the bogus one is the narrower and
safer half of that choice, and it needs no workflow change, so it does not touch the
`if:` block #12425/#12426/#12432/#12433 are all editing.

**Known limitation, stated honestly:** detection rests on `make` itself being
signalled, which is what happens when the runner kills the step's process group. If
some future path let `make` observe its child's death and exit `2` instead, that run
would classify as `checks` and behave exactly as it does today — the fix degrades to
the current behaviour rather than to something worse.

## Test plan

- `bash scripts/test_signoff_disk_guard.sh` — 48 pass (11 new). Verified as genuine
  regression tests by running the new cases against `origin/trunk`'s `scripts/signoff`:
  9 fail there, all 48 pass here.
  - `failure_kind`: `143`/`130`/`137`/`128` classify as `signalled`; `2` and `127`
    stay `checks`; a signalled run stays `signalled` on a near-empty volume.
  - `describe_check_failure`: a signalled run yields an empty description and says
    "the checks reached no verdict"; the disk and check-failure kinds still publish
    their verdicts, so the guard cannot silence every failure unnoticed.
- `bash -n scripts/signoff` and `shellcheck -x` — clean; the only findings are
  pre-existing `SC2016` infos on untouched lines.
- `make lint` and `make nextest` — via `make signoff` on this branch. No Rust files
  change, so the Rust gate is skipped by design; the sign-off still attests HEAD.
- CI: `Sign-off Disk Guard Tests` is triggered by `scripts/signoff` changes, so this
  change is gated by the suite above on every push.

Fixes #12518

## Checklist

- [x] Tests added that fail on the old code and pass on the new
- [x] No behaviour change for a run that genuinely reached a verdict
- [x] No workflow `if:` changes, so no conflict with the open sign-off PRs
- [x] `docs/dev/ci_signoff.md` updated
- [ ] Sign-off green on this branch
