### PR TITLE
chore(deps): bump datafusion and table-providers for the DuckDB timezone and retention fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6091,7 +6091,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6143,7 +6143,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6167,7 +6167,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6191,7 +6191,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6216,7 +6216,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "futures",
  "log",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "async-compression",
@@ -6263,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6286,7 +6286,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6308,7 +6308,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6330,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6379,12 +6379,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6405,7 +6405,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6427,7 +6427,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6479,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6510,7 +6510,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6530,7 +6530,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6554,7 +6554,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6593,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6609,7 +6609,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6618,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6628,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "chrono",
@@ -6679,7 +6679,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6700,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6714,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "chrono",
@@ -6730,7 +6730,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6750,7 +6750,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6782,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "chrono",
@@ -6811,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6823,7 +6823,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6838,7 +6838,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6851,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6897,7 +6897,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b8b95926912cd6fbee8e58a1b5104717b4675ef4#b8b95926912cd6fbee8e58a1b5104717b4675ef4"
+source = "git+https://github.com/spiceai/datafusion.git?rev=fed13d9b9817aac30891bd96bb88c9b0afedc4c9#fed13d9b9817aac30891bd96bb88c9b0afedc4c9"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6916,7 +6916,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=1b83cbf0e131fc30e53663ed519f077a5ee65917#1b83cbf0e131fc30e53663ed519f077a5ee65917"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=99e33a11fac58b89edca3ee522e41d777e39cabb#99e33a11fac58b89edca3ee522e41d777e39cabb"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,7 +251,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "1b83cbf0e131fc30e53663ed519f077a5ee65917" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "99e33a11fac58b89edca3ee522e41d777e39cabb" } # spiceai-54
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",
@@ -477,41 +477,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" } # TEMP branch viktor/spiceai-54 — re-pin to spiceai-54 after spiceai/datafusion#187 merges
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "b8b95926912cd6fbee8e58a1b5104717b4675ef4" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" } # TEMP branch viktor/spiceai-54 — re-pin to spiceai-54 after spiceai/datafusion#187 merges
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -477,7 +477,7 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" } # TEMP branch viktor/spiceai-54 — re-pin to spiceai-54 after spiceai/datafusion#187 merges
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" } # spiceai-54
 datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
 datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }
 datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "fed13d9b9817aac30891bd96bb88c9b0afedc4c9" }


### PR DESCRIPTION
Picks up two DuckDB accelerator fixes from the forks.

## `spiceai/datafusion#195` — `Unknown TimeZone '+00:00'`

A DuckDB-accelerated dataset whose time column carried an Arrow **fixed-offset** timezone failed to load and stayed permanently unhealthy:

```
Not implemented Error: Unknown TimeZone '+00:00'!
```

`Dialect::timestamp_at_time_zone_to_sql` rendered every `CAST(x AS Timestamp(_, Some(tz)))` as `x AT TIME ZONE '<tz>'`, and `DuckDBDialect` did not override it (MySQL, SQLite and BigQuery do). DuckDB resolves `AT TIME ZONE` through an ICU zone-**name** lookup, so it rejects every offset spelling. `iceberg-rust` maps **every** `timestamptz` column to `+00:00`, so any Iceberg dataset with a `timestamptz` time column accelerated into DuckDB with an append refresh hit this.

`DuckDBDialect` now falls back to `CAST(x AS TIMESTAMP WITH TIME ZONE)` for the zero-offset spellings (`+00:00`, `-00:00`, `+0000`, `-0000`, `+00`, `-00`), which denote UTC and preserve the instant. Non-zero offsets are deliberately left verbatim and still raise the DuckDB error — ICU has no equivalent spelling to map them onto (`GMT+05:00` is rejected too, and `Etc/GMT±N` covers only whole hours **with an inverted sign**), so failing loudly beats risking a wrong instant.

## `spiceai/datafusion-table-providers#36` — `epoch_ms(BOOLEAN)`

The periodic retention loop against a DuckDB accelerator failed to bind and logged a binder error every check interval:

```
[retention] Binder Error: No function matches the given name and argument types 'epoch_ms(BOOLEAN)'
```

The DuckDB timestamp normalization in `to_sql_with_engine` ran for **every** `BinaryExpr` — including `AND`/`OR` — and decided from the *rendered SQL text* of the right operand rather than operand **types**. The left operand of a connective is a predicate, so it got wrapped: `TO_TIMESTAMP(EPOCH_MS("is_active") / 1000) AND …`. The rewrite is now gated to comparison operators.

Scope: DuckDB also applies `retention_sql` through an engine-level write-completion hook, which does not go through `to_sql_with_engine`, so datasets that keep refreshing still got evicted. This defect broke the periodic loop.

## Verification

Both fixes were reproduced and then verified end-to-end against a runtime build carrying these exact revisions, on Linux:

| | before | after |
|---|---|---|
| `event_time AT TIME ZONE '+00:00'` (and `+0000`, `+00`, `-00:00`) | `Unknown TimeZone` | same result as `'UTC'` |
| `event_time AT TIME ZONE '-05:00'` (non-zero) | `Unknown TimeZone` | `Unknown TimeZone` — fail-safe preserved |
| retention with a boolean + timestamp predicate | `Binder Error: epoch_ms(BOOLEAN)` every cycle | evicts the correct row, no error |

Upstream tests are mutation-checked — each regression test was observed failing before its fix and passing after.

## Scope of the bump

Each dependency moves by **exactly one commit**, and the `Cargo.lock` diff is rev swaps only — no other dependency versions change.

- `datafusion`: `b8b9592` → `fed13d9`
- `datafusion-table-providers`: `1b83cbf` → `99e33a1`

Fixes #12528
Fixes #12529
