### PR TITLE
fix(cayenne): read a scan's cold manifest from the capture that named its warm snapshot (fixes #12555)

### DIFF
--- a/crates/cayenne/src/provider/cold_partition.rs
+++ b/crates/cayenne/src/provider/cold_partition.rs
@@ -44,7 +44,6 @@ limitations under the License.
 //! drains: every tombstone's potential host file is in the rewrite set, so
 //! every tombstone is physically applied.
 
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Int64Array};
@@ -57,12 +56,20 @@ use crate::metadata::ColdTierFile;
 use crate::row_converter::{Row, RowConverter};
 use crate::stats::statistics_from_persisted_blob;
 
-/// `SessionConfig` extension restricting the cold scan branch to a file
-/// subset. Attached ONLY by the promotion's private session so the
-/// carry-forward rewrite reads the dirty files and nothing else; user-query
-/// sessions never carry it, so queries always see the full manifest.
+/// `SessionConfig` extension pinning the cold scan branch to an explicit file
+/// set. Attached ONLY by the promotion's private session so the carry-forward
+/// rewrite reads the dirty files and nothing else.
+///
+/// It carries the manifest ROWS the promotion classified, not just their URLs,
+/// so the rewrite stream is built from the same listing the classification ran
+/// against. Selecting a subset out of whatever listing the scan happened to
+/// capture would let a stale capture silently drop a dirty file from the
+/// rewrite while the commit still retires it from the manifest.
+///
+/// User-query sessions never carry it; they read the manifest captured under
+/// the listing fence with the rest of the scan's visible state.
 #[derive(Debug)]
-pub(crate) struct ColdScanFileSubset(pub HashSet<String>);
+pub(crate) struct ColdScanFiles(pub Arc<Vec<ColdTierFile>>);
 
 /// The cold manifest split for one promotion pass.
 pub(crate) struct ColdFilePartition {

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -8107,8 +8107,7 @@ impl CayenneTableProvider {
         // snapshot flip together under the write fence, so listing cold after the
         // fence is dropped can pair a post-promotion manifest with the
         // pre-promotion warm snapshot and fold a cold-resident key twice.
-        let fold_cold_manifest =
-            fold_cold && self.table_metadata.vortex_config.cold_tier_enabled();
+        let fold_cold_manifest = fold_cold && self.table_metadata.vortex_config.cold_tier_enabled();
         let (mem_snapshots, protected_snapshots, current_snapshot_id, cold_files) = {
             let _fence = self.listing_fence.read().await;
             let mem_snapshots: Vec<Arc<crate::provider::mem_tier::MemTier>> = self

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -1032,6 +1032,25 @@ struct RawScanInput {
     /// Current snapshot id captured under the read fence — the file set the scan
     /// reads. Pinned against GC by [`Self::scan_guard`].
     current_snapshot_id: String,
+    /// Cold-tier (datalake) manifest captured under the SAME read fence as
+    /// [`Self::current_snapshot_id`], so the two visibility points a promotion
+    /// publishes cannot be mixed across versions.
+    ///
+    /// A cold promotion publishes BOTH the new cold manifest and the fresh empty
+    /// warm snapshot in one `listing_fence.write()` section. Reading the manifest
+    /// later — during plan-build, off the fence — pairs the OLD warm snapshot
+    /// with the NEW cold manifest and counts every promoted row TWICE. Capturing
+    /// it here makes the pair coherent by construction, and it also drops one
+    /// metastore round-trip per scan (the manifest now rides the cached bundle).
+    ///
+    /// Empty (and not read at all) when the cold tier is disabled.
+    ///
+    /// Needs NO [`ScanViewKey`] component: every write to `cayenne_cold_tier_file`
+    /// happens in the same metastore transaction that moves
+    /// `cayenne_table.current_snapshot_id` (`commit_overwrite_to_cold_in_txn` and
+    /// `commit_overwrite_in_txn`), so the manifest cannot change without
+    /// `current_snapshot_id` — already a key component — changing with it.
+    cold_files: Arc<Vec<crate::metadata::ColdTierFile>>,
     /// Inline-memtable structural epoch (`inlined_structural_epoch`) observed at
     /// capture. Part of the [`Self::changed`] key — the same key the retired memos
     /// used, so a build is skipped iff no scan-visible state moved.
@@ -8026,6 +8045,26 @@ impl CayenneTableProvider {
         Ok(ColdKeysetSource::Bloom)
     }
 
+    /// List the cold-tier manifest for the keyset rebuild's fenced capture.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the metastore cannot serve the manifest. There is no
+    /// directory-listing fallback for the cold tier, so a rebuild must fail rather
+    /// than continue with a keyset missing every cold-resident key (which would let
+    /// an upsert false-negative and leak the prior copy of the row).
+    async fn list_cold_files_for_keyset_rebuild(
+        &self,
+    ) -> Result<Vec<crate::metadata::ColdTierFile>> {
+        self.catalog
+            .list_cold_tier_files(&self.table_metadata.table_id)
+            .await
+            .map_err(|e| Error::Internal {
+                table: self.table_metadata.table_name.clone(),
+                message: format!("keyset rebuild could not list the cold manifest: {e}"),
+            })
+    }
+
     /// Rebuild the PK existence index from durable state in ONE bounded
     /// streaming pass: every scanned key routes straight to its shard
     /// ([`BoundedShardedPkIndexBuilder`]), and an upsert table whose exact
@@ -8063,7 +8102,14 @@ impl CayenneTableProvider {
         // mem-tier snapshot stays inside the same fence so a concurrent
         // off-`write_lock` checkpoint cannot hide a live key either: it is in this
         // snapshot or already durable in the scan that follows.
-        let (mem_snapshots, protected_snapshots, current_snapshot_id) = {
+        // The cold manifest joins the same fenced capture when this rebuild folds
+        // the cold tier: promotion publishes the cold manifest and the warm
+        // snapshot flip together under the write fence, so listing cold after the
+        // fence is dropped can pair a post-promotion manifest with the
+        // pre-promotion warm snapshot and fold a cold-resident key twice.
+        let fold_cold_manifest =
+            fold_cold && self.table_metadata.vortex_config.cold_tier_enabled();
+        let (mem_snapshots, protected_snapshots, current_snapshot_id, cold_files) = {
             let _fence = self.listing_fence.read().await;
             let mem_snapshots: Vec<Arc<crate::provider::mem_tier::MemTier>> = self
                 .mem_tier
@@ -8074,7 +8120,17 @@ impl CayenneTableProvider {
             // Wait-free Arc::clone — the inner HashMap is shared, not cloned.
             let protected_snapshots = self.protected_snapshots.load_full();
             let current_snapshot_id = self.get_current_snapshot_id();
-            (mem_snapshots, protected_snapshots, current_snapshot_id)
+            let cold_files = if fold_cold_manifest {
+                self.list_cold_files_for_keyset_rebuild().await?
+            } else {
+                Vec::new()
+            };
+            (
+                mem_snapshots,
+                protected_snapshots,
+                current_snapshot_id,
+                cold_files,
+            )
         };
 
         let ctx = self.create_session_context();
@@ -8193,6 +8249,7 @@ impl CayenneTableProvider {
             && let Some(cold_plan) = self
                 .build_cold_tier_scan_plan(
                     &ctx.state(),
+                    &cold_files,
                     Some(&pk_projection),
                     &[],
                     None,
@@ -16100,7 +16157,7 @@ impl CayenneTableProvider {
     /// ([`Self::partition_cold_manifest_for_promotion`]), read the canonical
     /// visible stream restricted to warm + dirty cold files (all deletes
     /// applied, single-version per key — the proven rewrite read with a
-    /// [`super::cold_partition::ColdScanFileSubset`] session extension),
+    /// [`super::cold_partition::ColdScanFiles`] session extension),
     /// Z-order cluster it, write read-optimized Vortex to the cold store, then
     /// atomically register the new files PLUS the carried-forward clean
     /// manifest rows + overwrite-clear the warm tier + flip to a fresh empty
@@ -16416,14 +16473,18 @@ impl CayenneTableProvider {
 
         // Canonical visible read (all tiers, all deletes applied, single-version
         // per key) — reuses the proven rewrite read so cold is correct by
-        // construction. The session's `ColdScanFileSubset` extension restricts
-        // its cold branch to the dirty files: clean files stay out of the
-        // stream entirely.
-        let dirty_urls: std::collections::HashSet<String> =
-            dirty_cold.iter().map(|f| f.file_url.clone()).collect();
+        // construction. The session's `ColdScanFiles` extension pins its cold
+        // branch to the dirty files: clean files stay out of the stream entirely.
+        //
+        // The extension carries the classified ROWS, so the rewrite reads exactly
+        // what the classification above decided. Passing only their URLs would
+        // leave the stream to intersect them with whatever manifest the scan
+        // captured, and any disagreement drops a dirty file from the rewrite while
+        // the commit below still retires it — losing its live rows.
+        let dirty_cold = Arc::new(dirty_cold);
         let ctx = self.create_compaction_session_context_with_config(
             SessionConfig::default().with_extension(Arc::new(
-                super::cold_partition::ColdScanFileSubset(dirty_urls),
+                super::cold_partition::ColdScanFiles(Arc::clone(&dirty_cold)),
             )),
         );
         let (stream, _generation_before) = self.visible_file_stream_for_rewrite(&ctx).await?;
@@ -18281,9 +18342,9 @@ impl CayenneTableProvider {
     }
 
     /// [`Self::create_compaction_session_context`] with an explicit config —
-    /// the carry-forward promotion attaches its [`ColdScanFileSubset`]
-    /// extension here so its private session's cold branch reads only the
-    /// dirty files being rewritten.
+    /// the carry-forward promotion attaches its
+    /// [`super::cold_partition::ColdScanFiles`] extension here so its private
+    /// session's cold branch reads only the dirty files being rewritten.
     fn create_compaction_session_context_with_config(
         &self,
         config: SessionConfig,
@@ -20728,6 +20789,36 @@ impl CayenneTableProvider {
         let current_snapshot_id = self.get_current_snapshot_id();
         let structural_epoch = self.inlined_structural_epoch.load(Ordering::Relaxed);
 
+        // The cold-tier manifest, under the SAME held fence as the snapshot id
+        // above. A promotion publishes its metastore commit and its warm snapshot
+        // flip inside one `listing_fence.write()` section precisely so a fenced
+        // reader observes them together; listing cold later (off the fence, during
+        // plan-build) reintroduces the double count this pairing prevents.
+        //
+        // This is a deliberate `.await` under the read fence — the mirror of the
+        // promotion's `.await` under the write fence, and for the same reason: for
+        // the cold tier the metastore commit IS a visibility flip, so both sides
+        // have to reach the metastore inside the fence to agree. The read fence
+        // admits every other scan concurrently and blocks only a promotion's
+        // write acquisition.
+        let cold_files = if self.table_metadata.vortex_config.cold_tier_enabled() {
+            let files = self
+                .catalog
+                .list_cold_tier_files(&self.table_metadata.table_id)
+                .await
+                .map_err(|e| {
+                    // No directory-listing fallback exists for cold, so a
+                    // metastore error fails the scan rather than dropping rows.
+                    datafusion_common::DataFusionError::Execution(format!(
+                        "Failed to list cold-tier files for table {}: {e}",
+                        self.table_metadata.table_name
+                    ))
+                })?;
+            Arc::new(files)
+        } else {
+            Arc::new(Vec::new())
+        };
+
         // Capture the (gated) read schema under the SAME held fence + seqlock-validated
         // window, so it is consistent with the data captured above and every scan-plan
         // branch can build from this one schema instead of re-reading the live
@@ -20754,6 +20845,7 @@ impl CayenneTableProvider {
             protected_map,
             inlined_view,
             current_snapshot_id,
+            cold_files,
             structural_epoch,
             scan_guard,
             read_schema,
@@ -25332,9 +25424,19 @@ impl CayenneTableProvider {
     /// with NO object-store round-trip. The returned plan is a Vortex
     /// `DataSourceExec`; the caller wraps it with the key-based (`Ignore`)
     /// deletion filter and unions it into the scan tree.
+    ///
+    /// `captured_cold_files` is the manifest the CALLER captured coherently with
+    /// the rest of the state its plan reads — this function never lists the
+    /// manifest itself. The cold manifest is one of the two visibility points a
+    /// promotion flips together under `listing_fence.write()`, so a listing taken
+    /// here (after the caller's capture, off the fence) would pair a NEW cold
+    /// manifest with an OLD warm snapshot and double-count every promoted row.
+    /// The promotion's own rewrite session overrides it with an explicit
+    /// [`super::cold_partition::ColdScanFiles`] set.
     async fn build_cold_tier_scan_plan(
         &self,
         state: &dyn Session,
+        captured_cold_files: &[crate::metadata::ColdTierFile],
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
@@ -25356,32 +25458,18 @@ impl CayenneTableProvider {
             Self::register_object_store_if_needed(state.runtime_env(), cold_config);
         }
 
-        let cold_files = self
-            .catalog
-            .list_cold_tier_files(&self.table_metadata.table_id)
-            .await
-            .map_err(|e| {
-                // No directory-listing fallback exists for cold (unlike the warm
-                // manifest), so a metastore error must fail the query rather than
-                // silently drop cold rows.
-                datafusion_common::DataFusionError::Execution(format!(
-                    "Failed to list cold-tier files for table {}: {e}",
-                    self.table_metadata.table_name
-                ))
-            })?;
-        // Carry-forward promotion: the promotion's PRIVATE session carries a
-        // `ColdScanFileSubset` config extension restricting this branch to the
-        // dirty files being rewritten (clean files are carried forward by
-        // manifest reference, never re-read). User-query sessions never carry
-        // the extension, so queries always see the full manifest.
-        let cold_files =
-            match scan_config.get_extension::<super::cold_partition::ColdScanFileSubset>() {
-                Some(subset) => cold_files
-                    .into_iter()
-                    .filter(|f| subset.0.contains(&f.file_url))
-                    .collect(),
-                None => cold_files,
-            };
+        // Carry-forward promotion: the promotion's PRIVATE session pins this
+        // branch to the dirty files it classified for rewrite (clean files are
+        // carried forward by manifest reference, never re-read). Its own listing
+        // is authoritative — the classification and the rewrite must agree on the
+        // exact file set, or the commit retires a dirty file whose rows were never
+        // read. User-query sessions never carry the extension and read the
+        // manifest the caller captured under the listing fence.
+        let pinned = scan_config.get_extension::<super::cold_partition::ColdScanFiles>();
+        let cold_files: &[crate::metadata::ColdTierFile] = match pinned.as_deref() {
+            Some(pinned) => pinned.0.as_slice(),
+            None => captured_cold_files,
+        };
         // No early all-empty guard needed: the per-file loop skips zero-size
         // files and the `object_store_url is None` / `kept.is_empty()` checks
         // below both return `Ok(None)` when nothing survives.
@@ -25407,7 +25495,7 @@ impl CayenneTableProvider {
         let table_name = self.table_metadata.table_name.clone();
         let mut object_store_url: Option<ListingTableUrl> = None;
         let mut kept: Vec<PartitionedFile> = Vec::with_capacity(cold_files.len());
-        for file in &cold_files {
+        for file in cold_files {
             if file.file_size_bytes <= 0 {
                 continue;
             }
@@ -26678,6 +26766,10 @@ impl TableProvider for CayenneTableProvider {
         let protected_map = Arc::clone(&scan_view.raw.protected_map);
         let inlined_view = Arc::clone(&scan_view.raw.inlined_view);
         let current_snapshot_id = scan_view.raw.current_snapshot_id.clone();
+        // The cold manifest from the SAME capture as `current_snapshot_id`: the two
+        // visibility points a promotion flips together must be read together, or a
+        // scan pairs the old warm snapshot with the new cold manifest.
+        let captured_cold_files = Arc::clone(&scan_view.raw.cold_files);
         let scan_guard = Arc::clone(&scan_view.raw.scan_guard);
         let deletion_snapshot = scan_view.merged_deletions.clone();
         let visible_segments = Arc::clone(&scan_view.visible_segments);
@@ -26912,6 +27004,7 @@ impl TableProvider for CayenneTableProvider {
         let cold_plan: Option<Arc<dyn ExecutionPlan>> = self
             .build_cold_tier_scan_plan(
                 state,
+                &captured_cold_files,
                 effective_projection.as_ref(),
                 scan_filters,
                 limit,

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -25414,6 +25414,7 @@ impl CayenneTableProvider {
     /// manifest with an OLD warm snapshot and double-count every promoted row.
     /// The promotion's own rewrite session overrides it with an explicit
     /// [`super::cold_partition::ColdScanFiles`] set.
+    #[expect(clippy::too_many_arguments)]
     async fn build_cold_tier_scan_plan(
         &self,
         state: &dyn Session,

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -8045,26 +8045,6 @@ impl CayenneTableProvider {
         Ok(ColdKeysetSource::Bloom)
     }
 
-    /// List the cold-tier manifest for the keyset rebuild's fenced capture.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when the metastore cannot serve the manifest. There is no
-    /// directory-listing fallback for the cold tier, so a rebuild must fail rather
-    /// than continue with a keyset missing every cold-resident key (which would let
-    /// an upsert false-negative and leak the prior copy of the row).
-    async fn list_cold_files_for_keyset_rebuild(
-        &self,
-    ) -> Result<Vec<crate::metadata::ColdTierFile>> {
-        self.catalog
-            .list_cold_tier_files(&self.table_metadata.table_id)
-            .await
-            .map_err(|e| Error::Internal {
-                table: self.table_metadata.table_name.clone(),
-                message: format!("keyset rebuild could not list the cold manifest: {e}"),
-            })
-    }
-
     /// Rebuild the PK existence index from durable state in ONE bounded
     /// streaming pass: every scanned key routes straight to its shard
     /// ([`BoundedShardedPkIndexBuilder`]), and an upsert table whose exact
@@ -8120,7 +8100,9 @@ impl CayenneTableProvider {
             let protected_snapshots = self.protected_snapshots.load_full();
             let current_snapshot_id = self.get_current_snapshot_id();
             let cold_files = if fold_cold_manifest {
-                self.list_cold_files_for_keyset_rebuild().await?
+                self.catalog
+                    .list_cold_tier_files(&self.table_metadata.table_id)
+                    .await?
             } else {
                 Vec::new()
             };

--- a/crates/cayenne/tests/cold_tier_test.rs
+++ b/crates/cayenne/tests/cold_tier_test.rs
@@ -657,6 +657,99 @@ async fn test_cold_tier_concurrent_scan_during_promotion_impl(
     Ok(())
 }
 
+test_with_backends!(test_cold_promotion_couples_manifest_and_snapshot_impl);
+
+/// A scan captures the cold manifest together with the warm snapshot id under one
+/// `listing_fence.read()`, and the scan-view cache keys that whole bundle on the
+/// snapshot id. Both rest on ONE metastore invariant: a promotion rewrites
+/// `cayenne_cold_tier_file` and repoints `cayenne_table.current_snapshot_id` in
+/// the SAME transaction, so the manifest cannot move without the cache key moving
+/// with it.
+///
+/// A cold-manifest write that left the snapshot id alone would let the cache keep
+/// serving a bundle whose manifest predates its own key, and the cold rows that
+/// write published would stay invisible to scans until something else flipped the
+/// warm snapshot. Pin the coupling directly, on both the fresh-graduation and the
+/// dirty-rewrite commit paths.
+async fn test_cold_promotion_couples_manifest_and_snapshot_impl(
+    fixture: common::TestFixture,
+) -> TestResult<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+    let cold_dir = fixture.temp_dir.path().join("cold");
+    std::fs::create_dir_all(&cold_dir)?;
+
+    let options = cold_table_options(&fixture, "couple_t", &schema, &cold_dir, 300_000);
+    let catalog: Arc<dyn MetadataCatalog> =
+        Arc::clone(&fixture.catalog) as Arc<dyn MetadataCatalog>;
+    let ctx = SessionContext::new();
+    let table =
+        Arc::new(CayenneTableProvider::create_table(catalog, options, ctx.runtime_env()).await?);
+    ctx.register_table("couple_t", Arc::clone(&table) as Arc<dyn TableProvider>)?;
+
+    insert_id_range(&table, &schema, 0..200).await?;
+    flush_warm(&table).await;
+    let before = fixture
+        .catalog
+        .get_table("couple_t")
+        .await?
+        .current_snapshot_id;
+    assert!(
+        fixture
+            .catalog
+            .list_cold_tier_files(table.table_id())
+            .await?
+            .is_empty(),
+        "no cold files exist before the first promotion"
+    );
+
+    // Fresh graduation: the manifest gains rows, so the snapshot id must move.
+    assert!(table.promote_warm_to_cold().await?, "promotion 1 fires");
+    let after_fresh = fixture
+        .catalog
+        .get_table("couple_t")
+        .await?
+        .current_snapshot_id;
+    assert!(
+        !fixture
+            .catalog
+            .list_cold_tier_files(table.table_id())
+            .await?
+            .is_empty(),
+        "the promotion registered cold files"
+    );
+    assert_ne!(
+        after_fresh, before,
+        "a promotion that writes the cold manifest must repoint current_snapshot_id \
+         in the same commit — the scan-view cache key is what pairs the two"
+    );
+
+    // Dirty rewrite: a tombstone forces the prior cold generation to be replaced,
+    // which rewrites the manifest again — and must move the id again.
+    delete_id(&table, 7).await?;
+    insert_id_range(&table, &schema, 200..203).await?;
+    flush_warm(&table).await;
+    assert!(table.promote_warm_to_cold().await?, "promotion 2 fires");
+    let after_dirty = fixture
+        .catalog
+        .get_table("couple_t")
+        .await?
+        .current_snapshot_id;
+    assert_ne!(
+        after_dirty, after_fresh,
+        "the dirty-rewrite commit must repoint current_snapshot_id too"
+    );
+    assert_eq!(
+        row_count(&ctx, "couple_t").await?,
+        202,
+        "the two promotions must leave every live row visible exactly once"
+    );
+
+    Ok(())
+}
+
 // ============================================================================
 // Restart: reopen a table that has a cold manifest
 // ============================================================================


### PR DESCRIPTION
Fixes #12555

## Summary

A cold promotion has **two** visibility publication points, and it already flips both inside one `listing_fence.write()` section precisely so a fenced reader observes them together:

1. the metastore commit that rewrites `cayenne_cold_tier_file` (the cold scan branch lists straight from the manifest), and
2. the in-memory flip to a fresh empty warm snapshot.

The scan only held up half of that bargain. It captured the warm snapshot id under `listing_fence.read()`, then deliberately released the fence for plan-build — and the cold branch listed the manifest *there*, off the fence. A promotion landing in the gap paired the **pre**-promotion warm snapshot with the **post**-promotion cold manifest, and every promoted row was counted twice.

That is exactly the shape of the reported failures: the excess equals the rows that pass promoted.

| assertion | expected | observed | excess | warm rows that pass promoted |
|---|---|---|---|---|
| promotion 2 (dirty rewrite) | 402 | 405 | 3 | 3 (`400..403`) |
| promotion 3 (carry-forward) | 502 | 602 | 100 | 100 (`500..600`) |
| promotion 1 (fresh) | 400 | 800 | 400 | 400 (`0..400`) |

It is a race on every backend, not a Turso defect. Turso's driver adds `await` points and latency to the commit, which widens the window until it is hit on essentially every run (6/6 nextest retries); SQLite's in-process commit is fast enough that the same code usually slips through. The sibling `_sqlite` passing was timing, not a guarantee — which is why the fix is structural rather than a widened window.

## Changes

- **The cold manifest joins the fenced capture.** `RawScanInput` (the one coherent per-scan capture) now carries the manifest, listed under the same held `listing_fence.read()` as `current_snapshot_id`. The two halves a promotion publishes together are now read together.
- **`build_cold_tier_scan_plan` takes the manifest as a parameter** and never reaches the metastore. That makes coherence a property of the signature rather than of a comment, and it fixes both callers: the query scan *and* the PK keyset rebuild, which had the identical split (fenced capture, then an unfenced cold listing during its fold pass).
- **The promotion's rewrite session pins the rows it classified.** `ColdScanFileSubset(HashSet<String>)` becomes `ColdScanFiles(Arc<Vec<ColdTierFile>>)`. Intersecting a URL set against whatever manifest the scan captured would let any disagreement drop a dirty file from the rewrite while the commit still retires it from the manifest — losing its live rows. Carrying the classified rows removes that coupling entirely.
- **No new scan-view cache key component**, and the test that says why: every write to `cayenne_cold_tier_file` happens in the same metastore transaction that repoints `cayenne_table.current_snapshot_id` (`commit_overwrite_to_cold_in_txn` reuses `commit_overwrite_in_txn`'s clear), and the key already carries the snapshot id. So the manifest cannot move without the key moving with it.

### On the `.await` under the read fence

The capture now awaits a metastore listing while holding `listing_fence.read()`. This is the mirror of the write side's existing deliberate exception ("for cold, the metastore commit IS a visibility flip"), and it is safe on the same lock discipline every writer already follows — fence first, metastore second:

- No writer holds a metastore transaction across its fence acquisition (`finalize_staged_write` completes `write_wal()` before taking the fence; `mutation_writer` does its metastore work after). So there is no fence↔metastore cycle.
- A reader holding the read fence implies no writer holds the write fence, so any in-flight transaction belongs to a writer that has not reached its fence acquisition and will complete on its own.
- The read fence admits every other scan concurrently; it blocks only a promotion's write acquisition.

## Performance impact

Net **fewer** metastore round-trips. The manifest listing moves off the per-scan plan-build path and onto the deduplicated scan-view bundle, so it now costs one query per distinct scan-visible state instead of one per scan; concurrent scans on the same state share it. Cold-tier-disabled tables read the manifest zero times, exactly as before. The added work inside the fence hold is that one listing, on the same cadence as the bundle build.

## Test plan

- `make lint`
- `make test`
- `test_cold_tier_concurrent_scan_during_promotion_impl_{sqlite,turso}` is the behavioural regression test and it already exists — it is the test failing on `trunk` today (deterministically on Turso, 6/6 retries). This change is what makes it pass, on both backends, for a structural reason rather than a timing one.
- **New** `test_cold_promotion_couples_manifest_and_snapshot_impl_{sqlite,turso}` pins the metastore invariant the no-new-cache-key argument rests on: a promotion must repoint `current_snapshot_id` in the same commit that rewrites the manifest, asserted on both the fresh-graduation and dirty-rewrite paths, plus a row count proving the two promotions leave every live row visible exactly once. Deterministic — no timing hammer.

## Checklist

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Sign-off green on the head commit
- [x] Regression coverage for the reported failure
- [x] Same-shape sibling call site (keyset rebuild) fixed in the same PR

## Notes for the reviewer

- The DELETE path's cold listing (`build_cold_tier_listing_tables`) was considered and left alone: it feeds tombstone recording, where re-recording a tombstone for an already-absent key is idempotent, so a stale/fresh manifest pairing there does not produce a wrong row count. Happy to fold it in if you would rather have the whole file set consistent.
- The adversarial cross-model review pass could not run (the Codex workspace is out of credits); the security pass found no relevant surface — the one error message added is the message that already existed at the call site it moved from.
