### PR TITLE
fix(test): truncate long inputs for all-MiniLM-L6-v2 MTEB spicepods

### DIFF
--- a/test/spicepods/search/mteb/arguana/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/arguana/hf[all-minilm-l6-v2]-arrow.yaml
@@ -31,3 +31,4 @@ embeddings:
   - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
     name: minilm_embed
     params:
+      truncate: END

--- a/test/spicepods/search/mteb/fiqa/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/fiqa/hf[all-minilm-l6-v2]-arrow.yaml
@@ -31,3 +31,4 @@ embeddings:
   - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
     name: minilm_embed
     params:
+      truncate: END

--- a/test/spicepods/search/mteb/miracl_en/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/miracl_en/hf[all-minilm-l6-v2]-arrow.yaml
@@ -31,3 +31,4 @@ embeddings:
   - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
     name: minilm_embed
     params:
+      truncate: END

--- a/test/spicepods/search/mteb/nfcorpus/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/nfcorpus/hf[all-minilm-l6-v2]-arrow.yaml
@@ -31,3 +31,4 @@ embeddings:
   - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
     name: minilm_embed
     params:
+      truncate: END

--- a/test/spicepods/search/mteb/quora/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/quora/hf[all-minilm-l6-v2]-arrow.yaml
@@ -31,4 +31,4 @@ embeddings:
   - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
     name: minilm_embed
     params:
-      hf_token: ${ secrets:SPICE_HUGGINGFACE_TOKEN }
+      truncate: END

--- a/test/spicepods/search/mteb/scidocs/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/scidocs/hf[all-minilm-l6-v2]-arrow.yaml
@@ -31,3 +31,4 @@ embeddings:
   - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
     name: minilm_embed
     params:
+      truncate: END

--- a/test/spicepods/search/mteb/scifact/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/scifact/hf[all-minilm-l6-v2]-arrow.yaml
@@ -31,3 +31,4 @@ embeddings:
   - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
     name: minilm_embed
     params:
+      truncate: END

--- a/test/spicepods/search/mteb/touche2020/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/touche2020/hf[all-minilm-l6-v2]-arrow.yaml
@@ -31,3 +31,4 @@ embeddings:
   - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
     name: minilm_embed
     params:
+      truncate: END

--- a/test/spicepods/search/mteb/trec_covid/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/trec_covid/hf[all-minilm-l6-v2]-arrow.yaml
@@ -31,3 +31,4 @@ embeddings:
   - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
     name: minilm_embed
     params:
+      truncate: END


### PR DESCRIPTION
## Summary

Sets `params.truncate: END` on all 9 `hf[all-minilm-l6-v2]-arrow.yaml` MTEB search benchmark spicepods (arguana, fiqa, miracl_en, nfcorpus, quora, scidocs, scifact, touche2020, trec_covid). Also drops an unnecessary `hf_token` param from the Quora variant (the model is public, no token required).

## Why

`sentence-transformers/all-MiniLM-L6-v2` has a 256-token max sequence length. Several MTEB corpora (FiQA forum posts, TREC-COVID/SciFact/NFCorpus abstracts) contain documents longer than that, which currently fails the whole embedding call instead of truncating:

```
Input validation error: `inputs` must have less than 256 tokens. Given: 422
```

## Dependency

**This PR depends on #12620**, which adds the `truncate` parameter to the `huggingface:` and `file:` embedding providers. Until #12620 merges, `spiced` won't recognize `truncate` on these spicepods.

Note this isn't specific to this branch's spicepods — any existing spicepod using `huggingface:` or `file:` embeddings with `all-MiniLM-L6-v2` (or any model with a similar sequence-length cap) against documents that exceed the model's max sequence length hits the same error today, with no way to opt into truncation instead.
