### PR TITLE
fix(standalone-instances): Update cloud connect URL to api.spice.ai

### DIFF
--- a/bin/spice/src/commands/connect/mod.rs
+++ b/bin/spice/src/commands/connect/mod.rs
@@ -144,7 +144,7 @@ pub struct ConnectArgs {
     pub target: Option<String>,
 
     /// Override the Spice Cloud enroll endpoint the adoption code is
-    /// presented to. Defaults to `https://cloud.spice.ai`. Also
+    /// presented to. Defaults to `https://api.spice.ai`. Also
     /// configurable via `SPICE_CLOUD_ENDPOINT`. The gateway (stream)
     /// address is issued by the enroll response, not configured here.
     #[arg(long, value_name = "URL")]

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 /// plane): the base URL the out-of-band HTTPS `/v1/cloud-connect/enroll`
 /// and `/v1/cloud-connect/renew` requests are made against. The gateway
 /// (stream) address is returned by the enroll response, not configured.
-pub const DEFAULT_ENDPOINT: &str = "https://cloud.spice.ai";
+pub const DEFAULT_ENDPOINT: &str = "https://api.spice.ai";
 
 /// Default lead time before the identity cert's `not_after` at which the
 /// client renews. The cloud issues 24h leaves, so a 12h lead yields the
@@ -76,7 +76,7 @@ fn adoption_code_from_env() -> Option<String> {
 /// Runtime config for the Cloud Connect client.
 #[derive(Debug, Clone)]
 pub struct CloudConnectConfig {
-    /// Cloud enroll endpoint (state plane), e.g. `https://cloud.spice.ai`.
+    /// Cloud enroll endpoint (state plane), e.g. `https://api.spice.ai`.
     /// Base URL for the out-of-band HTTPS `/v1/cloud-connect/enroll` and
     /// `/v1/cloud-connect/renew` requests. This is **not** the stream
     /// endpoint: the gateway address for the mTLS `CloudConnect` stream

--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -1006,7 +1006,7 @@ mod tests {
 
     #[test]
     fn enroll_attributes_read_the_config() {
-        let mut config = test_config("https://cloud.spice.ai");
+        let mut config = test_config("https://api.spice.ai");
         config.adopt_app_name = Some("edge-fleet".to_string());
         config.adopt_create_app = true;
         config.instance_region = Some("us-west-2".to_string());
@@ -1053,7 +1053,7 @@ mod tests {
         // A skewed clock never reached the cloud, so the adoption code is
         // still live: classifying this as authoritative would burn it.
         let err = Error::CertificateValidity {
-            url: "https://cloud.spice.ai/v1/cloud-connect/enroll".to_string(),
+            url: "https://api.spice.ai/v1/cloud-connect/enroll".to_string(),
             advice: "host clock is 42 minutes behind Spice Cloud".to_string(),
         };
         assert!(!err.is_authoritative_rejection());
@@ -1088,15 +1088,15 @@ mod tests {
 
     #[test]
     fn enroll_urls_join_with_and_without_trailing_slash() {
-        for endpoint in ["https://cloud.spice.ai/", "https://cloud.spice.ai"] {
+        for endpoint in ["https://api.spice.ai/", "https://api.spice.ai"] {
             let client = EnrollClient::new(&test_config(endpoint)).expect("client");
             assert_eq!(
                 client.enroll_url,
-                "https://cloud.spice.ai/v1/cloud-connect/enroll"
+                "https://api.spice.ai/v1/cloud-connect/enroll"
             );
             assert_eq!(
                 client.renew_url,
-                "https://cloud.spice.ai/v1/cloud-connect/renew"
+                "https://api.spice.ai/v1/cloud-connect/renew"
             );
         }
     }

--- a/crates/runtime-cloud-connect/src/release.rs
+++ b/crates/runtime-cloud-connect/src/release.rs
@@ -218,11 +218,11 @@ mod tests {
 
     #[test]
     fn release_url_joins_with_and_without_trailing_slash() {
-        for endpoint in ["https://cloud.spice.ai/", "https://cloud.spice.ai"] {
+        for endpoint in ["https://api.spice.ai/", "https://api.spice.ai"] {
             let base = endpoint.trim_end_matches('/');
             assert_eq!(
                 format!("{base}{RELEASE_PATH}"),
-                "https://cloud.spice.ai/v1/cloud-connect/release"
+                "https://api.spice.ai/v1/cloud-connect/release"
             );
         }
     }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Updates the standalone instances `spice connect` default endpoint to be the correct `api.spice.ai` instead of `cloud.spice.ai`
