### PR TITLE
test(cayenne): measure small-file fan-out against the seeded appends, not a listed count (fixes #12602)

### DIFF
--- a/crates/cayenne/tests/small_files_compaction_test.rs
+++ b/crates/cayenne/tests/small_files_compaction_test.rs
@@ -194,6 +194,29 @@ async fn count_rows_matching(ctx: &SessionContext, table_name: &str, where_claus
         .value(0)
 }
 
+/// Report the current snapshot once its file count is below
+/// `uncompacted_file_count`, i.e. once small-file compaction has consolidated
+/// the seeded appends, or `None` if no compaction is reachable.
+///
+/// `uncompacted_file_count` must be the number of files the test *seeded*, not
+/// a count sampled from the store after the writes. Appends drive
+/// `schedule_post_write_compaction`, which is NOT disabled by
+/// `compaction_background_interval_ms: 0` — that only stops the interval
+/// scheduler — so a post-write pass runs on the dedicated compaction runtime and
+/// can consolidate the seed while the test is still writing it. A count sampled
+/// afterwards may therefore already be the compacted count, making a further
+/// reduction unreachable and this helper's answer depend on that race.
+///
+/// Quiescing first is what makes the answer deterministic. A post-write pass and
+/// this helper both call `compact_current_snapshot_small_files`, so they contend
+/// for the same `compaction_lock` (`try_lock`, so the loser reports a no-op) and
+/// for the same one-shot `new_files_since_last_compaction` credit, which the
+/// winner resets on commit. Once that credit is spent the explicit trigger
+/// declines *permanently*, so waiting longer cannot recover it — the wait has to
+/// end with the background pass, not with a wall clock. After the drain no pass
+/// is in flight or scheduled and only a new write could schedule one, so the
+/// observation below is stable; the bounded loop is a backstop for a staged
+/// append still finalizing, not the mechanism.
 async fn wait_until_current_snapshot_compacts(
     table: &Arc<CayenneTableProvider>,
     fixture: &common::TestFixture,
@@ -202,6 +225,8 @@ async fn wait_until_current_snapshot_compacts(
 ) -> Result<Option<(String, usize)>, Box<dyn std::error::Error>> {
     const TIMEOUT: Duration = Duration::from_secs(10);
     const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+    table.drain_in_flight_maintenance().await?;
 
     let started = Instant::now();
     loop {
@@ -982,6 +1007,9 @@ async fn compact_current_after_seed_then_more_preserves_all_rows(
     let expected = small_rows * (seed_batches + more);
     assert_eq!(count_rows(&ctx, "two_phase_compact").await, expected);
 
+    // Quiesce before sampling, so `files_before` is a settled count rather than
+    // one a post-write pass is still moving underneath the comparison below.
+    table.drain_in_flight_maintenance().await?;
     let snap_before = fixture
         .catalog
         .get_table("two_phase_compact")
@@ -1292,17 +1320,21 @@ async fn warm_subset_preserves_key_deletes_and_rows(
     Ok(())
 }
 
-test_with_backends!(warm_subset_reduces_small_file_fanout);
-async fn warm_subset_reduces_small_file_fanout(
+// Regression test for #12602: the seed's own appends schedule a post-write
+// compaction on the dedicated compaction runtime, so a fan-out measured right
+// after the writes raced that pass and the tests built on it were flaky.
+// `drain_in_flight_maintenance` is what ends the race; assert it actually
+// leaves nothing running, since every fan-out assertion here now rests on it.
+test_with_backends!(post_write_compaction_is_quiesced_by_the_drain);
+async fn post_write_compaction_is_quiesced_by_the_drain(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let schema = pk_schema();
     let (table, ctx, table_id) = build_table(
         &fixture,
-        "warm_subset_fanout",
+        "quiesced_fanout",
         Arc::clone(&schema),
         None,
-        // Append-only + Key mode → subset rewrite (no position full path).
         aggressive_key_deletion_compaction_config(),
     )
     .await;
@@ -1317,22 +1349,84 @@ async fn warm_subset_reduces_small_file_fanout(
         .await?;
     }
 
+    table.drain_in_flight_maintenance().await?;
+
+    let observe = || async {
+        let snapshot_id = fixture
+            .catalog
+            .get_table("quiesced_fanout")
+            .await
+            .expect("get_table")
+            .current_snapshot_id;
+        let files = count_vortex_files(&fixture.data_path, &table_id, &snapshot_id).await;
+        (snapshot_id, files)
+    };
+
+    // Nothing writes between these two samples, and only a write can schedule a
+    // post-write pass, so a drained table must report the same snapshot and the
+    // same fan-out both times. The wait is deliberate — the property under test
+    // is that no pass lands during it, so it cannot be replaced by polling.
+    let first = observe().await;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let second = observe().await;
+    assert_eq!(
+        first, second,
+        "a drained table must not move its snapshot or fan-out (was {first:?}, then {second:?})"
+    );
+
+    // The drain waits for the pass rather than cancelling it, so the rows it
+    // consolidated must all still be readable.
+    assert_eq!(
+        count_rows(&ctx, "quiesced_fanout").await,
+        batch_rows * batches,
+        "draining compaction must preserve every seeded row"
+    );
+
+    Ok(())
+}
+
+test_with_backends!(warm_subset_reduces_small_file_fanout);
+async fn warm_subset_reduces_small_file_fanout(
+    fixture: common::TestFixture,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = pk_schema();
+    let (table, ctx, _table_id) = build_table(
+        &fixture,
+        "warm_subset_fanout",
+        Arc::clone(&schema),
+        None,
+        // Append-only + Key mode → subset rewrite (no position full path).
+        aggressive_key_deletion_compaction_config(),
+    )
+    .await;
+
+    // Sample the pre-seed snapshot BEFORE writing: an append can drive a
+    // post-write compaction that advances the snapshot mid-seed, so a pointer
+    // read taken after the loop is not reliably the un-compacted one.
     let pre_snapshot = fixture
         .catalog
         .get_table("warm_subset_fanout")
         .await?
         .current_snapshot_id;
-    let pre_count = count_vortex_files(&fixture.data_path, &table_id, &pre_snapshot).await;
-    assert!(
-        pre_count > 1,
-        "seed must leave more than one vortex file to compact (found {pre_count})"
-    );
 
-    // Threshold is `pre_count` so the helper cannot return early without a
-    // real reduction (or an explicit compact commit that then must still
-    // show `post_count < pre_count` below).
+    let batch_rows: i64 = 1500;
+    let batches = 12_i64;
+    for batch_idx in 0..batches {
+        common::insert_batch(
+            &table,
+            make_batch(&schema, batch_idx * batch_rows, batch_rows),
+        )
+        .await?;
+    }
+
+    // Each batch is larger than `INLINE_MAX_ROWS`, so an un-compacted seed is
+    // one vortex file per batch. That seeded count — not a count listed after
+    // the writes — is the fan-out compaction has to beat; see
+    // `wait_until_current_snapshot_compacts` for why a listed count can already
+    // be the compacted one.
+    let seeded_files = usize::try_from(batches).expect("batch count fits usize");
     let Some((post_snap, post_count)) =
-        wait_until_current_snapshot_compacts(&table, &fixture, "warm_subset_fanout", pre_count)
+        wait_until_current_snapshot_compacts(&table, &fixture, "warm_subset_fanout", seeded_files)
             .await?
     else {
         panic!("warm-subset compaction should fire");
@@ -1340,8 +1434,8 @@ async fn warm_subset_reduces_small_file_fanout(
 
     assert_ne!(post_snap, pre_snapshot, "compact must advance the snapshot");
     assert!(
-        post_count < pre_count,
-        "subset compact must strictly reduce fan-out (pre={pre_count}, post={post_count})"
+        post_count < seeded_files,
+        "subset compact must strictly reduce fan-out (seeded={seeded_files}, post={post_count})"
     );
     assert_eq!(
         count_rows(&ctx, "warm_subset_fanout").await,

--- a/crates/cayenne/tests/small_files_compaction_test.rs
+++ b/crates/cayenne/tests/small_files_compaction_test.rs
@@ -204,19 +204,55 @@ async fn count_rows_matching(ctx: &SessionContext, table_name: &str, where_claus
         .value(0)
 }
 
+/// Wait for `table`'s in-flight maintenance to drain, bounded.
+///
+/// `drain_in_flight_maintenance` has no timeout of its own, so a pass that never
+/// finishes would hang until the much larger harness process timeout, reporting
+/// nothing about where it stopped. `context` names what the caller was about to
+/// do, so the panic identifies which wait wedged.
+async fn drain_in_flight_maintenance_bounded(
+    table: &Arc<CayenneTableProvider>,
+    fixture: &common::TestFixture,
+    table_name: &str,
+    context: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    const DRAIN_TIMEOUT: Duration = Duration::from_mins(2);
+
+    let Ok(drained) =
+        tokio::time::timeout(DRAIN_TIMEOUT, table.drain_in_flight_maintenance()).await
+    else {
+        let table_meta = fixture.catalog.get_table(table_name).await?;
+        let snapshot_id = table_meta.current_snapshot_id;
+        let files =
+            count_vortex_files(&fixture.data_path, &table_meta.table_id, &snapshot_id).await;
+        panic!(
+            "draining {table_name}'s in-flight maintenance did not finish within \
+             {DRAIN_TIMEOUT:?} before {context} (snapshot {snapshot_id}, {files} files)"
+        );
+    };
+    drained?;
+
+    Ok(())
+}
+
 /// Report the current snapshot once its file count is below
 /// `uncompacted_file_count`, i.e. once small-file compaction has consolidated
 /// the seeded appends, or `None` if no compaction is reachable.
 ///
-/// `uncompacted_file_count` must be the number of appends the test *seeded*, not
-/// a count listed from the store after the writes. Appends drive
-/// `schedule_post_write_compaction`, which is NOT disabled by
-/// `compaction_background_interval_ms: 0` — that only stops the interval
-/// scheduler — so a pass gets spawned and can consolidate the seed while the test
-/// is still writing it. (These tests install no dedicated compaction runtime, so
-/// that pass lands on the ambient one and interleaves at the test's await points.)
-/// A count listed afterwards may therefore already be the compacted count, making
-/// a further reduction unreachable and this helper's answer depend on that race.
+/// Pass the number of appends the test *seeded* whenever the caller asserts that
+/// compaction fired. Appends drive `schedule_post_write_compaction`, which is NOT
+/// disabled by `compaction_background_interval_ms: 0` — that only stops the
+/// interval scheduler — so a pass gets spawned and can consolidate the seed while
+/// the test is still writing it. (These tests install no dedicated compaction
+/// runtime, so that pass lands on the ambient one and interleaves at the test's
+/// await points.) A count listed from the store after the writes may therefore
+/// already be the compacted count, making a further reduction unreachable and this
+/// helper's answer depend on that race.
+///
+/// A caller for which both answers are correct may still pass a listed count —
+/// `two_phase_compact`'s phase B does, and reads `None` as "post-write already
+/// drained the backlog". What a listed count cannot support is asserting that
+/// `Some` must come back.
 ///
 /// Quiescing first is what makes the answer deterministic. A post-write pass and
 /// this helper both call `compact_current_snapshot_small_files`, so they contend
@@ -229,9 +265,7 @@ async fn count_rows_matching(ctx: &SessionContext, table_name: &str, where_claus
 /// observation below is stable; the bounded loop is a backstop for a staged
 /// append still finalizing, not the mechanism.
 ///
-/// The drain is bounded here because it has none of its own: a pass that never
-/// finishes would otherwise hang until the much larger harness process timeout,
-/// reporting nothing about where it stopped.
+/// The drain is bounded (see [`drain_in_flight_maintenance_bounded`]).
 async fn wait_until_current_snapshot_compacts(
     table: &Arc<CayenneTableProvider>,
     fixture: &common::TestFixture,
@@ -240,22 +274,14 @@ async fn wait_until_current_snapshot_compacts(
 ) -> Result<Option<(String, usize)>, Box<dyn std::error::Error>> {
     const TIMEOUT: Duration = Duration::from_secs(10);
     const POLL_INTERVAL: Duration = Duration::from_millis(50);
-    const DRAIN_TIMEOUT: Duration = Duration::from_mins(2);
 
-    let Ok(drained) =
-        tokio::time::timeout(DRAIN_TIMEOUT, table.drain_in_flight_maintenance()).await
-    else {
-        let table_meta = fixture.catalog.get_table(table_name).await?;
-        let snapshot_id = table_meta.current_snapshot_id;
-        let files =
-            count_vortex_files(&fixture.data_path, &table_meta.table_id, &snapshot_id).await;
-        panic!(
-            "draining {table_name}'s in-flight maintenance did not finish within \
-             {DRAIN_TIMEOUT:?} (snapshot {snapshot_id}, {files} files, \
-             target below {uncompacted_file_count})"
-        );
-    };
-    drained?;
+    drain_in_flight_maintenance_bounded(
+        table,
+        fixture,
+        table_name,
+        &format!("waiting for a fan-out below {uncompacted_file_count}"),
+    )
+    .await?;
 
     let started = Instant::now();
     loop {
@@ -1379,7 +1405,13 @@ async fn a_seed_is_consolidated_before_its_fanout_can_be_listed(
     }
 
     // Let the unasked-for pass finish instead of racing it.
-    table.drain_in_flight_maintenance().await?;
+    drain_in_flight_maintenance_bounded(
+        &table,
+        &fixture,
+        "consolidated_seed",
+        "listing the settled fan-out",
+    )
+    .await?;
 
     let settled_snapshot = fixture
         .catalog
@@ -1427,7 +1459,11 @@ async fn warm_subset_reduces_small_file_fanout(
         "warm_subset_fanout",
         Arc::clone(&schema),
         None,
-        // Append-only + Key mode → subset rewrite (no position full path).
+        // No primary key, so `DeletionMode::Key` resolves to position-based
+        // deletion and `subset_rewrite_eligibility` rejects the subset rewrite
+        // outright — what this exercises is the full-rewrite small-file path.
+        // `warm_subset_preserves_key_deletes_and_rows` builds a real PK table and
+        // is the one that covers subset rewrite.
         aggressive_key_deletion_compaction_config(),
     )
     .await;

--- a/crates/cayenne/tests/small_files_compaction_test.rs
+++ b/crates/cayenne/tests/small_files_compaction_test.rs
@@ -1320,19 +1320,21 @@ async fn warm_subset_preserves_key_deletes_and_rows(
     Ok(())
 }
 
-// Regression test for #12602: the seed's own appends schedule a post-write
-// compaction on the dedicated compaction runtime, so a fan-out measured right
-// after the writes raced that pass and the tests built on it were flaky.
-// `drain_in_flight_maintenance` is what ends the race; assert it actually
-// leaves nothing running, since every fan-out assertion here now rests on it.
-test_with_backends!(post_write_compaction_is_quiesced_by_the_drain);
-async fn post_write_compaction_is_quiesced_by_the_drain(
+// Regression test for #12602. Pins the hazard every fan-out assertion here rests
+// on: a seed's own appends get consolidated by a post-write pass nobody asked
+// for, so a fan-out listed after the writes is already the compacted one.
+// Reaching that state deliberately — rather than hoping to race into it — is
+// what makes this deterministic: from here a premise listed off the store can
+// never be beaten, because the pass that produced it also spent the one-shot
+// `new_files_since_last_compaction` credit the explicit trigger needs.
+test_with_backends!(a_seed_is_consolidated_before_its_fanout_can_be_listed);
+async fn a_seed_is_consolidated_before_its_fanout_can_be_listed(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let schema = pk_schema();
     let (table, ctx, table_id) = build_table(
         &fixture,
-        "quiesced_fanout",
+        "consolidated_seed",
         Arc::clone(&schema),
         None,
         aggressive_key_deletion_compaction_config(),
@@ -1341,6 +1343,7 @@ async fn post_write_compaction_is_quiesced_by_the_drain(
 
     let batch_rows: i64 = 1500;
     let batches = 12_i64;
+    let seeded_files = usize::try_from(batches).expect("batch count fits usize");
     for batch_idx in 0..batches {
         common::insert_batch(
             &table,
@@ -1349,35 +1352,38 @@ async fn post_write_compaction_is_quiesced_by_the_drain(
         .await?;
     }
 
+    // Let the unasked-for pass finish instead of racing it.
     table.drain_in_flight_maintenance().await?;
 
-    let observe = || async {
-        let snapshot_id = fixture
-            .catalog
-            .get_table("quiesced_fanout")
-            .await
-            .expect("get_table")
-            .current_snapshot_id;
-        let files = count_vortex_files(&fixture.data_path, &table_id, &snapshot_id).await;
-        (snapshot_id, files)
-    };
-
-    // Nothing writes between these two samples, and only a write can schedule a
-    // post-write pass, so a drained table must report the same snapshot and the
-    // same fan-out both times. The wait is deliberate — the property under test
-    // is that no pass lands during it, so it cannot be replaced by polling.
-    let first = observe().await;
-    tokio::time::sleep(Duration::from_millis(250)).await;
-    let second = observe().await;
-    assert_eq!(
-        first, second,
-        "a drained table must not move its snapshot or fan-out (was {first:?}, then {second:?})"
+    let settled_snapshot = fixture
+        .catalog
+        .get_table("consolidated_seed")
+        .await?
+        .current_snapshot_id;
+    let settled_files = count_vortex_files(&fixture.data_path, &table_id, &settled_snapshot).await;
+    assert!(
+        settled_files < seeded_files,
+        "a post-write pass must consolidate the seed unprompted, which is what makes a \
+         listed fan-out unusable as the premise (seeded={seeded_files}, settled={settled_files})"
     );
 
-    // The drain waits for the pass rather than cancelling it, so the rows it
-    // consolidated must all still be readable.
+    // Measured against the seeded count the reduction is still visible from this
+    // already-consolidated state; measured against `settled_files` it could not be.
+    let Some((_post_snap, post_count)) =
+        wait_until_current_snapshot_compacts(&table, &fixture, "consolidated_seed", seeded_files)
+            .await?
+    else {
+        panic!("an already-consolidated seed must still report a reduced fan-out");
+    };
+    assert!(
+        post_count < seeded_files,
+        "fan-out must stay below the seeded count (seeded={seeded_files}, post={post_count})"
+    );
+
+    // The drain waits for the pass rather than cancelling it, so every row it
+    // consolidated must still be readable.
     assert_eq!(
-        count_rows(&ctx, "quiesced_fanout").await,
+        count_rows(&ctx, "consolidated_seed").await,
         batch_rows * batches,
         "draining compaction must preserve every seeded row"
     );

--- a/crates/cayenne/tests/small_files_compaction_test.rs
+++ b/crates/cayenne/tests/small_files_compaction_test.rs
@@ -64,9 +64,13 @@ fn aggressive_compaction_config() -> VortexConfig {
         compaction_trigger_files: 4,
         compaction_max_levels: 3,
         compaction_max_files_per_pick: 32,
-        // Disable the background scheduler so tests are deterministic — we
-        // drive compaction explicitly via maybe_compact_small_files() on the
-        // inline path or by triggering it from the test body.
+        // Stops the interval scheduler, so tests drive compaction explicitly via
+        // maybe_compact_small_files() on the inline path or from the test body.
+        // NOTE: it does NOT stop compaction from running on its own. An append
+        // still calls `schedule_post_write_compaction`, which spawns a pass
+        // regardless of this interval, so a test that measures file counts around
+        // its own writes must quiesce first — see
+        // `wait_until_current_snapshot_compacts`.
         compaction_background_interval_ms: 0,
         ..VortexConfig::default()
     }
@@ -132,10 +136,16 @@ fn value_payload(prefix: &str, row_id: i64) -> String {
 }
 
 /// Count `.vortex` files in `<data_path>/<table_id>/<current_snapshot_id>`.
+///
+/// A snapshot dir that does not exist yet holds no files, so that reads as 0. Any
+/// other error is raised: treating it as 0 would read as "compaction consolidated
+/// everything" and pass the very assertions that call this.
 async fn count_vortex_files(data_path: &Path, table_id: &str, snapshot_id: &str) -> usize {
     let snapshot_dir = data_path.join(table_id).join(snapshot_id);
-    let Ok(mut entries) = tokio::fs::read_dir(&snapshot_dir).await else {
-        return 0;
+    let mut entries = match tokio::fs::read_dir(&snapshot_dir).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return 0,
+        Err(e) => panic!("read_dir {} failed: {e}", snapshot_dir.display()),
     };
     let mut count = 0;
     while let Some(entry) = entries.next_entry().await.expect("read_dir") {
@@ -198,14 +208,15 @@ async fn count_rows_matching(ctx: &SessionContext, table_name: &str, where_claus
 /// `uncompacted_file_count`, i.e. once small-file compaction has consolidated
 /// the seeded appends, or `None` if no compaction is reachable.
 ///
-/// `uncompacted_file_count` must be the number of files the test *seeded*, not
-/// a count sampled from the store after the writes. Appends drive
+/// `uncompacted_file_count` must be the number of appends the test *seeded*, not
+/// a count listed from the store after the writes. Appends drive
 /// `schedule_post_write_compaction`, which is NOT disabled by
 /// `compaction_background_interval_ms: 0` — that only stops the interval
-/// scheduler — so a post-write pass runs on the dedicated compaction runtime and
-/// can consolidate the seed while the test is still writing it. A count sampled
-/// afterwards may therefore already be the compacted count, making a further
-/// reduction unreachable and this helper's answer depend on that race.
+/// scheduler — so a pass gets spawned and can consolidate the seed while the test
+/// is still writing it. (These tests install no dedicated compaction runtime, so
+/// that pass lands on the ambient one and interleaves at the test's await points.)
+/// A count listed afterwards may therefore already be the compacted count, making
+/// a further reduction unreachable and this helper's answer depend on that race.
 ///
 /// Quiescing first is what makes the answer deterministic. A post-write pass and
 /// this helper both call `compact_current_snapshot_small_files`, so they contend
@@ -217,6 +228,10 @@ async fn count_rows_matching(ctx: &SessionContext, table_name: &str, where_claus
 /// is in flight or scheduled and only a new write could schedule one, so the
 /// observation below is stable; the bounded loop is a backstop for a staged
 /// append still finalizing, not the mechanism.
+///
+/// The drain is bounded here because it has none of its own: a pass that never
+/// finishes would otherwise hang until the much larger harness process timeout,
+/// reporting nothing about where it stopped.
 async fn wait_until_current_snapshot_compacts(
     table: &Arc<CayenneTableProvider>,
     fixture: &common::TestFixture,
@@ -225,8 +240,22 @@ async fn wait_until_current_snapshot_compacts(
 ) -> Result<Option<(String, usize)>, Box<dyn std::error::Error>> {
     const TIMEOUT: Duration = Duration::from_secs(10);
     const POLL_INTERVAL: Duration = Duration::from_millis(50);
+    const DRAIN_TIMEOUT: Duration = Duration::from_secs(120);
 
-    table.drain_in_flight_maintenance().await?;
+    match tokio::time::timeout(DRAIN_TIMEOUT, table.drain_in_flight_maintenance()).await {
+        Ok(drained) => drained?,
+        Err(_) => {
+            let table_meta = fixture.catalog.get_table(table_name).await?;
+            let snapshot_id = table_meta.current_snapshot_id;
+            let files =
+                count_vortex_files(&fixture.data_path, &table_meta.table_id, &snapshot_id).await;
+            panic!(
+                "draining {table_name}'s in-flight maintenance did not finish within \
+                 {DRAIN_TIMEOUT:?} (snapshot {snapshot_id}, {files} files, \
+                 target below {uncompacted_file_count})"
+            );
+        }
+    }
 
     let started = Instant::now();
     loop {
@@ -1007,9 +1036,6 @@ async fn compact_current_after_seed_then_more_preserves_all_rows(
     let expected = small_rows * (seed_batches + more);
     assert_eq!(count_rows(&ctx, "two_phase_compact").await, expected);
 
-    // Quiesce before sampling, so `files_before` is a settled count rather than
-    // one a post-write pass is still moving underneath the comparison below.
-    table.drain_in_flight_maintenance().await?;
     let snap_before = fixture
         .catalog
         .get_table("two_phase_compact")
@@ -1332,18 +1358,18 @@ async fn a_seed_is_consolidated_before_its_fanout_can_be_listed(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let schema = pk_schema();
-    let (table, ctx, table_id) = build_table(
-        &fixture,
-        "consolidated_seed",
-        Arc::clone(&schema),
-        None,
-        aggressive_key_deletion_compaction_config(),
-    )
-    .await;
+    // A real PK (and no `OnConflict`), so the table is not silently resolved to
+    // the position-based strategy the way a PK-less one is.
+    let (table, ctx, table_id) =
+        build_append_only_key_delete_table(&fixture, "consolidated_seed", Arc::clone(&schema))
+            .await;
 
     let batch_rows: i64 = 1500;
     let batches = 12_i64;
-    let seeded_files = usize::try_from(batches).expect("batch count fits usize");
+    // One append of 1500 rows clears `INLINE_MAX_ROWS` and, at ~130 KiB against a
+    // 1 MiB target, is not sharded, so the un-compacted seed is one file per
+    // append. Counted in appends because that is the number the test controls.
+    let seeded_appends = usize::try_from(batches).expect("batch count fits usize");
     for batch_idx in 0..batches {
         common::insert_batch(
             &table,
@@ -1362,22 +1388,22 @@ async fn a_seed_is_consolidated_before_its_fanout_can_be_listed(
         .current_snapshot_id;
     let settled_files = count_vortex_files(&fixture.data_path, &table_id, &settled_snapshot).await;
     assert!(
-        settled_files < seeded_files,
+        settled_files < seeded_appends,
         "a post-write pass must consolidate the seed unprompted, which is what makes a \
-         listed fan-out unusable as the premise (seeded={seeded_files}, settled={settled_files})"
+         listed fan-out unusable as the premise (seeded={seeded_appends}, settled={settled_files})"
     );
 
-    // Measured against the seeded count the reduction is still visible from this
+    // Measured against the seeded appends the reduction is still visible from this
     // already-consolidated state; measured against `settled_files` it could not be.
     let Some((_post_snap, post_count)) =
-        wait_until_current_snapshot_compacts(&table, &fixture, "consolidated_seed", seeded_files)
+        wait_until_current_snapshot_compacts(&table, &fixture, "consolidated_seed", seeded_appends)
             .await?
     else {
         panic!("an already-consolidated seed must still report a reduced fan-out");
     };
     assert!(
-        post_count < seeded_files,
-        "fan-out must stay below the seeded count (seeded={seeded_files}, post={post_count})"
+        post_count < seeded_appends,
+        "fan-out must stay below the seeded appends (seeded={seeded_appends}, post={post_count})"
     );
 
     // The drain waits for the pass rather than cancelling it, so every row it
@@ -1425,23 +1451,27 @@ async fn warm_subset_reduces_small_file_fanout(
         .await?;
     }
 
-    // Each batch is larger than `INLINE_MAX_ROWS`, so an un-compacted seed is
-    // one vortex file per batch. That seeded count — not a count listed after
-    // the writes — is the fan-out compaction has to beat; see
+    // Each append clears `INLINE_MAX_ROWS` and is too small to shard, so an
+    // un-compacted seed is one vortex file per append. That seeded count — not a
+    // count listed after the writes — is the fan-out compaction has to beat; see
     // `wait_until_current_snapshot_compacts` for why a listed count can already
     // be the compacted one.
-    let seeded_files = usize::try_from(batches).expect("batch count fits usize");
-    let Some((post_snap, post_count)) =
-        wait_until_current_snapshot_compacts(&table, &fixture, "warm_subset_fanout", seeded_files)
-            .await?
+    let seeded_appends = usize::try_from(batches).expect("batch count fits usize");
+    let Some((post_snap, post_count)) = wait_until_current_snapshot_compacts(
+        &table,
+        &fixture,
+        "warm_subset_fanout",
+        seeded_appends,
+    )
+    .await?
     else {
-        panic!("warm-subset compaction should fire");
+        panic!("small-file compaction should fire");
     };
 
     assert_ne!(post_snap, pre_snapshot, "compact must advance the snapshot");
     assert!(
-        post_count < seeded_files,
-        "subset compact must strictly reduce fan-out (seeded={seeded_files}, post={post_count})"
+        post_count < seeded_appends,
+        "compaction must strictly reduce fan-out (seeded={seeded_appends}, post={post_count})"
     );
     assert_eq!(
         count_rows(&ctx, "warm_subset_fanout").await,

--- a/crates/cayenne/tests/small_files_compaction_test.rs
+++ b/crates/cayenne/tests/small_files_compaction_test.rs
@@ -240,22 +240,22 @@ async fn wait_until_current_snapshot_compacts(
 ) -> Result<Option<(String, usize)>, Box<dyn std::error::Error>> {
     const TIMEOUT: Duration = Duration::from_secs(10);
     const POLL_INTERVAL: Duration = Duration::from_millis(50);
-    const DRAIN_TIMEOUT: Duration = Duration::from_secs(120);
+    const DRAIN_TIMEOUT: Duration = Duration::from_mins(2);
 
-    match tokio::time::timeout(DRAIN_TIMEOUT, table.drain_in_flight_maintenance()).await {
-        Ok(drained) => drained?,
-        Err(_) => {
-            let table_meta = fixture.catalog.get_table(table_name).await?;
-            let snapshot_id = table_meta.current_snapshot_id;
-            let files =
-                count_vortex_files(&fixture.data_path, &table_meta.table_id, &snapshot_id).await;
-            panic!(
-                "draining {table_name}'s in-flight maintenance did not finish within \
-                 {DRAIN_TIMEOUT:?} (snapshot {snapshot_id}, {files} files, \
-                 target below {uncompacted_file_count})"
-            );
-        }
-    }
+    let Ok(drained) =
+        tokio::time::timeout(DRAIN_TIMEOUT, table.drain_in_flight_maintenance()).await
+    else {
+        let table_meta = fixture.catalog.get_table(table_name).await?;
+        let snapshot_id = table_meta.current_snapshot_id;
+        let files =
+            count_vortex_files(&fixture.data_path, &table_meta.table_id, &snapshot_id).await;
+        panic!(
+            "draining {table_name}'s in-flight maintenance did not finish within \
+             {DRAIN_TIMEOUT:?} (snapshot {snapshot_id}, {files} files, \
+             target below {uncompacted_file_count})"
+        );
+    };
+    drained?;
 
     let started = Instant::now();
     loop {


### PR DESCRIPTION
## Summary

`crates/cayenne/tests/small_files_compaction_test.rs` took down sign-offs: one test in 9744 failed, the run exited 100, and the red was indistinguishable at a glance from a real regression on branches that cannot reach Cayenne.

The tests measured small-file fan-out against a count listed from the store *after* their own seed writes. Those appends drive `schedule_post_write_compaction`, which `compaction_background_interval_ms: 0` does **not** disable — that field only stops the interval scheduler, as the production docs state. A compaction pass therefore gets spawned and can consolidate the seed while the test is still writing it, so the "un-compacted" premise was sometimes already the compacted count.

From there the failure is permanent, not slow. That pass and the test's explicit trigger both call `compact_current_snapshot_small_files`, so they contend for the same `compaction_lock` (a `try_lock`, so the loser reports a no-op) and for the same one-shot `new_files_since_last_compaction` credit, which the winner resets on commit. Once the credit is spent the explicit trigger declines forever, and no reduction below an already-reduced premise is reachable.

That is why the issue's suggested direction — a more generous wall-clock budget — could not have worked: the poll loop was not waiting for something still in progress, it was re-asking a question that was already settled. A probe confirmed it: `pre_count=7` against `seeded_batches=12`, then the same snapshot id across all 200 poll iterations before the panic.

## Changes

- Take the fan-out premise from the number of appends the test seeded, and sample the pre-seed snapshot before writing rather than after.
- Quiesce with `drain_in_flight_maintenance` before observing, so the wait ends with the background pass instead of a wall clock, and bound that drain — it has no timeout of its own, so a stuck pass would otherwise hang to the harness process timeout saying nothing about where it stopped.
- Add a regression test that reaches the already-consolidated state deliberately instead of racing into it, so the hazard is asserted rather than hoped for.
- Stop `count_vortex_files` reporting every `read_dir` error as zero files, which reads as a successful compaction to the assertions that call it.
- Correct the config comment that claimed this setting made the tests deterministic — it is what led the assertions to be written this way.

## Verification

Reproduced first, then measured before and after, since a flake fix that is only argued is not fixed.

- Reproduced locally on the first attempt, matching the reported panic site.
- Control, under CPU saturation: the pre-change tests fail **3/10** runs at the reported assertion; after the change, **0/10**. The whole file then passed **12/12** under the same load.
- Neuter matrix: restoring the listed-count premise is caught **6/6 deterministically** by the new test and 5/10 at the original site.

Two things I could not establish, stated plainly rather than implied:

1. `warm_subset_preserves_key_deletes_and_rows` already passed its seeded count as the premise, so the premise change does not explain its CI failure. The remaining mechanism is the wall clock expiring while maintenance or compaction still holds the lock, which the drain removes. I could **not** reproduce that variant locally (0/20 under 2x CPU oversubscription), and no test pins the drain — the three neuters that remove it are all caught 0/10. It is kept on the strength of the mechanism, not evidence.
2. One append is one vortex file for this fixture (1500 rows, ~130 KiB against a 1 MiB target), but that is a property of the fixture rather than a guarantee — write sharding is decided on estimated bytes. The assumption is now stated in the test instead of being silent.

The adversarial review also found a coverage defect that predates this change and is out of scope here: these tests run on a PK-less table, which resolves to the position-based deletion strategy that the subset-rewrite gate rejects, so the "warm subset" names describe a path they never take. Filed as #12612, along with the observation that `two_phase_compact`'s phase-B fallback asserts something phase A already guarantees. The new test in this PR uses a real primary key so it does not inherit the same problem.

## Test plan

- [x] `make lint` — clean
- [x] `make nextest` — the cayenne small-files compaction target passes 34/34 (2 new), repeatedly and under load
- [x] No production code changed, so `docs/cayenne/cayenne.md` needs no update (rule reviewed)

## Checklist

- [x] Root cause reproduced before fixing, and the fix measured against a control
- [x] Regression test that fails on the old premise and passes on the new one
- [x] Lint and formatting clean
- [x] No `unwrap()`; no production behavior change

Fixes #12602