### PR TITLE
fix(cayenne): consolidate the two partition creators, fixing the accelerator's missing directory sync (fixes #12212)

### DIFF
--- a/crates/cayenne/src/lib.rs
+++ b/crates/cayenne/src/lib.rs
@@ -96,6 +96,8 @@ pub use metadata::{
     ObjectStoreConfig, PartitionMetadata, StorageClass, TableMetadata, TableStatistics,
 };
 pub use metastore::sqlite::{SqliteAutoVacuum, SqliteMetastoreConfig, set_sqlite_metastore_config};
+#[cfg(feature = "partition-table-provider")]
+pub use partition_creator::CayennePartitionCreator;
 pub use provider::constants::{STAGING_DIR_NAME, STAGING_WAL_FILENAME, STAGING_WAL_TMP_FILENAME};
 pub use provider::{
     CayenneCdcWrite, CayenneContext, CayenneStagedAppend, CayenneStagedUpsert,

--- a/crates/cayenne/src/partition_creator.rs
+++ b/crates/cayenne/src/partition_creator.rs
@@ -55,7 +55,14 @@ static UNSUPPORTED_LOCAL_PARTITION_PATTERN: LazyLock<Regex> =
 ///
 /// Creates and opens per-partition [`CayenneTableProvider`]s rooted at
 /// Hive-style subdirectories under `base_path`.
-pub(crate) struct CayennePartitionCreator {
+///
+/// Two callers construct this: `CREATE TABLE … PARTITIONED BY` in
+/// [`crate::ddl::operations`], and the Cayenne accelerator in `runtime`. They
+/// differ in exactly two ways, and both are opt-in on top of the DDL defaults:
+/// the accelerator shares one background-compaction budget across every
+/// partition ([`Self::with_background_compaction`]), and its tables are targets
+/// for the accelerated dual-write path ([`Self::with_direct_partition_writes`]).
+pub struct CayennePartitionCreator {
     table_name: String,
     base_path: PathBuf,
     partition_by: Vec<PartitionedBy>,
@@ -71,6 +78,14 @@ pub(crate) struct CayennePartitionCreator {
     on_conflict: Option<datafusion_table_providers::util::on_conflict::OnConflict>,
     /// Shared context (footer/segment caches) created once, shared across all partitions.
     context: Arc<CayenneContext>,
+    /// Compaction budget shared with the creating engine, if it runs one. Every
+    /// partition provider spawns its background compaction task through this
+    /// semaphore, so the whole table shares one concurrency budget. `None`
+    /// leaves partitions without an interval compactor; they still compact on
+    /// write through `schedule_post_write_compaction`.
+    compaction_semaphore: Option<Arc<tokio::sync::Semaphore>>,
+    /// See [`PartitionCreator::accepts_direct_partition_writes`].
+    accepts_direct_partition_writes: bool,
 }
 
 impl std::fmt::Debug for CayennePartitionCreator {
@@ -93,13 +108,23 @@ impl std::fmt::Debug for CayennePartitionCreator {
             .field("primary_key", &self.primary_key)
             .field("on_conflict", &self.on_conflict.is_some())
             .field("context", &"<CayenneContext>")
-            .finish()
+            .field("compaction_semaphore", &self.compaction_semaphore.is_some())
+            .field(
+                "accepts_direct_partition_writes",
+                &self.accepts_direct_partition_writes,
+            )
+            .finish_non_exhaustive()
     }
 }
 
 impl CayennePartitionCreator {
+    /// Create a partition creator with the `CREATE TABLE … PARTITIONED BY`
+    /// defaults: no shared compaction budget, and not a dual-write target.
+    /// The accelerator opts into both with [`Self::with_background_compaction`]
+    /// and [`Self::with_direct_partition_writes`].
     #[expect(clippy::too_many_arguments)]
-    pub(crate) fn new(
+    #[must_use]
+    pub fn new(
         table_name: String,
         base_path: PathBuf,
         partition_by: Vec<PartitionedBy>,
@@ -132,7 +157,38 @@ impl CayennePartitionCreator {
             primary_key,
             on_conflict,
             context,
+            compaction_semaphore: None,
+            accepts_direct_partition_writes: false,
         }
+    }
+
+    /// Run each partition's background compaction through `semaphore`, so every
+    /// partition of this table draws on one shared concurrency budget.
+    #[must_use]
+    pub fn with_background_compaction(mut self, semaphore: Arc<tokio::sync::Semaphore>) -> Self {
+        self.compaction_semaphore = Some(semaphore);
+        self
+    }
+
+    /// Accept writes addressed to the partition table itself, making this table
+    /// a target for the accelerated dual-write path. See
+    /// [`PartitionCreator::accepts_direct_partition_writes`].
+    #[must_use]
+    pub fn with_direct_partition_writes(mut self) -> Self {
+        self.accepts_direct_partition_writes = true;
+        self
+    }
+
+    /// Wire a freshly opened partition provider into the shared caches and, when
+    /// the creating engine runs one, the shared compaction budget.
+    fn init_partition_provider(&self, provider: &Arc<crate::CayenneTableProvider>) {
+        if let Some(semaphore) = &self.compaction_semaphore {
+            provider.spawn_background_compaction(Arc::clone(semaphore));
+        }
+        // Wire the demand scan-view cache (weak self-ref for spawn_blocking builds +
+        // the idle evictor) so a partition provider offloads its builds and releases
+        // idle cached views' pinned snapshot dirs, like the top-level provider.
+        provider.init_scan_view_cache();
     }
 
     fn partition_column_labels(&self) -> Vec<String> {
@@ -173,6 +229,16 @@ impl CayennePartitionCreator {
 
 #[async_trait]
 impl PartitionCreator for CayennePartitionCreator {
+    /// Cayenne owns its partition storage, so a partitioned Cayenne table can be
+    /// written to directly — but only the accelerator asks for that, via
+    /// [`Self::with_direct_partition_writes`]. A table created through
+    /// `CREATE TABLE … PARTITIONED BY` is not reachable from the dual-write path
+    /// at all (it is a catalog table, never an accelerator), so it keeps the
+    /// trait's conservative default.
+    fn accepts_direct_partition_writes(&self) -> bool {
+        self.accepts_direct_partition_writes
+    }
+
     async fn create_partition(
         &self,
         partition_values: Vec<ScalarValue>,
@@ -185,7 +251,7 @@ impl PartitionCreator for CayennePartitionCreator {
         if partition_values.len() != self.partition_by.len() {
             return Err(creator::Error::CreatePartition {
                 source: format!(
-                    "Expected {} partition values but got {}",
+                    "Expected {} partition values but got {} (one per partition_by expression)",
                     self.partition_by.len(),
                     partition_values.len()
                 )
@@ -208,8 +274,9 @@ impl PartitionCreator for CayennePartitionCreator {
                 if UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match(value) {
                     return Err(creator::Error::CreatePartition {
                         source: format!(
-                            "Partition value '{value}' is not supported for local filesystem. \
-                             Values matching '*#<digits>' are only supported on S3 Express One Zone."
+                            "Partition value '{value}' is not supported for local filesystem locations. \
+                             Values matching the pattern '*#<digits>' (e.g., 'abcdef#123') are only \
+                             supported for S3 Express One Zone locations."
                         )
                         .into(),
                     });
@@ -295,10 +362,7 @@ impl PartitionCreator for CayennePartitionCreator {
             .context(creator::CreatePartitionSnafu)?;
 
         let table_provider = Arc::new(cayenne_table);
-        // Wire the demand scan-view cache (weak self-ref for spawn_blocking builds +
-        // the idle evictor) so a partition provider offloads its builds and releases
-        // idle cached views' pinned snapshot dirs, like the top-level provider.
-        table_provider.init_scan_view_cache();
+        self.init_partition_provider(&table_provider);
         Ok(Partition {
             partition_values,
             table_provider,
@@ -386,7 +450,7 @@ impl PartitionCreator for CayennePartitionCreator {
             };
 
             let table_provider = Arc::new(cayenne_table);
-            table_provider.init_scan_view_cache();
+            self.init_partition_provider(&table_provider);
             result.push(Partition {
                 partition_values,
                 table_provider,
@@ -432,4 +496,275 @@ fn encode_identifier_hex(value: &str) -> String {
         let _ = write!(encoded, "{byte:02X}");
     }
     encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use datafusion::execution::context::SessionContext;
+    use datafusion::prelude::col;
+    use datafusion::scalar::ScalarValue;
+    use tempfile::TempDir;
+
+    use crate::metadata::{CreateTableOptions, VortexConfig};
+    use crate::{CayenneCatalog, CayenneTableProvider};
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    const TABLE: &str = "partitioned_events";
+
+    struct Fixture {
+        catalog: Arc<dyn MetadataCatalog>,
+        table_id: String,
+        schema: SchemaRef,
+        base_path: PathBuf,
+        runtime_env: Arc<RuntimeEnv>,
+        _tmp: TempDir,
+    }
+
+    /// A parent table registered in a sqlite metastore, partitioned by the
+    /// `bucket` column, with its data rooted in a temp dir.
+    async fn fixture() -> Fixture {
+        let tmp = TempDir::new().expect("tempdir");
+        let base_path = tmp.path().join(TABLE);
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("bucket", DataType::Utf8, false),
+        ]));
+
+        let catalog: Arc<dyn MetadataCatalog> = Arc::new(
+            CayenneCatalog::new(format!("sqlite://{}", tmp.path().join("meta.db").display()))
+                .expect("catalog opens"),
+        );
+        catalog.init().await.expect("catalog schema initializes");
+
+        let table_id = catalog
+            .create_table(CreateTableOptions {
+                table_name: TABLE.to_string(),
+                schema: Arc::clone(&schema),
+                primary_key: vec![],
+                on_conflict: None,
+                base_path: base_path.to_string_lossy().to_string(),
+                partition_column: Some("bucket".to_string()),
+                vortex_config: VortexConfig::default(),
+            })
+            .await
+            .expect("catalog create_table");
+
+        Fixture {
+            catalog,
+            table_id,
+            schema,
+            base_path,
+            runtime_env: SessionContext::new().runtime_env(),
+            _tmp: tmp,
+        }
+    }
+
+    fn creator_for(fixture: &Fixture) -> CayennePartitionCreator {
+        CayennePartitionCreator::new(
+            TABLE.to_string(),
+            fixture.base_path.clone(),
+            vec![PartitionedBy {
+                name: "bucket".to_string(),
+                expression: col("bucket"),
+            }],
+            Arc::clone(&fixture.schema),
+            Arc::clone(&fixture.catalog),
+            fixture.table_id.clone(),
+            UnsupportedTypeAction::Error,
+            Vec::new(),
+            None,
+            crate::metadata::VortexConfig::default(),
+            None,
+            Vec::new(),
+            None,
+            Arc::clone(&fixture.runtime_env),
+        )
+    }
+
+    fn bucket(value: &str) -> ScalarValue {
+        ScalarValue::Utf8(Some(value.to_string()))
+    }
+
+    /// The `CREATE TABLE … PARTITIONED BY` path is not reachable from the
+    /// accelerated dual-write path (it produces a catalog table, never an
+    /// accelerator), so it keeps the trait's conservative default; the
+    /// accelerator opts in explicitly.
+    #[tokio::test]
+    async fn only_the_accelerator_opts_into_direct_partition_writes() {
+        let fixture = fixture().await;
+
+        assert!(
+            !creator_for(&fixture).accepts_direct_partition_writes(),
+            "a DDL-created partitioned table must not be a dual-write target"
+        );
+        assert!(
+            creator_for(&fixture)
+                .with_direct_partition_writes()
+                .accepts_direct_partition_writes(),
+            "the accelerator opts in, so its partitions must be dual-write targets"
+        );
+        assert!(
+            !creator_for(&fixture)
+                .with_background_compaction(Arc::new(tokio::sync::Semaphore::new(1)))
+                .accepts_direct_partition_writes(),
+            "sharing a compaction budget must not imply accepting direct writes"
+        );
+    }
+
+    fn assert_background_compaction(partitions: &[Partition], expected: bool, context: &str) {
+        assert!(!partitions.is_empty(), "{context}: nothing to assert on");
+        for partition in partitions {
+            let provider = partition
+                .table_provider
+                .downcast_ref::<CayenneTableProvider>()
+                .expect("a Cayenne partition is backed by a CayenneTableProvider");
+            assert_eq!(
+                provider.has_background_compactor(),
+                expected,
+                "{context}: background compaction must follow the shared budget"
+            );
+        }
+    }
+
+    /// Each partition provider joins the creating engine's compaction budget
+    /// only when one was supplied — on the create path and on the reopen path
+    /// alike. Without a budget a partition still compacts on write, but runs no
+    /// interval compactor.
+    #[tokio::test]
+    async fn partitions_join_the_shared_compaction_budget_only_when_it_is_supplied() {
+        let fixture = fixture().await;
+        let plain = creator_for(&fixture);
+        let shared = creator_for(&fixture)
+            .with_background_compaction(Arc::new(tokio::sync::Semaphore::new(4)));
+
+        let created_plain = plain
+            .create_partition(vec![bucket("solo")])
+            .await
+            .expect("partition is created without a shared budget");
+        assert_background_compaction(&[created_plain], false, "created without a budget");
+
+        let created_shared = shared
+            .create_partition(vec![bucket("shared")])
+            .await
+            .expect("partition is created with a shared budget");
+        assert_background_compaction(&[created_shared], true, "created with a budget");
+
+        // Reopening the same two partitions must make the same decision.
+        let reopened_plain = plain
+            .infer_existing_partitions()
+            .await
+            .expect("partitions are inferred without a shared budget");
+        assert_background_compaction(&reopened_plain, false, "reopened without a budget");
+
+        let reopened_shared = shared
+            .infer_existing_partitions()
+            .await
+            .expect("partitions are inferred with a shared budget");
+        assert_background_compaction(&reopened_shared, true, "reopened with a budget");
+    }
+
+    /// A created partition must be recoverable: the Hive-style directory exists
+    /// on disk and re-opening the table reads back every partition value.
+    #[tokio::test]
+    async fn created_partitions_round_trip_through_inference() {
+        let fixture = fixture().await;
+        let creator = creator_for(&fixture);
+
+        for value in ["alpha", "beta"] {
+            creator
+                .create_partition(vec![bucket(value)])
+                .await
+                .expect("partition is created");
+        }
+
+        // Partition values are encoded into the directory name, so assert the
+        // shape and the count rather than a spelling the codec owns.
+        let partition_dirs: Vec<String> = std::fs::read_dir(&fixture.base_path)
+            .expect("the table directory is readable")
+            .map(|entry| {
+                entry
+                    .expect("the directory entry is readable")
+                    .file_name()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .filter(|name| name.starts_with("bucket="))
+            .collect();
+        assert_eq!(
+            partition_dirs.len(),
+            2,
+            "one Hive-style directory per created partition, got {partition_dirs:?}"
+        );
+
+        let inferred = creator
+            .infer_existing_partitions()
+            .await
+            .expect("partitions are inferred");
+        let mut values: Vec<String> = inferred
+            .iter()
+            .map(|partition| match partition.partition_values.as_slice() {
+                [ScalarValue::Utf8(Some(value))] => value.clone(),
+                other => panic!("expected one Utf8 partition value, got {other:?}"),
+            })
+            .collect();
+        values.sort();
+        assert_eq!(values, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+
+    /// One value per `partition_by` expression, no more and no fewer.
+    #[tokio::test]
+    async fn partition_values_must_match_the_partition_by_arity() {
+        let fixture = fixture().await;
+        let creator = creator_for(&fixture);
+
+        let empty = creator
+            .create_partition(vec![])
+            .await
+            .expect_err("no partition values must be rejected");
+        assert!(
+            empty.to_string().contains("At least one partition value"),
+            "unexpected error for zero values: {empty}"
+        );
+
+        let too_many = creator
+            .create_partition(vec![bucket("alpha"), bucket("beta")])
+            .await
+            .expect_err("surplus partition values must be rejected");
+        assert!(
+            too_many
+                .to_string()
+                .contains("Expected 1 partition values but got 2"),
+            "unexpected error for surplus values: {too_many}"
+        );
+    }
+
+    /// The pattern gates on a `#` followed only by digits at the end of the
+    /// value; everything else is a legal local partition value.
+    #[test]
+    fn unsupported_local_partition_pattern_matches_only_a_trailing_hash_digits() {
+        for unsupported in ["abcdef#123", "test#1", "some_value#999999", "#0", "a#1"] {
+            assert!(
+                UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match(unsupported),
+                "'{unsupported}' must be treated as S3 Express One Zone only"
+            );
+        }
+        for supported in [
+            "abcdef",
+            "test_123",
+            "2024-01-01",
+            "partition_value",
+            "123",
+            "abc#def",
+            "test#",
+            "test#abc",
+            "test#123abc",
+        ] {
+            assert!(
+                !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match(supported),
+                "'{supported}' must be a legal local filesystem partition value"
+            );
+        }
+    }
 }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -28096,11 +28096,12 @@ impl CayenneTableProvider {
         self.background_compactor.set(compactor).is_ok()
     }
 
-    /// Whether a background compaction task is running for this provider.
+    /// Whether an interval background compactor was spawned for this provider.
     ///
-    /// Post-write compaction is scheduled independently of this task, so a
-    /// provider without one still compacts as it is written to — this reports
-    /// only whether the *interval* compactor was spawned.
+    /// Reports only that the task was spawned, not that it is still running: a
+    /// spawned compactor exits on its own once the shared compaction semaphore
+    /// is closed. Post-write compaction is scheduled independently of it, so a
+    /// provider without one still compacts as it is written to.
     #[must_use]
     pub fn has_background_compactor(&self) -> bool {
         self.background_compactor.get().is_some()

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -28096,6 +28096,16 @@ impl CayenneTableProvider {
         self.background_compactor.set(compactor).is_ok()
     }
 
+    /// Whether a background compaction task is running for this provider.
+    ///
+    /// Post-write compaction is scheduled independently of this task, so a
+    /// provider without one still compacts as it is written to — this reports
+    /// only whether the *interval* compactor was spawned.
+    #[must_use]
+    pub fn has_background_compactor(&self) -> bool {
+        self.background_compactor.get().is_some()
+    }
+
     /// Spawn the periodic mem-tier checkpoint task for this provider, if memory
     /// mode is active, the configured interval is non-zero, and no task is
     /// already spawned. Must be called after the provider is wrapped in an `Arc`

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -28,25 +28,16 @@ use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, RwLock, Weak};
 use std::time::Duration;
 
-use regex::Regex;
-
 use arrow_schema::{DataType, Schema};
 use async_trait::async_trait;
+use cayenne::CayennePartitionCreator;
 use data_components::poly::PolyTableProvider;
-use datafusion::common::DFSchema;
 use datafusion::common::arrow::datatypes::SchemaRef;
 use datafusion::datasource::TableProvider;
-use datafusion::error::DataFusionError;
 use datafusion::execution::runtime_env::RuntimeEnv;
-use datafusion::logical_expr::{CreateExternalTable, TableProviderFilterPushDown};
+use datafusion::logical_expr::CreateExternalTable;
 use datafusion::prelude::Expr;
-use datafusion::scalar::ScalarValue;
 use datafusion_table_providers::UnsupportedTypeAction;
-use runtime_table_partition::Partition;
-use runtime_table_partition::creator::filename::{
-    encode_composite_key, encode_key, parse_partition_value, to_hive_partition_dir,
-};
-use runtime_table_partition::creator::{self, PartitionCreator};
 use runtime_table_partition::expression::PartitionedBy;
 use runtime_table_partition::provider::PartitionTableProvider;
 use snafu::prelude::*;
@@ -111,15 +102,6 @@ pub enum Error {
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
-
-/// Regex pattern for partition values that are not supported on local filesystem.
-/// Partition values matching `.*#\d+` (e.g., "abcdef#123") are only supported on S3 Express
-/// One Zone locations, not on local filesystem paths.
-static UNSUPPORTED_LOCAL_PARTITION_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| match Regex::new(r".*#\d+$") {
-        Ok(compiled) => compiled,
-        Err(e) => unreachable!("Unable to compile regexp: {e}"),
-    });
 
 fn maintained_aggregate_specs_for_cayenne(
     acceleration: Option<&Acceleration>,
@@ -3457,23 +3439,29 @@ impl DataAccelerator for CayenneAccelerator {
                 );
             }
 
-            let creator = Arc::new(CayennePartitionCreator::new(
-                table_name.clone(),
-                PathBuf::from(&dir_path),
-                partition_by.clone(),
-                Arc::clone(&arrow_schema),
-                catalog,
-                table_metadata.table_id,
-                unsupported_type_action,
-                retention_filters,
-                time_retention_filter_builder,
-                vortex_config,
-                object_store_config,
-                primary_keys.clone(),
-                on_conflict,
-                runtime_env,
-                Arc::clone(&self.compaction_semaphore),
-            ));
+            let creator = Arc::new(
+                CayennePartitionCreator::new(
+                    table_name.clone(),
+                    PathBuf::from(&dir_path),
+                    partition_by.clone(),
+                    Arc::clone(&arrow_schema),
+                    catalog,
+                    table_metadata.table_id,
+                    unsupported_type_action,
+                    retention_filters,
+                    time_retention_filter_builder,
+                    vortex_config,
+                    object_store_config,
+                    primary_keys.clone(),
+                    on_conflict,
+                    runtime_env,
+                )
+                // Per-partition background compaction draws on the accelerator's
+                // one budget, and an accelerated partitioned table is a target for
+                // the dual-write path.
+                .with_background_compaction(Arc::clone(&self.compaction_semaphore))
+                .with_direct_partition_writes(),
+            );
 
             // Wrap the base table provider with partitioning logic, installing
             // the Cayenne-specific cross-partition insert strategy so that
@@ -3772,428 +3760,6 @@ fn serialize_partition_child_writes(
         );
     }
     config.write_concurrency = Some(1);
-}
-
-/// Partition creator for Cayenne accelerator.
-///
-/// Supports single and composite partition keys (e.g., `partition_by: [year, month, day]`).
-/// For composite partitions, data is stored in nested Hive-style directories.
-pub(crate) struct CayennePartitionCreator {
-    table_name: String,
-    base_path: PathBuf,
-    /// Partition expressions. For hierarchical partitions like `partition_by: [year, month]`,
-    /// this contains all expressions in order.
-    partition_by: Vec<PartitionedBy>,
-    schema: SchemaRef,
-    catalog: Arc<dyn cayenne::MetadataCatalog>,
-    table_id: String,
-    unsupported_type_action: UnsupportedTypeAction,
-    retention_filters: Vec<Expr>,
-    time_retention_filter_builder: Option<cayenne::TimeRetentionFilterBuilder>,
-    vortex_config: cayenne::metadata::VortexConfig,
-    object_store_config: Option<cayenne::metadata::ObjectStoreConfig>,
-    primary_key: Vec<String>,
-    on_conflict: Option<datafusion_table_providers::util::on_conflict::OnConflict>,
-    /// Shared Cayenne context with cache, created once and shared across all partitions.
-    context: Arc<cayenne::CayenneContext>,
-    /// Shared compaction semaphore inherited from the parent
-    /// [`CayenneAccelerator`]. Per-partition providers spawn their own
-    /// background compaction tasks through this semaphore so the whole accelerator
-    /// shares one concurrency budget.
-    compaction_semaphore: Arc<tokio::sync::Semaphore>,
-}
-
-impl std::fmt::Debug for CayennePartitionCreator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CayennePartitionCreator")
-            .field("table_name", &self.table_name)
-            .field("base_path", &self.base_path)
-            .field("partition_by", &self.partition_by)
-            .field("schema", &self.schema)
-            .field("catalog", &"<dyn MetadataCatalog>")
-            .field("table_id", &self.table_id)
-            .field("unsupported_type_action", &self.unsupported_type_action)
-            .field("retention_filters", &self.retention_filters.len())
-            .field(
-                "time_retention_filter_builder",
-                &self.time_retention_filter_builder.is_some(),
-            )
-            .field("vortex_config", &"<VortexConfig>")
-            .field("object_store_config", &self.object_store_config.is_some())
-            .field("primary_key", &self.primary_key)
-            .field("on_conflict", &self.on_conflict.is_some())
-            .field("context", &"<CayenneContext>")
-            .finish_non_exhaustive()
-    }
-}
-
-impl CayennePartitionCreator {
-    #[expect(clippy::too_many_arguments)]
-    pub(crate) fn new(
-        table_name: String,
-        base_path: PathBuf,
-        partition_by: Vec<PartitionedBy>,
-        schema: SchemaRef,
-        catalog: Arc<dyn cayenne::MetadataCatalog>,
-        table_id: String,
-        unsupported_type_action: UnsupportedTypeAction,
-        retention_filters: Vec<Expr>,
-        time_retention_filter_builder: Option<cayenne::TimeRetentionFilterBuilder>,
-        vortex_config: cayenne::metadata::VortexConfig,
-        object_store_config: Option<cayenne::metadata::ObjectStoreConfig>,
-        primary_key: Vec<String>,
-        on_conflict: Option<datafusion_table_providers::util::on_conflict::OnConflict>,
-        runtime_env: Arc<RuntimeEnv>,
-        compaction_semaphore: Arc<tokio::sync::Semaphore>,
-    ) -> Self {
-        // Create shared Cayenne context with cache once, to be shared across all partitions.
-        // This ensures all partitions share the same footer/segment caches instead of
-        // each partition creating its own cache.
-        let context = cayenne::CayenneContext::new_for_partition_child(
-            &vortex_config,
-            runtime_env,
-            &table_name,
-        );
-
-        Self {
-            table_name,
-            base_path,
-            partition_by,
-            schema,
-            catalog,
-            table_id,
-            unsupported_type_action,
-            retention_filters,
-            time_retention_filter_builder,
-            vortex_config,
-            object_store_config,
-            primary_key,
-            on_conflict,
-            context,
-            compaction_semaphore,
-        }
-    }
-
-    /// Returns the partition column labels for all partition expressions.
-    fn partition_column_labels(&self) -> Vec<String> {
-        self.partition_by
-            .iter()
-            .map(|p| match &p.expression {
-                Expr::Column(col) => col.name.clone(),
-                _ => p.name.clone(),
-            })
-            .collect()
-    }
-
-    /// Generate a unique table name for this partition based on composite key.
-    fn partition_table_name(&self, partition_key: &str) -> String {
-        format!(
-            "{}_p{}",
-            self.table_name,
-            encode_identifier_hex(partition_key)
-        )
-    }
-
-    fn legacy_partition_table_name(&self, partition_values: &[String]) -> String {
-        format!("{}_{}", self.table_name, partition_values.join("_"))
-    }
-
-    /// Generate partition directory path from multiple partition values.
-    /// Creates nested Hive-style directories (e.g., `year=2025/month=10/day=15/`).
-    fn partition_dir(&self, partition_values: &[ScalarValue]) -> Result<PathBuf, creator::Error> {
-        let pairings: Vec<(PartitionedBy, ScalarValue)> = self
-            .partition_by
-            .iter()
-            .cloned()
-            .zip(partition_values.iter().cloned())
-            .collect();
-
-        let partition_dir = to_hive_partition_dir(&pairings)
-            .boxed()
-            .context(creator::CreatePartitionSnafu)?;
-
-        Ok(self.base_path.join(partition_dir))
-    }
-}
-
-#[async_trait]
-impl PartitionCreator for CayennePartitionCreator {
-    /// Cayenne owns its partition storage, so a partitioned Cayenne table can be
-    /// written to directly. This is what the accelerated dual-write path used to
-    /// establish by downcasting to this type.
-    fn accepts_direct_partition_writes(&self) -> bool {
-        true
-    }
-
-    async fn create_partition(
-        &self,
-        partition_values: Vec<ScalarValue>,
-    ) -> Result<Partition, creator::Error> {
-        if partition_values.is_empty() {
-            return Err(creator::Error::CreatePartition {
-                source: "At least one partition value is required".into(),
-            });
-        }
-
-        if partition_values.len() != self.partition_by.len() {
-            return Err(creator::Error::CreatePartition {
-                source: format!(
-                    "Expected {} partition values but got {} (one per partition_by expression)",
-                    self.partition_by.len(),
-                    partition_values.len()
-                )
-                .into(),
-            });
-        }
-
-        let partition_dir = self.partition_dir(&partition_values)?;
-        let partition_path = partition_dir.to_string_lossy().to_string();
-
-        // Encode partition values as strings for metadata storage
-        let partition_value_strings: Vec<String> = partition_values
-            .iter()
-            .map(encode_key)
-            .collect::<Result<Vec<_>, _>>()
-            .boxed()
-            .context(creator::CreatePartitionSnafu)?;
-
-        // Validate partition values for local filesystem compatibility.
-        // Partition values matching the pattern `.*#\d+` (e.g., "abcdef#123") are not supported
-        // on local filesystem paths but are supported on remote Object Store locations.
-        if self.object_store_config.is_none() {
-            for value in &partition_value_strings {
-                if UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match(value) {
-                    return Err(creator::Error::CreatePartition {
-                        source: format!(
-                            "Partition value '{value}' is not supported for local filesystem locations. \
-                            Values matching the pattern '*#<digits>' (e.g., 'abcdef#123') are only supported \
-                            for S3 Express One Zone locations."
-                        )
-                        .into(),
-                    });
-                }
-            }
-        }
-
-        tracing::debug!("creating Cayenne partition at {partition_path}");
-
-        // Create the partition directory (including nested directories for composite partitions).
-        // Use tokio's async variant so partition creation does not block the runtime thread.
-        tokio::fs::create_dir_all(&partition_dir)
-            .await
-            .boxed()
-            .context(creator::CreatePartitionSnafu)?;
-        let partition_column_names = self.partition_column_labels();
-
-        let partition_key = encode_composite_key(&partition_values)
-            .boxed()
-            .context(creator::CreatePartitionSnafu)?;
-
-        // Create partition metadata with composite key support
-        let partition_metadata = cayenne::PartitionMetadata::new_composite(
-            self.table_id.clone(),
-            partition_column_names,
-            partition_value_strings.clone(),
-            partition_path.clone(),
-            false, // path_is_relative
-        );
-
-        self.catalog
-            .add_partition(partition_metadata)
-            .await
-            .boxed()
-            .context(creator::CreatePartitionSnafu)?;
-
-        // Create table options for this partition
-        let table_options = cayenne::metadata::CreateTableOptions {
-            table_name: self.partition_table_name(&partition_key),
-            schema: Arc::clone(&self.schema),
-            primary_key: self.primary_key.clone(),
-            on_conflict: self.on_conflict.clone(),
-            base_path: partition_path.clone(),
-            partition_column: None, // Partitions themselves are not partitioned
-            vortex_config: self.vortex_config.clone(),
-        };
-
-        // Create Cayenne table provider for this partition with S3 support.
-        // Use the shared context to share footer/segment caches across partitions.
-        let mut builder = cayenne::CayenneTableProviderBuilder::new(
-            Arc::clone(&self.catalog),
-            Arc::clone(self.context.runtime_env()),
-        )
-        .with_context(Arc::clone(&self.context))
-        .with_retention_filters(self.retention_filters.clone());
-        if let Some(ref retention_builder) = self.time_retention_filter_builder {
-            builder = builder.with_time_retention_filter_builder(retention_builder.clone());
-        }
-        if let Some(ref object_store) = self.object_store_config {
-            builder = builder.with_object_store(object_store.clone());
-        }
-        let cayenne_table = builder
-            .create(table_options)
-            .await
-            .boxed()
-            .context(creator::CreatePartitionSnafu)?;
-
-        let partition_provider = Arc::new(cayenne_table);
-        partition_provider.spawn_background_compaction(Arc::clone(&self.compaction_semaphore));
-        partition_provider.init_scan_view_cache();
-        Ok(Partition {
-            partition_values,
-            table_provider: partition_provider,
-        })
-    }
-
-    async fn infer_existing_partitions(&self) -> Result<Vec<Partition>, creator::Error> {
-        // Query catalog for existing partitions
-        let partitions = self
-            .catalog
-            .get_partitions(&self.table_id)
-            .await
-            .boxed()
-            .context(creator::InferringPartitionsSnafu)?;
-
-        let mut result = Vec::new();
-
-        let df_schema = DFSchema::try_from(Arc::clone(&self.schema))
-            .boxed()
-            .context(creator::InferringPartitionsSnafu)?;
-
-        let expected_partition_columns = self.partition_column_labels();
-
-        for partition_meta in partitions {
-            // Validate that stored partition metadata matches current partition_by expressions.
-            // Both the column names and their order must match exactly, otherwise the partition
-            // was created with different partition_by configuration and cannot be safely used.
-            // Silently skipping mismatched partitions would cause incomplete query results (data loss).
-            if partition_meta.partition_columns != expected_partition_columns {
-                return Err(creator::Error::PartitionByExpressionsChanged);
-            }
-
-            let mut partition_values = Vec::with_capacity(self.partition_by.len());
-            for (partition_expr, value_str) in self
-                .partition_by
-                .iter()
-                .zip(&partition_meta.partition_values)
-            {
-                let partition_value = parse_partition_value(&df_schema, partition_expr, value_str)
-                    .map_err(|e| creator::Error::InferringPartitions {
-                        source: Box::new(e),
-                    })?;
-                partition_values.push(partition_value);
-            }
-
-            let partition_key = partition_meta.composite_key();
-            let partition_table_name = self.partition_table_name(&partition_key);
-
-            // Use builder pattern to pass object store config for S3 support.
-            // Use the shared context to share footer/segment caches across partitions.
-            let mut builder = cayenne::CayenneTableProviderBuilder::new(
-                Arc::clone(&self.catalog),
-                Arc::clone(self.context.runtime_env()),
-            )
-            .with_context(Arc::clone(&self.context))
-            .with_retention_filters(self.retention_filters.clone());
-            if let Some(ref retention_builder) = self.time_retention_filter_builder {
-                builder = builder.with_time_retention_filter_builder(retention_builder.clone());
-            }
-            if let Some(ref object_store) = self.object_store_config {
-                builder = builder.with_object_store(object_store.clone());
-            }
-            let cayenne_table = match builder.open(&partition_table_name).await {
-                Ok(table) => table,
-                Err(cayenne::provider::Error::Catalog {
-                    source: cayenne::CatalogError::TableNotFound { .. },
-                }) => {
-                    let legacy_name =
-                        self.legacy_partition_table_name(&partition_meta.partition_values);
-                    let mut legacy_builder = cayenne::CayenneTableProviderBuilder::new(
-                        Arc::clone(&self.catalog),
-                        Arc::clone(self.context.runtime_env()),
-                    )
-                    .with_context(Arc::clone(&self.context))
-                    .with_retention_filters(self.retention_filters.clone());
-                    if let Some(ref retention_builder) = self.time_retention_filter_builder {
-                        legacy_builder = legacy_builder
-                            .with_time_retention_filter_builder(retention_builder.clone());
-                    }
-                    if let Some(ref object_store) = self.object_store_config {
-                        legacy_builder = legacy_builder.with_object_store(object_store.clone());
-                    }
-                    legacy_builder
-                        .open(&legacy_name)
-                        .await
-                        .boxed()
-                        .context(creator::InferringPartitionsSnafu)?
-                }
-                Err(error) => {
-                    return Err(creator::Error::InferringPartitions {
-                        source: Box::new(error),
-                    });
-                }
-            };
-
-            let partition_provider = Arc::new(cayenne_table);
-            partition_provider.spawn_background_compaction(Arc::clone(&self.compaction_semaphore));
-            partition_provider.init_scan_view_cache();
-            result.push(Partition {
-                partition_values,
-                table_provider: partition_provider,
-            });
-        }
-
-        Ok(result)
-    }
-
-    fn supports_filters_pushdown(
-        &self,
-        filters: &[&Expr],
-    ) -> Result<Vec<TableProviderFilterPushDown>, DataFusionError> {
-        // Partition pruning works for filters on partition columns, even though
-        // Cayenne doesn't have native filter pushdown to the storage layer
-        use datafusion::logical_expr::TableProviderFilterPushDown;
-
-        // Collect all partition columns from all partition expressions
-        let partition_columns: std::collections::HashSet<_> = self
-            .partition_by
-            .iter()
-            .flat_map(|p| p.expression.column_refs())
-            .collect();
-
-        Ok(filters
-            .iter()
-            .map(|filter| {
-                let filter_columns = filter.column_refs();
-
-                // Check if filter columns match partition columns (ignoring table qualifiers)
-                // Both `order_date` and `table.order_date` should match partition column `order_date`
-                let matches_partition_cols = filter_columns.is_empty()
-                    || filter_columns.iter().all(|filter_col| {
-                        partition_columns
-                            .iter()
-                            .any(|part_col| filter_col.name == part_col.name)
-                    });
-
-                // If filter references partition columns or contains the partition expression,
-                // it can be used for partition pruning
-                if matches_partition_cols {
-                    TableProviderFilterPushDown::Inexact
-                } else {
-                    TableProviderFilterPushDown::Unsupported
-                }
-            })
-            .collect())
-    }
-}
-
-fn encode_identifier_hex(value: &str) -> String {
-    use std::fmt::Write as _;
-
-    let mut encoded = String::with_capacity(value.len() * 2);
-    for byte in value.as_bytes() {
-        let _ = write!(encoded, "{byte:02X}");
-    }
-    encoded
 }
 
 data_accelerator_api::register_data_accelerator!(Engine::Cayenne, CayenneAccelerator);
@@ -6064,72 +5630,6 @@ mod tests {
         assert_eq!(
             CayenneAccelerator::resolve_metadata_dir(Some(&acceleration)),
             "/persistent/data/metadata"
-        );
-    }
-
-    #[test]
-    fn test_unsupported_local_partition_pattern() {
-        // Pattern should match values ending with `#<digits>` (e.g., "abcdef#123")
-        // These are only supported on S3 Express One Zone, not local filesystem.
-
-        // Values that should match (unsupported on local filesystem)
-        assert!(
-            UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("abcdef#123"),
-            "Expected 'abcdef#123' to match unsupported pattern"
-        );
-        assert!(
-            UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("test#1"),
-            "Expected 'test#1' to match unsupported pattern"
-        );
-        assert!(
-            UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("some_value#999999"),
-            "Expected 'some_value#999999' to match unsupported pattern"
-        );
-        assert!(
-            UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("#0"),
-            "Expected '#0' to match unsupported pattern"
-        );
-        assert!(
-            UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("a#1"),
-            "Expected 'a#1' to match unsupported pattern"
-        );
-
-        // Values that should NOT match (supported on local filesystem)
-        assert!(
-            !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("abcdef"),
-            "Expected 'abcdef' to not match unsupported pattern"
-        );
-        assert!(
-            !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("test_123"),
-            "Expected 'test_123' to not match unsupported pattern"
-        );
-        assert!(
-            !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("2024-01-01"),
-            "Expected '2024-01-01' to not match unsupported pattern"
-        );
-        assert!(
-            !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("partition_value"),
-            "Expected 'partition_value' to not match unsupported pattern"
-        );
-        assert!(
-            !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("123"),
-            "Expected '123' (pure digits) to not match unsupported pattern"
-        );
-        assert!(
-            !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("abc#def"),
-            "Expected 'abc#def' (# not followed by only digits) to not match unsupported pattern"
-        );
-        assert!(
-            !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("test#"),
-            "Expected 'test#' (# with no digits) to not match unsupported pattern"
-        );
-        assert!(
-            !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("test#abc"),
-            "Expected 'test#abc' (# followed by non-digits) to not match unsupported pattern"
-        );
-        assert!(
-            !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match("test#123abc"),
-            "Expected 'test#123abc' (digits followed by non-digits) to not match unsupported pattern"
         );
     }
 }


### PR DESCRIPTION
Fixes #12212

## Summary

Two `CayennePartitionCreator` types were live in different crates — one in `crates/cayenne/src/partition_creator.rs` behind `CREATE TABLE … PARTITIONED BY`, one in `crates/runtime/src/dataaccelerator/cayenne/mod.rs` behind the accelerator. Both `pub(crate)`, so the compiler could not see the overlap, and #12212 flagged the risk without diffing the two `impl PartitionCreator` bodies.

They had already drifted, in both directions:

- **The `cayenne` copy syncs the parent directory after creating a partition sub-directory; the `runtime` copy does not.** That sync landed in c4046a7c6 (#10840) on one copy only. On the accelerator path — the common one — a partition is therefore recorded in the metastore while the directory entry that holds its data is still only in the page cache: a crash in that window leaves the catalog pointing at a partition directory the filesystem no longer has. The comment on the surviving copy states the contract this breaks ("the same uniform contract as snapshot directories, `_partitioned_wal/`, deletions/ subdirs, and initial table creation").
- **Only the `runtime` copy runs per-partition background compaction through the accelerator's shared semaphore.** A DDL-created partitioned table gets no interval compactor.
- Two error messages had diverged in wording.

## Changes

- `cayenne::CayennePartitionCreator` is now the only one; the `runtime` copy is deleted, along with its duplicate `UNSUPPORTED_LOCAL_PARTITION_PATTERN` and `encode_identifier_hex`. The regex's unit test moves with it, so that coverage is preserved rather than dropped.
- The two genuine differences are explicit opt-ins on top of the DDL defaults, rather than a second type: `with_background_compaction(semaphore)` and `with_direct_partition_writes()`. The accelerator's call site asks for both and says why.
- **The dual-write question #12212 raises is answered as "intentional".** `extract_cayenne_write_target` is only reached from `AcceleratedTable` and the transaction write path, both of which start from an accelerator — a `CREATE TABLE … PARTITIONED BY` table is a catalog table and never arrives there, so the capability's value on that path is unobservable and it keeps the trait's conservative default. That reasoning is now a comment on the impl instead of an accident of which type the code named.
- **Behavior change, deliberate:** the accelerated path now takes the parent-directory sync. Nothing else changes on either path — the compaction budget and the dual-write capability are wired to exactly what each caller had before.
- `CayenneTableProvider::has_background_compactor()` added, so the compaction wiring is assertable instead of only observable through a spawn side effect.

## Not in this PR

- **The S3 Express One Zone guard in `create_partition` is unreachable** — it tests the *encoded* keys (`v1.<type>.v<hex>`), which can never contain a `#`. Filing separately (#12616); deciding it means either deleting a guard or starting to reject values that are accepted today, neither of which belongs in a consolidation.
- **DDL-created partitioned tables still run no interval compactor** (#12617). Giving them one means deciding what budget a catalog-level `CREATE TABLE` draws on; this PR preserves today's behavior and makes the asymmetry visible.

## Test plan

- `make lint`
- `make test`
- 5 new unit tests in `crates/cayenne/src/partition_creator.rs`: the dual-write capability on both paths, the shared compaction budget across *both* the create and the reopen path, a create→infer round trip with the partition directories on disk, partition-value arity errors, and the ported regex test.
- **Neuter matrix: 9 mutations, 9 caught.** Capability forced true / forced false / opt-in made a no-op; compaction never spawned / always spawned / provider init dropped from `create_partition` / dropped from `infer_existing_partitions`; arity check removed; catalog registration removed.
- **Not pinned, stated rather than implied:** the parent-directory sync itself. An `fsync` is not observable from a test without a syscall seam, so the durability fix rides on the consolidation rather than on a regression test. The accelerator's one-expression call site (`with_background_compaction(...).with_direct_partition_writes()`) is likewise untested — building a `CayenneAccelerator` needs a full dataset source.
- `docs/cayenne/cayenne.md` reviewed per the repo rule: it does not describe partition-directory creation or these creator types, and no statement in it becomes inaccurate, so it needs no update.

## Checklist

- [x] Tests added for the behavior this changes
- [x] Regression coverage shown to fail without the fix (neuter matrix above)
- [x] `cargo fmt` clean; scoped clippy (`--lib --tests`) clean on both crates
- [x] Crate-layering guard passes (`runtime` → `cayenne` is downward)
- [x] No behavior change on the DDL path; the one accelerator-path change is called out above
