### PR TITLE
chore(deps): bump datafusion and table-providers for the DuckDB timezone and retention fixes (2.1 backport)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5584,7 +5584,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5636,7 +5636,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5660,7 +5660,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5684,7 +5684,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5709,7 +5709,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "futures",
  "log",
@@ -5719,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "async-compression",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5801,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5823,7 +5823,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5872,12 +5872,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5898,7 +5898,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -5920,7 +5920,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -5972,7 +5972,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6003,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6047,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6071,7 +6071,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6086,7 +6086,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6102,7 +6102,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6111,7 +6111,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "chrono",
@@ -6172,7 +6172,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6193,7 +6193,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6207,7 +6207,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "chrono",
@@ -6223,7 +6223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6243,7 +6243,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6275,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "chrono",
@@ -6304,7 +6304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6316,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6344,7 +6344,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6372,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6390,7 +6390,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.0.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=904c487edc227a0de74c1be711942bb574fd981f#904c487edc227a0de74c1be711942bb574fd981f"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b91dfae3eea4c10f2efc691a987f62d25d56ca19#b91dfae3eea4c10f2efc691a987f62d25d56ca19"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6409,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=1b83cbf0e131fc30e53663ed519f077a5ee65917#1b83cbf0e131fc30e53663ed519f077a5ee65917"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=99e33a11fac58b89edca3ee522e41d777e39cabb#99e33a11fac58b89edca3ee522e41d777e39cabb"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ datafusion-proto-common = "54.0.0"
 datafusion-pruning = "54.0.0"
 datafusion-spark = "54.0.0"
 datafusion-substrait = "54.0.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "1b83cbf0e131fc30e53663ed519f077a5ee65917" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "99e33a11fac58b89edca3ee522e41d777e39cabb" } # spiceai-54
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",
@@ -391,41 +391,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "904c487edc227a0de74c1be711942bb574fd981f" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "b91dfae3eea4c10f2efc691a987f62d25d56ca19" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).


### PR DESCRIPTION
> **2.1 release-line backport** of #12545. Opened so the fixes are ready if a v2.1.4 is cut; the release decision is separate.

Picks up two DuckDB accelerator fixes from the forks.

## `spiceai/datafusion#195` — `Unknown TimeZone '+00:00'`

A DuckDB-accelerated dataset whose time column carried an Arrow **fixed-offset** timezone failed to load and stayed permanently unhealthy:

```
Not implemented Error: Unknown TimeZone '+00:00'!
```

`Dialect::timestamp_at_time_zone_to_sql` rendered every `CAST(x AS Timestamp(_, Some(tz)))` as `x AT TIME ZONE '<tz>'`, and `DuckDBDialect` did not override it (MySQL, SQLite and BigQuery do). DuckDB resolves `AT TIME ZONE` through an ICU zone-**name** lookup, so it rejects every offset spelling. `iceberg-rust` maps **every** `timestamptz` column to `+00:00`, so any Iceberg dataset with a `timestamptz` time column accelerated into DuckDB with an append refresh hit this.

`DuckDBDialect` now falls back to `CAST(x AS TIMESTAMP WITH TIME ZONE)` for the zero-offset spellings (`+00:00`, `-00:00`, `+0000`, `-0000`, `+00`, `-00`), which denote UTC and preserve the instant. Non-zero offsets are deliberately left verbatim and still raise the DuckDB error — ICU has no equivalent spelling to map them onto (`GMT+05:00` is rejected too, and `Etc/GMT±N` covers only whole hours **with an inverted sign**), so failing loudly beats risking a wrong instant.

## `spiceai/datafusion-table-providers#36` — `epoch_ms(BOOLEAN)`

The periodic retention loop against a DuckDB accelerator failed to bind and logged a binder error every check interval:

```
[retention] Binder Error: No function matches the given name and argument types 'epoch_ms(BOOLEAN)'
```

The DuckDB timestamp normalization in `to_sql_with_engine` ran for **every** `BinaryExpr` — including `AND`/`OR` — and decided from the *rendered SQL text* of the right operand rather than operand **types**. The left operand of a connective is a predicate, so it got wrapped: `TO_TIMESTAMP(EPOCH_MS("is_active") / 1000) AND …`. The rewrite is now gated to comparison operators.

Scope: DuckDB also applies `retention_sql` through an engine-level write-completion hook, which does not go through `to_sql_with_engine`, so datasets that keep refreshing still got evicted. This defect broke the periodic loop.

## Verification

Both fixes were reproduced and then verified end-to-end against a runtime build carrying these exact revisions, on Linux:

| | before | after |
|---|---|---|
| `event_time AT TIME ZONE '+00:00'` (and `+0000`, `+00`, `-00:00`) | `Unknown TimeZone` | same result as `'UTC'` |
| `event_time AT TIME ZONE '-05:00'` (non-zero) | `Unknown TimeZone` | `Unknown TimeZone` — fail-safe preserved |
| retention with a boolean + timestamp predicate | `Binder Error: epoch_ms(BOOLEAN)` every cycle | evicts the correct row, no error |

Upstream tests are mutation-checked — each regression test was observed failing before its fix and passing after.

## Scope of the bump

Each dependency moves by **exactly one commit**, and the `Cargo.lock` diff is rev swaps only — no other dependency versions change.

- `datafusion`: `904c487` → `b91dfae` (spiceai/datafusion#196, the 2.1 backport of #195)
- `datafusion-table-providers`: `1b83cbf` → `99e33a1`

Fixes #12528
Fixes #12529
