### PR TITLE
fix(google-genai): read a Gemini SSE stream as bytes, so a split character survives (fixes #12597)

### DIFF
--- a/crates/google-genai/src/generate.rs
+++ b/crates/google-genai/src/generate.rs
@@ -194,45 +194,84 @@ impl Client {
     }
 }
 
-/// Length of the line terminator beginning at `buf[i]`, or `None` if one does not begin there.
-///
-/// A `\r` last in `buf` is only a terminator once `at_eof` says no more bytes can arrive to make it
-/// the first half of a `\r\n`; until then which one it is cannot be known.
-fn terminator_len(buf: &[u8], i: usize, at_eof: bool) -> Option<usize> {
-    match buf.get(i)? {
-        b'\n' => Some(1),
-        b'\r' if buf.get(i + 1) == Some(&b'\n') => Some(2),
-        b'\r' if i + 1 < buf.len() || at_eof => Some(1),
-        _ => None,
+/// What begins at `buf[i]`.
+enum Terminator {
+    /// A `\n`, or a `\r\n` whose `\n` is present: the line ends here and the next one starts a
+    /// known number of bytes later.
+    Complete(usize),
+    /// A `\r` last in `buf`. The line ends here either way - a `\r` alone terminates it, and so
+    /// does a `\r\n` - but whether the next line starts one byte or two later is not known until
+    /// the byte after it arrives.
+    TrailingCr,
+    /// Not a line terminator.
+    None,
+}
+
+fn terminator_at(buf: &[u8], i: usize) -> Terminator {
+    match buf.get(i) {
+        Some(b'\n') => Terminator::Complete(1),
+        Some(b'\r') if buf.get(i + 1) == Some(&b'\n') => Terminator::Complete(2),
+        Some(b'\r') if i + 1 < buf.len() => Terminator::Complete(1),
+        Some(b'\r') => Terminator::TrailingCr,
+        _ => Terminator::None,
     }
 }
 
-/// Byte offsets `(event_end, next_event_start)` of the blank line that terminates the first event
-/// in `buf`, or `None` while more bytes could still complete one.
+/// Where the first event in a buffer ends.
+#[derive(Debug, PartialEq, Eq)]
+struct EventBoundary {
+    /// Offset just past the event's last field line - the start of the blank line that ends it.
+    end: usize,
+    /// Offset the next event starts at.
+    next_start: usize,
+    /// The blank line ended with a `\r` last in the buffer, so a `\n` read next belongs to that
+    /// terminator rather than starting a line. The event itself is complete regardless.
+    may_skip_lf: bool,
+}
+
+/// The blank line that terminates the first event in `buf`, or `None` if the buffer does not hold a
+/// complete event yet.
 ///
 /// A line ends with `\n`, `\r\n` or `\r`, so the blank line is any two consecutive terminators.
-/// Searching the bytes - rather than decoding each network read as text and searching that - is
-/// what makes the decode below land on a character boundary: a multi-byte UTF-8 sequence never
-/// contains `\n` or `\r`, so an event never ends inside one.
-fn find_event_boundary(buf: &[u8], at_eof: bool) -> Option<(usize, usize)> {
+/// The answer never depends on whether more bytes may arrive: an event that is complete is reported
+/// immediately, so a live connection can never withhold one. Searching the bytes - rather than
+/// decoding each network read as text and searching that - is what makes the decode below land on a
+/// character boundary: a multi-byte UTF-8 sequence never contains `\n` or `\r`, so an event never
+/// ends inside one.
+fn find_event_boundary(buf: &[u8]) -> Option<EventBoundary> {
     let mut i = 0;
     while i < buf.len() {
-        let Some(first) = terminator_len(buf, i, at_eof) else {
+        // A trailing `\r` has nothing after it, so no blank line starts here yet.
+        let Terminator::Complete(first) = terminator_at(buf, i) else {
             i += 1;
             continue;
         };
 
         let after = i + first;
-        if let Some(second) = terminator_len(buf, after, at_eof) {
-            return Some((i, after + second));
+        match terminator_at(buf, after) {
+            Terminator::Complete(second) => {
+                return Some(EventBoundary {
+                    end: i,
+                    next_start: after + second,
+                    may_skip_lf: false,
+                });
+            }
+            Terminator::TrailingCr => {
+                return Some(EventBoundary {
+                    end: i,
+                    next_start: after + 1,
+                    may_skip_lf: true,
+                });
+            }
+            // Either the next line carries data, or the buffer stops before there is a next line
+            // to look at.
+            Terminator::None => {
+                if after >= buf.len() {
+                    return None;
+                }
+                i = after;
+            }
         }
-
-        // Either the next line carries data, or the buffer stops before a blank line can be told
-        // apart from a terminator that has arrived only halfway.
-        if after >= buf.len() {
-            return None;
-        }
-        i = after;
     }
 
     None
@@ -265,24 +304,49 @@ fn event_data(event: &str) -> Option<String> {
     data
 }
 
+/// What `parse_sse_stream` carries between polls.
+#[derive(Default)]
+struct SseReader {
+    /// Bytes read but not yet framed into an event.
+    bytes: Vec<u8>,
+    /// The last event's blank line ended with a `\r` that was then the final byte, so a `\n` read
+    /// next completes that terminator instead of starting a line.
+    skip_leading_lf: bool,
+    /// The body has ended. Held so the inner stream is not polled again after it has finished.
+    ended: bool,
+}
+
 fn parse_sse_stream(
     stream: Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>>,
 ) -> impl Stream<Item = Result<GenerateContentResponse>> + Send {
     futures::stream::unfold(
-        (stream, Vec::<u8>::new(), false),
-        |(mut stream, mut buffer, mut at_eof)| async move {
+        (stream, SseReader::default()),
+        |(mut stream, mut reader)| async move {
             loop {
+                // A boundary that set this leaves the buffer empty, so the byte in question is
+                // always the first one here.
+                if reader.skip_leading_lf {
+                    if reader.bytes.first() == Some(&b'\n') {
+                        reader.bytes.drain(..1);
+                        reader.skip_leading_lf = false;
+                    } else if !reader.bytes.is_empty() || reader.ended {
+                        // Something else arrived, so that terminator really was a bare `\r`.
+                        reader.skip_leading_lf = false;
+                    }
+                }
+
                 // Take every event the buffer already holds before reading again: one read can
                 // carry a comment or keep-alive ahead of a data event, and awaiting another read
                 // would hold that event back until the server happened to send more - or, at the
                 // end of the body, report the stream as truncated instead.
-                while let Some((event_end, next_event_start)) = find_event_boundary(&buffer, at_eof)
-                {
-                    let event = std::str::from_utf8(&buffer[..event_end]).map(str::to_string);
+                while let Some(boundary) = find_event_boundary(&reader.bytes) {
+                    let event =
+                        std::str::from_utf8(&reader.bytes[..boundary.end]).map(str::to_string);
 
                     // Consume the event either way, so a stream carrying one undecodable event
                     // reports it once and then continues rather than repeating it forever.
-                    buffer.drain(..next_event_start);
+                    reader.bytes.drain(..boundary.next_start);
+                    reader.skip_leading_lf = boundary.may_skip_lf;
 
                     let event = match event {
                         Ok(event) => event,
@@ -292,7 +356,7 @@ fn parse_sse_stream(
                                     message: format!("Invalid UTF-8 in SSE event: {e}"),
                                 }
                                 .fail(),
-                                (stream, buffer, at_eof),
+                                (stream, reader),
                             ));
                         }
                     };
@@ -311,44 +375,41 @@ fn parse_sse_stream(
 
                     let result = serde_json::from_str(&data).context(JsonSnafu);
 
-                    return Some((result, (stream, buffer, at_eof)));
+                    return Some((result, (stream, reader)));
                 }
 
                 // Every event the body held has been delivered by now, so whatever is left is a
                 // tail the server never terminated. Report it once and end there: consumers
                 // forward each item rather than stopping at the first error, so keeping the tail
                 // would yield this same error on every later poll and the stream would never end.
-                if at_eof {
-                    if buffer.is_empty() {
+                if reader.ended {
+                    if reader.bytes.is_empty() {
                         return None;
                     }
 
-                    buffer.clear();
+                    reader.bytes.clear();
 
                     return Some((
                         StreamSnafu {
                             message: "Unexpected end of stream while parsing SSE event".to_string(),
                         }
                         .fail(),
-                        (stream, buffer, at_eof),
+                        (stream, reader),
                     ));
                 }
 
                 match stream.next().await {
-                    Some(Ok(bytes)) => buffer.extend_from_slice(&bytes),
+                    Some(Ok(bytes)) => reader.bytes.extend_from_slice(&bytes),
                     Some(Err(e)) => {
                         return Some((
                             StreamSnafu {
                                 message: e.to_string(),
                             }
                             .fail(),
-                            (stream, buffer, at_eof),
+                            (stream, reader),
                         ));
                     }
-                    // Note the end rather than acting on it, and go back around: a `\r` held back
-                    // as possibly-half-a-`\r\n` is a terminator now that nothing follows it, so a
-                    // complete final event has to be looked for again before the tail is judged.
-                    None => at_eof = true,
+                    None => reader.ended = true,
                 }
             }
         },
@@ -452,6 +513,33 @@ mod tests {
             futures::stream::iter(reads),
             futures::stream::pending(),
         ))
+    }
+
+    /// A stream that panics if it is polled after it has finished - which the `Stream` contract
+    /// permits an implementation to do. It is what makes "a body that has ended is never polled
+    /// again" a tested property rather than a hope about how `reqwest` happens to behave.
+    struct PanicsAfterEnd {
+        reads: std::vec::IntoIter<bytes::Bytes>,
+        finished: bool,
+    }
+
+    impl Stream for PanicsAfterEnd {
+        type Item = std::result::Result<bytes::Bytes, reqwest::Error>;
+
+        fn poll_next(
+            mut self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            assert!(!self.finished, "the stream was polled after it ended");
+
+            match self.reads.next() {
+                Some(read) => std::task::Poll::Ready(Some(Ok(read))),
+                None => {
+                    self.finished = true;
+                    std::task::Poll::Ready(None)
+                }
+            }
+        }
     }
 
     fn text_of(response: &GenerateContentResponse) -> String {
@@ -685,42 +773,115 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_cr_terminated_final_event_is_delivered_at_the_end_of_the_body() {
-        // SSE allows a bare `\r` line ending, so `\r\r` is this body's last blank line and the
-        // event before it is complete - even though nothing follows to prove the second `\r` is
-        // not the first half of a `\r\n`.
+    async fn a_cr_terminated_event_is_not_held_back_by_a_live_connection() {
+        // SSE allows a bare `\r` line ending, so `\r\r` is a blank line and the event before it is
+        // complete. Whether that second `\r` later turns out to be the start of a `\r\n` decides
+        // only where the *next* event begins, so nothing may wait on it.
         let event = text_event("Hello").replace("\r\n", "\r");
 
-        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![event.as_bytes()])));
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble_then_pending(vec![
+            event.as_bytes(),
+        ])));
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(5), parsed_stream.next())
+            .await
+            .expect("a complete CR-framed event must not wait for another read")
+            .expect("stream should yield one item")
+            .expect("should parse successfully");
+
+        assert_eq!(text_of(&first), "Hello");
+    }
+
+    #[tokio::test]
+    async fn a_final_lf_completing_a_split_terminator_is_not_a_truncated_tail() {
+        // The body ends `\r\n\r\n`, split so its last byte arrives alone. The event is delivered on
+        // the first read - the `\r` ends the blank line - which leaves that `\n` to be recognized
+        // as the rest of a terminator already acted on, not as an unterminated event.
+        let event = text_event("Hello");
+        let bytes = event.as_bytes();
+        let split = bytes.len() - 1;
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![
+            &bytes[..split],
+            &bytes[split..],
+        ])));
 
         let first = parsed_stream
             .next()
             .await
-            .expect("a CR-terminated final event should be yielded, not reported as truncated")
+            .expect("stream should yield one item")
             .expect("should parse successfully");
-
         assert_eq!(text_of(&first), "Hello");
+
         assert!(
             parsed_stream.next().await.is_none(),
-            "the stream should end once the buffer is drained"
+            "the trailing `\\n` completes a terminator and is not a truncated event"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_body_that_has_ended_is_not_read_again() {
+        let stream = PanicsAfterEnd {
+            reads: vec![bytes::Bytes::from_static(b"data: {\"candidates\":[")].into_iter(),
+            finished: false,
+        };
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(Box::pin(stream)));
+
+        parsed_stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect_err("a truncated tail should be an error");
+
+        assert!(
+            parsed_stream.next().await.is_none(),
+            "the stream should end"
         );
     }
 
     #[test]
-    fn a_trailing_cr_waits_for_the_byte_that_classifies_it() {
-        // `\r` last, more bytes still possible: it may grow into the `\r\n` of a blank line.
-        assert_eq!(find_event_boundary(b"data: a\r\n\r", false), None);
+    fn an_event_is_framed_without_regard_for_whether_more_bytes_may_arrive() {
+        // A `\r\n` blank line: both terminators are complete, so the next event starts after them.
         assert_eq!(
-            find_event_boundary(b"data: a\r\n\r\n", false),
-            Some((7, 11))
+            find_event_boundary(b"data: a\r\n\r\n"),
+            Some(EventBoundary {
+                end: 7,
+                next_start: 11,
+                may_skip_lf: false,
+            })
         );
-        // `\r\r` is a blank line in its own right once a following byte proves the second `\r` is
-        // not the start of a `\r\n`...
-        assert_eq!(find_event_boundary(b"data: a\r\rx", false), Some((7, 9)));
-        // ...and the end of the body proves the same thing.
-        assert_eq!(find_event_boundary(b"data: a\r\r", false), None);
-        assert_eq!(find_event_boundary(b"data: a\r\r", true), Some((7, 9)));
-        // One terminator is not a blank line, at the end of the body or anywhere else.
-        assert_eq!(find_event_boundary(b"data: a\r", true), None);
+        // The blank line's second terminator is a `\r` last in the buffer. The event is complete;
+        // only whether a `\n` follows it is unknown, so the next event provisionally starts right
+        // after it and a `\n` read next is recognized as part of that terminator.
+        assert_eq!(
+            find_event_boundary(b"data: a\r\n\r"),
+            Some(EventBoundary {
+                end: 7,
+                next_start: 10,
+                may_skip_lf: true,
+            })
+        );
+        assert_eq!(
+            find_event_boundary(b"data: a\r\r"),
+            Some(EventBoundary {
+                end: 7,
+                next_start: 9,
+                may_skip_lf: true,
+            })
+        );
+        // A following byte settles it: that second `\r` was bare.
+        assert_eq!(
+            find_event_boundary(b"data: a\r\rx"),
+            Some(EventBoundary {
+                end: 7,
+                next_start: 9,
+                may_skip_lf: false,
+            })
+        );
+        // One terminator is not a blank line, and neither is none.
+        assert_eq!(find_event_boundary(b"data: a\r"), None);
+        assert_eq!(find_event_boundary(b"data: a\r\nb"), None);
+        assert_eq!(find_event_boundary(b"data: a"), None);
     }
 }

--- a/crates/google-genai/src/generate.rs
+++ b/crates/google-genai/src/generate.rs
@@ -194,6 +194,12 @@ impl Client {
     }
 }
 
+// The reader below is written here rather than taken from a crate. `eventsource-stream` and the
+// `reqwest-eventsource` fork `crates/llms` pins both decode SSE correctly, but both end a stream
+// silently when the body stops mid-event, and reporting that rather than passing off a partial
+// answer as a whole one is the behavior this module exists to keep. Sharing one decoder across the
+// workspace's SSE readers is worth doing - see #12597 - but it belongs in its own change.
+
 /// What begins at `buf[i]`.
 enum Terminator {
     /// A `\n`, or a `\r\n` whose `\n` is present: the line ends here and the next one starts a
@@ -210,9 +216,11 @@ enum Terminator {
 fn terminator_at(buf: &[u8], i: usize) -> Terminator {
     match buf.get(i) {
         Some(b'\n') => Terminator::Complete(1),
-        Some(b'\r') if buf.get(i + 1) == Some(&b'\n') => Terminator::Complete(2),
-        Some(b'\r') if i + 1 < buf.len() => Terminator::Complete(1),
-        Some(b'\r') => Terminator::TrailingCr,
+        Some(b'\r') => match buf.get(i + 1) {
+            Some(b'\n') => Terminator::Complete(2),
+            Some(_) => Terminator::Complete(1),
+            None => Terminator::TrailingCr,
+        },
         _ => Terminator::None,
     }
 }
@@ -324,15 +332,13 @@ fn parse_sse_stream(
         |(mut stream, mut reader)| async move {
             loop {
                 // A boundary that set this leaves the buffer empty, so the byte in question is
-                // always the first one here.
-                if reader.skip_leading_lf {
+                // always the first one here - and once there is one, or there will never be one,
+                // the terminator it belongs to is settled either way.
+                if reader.skip_leading_lf && (!reader.bytes.is_empty() || reader.ended) {
                     if reader.bytes.first() == Some(&b'\n') {
                         reader.bytes.drain(..1);
-                        reader.skip_leading_lf = false;
-                    } else if !reader.bytes.is_empty() || reader.ended {
-                        // Something else arrived, so that terminator really was a bare `\r`.
-                        reader.skip_leading_lf = false;
                     }
+                    reader.skip_leading_lf = false;
                 }
 
                 // Take every event the buffer already holds before reading again: one read can
@@ -340,16 +346,17 @@ fn parse_sse_stream(
                 // would hold that event back until the server happened to send more - or, at the
                 // end of the body, report the stream as truncated instead.
                 while let Some(boundary) = find_event_boundary(&reader.bytes) {
-                    let event =
-                        std::str::from_utf8(&reader.bytes[..boundary.end]).map(str::to_string);
+                    // Read the event's fields while its bytes are still in the buffer, so nothing
+                    // has to be copied out of it first.
+                    let data = std::str::from_utf8(&reader.bytes[..boundary.end]).map(event_data);
 
                     // Consume the event either way, so a stream carrying one undecodable event
                     // reports it once and then continues rather than repeating it forever.
                     reader.bytes.drain(..boundary.next_start);
                     reader.skip_leading_lf = boundary.may_skip_lf;
 
-                    let event = match event {
-                        Ok(event) => event,
+                    let data = match data {
+                        Ok(data) => data,
                         Err(e) => {
                             return Some((
                                 StreamSnafu {
@@ -361,7 +368,7 @@ fn parse_sse_stream(
                         }
                     };
 
-                    let Some(data) = event_data(&event) else {
+                    let Some(data) = data else {
                         continue;
                     };
 
@@ -485,32 +492,28 @@ mod tests {
         chunk.expect_err("chunk should be an error");
     }
 
-    /// A stream that hands out exactly the byte groups it is given, so a test can put a boundary
-    /// wherever it likes - including inside a multi-byte character or a `\r\n` pair.
-    fn dribble(
-        reads: Vec<&[u8]>,
-    ) -> Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>> {
-        let reads: Vec<_> = reads
+    type ByteStream =
+        Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>>;
+
+    fn reads_of(reads: Vec<&[u8]>) -> Vec<std::result::Result<bytes::Bytes, reqwest::Error>> {
+        reads
             .into_iter()
             .map(|read| Ok(bytes::Bytes::copy_from_slice(read)))
-            .collect();
+            .collect()
+    }
 
-        Box::pin(futures::stream::iter(reads))
+    /// A stream that hands out exactly the byte groups it is given, so a test can put a boundary
+    /// wherever it likes - including inside a multi-byte character or a `\r\n` pair.
+    fn dribble(reads: Vec<&[u8]>) -> ByteStream {
+        Box::pin(futures::stream::iter(reads_of(reads)))
     }
 
     /// The same, but the stream never ends: after the given reads it stays pending, the way a
     /// server that has sent a keep-alive and nothing since does.
-    fn dribble_then_pending(
-        reads: Vec<&[u8]>,
-    ) -> Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>> {
-        let reads: Vec<_> = reads
-            .into_iter()
-            .map(|read| Ok(bytes::Bytes::copy_from_slice(read)))
-            .collect();
-
+    fn dribble_then_pending(reads: Vec<&[u8]>) -> ByteStream {
         // Both `StreamExt` traits in scope carry `chain`, so name the one being used.
         Box::pin(futures::StreamExt::chain(
-            futures::stream::iter(reads),
+            futures::stream::iter(reads_of(reads)),
             futures::stream::pending(),
         ))
     }
@@ -532,12 +535,11 @@ mod tests {
         ) -> std::task::Poll<Option<Self::Item>> {
             assert!(!self.finished, "the stream was polled after it ended");
 
-            match self.reads.next() {
-                Some(read) => std::task::Poll::Ready(Some(Ok(read))),
-                None => {
-                    self.finished = true;
-                    std::task::Poll::Ready(None)
-                }
+            if let Some(read) = self.reads.next() {
+                std::task::Poll::Ready(Some(Ok(read)))
+            } else {
+                self.finished = true;
+                std::task::Poll::Ready(None)
             }
         }
     }

--- a/crates/google-genai/src/generate.rs
+++ b/crates/google-genai/src/generate.rs
@@ -194,48 +194,126 @@ impl Client {
     }
 }
 
+/// Length of the line terminator beginning at `buf[i]`, or `None` if one does not begin there.
+///
+/// A `\r` that is the last byte of `buf` reports `None`: it may be the first half of a `\r\n`
+/// whose `\n` has not been read yet, and only more bytes can say which.
+fn terminator_len(buf: &[u8], i: usize) -> Option<usize> {
+    match buf.get(i)? {
+        b'\n' => Some(1),
+        b'\r' if buf.get(i + 1) == Some(&b'\n') => Some(2),
+        b'\r' if i + 1 < buf.len() => Some(1),
+        _ => None,
+    }
+}
+
+/// Byte offsets `(event_end, next_event_start)` of the blank line that terminates the first event
+/// in `buf`, or `None` while more bytes could still complete one.
+///
+/// A line ends with `\n`, `\r\n` or `\r`, so the blank line is any two consecutive terminators.
+/// Searching the bytes - rather than decoding each network read as text and searching that - is
+/// what makes the decode below land on a character boundary: a multi-byte UTF-8 sequence never
+/// contains `\n` or `\r`, so an event never ends inside one.
+fn find_event_boundary(buf: &[u8]) -> Option<(usize, usize)> {
+    let mut i = 0;
+    while i < buf.len() {
+        let Some(first) = terminator_len(buf, i) else {
+            i += 1;
+            continue;
+        };
+
+        let after = i + first;
+        if let Some(second) = terminator_len(buf, after) {
+            return Some((i, after + second));
+        }
+
+        // Either the next line carries data, or the buffer stops before a blank line can be told
+        // apart from a terminator that has arrived only halfway.
+        if after >= buf.len() {
+            return None;
+        }
+        i = after;
+    }
+
+    None
+}
+
+/// The payload of one SSE event: the values of its `data:` fields joined by `\n`, or `None` for an
+/// event that carries no `data:` field at all, such as a comment or a bare `event:` line.
+fn event_data(event: &str) -> Option<String> {
+    let mut data: Option<String> = None;
+
+    // Split on either terminator so an event framed with `\r`, `\n` or `\r\n` reads the same way;
+    // the empty segment a `\r\n` leaves behind carries no field and is skipped.
+    for line in event.split(['\r', '\n']) {
+        let Some(value) = line.strip_prefix("data:") else {
+            continue;
+        };
+
+        // One space after the colon is part of the framing, not of the value.
+        let value = value.strip_prefix(' ').unwrap_or(value);
+
+        match &mut data {
+            Some(data) => {
+                data.push('\n');
+                data.push_str(value);
+            }
+            None => data = Some(value.to_string()),
+        }
+    }
+
+    data
+}
+
 fn parse_sse_stream(
     stream: Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>>,
 ) -> impl Stream<Item = Result<GenerateContentResponse>> + Send {
     futures::stream::unfold(
-        (stream, String::new()),
+        (stream, Vec::<u8>::new()),
         |(mut stream, mut buffer)| async move {
             loop {
-                if let Some(pos) = buffer.find("\n\n") {
-                    let event = buffer[..pos].to_string();
+                // Take every event the buffer already holds before reading again: one read can
+                // carry a comment or keep-alive ahead of a data event, and awaiting another read
+                // would report the end of the stream instead of the event already in hand.
+                while let Some((event_end, next_event_start)) = find_event_boundary(&buffer) {
+                    let event = std::str::from_utf8(&buffer[..event_end]).map(str::to_string);
 
-                    buffer = buffer[pos + 2..].to_string();
+                    // Consume the event either way, so a stream carrying one undecodable event
+                    // reports it once and then continues rather than repeating it forever.
+                    buffer.drain(..next_event_start);
 
-                    for line in event.lines() {
-                        if let Some(data) = line.strip_prefix("data: ") {
-                            if data == "[DONE]" {
-                                return None;
-                            }
-
-                            if data.trim().is_empty() {
-                                continue;
-                            }
-
-                            let result = serde_json::from_str(data).context(JsonSnafu);
-
-                            return Some((result, (stream, buffer)));
+                    let event = match event {
+                        Ok(event) => event,
+                        Err(e) => {
+                            return Some((
+                                StreamSnafu {
+                                    message: format!("Invalid UTF-8 in SSE event: {e}"),
+                                }
+                                .fail(),
+                                (stream, buffer),
+                            ));
                         }
+                    };
+
+                    let Some(data) = event_data(&event) else {
+                        continue;
+                    };
+
+                    if data == "[DONE]" {
+                        return None;
                     }
+
+                    if data.trim().is_empty() {
+                        continue;
+                    }
+
+                    let result = serde_json::from_str(&data).context(JsonSnafu);
+
+                    return Some((result, (stream, buffer)));
                 }
 
                 match stream.next().await {
-                    Some(Ok(bytes)) => {
-                        let text = std::str::from_utf8(&bytes).map_err(|e| {
-                            crate::error::Error::StreamError {
-                                message: format!("Invalid UTF-8: {e}"),
-                            }
-                        });
-
-                        match text {
-                            Ok(t) => buffer.push_str(&t.replace("\r\n", "\n")),
-                            Err(e) => return Some((Err(e), (stream, buffer))),
-                        }
-                    }
+                    Some(Ok(bytes)) => buffer.extend_from_slice(&bytes),
                     Some(Err(e)) => {
                         return Some((
                             StreamSnafu {
@@ -249,6 +327,12 @@ fn parse_sse_stream(
                         if buffer.is_empty() {
                             return None;
                         }
+
+                        // Report the truncated tail once and end there. Consumers forward each
+                        // item rather than stopping at the first error, so leaving the tail in the
+                        // buffer would yield this same error on every later poll: the stream would
+                        // never end.
+                        buffer.clear();
 
                         return Some((
                             StreamSnafu {
@@ -332,5 +416,241 @@ mod tests {
             .expect("stream should yield one item");
 
         chunk.expect_err("chunk should be an error");
+    }
+
+    /// A stream that hands out exactly the byte groups it is given, so a test can put a boundary
+    /// wherever it likes - including inside a multi-byte character or a `\r\n` pair.
+    fn dribble(
+        reads: Vec<&[u8]>,
+    ) -> Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>> {
+        let reads: Vec<_> = reads
+            .into_iter()
+            .map(|read| Ok(bytes::Bytes::copy_from_slice(read)))
+            .collect();
+
+        Box::pin(futures::stream::iter(reads))
+    }
+
+    fn text_of(response: &GenerateContentResponse) -> String {
+        response
+            .candidates
+            .iter()
+            .flat_map(|candidate| &candidate.content.parts)
+            .map(|part| match part {
+                crate::types::Part::Text { text } => text.clone(),
+                other => panic!("expected a text part, got {other:?}"),
+            })
+            .collect()
+    }
+
+    fn text_event(text: &str) -> String {
+        format!(
+            "data: {{\"candidates\":[{{\"content\":{{\"role\":\"model\",\"parts\":[{{\"text\":\"{text}\"}}]}}}}]}}\r\n\r\n"
+        )
+    }
+
+    #[tokio::test]
+    async fn a_character_split_across_two_reads_survives() {
+        // "é" is two bytes; the read boundary falls between them.
+        let event = text_event("caf\u{e9}");
+        let bytes = event.as_bytes();
+        let split = event
+            .find('\u{e9}')
+            .expect("the event should carry the character")
+            + 1;
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![
+            &bytes[..split],
+            &bytes[split..],
+        ])));
+
+        let first = parsed_stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect("a character split across two reads should still parse");
+
+        assert_eq!(text_of(&first), "caf\u{e9}");
+    }
+
+    #[tokio::test]
+    async fn a_four_byte_character_split_across_three_reads_survives() {
+        let event = text_event("hi \u{1f600}");
+        let bytes = event.as_bytes();
+        let start = event
+            .find('\u{1f600}')
+            .expect("the event should carry the character");
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![
+            &bytes[..=start],
+            &bytes[start + 1..start + 3],
+            &bytes[start + 3..],
+        ])));
+
+        let first = parsed_stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect("a character split across three reads should still parse");
+
+        assert_eq!(text_of(&first), "hi \u{1f600}");
+    }
+
+    #[tokio::test]
+    async fn a_crlf_split_across_two_reads_still_terminates_the_event() {
+        let event = text_event("Hello");
+        let bytes = event.as_bytes();
+        // Split inside the final `\r\n`, so neither read holds a complete terminator pair.
+        let split = bytes.len() - 1;
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![
+            &bytes[..split],
+            &bytes[split..],
+        ])));
+
+        let first = parsed_stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect("an event whose terminator spans two reads should parse");
+
+        assert_eq!(text_of(&first), "Hello");
+    }
+
+    #[tokio::test]
+    async fn a_bare_lf_terminated_event_parses() {
+        let event = text_event("Hello").replace("\r\n", "\n");
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![event.as_bytes()])));
+
+        let first = parsed_stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect("an `\\n\\n`-separated event should parse");
+
+        assert_eq!(text_of(&first), "Hello");
+    }
+
+    #[tokio::test]
+    async fn a_keep_alive_ahead_of_the_last_event_does_not_hide_it() {
+        let body = format!(": keep-alive\r\n\r\n{}", text_event("Hello"));
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![body.as_bytes()])));
+
+        let first = parsed_stream
+            .next()
+            .await
+            .expect("the data event after the keep-alive should still be yielded")
+            .expect("should parse successfully");
+
+        assert_eq!(text_of(&first), "Hello");
+        assert!(
+            parsed_stream.next().await.is_none(),
+            "the stream should end once the buffer is drained"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_events_data_fields_are_joined() {
+        let body = "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\r\ndata: \"parts\":[{\"text\":\"Hello\"}]}}]}\r\n\r\n";
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![body.as_bytes()])));
+
+        let first = parsed_stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect("an event split over two data fields should parse as one payload");
+
+        assert_eq!(text_of(&first), "Hello");
+    }
+
+    #[tokio::test]
+    async fn a_data_field_without_a_space_after_the_colon_parses() {
+        let event = text_event("Hello").replace("data: ", "data:");
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![event.as_bytes()])));
+
+        let first = parsed_stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect("the space after `data:` is optional");
+
+        assert_eq!(text_of(&first), "Hello");
+    }
+
+    #[tokio::test]
+    async fn a_done_sentinel_ends_the_stream() {
+        let body = format!("{}data: [DONE]\r\n\r\n", text_event("Hello"));
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![body.as_bytes()])));
+
+        parsed_stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect("should parse successfully");
+
+        assert!(
+            parsed_stream.next().await.is_none(),
+            "`[DONE]` should end the stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_undecodable_event_is_reported_once_and_the_next_event_still_arrives() {
+        // A lone continuation byte is invalid wherever it lands, so this is a genuinely broken
+        // event rather than a character waiting for its other half.
+        let mut body = b"data: \x80\r\n\r\n".to_vec();
+        body.extend_from_slice(text_event("Hello").as_bytes());
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![&body])));
+
+        let error = parsed_stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect_err("an undecodable event should be an error");
+        assert!(
+            error.to_string().contains("Invalid UTF-8 in SSE event"),
+            "unexpected error: {error}"
+        );
+
+        let second = parsed_stream
+            .next()
+            .await
+            .expect("the following event should still be yielded")
+            .expect("should parse successfully");
+        assert_eq!(text_of(&second), "Hello");
+    }
+
+    #[tokio::test]
+    async fn a_truncated_tail_is_reported_once_and_then_the_stream_ends() {
+        let body = "data: {\"candidates\":[{\"content\":{\"role\":\"model\"";
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![body.as_bytes()])));
+
+        parsed_stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect_err("a truncated tail should be an error");
+
+        assert!(
+            parsed_stream.next().await.is_none(),
+            "the stream must end after reporting the tail, not repeat the error forever"
+        );
+    }
+
+    #[test]
+    fn a_trailing_cr_waits_for_the_byte_that_classifies_it() {
+        // `\r` last: it may still grow into the `\r\n` that completes a blank line.
+        assert_eq!(find_event_boundary(b"data: a\r\n\r"), None);
+        assert_eq!(find_event_boundary(b"data: a\r\n\r\n"), Some((7, 11)));
+        // `\r\r` is a blank line in its own right once a following byte proves the second `\r`
+        // is not the start of a `\r\n`.
+        assert_eq!(find_event_boundary(b"data: a\r\rx"), Some((7, 9)));
     }
 }

--- a/crates/google-genai/src/generate.rs
+++ b/crates/google-genai/src/generate.rs
@@ -274,7 +274,8 @@ fn parse_sse_stream(
             loop {
                 // Take every event the buffer already holds before reading again: one read can
                 // carry a comment or keep-alive ahead of a data event, and awaiting another read
-                // would report the end of the stream instead of the event already in hand.
+                // would hold that event back until the server happened to send more - or, at the
+                // end of the body, report the stream as truncated instead.
                 while let Some((event_end, next_event_start)) = find_event_boundary(&buffer, at_eof)
                 {
                     let event = std::str::from_utf8(&buffer[..event_end]).map(str::to_string);
@@ -436,6 +437,23 @@ mod tests {
         Box::pin(futures::stream::iter(reads))
     }
 
+    /// The same, but the stream never ends: after the given reads it stays pending, the way a
+    /// server that has sent a keep-alive and nothing since does.
+    fn dribble_then_pending(
+        reads: Vec<&[u8]>,
+    ) -> Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>> {
+        let reads: Vec<_> = reads
+            .into_iter()
+            .map(|read| Ok(bytes::Bytes::copy_from_slice(read)))
+            .collect();
+
+        // Both `StreamExt` traits in scope carry `chain`, so name the one being used.
+        Box::pin(futures::StreamExt::chain(
+            futures::stream::iter(reads),
+            futures::stream::pending(),
+        ))
+    }
+
     fn text_of(response: &GenerateContentResponse) -> String {
         response
             .candidates
@@ -554,6 +572,23 @@ mod tests {
             parsed_stream.next().await.is_none(),
             "the stream should end once the buffer is drained"
         );
+    }
+
+    #[tokio::test]
+    async fn a_keep_alive_does_not_hold_back_an_event_already_in_the_buffer() {
+        let body = format!(": keep-alive\r\n\r\n{}", text_event("Hello"));
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble_then_pending(vec![
+            body.as_bytes(),
+        ])));
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(5), parsed_stream.next())
+            .await
+            .expect("the buffered event must be delivered without awaiting another read")
+            .expect("stream should yield one item")
+            .expect("should parse successfully");
+
+        assert_eq!(text_of(&first), "Hello");
     }
 
     #[tokio::test]

--- a/crates/google-genai/src/generate.rs
+++ b/crates/google-genai/src/generate.rs
@@ -196,13 +196,13 @@ impl Client {
 
 /// Length of the line terminator beginning at `buf[i]`, or `None` if one does not begin there.
 ///
-/// A `\r` that is the last byte of `buf` reports `None`: it may be the first half of a `\r\n`
-/// whose `\n` has not been read yet, and only more bytes can say which.
-fn terminator_len(buf: &[u8], i: usize) -> Option<usize> {
+/// A `\r` last in `buf` is only a terminator once `at_eof` says no more bytes can arrive to make it
+/// the first half of a `\r\n`; until then which one it is cannot be known.
+fn terminator_len(buf: &[u8], i: usize, at_eof: bool) -> Option<usize> {
     match buf.get(i)? {
         b'\n' => Some(1),
         b'\r' if buf.get(i + 1) == Some(&b'\n') => Some(2),
-        b'\r' if i + 1 < buf.len() => Some(1),
+        b'\r' if i + 1 < buf.len() || at_eof => Some(1),
         _ => None,
     }
 }
@@ -214,16 +214,16 @@ fn terminator_len(buf: &[u8], i: usize) -> Option<usize> {
 /// Searching the bytes - rather than decoding each network read as text and searching that - is
 /// what makes the decode below land on a character boundary: a multi-byte UTF-8 sequence never
 /// contains `\n` or `\r`, so an event never ends inside one.
-fn find_event_boundary(buf: &[u8]) -> Option<(usize, usize)> {
+fn find_event_boundary(buf: &[u8], at_eof: bool) -> Option<(usize, usize)> {
     let mut i = 0;
     while i < buf.len() {
-        let Some(first) = terminator_len(buf, i) else {
+        let Some(first) = terminator_len(buf, i, at_eof) else {
             i += 1;
             continue;
         };
 
         let after = i + first;
-        if let Some(second) = terminator_len(buf, after) {
+        if let Some(second) = terminator_len(buf, after, at_eof) {
             return Some((i, after + second));
         }
 
@@ -269,13 +269,14 @@ fn parse_sse_stream(
     stream: Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>>,
 ) -> impl Stream<Item = Result<GenerateContentResponse>> + Send {
     futures::stream::unfold(
-        (stream, Vec::<u8>::new()),
-        |(mut stream, mut buffer)| async move {
+        (stream, Vec::<u8>::new(), false),
+        |(mut stream, mut buffer, mut at_eof)| async move {
             loop {
                 // Take every event the buffer already holds before reading again: one read can
                 // carry a comment or keep-alive ahead of a data event, and awaiting another read
                 // would report the end of the stream instead of the event already in hand.
-                while let Some((event_end, next_event_start)) = find_event_boundary(&buffer) {
+                while let Some((event_end, next_event_start)) = find_event_boundary(&buffer, at_eof)
+                {
                     let event = std::str::from_utf8(&buffer[..event_end]).map(str::to_string);
 
                     // Consume the event either way, so a stream carrying one undecodable event
@@ -290,7 +291,7 @@ fn parse_sse_stream(
                                     message: format!("Invalid UTF-8 in SSE event: {e}"),
                                 }
                                 .fail(),
-                                (stream, buffer),
+                                (stream, buffer, at_eof),
                             ));
                         }
                     };
@@ -309,7 +310,27 @@ fn parse_sse_stream(
 
                     let result = serde_json::from_str(&data).context(JsonSnafu);
 
-                    return Some((result, (stream, buffer)));
+                    return Some((result, (stream, buffer, at_eof)));
+                }
+
+                // Every event the body held has been delivered by now, so whatever is left is a
+                // tail the server never terminated. Report it once and end there: consumers
+                // forward each item rather than stopping at the first error, so keeping the tail
+                // would yield this same error on every later poll and the stream would never end.
+                if at_eof {
+                    if buffer.is_empty() {
+                        return None;
+                    }
+
+                    buffer.clear();
+
+                    return Some((
+                        StreamSnafu {
+                            message: "Unexpected end of stream while parsing SSE event".to_string(),
+                        }
+                        .fail(),
+                        (stream, buffer, at_eof),
+                    ));
                 }
 
                 match stream.next().await {
@@ -320,29 +341,13 @@ fn parse_sse_stream(
                                 message: e.to_string(),
                             }
                             .fail(),
-                            (stream, buffer),
+                            (stream, buffer, at_eof),
                         ));
                     }
-                    None => {
-                        if buffer.is_empty() {
-                            return None;
-                        }
-
-                        // Report the truncated tail once and end there. Consumers forward each
-                        // item rather than stopping at the first error, so leaving the tail in the
-                        // buffer would yield this same error on every later poll: the stream would
-                        // never end.
-                        buffer.clear();
-
-                        return Some((
-                            StreamSnafu {
-                                message: "Unexpected end of stream while parsing SSE event"
-                                    .to_string(),
-                            }
-                            .fail(),
-                            (stream, buffer),
-                        ));
-                    }
+                    // Note the end rather than acting on it, and go back around: a `\r` held back
+                    // as possibly-half-a-`\r\n` is a terminator now that nothing follows it, so a
+                    // complete final event has to be looked for again before the tail is judged.
+                    None => at_eof = true,
                 }
             }
         },
@@ -644,13 +649,43 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn a_cr_terminated_final_event_is_delivered_at_the_end_of_the_body() {
+        // SSE allows a bare `\r` line ending, so `\r\r` is this body's last blank line and the
+        // event before it is complete - even though nothing follows to prove the second `\r` is
+        // not the first half of a `\r\n`.
+        let event = text_event("Hello").replace("\r\n", "\r");
+
+        let mut parsed_stream = Box::pin(parse_sse_stream(dribble(vec![event.as_bytes()])));
+
+        let first = parsed_stream
+            .next()
+            .await
+            .expect("a CR-terminated final event should be yielded, not reported as truncated")
+            .expect("should parse successfully");
+
+        assert_eq!(text_of(&first), "Hello");
+        assert!(
+            parsed_stream.next().await.is_none(),
+            "the stream should end once the buffer is drained"
+        );
+    }
+
     #[test]
     fn a_trailing_cr_waits_for_the_byte_that_classifies_it() {
-        // `\r` last: it may still grow into the `\r\n` that completes a blank line.
-        assert_eq!(find_event_boundary(b"data: a\r\n\r"), None);
-        assert_eq!(find_event_boundary(b"data: a\r\n\r\n"), Some((7, 11)));
-        // `\r\r` is a blank line in its own right once a following byte proves the second `\r`
-        // is not the start of a `\r\n`.
-        assert_eq!(find_event_boundary(b"data: a\r\rx"), Some((7, 9)));
+        // `\r` last, more bytes still possible: it may grow into the `\r\n` of a blank line.
+        assert_eq!(find_event_boundary(b"data: a\r\n\r", false), None);
+        assert_eq!(
+            find_event_boundary(b"data: a\r\n\r\n", false),
+            Some((7, 11))
+        );
+        // `\r\r` is a blank line in its own right once a following byte proves the second `\r` is
+        // not the start of a `\r\n`...
+        assert_eq!(find_event_boundary(b"data: a\r\rx", false), Some((7, 9)));
+        // ...and the end of the body proves the same thing.
+        assert_eq!(find_event_boundary(b"data: a\r\r", false), None);
+        assert_eq!(find_event_boundary(b"data: a\r\r", true), Some((7, 9)));
+        // One terminator is not a blank line, at the end of the body or anywhere else.
+        assert_eq!(find_event_boundary(b"data: a\r", true), None);
     }
 }


### PR DESCRIPTION
## Summary

`parse_sse_stream` decoded each network read on its own with `std::str::from_utf8`. A multi-byte
character split across two reads is not invalid UTF-8 — it is half of a character, with the other
half in the next read — but decoding the halves separately made it look invalid and failed the whole
stream with `Invalid UTF-8`, blaming the model for bytes that were fine. Any answer containing
accented text, CJK or an emoji could hit it, on a boundary that moves with the link and any proxy in
between, which is why it looked intermittent. `crates/llms/src/google/chat.rs` reaches this parser,
so it surfaced mid-answer on the runtime's Gemini chat path.

The same per-read handling normalized `\r\n` inside one read, so a terminator split across two reads
never formed an event separator either.

Frame in the bytes instead: find the blank line that ends an event, then decode only that event. A
UTF-8 sequence never contains `\n` or `\r`, so the decode always lands on a character boundary, and
an `Invalid UTF-8` error now means the bytes really are invalid.

Fixes #12597

## Changes

All in `crates/google-genai/src/generate.rs`. Four further reads that did not deliver everything
they held — the same shape as the reported bug — came out of the same function and are fixed with
it, rather than left for follow-ups:

- **A dataless event sent the loop back to the network.** A comment or keep-alive was taken from the
  buffer, found to carry no `data:` field, and then awaited another read — holding back a data event
  already sitting behind it until the server happened to send more, or, at the end of the body,
  reporting `Unexpected end of stream` and dropping it. The buffer is now drained of every event it
  holds before another read is awaited.
- **Framing no longer depends on whether more bytes may arrive.** A blank line may end with a bare
  `\r`, and whether that `\r` stays bare or turns out to be a `\r\n` cannot change that the line —
  and so the event — is complete; it decides only where the *next* event begins. So the framer
  answers from the bytes alone and carries that single unresolved bit: a `\n` read immediately after
  such a terminator completes it rather than starting a line. A complete event is therefore never
  withheld, and a terminator split across two reads leaves no stray byte to be mistaken for an
  unterminated event.
- **An event's later `data:` fields were discarded** rather than joined with `\n` as the SSE grammar
  defines, and a `data:` field written without the optional space after the colon was not read at
  all.
- **The truncated-tail error was returned with the tail still buffered**, so every later poll
  produced it again. Consumers forward each item rather than stopping at the first error
  (`convert_google_stream_to_openai` is a `map`), so that stream never ended. It is now reported
  once and the stream ends — and the end of the body is tracked so a stream that has finished is not
  polled a second time, which the `Stream` contract permits an implementation to panic on.

A comment records why the reader is written here rather than taken from `eventsource-stream` or the
`reqwest-eventsource` fork `crates/llms` pins: both end a stream silently when the body stops
mid-event, and reporting that instead of passing a partial answer off as a whole one is the behavior
this module exists to keep. Sharing one decoder across the workspace's SSE readers is still worth
doing — #12597 says so — but as its own change.

## Test plan

- `make lint` — clean, including the `--tests` pass.
- `make nextest` — full unit suite.
- 19 unit tests in the module (16 new), all green; the 3 pre-existing ones are unchanged and pass.
- **Neuter matrix: 13 reverts, every one caught by a named test.** Each element of the fix was
  reverted in turn — the per-read decode, each of the three line-terminator cases, the possible-`\n`
  carry (both setting it and consuming it), the dataless-event drain, the `data:`-field join, the
  optional space, the `data:` prefix, the drain-before-error, the tail clear, and acting on the end
  of the body immediately — and in every case a test failed.
- The new tests drive the parser through a stream that hands out exactly the byte groups given, so a
  boundary can be placed inside a two-byte character, inside a four-byte character across three
  reads, and inside a `\r\n` pair. Two drive a stream that stays *pending* after its reads, which is
  the shape a server that just sent a keep-alive has — that is what pins an event being delivered
  rather than held back, and an earlier version of one of them passed either way because it let its
  stream end. One drives a stream that panics if polled after it finishes, so "a body that has ended
  is not read again" is tested rather than assumed.

## Review

Two rounds of Codex adversarial review, both of which found real defects that are fixed here:

1. The first version accepted a bare-`\r` blank line mid-stream but not at the end of the body, so a
   standards-valid CR-framed final event was reported as truncated.
2. Making that end-of-body-aware then withheld the same complete event for as long as a live
   connection stayed open. That is what drove the framer to stop consulting the end of the body at
   all — the shape it should have had from the start.

`/security-review`: no findings. The untrusted input is the model endpoint's response body; the
indices are provably in range (`end` is the scan index, and `next_start` cannot exceed the buffer
length), the error text carries a UTF-8 offset and length rather than payload bytes, and the payload
still deserializes into the same typed struct.

## Deferred

- #12600 — the accumulation buffer has no bound, so an endpoint that never terminates an event grows
  the process's memory. Pre-existing (the previous version accumulated into a `String` the same way),
  and the cap is a behavior decision: it has to be sized against a response carrying inline data or
  it turns a valid long answer into a failure.

## Checklist

- [x] Regression test that fails on the old code and passes on the new
- [x] Whole bug class in this function fixed, not just the reported instance
- [x] No `unwrap`/`expect` in production code
- [x] Adversarial review and security review run before the PR was opened
- [x] Lint clean, formatted, unit suite green
