### PR TITLE
fix(mssql): follow an availability group's read-only routing redirect (fixes #11453)

### DIFF
--- a/crates/data_components/src/mssql/connection_manager.rs
+++ b/crates/data_components/src/mssql/connection_manager.rs
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 use async_trait::async_trait;
-use bb8::Pool;
+use bb8::{ErrorSink, Pool};
 use snafu::ResultExt;
-use tiberius::{Client, Config};
+use tiberius::{Client, Config, error::Error as TiberiusError};
 use tokio::net::TcpStream;
 
 use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
@@ -25,6 +25,16 @@ use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
 use super::SqlServerAccessSnafu;
 
 pub type SqlServerConnectionPool = Pool<SqlServerConnectionManager>;
+
+/// How many read-only routing redirects to follow before reporting the chain as broken.
+///
+/// A SQL Server availability group answers a read-intent login with a routing
+/// `ENVCHANGE`, which tiberius surfaces as [`TiberiusError::Routing`]. The login
+/// itself succeeded — the server is naming the replica the session belongs on — so a
+/// connection only exists once the client re-dials that address. One hop is what a
+/// well-formed routing list needs, and bounding the chain keeps a list that routes
+/// back to the listener from redirecting for as long as the pool will wait.
+const MAX_ROUTING_REDIRECTS: usize = 3;
 
 #[derive(Clone, Debug)]
 pub struct SqlServerConnectionManager {
@@ -39,11 +49,74 @@ impl SqlServerConnectionManager {
     pub async fn create(config: Config) -> super::Result<SqlServerConnectionPool> {
         let manager = SqlServerConnectionManager::new(config);
         let pool = bb8::Pool::builder()
+            .error_sink(Box::new(LogConnectionErrors))
             .build(manager)
             .await
             .context(SqlServerAccessSnafu)?;
         Ok(pool)
     }
+
+    /// Connects with this manager's configuration, following any read-only routing
+    /// redirect the server answers with.
+    ///
+    /// Each redirect re-dials a *clone* of the configured settings with only the host
+    /// and port replaced, so the credentials, database, encryption and application name
+    /// the routed replica needs are the ones the dataset supplied.
+    async fn connect_with<C, F, Fut>(&self, connect: F) -> Result<C, TiberiusError>
+    where
+        F: Fn(Config) -> Fut,
+        Fut: Future<Output = Result<C, TiberiusError>>,
+    {
+        let mut config = self.config.clone();
+        let mut redirects = 0;
+        loop {
+            match connect(config.clone()).await {
+                Err(TiberiusError::Routing { host, port }) => {
+                    if redirects == MAX_ROUTING_REDIRECTS {
+                        return Err(TiberiusError::Protocol(
+                            format!(
+                                "the server redirected the connection more than {MAX_ROUTING_REDIRECTS} times without completing a login, most recently to {host}:{port}. Check the availability group's read-only routing list: a list that routes back to the listener redirects for as long as the connection is retried. For details, visit: https://spiceai.org/docs/components/data-connectors/mssql"
+                            )
+                            .into(),
+                        ));
+                    }
+                    redirects += 1;
+                    tracing::debug!("SQL Server routed the connection to {host}:{port}");
+                    config.host(host);
+                    config.port(port);
+                }
+                result => return result,
+            }
+        }
+    }
+}
+
+/// Reports the per-attempt connection failures the pool retries through.
+///
+/// `bb8` re-dials a failed connection on a backoff until its connection timeout
+/// expires and hands each intermediate error to the pool's error sink, which
+/// defaults to `NopErrorSink`. Under that default a caller sees only
+/// `RunError::TimedOut`, so a login rejected for a specific, reportable reason —
+/// wrong credentials, an unreachable replica, a routing list that never settles —
+/// is indistinguishable from a server that is simply not answering.
+#[derive(Clone, Copy, Debug)]
+struct LogConnectionErrors;
+
+impl ErrorSink<TiberiusError> for LogConnectionErrors {
+    fn sink(&self, error: TiberiusError) {
+        tracing::warn!("Failed to connect to SQL Server: {error}. Retrying.");
+    }
+
+    fn boxed_clone(&self) -> Box<dyn ErrorSink<TiberiusError>> {
+        Box::new(*self)
+    }
+}
+
+/// Opens a TDS connection to the address `config` names.
+async fn connect_over_tcp(config: Config) -> Result<Client<Compat<TcpStream>>, TiberiusError> {
+    let tcp = TcpStream::connect(config.get_addr()).await?;
+    tcp.set_nodelay(true)?;
+    Client::connect(config, tcp.compat_write()).await
 }
 
 #[async_trait]
@@ -52,12 +125,7 @@ impl bb8::ManageConnection for SqlServerConnectionManager {
     type Error = tiberius::error::Error;
 
     fn connect(&self) -> impl Future<Output = Result<Self::Connection, Self::Error>> + Send {
-        Box::pin(async move {
-            let tcp = TcpStream::connect(&self.config.get_addr()).await?;
-            tcp.set_nodelay(true)?;
-            let client = Client::connect(self.config.clone(), tcp.compat_write()).await?;
-            Ok(client)
-        })
+        Box::pin(self.connect_with(connect_over_tcp))
     }
 
     fn is_valid(
@@ -72,5 +140,210 @@ impl bb8::ManageConnection for SqlServerConnectionManager {
 
     fn has_broken(&self, _: &mut Self::Connection) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        future::{Ready, ready},
+        io::Write,
+        sync::Arc,
+    };
+
+    use parking_lot::Mutex;
+
+    use super::{
+        Config, ErrorSink, LogConnectionErrors, MAX_ROUTING_REDIRECTS, SqlServerConnectionManager,
+        TiberiusError,
+    };
+
+    const LISTENER: &str = "ag-listener";
+    const LISTENER_PORT: u16 = 1433;
+
+    fn listener_config() -> Config {
+        let mut config = Config::new();
+        config.host(LISTENER);
+        config.port(LISTENER_PORT);
+        config
+    }
+
+    fn routing_to(host: &str, port: u16) -> TiberiusError {
+        TiberiusError::Routing {
+            host: host.to_string(),
+            port,
+        }
+    }
+
+    /// Answers each connection attempt from a script, recording the address it was dialled at.
+    ///
+    /// The connection value is the address itself, so a test can assert which replica the
+    /// returned connection was established against rather than only that one was returned.
+    struct ScriptedServer {
+        dialled: Mutex<Vec<String>>,
+        replies: Mutex<VecDeque<Result<(), TiberiusError>>>,
+    }
+
+    impl ScriptedServer {
+        fn new(replies: Vec<Result<(), TiberiusError>>) -> Arc<Self> {
+            Arc::new(Self {
+                dialled: Mutex::new(Vec::new()),
+                replies: Mutex::new(replies.into()),
+            })
+        }
+
+        /// Replies every attempt with a routing redirect that points back at the listener,
+        /// which is the misconfiguration the redirect bound exists to terminate.
+        fn always_routing() -> Arc<Self> {
+            Arc::new(Self {
+                dialled: Mutex::new(Vec::new()),
+                replies: Mutex::new(VecDeque::new()),
+            })
+        }
+
+        fn connect(self: Arc<Self>, config: &Config) -> Ready<Result<String, TiberiusError>> {
+            let addr = config.get_addr();
+            self.dialled.lock().push(addr.clone());
+            let reply = self
+                .replies
+                .lock()
+                .pop_front()
+                .unwrap_or_else(|| Err(routing_to(LISTENER, LISTENER_PORT)));
+            ready(reply.map(|()| addr))
+        }
+
+        fn dialled(&self) -> Vec<String> {
+            self.dialled.lock().clone()
+        }
+    }
+
+    /// Drives the manager's own connect path, so a regression that stops it consulting
+    /// the routing logic fails here rather than only inside a helper nothing calls.
+    async fn connect_via(server: &Arc<ScriptedServer>) -> Result<String, TiberiusError> {
+        let server = Arc::clone(server);
+        SqlServerConnectionManager::new(listener_config())
+            .connect_with(move |config| Arc::clone(&server).connect(&config))
+            .await
+    }
+
+    #[tokio::test]
+    async fn a_routing_redirect_is_followed_to_the_named_replica() {
+        let server = ScriptedServer::new(vec![Err(routing_to("read-replica", 1444)), Ok(())]);
+
+        let addr = connect_via(&server)
+            .await
+            .expect("the routed replica accepted the login");
+
+        assert_eq!(addr, "read-replica:1444");
+        assert_eq!(
+            server.dialled(),
+            vec!["ag-listener:1433", "read-replica:1444"]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_login_that_is_not_routed_is_dialled_once() {
+        let server = ScriptedServer::new(vec![Ok(())]);
+
+        let addr = connect_via(&server).await.expect("the listener accepted");
+
+        assert_eq!(addr, "ag-listener:1433");
+        assert_eq!(server.dialled(), vec!["ag-listener:1433"]);
+    }
+
+    #[tokio::test]
+    async fn a_non_routing_error_is_returned_unchanged() {
+        let server = ScriptedServer::new(vec![Err(TiberiusError::Protocol("login failed".into()))]);
+
+        let Err(error) = connect_via(&server).await else {
+            panic!("expected the connection to fail");
+        };
+
+        assert_eq!(error, TiberiusError::Protocol("login failed".into()));
+        assert_eq!(server.dialled(), vec!["ag-listener:1433"]);
+    }
+
+    #[tokio::test]
+    async fn a_chain_of_redirects_is_bounded_and_reported() {
+        let server = ScriptedServer::always_routing();
+
+        let Err(error) = connect_via(&server).await else {
+            panic!("expected a routing list that never settles to fail");
+        };
+
+        let TiberiusError::Protocol(message) = &error else {
+            panic!("expected the exhausted chain to be reported as a protocol error, got {error}");
+        };
+        assert!(
+            message.contains("ag-listener:1433"),
+            "the message should name the address it was last redirected to: {message}"
+        );
+        assert!(
+            message.contains("read-only routing list"),
+            "the message should name the configuration to check: {message}"
+        );
+        let dialled = server.dialled().len();
+        assert_eq!(dialled, MAX_ROUTING_REDIRECTS + 1);
+        // Asserted against a literal as well as the constant: the equality above moves with
+        // `MAX_ROUTING_REDIRECTS`, so on its own it would accept a bound raised high enough
+        // that a routing loop still dials for as long as the caller is willing to wait.
+        assert!(
+            dialled <= 8,
+            "a routing chain must terminate within a few dials, not {dialled}"
+        );
+    }
+
+    /// Collects everything a subscriber writes, so a test can count emitted events.
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturedLogs {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl tracing_subscriber::fmt::MakeWriter<'_> for CapturedLogs {
+        type Writer = CapturedLogs;
+
+        fn make_writer(&self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    impl CapturedLogs {
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().clone()).expect("captured logs are UTF-8")
+        }
+    }
+
+    #[test]
+    fn every_connection_failure_the_pool_retries_is_reported_once() {
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(logs.clone())
+            .with_max_level(tracing::Level::WARN)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            LogConnectionErrors.sink(routing_to("read-replica", 1444));
+        });
+
+        let contents = logs.contents();
+        assert_eq!(
+            contents.matches("Failed to connect to SQL Server").count(),
+            1,
+            "each retried failure should be reported exactly once: {contents}"
+        );
+        assert!(
+            contents.contains("read-replica:1444"),
+            "the report should carry the underlying error: {contents}"
+        );
     }
 }

--- a/crates/data_components/src/mssql/connection_manager.rs
+++ b/crates/data_components/src/mssql/connection_manager.rs
@@ -36,6 +36,39 @@ pub type SqlServerConnectionPool = Pool<SqlServerConnectionManager>;
 /// back to the listener from redirecting for as long as the pool will wait.
 const MAX_ROUTING_REDIRECTS: usize = 3;
 
+/// How much of a server-supplied diagnostic to keep when reporting it.
+///
+/// Long enough for a real login rejection, short enough that a peer cannot decide
+/// how much of an operator's log one failed connection occupies.
+const MAX_REPORTED_CHARS: usize = 512;
+
+/// Renders server-supplied diagnostic text as one bounded log line.
+///
+/// A TDS error message and a routing target are both chosen by the peer, and
+/// `tiberius` surfaces them verbatim. Every log record here has to stay on a single
+/// line, so control characters are replaced rather than passed through — otherwise a
+/// peer emitting newlines splits one failure across several records, each of which
+/// reads like an independent event.
+fn as_one_line(text: &str) -> String {
+    let mut reported: String = text
+        .chars()
+        .take(MAX_REPORTED_CHARS)
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect();
+    // `nth` rather than `count`: asking how long the whole text is would walk all of it,
+    // which is the work the cap exists to avoid.
+    if text.chars().nth(MAX_REPORTED_CHARS).is_some() {
+        reported.push('…');
+    }
+    reported
+}
+
 #[derive(Clone, Debug)]
 pub struct SqlServerConnectionManager {
     config: Config,
@@ -75,13 +108,17 @@ impl SqlServerConnectionManager {
                     if redirects == MAX_ROUTING_REDIRECTS {
                         return Err(TiberiusError::Protocol(
                             format!(
-                                "the server redirected the connection more than {MAX_ROUTING_REDIRECTS} times without completing a login, most recently to {host}:{port}. Check the availability group's read-only routing list: a list that routes back to the listener redirects for as long as the connection is retried. For details, visit: https://spiceai.org/docs/components/data-connectors/mssql"
+                                "the server redirected the connection more than {MAX_ROUTING_REDIRECTS} times without completing a login, most recently to {}:{port}. Check the availability group's read-only routing list: a list that routes back to the listener redirects for as long as the connection is retried. For details, visit: https://spiceai.org/docs/components/data-connectors/mssql",
+                                as_one_line(&host)
                             )
                             .into(),
                         ));
                     }
                     redirects += 1;
-                    tracing::debug!("SQL Server routed the connection to {host}:{port}");
+                    tracing::debug!(
+                        "SQL Server routed the connection to {}:{port}",
+                        as_one_line(&host)
+                    );
                     config.host(host);
                     config.port(port);
                 }
@@ -104,7 +141,10 @@ struct LogConnectionErrors;
 
 impl ErrorSink<TiberiusError> for LogConnectionErrors {
     fn sink(&self, error: TiberiusError) {
-        tracing::warn!("Failed to connect to SQL Server: {error}. Retrying.");
+        tracing::warn!(
+            "Failed to connect to SQL Server: {}. Retrying.",
+            as_one_line(&error.to_string())
+        );
     }
 
     fn boxed_clone(&self) -> Box<dyn ErrorSink<TiberiusError>> {
@@ -155,8 +195,8 @@ mod tests {
     use parking_lot::Mutex;
 
     use super::{
-        Config, ErrorSink, LogConnectionErrors, MAX_ROUTING_REDIRECTS, SqlServerConnectionManager,
-        TiberiusError,
+        Config, ErrorSink, LogConnectionErrors, MAX_REPORTED_CHARS, MAX_ROUTING_REDIRECTS,
+        SqlServerConnectionManager, TiberiusError,
     };
 
     const LISTENER: &str = "ag-listener";
@@ -186,19 +226,13 @@ mod tests {
     }
 
     impl ScriptedServer {
+        /// Answers the first attempts from `replies`; once they run out, every further
+        /// attempt is redirected back at the listener — the misconfiguration the
+        /// redirect bound exists to terminate.
         fn new(replies: Vec<Result<(), TiberiusError>>) -> Arc<Self> {
             Arc::new(Self {
                 dialled: Mutex::new(Vec::new()),
                 replies: Mutex::new(replies.into()),
-            })
-        }
-
-        /// Replies every attempt with a routing redirect that points back at the listener,
-        /// which is the misconfiguration the redirect bound exists to terminate.
-        fn always_routing() -> Arc<Self> {
-            Arc::new(Self {
-                dialled: Mutex::new(Vec::new()),
-                replies: Mutex::new(VecDeque::new()),
             })
         }
 
@@ -266,7 +300,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_chain_of_redirects_is_bounded_and_reported() {
-        let server = ScriptedServer::always_routing();
+        let server = ScriptedServer::new(Vec::new());
 
         let Err(error) = connect_via(&server).await else {
             panic!("expected a routing list that never settles to fail");
@@ -323,19 +357,22 @@ mod tests {
         }
     }
 
-    #[test]
-    fn every_connection_failure_the_pool_retries_is_reported_once() {
+    /// Runs `emit` against a subscriber that keeps only warnings, and returns what it wrote.
+    fn warnings_from(emit: impl FnOnce()) -> String {
         let logs = CapturedLogs::default();
         let subscriber = tracing_subscriber::fmt()
             .with_writer(logs.clone())
             .with_max_level(tracing::Level::WARN)
             .finish();
+        tracing::subscriber::with_default(subscriber, emit);
+        logs.contents()
+    }
 
-        tracing::subscriber::with_default(subscriber, || {
+    #[test]
+    fn every_connection_failure_the_pool_retries_is_reported_once() {
+        let contents = warnings_from(|| {
             LogConnectionErrors.sink(routing_to("read-replica", 1444));
         });
-
-        let contents = logs.contents();
         assert_eq!(
             contents.matches("Failed to connect to SQL Server").count(),
             1,
@@ -344,6 +381,35 @@ mod tests {
         assert!(
             contents.contains("read-replica:1444"),
             "the report should carry the underlying error: {contents}"
+        );
+    }
+
+    #[test]
+    fn a_server_supplied_diagnostic_stays_on_one_bounded_line() {
+        // What a hostile — or merely broken — server can put in a TDS error token: line
+        // breaks that would split one failure across several records, and a body long
+        // enough to let the peer decide how much of the log it occupies.
+        let hostile = format!("first line\r\nsecond line\t{}", "A".repeat(4096));
+        let contents = warnings_from(|| {
+            LogConnectionErrors.sink(TiberiusError::Protocol(hostile.into()));
+        });
+        assert_eq!(
+            contents.lines().count(),
+            1,
+            "one failure must be one record: {contents}"
+        );
+        assert!(
+            contents.contains("first line  second line "),
+            "the text should survive with its control characters replaced: {contents}"
+        );
+        assert!(
+            contents.contains('…'),
+            "an over-long diagnostic should be marked as truncated: {contents}"
+        );
+        assert!(
+            contents.chars().count() < 2 * MAX_REPORTED_CHARS,
+            "the record should be bounded by the cap, not by what the peer sent ({} chars)",
+            contents.chars().count()
         );
     }
 }


### PR DESCRIPTION
## Summary

A SQL Server Always-On availability group answers a read-intent login with a
routing `ENVCHANGE` naming the replica the session belongs on. The login itself
succeeded — the server is telling the client where the session lives — and
tiberius reports it as `Error::Routing { host, port }`, expecting the caller to
re-dial that address. `SqlServerConnectionManager::connect` propagated the error
instead, so the connection never completed. `bb8` then re-dialled the same
listener on its backoff loop, was routed identically every time, and the caller
saw only `RunError::TimedOut` after 30 seconds.

The pool was also built with `bb8`'s default `NopErrorSink`, which discards every
per-attempt error. So the one place the real cause was visible — the login the
pool kept retrying — reached neither a log nor the caller: an availability group
that routed and a server that was simply unreachable produced the identical
30-second timeout.

Fixes #11453

## Changes

- **Follow the redirect.** `connect_with` re-dials the named replica, carrying a
  *clone* of the configured settings with only host and port replaced, so the
  credentials, database, encryption level and trust configuration the routed
  replica is reached with are the ones the dataset supplied. The chain is bounded
  at 3 hops: one is what a well-formed routing list needs, and a list that points
  back at the listener would otherwise redirect for as long as the pool waits.
  Exhausting it reports the last address and names the routing list as the thing
  to check, rather than timing out anonymously.
- **Install an error sink** so every failure `bb8` retries through is logged with
  its reason.
- **Bound what a peer can put in a log record.** The TDS error token and the
  routing target are both text the server chose, and tiberius renders them
  verbatim. Both now go through `as_one_line`, which replaces control characters
  and caps the length, so one failure stays one log record and a peer cannot
  decide how much of the log it occupies.

The redirect is what every SQL Server client driver does for read-only routing,
and is the procedure tiberius's own README prescribes. Note for reviewers: it
does mean a login is completed against a host the *server* named. That host is
reached with the same encryption and certificate-trust settings as the original,
and the party naming it is the server the operator already configured and already
sends credentials to, so it grants no access an attacker did not already have.

## Deferred, with issues

- **#12605** — `MultiSubnetFailover=Yes` is still ignored, so a passive
  availability-group address can stall the connect. It cannot be fixed here:
  `tiberius::Config` neither parses nor exposes the keyword, so honouring it needs
  a change in the `spiceai/tiberius` fork. This is the third defect #11453
  reported.
- **#12606** — no deadline bounds a single connection attempt, so a peer that
  accepts TCP and then stalls pins a pool slot. This predates the change (the same
  unbounded await has always covered the listener), but following a redirect
  widens it to addresses the server names. Raised by the adversarial review. The
  correct bound covers the primary attempt too, so applying one only to the
  redirect path would leave the original hang in place while implying it had been
  handled.

## Test plan
- [x] Added regression test for a read-only routing redirect being followed to the named replica, driven through the manager's own connect path
- [x] Added edge case tests for an unrouted login (dialled once), a non-routing error (returned unchanged, no retry), a routing list that never settles (bounded, and reported naming the address and the routing list), the retry log being emitted exactly once and carrying the error, and a hostile diagnostic (embedded newlines, 4 KiB body) staying one bounded record
- [x] 11-case mutation matrix over the fix, every case caught by a named test: routing not followed; bound raised to 100; exhaustion not reported; redirect drops the host; redirect drops the port; sink at DEBUG; sink emitting twice; sink dropping the error text; no control-character replacement; no length cap; sink not sanitizing
- [x] `make lint` passes (workspace-wide `cargo fmt --all -- --check` + full clippy — not a per-crate `cargo clippy -p <crate>`)
- [x] `make test` passes
- [x] `make signoff` run after the final push (`Attestation` check is green)
