### PR TITLE
fix(cloud-connect): send the credentials for `spice connect remove`

### DIFF
--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -730,12 +730,27 @@ fn discard_pending_code_file(config: &CloudConnectConfig) {
 /// private key, base64-encoded. This authorizes the rotation — a leaked
 /// certificate alone (which is not a secret) must not be able to renew.
 pub(crate) fn sign_pop(current_private_key_pem: &str, csr_pem: &str) -> Result<String> {
-    let key = pem::parse(current_private_key_pem).map_err(|source| Error::ProofOfPossession {
-        reason: format!("current private key is not valid PEM: {source}"),
-    })?;
     let csr = pem::parse(csr_pem).map_err(|source| Error::ProofOfPossession {
         reason: format!("CSR is not valid PEM: {source}"),
     })?;
+    sign_pop_payload(current_private_key_pem, csr.contents())
+        .map_err(|reason| Error::ProofOfPossession { reason })
+}
+
+/// Sign an arbitrary proof-of-possession payload with an identity's private
+/// key: a DER-encoded ECDSA P-256/SHA-256 signature over `payload`,
+/// base64-encoded. `/renew` signs a CSR's DER bytes ([`sign_pop`]);
+/// `/release` signs its own domain-separated `release\n{instance_id}` payload.
+///
+/// The error is the bare reason rather than a typed error so each flow names
+/// itself in the error it surfaces, instead of nesting one flow's message
+/// inside another's.
+pub(crate) fn sign_pop_payload(
+    private_key_pem: &str,
+    payload: &[u8],
+) -> std::result::Result<String, String> {
+    let key = pem::parse(private_key_pem)
+        .map_err(|source| format!("current private key is not valid PEM: {source}"))?;
 
     // aws-lc-rs is the same backend rcgen generated the keypair with (see
     // Cargo.toml), so the persisted PKCS#8 always round-trips here.
@@ -743,16 +758,11 @@ pub(crate) fn sign_pop(current_private_key_pem: &str, csr_pem: &str) -> Result<S
         &aws_lc_rs::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
         key.contents(),
     )
-    .map_err(|source| Error::ProofOfPossession {
-        reason: format!("current private key is not a PKCS#8 ECDSA P-256 key: {source}"),
-    })?;
+    .map_err(|source| format!("current private key is not a PKCS#8 ECDSA P-256 key: {source}"))?;
     let rng = aws_lc_rs::rand::SystemRandom::new();
-    let signature =
-        key_pair
-            .sign(&rng, csr.contents())
-            .map_err(|source| Error::ProofOfPossession {
-                reason: format!("signing failed: {source}"),
-            })?;
+    let signature = key_pair
+        .sign(&rng, payload)
+        .map_err(|source| format!("signing failed: {source}"))?;
     Ok(base64::engine::general_purpose::STANDARD.encode(signature.as_ref()))
 }
 

--- a/crates/runtime-cloud-connect/src/release.rs
+++ b/crates/runtime-cloud-connect/src/release.rs
@@ -63,11 +63,14 @@ pub enum Error {
     ClientBuild { source: reqwest::Error },
 
     #[snafu(display(
-        "The local identity cannot be presented as a TLS client certificate: {source}. \
-         The identity file is corrupt — clear it with `spice connect remove` and delete the \
-         instance in the Spice Cloud portal."
+        "Failed to release instance {instance_id} (Spice Cloud): the local identity file is \
+         invalid ({source}). Delete this instance in the Spice Cloud portal to finish removing \
+         it. See: https://spiceai.org/docs"
     ))]
-    Identity { source: reqwest::Error },
+    Identity {
+        instance_id: String,
+        source: reqwest::Error,
+    },
 
     #[snafu(display("Invalid CA certificate PEM for the Spice Cloud release request: {source}"))]
     CaCert { source: reqwest::Error },
@@ -86,10 +89,9 @@ pub enum Error {
     Rejected { status: u16, message: String },
 
     #[snafu(display(
-        "Failed to release instance {instance_id} (Spice Cloud): the stored identity's private \
-         key could not sign the release proof-of-possession ({reason}). The identity file is \
-         unusable, so the cloud cannot be told this instance is gone — delete the instance in \
-         the Spice Cloud portal instead. See: https://spiceai.org/docs"
+        "Failed to release instance {instance_id} (Spice Cloud): the local identity file is \
+         invalid ({reason}). Delete this instance in the Spice Cloud portal to finish removing \
+         it. See: https://spiceai.org/docs"
     ))]
     ProofOfPossession { instance_id: String, reason: String },
 }
@@ -199,7 +201,9 @@ pub async fn release(
     client_pem.push_str(identity.private_key_pem.trim_end());
     client_pem.push('\n');
     let client_identity =
-        reqwest::Identity::from_pem(client_pem.as_bytes()).context(IdentitySnafu)?;
+        reqwest::Identity::from_pem(client_pem.as_bytes()).context(IdentitySnafu {
+            instance_id: identity.identifier.clone(),
+        })?;
 
     let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))

--- a/crates/runtime-cloud-connect/src/release.rs
+++ b/crates/runtime-cloud-connect/src/release.rs
@@ -18,9 +18,19 @@ limitations under the License.
 //! instance is gone.
 //!
 //! `POST /v1/cloud-connect/release` sits on the same state-plane surface as
-//! `/enroll` and `/renew` and is authorised by the instance's own mTLS leaf —
-//! the leaf names exactly one instance, so a host can only release itself and
-//! no new trust boundary is introduced.
+//! `/enroll` and `/renew`, and is authorized the way `/renew` is: by
+//! proof-of-possession carried in the request body. The request presents the
+//! instance's current leaf (`cert_pem`), whose SPIFFE SAN names exactly one
+//! instance, together with a signature made by that leaf's private key
+//! (`pop_sig`) over `release\n{instance_id}`. A certificate is not a secret, so
+//! the signature — not the certificate — is what proves the caller is the
+//! instance; the `release` domain prefix keeps the signature from being
+//! replayable against another endpoint, and the instance id keeps it from being
+//! replayable for another instance.
+//!
+//! The credential rides in the body rather than the TLS layer for the same
+//! reason `/renew` does: the presented leaf may already be expired, which is
+//! precisely the state a host being decommissioned can be in.
 //!
 //! It is an HTTPS call rather than a frame on the `CloudConnect` stream because
 //! that stream is cloud→instance dispatch, and a release has to work at the
@@ -33,13 +43,16 @@ limitations under the License.
 
 use std::time::Duration;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 
 use crate::identity::Identity;
 
 /// Path of the cloud release endpoint, relative to the enroll base URL.
 pub const RELEASE_PATH: &str = "/v1/cloud-connect/release";
+
+/// Domain-separation prefix of the release proof-of-possession payload.
+const POP_DOMAIN: &str = "release";
 
 /// Errors from the host-initiated release call.
 #[derive(Debug, Snafu)]
@@ -71,9 +84,40 @@ pub enum Error {
 
     #[snafu(display("Spice Cloud rejected the release request ({status}): {message}"))]
     Rejected { status: u16, message: String },
+
+    #[snafu(display(
+        "Failed to release instance {instance_id} (Spice Cloud): the stored identity's private \
+         key could not sign the release proof-of-possession ({reason}). The identity file is \
+         unusable, so the cloud cannot be told this instance is gone — delete the instance in \
+         the Spice Cloud portal instead. See: https://spiceai.org/docs"
+    ))]
+    ProofOfPossession { instance_id: String, reason: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Wire shape of the release request. Mirrors the `/renew` request's
+/// credential half: the current leaf plus a proof-of-possession signature made
+/// by its private key. There is no CSR — nothing is being issued — so the
+/// signature covers [`pop_payload`] instead of a CSR's DER bytes.
+///
+/// The instance being released is **not** a field: the cloud reads it from the
+/// certificate's SPIFFE SAN, which is the only statement of identity a caller
+/// cannot choose for itself.
+#[derive(Serialize)]
+struct ReleaseRequest<'a> {
+    cert_pem: &'a str,
+    pop_sig: &'a str,
+}
+
+/// The exact bytes a release proof-of-possession signs: the `release` domain
+/// prefix, a newline, and the instance id. The cloud rebuilds this string from
+/// the presented certificate's SPIFFE SAN and verifies the signature against
+/// that certificate's public key, so the separator must be a real newline
+/// (0x0A) — an escaped `\n` would be two bytes the cloud never signs over.
+fn pop_payload(instance_id: &str) -> String {
+    format!("{POP_DOMAIN}\n{instance_id}")
+}
 
 /// Error body shape the cloud endpoints return (`{ "error": "..." }`).
 #[derive(Deserialize)]
@@ -100,8 +144,8 @@ struct ReleaseResponseWire {
     app_name: Option<String>,
 }
 
-/// Report this instance's release to Spice Cloud, authenticating with its own
-/// identity leaf.
+/// Report this instance's release to Spice Cloud, presenting its identity leaf
+/// and a proof-of-possession signature made with that leaf's private key.
 ///
 /// `enroll_endpoint` is the state-plane base URL (the same one `/enroll` and
 /// `/renew` are reached on). `ca_cert_pem` overrides the trust roots for
@@ -110,10 +154,12 @@ struct ReleaseResponseWire {
 /// # Errors
 ///
 /// Returns [`Error::Rejected`] when the cloud refuses the release (including
-/// the not-found a cross-org or already-deleted instance gets), and the
-/// transport variants when the cloud cannot be reached. A caller performing a
-/// `spice connect remove` treats **every** error as non-fatal: local state is
-/// cleared regardless, and the portal-side delete stays authoritative.
+/// the not-found a cross-org or already-deleted instance gets),
+/// [`Error::ProofOfPossession`] when the stored private key cannot sign the
+/// request, and the transport variants when the cloud cannot be reached. A
+/// caller performing a `spice connect remove` treats **every** error as
+/// non-fatal: local state is cleared regardless, and the portal-side delete
+/// stays authoritative.
 pub async fn release(
     enroll_endpoint: &str,
     identity: &Identity,
@@ -122,8 +168,29 @@ pub async fn release(
     let base = enroll_endpoint.trim_end_matches('/');
     let url = format!("{base}{RELEASE_PATH}");
 
-    // The leaf + its private key are the credential. reqwest wants them in one
-    // PEM buffer, so concatenate rather than re-encoding either.
+    // The body carries the credential: the leaf names the instance (its SPIFFE
+    // SAN) and the signature proves this host holds the leaf's private key, so
+    // a copy of the certificate alone cannot release the instance. Signed
+    // before the client is built so an unusable key is reported as what it is
+    // rather than as a TLS setup failure.
+    let pop_sig = crate::enroll::sign_pop_payload(
+        &identity.private_key_pem,
+        pop_payload(&identity.identifier).as_bytes(),
+    )
+    .map_err(|reason| Error::ProofOfPossession {
+        instance_id: identity.identifier.clone(),
+        reason,
+    })?;
+    let request = ReleaseRequest {
+        cert_pem: &identity.identity_cert_pem,
+        pop_sig: &pop_sig,
+    };
+
+    // The leaf is also presented as the TLS client identity, for a control
+    // plane that fronts this surface with mTLS. reqwest wants the certificate
+    // and its key in one PEM buffer, so concatenate rather than re-encoding
+    // either. This is transport, not authorization — the release is authorized
+    // by the proof-of-possession above.
     let mut client_pem = String::with_capacity(
         identity.identity_cert_pem.len() + identity.private_key_pem.len() + 2,
     );
@@ -145,15 +212,7 @@ pub async fn release(
     }
     let http = builder.build().context(ClientBuildSnafu)?;
 
-    // The body carries no credential — the mTLS leaf is the authorisation. The
-    // instance id is sent so the cloud can reject a mismatch outright rather
-    // than inferring the subject from the certificate alone.
-    let response = match http
-        .post(&url)
-        .json(&serde_json::json!({ "instance_id": identity.identifier }))
-        .send()
-        .await
-    {
+    let response = match http.post(&url).json(&request).send().await {
         Ok(response) => response,
         Err(source) => {
             if crate::clock_skew::looks_like_certificate_validity_failure(&source) {
@@ -214,6 +273,8 @@ fn bounded(s: &str, max: usize) -> String {
 
 #[cfg(test)]
 mod tests {
+    use base64::Engine as _;
+
     use super::*;
 
     #[test]
@@ -263,5 +324,158 @@ mod tests {
         // A multi-byte char straddling the limit must not be split.
         let s = "aa\u{e9}bb";
         assert_eq!(bounded(s, 3), "aa");
+    }
+
+    #[test]
+    fn pop_payload_separates_the_domain_from_the_instance_with_one_real_newline() {
+        let payload = pop_payload("inst_1");
+        assert_eq!(payload, "release\ninst_1");
+        // The cloud rebuilds these bytes and verifies the signature over them,
+        // so the separator must be the single byte 0x0A. A literal backslash-n
+        // would be two bytes the cloud never signs, and every release would
+        // come back 401.
+        assert_eq!(
+            payload.as_bytes(),
+            b"release\x0Ainst_1",
+            "the domain separator must be a real newline byte"
+        );
+        assert!(!payload.contains('\\'), "the payload must carry no escapes");
+    }
+
+    #[test]
+    fn release_request_carries_only_the_certificate_and_the_pop_signature() {
+        let value = serde_json::to_value(ReleaseRequest {
+            cert_pem: "-----BEGIN CERTIFICATE-----\nMOCK\n-----END CERTIFICATE-----",
+            pop_sig: "dGVzdC1zaWduYXR1cmU=",
+        })
+        .expect("serialize release request");
+
+        assert_eq!(
+            value["cert_pem"],
+            "-----BEGIN CERTIFICATE-----\nMOCK\n-----END CERTIFICATE-----"
+        );
+        assert_eq!(value["pop_sig"], "dGVzdC1zaWduYXR1cmU=");
+        // The instance is read from the certificate's SPIFFE SAN, so an
+        // `instance_id` field is not part of the contract — sending one instead
+        // of the credential is what left the release unauthenticatable.
+        assert!(value.get("instance_id").is_none());
+        assert_eq!(
+            value
+                .as_object()
+                .expect("serialize produces an object")
+                .len(),
+            2,
+            "the release request must carry exactly the two credential fields"
+        );
+    }
+
+    /// Extract the uncompressed EC point from a P-256 SPKI DER blob: the final
+    /// 65 bytes (0x04 || X || Y). Test-only shortcut — production verification
+    /// happens server-side.
+    fn p256_point_from_spki(spki_der: &[u8]) -> &[u8] {
+        assert!(spki_der.len() > 65, "SPKI too short for a P-256 key");
+        &spki_der[spki_der.len() - 65..]
+    }
+
+    /// A self-signed leaf and its key, standing in for an issued identity: the
+    /// release only needs the certificate to be forwardable and its key to
+    /// sign, neither of which depends on who signed the leaf.
+    fn test_identity(identifier: &str) -> (Identity, String) {
+        let key_pair = rcgen::KeyPair::generate().expect("generate keypair");
+        let mut params =
+            rcgen::CertificateParams::new(Vec::<String>::new()).expect("certificate params");
+        params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, "spice-release-test");
+        let cert = params.self_signed(&key_pair).expect("self-signed leaf");
+
+        let identity = Identity {
+            identifier: identifier.to_string(),
+            identity_cert_pem: cert.pem(),
+            private_key_pem: key_pair.serialize_pem(),
+            public_key_pem: key_pair.public_key_pem(),
+            ca_bundle_pem: String::new(),
+            gateway_addr: String::new(),
+            not_after_unix: None,
+            enc_private_key_pem: String::new(),
+            enc_public_key_pem: String::new(),
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+        };
+        let public_key_pem = key_pair.public_key_pem();
+        (identity, public_key_pem)
+    }
+
+    /// The release request as it actually goes out over the wire, against an
+    /// in-process mock of the cloud endpoint (plain HTTP: the production call
+    /// is HTTPS, which is reqwest's standard path and not what this asserts).
+    #[tokio::test]
+    async fn release_posts_the_certificate_and_a_pop_signature_the_cloud_can_verify() {
+        use std::sync::Arc;
+
+        use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
+        use tokio::sync::Mutex;
+
+        type Captured = Arc<Mutex<Vec<serde_json::Value>>>;
+
+        async fn release_handler(
+            State(captured): State<Captured>,
+            Json(body): Json<serde_json::Value>,
+        ) -> (StatusCode, Json<serde_json::Value>) {
+            captured.lock().await.push(body);
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({ "status": "removed", "app_name": "edge-fleet" })),
+            )
+        }
+
+        let captured: Captured = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route(RELEASE_PATH, post(release_handler))
+            .with_state(Arc::clone(&captured));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock release endpoint");
+        let addr = listener.local_addr().expect("local_addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let (identity, public_key_pem) = test_identity("inst_release_1");
+        let outcome = release(&format!("http://{addr}"), &identity, None)
+            .await
+            .expect("release must succeed against the mock endpoint");
+        assert_eq!(outcome.status, "removed");
+        assert_eq!(outcome.app_name.as_deref(), Some("edge-fleet"));
+
+        let requests = captured.lock().await;
+        assert_eq!(requests.len(), 1, "exactly one release request");
+        let body = &requests[0];
+        assert_eq!(
+            body["cert_pem"], identity.identity_cert_pem,
+            "the request must present the instance's own leaf"
+        );
+        assert!(
+            body.get("instance_id").is_none(),
+            "the instance is named by the certificate's SAN, not by the body"
+        );
+
+        // The signature must verify against the leaf's public key over exactly
+        // the bytes the cloud rebuilds from the SAN — this is the check the
+        // endpoint performs, and the reason a body without `pop_sig` is a 401.
+        let sig = base64::engine::general_purpose::STANDARD
+            .decode(body["pop_sig"].as_str().expect("pop_sig is a string"))
+            .expect("pop_sig is base64");
+        let spki = pem::parse(&public_key_pem).expect("public key PEM");
+        let key = aws_lc_rs::signature::UnparsedPublicKey::new(
+            &aws_lc_rs::signature::ECDSA_P256_SHA256_ASN1,
+            p256_point_from_spki(spki.contents()),
+        );
+        key.verify(pop_payload(&identity.identifier).as_bytes(), &sig)
+            .expect("the release signature must verify over `release\\n{instance_id}`");
+        // ...and must not verify over anything else, so a captured signature
+        // cannot release a different instance.
+        key.verify(pop_payload("inst_other").as_bytes(), &sig)
+            .expect_err("the signature must be bound to this instance id");
     }
 }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

## What

`spice connect remove` posted `{ "instance_id": "..." }` to `/v1/cloud-connect/release` — a body with none of the fields the endpoint authorizes on, so the release could never be accepted. An instance id the caller picks for itself proves nothing.

The request carries the same credential shape `/renew` uses:

- `cert_pem` — the instance's current leaf. Its SPIFFE SAN names the instance, which is the one statement of identity a caller cannot choose for itself, so `instance_id` is no longer sent at all.
- `pop_sig` — an ECDSA P-256 signature made with that leaf's private key over `release\n{instance_id}`. A certificate is not a secret, so the signature is what proves the caller is the instance. The `release` prefix keeps the signature from being replayable as a renewal, and the instance id keeps it from being replayable for another instance.

The credential is sent in the body rather than the TLS layer for the same reason renewal does: a host being decommissioned may already have an expired leaf.

## Also

- The renewal signer now takes payload bytes, so renewal and release share one implementation instead of duplicating the crypto.
- Signing moved ahead of the HTTP client build, so an unusable private key is reported as a proof-of-possession failure that names the instance, not as a TLS setup error.
- The module doc and the request-site comment said the mTLS leaf authorized the call and that the instance id was sent so the cloud could reject a mismatch. Neither is true under this contract, so both are corrected rather than left to teach the wrong model. The leaf is still presented as a TLS client identity, now labelled as transport.

## Tests

The release path had no wire-shape coverage, which is how a body with zero required fields shipped. Added:

- An in-process mock of the release endpoint asserting what actually goes out: the leaf, no `instance_id`, and a signature that verifies against the leaf's public key over the payload the cloud rebuilds — and does not verify for a different instance id.
- Unit tests pinning the payload separator to a real newline byte (an escaped `\n` would be two bytes the cloud never signs) and the request to exactly its two fields.