### PR TITLE
fix(deps): bump the Vortex pin to pick up the task-cancellation fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21638,7 +21638,7 @@ dependencies = [
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "vortex-alp",
  "vortex-array",
@@ -21672,7 +21672,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -21690,7 +21690,7 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "arc-swap",
  "arcref",
@@ -21741,7 +21741,7 @@ dependencies = [
 [[package]]
 name = "vortex-array-macros"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -21751,7 +21751,7 @@ dependencies = [
 [[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -21778,7 +21778,7 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "arrow-buffer",
  "bitvec",
@@ -21791,7 +21791,7 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "num-traits",
  "vortex-array",
@@ -21804,7 +21804,7 @@ dependencies = [
 [[package]]
 name = "vortex-compressor"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -21860,7 +21860,7 @@ dependencies = [
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -21874,7 +21874,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -21888,7 +21888,7 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -21901,7 +21901,7 @@ dependencies = [
 [[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "fastlanes",
  "itertools 0.14.0",
@@ -21918,7 +21918,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -21928,7 +21928,6 @@ dependencies = [
  "kanal",
  "moka",
  "object_store 0.13.2",
- "oneshot 0.2.1",
  "parking_lot",
  "pin-project-lite",
  "tokio",
@@ -21962,7 +21961,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -21972,7 +21971,7 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "fsst-rs",
  "prost 0.14.3",
@@ -21986,7 +21985,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "async-fs",
  "async-stream",
@@ -22016,7 +22015,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -22033,7 +22032,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "arcref",
  "arrow-array",
@@ -22075,7 +22074,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer",
@@ -22085,7 +22084,7 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "parking_lot",
  "sketches-ddsketch",
@@ -22094,7 +22093,7 @@ dependencies = [
 [[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "pco",
  "prost 0.14.3",
@@ -22108,7 +22107,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "prost 0.14.3",
  "prost-types",
@@ -22117,7 +22116,7 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "arrow-array",
  "itertools 0.14.0",
@@ -22133,7 +22132,7 @@ dependencies = [
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "async-trait",
  "futures",
@@ -22149,7 +22148,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "num-traits",
  "prost 0.14.3",
@@ -22165,7 +22164,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "dashmap",
  "lasso",
@@ -22177,7 +22176,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -22192,7 +22191,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "dashmap",
  "hashbrown 0.17.1",
@@ -22202,7 +22201,7 @@ dependencies = [
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "vortex-array",
  "vortex-buffer",
@@ -22215,7 +22214,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=70b2429e31e9f122774200047c6aec3dc8f8136f#70b2429e31e9f122774200047c6aec3dc8f8136f"
+source = "git+https://github.com/spiceai/vortex.git?rev=9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2#9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2"
 dependencies = [
  "itertools 0.14.0",
  "prost 0.14.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,13 +360,13 @@ flatbuffers = "25.2.10"
 # Vortex tagged releases publish version 0.1.0 in their Cargo.toml, not the actual release version,
 # so we specify git deps here directly. The [patch.crates-io] entries below exist to override
 # transitive vortex dependencies pulled in by other patched crates.
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
-vortex-btrblocks = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54
+vortex-btrblocks = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54
 vortex-datafusion = { path = "crates/vortex" }
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54
 
 x509-certificate = "0.25.0"
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "93b75c3c7d1a812b23d00b45adf537d7a2415496" } # spiceai/spice-rs#77
@@ -490,9 +490,9 @@ arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a4037
 arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a40370d014a0f8eed12ee0d5a914e8cb2070d8" } # branch: lukim/spiceai-58.3.0
 parquet = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a40370d014a0f8eed12ee0d5a914e8cb2070d8" }      # branch: lukim/spiceai-58.3.0
 
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54
 vortex-datafusion = { path = "crates/vortex" }
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "70b2429e31e9f122774200047c6aec3dc8f8136f" } # spiceai-2.1-54
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "9c4b2ce6d479bb4e71d868c2b5ac12fa77111af2" } # spiceai-2.1-54


### PR DESCRIPTION
## Summary

Cancelling a task spawned onto the Vortex IO runtime dropped a one-shot channel receiver that
had already been polled, while its sender was still delivering a result. The receiver released
its stored waker from inside its own destructor, freeing it under the sender about to call it.
That corrupts the heap and faults on an indirect call through the freed vtable, which presents
as a `SIGSEGV` on a `tokio-rt-worker` thread — at arbitrary uptime, and uncorrelated with
throughput, because what matters is whether a cancellation interleaves with a completion.

This is a dependency bump only: it moves the Vortex pin to a revision that carries the fix.

## What changed upstream

spiceai/vortex#83 moves the spawned-task and segment-read result channels to tokio's one-shot
channel, which does not release a waker from inside its receiver's destructor. It also adds a
stress test that reproduces the fault on every run against an affected revision.

## Testing

The fix was validated in the Vortex fork: the cancellation stress test crashes the test
process within a second before the change and is clean after it, and the existing `vortex-io`
and `vortex-file` suites pass with and without the `tokio` feature.

A regression test that fails on an affected pin is going onto `trunk` alongside the
corresponding pin bump there, rather than into this release-line change, to keep this one to a
dependency bump.
