### PR TITLE
fix(mysql): raise net_write_timeout on the shared binlog dump session (fixes #12527)

### DIFF
--- a/crates/data-connectors/connector-mysql/src/replication.rs
+++ b/crates/data-connectors/connector-mysql/src/replication.rs
@@ -476,6 +476,21 @@ pub(crate) const REPLICATION_METRICS: &[MetricSpec] = &[
          is the unambiguous signal for which dataset stalled the group.",
     )
     .auto_register(),
+    MetricSpec::new(
+        "replication_member_send_stalled_seconds_total",
+        MetricType::ObservableCounterU64,
+    )
+    .description(
+        "Cumulative seconds the shared binlog pump spent blocked delivering committed \
+         changes into this dataset's channel because its sink was not draining (a slow \
+         apply loop). The pump reads the dump socket for the whole group, so this is also \
+         how long the socket went undrained on this dataset's behalf: once a single stall \
+         exceeds the dump session's net_write_timeout the source aborts the connection and \
+         every changes-mode dataset on it resumes from its acked position, so a rising \
+         value names the dataset that will trigger the next reconnect. Paired with \
+         replication_reconnects_total.",
+    )
+    .auto_register(),
 ];
 
 /// Observation callback for one of the [`REPLICATION_METRICS`], or `None`
@@ -585,6 +600,11 @@ pub(crate) fn observe_replication_metric(
         "replication_member_attached" => ObserveMetricCallback::U64(Box::new(move |instrument| {
             instrument.observe(m.member_attached(), &attributes);
         })),
+        "replication_member_send_stalled_seconds_total" => {
+            ObserveMetricCallback::U64(Box::new(move |instrument| {
+                instrument.observe(m.member_send_stalled_seconds_total(), &attributes);
+            }))
+        }
         _ => return None,
     };
     Some(callback)

--- a/crates/data_components/src/mysql_replication/binlog.rs
+++ b/crates/data_components/src/mysql_replication/binlog.rs
@@ -95,10 +95,11 @@ const DUMP_NET_WRITE_TIMEOUT_SECS: u32 = 180;
 /// One statement issued on the dump connection before `COM_BINLOG_DUMP`.
 struct PreDumpStatement {
     sql: String,
-    /// Whether a rejection deserves a user-visible warning. The heartbeat
-    /// spellings are deliberately tried in pairs and one of them is unknown on
-    /// any given server version, so those stay at debug.
-    warn_on_error: bool,
+    /// What the user loses if the server rejects this statement, when that is
+    /// worth saying. The heartbeat spellings are deliberately tried in pairs
+    /// and one of them is unknown on any given server version, so those carry
+    /// nothing and a rejection stays at debug.
+    rejection_warning: Option<&'static str>,
 }
 
 /// The session setup a dump connection needs, in the order it is issued.
@@ -124,7 +125,7 @@ fn pre_dump_session_statements(checkpoint_interval: Duration) -> Vec<PreDumpStat
             .into_iter()
             .map(|var| PreDumpStatement {
                 sql: format!("SET @{var} = {heartbeat_nanos}"),
-                warn_on_error: false,
+                rejection_warning: None,
             })
             .collect();
     // `net_write_timeout` is a system variable, so it needs the `SESSION`
@@ -137,7 +138,9 @@ fn pre_dump_session_statements(checkpoint_interval: Duration) -> Vec<PreDumpStat
             "SET SESSION net_write_timeout = \
              GREATEST(@@SESSION.net_write_timeout, {DUMP_NET_WRITE_TIMEOUT_SECS})"
         ),
-        warn_on_error: true,
+        rejection_warning: Some(
+            "the source can still abort the shared binlog connection when one dataset's apply loop stalls, delaying changes for every changes-mode dataset on it. Grant the replication user permission to set session variables, or raise the source's net_write_timeout. See: https://spiceai.org/docs/components/data-connectors/mysql",
+        ),
     });
     statements
 }
@@ -151,14 +154,19 @@ pub(super) async fn open_binlog_stream(
 ) -> std::result::Result<BinlogStream, mysql_async::Error> {
     let mut conn = Conn::new(params.opts.clone()).await?;
 
-    for PreDumpStatement { sql, warn_on_error } in
-        pre_dump_session_statements(params.checkpoint_interval)
+    for PreDumpStatement {
+        sql,
+        rejection_warning,
+    } in pre_dump_session_statements(params.checkpoint_interval)
     {
         if let Err(e) = mysql_async::prelude::Queryable::query_drop(&mut conn, sql.as_str()).await {
-            if warn_on_error {
-                tracing::warn!(dataset = %dataset_name, statement = %sql, error = %e, "Failed to configure the MySQL binlog dump session: the source can still abort the shared binlog connection when one dataset's apply loop stalls, delaying changes for every changes-mode dataset on this connection. Grant the replication user permission to set session variables, or raise the source's net_write_timeout. See: https://spiceai.org/docs/components/data-connectors/mysql");
-            } else {
-                tracing::debug!(dataset = %dataset_name, statement = %sql, error = %e, "failed to set a binlog dump session variable");
+            match rejection_warning {
+                Some(consequence) => {
+                    tracing::warn!(dataset = %dataset_name, statement = %sql, error = %e, "Failed to configure the MySQL binlog dump session for dataset {dataset_name}: {consequence}");
+                }
+                None => {
+                    tracing::debug!(dataset = %dataset_name, statement = %sql, error = %e, "failed to set a binlog dump session variable");
+                }
             }
         }
     }
@@ -1024,6 +1032,17 @@ mod tests {
             .map(|statement| statement.sql.as_str())
     }
 
+    /// The warning the statement setting `variable` carries, if it carries one.
+    fn statement_rejection_warning(
+        statements: &[PreDumpStatement],
+        variable: &str,
+    ) -> Option<&'static str> {
+        statements
+            .iter()
+            .find(|statement| statement.sql.contains(variable))
+            .and_then(|statement| statement.rejection_warning)
+    }
+
     #[test]
     fn the_dump_session_raises_net_write_timeout() {
         // Regression test for #12527: without this the source aborts the shared
@@ -1079,12 +1098,18 @@ mod tests {
         let statements = pre_dump_session_statements(Duration::from_secs(10));
         for statement in &statements {
             assert_eq!(
-                statement.warn_on_error,
+                statement.rejection_warning.is_some(),
                 statement.sql.contains("net_write_timeout"),
                 "unexpected error visibility for {}",
                 statement.sql
             );
         }
+        let warning = statement_rejection_warning(&statements, "net_write_timeout")
+            .expect("a rejected net_write_timeout must say what it costs");
+        assert!(
+            warning.contains("https://spiceai.org/docs/"),
+            "the warning must point at the fix: {warning}"
+        );
     }
 
     #[test]

--- a/crates/data_components/src/mysql_replication/binlog.rs
+++ b/crates/data_components/src/mysql_replication/binlog.rs
@@ -65,6 +65,83 @@ use crate::cdc::{ChangeEnvelope, StreamError, build_heartbeat_envelope};
 /// that (fake rotates and heartbeats report 0) are not resumable.
 pub(super) const MIN_VALID_EVENT_POS: u64 = 4;
 
+/// Floor, in seconds, for how long the source will hold unread dump data before
+/// aborting the connection. Applied to the dump session because the server
+/// default is 60s.
+///
+/// The dump is one-way once started, so the server never waits for us to say
+/// anything — `net_write_timeout` fires purely on data we have not read. Every
+/// `refresh_mode: changes` dataset on a connection shares one dump, and the
+/// pump must-delivers each envelope into a bounded per-dataset channel, so a
+/// single dataset whose apply loop stalls (an in-memory-tier spill, for
+/// instance) stops the socket being drained for all of them. At the default the
+/// source then aborts the dump and every member resumes from its last acked
+/// position while already far behind, which deepens lag and invites the next
+/// abort.
+///
+/// 180s clears the worst apply cycle observed on CH-benCHmark SF1000 (~100s)
+/// with ~1.8x margin. This is empirical headroom, not a bound: the apply tail
+/// is not provably bounded (`cdc_max_coalesced_envelopes`/`_bytes` bound the
+/// burst, not how long a spill takes), so a genuinely wedged apply still
+/// reaches the timeout — it stays visible as the member send stall warning and
+/// its `replication_member_send_stalled_seconds_total` counter.
+///
+/// A floor rather than an assignment: an operator who already raised
+/// `net_write_timeout` past this — the manual workaround for exactly this
+/// symptom — must not have it lowered by connecting a newer runtime, so the
+/// statement takes the greater of their value and this one.
+const DUMP_NET_WRITE_TIMEOUT_SECS: u32 = 180;
+
+/// One statement issued on the dump connection before `COM_BINLOG_DUMP`.
+struct PreDumpStatement {
+    sql: String,
+    /// Whether a rejection deserves a user-visible warning. The heartbeat
+    /// spellings are deliberately tried in pairs and one of them is unknown on
+    /// any given server version, so those stay at debug.
+    warn_on_error: bool,
+}
+
+/// The session setup a dump connection needs, in the order it is issued.
+///
+/// Split out from [`open_binlog_stream`] so the statements — in particular
+/// which of them address a *user* variable versus a *system* one — are
+/// assertable without a `MySQL` server.
+fn pre_dump_session_statements(checkpoint_interval: Duration) -> Vec<PreDumpStatement> {
+    // Ask the source to send heartbeat events while idle so the stream can
+    // detect dead connections and advance its checkpoint. Half the
+    // checkpoint interval (min 500ms) keeps idle persists within ~1.5×
+    // the interval. The session variable is in nanoseconds; MySQL 8.4
+    // renamed the replica-facing vocabulary, so set both spellings (unknown
+    // user variables are inert).
+    let heartbeat_nanos = (checkpoint_interval / 2)
+        .max(Duration::from_millis(500))
+        .as_nanos()
+        .min(u128::from(u64::MAX));
+    // Two separate statements: if a server rejects one spelling, the other
+    // must still take effect (a combined statement fails atomically).
+    let mut statements: Vec<PreDumpStatement> =
+        ["master_heartbeat_period", "source_heartbeat_period"]
+            .into_iter()
+            .map(|var| PreDumpStatement {
+                sql: format!("SET @{var} = {heartbeat_nanos}"),
+                warn_on_error: false,
+            })
+            .collect();
+    // `net_write_timeout` is a system variable, so it needs the `SESSION`
+    // form — the `SET @net_write_timeout` spelling the heartbeats use would
+    // define an unrelated user variable and leave the server default in place.
+    // `GREATEST` against the inherited value keeps this a floor in one
+    // statement, with no round-trip to read the current setting first.
+    statements.push(PreDumpStatement {
+        sql: format!(
+            "SET SESSION net_write_timeout = \
+             GREATEST(@@SESSION.net_write_timeout, {DUMP_NET_WRITE_TIMEOUT_SECS})"
+        ),
+        warn_on_error: true,
+    });
+    statements
+}
+
 pub(super) async fn open_binlog_stream(
     params: &ReplicationParams,
     resume: &BinlogPosition,
@@ -74,26 +151,15 @@ pub(super) async fn open_binlog_stream(
 ) -> std::result::Result<BinlogStream, mysql_async::Error> {
     let mut conn = Conn::new(params.opts.clone()).await?;
 
-    // Ask the source to send heartbeat events while idle so the stream can
-    // detect dead connections and advance its checkpoint. Half the
-    // checkpoint interval (min 500ms) keeps idle persists within ~1.5×
-    // the interval. The session variable is in nanoseconds; MySQL 8.4
-    // renamed the replica-facing vocabulary, so set both spellings (unknown
-    // user variables are inert).
-    let heartbeat_nanos = (params.checkpoint_interval / 2)
-        .max(Duration::from_millis(500))
-        .as_nanos()
-        .min(u128::from(u64::MAX));
-    // Two separate statements: if a server rejects one spelling, the other
-    // must still take effect (a combined statement fails atomically).
-    for var in ["master_heartbeat_period", "source_heartbeat_period"] {
-        if let Err(e) = mysql_async::prelude::Queryable::query_drop(
-            &mut conn,
-            format!("SET @{var} = {heartbeat_nanos}"),
-        )
-        .await
-        {
-            tracing::debug!(dataset = %dataset_name, error = %e, "failed to set @{var}");
+    for PreDumpStatement { sql, warn_on_error } in
+        pre_dump_session_statements(params.checkpoint_interval)
+    {
+        if let Err(e) = mysql_async::prelude::Queryable::query_drop(&mut conn, sql.as_str()).await {
+            if warn_on_error {
+                tracing::warn!(dataset = %dataset_name, statement = %sql, error = %e, "Failed to configure the MySQL binlog dump session: one dataset's slow apply loop can now abort the shared binlog connection, delaying changes for every changes-mode dataset on this connection. Grant the replication user permission to set session variables, or raise the source's net_write_timeout. See: https://spiceai.org/docs/components/data-connectors/mysql");
+            } else {
+                tracing::debug!(dataset = %dataset_name, statement = %sql, error = %e, "failed to set a binlog dump session variable");
+            }
         }
     }
 
@@ -943,6 +1009,108 @@ mod tests {
 
     use super::*;
     use crate::mysql_replication::setup::SourceColumn;
+
+    /// `MySQL`'s documented default for `net_write_timeout`, which is what aborts
+    /// a dump whose socket the pump stopped draining (#12527).
+    const SERVER_DEFAULT_NET_WRITE_TIMEOUT_SECS: u32 = 60;
+
+    fn statement_setting<'a>(
+        statements: &'a [PreDumpStatement],
+        variable: &str,
+    ) -> Option<&'a str> {
+        statements
+            .iter()
+            .find(|statement| statement.sql.contains(variable))
+            .map(|statement| statement.sql.as_str())
+    }
+
+    #[test]
+    fn the_dump_session_raises_net_write_timeout() {
+        // Regression test for #12527: without this the source aborts the shared
+        // dump 60s into one dataset's slow apply cycle, and every
+        // `refresh_mode: changes` dataset on the connection re-streams from its
+        // acked position while already behind.
+        let statements = pre_dump_session_statements(Duration::from_secs(10));
+        let sql = statement_setting(&statements, "net_write_timeout")
+            .expect("the dump session must raise net_write_timeout");
+        assert_eq!(
+            sql,
+            format!(
+                "SET SESSION net_write_timeout = \
+                 GREATEST(@@SESSION.net_write_timeout, {DUMP_NET_WRITE_TIMEOUT_SECS})"
+            ),
+            "net_write_timeout is a SYSTEM variable: the `SET @net_write_timeout` spelling the \
+             heartbeats use would define an unrelated user variable and silently leave the \
+             server default in place"
+        );
+        assert!(
+            !sql.contains("SET @net_write_timeout"),
+            "a user-variable spelling is inert for a system variable: {sql}"
+        );
+        const {
+            assert!(
+                DUMP_NET_WRITE_TIMEOUT_SECS > SERVER_DEFAULT_NET_WRITE_TIMEOUT_SECS,
+                "raising the timeout to at most the server default would change nothing"
+            );
+        }
+    }
+
+    #[test]
+    fn the_dump_session_never_lowers_an_operators_higher_net_write_timeout() {
+        // Raising `net_write_timeout` on the source is the manual workaround for
+        // this symptom, so an operator who has already done it must not have it
+        // lowered by connecting a runtime carrying this fix. `GREATEST` against
+        // the session's inherited value makes the statement a floor; a bare
+        // assignment would clamp their setting down to ours.
+        let statements = pre_dump_session_statements(Duration::from_secs(10));
+        let sql = statement_setting(&statements, "net_write_timeout")
+            .expect("the dump session must raise net_write_timeout");
+        assert!(
+            sql.contains("GREATEST(@@SESSION.net_write_timeout,"),
+            "the statement must take the greater of the inherited value and ours: {sql}"
+        );
+    }
+
+    #[test]
+    fn a_rejected_net_write_timeout_is_worth_a_warning() {
+        // The heartbeat spellings are tried in pairs and one is always unknown,
+        // so those must stay quiet; a rejected net_write_timeout leaves the
+        // reconnect cliff in place and is the one the user can act on.
+        let statements = pre_dump_session_statements(Duration::from_secs(10));
+        for statement in &statements {
+            assert_eq!(
+                statement.warn_on_error,
+                statement.sql.contains("net_write_timeout"),
+                "unexpected error visibility for {}",
+                statement.sql
+            );
+        }
+    }
+
+    #[test]
+    fn both_heartbeat_spellings_are_set_as_user_variables_in_nanoseconds() {
+        // Half the checkpoint interval, in nanoseconds, on both the pre-8.4 and
+        // 8.4 spellings — unchanged by the net_write_timeout addition.
+        let statements = pre_dump_session_statements(Duration::from_secs(10));
+        for var in ["master_heartbeat_period", "source_heartbeat_period"] {
+            assert_eq!(
+                statement_setting(&statements, var),
+                Some(format!("SET @{var} = 5000000000").as_str()),
+                "{var} must stay a user variable, in nanoseconds"
+            );
+        }
+    }
+
+    #[test]
+    fn a_tiny_checkpoint_interval_floors_the_heartbeat_at_500ms() {
+        // A sub-second interval would otherwise ask the source to heartbeat
+        // continuously.
+        let statements = pre_dump_session_statements(Duration::from_millis(100));
+        assert_eq!(
+            statement_setting(&statements, "master_heartbeat_period"),
+            Some("SET @master_heartbeat_period = 500000000")
+        );
+    }
 
     /// A layout of `(name, COLUMN_TYPE)` columns in ordinal order.
     fn layout_of(columns: &[(&str, &str)]) -> TableLayout {

--- a/crates/data_components/src/mysql_replication/binlog.rs
+++ b/crates/data_components/src/mysql_replication/binlog.rs
@@ -156,7 +156,7 @@ pub(super) async fn open_binlog_stream(
     {
         if let Err(e) = mysql_async::prelude::Queryable::query_drop(&mut conn, sql.as_str()).await {
             if warn_on_error {
-                tracing::warn!(dataset = %dataset_name, statement = %sql, error = %e, "Failed to configure the MySQL binlog dump session: one dataset's slow apply loop can now abort the shared binlog connection, delaying changes for every changes-mode dataset on this connection. Grant the replication user permission to set session variables, or raise the source's net_write_timeout. See: https://spiceai.org/docs/components/data-connectors/mysql");
+                tracing::warn!(dataset = %dataset_name, statement = %sql, error = %e, "Failed to configure the MySQL binlog dump session: the source can still abort the shared binlog connection when one dataset's apply loop stalls, delaying changes for every changes-mode dataset on this connection. Grant the replication user permission to set session variables, or raise the source's net_write_timeout. See: https://spiceai.org/docs/components/data-connectors/mysql");
             } else {
                 tracing::debug!(dataset = %dataset_name, statement = %sql, error = %e, "failed to set a binlog dump session variable");
             }

--- a/crates/data_components/src/mysql_replication/metrics.rs
+++ b/crates/data_components/src/mysql_replication/metrics.rs
@@ -68,6 +68,12 @@ pub struct MetricsCollector {
     /// member holds the shared resume position back, so this is the
     /// unambiguous signal for *which* dataset stalled the group.
     member_attached: AtomicU64,
+    /// Cumulative seconds the shared dump's pump spent blocked delivering
+    /// committed changes into this dataset's channel because its sink was not
+    /// draining. The pump reads the dump socket for the whole group, so this is
+    /// also the time the socket went undrained — the source aborts the dump once
+    /// that passes its `net_write_timeout`.
+    member_send_stalled_seconds: AtomicU64,
 }
 
 impl MetricsCollector {
@@ -168,6 +174,12 @@ impl MetricsCollector {
     /// pinning the shared resume position).
     pub fn mark_member_detached(&self) {
         self.member_attached.store(0, Ordering::Relaxed);
+    }
+
+    /// Accrue another stall interval spent waiting on this dataset's channel.
+    pub fn add_send_stalled(&self, secs: u64) {
+        self.member_send_stalled_seconds
+            .fetch_add(secs, Ordering::Relaxed);
     }
 }
 
@@ -307,6 +319,14 @@ impl Metrics {
     #[must_use]
     pub fn member_attached(&self) -> u64 {
         self.collector.member_attached.load(Ordering::Relaxed)
+    }
+    /// Cumulative seconds the shared dump's pump waited on this dataset's
+    /// channel, i.e. seconds the dump socket went undrained on its behalf.
+    #[must_use]
+    pub fn member_send_stalled_seconds_total(&self) -> u64 {
+        self.collector
+            .member_send_stalled_seconds
+            .load(Ordering::Relaxed)
     }
 }
 

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -1861,6 +1861,7 @@ async fn deliver_commit(
         );
         slot.deliver(commit_pos);
         match deliver_to_member(
+            &member.metrics,
             &member.sender,
             Ok(envelope),
             shutdown_epoch,
@@ -1952,6 +1953,7 @@ async fn handle_statement(
                 );
                 slot.deliver(&commit_pos);
                 match deliver_to_member(
+                    &member.metrics,
                     &member.sender,
                     Ok(envelope),
                     shutdown_epoch,
@@ -2031,6 +2033,7 @@ enum DeliverOutcome {
 /// prolonged stall and abandoning on shutdown. One slow member must not wedge
 /// the pump (and thus the group) or block shutdown indefinitely.
 async fn deliver_to_member(
+    metrics: &MetricsCollector,
     sender: &mpsc::Sender<std::result::Result<ChangeEnvelope, StreamError>>,
     envelope: std::result::Result<ChangeEnvelope, StreamError>,
     shutdown_epoch: u64,
@@ -2047,7 +2050,14 @@ async fn deliver_to_member(
                     return DeliverOutcome::ShutdownAbandon;
                 }
                 stalled_for += MEMBER_SEND_STALL_WARN;
-                tracing::warn!(dataset = %dataset, stalled_for = ?stalled_for, "shared mysql binlog member sink is not draining; the pump is waiting to deliver committed changes");
+                // The pump reads the dump socket for the whole group, so this
+                // wait is also time the socket goes undrained: past the
+                // session's `net_write_timeout` the source aborts the dump and
+                // every member on it resumes from its acked position. Counted,
+                // not only logged, so a wedged apply stays visible after the
+                // warning scrolls away.
+                metrics.add_send_stalled(MEMBER_SEND_STALL_WARN.as_secs());
+                tracing::warn!(dataset = %dataset, stalled_for = ?stalled_for, "shared mysql binlog member sink is not draining; the pump is waiting to deliver committed changes (watch dataset_mysql_replication_member_send_stalled_seconds_total)");
                 pending = returned;
             }
         }
@@ -2352,6 +2362,8 @@ async fn poll_head_and_heartbeat(
 
 #[cfg(test)]
 mod tests {
+    use crate::mysql_replication::metrics::Metrics;
+
     use super::*;
 
     fn key(db: &str, t: &str) -> MemberKey {
@@ -2708,6 +2720,64 @@ mod tests {
         );
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn a_member_stall_accrues_the_send_stalled_counter() {
+        // The pump reads the dump socket for the whole group, so time spent
+        // waiting on one member's full channel is time the socket goes
+        // undrained — the thing that ends in an aborted dump (#12527). The
+        // warning scrolls away; the counter is what names the dataset that will
+        // trigger the next reconnect.
+        //
+        // The stall interval is a constant, so the virtual clock converts
+        // cleanly: no production path here derives a sleep from a real-clock
+        // read.
+        let metrics = MetricsCollector::new();
+        let (sender, mut receiver) = mpsc::channel(1);
+        sender
+            .send(Err(StreamError::External(
+                "occupies the channel".to_string(),
+            )))
+            .await
+            .expect("the channel starts empty");
+
+        let deliver = {
+            let metrics = Arc::clone(&metrics);
+            let epoch = crate::cdc::shutdown_epoch();
+            tokio::spawn(async move {
+                deliver_to_member(
+                    &metrics,
+                    &sender,
+                    Err(StreamError::External("must be delivered".to_string())),
+                    epoch,
+                    "test_dataset",
+                )
+                .await
+            })
+        };
+
+        // Two stall intervals with the channel still full, then drain it so the
+        // must-deliver completes rather than looping forever.
+        tokio::time::sleep(MEMBER_SEND_STALL_WARN * 2 + Duration::from_millis(1)).await;
+        let stalled = Metrics::new(Arc::clone(&metrics)).member_send_stalled_seconds_total();
+        assert_eq!(
+            stalled,
+            MEMBER_SEND_STALL_WARN.as_secs() * 2,
+            "each stall interval must accrue, so one long stall is distinguishable from none"
+        );
+
+        let _queued = receiver.recv().await.expect("the queued envelope");
+        let outcome = deliver.await.expect("the delivery task");
+        assert!(
+            matches!(outcome, DeliverOutcome::Sent),
+            "a stalled delivery must still be delivered once the sink drains"
+        );
+        assert_eq!(
+            Metrics::new(metrics).member_send_stalled_seconds_total(),
+            stalled,
+            "a successful send must not accrue stall time"
+        );
+    }
+
     #[tokio::test]
     async fn deliver_to_member_reports_receiver_gone() {
         // A dropped receiver (dataset stream torn down) must surface as
@@ -2716,6 +2786,7 @@ mod tests {
         let (sender, receiver) = mpsc::channel(1);
         drop(receiver);
         let outcome = deliver_to_member(
+            &MetricsCollector::new(),
             &sender,
             Err(StreamError::External("x".to_string())),
             crate::cdc::shutdown_epoch(),


### PR DESCRIPTION
## Summary

Every `refresh_mode: changes` dataset on a MySQL connection shares one `COM_BINLOG_DUMP` stream, and the pump must-delivers each envelope into a bounded per-dataset channel with unbounded retry. So when one dataset's apply loop stalls — an in-memory-tier spill, for instance — the pump stops reading the dump socket for **every** dataset on that connection.

`COM_BINLOG_DUMP` is one-way once started: the server is not waiting for us to say anything, so `net_write_timeout` fires purely on data we have not read. At the server default of 60s a single stalled apply cycle is enough for the source to abort the dump:

```
WARN mysql_replication::binlog: binlog connection lost; reconnecting attempt=1
  error=Input/output error: bytes remaining on stream
```

Every member then resumes from its last acked position while the pipeline is already several hundred seconds behind, which deepens lag, lengthens the next stall, and invites the next abort. Measured on CH-benCHmark SF1000 adaptive, that makes the whole config bimodal: the one reconnect-free run of six was ~2x faster (109k rows/s, 253s worst P99 freshness) than every run that took a reconnect (54–77k rows/s, 448–633s).

Postgres does not have this because a separate keepalive task acks independently of apply progress and the server retains WAL in the slot. MySQL cannot copy that — the dump is one-way — but it does not need to: binlog files plus a client-owned position make any position within retention re-openable, which is already the recovery path. The connection abort just gets there involuntarily, for every dataset at once.

This raises `net_write_timeout` on the dump session (option 1 in #12527), which is the change that removes the cliff without altering the topology.

## Changes

- **`SET SESSION net_write_timeout = GREATEST(@@net_write_timeout, 180)`** on the dump connection, in the pre-dump window that already sets the heartbeat variables. 180s clears the worst apply cycle observed at SF1000 (~100s) with ~1.8x margin. Two details the statement depends on:
  - It is a **floor**, not an assignment. Raising `net_write_timeout` on the source is the existing manual workaround for this exact symptom, so an operator who has already set it to, say, 600 must not have it clamped back down to 180 by connecting a newer runtime. `GREATEST` against the inherited session value gets that in one statement with no round-trip.
  - `net_write_timeout` is a **system** variable, so it needs the `SESSION` form. The heartbeat period next to it is a **user** variable (`SET @master_heartbeat_period`), and the `@var` spelling applied to a system variable would define an unrelated user variable and silently leave the server default in place. A unit test pins that distinction, because nothing at runtime would report it.
- The pre-dump statements moved into `pre_dump_session_statements`, a pure function returning the statements in issue order, so which variable form each one uses is assertable without a MySQL server. A rejected `net_write_timeout` now warns (with the consequence and the remedy) where the heartbeat spellings stay at debug — those are deliberately tried in pairs and one is always unknown on a given server version.
- **`replication_member_send_stalled_seconds_total`**, exported per dataset, accruing the time the pump spent blocked on that dataset's channel. This is the sibling of the metric the Postgres shared-slot path already exports under the same name, and it is the reason 180s is safe to ship as empirical headroom rather than a proof: the apply tail is not provably bounded (`cdc_max_coalesced_envelopes`/`_bytes` bound the burst, not how long a spill takes), so a genuinely wedged apply still reaches the timeout — and now stays visible as a counter after the warning scrolls away. The existing stall warning points at the metric by name.

Deliberately not in scope: the dataset-to-dump grouping (option 2) is spicepod-only and orthogonal, and the non-blocking router (option 3) is a redesign that needs a binlog-retention-headroom metric first. The contributing spill defect — the adaptive tuner reading cgroup `memory.current` including reclaimable page cache — affects Postgres too and is tracked separately.

## Test plan

- `make lint`
- `make nextest`
- New unit tests, all in the crates the change touches:
  - the dump session raises `net_write_timeout`, in the system-variable form, above the server default
  - the statement never lowers an operator's already-higher `net_write_timeout`
  - a rejected `net_write_timeout` is the one pre-dump statement worth warning about
  - both heartbeat spellings survive the refactor, as user variables in nanoseconds
  - a sub-second checkpoint interval still floors the heartbeat at 500ms
  - a stalled delivery accrues the stall counter per interval, and a successful send accrues nothing
- Seven deterministic neuters, each caught by a distinct assertion: dropping the statement; the `SET @net_write_timeout` user-variable spelling; a bare assignment instead of `GREATEST`; a timeout equal to the server default; silencing the rejection warning; dropping the metric accrual; accruing on the success path.
- The behaviour this fixes is a source-side timeout under sustained load, so the acceptance criteria in #12527 (in-load reconnects = 0 across 3 CH-benCHmark SF1000 adaptive runs, freshness and rows/s within 20% of the reconnect-free reference) need a benchmark run to confirm and are not covered by unit tests.

## Checklist

- [x] Root cause identified and stated
- [x] Regression tests that fail without the fix
- [x] No new blocking calls in async paths
- [x] Metric mirrors the existing Postgres sibling's name and semantics
- [ ] Benchmark acceptance criteria from #12527 confirmed on a CH-benCHmark SF1000 adaptive run

Fixes #12527
