### PR TITLE
fix(ci): use spiceio and sccache for E2E macOS aarch64 builds

### DIFF
--- a/.github/actions/build-spiced/action.yml
+++ b/.github/actions/build-spiced/action.yml
@@ -45,13 +45,16 @@ inputs:
     required: false
     default: '../../target'
   minio_endpoint:
-    description: 'MinIO endpoint for sccache'
+    description: 'MinIO endpoint for sccache (Linux/Windows)'
     required: false
   minio_access_key:
     description: 'MinIO access key for sccache'
     required: false
   minio_secret_key:
     description: 'MinIO secret key for sccache'
+    required: false
+  spiceio_endpoint:
+    description: 'Spiceio S3-compatible endpoint for sccache (macOS)'
     required: false
 
 outputs:
@@ -114,7 +117,7 @@ runs:
       id: check-sccache
       shell: bash
       run: |
-        if [ -z "${{ inputs.minio_endpoint }}" ]; then
+        if [ -z "${{ inputs.minio_endpoint }}" ] && [ -z "${{ inputs.spiceio_endpoint }}" ]; then
           echo "SCCACHE_SETUP=false" >> $GITHUB_OUTPUT
           echo "RUSTC_WRAPPER=" >> $GITHUB_OUTPUT
         else
@@ -127,6 +130,7 @@ runs:
       uses: ./.github/actions/setup-sccache
       with:
         minio_endpoint: ${{ inputs.minio_endpoint }}
+        spiceio_endpoint: ${{ inputs.spiceio_endpoint }}
 
     - name: Resolve build paths
       id: resolve-build-paths

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Set up spiceio
         if: matrix.target.builder == 'spiceai-macos' && env.HAS_SPICEIO_SECRET == 'true'
         id: setup-spiceio
-        uses: spiceai/spiceio/.github/actions/setup@0870da59576dda1aef80e99c067c3bf14da7307b # v0.6.0
+        uses: spiceai/spiceio/.github/actions/setup@97c3578dcf337786923da33cecd350e7335386b6 # v0.7.0
         with:
           smb-url: smb://runner@192.168.3.148/ai_platform_dev
           smb-pass: ${{ secrets.UNAS_SMB_PASS }}

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -109,6 +109,8 @@ jobs:
     runs-on: ${{ matrix.target.builder }}
     needs: [setup-matrix, check_changes]
     if: ${{ needs.check_changes.outputs.relevant_changes == 'true' }}
+    env:
+      HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
 
     strategy:
       matrix:
@@ -149,6 +151,18 @@ jobs:
       - name: Install Protoc
         uses: ./.github/actions/install-protoc
 
+      - name: Set up spiceio
+        if: matrix.target.builder == 'spiceai-macos' && env.HAS_SPICEIO_SECRET == 'true'
+        id: setup-spiceio
+        uses: spiceai/spiceio/.github/actions/setup@0870da59576dda1aef80e99c067c3bf14da7307b # v0.6.0
+        with:
+          smb-url: smb://runner@192.168.3.148/ai_platform_dev
+          smb-pass: ${{ secrets.UNAS_SMB_PASS }}
+          token: ${{ github.token }}
+          bucket: sccache
+          region: us-west-1
+          immutable-objects: "true"
+
       - name: Build spiced and spice CLI
         if: matrix.target.target_os != 'darwin'
         uses: ./.github/actions/build-spiced
@@ -166,6 +180,28 @@ jobs:
           build_cli: 'true'
           upload_artifact: 'true'
           artifact_name: build_${{ matrix.target.target_os }}_${{ matrix.target.target_arch }}
+          spiceio_endpoint: ${{ steps.setup-spiceio.outputs.endpoint }}
+
+      - name: Show sccache stats
+        if: always() && matrix.target.builder == 'spiceai-macos' && env.SCCACHE_SETUP == 'true'
+        # `always()`: this is the one step that reports cache health, and without it
+        # it is skipped on exactly the failures it would explain (#12420). The `||`
+        # keeps a diagnostic from ever deciding a verdict — when the cache backend is
+        # gone `--show-stats` cannot answer either, and that is itself the finding.
+        run: |
+          sccache --show-stats || echo "::warning::sccache --show-stats failed, so the cache server is not answering either. Read a build failure in this job as a possible cache-backend outage rather than a code failure."
+
+      - name: Kill spiceio
+        if: always() && matrix.target.builder == 'spiceai-macos' && steps.setup-spiceio.outputs.pid != ''
+        run: kill ${{ steps.setup-spiceio.outputs.pid }} || true
+
+      - name: Upload spiceio logs
+        if: always() && matrix.target.builder == 'spiceai-macos'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: spiceio-e2e-build-logs
+          path: ${{ runner.temp }}/spiceio.log
+          if-no-files-found: ignore
 
   setup-model-matrix:
     name: Setup model strategy matrix


### PR DESCRIPTION
## Summary

- Wire spiceio + sccache into the E2E CI **Build macOS aarch64 (Apple Silicon) binaries** job on `spiceai-macos`, matching the pattern already used in `pr.yml` and `integration_models.yml`.
- Extend `build-spiced` with an optional `spiceio_endpoint` input so sccache can target the spiceio S3-compatible backend on macOS (not only MinIO on Linux/Windows).
- After the macOS build: show sccache stats, tear down spiceio, and upload spiceio logs for diagnosis.

Previously this job relied only on `Swatinem/rust-cache` and never set `RUSTC_WRAPPER=sccache`, so macOS E2E binary builds paid full compile cost every run.

## Test plan

- [ ] Confirm the E2E CI `build` matrix leg **Build macOS aarch64 (Apple Silicon) binaries** runs on `spiceai-macos`
- [ ] Confirm the **Set up spiceio** step runs when `UNAS_SMB_PASS` is available
- [ ] Confirm **Build spiced and spice CLI (macOS)** receives a non-empty `spiceio_endpoint` and enables sccache (`RUSTC_WRAPPER=sccache`)
- [ ] Confirm **Show sccache stats** reports cache hits/misses after the build
- [ ] Confirm spiceio is killed and `spiceio-e2e-build-logs` artifact is uploaded
- [ ] Confirm Linux E2E build leg is unchanged (no spiceio / no new sccache wiring)