### PR TITLE
fix(cli): read a streamed answer as events, and a failed body read as a failure (fixes #12588)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19175,6 +19175,7 @@ dependencies = [
  "flate2",
  "fundu",
  "futures",
+ "http 1.4.1",
  "humantime",
  "insta",
  "keyring",

--- a/bin/spice/Cargo.toml
+++ b/bin/spice/Cargo.toml
@@ -118,6 +118,7 @@ release = []
 
 [dev-dependencies]
 assert_cmd = "2"
+http.workspace = true
 insta = { workspace = true, features = ["filters", "json"] }
 predicates = "3"
 rstest = "0.26.1"

--- a/bin/spice/src/commands/chat.rs
+++ b/bin/spice/src/commands/chat.rs
@@ -160,7 +160,12 @@ impl StreamErrorPayload {
 /// A choice in a chat chunk.
 #[derive(Deserialize)]
 struct ChunkChoice {
-    delta: Delta,
+    /// Absent on a choice that carries no content. Azure `OpenAI`'s asynchronous content
+    /// filtering emits annotation choices holding only `content_filter_results`, and those
+    /// arrive on a passing stream too -- so a choice without a delta is an ordinary event
+    /// with nothing to print, not an unreadable one.
+    #[serde(default)]
+    delta: Option<Delta>,
 }
 
 /// Delta content in a streaming response.
@@ -619,8 +624,13 @@ async fn send_chat_streaming(
             // The stream ended. A server that closed without its final blank line still has
             // one event's worth of bytes buffered here, and dropping it would lose the tail
             // of the answer.
-            if let Some(event) = decoder.finish() {
-                apply_event(&event, &url, emit_tokens, start_time, &mut state).await?;
+            decoder.close();
+            while let Some(event) = decoder.next_event() {
+                if apply_event(&event, &url, emit_tokens, start_time, &mut state).await?
+                    == EventOutcome::Stop
+                {
+                    break;
+                }
             }
             break 'stream;
         };
@@ -632,25 +642,35 @@ async fn send_chat_streaming(
             .build()
         })?;
 
-        decoder.push(&chunk).map_err(|oversized| {
-            InvalidResponseSnafu {
-                message: format!(
-                    "The model at {url} sent {} bytes of a single response event without ending it. Check the runtime's logs for the model, then retry. See: https://spiceai.org/docs/components/models",
-                    oversized.bytes
-                ),
-            }
-            .build()
-        })?;
+        let data_before = decoder.data_fields_seen();
+        decoder.push(&chunk);
 
         while let Some(event) = decoder.next_event() {
-            // An event, rather than the keep-alive comment that carries no news.
-            last_event = Instant::now();
-
             if apply_event(&event, &url, emit_tokens, start_time, &mut state).await?
                 == EventOutcome::Stop
             {
                 break 'stream;
             }
+        }
+
+        // Progress is a `data` line arriving, not an event completing: a large event spread
+        // over several reads is the model producing, even before its terminator lands. A
+        // keep-alive comment carries no data field, so it still cannot hold the stream open.
+        if decoder.data_fields_seen() != data_before {
+            last_event = Instant::now();
+        }
+
+        // Asked after draining, so the cap bounds one event the stream never ends rather
+        // than however many whole events happened to arrive in a single read.
+        if let Some(oversized) = decoder.oversized() {
+            state.stop_spinner().await;
+            return Err(InvalidResponseSnafu {
+                message: format!(
+                    "The model at {url} sent {} bytes of a single response event without ending it. Check the runtime's logs for the model, then retry. See: https://spiceai.org/docs/components/models",
+                    oversized.bytes
+                ),
+            }
+            .build());
         }
     }
 
@@ -758,7 +778,11 @@ async fn apply_event(
     }
 
     for choice in &chunk.choices {
-        if let Some(content) = &choice.delta.content {
+        if let Some(content) = choice
+            .delta
+            .as_ref()
+            .and_then(|delta| delta.content.as_ref())
+        {
             // Record first token time and stop spinner
             if state.first_token.is_none() {
                 state.first_token = Some(start_time.elapsed());
@@ -1142,6 +1166,67 @@ data: {"type":"error","message":"the model ran out of context"}"#
             .expect("an empty event is not a failure");
 
         assert_eq!(response.content, "answer");
+    }
+
+    /// Azure `OpenAI`'s asynchronous content filtering emits annotation choices carrying only
+    /// `content_filter_results` and no `delta`, on passing streams as well as filtered ones.
+    /// Treating every payload that is not a plain content chunk as unreadable would stop the
+    /// stream on a valid event and lose every token after it.
+    #[tokio::test]
+    async fn an_annotation_choice_without_a_delta_does_not_stop_the_stream() {
+        let server = SlowServer::dribbling(
+            vec![
+                format!(
+                    "{}\n\n",
+                    r#"data: {"choices":[{"delta":{"content":"before "}}]}"#
+                ),
+                format!(
+                    "{}\n\n",
+                    r#"data: {"choices":[{"index":0,"finish_reason":null,"content_filter_results":{},"content_filter_offsets":{"check_offset":44,"start_offset":44,"end_offset":198}}],"usage":null}"#
+                ),
+                format!(
+                    "{}\n\n",
+                    r#"data: {"choices":[{"delta":{"content":"after"}}]}"#
+                ),
+            ],
+            Duration::from_millis(5),
+        );
+
+        let response = stream_from(&server)
+            .await
+            .expect("an annotation choice is a valid event with nothing to print");
+
+        assert_eq!(response.content, "before after");
+    }
+
+    /// A single event spread over several reads is the model producing, even before its
+    /// terminator arrives. Recording progress only at dispatch times such a stream out.
+    #[tokio::test]
+    async fn a_data_line_keeps_the_stream_alive_before_its_event_ends() {
+        let progress_bound = Duration::from_millis(500);
+        // One multiline event, in three reads. Its data lands well inside the bound each
+        // time, but the terminator does not arrive until after the bound has elapsed.
+        let server = SlowServer::dribbling(
+            vec![
+                "data: {\"choices\":[{\"delta\":\n".to_string(),
+                "data:  {\"content\":\"slow\"}}]}\n".to_string(),
+                "\n".to_string(),
+            ],
+            Duration::from_millis(200),
+        );
+
+        let ctx = RuntimeContext::with_deadlines_for_test(
+            server.url(),
+            Deadline::Total(Duration::from_secs(30)),
+            Deadline::Silence(progress_bound),
+        );
+
+        let response =
+            send_chat_streaming(&ctx, &test_chat_config(), &one_shot_prompt(), false, false)
+                .await
+                .expect("an event still arriving is a stream that is producing");
+
+        assert_eq!(response.content, "slow");
     }
 
     /// A server that hangs up without the blank line terminating its last event still sent

--- a/bin/spice/src/commands/chat.rs
+++ b/bin/spice/src/commands/chat.rs
@@ -22,6 +22,7 @@ use crate::error::{
     NoModelsConfiguredSnafu, Result,
 };
 use crate::output::{OutputFormat, write_json};
+use crate::sse::{SseDecoder, SseEvent};
 use clap::Args;
 use futures::StreamExt;
 use repl::util::{Spinner, create_editor_with_history, save_history};
@@ -128,6 +129,34 @@ struct ChatChunk {
     usage: Option<Usage>,
 }
 
+/// The payload of an error the server reports mid-stream.
+///
+/// The runtime sends its own as an `error`-named event carrying `{"type":…,"message":…}`;
+/// an OpenAI-compatible server nests the same information under `error`. Either way the
+/// stream is over, and whatever has been printed is a partial answer rather than a whole one.
+#[derive(Deserialize)]
+struct StreamErrorPayload {
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    error: Option<NestedStreamError>,
+}
+
+#[derive(Deserialize)]
+struct NestedStreamError {
+    #[serde(default)]
+    message: Option<String>,
+}
+
+impl StreamErrorPayload {
+    /// The most specific message the payload carries.
+    fn message(&self) -> Option<&str> {
+        self.message
+            .as_deref()
+            .or_else(|| self.error.as_ref()?.message.as_deref())
+    }
+}
+
 /// A choice in a chat chunk.
 #[derive(Deserialize)]
 struct ChunkChoice {
@@ -142,7 +171,7 @@ struct Delta {
 }
 
 /// Token usage statistics.
-#[derive(Serialize, Deserialize, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
 #[serde(rename_all = "snake_case")]
 #[expect(clippy::struct_field_names)]
 struct Usage {
@@ -152,6 +181,7 @@ struct Usage {
 }
 
 /// Chat response with timing and usage statistics.
+#[derive(Debug)]
 struct ChatResponse {
     content: String,
     total_duration: std::time::Duration,
@@ -553,11 +583,18 @@ async fn send_chat_streaming(
     }
 
     // Stream the response
-    let mut full_response = String::new();
     let mut stream = response.bytes_stream();
-    let mut spinner = spinner;
-    let mut first_token_time: Option<std::time::Duration> = None;
-    let mut usage: Option<Usage> = None;
+    let mut state = StreamState {
+        response: String::new(),
+        usage: None,
+        first_token: None,
+        spinner,
+    };
+
+    // An event can straddle two reads, so the bytes are reassembled into events before
+    // anything is read out of them; a reader that took each read as whole lines would drop
+    // whichever events happened to be split, without saying so.
+    let mut decoder = SseDecoder::new();
 
     // The client's read deadline counts bytes, and the runtime keeps this stream alive with an
     // SSE comment every 30 seconds, so it can never fire here however long the model has been
@@ -569,9 +606,7 @@ async fn send_chat_streaming(
     'stream: loop {
         let remaining = progress_deadline.saturating_sub(last_event.elapsed());
         let Ok(next) = tokio::time::timeout(remaining, stream.next()).await else {
-            if let Some(s) = spinner {
-                s.stop().await;
-            }
+            state.stop_spinner().await;
             return Err(InvalidResponseSnafu {
                 message: format!(
                     "The model at {url} sent nothing for {}s. The connection is still open, so the request is being held rather than refused -- check the runtime's logs for the model, then retry. See: https://spiceai.org/docs/components/models",
@@ -581,6 +616,12 @@ async fn send_chat_streaming(
             .build());
         };
         let Some(chunk_result) = next else {
+            // The stream ended. A server that closed without its final blank line still has
+            // one event's worth of bytes buffered here, and dropping it would lose the tail
+            // of the answer.
+            if let Some(event) = decoder.finish() {
+                apply_event(&event, &url, emit_tokens, start_time, &mut state).await?;
+            }
             break 'stream;
         };
 
@@ -591,61 +632,147 @@ async fn send_chat_streaming(
             .build()
         })?;
 
-        let text = String::from_utf8_lossy(&chunk);
+        decoder.push(&chunk).map_err(|oversized| {
+            InvalidResponseSnafu {
+                message: format!(
+                    "The model at {url} sent {} bytes of a single response event without ending it. Check the runtime's logs for the model, then retry. See: https://spiceai.org/docs/components/models",
+                    oversized.bytes
+                ),
+            }
+            .build()
+        })?;
 
-        // Parse SSE events
-        for line in text.lines() {
-            if let Some(data) = line.strip_prefix("data: ") {
-                // An event, rather than the keep-alive comment that carries no news.
-                last_event = Instant::now();
+        while let Some(event) = decoder.next_event() {
+            // An event, rather than the keep-alive comment that carries no news.
+            last_event = Instant::now();
 
-                if data == "[DONE]" {
-                    // The protocol's terminator. Reading on would wait for an EOF the server
-                    // is under no obligation to send promptly.
-                    break 'stream;
-                }
-
-                // Parse the JSON chunk
-                if let Ok(chat_chunk) = serde_json::from_str::<ChatChunk>(data) {
-                    // Capture usage from the final chunk (if present)
-                    if chat_chunk.usage.is_some() {
-                        usage = chat_chunk.usage;
-                    }
-
-                    for choice in &chat_chunk.choices {
-                        if let Some(content) = &choice.delta.content {
-                            // Record first token time and stop spinner
-                            if first_token_time.is_none() {
-                                first_token_time = Some(start_time.elapsed());
-                                if let Some(s) = spinner.take() {
-                                    s.stop().await;
-                                }
-                            }
-                            if emit_tokens {
-                                print!("{content}");
-                                let _ = io::stdout().flush();
-                            }
-                            full_response.push_str(content);
-                        }
-                    }
-                }
+            if apply_event(&event, &url, emit_tokens, start_time, &mut state).await?
+                == EventOutcome::Stop
+            {
+                break 'stream;
             }
         }
     }
 
-    // Ensure spinner is stopped
-    if let Some(s) = spinner {
-        s.stop().await;
-    }
-
-    let total_duration = start_time.elapsed();
+    state.stop_spinner().await;
 
     Ok(ChatResponse {
-        content: full_response,
-        total_duration,
-        first_token_duration: first_token_time,
-        usage,
+        content: state.response,
+        total_duration: start_time.elapsed(),
+        first_token_duration: state.first_token,
+        usage: state.usage,
     })
+}
+
+/// What the stream should do once an event has been read.
+#[derive(Debug, PartialEq, Eq)]
+enum EventOutcome {
+    /// Keep reading.
+    Continue,
+    /// The stream is over: the server said so.
+    Stop,
+}
+
+/// The answer as it accumulates across the stream's events.
+struct StreamState {
+    response: String,
+    usage: Option<Usage>,
+    first_token: Option<std::time::Duration>,
+    spinner: Option<Spinner>,
+}
+
+impl StreamState {
+    async fn stop_spinner(&mut self) {
+        if let Some(spinner) = self.spinner.take() {
+            spinner.stop().await;
+        }
+    }
+}
+
+/// Read one SSE event into the answer.
+///
+/// Every event the server sends is either content, the protocol's terminator, or a report
+/// that the stream has failed. An event that is none of those cannot be read as content, and
+/// discarding it would leave the user a truncated answer presented as a whole one — so it is
+/// an error, not a skip.
+async fn apply_event(
+    event: &SseEvent,
+    url: &str,
+    emit_tokens: bool,
+    start_time: Instant,
+    state: &mut StreamState,
+) -> Result<EventOutcome> {
+    // The runtime reports a mid-stream failure as an `error` event. Read as content it
+    // parses as nothing, which is how it used to disappear.
+    if event.name.as_deref() == Some("error") {
+        state.stop_spinner().await;
+        let detail = serde_json::from_str::<StreamErrorPayload>(&event.data)
+            .ok()
+            .and_then(|payload| payload.message().map(ToOwned::to_owned))
+            .unwrap_or_else(|| "the server did not say why".to_string());
+
+        return Err(InvalidResponseSnafu {
+            message: format!(
+                "The model at {url} failed part-way through its answer: {detail}. Any answer printed above is incomplete. Check the runtime's logs for the model, then retry. See: https://spiceai.org/docs/components/models"
+            ),
+        }
+        .build());
+    }
+
+    // An event with no payload — a bare `event:` line, or a keep-alive a proxy reframed —
+    // carries no content and no failure. It is progress, not something to read.
+    if event.data.is_empty() {
+        return Ok(EventOutcome::Continue);
+    }
+
+    if event.data == "[DONE]" {
+        // The protocol's terminator. Reading on would wait for an EOF the server is under no
+        // obligation to send promptly.
+        return Ok(EventOutcome::Stop);
+    }
+
+    let Ok(chunk) = serde_json::from_str::<ChatChunk>(&event.data) else {
+        state.stop_spinner().await;
+
+        // An OpenAI-compatible server reports a failure in an unnamed event instead, so the
+        // payload gets one more reading before this is called unintelligible.
+        let detail = serde_json::from_str::<StreamErrorPayload>(&event.data)
+            .ok()
+            .and_then(|payload| payload.message().map(ToOwned::to_owned))
+            .map_or_else(
+                || "the response could not be read".to_string(),
+                |message| format!("the model reported: {message}"),
+            );
+
+        return Err(InvalidResponseSnafu {
+            message: format!(
+                "The model at {url} sent a response event that is not a chat completion -- {detail}. Any answer printed above is incomplete. Check the runtime's logs for the model, then retry. See: https://spiceai.org/docs/components/models"
+            ),
+        }
+        .build());
+    };
+
+    // Capture usage from the final chunk (if present)
+    if chunk.usage.is_some() {
+        state.usage = chunk.usage;
+    }
+
+    for choice in &chunk.choices {
+        if let Some(content) = &choice.delta.content {
+            // Record first token time and stop spinner
+            if state.first_token.is_none() {
+                state.first_token = Some(start_time.elapsed());
+                state.stop_spinner().await;
+            }
+            if emit_tokens {
+                print!("{content}");
+                let _ = io::stdout().flush();
+            }
+            state.response.push_str(content);
+        }
+    }
+
+    Ok(EventOutcome::Continue)
 }
 
 #[cfg(test)]
@@ -828,6 +955,202 @@ mod tests {
             "took {:?}",
             started.elapsed()
         );
+    }
+
+    /// A context whose deadlines are generous enough that only the response itself ends the
+    /// read — every test below is about what is read, not about when reading stops.
+    fn unhurried_context(url: &str) -> RuntimeContext {
+        RuntimeContext::with_deadlines_for_test(
+            url,
+            Deadline::Total(Duration::from_secs(30)),
+            Deadline::Silence(Duration::from_secs(30)),
+        )
+    }
+
+    async fn stream_from(server: &SlowServer) -> Result<ChatResponse> {
+        let ctx = unhurried_context(server.url());
+        send_chat_streaming(&ctx, &test_chat_config(), &one_shot_prompt(), false, false).await
+    }
+
+    /// An SSE event is not obliged to arrive in one read. Splitting one mid-payload used to
+    /// lose it entirely — the leading fragment is truncated JSON and the trailing one has no
+    /// `data:` prefix, so both were discarded without a word. That is
+    /// <https://github.com/spiceai/spiceai/issues/12588>.
+    #[tokio::test]
+    async fn an_event_split_across_two_reads_is_not_dropped() {
+        let event = format!(
+            "{}\n\n",
+            r#"data: {"choices":[{"delta":{"content":"whole"}}]}"#
+        );
+        let split = event.len() / 2;
+        let server = SlowServer::dribbling(
+            vec![event[..split].to_string(), event[split..].to_string()],
+            Duration::from_millis(10),
+        );
+
+        let response = stream_from(&server)
+            .await
+            .expect("an event split across two reads is still one event");
+
+        assert_eq!(response.content, "whole");
+    }
+
+    /// The tokens either side of a split must survive too, and in order — a decoder that
+    /// dropped only the split event would still pass the test above if it were the sole event.
+    #[tokio::test]
+    async fn tokens_either_side_of_a_split_event_keep_their_order() {
+        let split_event = format!(
+            "{}\n\n",
+            r#"data: {"choices":[{"delta":{"content":"middle "}}]}"#
+        );
+        let split = split_event.len() / 2;
+        let server = SlowServer::dribbling(
+            vec![
+                format!(
+                    "{}\n\n",
+                    r#"data: {"choices":[{"delta":{"content":"first "}}]}"#
+                ),
+                split_event[..split].to_string(),
+                split_event[split..].to_string(),
+                format!(
+                    "{}\n\n",
+                    r#"data: {"choices":[{"delta":{"content":"last"}}]}"#
+                ),
+            ],
+            Duration::from_millis(5),
+        );
+
+        let response = stream_from(&server)
+            .await
+            .expect("every event should be read");
+
+        assert_eq!(response.content, "first middle last");
+    }
+
+    /// A multi-byte character split across two reads must be reassembled. Decoding each read
+    /// on its own replaces both halves with U+FFFD, corrupting the answer silently.
+    #[tokio::test]
+    async fn a_character_split_across_two_reads_is_not_corrupted() {
+        let event = format!(
+            "{}\n\n",
+            r#"data: {"choices":[{"delta":{"content":"café"}}]}"#
+        );
+        // Between the two bytes of `é`, which is the last character before the closing quote.
+        let split = event
+            .find('é')
+            .expect("the payload contains the character being split")
+            + 1;
+        // The halves are carried as bytes: putting them through `String` would replace the
+        // split character here, in the fixture, and the test would pass on any decoder.
+        let server = SlowServer::dribbling_bytes(
+            vec![
+                event.as_bytes()[..split].to_vec(),
+                event.as_bytes()[split..].to_vec(),
+            ],
+            Duration::from_millis(10),
+        );
+
+        let response = stream_from(&server)
+            .await
+            .expect("a character split across two reads is still one character");
+
+        assert_eq!(response.content, "café");
+    }
+
+    /// The runtime reports a mid-stream failure as an `error` event
+    /// (`to_openai_error_event` in `crates/runtime/src/http/v1/chat.rs`). Read as a chat
+    /// completion it parses as nothing, so it used to be discarded — leaving the user a
+    /// truncated answer, printed as though it were whole, with no error and no exit code.
+    #[tokio::test]
+    async fn an_error_event_ends_the_stream_rather_than_truncating_the_answer() {
+        let server = SlowServer::dribbling(
+            vec![
+                format!(
+                    "{}\n\n",
+                    r#"data: {"choices":[{"delta":{"content":"partial"}}]}"#
+                ),
+                format!(
+                    "{}\n\n",
+                    r#"event: error
+data: {"type":"error","message":"the model ran out of context"}"#
+                ),
+            ],
+            Duration::from_millis(5),
+        );
+
+        let error = stream_from(&server)
+            .await
+            .expect_err("a stream that failed part-way through has no complete answer");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("the model ran out of context"),
+            "the server's reason should reach the user, got: {message}"
+        );
+        assert!(
+            message.contains("incomplete"),
+            "the user should be told the printed answer is partial, got: {message}"
+        );
+    }
+
+    /// The same failure from an OpenAI-compatible server, which nests it under `error` in an
+    /// unnamed event instead of naming the event.
+    #[tokio::test]
+    async fn an_unnamed_error_payload_is_reported_with_its_reason() {
+        let server = SlowServer::dribbling(
+            vec![format!(
+                "{}\n\n",
+                r#"data: {"error":{"message":"upstream rate limit"}}"#
+            )],
+            Duration::from_millis(5),
+        );
+
+        let error = stream_from(&server)
+            .await
+            .expect_err("an event that is not a chat completion is not an answer");
+
+        assert!(
+            error.to_string().contains("upstream rate limit"),
+            "the server's reason should reach the user, got: {error}"
+        );
+    }
+
+    /// An event with no payload — a bare `event:` line, or a keep-alive a proxy reframed —
+    /// is neither content nor a failure, and must not be mistaken for either.
+    #[tokio::test]
+    async fn an_event_with_no_payload_does_not_end_the_stream() {
+        let server = SlowServer::dribbling(
+            vec![
+                "event: ping\n\n".to_string(),
+                format!(
+                    "{}\n\n",
+                    r#"data: {"choices":[{"delta":{"content":"answer"}}]}"#
+                ),
+            ],
+            Duration::from_millis(5),
+        );
+
+        let response = stream_from(&server)
+            .await
+            .expect("an empty event is not a failure");
+
+        assert_eq!(response.content, "answer");
+    }
+
+    /// A server that hangs up without the blank line terminating its last event still sent
+    /// that event, and its tokens belong in the answer.
+    #[tokio::test]
+    async fn a_final_event_without_its_terminator_is_still_read() {
+        let server = SlowServer::dribbling(
+            vec![r#"data: {"choices":[{"delta":{"content":"tail"}}]}"#.to_string()],
+            Duration::from_millis(5),
+        );
+
+        let response = stream_from(&server)
+            .await
+            .expect("the last event arrived, only its terminator did not");
+
+        assert_eq!(response.content, "tail");
     }
 
     #[test]

--- a/bin/spice/src/commands/chat.rs
+++ b/bin/spice/src/commands/chat.rs
@@ -1091,6 +1091,13 @@ data: {"type":"error","message":"the model ran out of context"}"#
             message.contains("incomplete"),
             "the user should be told the printed answer is partial, got: {message}"
         );
+        // The wording the named branch produces, and the generic unreadable-event branch
+        // does not. Without this the test passes with that branch removed: the payload
+        // falls through to the generic path, which happens to quote the same reason.
+        assert!(
+            message.contains("failed part-way through its answer"),
+            "an error event should be reported as a failed answer, not as an unreadable event: {message}"
+        );
     }
 
     /// The same failure from an OpenAI-compatible server, which nests it under `error` in an

--- a/bin/spice/src/commands/chat.rs
+++ b/bin/spice/src/commands/chat.rs
@@ -1146,13 +1146,14 @@ data: {"type":"error","message":"the model ran out of context"}"#
         );
     }
 
-    /// An event with no payload — a bare `event:` line, or a keep-alive a proxy reframed —
-    /// is neither content nor a failure, and must not be mistaken for either.
+    /// An event whose data field is empty — the heartbeat some servers send in place of a
+    /// comment — is neither content nor a failure, and must not be mistaken for either.
+    /// (A frame carrying no data field at all is not dispatched at all; `sse` covers that.)
     #[tokio::test]
     async fn an_event_with_no_payload_does_not_end_the_stream() {
         let server = SlowServer::dribbling(
             vec![
-                "event: ping\n\n".to_string(),
+                "data: \n\n".to_string(),
                 format!(
                     "{}\n\n",
                     r#"data: {"choices":[{"delta":{"content":"answer"}}]}"#

--- a/bin/spice/src/commands/chat.rs
+++ b/bin/spice/src/commands/chat.rs
@@ -149,11 +149,15 @@ struct NestedStreamError {
 }
 
 impl StreamErrorPayload {
-    /// The most specific message the payload carries.
-    fn message(&self) -> Option<&str> {
-        self.message
+    /// The reason `data` gives for the stream failing, if it reads as a failure and gives one.
+    fn reason_in(data: &str) -> Option<String> {
+        let payload = serde_json::from_str::<Self>(data).ok()?;
+        let message = payload
+            .message
             .as_deref()
-            .or_else(|| self.error.as_ref()?.message.as_deref())
+            .or_else(|| payload.error.as_ref()?.message.as_deref())?;
+
+        Some(message.to_string())
     }
 }
 
@@ -625,13 +629,7 @@ async fn send_chat_streaming(
             // one event's worth of bytes buffered here, and dropping it would lose the tail
             // of the answer.
             decoder.close();
-            while let Some(event) = decoder.next_event() {
-                if apply_event(&event, &url, emit_tokens, start_time, &mut state).await?
-                    == EventOutcome::Stop
-                {
-                    break;
-                }
-            }
+            drain_events(&mut decoder, &url, emit_tokens, start_time, &mut state).await?;
             break 'stream;
         };
 
@@ -645,12 +643,10 @@ async fn send_chat_streaming(
         let data_before = decoder.data_fields_seen();
         decoder.push(&chunk);
 
-        while let Some(event) = decoder.next_event() {
-            if apply_event(&event, &url, emit_tokens, start_time, &mut state).await?
-                == EventOutcome::Stop
-            {
-                break 'stream;
-            }
+        if drain_events(&mut decoder, &url, emit_tokens, start_time, &mut state).await?
+            == EventOutcome::Stop
+        {
+            break 'stream;
         }
 
         // Progress is a `data` line arriving, not an event completing: a large event spread
@@ -662,12 +658,11 @@ async fn send_chat_streaming(
 
         // Asked after draining, so the cap bounds one event the stream never ends rather
         // than however many whole events happened to arrive in a single read.
-        if let Some(oversized) = decoder.oversized() {
+        if let Some(buffered) = decoder.oversized_bytes() {
             state.stop_spinner().await;
             return Err(InvalidResponseSnafu {
                 message: format!(
-                    "The model at {url} sent {} bytes of a single response event without ending it. Check the runtime's logs for the model, then retry. See: https://spiceai.org/docs/components/models",
-                    oversized.bytes
+                    "The model at {url} sent {buffered} bytes of a single response event without ending it. Check the runtime's logs for the model, then retry. See: https://spiceai.org/docs/components/models"
                 ),
             }
             .build());
@@ -684,8 +679,25 @@ async fn send_chat_streaming(
     })
 }
 
+/// Read every event the decoder has ready, stopping early if one ends the stream.
+async fn drain_events(
+    decoder: &mut SseDecoder,
+    url: &str,
+    emit_tokens: bool,
+    start_time: Instant,
+    state: &mut StreamState,
+) -> Result<EventOutcome> {
+    while let Some(event) = decoder.next_event() {
+        if apply_event(&event, url, emit_tokens, start_time, state).await? == EventOutcome::Stop {
+            return Ok(EventOutcome::Stop);
+        }
+    }
+
+    Ok(EventOutcome::Continue)
+}
+
 /// What the stream should do once an event has been read.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 enum EventOutcome {
     /// Keep reading.
     Continue,
@@ -726,9 +738,7 @@ async fn apply_event(
     // parses as nothing, which is how it used to disappear.
     if event.name.as_deref() == Some("error") {
         state.stop_spinner().await;
-        let detail = serde_json::from_str::<StreamErrorPayload>(&event.data)
-            .ok()
-            .and_then(|payload| payload.message().map(ToOwned::to_owned))
+        let detail = StreamErrorPayload::reason_in(&event.data)
             .unwrap_or_else(|| "the server did not say why".to_string());
 
         return Err(InvalidResponseSnafu {
@@ -756,13 +766,10 @@ async fn apply_event(
 
         // An OpenAI-compatible server reports a failure in an unnamed event instead, so the
         // payload gets one more reading before this is called unintelligible.
-        let detail = serde_json::from_str::<StreamErrorPayload>(&event.data)
-            .ok()
-            .and_then(|payload| payload.message().map(ToOwned::to_owned))
-            .map_or_else(
-                || "the response could not be read".to_string(),
-                |message| format!("the model reported: {message}"),
-            );
+        let detail = StreamErrorPayload::reason_in(&event.data).map_or_else(
+            || "the response could not be read".to_string(),
+            |message| format!("the model reported: {message}"),
+        );
 
         return Err(InvalidResponseSnafu {
             message: format!(
@@ -826,6 +833,32 @@ mod tests {
         }
     }
 
+    /// One SSE event carrying `text` as a content delta — the shape of every chunk a chat
+    /// completion stream sends.
+    fn content_event(text: &str) -> String {
+        format!("data: {{\"choices\":[{{\"delta\":{{\"content\":\"{text}\"}}}}]}}\n\n")
+    }
+
+    /// One SSE event carrying `payload` verbatim, for the events that are not content.
+    fn raw_event(payload: &str) -> String {
+        format!("data: {payload}\n\n")
+    }
+
+    /// A context whose deadlines are generous enough that only the response itself ends the
+    /// read — most of these tests are about what is read, not about when reading stops.
+    fn unhurried_context(url: &str) -> RuntimeContext {
+        RuntimeContext::with_deadlines_for_test(
+            url,
+            Deadline::Total(Duration::from_secs(30)),
+            Deadline::Silence(Duration::from_secs(30)),
+        )
+    }
+
+    async fn stream_from(server: &SlowServer) -> Result<ChatResponse> {
+        let ctx = unhurried_context(server.url());
+        send_chat_streaming(&ctx, &test_chat_config(), &one_shot_prompt(), false, false).await
+    }
+
     /// A streamed answer that keeps arriving must not be cut off for taking longer than the
     /// control-plane deadline — the failure reported in
     /// <https://github.com/spiceai/spiceai/issues/12583>.
@@ -835,9 +868,8 @@ mod tests {
     #[tokio::test]
     async fn a_streamed_answer_outlives_the_control_plane_deadline() {
         let control_plane = Duration::from_millis(400);
-        let chunk = r#"data: {"choices":[{"delta":{"content":"token "}}]}"#.to_string();
         let server = SlowServer::dribbling(
-            std::iter::repeat_n(format!("{chunk}\n\n"), 8).collect(),
+            std::iter::repeat_n(content_event("token "), 8).collect(),
             control_plane / 4,
         );
 
@@ -893,25 +925,13 @@ mod tests {
     /// looking hung after it already has the whole answer.
     #[tokio::test]
     async fn a_completed_answer_does_not_wait_for_the_server_to_hang_up() {
-        let mut chunks: Vec<String> = std::iter::repeat_n(
-            format!(
-                "{}\n\n",
-                r#"data: {"choices":[{"delta":{"content":"token "}}]}"#
-            ),
-            3,
-        )
-        .collect();
-        chunks.push("data: [DONE]\n\n".to_string());
+        let mut chunks: Vec<String> = std::iter::repeat_n(content_event("token "), 3).collect();
+        chunks.push(raw_event("[DONE]"));
 
         // The connection stays open after `[DONE]`, so only the terminator can end the read.
         let server = SlowServer::dribbling_then_holding(chunks, Duration::from_millis(20));
 
-        let ctx = RuntimeContext::with_deadlines_for_test(
-            server.url(),
-            Deadline::Total(Duration::from_secs(30)),
-            Deadline::Silence(Duration::from_secs(30)),
-        );
-
+        let ctx = unhurried_context(server.url());
         let config = test_chat_config();
         let messages = one_shot_prompt();
 
@@ -981,31 +1001,13 @@ mod tests {
         );
     }
 
-    /// A context whose deadlines are generous enough that only the response itself ends the
-    /// read — every test below is about what is read, not about when reading stops.
-    fn unhurried_context(url: &str) -> RuntimeContext {
-        RuntimeContext::with_deadlines_for_test(
-            url,
-            Deadline::Total(Duration::from_secs(30)),
-            Deadline::Silence(Duration::from_secs(30)),
-        )
-    }
-
-    async fn stream_from(server: &SlowServer) -> Result<ChatResponse> {
-        let ctx = unhurried_context(server.url());
-        send_chat_streaming(&ctx, &test_chat_config(), &one_shot_prompt(), false, false).await
-    }
-
     /// An SSE event is not obliged to arrive in one read. Splitting one mid-payload used to
     /// lose it entirely — the leading fragment is truncated JSON and the trailing one has no
     /// `data:` prefix, so both were discarded without a word. That is
     /// <https://github.com/spiceai/spiceai/issues/12588>.
     #[tokio::test]
     async fn an_event_split_across_two_reads_is_not_dropped() {
-        let event = format!(
-            "{}\n\n",
-            r#"data: {"choices":[{"delta":{"content":"whole"}}]}"#
-        );
+        let event = content_event("whole");
         let split = event.len() / 2;
         let server = SlowServer::dribbling(
             vec![event[..split].to_string(), event[split..].to_string()],
@@ -1023,23 +1025,14 @@ mod tests {
     /// dropped only the split event would still pass the test above if it were the sole event.
     #[tokio::test]
     async fn tokens_either_side_of_a_split_event_keep_their_order() {
-        let split_event = format!(
-            "{}\n\n",
-            r#"data: {"choices":[{"delta":{"content":"middle "}}]}"#
-        );
+        let split_event = content_event("middle ");
         let split = split_event.len() / 2;
         let server = SlowServer::dribbling(
             vec![
-                format!(
-                    "{}\n\n",
-                    r#"data: {"choices":[{"delta":{"content":"first "}}]}"#
-                ),
+                content_event("first "),
                 split_event[..split].to_string(),
                 split_event[split..].to_string(),
-                format!(
-                    "{}\n\n",
-                    r#"data: {"choices":[{"delta":{"content":"last"}}]}"#
-                ),
+                content_event("last"),
             ],
             Duration::from_millis(5),
         );
@@ -1055,10 +1048,7 @@ mod tests {
     /// on its own replaces both halves with U+FFFD, corrupting the answer silently.
     #[tokio::test]
     async fn a_character_split_across_two_reads_is_not_corrupted() {
-        let event = format!(
-            "{}\n\n",
-            r#"data: {"choices":[{"delta":{"content":"café"}}]}"#
-        );
+        let event = content_event("café");
         // Between the two bytes of `é`, which is the last character before the closing quote.
         let split = event
             .find('é')
@@ -1089,15 +1079,9 @@ mod tests {
     async fn an_error_event_ends_the_stream_rather_than_truncating_the_answer() {
         let server = SlowServer::dribbling(
             vec![
-                format!(
-                    "{}\n\n",
-                    r#"data: {"choices":[{"delta":{"content":"partial"}}]}"#
-                ),
-                format!(
-                    "{}\n\n",
-                    r#"event: error
-data: {"type":"error","message":"the model ran out of context"}"#
-                ),
+                content_event("partial"),
+                "event: error\ndata: {\"type\":\"error\",\"message\":\"the model ran out of context\"}\n\n"
+                    .to_string(),
             ],
             Duration::from_millis(5),
         );
@@ -1129,10 +1113,7 @@ data: {"type":"error","message":"the model ran out of context"}"#
     #[tokio::test]
     async fn an_unnamed_error_payload_is_reported_with_its_reason() {
         let server = SlowServer::dribbling(
-            vec![format!(
-                "{}\n\n",
-                r#"data: {"error":{"message":"upstream rate limit"}}"#
-            )],
+            vec![raw_event(r#"{"error":{"message":"upstream rate limit"}}"#)],
             Duration::from_millis(5),
         );
 
@@ -1152,13 +1133,7 @@ data: {"type":"error","message":"the model ran out of context"}"#
     #[tokio::test]
     async fn an_event_with_no_payload_does_not_end_the_stream() {
         let server = SlowServer::dribbling(
-            vec![
-                "data: \n\n".to_string(),
-                format!(
-                    "{}\n\n",
-                    r#"data: {"choices":[{"delta":{"content":"answer"}}]}"#
-                ),
-            ],
+            vec!["data: \n\n".to_string(), content_event("answer")],
             Duration::from_millis(5),
         );
 
@@ -1177,18 +1152,11 @@ data: {"type":"error","message":"the model ran out of context"}"#
     async fn an_annotation_choice_without_a_delta_does_not_stop_the_stream() {
         let server = SlowServer::dribbling(
             vec![
-                format!(
-                    "{}\n\n",
-                    r#"data: {"choices":[{"delta":{"content":"before "}}]}"#
+                content_event("before "),
+                raw_event(
+                    r#"{"choices":[{"index":0,"finish_reason":null,"content_filter_results":{},"content_filter_offsets":{"check_offset":44,"start_offset":44,"end_offset":198}}],"usage":null}"#,
                 ),
-                format!(
-                    "{}\n\n",
-                    r#"data: {"choices":[{"index":0,"finish_reason":null,"content_filter_results":{},"content_filter_offsets":{"check_offset":44,"start_offset":44,"end_offset":198}}],"usage":null}"#
-                ),
-                format!(
-                    "{}\n\n",
-                    r#"data: {"choices":[{"delta":{"content":"after"}}]}"#
-                ),
+                content_event("after"),
             ],
             Duration::from_millis(5),
         );
@@ -1235,7 +1203,7 @@ data: {"type":"error","message":"the model ran out of context"}"#
     #[tokio::test]
     async fn a_final_event_without_its_terminator_is_still_read() {
         let server = SlowServer::dribbling(
-            vec![r#"data: {"choices":[{"delta":{"content":"tail"}}]}"#.to_string()],
+            vec![content_event("tail").trim_end().to_string()],
             Duration::from_millis(5),
         );
 

--- a/bin/spice/src/commands/nsql/analyze.rs
+++ b/bin/spice/src/commands/nsql/analyze.rs
@@ -45,7 +45,7 @@ limitations under the License.
 //! `runtime.task_history` for metrics after the request completes.
 
 use crate::context::RuntimeContext;
-use crate::error::{ConnectionFailedSnafu, InvalidResponseSnafu, Result};
+use crate::error::{ConnectionFailedSnafu, InvalidResponseSnafu, Result, read_response};
 use clap::Args;
 use opentelemetry::trace::TraceId;
 use rand::Rng;
@@ -342,8 +342,7 @@ async fn send_nsql_request_with_trace(
         .await
         .context(ConnectionFailedSnafu { endpoint: &url })?;
 
-    let status = response.status();
-    let text = response.text().await.unwrap_or_default();
+    let (status, text) = read_response(response, &url).await?;
 
     if !status.is_success() {
         return Err(InvalidResponseSnafu {

--- a/bin/spice/src/commands/nsql/mod.rs
+++ b/bin/spice/src/commands/nsql/mod.rs
@@ -21,7 +21,7 @@ mod analyze;
 use crate::context::RuntimeContext;
 use crate::error::{
     ConnectionFailedSnafu, InvalidResponseSnafu, ModelNotFoundSnafu, NoModelsConfiguredSnafu,
-    Result,
+    Result, read_response,
 };
 use clap::{Args, Subcommand};
 use repl::util::{Spinner, create_editor_with_history, save_history};
@@ -210,8 +210,7 @@ async fn send_nsql_request(ctx: &RuntimeContext, query: &str, model: &str) -> Re
         .await
         .context(ConnectionFailedSnafu { endpoint: &url })?;
 
-    let status = response.status();
-    let text = response.text().await.unwrap_or_default();
+    let (status, text) = read_response(response, &url).await?;
 
     if !status.is_success() {
         return Err(InvalidResponseSnafu {
@@ -274,5 +273,37 @@ mod tests {
         // The server answers every path alike, so without this the test would pass against any
         // route and would pin only the client, not the endpoint.
         assert_eq!(server.targets(), vec!["/v1/nsql".to_string()]);
+    }
+
+    /// A `200` whose body stops part-way through is not an empty translation — the defect
+    /// reported in <https://github.com/spiceai/spiceai/issues/12587>. Reading the body with
+    /// `unwrap_or_default` returned `Ok("")` here, which is indistinguishable from a model
+    /// that legitimately produced nothing.
+    #[tokio::test]
+    async fn a_truncated_translation_is_an_error_not_an_empty_one() {
+        let server = SlowServer::truncating(
+            vec!["SELECT ".to_string(), "1".to_string()],
+            Duration::from_millis(5),
+        );
+
+        let ctx = RuntimeContext::with_deadlines_for_test(
+            server.url(),
+            Deadline::Total(Duration::from_secs(30)),
+            Deadline::Silence(Duration::from_secs(30)),
+        );
+
+        let error = send_nsql_request(&ctx, "how many rows", "test-model")
+            .await
+            .expect_err("a body that stopped part-way through is not a translation");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("Failed to read the response"),
+            "expected the read failure to be reported, got: {message}"
+        );
+        assert!(
+            message.contains("/v1/nsql"),
+            "the error should name the endpoint, got: {message}"
+        );
     }
 }

--- a/bin/spice/src/commands/nsql/mod.rs
+++ b/bin/spice/src/commands/nsql/mod.rs
@@ -214,7 +214,7 @@ async fn send_nsql_request(ctx: &RuntimeContext, query: &str, model: &str) -> Re
 
     if !status.is_success() {
         return Err(InvalidResponseSnafu {
-            message: format!("Query failed: {text}"),
+            message: format!("Query failed with status {status}: {text}"),
         }
         .build());
     }

--- a/bin/spice/src/commands/search.rs
+++ b/bin/spice/src/commands/search.rs
@@ -285,7 +285,7 @@ async fn send_search_request(
 
     if !status.is_success() {
         return Err(InvalidResponseSnafu {
-            message: format!("Search failed: {text}"),
+            message: format!("Search failed with status {status}: {text}"),
         }
         .build());
     }

--- a/bin/spice/src/commands/search.rs
+++ b/bin/spice/src/commands/search.rs
@@ -17,7 +17,7 @@ limitations under the License.
 //! `spice search` command - Semantic search REPL.
 
 use crate::context::RuntimeContext;
-use crate::error::{ConnectionFailedSnafu, InvalidResponseSnafu, Result};
+use crate::error::{ConnectionFailedSnafu, InvalidResponseSnafu, Result, read_response};
 use crate::output::{OutputFormat, TableOutput};
 use clap::Args;
 use repl::util::{Spinner, create_editor_with_history, save_history};
@@ -273,7 +273,6 @@ async fn send_search_request(
         .await
         .context(ConnectionFailedSnafu { endpoint: &url })?;
 
-    let status = response.status();
     // Check cache status header
     let cache_status = response
         .headers()
@@ -282,7 +281,7 @@ async fn send_search_request(
         .map(String::from);
     let from_cache = matches!(cache_status.as_deref(), Some("HIT" | "STALE"));
 
-    let text = response.text().await.unwrap_or_default();
+    let (status, text) = read_response(response, &url).await?;
 
     if !status.is_success() {
         return Err(InvalidResponseSnafu {

--- a/bin/spice/src/error.rs
+++ b/bin/spice/src/error.rs
@@ -17,7 +17,7 @@ limitations under the License.
 //! Error types for the Spice CLI.
 
 use reqwest::StatusCode;
-use snafu::Snafu;
+use snafu::{IntoError, Snafu};
 use std::path::PathBuf;
 
 /// Result type alias for the Spice CLI.
@@ -71,6 +71,15 @@ pub enum Error {
     /// Invalid HTTP response
     #[snafu(display("Invalid HTTP response: {message}"))]
     InvalidResponse { message: String },
+
+    /// A response the runtime reported as successful did not arrive in full
+    #[snafu(display(
+        "Failed to read the response from {endpoint}: {source}. The request was accepted, so the result may be incomplete rather than empty -- check the runtime's logs, then retry. See: https://spiceai.org/docs/api"
+    ))]
+    ResponseIncomplete {
+        endpoint: String,
+        source: reqwest::Error,
+    },
 
     /// A Spicepod registry failed to serve a pod. The message is already fully formed, so it is
     /// displayed verbatim rather than blamed on the user's argument.
@@ -194,9 +203,101 @@ pub async fn check_response(
     .build())
 }
 
+/// Read a response's status and body, distinguishing a body that failed to arrive from one
+/// that was empty.
+///
+/// On a non-success status the body only decorates a message that already reports the
+/// failure, so a read error there yields an empty string rather than replacing the status
+/// the caller is about to report. On a success status the body *is* the result: a read that
+/// stopped part-way — a deadline firing mid-response, a reset connection, a truncated
+/// response — must be reported rather than defaulted to an empty success.
+pub async fn read_response(
+    response: reqwest::Response,
+    endpoint: &str,
+) -> Result<(StatusCode, String)> {
+    let status = response.status();
+    match response.text().await {
+        Ok(body) => Ok((status, body)),
+        Err(_) if !status.is_success() => Ok((status, String::new())),
+        Err(source) => Err(ResponseIncompleteSnafu {
+            endpoint: endpoint.to_string(),
+        }
+        .into_error(source)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A response whose body fails part-way through, under the caller's choice of status.
+    fn response_with_unreadable_body(status: StatusCode) -> reqwest::Response {
+        let failure = std::io::Error::other("the connection went away mid-body");
+        let body = reqwest::Body::wrap_stream(futures::stream::once(async {
+            Err::<Vec<u8>, std::io::Error>(failure)
+        }));
+
+        let response = http::Response::builder()
+            .status(status)
+            .body(body)
+            .expect("a response with a status and a body is well-formed");
+
+        reqwest::Response::from(response)
+    }
+
+    /// A body that stopped part-way through is not an empty result: reading it with
+    /// `unwrap_or_default` reported an empty success, which is
+    /// <https://github.com/spiceai/spiceai/issues/12587>.
+    #[tokio::test]
+    async fn a_body_that_fails_on_a_success_status_is_an_error() {
+        let response = response_with_unreadable_body(StatusCode::OK);
+
+        let error = read_response(response, "http://runtime/v1/nsql")
+            .await
+            .expect_err("a body that did not arrive is not a result");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("http://runtime/v1/nsql"),
+            "the error should name the endpoint, got: {message}"
+        );
+        assert!(
+            matches!(error, Error::ResponseIncomplete { .. }),
+            "expected an incomplete-response error, got: {message}"
+        );
+    }
+
+    /// On a failing status the body is only decoration for a message that already reports the
+    /// failure, so a body that could not be read must not replace the status with a transport
+    /// error — the caller still has to be able to say what the server answered.
+    #[tokio::test]
+    async fn a_body_that_fails_on_an_error_status_keeps_the_status() {
+        let response = response_with_unreadable_body(StatusCode::INTERNAL_SERVER_ERROR);
+
+        let (status, body) = read_response(response, "http://runtime/v1/nsql")
+            .await
+            .expect("the status is the result here, not the body");
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body, "");
+    }
+
+    #[tokio::test]
+    async fn a_body_that_arrives_is_returned_with_its_status() {
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .status(StatusCode::OK)
+                .body("SELECT 1")
+                .expect("a response with a status and a body is well-formed"),
+        );
+
+        let (status, body) = read_response(response, "http://runtime/v1/nsql")
+            .await
+            .expect("a body that arrived in full is a result");
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "SELECT 1");
+    }
 
     #[test]
     fn test_unauthorized_error_message() {

--- a/bin/spice/src/error.rs
+++ b/bin/spice/src/error.rs
@@ -17,7 +17,7 @@ limitations under the License.
 //! Error types for the Spice CLI.
 
 use reqwest::StatusCode;
-use snafu::{IntoError, Snafu};
+use snafu::Snafu;
 use std::path::PathBuf;
 
 /// Result type alias for the Spice CLI.
@@ -219,10 +219,10 @@ pub async fn read_response(
     match response.text().await {
         Ok(body) => Ok((status, body)),
         Err(_) if !status.is_success() => Ok((status, String::new())),
-        Err(source) => Err(ResponseIncompleteSnafu {
+        Err(source) => Err(Error::ResponseIncomplete {
             endpoint: endpoint.to_string(),
-        }
-        .into_error(source)),
+            source,
+        }),
     }
 }
 

--- a/bin/spice/src/lib.rs
+++ b/bin/spice/src/lib.rs
@@ -31,6 +31,7 @@ pub mod github;
 pub mod manifest;
 pub mod output;
 pub mod registry;
+pub(crate) mod sse;
 
 #[cfg(test)]
 pub(crate) mod test_support;

--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -775,6 +775,7 @@ fn machine_error_code(error: &spice::error::Error) -> &'static str {
         spice::error::Error::ConnectionFailed { .. } => "connection_failed",
         spice::error::Error::HttpRequestFailed { .. } => "http_request_failed",
         spice::error::Error::InvalidResponse { .. } => "invalid_response",
+        spice::error::Error::ResponseIncomplete { .. } => "response_incomplete",
         spice::error::Error::Registry { .. } => "registry",
         spice::error::Error::ConfigIo { .. } => "config_io",
         spice::error::Error::ConfigParse { .. } => "config_parse",

--- a/bin/spice/src/sse.rs
+++ b/bin/spice/src/sse.rs
@@ -38,6 +38,14 @@ limitations under the License.
 //! Dispatch follows the standard too: a blank line ends an event only if a `data` field was
 //! seen. A frame carrying just `event: ping` is *not* an event — dispatching one would tell
 //! the caller the stream is producing when it is not.
+//!
+//! `eventsource-stream` is already in this binary's dependency tree (through `async-openai`)
+//! and covers the framing above. It is not used here because it yields whole events and
+//! nothing else, and the three things this decoder is for all live outside that: the caller
+//! needs to know a `data` line arrived *before* its event ends, to tell a large event still
+//! being received from a stalled stream; it needs the event a server left unterminated when
+//! it closed, which that crate drops; and it needs a bound on how much one unterminated event
+//! may buffer, which that crate does not impose.
 
 /// The most bytes one event may occupy before the decoder refuses to keep buffering.
 ///
@@ -47,19 +55,12 @@ limitations under the License.
 pub(crate) const MAX_EVENT_BYTES: usize = 8 * 1024 * 1024;
 
 /// One dispatched SSE event.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub(crate) struct SseEvent {
     /// The `event:` field, when the stream set one.
     pub(crate) name: Option<String>,
     /// The `data:` fields, joined with newlines as the standard specifies.
     pub(crate) data: String,
-}
-
-/// An event grew past [`MAX_EVENT_BYTES`] without being terminated.
-#[derive(Debug)]
-pub(crate) struct OversizedEvent {
-    /// How many bytes had accumulated when the decoder gave up.
-    pub(crate) bytes: usize,
 }
 
 /// Reassembles [`SseEvent`]s from a byte stream delivered in arbitrary pieces.
@@ -122,14 +123,14 @@ impl SseDecoder {
         self.at_eof = true;
     }
 
-    /// Whether one unterminated event has grown past [`MAX_EVENT_BYTES`].
+    /// How many bytes one unterminated event has grown to, once past [`MAX_EVENT_BYTES`].
     ///
     /// Ask this only after draining with [`SseDecoder::next_event`]: before that the buffer
     /// also holds whole events waiting to be read, and one transport read may carry many of
     /// them. The limit is on an event the stream never ends, not on how much arrives at once.
-    pub(crate) fn oversized(&self) -> Option<OversizedEvent> {
+    pub(crate) fn oversized_bytes(&self) -> Option<usize> {
         let buffered = self.unread().len() + self.data.len();
-        (buffered > MAX_EVENT_BYTES).then_some(OversizedEvent { bytes: buffered })
+        (buffered > MAX_EVENT_BYTES).then_some(buffered)
     }
 
     /// How many `data` fields have been read so far.
@@ -295,7 +296,7 @@ mod tests {
                 events.push(event);
             }
             assert!(
-                decoder.oversized().is_none(),
+                decoder.oversized_bytes().is_none(),
                 "test payloads are far below the size cap"
             );
         }
@@ -448,7 +449,7 @@ mod tests {
         let mut decoder = SseDecoder::new();
         let mut pushed = 0usize;
 
-        while decoder.oversized().is_none() {
+        while decoder.oversized_bytes().is_none() {
             let chunk = vec![b'x'; 1024 * 1024];
             decoder.push(&chunk);
             pushed += chunk.len();
@@ -458,8 +459,10 @@ mod tests {
             );
         }
 
-        let oversized = decoder.oversized().expect("the loop ended on the cap");
-        assert!(oversized.bytes > MAX_EVENT_BYTES);
+        let buffered = decoder
+            .oversized_bytes()
+            .expect("the loop ended on the cap");
+        assert!(buffered > MAX_EVENT_BYTES);
     }
 
     /// The cap bounds one unterminated event, not one transport read. A read that happens to
@@ -480,7 +483,7 @@ mod tests {
 
         assert_eq!(dispatched, repeats);
         assert!(
-            decoder.oversized().is_none(),
+            decoder.oversized_bytes().is_none(),
             "every event was terminated, so nothing is over the cap"
         );
     }

--- a/bin/spice/src/sse.rs
+++ b/bin/spice/src/sse.rs
@@ -1,0 +1,380 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Reassembling Server-Sent Events from a byte stream.
+//!
+//! Chunk boundaries in an HTTP body are a property of the transport, not of the protocol
+//! carried over it: an SSE event can straddle two reads, and a multi-byte character can
+//! straddle two reads inside that. A reader that treats each chunk as a whole number of
+//! lines loses whichever events happen to be split, silently — there is nothing malformed
+//! about the stream, only about the reading of it.
+//!
+//! [`SseDecoder`] buffers what has arrived and yields only events it has seen the end of.
+//! Bytes are held rather than decoded on arrival, so a character split across two reads is
+//! reassembled instead of becoming a replacement character: `\n` cannot occur inside a
+//! multi-byte UTF-8 sequence, so a line boundary is always a character boundary too.
+//!
+//! The field grammar is the one from the [HTML standard](https://html.spec.whatwg.org/multipage/server-sent-events.html):
+//! a line of `field: value`, a comment line starting with `:`, and a blank line ending the
+//! event. Line terminators are `\n` and `\r\n`; a lone `\r`, which the standard also allows
+//! but which nothing in this stack emits, is treated as part of the line rather than as a
+//! terminator — recognising it would mean a server that never sends `\n` could hold the
+//! decoder's buffer open indefinitely.
+
+/// The most bytes one event may occupy before the decoder refuses to keep buffering.
+///
+/// A stream that never sends a line terminator would otherwise grow this buffer without
+/// bound. Individual chat completion chunks are a few hundred bytes; a tool call carrying a
+/// large argument payload is the realistic upper end, and stays far below this.
+pub(crate) const MAX_EVENT_BYTES: usize = 8 * 1024 * 1024;
+
+/// One dispatched SSE event.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct SseEvent {
+    /// The `event:` field, when the stream set one.
+    pub(crate) name: Option<String>,
+    /// The `data:` fields, joined with newlines as the standard specifies.
+    pub(crate) data: String,
+}
+
+/// An event grew past [`MAX_EVENT_BYTES`] without being terminated.
+#[derive(Debug)]
+pub(crate) struct OversizedEvent {
+    /// How many bytes had accumulated when the decoder gave up.
+    pub(crate) bytes: usize,
+}
+
+/// Reassembles [`SseEvent`]s from a byte stream delivered in arbitrary pieces.
+#[derive(Debug, Default)]
+pub(crate) struct SseDecoder {
+    /// Bytes received that are not yet a complete line.
+    pending: Vec<u8>,
+    /// The `event:` field of the event being accumulated.
+    name: Option<String>,
+    /// The `data:` fields of the event being accumulated, already joined.
+    data: String,
+    /// Whether any field has been read since the last dispatch. Distinguishes a blank line
+    /// that ends an event from one that separates two events, so a keep-alive comment
+    /// followed by a blank line does not dispatch an empty event.
+    started: bool,
+}
+
+impl SseDecoder {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Take another piece of the stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OversizedEvent`] if a single event has grown past [`MAX_EVENT_BYTES`]
+    /// without being terminated.
+    pub(crate) fn push(&mut self, bytes: &[u8]) -> Result<(), OversizedEvent> {
+        self.pending.extend_from_slice(bytes);
+
+        let buffered = self.pending.len() + self.data.len();
+        if buffered > MAX_EVENT_BYTES {
+            return Err(OversizedEvent { bytes: buffered });
+        }
+
+        Ok(())
+    }
+
+    /// Yield the next event that has arrived in full, if any.
+    ///
+    /// Call this until it returns `None`: one read can carry several events.
+    pub(crate) fn next_event(&mut self) -> Option<SseEvent> {
+        while let Some(line) = self.take_line() {
+            if let Some(event) = self.read_field(&line) {
+                return Some(event);
+            }
+        }
+
+        None
+    }
+
+    /// Dispatch what the stream left unterminated at its end.
+    ///
+    /// The standard discards an event the stream did not terminate. That rule protects a
+    /// consumer that acts on partial data, which this one does not — the payload still has
+    /// to parse as a whole — so the final event of a server that closes without its blank
+    /// line is kept rather than lost, and a genuinely truncated one surfaces as a parse
+    /// failure rather than as a quietly shorter answer.
+    pub(crate) fn finish(&mut self) -> Option<SseEvent> {
+        if !self.pending.is_empty() {
+            let line = String::from_utf8_lossy(&self.pending).into_owned();
+            self.pending.clear();
+            if let Some(event) = self.read_field(&line) {
+                return Some(event);
+            }
+        }
+
+        self.started.then(|| self.dispatch())
+    }
+
+    /// Split off the next complete line, without its terminator.
+    fn take_line(&mut self) -> Option<String> {
+        let end = self.pending.iter().position(|byte| *byte == b'\n')?;
+        let mut line: Vec<u8> = self.pending.drain(..=end).collect();
+
+        line.pop();
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+
+        Some(String::from_utf8_lossy(&line).into_owned())
+    }
+
+    /// Apply one line to the event being accumulated, returning an event if it ended one.
+    fn read_field(&mut self, line: &str) -> Option<SseEvent> {
+        if line.is_empty() {
+            return self.started.then(|| self.dispatch());
+        }
+
+        // A comment. The runtime's keep-alive is one of these: it says the connection is up,
+        // not that anything has been produced, so it must not start an event.
+        if line.starts_with(':') {
+            return None;
+        }
+
+        let (field, value) = match line.split_once(':') {
+            // The standard strips a single leading space, and only one.
+            Some((field, value)) => (field, value.strip_prefix(' ').unwrap_or(value)),
+            // A field with no colon carries an empty value.
+            None => (line, ""),
+        };
+
+        match field {
+            "data" => {
+                self.started = true;
+                if !self.data.is_empty() {
+                    self.data.push('\n');
+                }
+                self.data.push_str(value);
+            }
+            "event" => {
+                self.started = true;
+                self.name = Some(value.to_string());
+            }
+            // `id` and `retry` steer reconnection, which this client does not do. Unknown
+            // fields are ignored by the standard.
+            _ => {}
+        }
+
+        None
+    }
+
+    /// Emit the accumulated event and reset for the next one.
+    fn dispatch(&mut self) -> SseEvent {
+        self.started = false;
+
+        SseEvent {
+            name: self.name.take(),
+            data: std::mem::take(&mut self.data),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feed `pieces` to a decoder in order and collect everything it dispatches, including
+    /// the tail. The split between pieces is what each test is varying.
+    fn decode(pieces: &[&str]) -> Vec<SseEvent> {
+        let mut decoder = SseDecoder::new();
+        let mut events = Vec::new();
+
+        for piece in pieces {
+            decoder
+                .push(piece.as_bytes())
+                .expect("test payloads are far below the size cap");
+            while let Some(event) = decoder.next_event() {
+                events.push(event);
+            }
+        }
+
+        events.extend(decoder.finish());
+        events
+    }
+
+    fn data_of(events: &[SseEvent]) -> Vec<&str> {
+        events.iter().map(|event| event.data.as_str()).collect()
+    }
+
+    #[test]
+    fn an_event_delivered_whole_is_dispatched() {
+        let events = decode(&["data: {\"a\":1}\n\n"]);
+
+        assert_eq!(data_of(&events), vec!["{\"a\":1}"]);
+        assert_eq!(events[0].name, None);
+    }
+
+    /// The defect this module exists for: the same event, split mid-payload across two
+    /// reads. Reading each read as whole lines drops both halves — the first is truncated
+    /// JSON, the second has no `data:` prefix.
+    #[test]
+    fn an_event_split_mid_payload_survives() {
+        let events = decode(&["data: {\"cho", "ices\":[]}\n\n"]);
+
+        assert_eq!(data_of(&events), vec!["{\"choices\":[]}"]);
+    }
+
+    #[test]
+    fn an_event_split_inside_its_field_name_survives() {
+        let events = decode(&["da", "ta: hello\n\n"]);
+
+        assert_eq!(data_of(&events), vec!["hello"]);
+    }
+
+    #[test]
+    fn an_event_split_between_its_payload_and_its_terminator_survives() {
+        let events = decode(&["data: hello\n", "\n"]);
+
+        assert_eq!(data_of(&events), vec!["hello"]);
+    }
+
+    /// A multi-byte character split across two reads must be reassembled, not replaced.
+    /// Decoding each read on its own turns the halves into U+FFFD.
+    #[test]
+    fn a_character_split_across_reads_is_reassembled() {
+        let snowman = "☃".as_bytes();
+        let mut decoder = SseDecoder::new();
+
+        decoder
+            .push(b"data: ")
+            .expect("the payload is far below the size cap");
+        decoder
+            .push(&snowman[..1])
+            .expect("the payload is far below the size cap");
+        assert!(decoder.next_event().is_none());
+        decoder
+            .push(&snowman[1..])
+            .expect("the payload is far below the size cap");
+        decoder
+            .push(b"\n\n")
+            .expect("the payload is far below the size cap");
+
+        let event = decoder.next_event().expect("the event is complete");
+        assert_eq!(event.data, "☃");
+    }
+
+    #[test]
+    fn several_events_in_one_read_are_all_dispatched() {
+        let events = decode(&["data: one\n\ndata: two\n\ndata: three\n\n"]);
+
+        assert_eq!(data_of(&events), vec!["one", "two", "three"]);
+    }
+
+    #[test]
+    fn a_comment_does_not_dispatch_an_event() {
+        let events = decode(&[": keep-alive\n\n", "data: real\n\n"]);
+
+        assert_eq!(data_of(&events), vec!["real"]);
+    }
+
+    #[test]
+    fn an_event_name_is_reported_with_its_payload() {
+        let events = decode(&["event: error\ndata: {\"message\":\"boom\"}\n\n"]);
+
+        assert_eq!(events[0].name.as_deref(), Some("error"));
+        assert_eq!(events[0].data, "{\"message\":\"boom\"}");
+    }
+
+    #[test]
+    fn a_name_does_not_carry_over_to_the_next_event() {
+        let events = decode(&["event: error\ndata: first\n\n", "data: second\n\n"]);
+
+        assert_eq!(events[0].name.as_deref(), Some("error"));
+        assert_eq!(events[1].name, None);
+    }
+
+    /// The standard joins repeated `data:` fields with a newline.
+    #[test]
+    fn repeated_data_fields_are_joined_with_newlines() {
+        let events = decode(&["data: one\ndata: two\n\n"]);
+
+        assert_eq!(data_of(&events), vec!["one\ntwo"]);
+    }
+
+    #[test]
+    fn crlf_terminators_are_accepted() {
+        let events = decode(&["data: hello\r\n\r\n"]);
+
+        assert_eq!(data_of(&events), vec!["hello"]);
+    }
+
+    /// Only one leading space is stripped, so a payload's own indentation survives.
+    #[test]
+    fn only_one_leading_space_is_stripped_from_a_value() {
+        let events = decode(&["data:  padded\n\n"]);
+
+        assert_eq!(data_of(&events), vec![" padded"]);
+    }
+
+    #[test]
+    fn a_field_with_no_value_is_read_as_empty() {
+        let events = decode(&["data\n\n"]);
+
+        assert_eq!(data_of(&events), vec![""]);
+    }
+
+    /// A server that closes without its final blank line still gets its last event read.
+    #[test]
+    fn an_unterminated_final_event_is_dispatched_at_the_end() {
+        let events = decode(&["data: last"]);
+
+        assert_eq!(data_of(&events), vec!["last"]);
+    }
+
+    #[test]
+    fn a_stream_that_ends_cleanly_dispatches_nothing_extra() {
+        let events = decode(&["data: only\n\n"]);
+
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn a_stream_of_only_comments_dispatches_nothing() {
+        let events = decode(&[": one\n", ": two\n"]);
+
+        assert!(events.is_empty());
+    }
+
+    /// A stream that never terminates a line must not grow the buffer without bound.
+    #[test]
+    fn an_event_past_the_size_cap_is_refused() {
+        let mut decoder = SseDecoder::new();
+        let mut pushed = 0usize;
+
+        loop {
+            let chunk = vec![b'x'; 1024 * 1024];
+            match decoder.push(&chunk) {
+                Ok(()) => pushed += chunk.len(),
+                Err(oversized) => {
+                    assert!(oversized.bytes > MAX_EVENT_BYTES);
+                    assert!(pushed <= MAX_EVENT_BYTES);
+                    return;
+                }
+            }
+            assert!(
+                pushed <= MAX_EVENT_BYTES,
+                "the decoder buffered {pushed} bytes without refusing"
+            );
+        }
+    }
+}

--- a/bin/spice/src/sse.rs
+++ b/bin/spice/src/sse.rs
@@ -29,10 +29,15 @@ limitations under the License.
 //!
 //! The field grammar is the one from the [HTML standard](https://html.spec.whatwg.org/multipage/server-sent-events.html):
 //! a line of `field: value`, a comment line starting with `:`, and a blank line ending the
-//! event. Line terminators are `\n` and `\r\n`; a lone `\r`, which the standard also allows
-//! but which nothing in this stack emits, is treated as part of the line rather than as a
-//! terminator — recognising it would mean a server that never sends `\n` could hold the
-//! decoder's buffer open indefinitely.
+//! event. All three terminators the standard allows are accepted — `\n`, `\r\n` and a lone
+//! `\r`. The last is not hypothetical: axum's `Event::data` writes the payload's own line
+//! breaks through verbatim, so a value containing a `\r` is framed with one
+//! (`axum::response::sse`, `EventDataWriter::write_buf`), and `sse-starlette`, which serves
+//! many OpenAI-compatible endpoints, can be configured to separate with `\r` throughout.
+//!
+//! Dispatch follows the standard too: a blank line ends an event only if a `data` field was
+//! seen. A frame carrying just `event: ping` is *not* an event — dispatching one would tell
+//! the caller the stream is producing when it is not.
 
 /// The most bytes one event may occupy before the decoder refuses to keep buffering.
 ///
@@ -60,17 +65,32 @@ pub(crate) struct OversizedEvent {
 /// Reassembles [`SseEvent`]s from a byte stream delivered in arbitrary pieces.
 #[derive(Debug, Default)]
 pub(crate) struct SseDecoder {
-    /// Bytes received that are not yet a complete line.
+    /// Bytes received but not yet handed out. Lines are taken by advancing `cursor` rather
+    /// than by draining, so a read carrying many events costs one compaction and not one
+    /// memmove of the remainder per event.
     pending: Vec<u8>,
+    /// How much of `pending` has already been read out.
+    cursor: usize,
     /// The `event:` field of the event being accumulated.
     name: Option<String>,
     /// The `data:` fields of the event being accumulated, already joined.
     data: String,
-    /// Whether any field has been read since the last dispatch. Distinguishes a blank line
-    /// that ends an event from one that separates two events, so a keep-alive comment
-    /// followed by a blank line does not dispatch an empty event.
-    started: bool,
+    /// Whether a `data` field has been read since the last dispatch. The standard dispatches
+    /// on a blank line only when the data buffer has been written to, so a frame of nothing
+    /// but `event:` or a comment ends no event.
+    data_seen: bool,
+    /// How many `data` fields have been read in total. A caller bounding the stream's
+    /// liveness uses this to tell a partly-received event from a stalled one.
+    data_fields: u64,
+    /// Whether a leading byte-order mark has been dealt with.
+    bom_checked: bool,
+    /// Whether the stream has ended, so a held-back `\r` is a terminator rather than half of
+    /// a `\r\n` still arriving.
+    at_eof: bool,
 }
+
+/// The byte-order mark the standard requires be stripped from the head of the stream.
+const BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
 
 impl SseDecoder {
     pub(crate) fn new() -> Self {
@@ -78,71 +98,141 @@ impl SseDecoder {
     }
 
     /// Take another piece of the stream.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`OversizedEvent`] if a single event has grown past [`MAX_EVENT_BYTES`]
-    /// without being terminated.
-    pub(crate) fn push(&mut self, bytes: &[u8]) -> Result<(), OversizedEvent> {
+    pub(crate) fn push(&mut self, bytes: &[u8]) {
+        self.compact();
         self.pending.extend_from_slice(bytes);
+        self.strip_bom();
+    }
 
-        let buffered = self.pending.len() + self.data.len();
-        if buffered > MAX_EVENT_BYTES {
-            return Err(OversizedEvent { bytes: buffered });
+    /// Drop what has already been read out, so the buffer holds only the unread remainder.
+    fn compact(&mut self) {
+        if self.cursor > 0 {
+            self.pending.drain(..self.cursor);
+            self.cursor = 0;
+        }
+    }
+
+    /// The bytes received but not yet read out.
+    fn unread(&self) -> &[u8] {
+        &self.pending[self.cursor..]
+    }
+
+    /// Tell the decoder that no more bytes are coming, so what it is holding is all there is.
+    pub(crate) fn close(&mut self) {
+        self.at_eof = true;
+    }
+
+    /// Whether one unterminated event has grown past [`MAX_EVENT_BYTES`].
+    ///
+    /// Ask this only after draining with [`SseDecoder::next_event`]: before that the buffer
+    /// also holds whole events waiting to be read, and one transport read may carry many of
+    /// them. The limit is on an event the stream never ends, not on how much arrives at once.
+    pub(crate) fn oversized(&self) -> Option<OversizedEvent> {
+        let buffered = self.unread().len() + self.data.len();
+        (buffered > MAX_EVENT_BYTES).then_some(OversizedEvent { bytes: buffered })
+    }
+
+    /// How many `data` fields have been read so far.
+    ///
+    /// This advances when a data line is read, not when the event it belongs to is
+    /// dispatched, so a caller can tell a large event still arriving from a stalled stream.
+    pub(crate) fn data_fields_seen(&self) -> u64 {
+        self.data_fields
+    }
+
+    /// Drop a leading BOM, waiting for as many bytes as it takes to know there is not one.
+    fn strip_bom(&mut self) {
+        if self.bom_checked {
+            return;
         }
 
-        Ok(())
+        if self.unread().len() >= BOM.len() {
+            if self.unread().starts_with(&BOM) {
+                self.cursor += BOM.len();
+            }
+            self.bom_checked = true;
+        } else if !BOM.starts_with(self.unread()) {
+            // What has arrived already rules a BOM out.
+            self.bom_checked = true;
+        }
     }
 
     /// Yield the next event that has arrived in full, if any.
     ///
-    /// Call this until it returns `None`: one read can carry several events.
-    pub(crate) fn next_event(&mut self) -> Option<SseEvent> {
-        while let Some(line) = self.take_line() {
-            if let Some(event) = self.read_field(&line) {
-                return Some(event);
-            }
-        }
-
-        None
-    }
-
-    /// Dispatch what the stream left unterminated at its end.
+    /// Call this until it returns `None`: one read can carry several events. After
+    /// [`SseDecoder::close`] it also yields what the stream left unterminated at its end.
     ///
-    /// The standard discards an event the stream did not terminate. That rule protects a
-    /// consumer that acts on partial data, which this one does not — the payload still has
-    /// to parse as a whole — so the final event of a server that closes without its blank
-    /// line is kept rather than lost, and a genuinely truncated one surfaces as a parse
-    /// failure rather than as a quietly shorter answer.
-    pub(crate) fn finish(&mut self) -> Option<SseEvent> {
-        if !self.pending.is_empty() {
-            let line = String::from_utf8_lossy(&self.pending).into_owned();
-            self.pending.clear();
+    /// The standard discards an event the stream did not terminate. That rule guards a
+    /// consumer that would act on half a payload; this one cannot, because the payload still
+    /// has to parse as a whole. And the tail is only reached after a *complete* HTTP body —
+    /// a body cut short surfaces as a transport error before the stream ends — so a server
+    /// that simply closed without its final blank line has its last event read rather than
+    /// dropped, while a genuinely truncated payload still fails to parse.
+    pub(crate) fn next_event(&mut self) -> Option<SseEvent> {
+        loop {
+            while let Some(line) = self.take_line() {
+                if let Some(event) = self.read_field(&line) {
+                    return Some(event);
+                }
+            }
+
+            if !self.at_eof {
+                return None;
+            }
+
+            if self.unread().is_empty() {
+                return self.data_seen.then(|| self.dispatch());
+            }
+
+            let line = String::from_utf8_lossy(self.unread()).into_owned();
+            self.cursor = self.pending.len();
             if let Some(event) = self.read_field(&line) {
                 return Some(event);
             }
         }
-
-        self.started.then(|| self.dispatch())
     }
 
     /// Split off the next complete line, without its terminator.
+    ///
+    /// All three terminators the standard allows are recognised. A `\r` at the very end of
+    /// the buffer is held back rather than treated as a line ending: the `\n` that would
+    /// make it a `\r\n` may be in the next read, and splitting the pair would invent a blank
+    /// line that ends an event early. Once the stream is closed there is no next read, so the
+    /// `\r` is a terminator of its own.
     fn take_line(&mut self) -> Option<String> {
-        let end = self.pending.iter().position(|byte| *byte == b'\n')?;
-        let mut line: Vec<u8> = self.pending.drain(..=end).collect();
+        let unread = self.unread();
+        let end = unread
+            .iter()
+            .position(|byte| *byte == b'\n' || *byte == b'\r')?;
 
-        line.pop();
-        if line.last() == Some(&b'\r') {
-            line.pop();
+        let carriage_return = unread[end] == b'\r';
+        if carriage_return && end + 1 == unread.len() && !self.at_eof {
+            return None;
         }
 
-        Some(String::from_utf8_lossy(&line).into_owned())
+        let terminator = if carriage_return && unread.get(end + 1) == Some(&b'\n') {
+            2
+        } else {
+            1
+        };
+
+        let line = String::from_utf8_lossy(&unread[..end]).into_owned();
+        self.cursor += end + terminator;
+
+        Some(line)
     }
 
     /// Apply one line to the event being accumulated, returning an event if it ended one.
     fn read_field(&mut self, line: &str) -> Option<SseEvent> {
         if line.is_empty() {
-            return self.started.then(|| self.dispatch());
+            if self.data_seen {
+                return Some(self.dispatch());
+            }
+
+            // The standard clears the buffers and dispatches nothing when the data buffer is
+            // empty, so a frame of only `event:` or comments is not an event.
+            self.name = None;
+            return None;
         }
 
         // A comment. The runtime's keep-alive is one of these: it says the connection is up,
@@ -160,14 +250,14 @@ impl SseDecoder {
 
         match field {
             "data" => {
-                self.started = true;
-                if !self.data.is_empty() {
+                if self.data_seen {
                     self.data.push('\n');
                 }
+                self.data_seen = true;
+                self.data_fields += 1;
                 self.data.push_str(value);
             }
             "event" => {
-                self.started = true;
                 self.name = Some(value.to_string());
             }
             // `id` and `retry` steer reconnection, which this client does not do. Unknown
@@ -180,7 +270,7 @@ impl SseDecoder {
 
     /// Emit the accumulated event and reset for the next one.
     fn dispatch(&mut self) -> SseEvent {
-        self.started = false;
+        self.data_seen = false;
 
         SseEvent {
             name: self.name.take(),
@@ -200,15 +290,20 @@ mod tests {
         let mut events = Vec::new();
 
         for piece in pieces {
-            decoder
-                .push(piece.as_bytes())
-                .expect("test payloads are far below the size cap");
+            decoder.push(piece.as_bytes());
             while let Some(event) = decoder.next_event() {
                 events.push(event);
             }
+            assert!(
+                decoder.oversized().is_none(),
+                "test payloads are far below the size cap"
+            );
         }
 
-        events.extend(decoder.finish());
+        decoder.close();
+        while let Some(event) = decoder.next_event() {
+            events.push(event);
+        }
         events
     }
 
@@ -255,19 +350,11 @@ mod tests {
         let snowman = "☃".as_bytes();
         let mut decoder = SseDecoder::new();
 
-        decoder
-            .push(b"data: ")
-            .expect("the payload is far below the size cap");
-        decoder
-            .push(&snowman[..1])
-            .expect("the payload is far below the size cap");
+        decoder.push(b"data: ");
+        decoder.push(&snowman[..1]);
         assert!(decoder.next_event().is_none());
-        decoder
-            .push(&snowman[1..])
-            .expect("the payload is far below the size cap");
-        decoder
-            .push(b"\n\n")
-            .expect("the payload is far below the size cap");
+        decoder.push(&snowman[1..]);
+        decoder.push(b"\n\n");
 
         let event = decoder.next_event().expect("the event is complete");
         assert_eq!(event.data, "☃");
@@ -361,20 +448,136 @@ mod tests {
         let mut decoder = SseDecoder::new();
         let mut pushed = 0usize;
 
-        loop {
+        while decoder.oversized().is_none() {
             let chunk = vec![b'x'; 1024 * 1024];
-            match decoder.push(&chunk) {
-                Ok(()) => pushed += chunk.len(),
-                Err(oversized) => {
-                    assert!(oversized.bytes > MAX_EVENT_BYTES);
-                    assert!(pushed <= MAX_EVENT_BYTES);
-                    return;
-                }
-            }
+            decoder.push(&chunk);
+            pushed += chunk.len();
             assert!(
-                pushed <= MAX_EVENT_BYTES,
+                pushed <= MAX_EVENT_BYTES + chunk.len(),
                 "the decoder buffered {pushed} bytes without refusing"
             );
         }
+
+        let oversized = decoder.oversized().expect("the loop ended on the cap");
+        assert!(oversized.bytes > MAX_EVENT_BYTES);
+    }
+
+    /// The cap bounds one unterminated event, not one transport read. A read that happens to
+    /// carry many whole small events is ordinary, and rejecting it would report an event the
+    /// stream never ended when in fact every event ended.
+    #[test]
+    fn many_whole_events_in_one_read_are_not_over_the_cap() {
+        let event = "data: {\"choices\":[]}\n\n";
+        let repeats = (MAX_EVENT_BYTES / event.len()) + 16;
+        let mut decoder = SseDecoder::new();
+
+        decoder.push(event.repeat(repeats).as_bytes());
+
+        let mut dispatched = 0usize;
+        while decoder.next_event().is_some() {
+            dispatched += 1;
+        }
+
+        assert_eq!(dispatched, repeats);
+        assert!(
+            decoder.oversized().is_none(),
+            "every event was terminated, so nothing is over the cap"
+        );
+    }
+
+    /// A frame carrying no `data` field is not an event. Dispatching one would tell a caller
+    /// that bounds liveness by events that the stream is producing when it is not.
+    #[test]
+    fn a_frame_with_only_an_event_name_dispatches_nothing() {
+        let events = decode(&["event: ping\n\n", "event: ping\n\n"]);
+
+        assert!(events.is_empty(), "got {events:?}");
+    }
+
+    /// ...and the name it carried must not leak onto the next event.
+    #[test]
+    fn a_name_from_an_undispatched_frame_does_not_leak() {
+        let events = decode(&["event: ping\n\n", "data: real\n\n"]);
+
+        assert_eq!(data_of(&events), vec!["real"]);
+        assert_eq!(events[0].name, None);
+    }
+
+    /// axum writes a payload's own line breaks through verbatim, so a value containing a
+    /// carriage return is framed with a lone `\r`.
+    #[test]
+    fn a_lone_carriage_return_terminates_a_line() {
+        let events = decode(&["data: one\rdata: two\r\r"]);
+
+        assert_eq!(data_of(&events), vec!["one\ntwo"]);
+    }
+
+    /// A `\r` at the end of a read may be the first half of a `\r\n` still arriving.
+    /// Splitting the pair would invent a blank line and end the event early.
+    #[test]
+    fn a_carriage_return_split_from_its_newline_is_not_a_blank_line() {
+        let events = decode(&["data: whole\r", "\ndata: same event\r\n\r\n"]);
+
+        assert_eq!(data_of(&events), vec!["whole\nsame event"]);
+    }
+
+    /// Once the stream is closed there is no next read, so a held-back `\r` is a terminator.
+    #[test]
+    fn a_trailing_carriage_return_at_the_end_of_the_stream_is_a_terminator() {
+        let events = decode(&["data: last\r"]);
+
+        assert_eq!(data_of(&events), vec!["last"]);
+    }
+
+    /// The standard strips a byte-order mark from the head of the stream. Reading it as part
+    /// of the first field name would silently empty the first event.
+    #[test]
+    fn a_leading_byte_order_mark_is_stripped() {
+        let events = decode(&["\u{feff}data: first\n\n"]);
+
+        assert_eq!(data_of(&events), vec!["first"]);
+    }
+
+    #[test]
+    fn a_byte_order_mark_split_across_reads_is_stripped() {
+        let bom = "\u{feff}".as_bytes();
+        let mut decoder = SseDecoder::new();
+
+        decoder.push(&bom[..1]);
+        decoder.push(&bom[1..]);
+        decoder.push(b"data: first\n\n");
+
+        let event = decoder.next_event().expect("the event is complete");
+        assert_eq!(event.data, "first");
+    }
+
+    /// Only at the head of the stream: the same bytes later are the payload's own.
+    #[test]
+    fn a_byte_order_mark_inside_a_payload_is_kept() {
+        let events = decode(&["data: first\n\n", "data: \u{feff}second\n\n"]);
+
+        assert_eq!(data_of(&events), vec!["first", "\u{feff}second"]);
+    }
+
+    /// Progress is a `data` line arriving, not an event completing -- a caller bounding
+    /// liveness must be able to see a large event still being received.
+    #[test]
+    fn a_data_line_counts_as_progress_before_its_event_ends() {
+        let mut decoder = SseDecoder::new();
+        assert_eq!(decoder.data_fields_seen(), 0);
+
+        decoder.push(b"data: still arriving\n");
+        assert!(decoder.next_event().is_none(), "the event has not ended");
+        assert_eq!(
+            decoder.data_fields_seen(),
+            1,
+            "a data line arrived, so the stream is producing"
+        );
+
+        // A comment is not progress: it says the connection is up, not that anything is
+        // being produced.
+        decoder.push(b": keep-alive\n");
+        while decoder.next_event().is_some() {}
+        assert_eq!(decoder.data_fields_seen(), 1);
     }
 }

--- a/bin/spice/src/test_support.rs
+++ b/bin/spice/src/test_support.rs
@@ -31,20 +31,30 @@ use std::time::Duration;
 /// How the server answers a connection.
 #[derive(Debug, Clone)]
 enum Behaviour {
-    /// Send the response head, then each body chunk with `gap` of quiet before it.
-    ///
-    /// When `then_hold` is set the connection is held open afterwards instead of being
-    /// closed, so a client that waits for EOF rather than for the protocol's own terminator
-    /// is left waiting.
+    /// Send the response head, then each body chunk with `gap` of quiet before it, and
+    /// finish the way `ending` says.
     Dribble {
-        chunks: Vec<String>,
+        chunks: Vec<Vec<u8>>,
         gap: Duration,
-        then_hold: bool,
+        ending: Ending,
     },
     /// Send the response head and then nothing at all, holding the connection open.
     StallAfterHead,
     /// Send nothing at all, not even the response head, holding the connection open.
     StallBeforeHead,
+}
+
+/// How a dribbling response ends once its chunks are sent.
+#[derive(Debug, Clone, Copy)]
+enum Ending {
+    /// End the chunked body properly and hang up.
+    Close,
+    /// Hold the connection open, so a client that waits for EOF rather than for the
+    /// protocol's own terminator is left waiting.
+    Hold,
+    /// Hang up without the terminating chunk, so the body the client is reading stops
+    /// part-way through — a truncated response on an already-successful status.
+    Truncate,
 }
 
 /// An HTTP/1.1 server that answers every connection the same slow way.
@@ -65,10 +75,16 @@ impl SlowServer {
     /// The response is therefore never quiet for longer than `gap`, but takes
     /// `gap * chunks.len()` in total — the shape that separates the two deadlines.
     pub(crate) fn dribbling(chunks: Vec<String>, gap: Duration) -> Self {
+        Self::dribbling_bytes(chunks.into_iter().map(String::into_bytes).collect(), gap)
+    }
+
+    /// As [`SlowServer::dribbling`], but with chunks that need not each be valid UTF-8 — the
+    /// shape a test needs to split a multi-byte character across two reads.
+    pub(crate) fn dribbling_bytes(chunks: Vec<Vec<u8>>, gap: Duration) -> Self {
         Self::start(Behaviour::Dribble {
             chunks,
             gap,
-            then_hold: false,
+            ending: Ending::Close,
         })
     }
 
@@ -76,9 +92,19 @@ impl SlowServer {
     /// rather than closing it — a server under no obligation to hang up promptly.
     pub(crate) fn dribbling_then_holding(chunks: Vec<String>, gap: Duration) -> Self {
         Self::start(Behaviour::Dribble {
-            chunks,
+            chunks: chunks.into_iter().map(String::into_bytes).collect(),
             gap,
-            then_hold: true,
+            ending: Ending::Hold,
+        })
+    }
+
+    /// Send `chunks` and then hang up without ending the chunked body, so the client's read
+    /// of an otherwise-successful response fails part-way through.
+    pub(crate) fn truncating(chunks: Vec<String>, gap: Duration) -> Self {
+        Self::start(Behaviour::Dribble {
+            chunks: chunks.into_iter().map(String::into_bytes).collect(),
+            gap,
+            ending: Ending::Truncate,
         })
     }
 
@@ -202,21 +228,26 @@ fn serve(
         Behaviour::Dribble {
             chunks,
             gap,
-            then_hold,
+            ending,
         } => {
             for chunk in chunks {
                 thread::sleep(*gap);
                 // Chunked transfer encoding: the length in hex, then the bytes.
-                let framed = format!("{:x}\r\n{chunk}\r\n", chunk.len());
-                if writer.write_all(framed.as_bytes()).is_err() || writer.flush().is_err() {
+                let mut framed = format!("{:x}\r\n", chunk.len()).into_bytes();
+                framed.extend_from_slice(chunk);
+                framed.extend_from_slice(b"\r\n");
+                if writer.write_all(&framed).is_err() || writer.flush().is_err() {
                     return;
                 }
             }
-            if *then_hold {
-                hold_open(running);
-            } else {
-                let _ = writer.write_all(b"0\r\n\r\n");
-                let _ = writer.flush();
+            match ending {
+                Ending::Hold => hold_open(running),
+                Ending::Close => {
+                    let _ = writer.write_all(b"0\r\n\r\n");
+                    let _ = writer.flush();
+                }
+                // Nothing more is written: the body stops mid-stream.
+                Ending::Truncate => {}
             }
         }
         Behaviour::StallAfterHead => hold_open(running),

--- a/bin/spice/src/test_support.rs
+++ b/bin/spice/src/test_support.rs
@@ -75,7 +75,7 @@ impl SlowServer {
     /// The response is therefore never quiet for longer than `gap`, but takes
     /// `gap * chunks.len()` in total — the shape that separates the two deadlines.
     pub(crate) fn dribbling(chunks: Vec<String>, gap: Duration) -> Self {
-        Self::dribbling_bytes(chunks.into_iter().map(String::into_bytes).collect(), gap)
+        Self::dribble(chunks, gap, Ending::Close)
     }
 
     /// As [`SlowServer::dribbling`], but with chunks that need not each be valid UTF-8 — the
@@ -88,24 +88,24 @@ impl SlowServer {
         })
     }
 
-    /// As [`SlowServer::dribbling`], but hold the connection open once the chunks are sent
-    /// rather than closing it — a server under no obligation to hang up promptly.
-    pub(crate) fn dribbling_then_holding(chunks: Vec<String>, gap: Duration) -> Self {
+    fn dribble(chunks: Vec<String>, gap: Duration, ending: Ending) -> Self {
         Self::start(Behaviour::Dribble {
             chunks: chunks.into_iter().map(String::into_bytes).collect(),
             gap,
-            ending: Ending::Hold,
+            ending,
         })
+    }
+
+    /// As [`SlowServer::dribbling`], but hold the connection open once the chunks are sent
+    /// rather than closing it — a server under no obligation to hang up promptly.
+    pub(crate) fn dribbling_then_holding(chunks: Vec<String>, gap: Duration) -> Self {
+        Self::dribble(chunks, gap, Ending::Hold)
     }
 
     /// Send `chunks` and then hang up without ending the chunked body, so the client's read
     /// of an otherwise-successful response fails part-way through.
     pub(crate) fn truncating(chunks: Vec<String>, gap: Duration) -> Self {
-        Self::start(Behaviour::Dribble {
-            chunks: chunks.into_iter().map(String::into_bytes).collect(),
-            gap,
-            ending: Ending::Truncate,
-        })
+        Self::dribble(chunks, gap, Ending::Truncate)
     }
 
     /// Answer each request with a response head and then silence, so a deadline is exercised


### PR DESCRIPTION
## Summary

Two ways the CLI turned lost data into a result that looks complete. They are one shape —
a read that did not deliver everything, reported as a whole answer — so they move together.

**A streamed answer was parsed one network read at a time.** `send_chat_streaming` took each
chunk from `bytes_stream()` and ran `text.lines()` over it, which assumes a read carries a
whole number of lines. Nothing in HTTP or SSE promises that. When an event straddled two
reads it was discarded twice over: the leading fragment is a `data:` line holding truncated
JSON, which `serde_json::from_str` rejected inside an `if let Ok(..)` that dropped it without
a word; the trailing fragment has no `data:` prefix, so it was skipped. The token disappeared
from the printed answer *and* from `full_response` — what `--output json` returns and what the
history keeps — with no error, no warning and no change of exit code. `String::from_utf8_lossy`
per chunk compounded it: a multi-byte character split across a boundary became U+FFFD.

**The same loop discarded every event it could not read as a chat completion.** That includes
the one the runtime sends when a stream fails part-way through: `create_sse_response` emits
`to_openai_error_event` as an `error`-named event carrying `{"type":…,"message":…}`
(`crates/runtime/src/http/v1/chat.rs`). `ChatChunk` requires `choices`, so that payload never
deserialized and the report of the failure was thrown away — leaving the user a truncated
answer presented as a finished one. Found while fixing the framing; it is the sharpest
instance of the same shape, so it is fixed here rather than filed.

**Three commands read a successful body with `unwrap_or_default`.** A read that stopped
part-way — a deadline firing mid-response, a reset connection, a truncated response — became
an empty string under a `200`. `spice nsql` returned it verbatim as the translated SQL; `spice
search` fell through to `serde_json::from_str("")` and reported `EOF while parsing a value at
line 1 column 0`, which names neither the cause nor the endpoint.

Fixes #12588
Fixes #12587

## Changes

- **`bin/spice/src/sse.rs` (new)** — `SseDecoder` buffers bytes and yields only events it has
  seen the end of, following the field grammar in the HTML standard (`field: value`, `:`
  comments, blank line ends the event, repeated `data:` joined with newlines). Holding bytes
  rather than decoding per read also reassembles a split character: `\n` cannot occur inside a
  multi-byte UTF-8 sequence, so a line boundary is always a character boundary. A single
  unterminated event is capped at 8 MiB so a server that never sends a terminator cannot grow
  the buffer without bound.
- **`chat.rs`** — reads through the decoder; the per-event work moves into `apply_event`. An
  `error` event, and any payload that is not a chat completion, is now reported with the
  server's own reason and a note that whatever was printed is incomplete. An event with no
  payload stays a no-op. At EOF the decoder's tail is dispatched, so a server that hangs up
  without its final blank line does not lose its last event.
- **`error.rs`** — `read_response` returns `(status, body)`, propagating a read failure on a
  success status as a new `ResponseIncomplete` naming the endpoint, and leaving the error
  branches alone: there the body only decorates a message that already reports the failure, so
  a body that could not be read must not replace the status the caller is about to report.
- **`nsql/mod.rs`, `nsql/analyze.rs`, `search.rs`** — the three success-branch reads use it.
- **`test_support.rs`** — `SlowServer` chunks are bytes, so a test can split a character
  across two reads without the fixture replacing it first; adds `truncating` (hang up without
  ending the chunked body) alongside the existing endings.

The `unwrap_or_default()` calls on error branches (`error.rs`, `github/mod.rs`, the `login`
sites, `trace.rs`, `chat.rs`'s non-2xx branch, `crates/repl/src/util.rs`) were checked and left
as they are — each is on a path that already reports a failure.

## What adversarial review changed

The first version of this fix was wrong in four ways that the review caught, all of them now
pinned by neuters:

- **A choice with no `delta` was treated as unreadable.** Azure OpenAI's asynchronous content
  filtering emits annotation choices holding only `content_filter_results`, on passing streams
  as well as filtered ones. Since an unreadable event now stops the stream, that would have
  lost every token after the first annotation — a regression against the old loop, which
  skipped them. `delta` is optional; `choices` remains what separates a completion from an
  error envelope.
- **A frame carrying only `event:` was dispatched.** The standard dispatches on a blank line
  only when the data buffer has been written to. The difference is load-bearing here: an empty
  event reset the progress deadline, so `event: ping` every 20 seconds would have held the CLI
  open indefinitely — defeating the liveness bound #12589 exists to provide.
- **Progress was recorded only when an event completed**, so one multiline event spread across
  reads timed out despite data arriving throughout. It is now recorded when a data line
  arrives; a comment carries no data field, so a keep-alive still cannot hold the stream open.
- **The size cap was checked before draining**, so one read carrying many small whole events
  was rejected as a single unterminated one.

Two framing gaps the review also named are fixed: a leading BOM left the first event empty,
and a lone `\r` was not treated as a terminator — axum writes a payload's own line breaks
through verbatim (`EventDataWriter::write_buf`), and `sse-starlette`, which serves many
OpenAI-compatible endpoints, can be configured to separate with `\r` throughout.

Taking lines by advancing a cursor rather than draining the buffer also made the decoder
linear: the test that puts 8 MiB of small events through one read went from 69s to 0.24s.

## Filed rather than fixed here

- **#12596** — `spice chat` never reads `finish_reason`, so a `content_filter` or `length`
  stop is presented as a complete answer. Every event arrives and is read correctly; the
  server reports the early stop in a field the CLI does not look at, so framing does not
  surface it. Pre-existing.
- **#12597** — `crates/google-genai`'s SSE reader decodes each chunk with
  `std::str::from_utf8`, so a character split across two reads fails the whole stream with
  "Invalid UTF-8". Same class as this fix, different crate.

## What this does not establish

An event that is not a chat completion is now an error rather than a silent skip. Against the
runtime and any OpenAI-compatible server a content event carries `choices` — including Azure's
annotation choices, which is why `delta` is optional — and a payload without it is either an
error envelope or something this client cannot render. A server that invented a new unnamed
event type carrying content would now stop the stream instead of ignoring it. That is the
intended trade: a truncated answer printed as a whole one is the failure being fixed.

`SseDecoder` is hand-rolled although `eventsource-stream` is already in this binary's
dependency tree through `async-openai`. That crate yields whole events and nothing else, and
all three things this decoder is for live outside that: progress before an event ends, the
tail a server leaves unterminated, and a bound on one unterminated event. The module doc says
so, so the next reader does not have to re-derive it.

## Test plan

- `make lint`
- `make nextest`
- 41 new unit tests, 263 passing in the crate. `bin/spice/src/sse.rs` covers the decoder
  directly (split mid-payload, inside a field name, between payload and terminator; a
  character split across reads; several events in one read; comments; names; all three line
  terminators including a CR split from its newline; a BOM, including one split across reads;
  repeated `data:`; the single-leading-space rule; an unterminated tail; the size cap, and a
  read carrying many whole events that is *not* over it; progress before an event ends).
  `chat.rs` covers the wiring through a real HTTP server (`SlowServer`): a split event, a
  split event between two whole ones, a split character, an `error` event, an OpenAI-shaped
  error payload, an Azure annotation choice, an empty payload, a multiline event that outlives
  the progress bound, an unterminated final event. `error.rs` covers both arms of
  `read_response`, and `nsql/mod.rs` covers a truncated `200` end to end.
- **17 neuters, each reverting one direction the fix could be wrong in; every one is caught.**
  Two initially survived and both were the tests being too loose, not the code being
  redundant — the assertions are tightened rather than the neuters dropped.

## Checklist

- [x] Tests added covering the reported failure and the sibling instances
- [x] Regression tests fail on the old code (neuter matrix)
- [x] `cargo clippy -p spice --lib --bins --tests` clean
- [x] `cargo fmt` clean
- [x] No `.unwrap()` in new code
- [ ] `make signoff` / `Attestation`

## Note on the base

Stacked on #12589 (`fix/12583-chat-stream-timeout`), which rewrites the same streaming loop
and adds the `SlowServer` fixture these tests use. The diff self-reduces when that merges.