### PR TITLE
fix(ci): probe a pinned Hugging Face revision at a URL the Hub has (fixes #12553)

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -379,27 +379,45 @@ jobs:
           }
 
           rc=0
-          while IFS= read -r repo; do
-            [ -n "${repo}" ] || continue
+          while IFS= read -r component; do
+            [ -n "${component}" ] || continue
+
+            # A spicepod pins a revision by joining it onto the repo id as
+            # `org/model:revision` — both `models` and `embeddings` do, and
+            # `split_hf_model_id` in crates/spicepod exists to undo that join before a
+            # loader talks to the Hub. The Hub has no repo under the joined name: a
+            # revision is a path segment, `<repo>/resolve/<revision>/…`. So probing the
+            # joined string asks for a repo that does not exist, which the Hub answers
+            # 404 with a token and 401 without — and both land in a branch below that
+            # blames the Hub or a quota rather than this URL. Undo the join here too.
+            repo_id="${component%%:*}"
+            revision="${component#*:}"
+            if [ "${revision}" = "${component}" ] || [ -z "${revision}" ]; then
+              revision=main
+            fi
+            url="https://huggingface.co/${repo_id}/resolve/${revision}/config.json"
+
             code=""
             for attempt in 1 2 3 4 5; do
-              code="$(probe "https://huggingface.co/${repo}/resolve/main/config.json")" || code="000"
+              code="$(probe "${url}")" || code="000"
               if [ "${code}" -lt 400 ] 2>/dev/null; then
-                echo "  ok    ${repo} (HTTP ${code}, attempt ${attempt})"
+                echo "  ok    ${component} @ ${revision} (HTTP ${code}, attempt ${attempt})"
                 break
               fi
-              echo "  retry ${repo}: HTTP ${code} (attempt ${attempt}/5)"
+              echo "  retry ${component} @ ${revision}: HTTP ${code} (attempt ${attempt}/5)"
               sleep $((attempt * 3))
             done
 
             if ! { [ "${code}" -lt 400 ]; } 2>/dev/null; then
               case "${code}" in
                 401|403)
-                  echo "::error::Hugging Face returned ${code} for ${repo} after 5 attempts. This is a Hub access/quota failure, not a code failure in this branch — anonymous downloads share a per-IP quota across the whole self-hosted pool. Set the SPICE_SECRET_HF_TOKEN secret, or run 'huggingface-cli login' on the runner." ;;
+                  echo "::error::Hugging Face returned ${code} for ${component} after 5 attempts (${url}). This is a Hub access/quota failure, not a code failure in this branch — anonymous downloads share a per-IP quota across the whole self-hosted pool. Set the SPICE_SECRET_HF_TOKEN secret, or run 'huggingface-cli login' on the runner." ;;
                 429)
-                  echo "::error::Hugging Face rate-limited ${repo} (429) after 5 attempts. Not a code failure in this branch." ;;
+                  echo "::error::Hugging Face rate-limited ${component} (429) after 5 attempts (${url}). Not a code failure in this branch." ;;
+                404)
+                  echo "::error::Hugging Face has no ${repo_id} at revision ${revision} (404, ${url}). Unlike the other codes here this one is about the spicepod: check the repo id and the pinned revision." ;;
                 *)
-                  echo "::error::Could not reach Hugging Face for ${repo} (HTTP ${code}) after 5 attempts. Not a code failure in this branch." ;;
+                  echo "::error::Could not reach Hugging Face for ${component} (HTTP ${code}) after 5 attempts (${url}). Not a code failure in this branch." ;;
               esac
               rc=1
             fi


### PR DESCRIPTION
Fixes #12553.

## The failure this removes

`e2e_test_ci.yml`'s **Pre-flight the Hugging Face components** step built its probe URL by
dropping the spicepod's `from:` value straight into the Hub's *repo id* position. A spicepod
pins a revision by joining it onto the repo id as `org/model:revision`, so the probe asked the
Hub for a repository that does not exist and the step failed a job whose model downloads would
have worked.

```
##[error]Could not reach Hugging Face for Qwen/Qwen2.5-3B-Instruct:aa8e72537993ba99e69dfaafa59ed015b17504d1 (HTTP 404) after 5 attempts. Not a code failure in this branch.
```

**Blast radius** — window 2026-08-04T13:16Z → 2026-08-05T11:05Z (200 most recent failed runs):
**3 failed runs across 3 distinct merge-queue branches**, each dequeuing its batch.

- https://github.com/spiceai/spiceai/actions/runs/30966250901 — `gh-readonly-queue/trunk/pr-12435-…`
- https://github.com/spiceai/spiceai/actions/runs/30965980716 — `gh-readonly-queue/trunk/pr-12261-…`
- https://github.com/spiceai/spiceai/actions/runs/30917038794

It is not intermittent — it fires on **every** run whose spicepod pins a revision. #12261
(`fix(e2e): stabilize model REPL tests`, open and `BLOCKED`) is the PR that pins them, so this
defect is currently blocking a valid change and would block every later one that pins a
revision.

## Root cause

A Hub revision is a **path segment** (`<repo>/resolve/<revision>/…`), not part of the repo id.
`spiced` already knows this: `split_hf_model_id` in `crates/spicepod/src/component/model.rs`
exists to undo the spicepod's join before a loader talks to the Hub, and its doc comment names
this exact failure — *"A loader that forwards that joined string to the Hub as the repo name
therefore asks for a repo that does not exist."* #12446 fixed the Rust loader. The workflow's
shell pre-flight was never given the same treatment.

Verified against the live Hub:

| Probed URL | Code |
|---|---|
| `…/Qwen/Qwen2.5-3B-Instruct:aa8e725…/resolve/main/config.json` | **401** anon / 404 with token |
| `…/Qwen/Qwen2.5-3B-Instruct/resolve/aa8e725…/config.json` | **200** |
| `…/BAAI/bge-base-en-v1.5:a5beb1e…/resolve/main/config.json` | **401** |
| `…/BAAI/bge-base-en-v1.5/resolve/a5beb1e…/config.json` | **200** |

The 401 is the worse half: it routed into the step's *"This is a Hub access/quota failure …
Set the SPICE_SECRET_HF_TOKEN secret"* branch — advice that cannot help, because the token was
present and working.

## What changed

- The pre-flight splits a pinned revision off the repo id, exactly as `split_hf_model_id`
  does (first colon separates; a trailing colon yields the default branch), and probes
  `https://huggingface.co/<repo_id>/resolve/<revision>/config.json`, defaulting the revision
  to `main`.
- `404` gets its own branch. With the URL correct it is the one code here that *is* about the
  branch under test — the spicepod naming a repo or revision that does not exist — and it now
  says so instead of claiming the Hub was unreachable.
- Every error line carries the URL it probed, so the next mismatch of this kind diagnoses
  itself from the run summary.

## What this does **not** weaken

- **No assertion is relaxed.** An unreachable Hub, a real quota 401/403, and a 429 all still
  fail the pre-flight and the job.
- **No retry was added or widened.** The existing 5 attempts still cover a *download*, never a
  check on the code under test — and they now retry a URL that can actually succeed, instead of
  spending 30s of sleeps on one that structurally cannot.
- **No trigger, required check, `continue-on-error`, or timeout was touched.**
- **No spicepod is exempted from the pre-flight.** The set of components probed is unchanged;
  only the URL each one is probed at changed.

## Test plan

- [x] `python .github/scripts/check_workflow_yaml.py` — `OK: 107 GitHub Actions definitions are well-formed` (the repo's own `Workflow YAML Check` gate for `.github/workflows/**`)
- [x] Extracted the step's shell verbatim and ran it against the live Hub on three spicepods — pinned (`org/model:sha` for both the model and the embedding), unpinned, and a trailing-colon edge case. All three: `HTTP 200`, exit 0.
- [x] Ran the **pre-fix** shell on the same pinned spicepod to confirm the mechanism rather than assume it: `HTTP 401` on all attempts for both components, exit 1 — i.e. the fix is what changes the outcome.
- [x] Confirmed the trailing-colon case (`org/model:`) resolves to `main`, matching `split_hf_model_id`'s documented behaviour rather than requesting the empty revision.
- [ ] `make lint` / `make test` — **not applicable and not run.** The diff is one workflow YAML file with no Rust. `pr.yml`'s no-Rust fast-track and `branch_has_rust_changes` in `scripts/signoff` both skip every Rust check for such a branch by design, so a sign-off would attest a run that did no work; `Attestation` fast-tracks instead. The full suite still runs in the merge queue.

## Notes on the review gate

The adversarial-review pass could not run on this host — there is no Node.js, so the
`codex-companion.mjs` entry point is unavailable. The change was reviewed manually for the
questions that pass asks: the token still reaches curl through a config on stdin (never argv),
the interpolated value is still a path suffix appended after a fixed `https://huggingface.co/`
origin so it cannot redirect the probe to another host, and the revision now lands in a path
segment rather than the repo-id position — strictly narrower than before.
