### PR TITLE
fix(ci): keep the build cache's S3 endpoint out of the runtime under test (fixes #12624)

### DIFF
--- a/.github/scripts/check_workflow_yaml.py
+++ b/.github/scripts/check_workflow_yaml.py
@@ -21,6 +21,11 @@
 # And it rejects an `if:` naming a context GitHub does not make available there,
 # which fails the same way for a different reason: GitHub rejects the definition
 # rather than the expression, so the workflow never schedules (#12396).
+#
+# Finally it rejects a step that runs the Spice runtime while the compiler
+# cache's `AWS_ENDPOINT_URL` is still in the job's environment, which redirects
+# the runtime's S3 traffic to the cache and reports as a dataset that never
+# loads (#12624).
 """Validate the repository's GitHub Actions workflow and composite action YAML."""
 
 from __future__ import annotations
@@ -89,6 +94,42 @@ CONTEXT_REMEDIES = {
     ),
 }
 
+# The compiler-cache proxy's setup action, which exports `AWS_ENDPOINT_URL` into
+# `$GITHUB_ENV` for the rest of the job.
+CACHE_SETUP_ACTION = "spiceio/.github/actions/setup"
+
+# Ways a step starts the Spice runtime from the workflow file: `nextest`, a test
+# binary the job downloaded rather than built, and the CLI. All three inherit the
+# step's environment, so all three see the cache endpoint. Optional `KEY=value`
+# prefixes are skipped so the binary form still reads as the command.
+#
+# What this cannot see: a `make` target or a composite action that starts the
+# runtime, because the command is in the Makefile or the action, not here. No job
+# combines those with the cache setup today. If one comes to, the guard has to
+# grow rather than be trusted.
+RUNTIME_INVOCATION = re.compile(
+    r"\bcargo\s+nextest\s+run\b"
+    r"|\bspice\s+run\b"
+    r"|^(?:\S+=\S+[ \t]+)*\./\S*integration_test\S*",
+    re.MULTILINE,
+)
+
+# Dropping it for the step's children. `unset` is the only form that works:
+# writing an empty value back to `$GITHUB_ENV` leaves the variable *set*, and
+# `object_store` then builds a store whose bucket endpoint is the empty string.
+#
+# The command has to sit at the top level of the script — indentation means it is
+# inside an `if` or a function and may not run — must not be `unset -f`, which
+# removes a function of that name and leaves the variable alone, and anything
+# after a `#` is its comment rather than its argument.
+DROPS_CACHE_ENDPOINT = re.compile(
+    r"^unset[ \t]+(?!-)[^\n#]*\bAWS_ENDPOINT_URL\b", re.MULTILINE
+)
+
+# A line whose first non-blank character is `#`. Removed before looking for a
+# runtime invocation, so a command named in a comment does not read as one.
+COMMENT_LINE = re.compile(r"^[ \t]*#[^\n]*$", re.MULTILINE)
+
 
 def workflow_files(github_dir: Path) -> list[Path]:
     """Return the workflow definitions under `<github_dir>/workflows`, sorted."""
@@ -136,6 +177,7 @@ def check_workflow(text: str) -> list[str]:
     else:
         problems.extend(check_step_budgets(jobs))
         problems.extend(check_workflow_conditions(jobs))
+        problems.extend(check_cache_endpoint_isolation(jobs))
 
     return problems
 
@@ -274,6 +316,64 @@ def check_step_budgets(jobs: dict) -> list[str]:
     return problems
 
 
+def check_cache_endpoint_isolation(jobs: dict) -> list[str]:
+    """Report steps that run the Spice runtime with the compiler cache's S3 endpoint set.
+
+    The cache proxy's setup action exports `AWS_ENDPOINT_URL` into `$GITHUB_ENV`
+    so the steps that follow it — sccache, the AWS CLI — reach the cache. The
+    build steps need that. A step that runs `spiced` must not inherit it:
+    `AmazonS3Builder::from_env()` maps `AWS_ENDPOINT_URL` to the S3 endpoint, so
+    every `s3://` dataset with no explicit endpoint of its own is fetched from
+    the cache, and every S3 Vectors call goes there too.
+
+    Nothing about the resulting failure names S3. The dataset stays unhealthy,
+    the runtime never reports ready, and the test fails on a readiness timeout —
+    #12624, where this took out all three test jobs of the models nightly, and
+    the first one masked the eight suites queued behind it.
+
+    Only steps that follow the setup see the export, so only those are checked,
+    and the drop has to come before the runtime starts to be worth anything. What
+    this does not model is shell semantics: a drop that is later re-exported, or
+    one the guard reads as top-level while a wrapper re-adds the variable, still
+    passes. It is a guard against the mistake that happened, not a proof.
+    """
+    problems = []
+    for name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        setup_at = next(
+            (
+                index
+                for index, step in enumerate(steps)
+                if isinstance(step, dict) and CACHE_SETUP_ACTION in str(step.get("uses", ""))
+            ),
+            None,
+        )
+        if setup_at is None:
+            continue
+        for position, step in enumerate(steps[setup_at + 1 :], start=setup_at + 2):
+            if not isinstance(step, dict):
+                continue
+            # Both searches read the same text so their offsets are comparable.
+            script = COMMENT_LINE.sub("", str(step.get("run", "")))
+            invocation = RUNTIME_INVOCATION.search(script)
+            if invocation is None:
+                continue
+            drop = DROPS_CACHE_ENDPOINT.search(script)
+            if drop is not None and drop.start() < invocation.start():
+                continue
+            label = step.get("name") or f"step {position}"
+            problems.append(
+                f"job `{name}` step `{label}` runs the Spice runtime after `{CACHE_SETUP_ACTION}` "
+                f"has exported `AWS_ENDPOINT_URL`, which sends every `s3://` dataset to the "
+                f"compiler cache — start the step with `unset AWS_ENDPOINT_URL`"
+            )
+    return problems
+
+
 def check_action(text: str) -> list[str]:
     """Return the problems with one composite action definition's contents."""
     document, problems = _parse_mapping(text)
@@ -334,8 +434,9 @@ def main(argv: list[str] | None = None) -> int:
     if failures:
         print(
             f"{len(failures)} GitHub Actions definition problem(s) found. A definition "
-            "GitHub cannot parse or schedule is silently disabled, and a budget it "
-            "pre-empts never fires, so this fails the build:",
+            "GitHub cannot parse or schedule is silently disabled, a budget it "
+            "pre-empts never fires, and a leaked cache endpoint reports as an "
+            "unrelated test failure, so this fails the build:",
             file=sys.stderr,
         )
         for failure in failures:

--- a/.github/scripts/test_check_workflow_yaml.py
+++ b/.github/scripts/test_check_workflow_yaml.py
@@ -377,6 +377,163 @@ class CheckConditionContextTest(unittest.TestCase):
         self.assertEqual(check_workflow_yaml.check_action(action), [])
 
 
+def _workflow_running_the_runtime(
+    command: str = "cargo nextest run --archive-file ./integration.tar.zst -- openai_test",
+    prelude: str = "",
+    with_cache_setup: bool = True,
+) -> str:
+    """A job that sets up the compiler cache and then runs the Spice runtime."""
+    return "".join(
+        [
+            "---\non:\n  workflow_dispatch:\n\njobs:\n  test-models:\n",
+            "    runs-on: spiceai-macos\n    steps:\n",
+            (
+                "      - name: Set up spiceio\n"
+                "        uses: spiceai/spiceio/.github/actions/setup@0870da5\n"
+                if with_cache_setup
+                else ""
+            ),
+            "      - name: Run OpenAI integration test\n        run: |\n",
+            f"          {prelude}\n" if prelude else "",
+            f"          {command}\n",
+        ]
+    )
+
+
+class CheckCacheEndpointIsolationTest(unittest.TestCase):
+    """#12624: the cache's `AWS_ENDPOINT_URL` redirects the runtime's S3 traffic."""
+
+    EXPECTED = (
+        "job `test-models` step `Run OpenAI integration test` runs the Spice runtime after "
+        "`spiceio/.github/actions/setup` has exported `AWS_ENDPOINT_URL`, which sends every "
+        "`s3://` dataset to the compiler cache — start the step with `unset AWS_ENDPOINT_URL`"
+    )
+
+    def test_a_test_run_after_the_cache_setup_is_reported(self):
+        """The shape trunk shipped on 2026-08-05, before the guard existed."""
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(_workflow_running_the_runtime()),
+            [self.EXPECTED],
+        )
+
+    def test_dropping_the_endpoint_first_is_accepted(self):
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_running_the_runtime(prelude="unset AWS_ENDPOINT_URL")
+            ),
+            [],
+        )
+
+    def test_a_spice_run_is_covered_too(self):
+        """The CLI reads the same environment as the archived test binary."""
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_running_the_runtime(command="spice run &")
+            ),
+            [self.EXPECTED],
+        )
+
+    def test_a_job_without_the_cache_setup_is_left_alone(self):
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_running_the_runtime(with_cache_setup=False)
+            ),
+            [],
+        )
+
+    def test_building_the_archive_still_gets_the_cache(self):
+        """`nextest archive` compiles — that is exactly what the endpoint is for."""
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_running_the_runtime(
+                    command="cargo nextest archive -p runtime --archive-file integration.tar.zst"
+                )
+            ),
+            [],
+        )
+
+    def test_a_downloaded_test_binary_is_covered_too(self):
+        """`integration_llms.yml` runs a binary it downloaded, with env prefixes."""
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_running_the_runtime(
+                    command='CARGO_MANIFEST_DIR="${PWD}" ./integration_test/llms_integration_test'
+                )
+            ),
+            [self.EXPECTED],
+        )
+
+    def test_the_variable_named_only_in_a_comment_does_not_count(self):
+        """A mention is not a drop; the guard must read the command, not the prose."""
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_running_the_runtime(prelude="# unset AWS_ENDPOINT_URL one day")
+            ),
+            [self.EXPECTED],
+        )
+
+    def test_a_runtime_named_only_in_a_comment_is_not_an_invocation(self):
+        """The converse false positive: prose about the command must not fail a step."""
+        workflow = (
+            "---\non:\n  workflow_dispatch:\n\njobs:\n  test-models:\n"
+            "    runs-on: spiceai-macos\n    steps:\n"
+            "      - name: Set up spiceio\n"
+            "        uses: spiceai/spiceio/.github/actions/setup@0870da5\n"
+            "      - name: Note\n        run: |\n"
+            "          # cargo nextest run happens in the next job\n"
+            "          echo noted\n"
+        )
+        self.assertEqual(check_workflow_yaml.check_workflow(workflow), [])
+
+    def test_dropping_it_after_the_runtime_has_started_is_reported(self):
+        """Order matters: the child process is already gone by then."""
+        workflow = (
+            "---\non:\n  workflow_dispatch:\n\njobs:\n  test-models:\n"
+            "    runs-on: spiceai-macos\n    steps:\n"
+            "      - name: Set up spiceio\n"
+            "        uses: spiceai/spiceio/.github/actions/setup@0870da5\n"
+            "      - name: Run OpenAI integration test\n        run: |\n"
+            "          cargo nextest run -- openai_test\n"
+            "          unset AWS_ENDPOINT_URL\n"
+        )
+        self.assertEqual(check_workflow_yaml.check_workflow(workflow), [self.EXPECTED])
+
+    def test_a_drop_inside_a_conditional_is_reported(self):
+        """Indented means it is inside an `if` or a function and may not run."""
+        workflow = (
+            "---\non:\n  workflow_dispatch:\n\njobs:\n  test-models:\n"
+            "    runs-on: spiceai-macos\n    steps:\n"
+            "      - name: Set up spiceio\n"
+            "        uses: spiceai/spiceio/.github/actions/setup@0870da5\n"
+            "      - name: Run OpenAI integration test\n        run: |\n"
+            '          if [ "$CI" = "false" ]; then\n'
+            "            unset AWS_ENDPOINT_URL\n"
+            "          fi\n"
+            "          cargo nextest run -- openai_test\n"
+        )
+        self.assertEqual(check_workflow_yaml.check_workflow(workflow), [self.EXPECTED])
+
+    def test_unset_f_removes_a_function_not_the_variable(self):
+        self.assertEqual(
+            check_workflow_yaml.check_workflow(
+                _workflow_running_the_runtime(prelude="unset -f AWS_ENDPOINT_URL")
+            ),
+            [self.EXPECTED],
+        )
+
+    def test_a_runtime_step_before_the_cache_setup_is_left_alone(self):
+        """The export does not exist yet, so there is nothing to inherit."""
+        workflow = (
+            "---\non:\n  workflow_dispatch:\n\njobs:\n  test-models:\n"
+            "    runs-on: spiceai-macos\n    steps:\n"
+            "      - name: Run OpenAI integration test\n        run: |\n"
+            "          cargo nextest run -- openai_test\n"
+            "      - name: Set up spiceio\n"
+            "        uses: spiceai/spiceio/.github/actions/setup@0870da5\n"
+        )
+        self.assertEqual(check_workflow_yaml.check_workflow(workflow), [])
+
+
 class CheckActionTest(unittest.TestCase):
     def test_valid_action_has_no_problems(self):
         self.assertEqual(check_workflow_yaml.check_action(VALID_ACTION), [])

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -200,6 +200,10 @@ jobs:
           SPICE_BEDROCK_ACCESS_KEY: ${{ secrets.AWS_BEDROCK_KEY }}
           SPICE_BEDROCK_SECRET_KEY: ${{ secrets.AWS_BEDROCK_SECRET }}
         run: |
+          # The spiceio setup action exports AWS_ENDPOINT_URL for sccache; the AWS SDK
+          # honours it for every service, so leaving it set sends this suite's Bedrock
+          # calls to the local build cache instead of AWS.
+          unset AWS_ENDPOINT_URL
           if [ "${{ matrix.target.needs_env }}" == "true" ]; then
             if [ -z "$SPICE_OPENAI_API_KEY" ]; then
               echo "Error: 'SPICE_OPENAI_API_KEY' is not defined."

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -37,6 +37,11 @@ env:
   AI_INTEGRATION_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/ai-integration-test-archive/integration.tar.zst
   AI_INTEGRATION_EXTENDED_TEST_ARCHIVE_S3_URI: s3://build/test_binaries/${{ github.run_id }}/ai-integration-test-archive-extended/integration-extended.tar.zst
 
+# The spiceio setup action exports AWS_ENDPOINT_URL (alongside SCCACHE_ENDPOINT) so that sccache
+# and the AWS CLI reach the local cache. The build jobs need it. The test jobs must not hand it to
+# spiced: it honours AWS_ENDPOINT_URL for every s3:// dataset and for the S3 Vectors API, so the
+# public fixtures these tests load resolve to the build cache instead of AWS and never become
+# ready. Every step below that runs the test binary drops it first.
 jobs:
   build:
     name: Build Test Binary (macOS)
@@ -213,6 +218,7 @@ jobs:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           if [ -z "${SPICE_SECRET_OPENAI_API_KEY:-}" ]; then
             echo "ERROR: SPICE_SECRET_OPENAI_API_KEY is required but not set"
             exit 1
@@ -225,6 +231,7 @@ jobs:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           if [ -z "${SPICE_SECRET_OPENAI_API_KEY:-}" ]; then
             echo "ERROR: SPICE_SECRET_OPENAI_API_KEY is required but not set"
             exit 1
@@ -239,6 +246,7 @@ jobs:
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
           SPICE_SECRET_ANTHROPIC_API_KEY: ${{ secrets.SPICE_SECRET_ANTHROPIC_API_KEY }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           if [ -z "${SPICE_SECRET_OPENAI_API_KEY:-}" ]; then
             echo "ERROR: SPICE_SECRET_OPENAI_API_KEY is required but not set"
             exit 1
@@ -257,6 +265,7 @@ jobs:
           SPICE_SECRET_ANTHROPIC_API_KEY: ${{ secrets.SPICE_SECRET_ANTHROPIC_API_KEY }}
           SPICE_SECRET_XAI_API_KEY: ${{ secrets.SPICE_SECRET_XAI_API_KEY }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           if [ -z "${SPICE_SECRET_OPENAI_API_KEY:-}" ]; then
             echo "ERROR: SPICE_SECRET_OPENAI_API_KEY is required but not set"
             exit 1
@@ -280,6 +289,7 @@ jobs:
           SPICE_SECRET_ANTHROPIC_API_KEY: ${{ secrets.SPICE_SECRET_ANTHROPIC_API_KEY }}
           SPICE_SECRET_XAI_API_KEY: ${{ secrets.SPICE_SECRET_XAI_API_KEY }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           if [ -z "${SPICE_SECRET_OPENAI_API_KEY:-}" ]; then
             echo "ERROR: SPICE_SECRET_OPENAI_API_KEY is required but not set"
             exit 1
@@ -291,6 +301,7 @@ jobs:
         env:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --archive-file ./integration_test/integration.tar.zst -- local_embeddings_beta_requirements
 
       - name: Run AI UDF with local model test
@@ -299,6 +310,7 @@ jobs:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_HF_TOKEN: ${{ secrets.SPICE_SECRET_HF_TOKEN }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --archive-file ./integration_test/integration.tar.zst -- test_ai_udf_with_local_model
 
       # Workers tests
@@ -308,6 +320,7 @@ jobs:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_SECRET_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           if [ -z "${SPICE_SECRET_OPENAI_API_KEY:-}" ]; then
             echo "ERROR: SPICE_SECRET_OPENAI_API_KEY is required but not set"
             exit 1
@@ -323,6 +336,7 @@ jobs:
           AWS_S3_VECTORS_KEY: ${{ secrets.AWS_S3_VECTORS_KEY }}
           AWS_S3_VECTORS_SECRET: ${{ secrets.AWS_S3_VECTORS_SECRET }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           if [ -z "${SPICE_SECRET_OPENAI_API_KEY:-}" ]; then
             echo "ERROR: SPICE_SECRET_OPENAI_API_KEY is required but not set"
             exit 1
@@ -393,6 +407,7 @@ jobs:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_HF_TOKEN: ${{ secrets.SPICE_SECRET_HF_TOKEN }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           if [ -z "${SPICE_HF_TOKEN:-}" ]; then
             echo "ERROR: SPICE_SECRET_HF_TOKEN is required but not set"
             exit 1
@@ -405,6 +420,7 @@ jobs:
           INSTA_UPDATE: ${{ github.event_name == 'schedule' && 'always' || github.event.inputs.update_snapshots }}
           SPICE_HF_TOKEN: ${{ secrets.SPICE_SECRET_HF_TOKEN }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           if [ -z "${SPICE_HF_TOKEN:-}" ]; then
             echo "ERROR: SPICE_SECRET_HF_TOKEN is required but not set"
             exit 1
@@ -474,6 +490,7 @@ jobs:
           AWS_BEDROCK_KEY: ${{ secrets.AWS_BEDROCK_KEY }}
           AWS_BEDROCK_SECRET: ${{ secrets.AWS_BEDROCK_SECRET }}
         run: |
+          unset AWS_ENDPOINT_URL # spiced must not use the build cache's S3 endpoint
           INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" cargo nextest run --workspace-remap "${PWD}" --archive-file ./integration_test/integration.tar.zst -- bedrock_test
 
       - name: Push snapshots to branch


### PR DESCRIPTION
Fixes #12624

## Summary (root cause)

`spiceai/spiceio`'s setup action writes `AWS_ENDPOINT_URL` into `$GITHUB_ENV` so the steps after it — sccache, the AWS CLI — reach the local cache. In `integration_models.yml` that export is still in the environment when the AI integration test binary runs, and `spiced` honours it: `AmazonS3Builder::from_env()` maps `AWS_ENDPOINT_URL` to the S3 endpoint, so every `s3://` dataset with no endpoint of its own is fetched from the compiler cache instead of AWS. With no explicit endpoint the registry builds the store virtual-hosted, and `object_store` then uses that endpoint verbatim as the bucket endpoint — which is why the bucket disappears from the request:

```
WARN runtime::init::dataset: Cannot connect to the dataset taxi_trips (s3). Object Store error:
  Generic S3 error: Error performing list request:
  Error performing GET http://127.0.0.1:8333/?list-type=2&prefix=taxi_trips%2F2024%2F - HTTP error: builder error
INFO runtime::init::dataset: Dataset load summary (after 30s): 1/2 ready, 1 unhealthy, 0 still initializing.
Error: Timed out waiting for components to load
```

Nothing in that failure names S3. The dataset stays unhealthy, the runtime never reports ready, and the test fails on a readiness timeout — six times over, once per nextest retry.

The export is new, and the nightly's failure mode changes exactly where it appears:

| nightly | pinned setup action | first failing step | `AWS_ENDPOINT_URL` in the job env |
|---|---|---|---|
| 2026-08-04 | v0.5.9 (`da41a0d`) | 17 — `Run search integration test` | absent |
| 2026-08-05 | v0.5.10 (`dc53e1f`) | 9 — `Run OpenAI integration test` | present |
| 2026-08-06 | v0.6.0 (`0870da5`) | 9 — `Run OpenAI integration test` | present |

All three test jobs of the nightly — `Test Models, AI & Search`, `Test Hugging Face Models`, `Test Bedrock Models` — have failed this way on every run since.

## Changes

- **`.github/workflows/integration_models.yml`** — the twelve steps that run the test binary drop `AWS_ENDPOINT_URL` first. The build steps keep it: compiling is what it is for.
- **`.github/workflows/integration_llms.yml`** — the same one-line drop. This job is green today, but it sets the cache up and then executes a downloaded test binary whose hosted matrix includes Bedrock, and the override is SDK-wide rather than S3-only. Fixing it here rather than waiting for it to break is the point of finding the class instead of the instance.
- **`.github/scripts/check_workflow_yaml.py`** — a fourth invariant for the existing Actions-definition gate: in a job that sets the compiler cache up, a step *after* that setup which starts the Spice runtime (`cargo nextest run`, `spice run`, or a downloaded `./integration_test/…` binary) must drop `AWS_ENDPOINT_URL` before it. Without this the two fixes above last exactly until someone adds a thirteenth test step.
- **`.github/scripts/test_check_workflow_yaml.py`** — twelve cases for the new check.

`unset` is the only form that works. Writing an empty value back to `$GITHUB_ENV` leaves the variable *set*, and `object_store` then builds a store whose bucket endpoint is the empty string — a different failure, not a fix. The comment above `jobs:` records that.

## What the guard does and does not prove

It requires the drop to be a top-level command that precedes the runtime, so an `unset` after the run, one nested inside an `if`, and `unset -f` (which removes a function, not the variable) are all rejected; a command named only in a comment is not treated as an invocation, and a runtime step *before* the setup is left alone. Each of those is a test.

It does not model shell semantics, so a drop that is later re-exported still passes, and it cannot see a runtime started from a `make` target or a composite action, where the command lives outside the workflow file. No job combines those with the cache setup today. The docstring says so rather than implying the guard is a proof.

## Why here and not at the source

The export is deliberate on spiceio's side and has no opt-out input, and other consumers rely on it for the AWS CLI. Ignoring an ambient `AWS_ENDPOINT_URL` in the runtime is not an option either — honouring it is standard AWS behaviour and is how users point Spice at MinIO or LocalStack. So the isolation belongs to the job that runs both a build cache and a runtime. The upstream half — making the generic export opt-in, since `AWS_ENDPOINT_URL` is not tool-scoped the way `SCCACHE_ENDPOINT` is — is filed as spiceai/spiceio#38; this change stands on its own either way.

## Not in scope

The step-9 failure also skipped steps 10-18, including the search suite and `Push snapshots to branch`. That masking is a separate defect in how the job is structured and is filed as #12625. It is also why #11112 cannot be confirmed resolved: the suite it tracks has not run since 2026-08-04.

## Test plan

No Rust changes, so there is nothing here for `make lint` / `make nextest` to cover and `Attestation` auto-passes a branch with no Rust-affecting files. What was run:

- `python3 .github/scripts/test_check_workflow_yaml.py -v` — 54 tests pass (42 pre-existing, 12 new).
- `python3 .github/scripts/check_workflow_yaml.py` — `OK: 108 GitHub Actions definitions are well-formed`.
- Neuter, per workflow: reverting only `integration_models.yml` reports **12** problems, one per unguarded step; reverting only `integration_llms.yml` reports **1**, naming that job's step. Both are 0 with the fixes applied.
- `Workflow YAML Check` runs on this PR through its existing `.github/workflows/**` path filter.

End-to-end confirmation is the next `integration tests (models)` run: `Run OpenAI integration test` reaching a real verdict instead of a readiness timeout, and steps 10-18 executing at all.

## Checklist

- [x] Root cause identified and stated, with the change that introduced it
- [x] Regression guard that fails on each pre-fix workflow and passes on both
- [x] Same class fixed in the second exposed workflow, not just the reported one
- [x] Guard scoped so build steps keep the cache endpoint they need
- [x] Guard's limits documented rather than implied away
- [x] No secrets, credentials or internal hostnames added to the workflows, the scripts, or this description
