### PR TITLE
fix(cloud-connect): Tolerate missing spicepods

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -1028,8 +1028,26 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
     result
 }
 
-/// What `build_app` decided about the deployed spicepod, logged once tracing
-/// exists.
+/// Whether a failed local spicepod load should be tolerated by starting on an
+/// empty spicepod instead of exiting.
+///
+/// Three conditions, each excluding a case where exiting is still the right
+/// answer:
+///
+/// - `--cloud-connect` only. A cloud-managed instance gets its configuration
+///   from a deployment, so having none yet is the ordinary freshly-connected
+///   state. Anywhere else, a missing spicepod means the user is in the wrong
+///   directory and should be told so.
+/// - No explicit path. `spiced --spicepod <path>` names a file the user expects
+///   to exist; an absent one is a typo, not a fresh connection.
+/// - Absent, not unloadable. A spicepod that exists but does not parse is still
+///   fatal — coming up empty over a YAML typo would hide it.
+fn tolerates_missing_spicepod(args: &Args, error: &app::Error) -> bool {
+    args.cloud_connect && args.spicepod.is_none() && error.is_spicepod_missing()
+}
+
+/// What `build_app` decided about which spicepod this start serves, logged once
+/// tracing exists.
 enum DeploymentNote {
     /// The runtime started on the deployed spicepod.
     Loaded { path: PathBuf },
@@ -1047,6 +1065,9 @@ enum DeploymentNote {
     /// The watcher is not installed: reconciling the local spicepod into a
     /// deployed app would swap the deployed configuration out from under it.
     PodsWatcherDeclined,
+    /// A cloud-managed instance found no spicepod — neither deployed nor local —
+    /// and started on an empty one.
+    NoSpicepod,
 }
 
 impl DeploymentNote {
@@ -1070,6 +1091,9 @@ impl DeploymentNote {
             ),
             Self::PodsWatcherDeclined => tracing::warn!(
                 "Spice Cloud Connect: --pods-watcher-enabled was ignored because this instance serves a deployed spicepod. Watching the local spicepod.yaml would replace the deployed configuration while the instance kept reporting the deployment as applied. Edit the app in Spice Cloud and deploy it instead."
+            ),
+            Self::NoSpicepod => tracing::warn!(
+                "No existing spicepod was found. Starting Runtime without one."
             ),
         }
     }
@@ -1191,6 +1215,17 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
                     local_error: e.to_string(),
                 });
                 None
+            } else if tolerates_missing_spicepod(args, &e) {
+                // A cloud-managed instance that has connected but not yet
+                // received a deployment has no spicepod anywhere: none was
+                // deployed, and `spice connect` writes nothing to the instance
+                // directory. Come up on an empty spicepod so the control plane
+                // can reach it and deploy one, rather than exiting with the
+                // "run spice init" guidance that does not apply here.
+                deployment_note = Some(DeploymentNote::NoSpicepod);
+                let mut app = App::default();
+                app.runtime = apply_overrides(app.runtime, &args.set_runtime)?;
+                Some(Arc::new(app))
             } else {
                 // In normal mode, fail immediately if spicepod cannot be loaded
                 return Err(Error::UnableToConstructSpiceApp {
@@ -1583,6 +1618,70 @@ mod tests {
         assert!(!should_warn_telemetry_disabled_setting_ignored(
             None, &config
         ));
+    }
+
+    /// The load failure a directory with no `spicepod.yaml` produces — what a
+    /// freshly connected instance hits on startup.
+    async fn missing_spicepod_error(dir: &std::path::Path) -> app::Error {
+        AppBuilder::build_from_path(dir)
+            .await
+            .err()
+            .expect("a directory with no spicepod.yaml must fail to load")
+    }
+
+    #[tokio::test]
+    async fn cloud_connect_starts_on_an_empty_spicepod_when_none_exists() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let error = missing_spicepod_error(dir.path()).await;
+
+        let args = Args::parse_from(["spiced", "--cloud-connect"]);
+        assert!(tolerates_missing_spicepod(&args, &error));
+    }
+
+    #[tokio::test]
+    async fn a_missing_spicepod_stays_fatal_without_cloud_connect() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let error = missing_spicepod_error(dir.path()).await;
+
+        let args = Args::parse_from(["spiced"]);
+        assert!(!tolerates_missing_spicepod(&args, &error));
+    }
+
+    #[tokio::test]
+    async fn an_explicitly_named_spicepod_stays_fatal_when_absent() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("spicepod.yaml");
+        let error = AppBuilder::build_from_path(&path)
+            .await
+            .err()
+            .expect("a spicepod.yaml that does not exist must fail to load");
+
+        let args = Args::parse_from([
+            std::ffi::OsStr::new("spiced"),
+            std::ffi::OsStr::new("--cloud-connect"),
+            path.as_os_str(),
+        ]);
+        assert_eq!(args.spicepod.as_deref(), Some(path.as_path()));
+        assert!(!tolerates_missing_spicepod(&args, &error));
+    }
+
+    /// A spicepod that exists but does not parse must not be swallowed as
+    /// "no spicepod" — the runtime would silently serve nothing.
+    #[tokio::test]
+    async fn a_malformed_spicepod_stays_fatal_under_cloud_connect() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        std::fs::write(
+            dir.path().join("spicepod.yaml"),
+            "version: v1\nkind: Spicepod\nname: broken\ndatasets: 'not a list'\n",
+        )
+        .expect("write spicepod.yaml");
+        let error = AppBuilder::build_from_path(dir.path())
+            .await
+            .err()
+            .expect("a malformed spicepod.yaml must fail to load");
+
+        let args = Args::parse_from(["spiced", "--cloud-connect"]);
+        assert!(!tolerates_missing_spicepod(&args, &error));
     }
 
     #[test]

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -1030,18 +1030,6 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
 
 /// Whether a failed local spicepod load should be tolerated by starting on an
 /// empty spicepod instead of exiting.
-///
-/// Three conditions, each excluding a case where exiting is still the right
-/// answer:
-///
-/// - `--cloud-connect` only. A cloud-managed instance gets its configuration
-///   from a deployment, so having none yet is the ordinary freshly-connected
-///   state. Anywhere else, a missing spicepod means the user is in the wrong
-///   directory and should be told so.
-/// - No explicit path. `spiced --spicepod <path>` names a file the user expects
-///   to exist; an absent one is a typo, not a fresh connection.
-/// - Absent, not unloadable. A spicepod that exists but does not parse is still
-///   fatal — coming up empty over a YAML typo would hide it.
 fn tolerates_missing_spicepod(args: &Args, error: &app::Error) -> bool {
     args.cloud_connect && args.spicepod.is_none() && error.is_spicepod_missing()
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -126,6 +126,17 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+impl Error {
+    /// Whether the load failed because the Spicepod file is absent, rather than
+    /// present but unloadable. See [`spicepod::Error::is_spicepod_missing`].
+    #[must_use]
+    pub fn is_spicepod_missing(&self) -> bool {
+        match self {
+            Self::UnableToLoadSpicepod { source, .. } => source.is_spicepod_missing(),
+        }
+    }
+}
+
 pub struct AppBuilder {
     name: String,
     secrets: Vec<Secret>,

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -132,6 +132,34 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+impl Error {
+    /// Whether the Spicepod file is absent, as opposed to present but
+    /// unloadable.
+    ///
+    /// A caller that tolerates a missing Spicepod — a Cloud Connect instance
+    /// that has connected but not yet received a deployment — must not also
+    /// tolerate a malformed one: silently serving nothing because of a YAML
+    /// typo hides the mistake instead of reporting it.
+    #[must_use]
+    pub fn is_spicepod_missing(&self) -> bool {
+        match self {
+            Self::SpicepodNotFound { .. } => true,
+            Self::UnableToOpenSpicepod { source, .. } => match source.as_ref() {
+                reader::Error::UnableToOpenPath { source, .. } => {
+                    source.kind() == std::io::ErrorKind::NotFound
+                }
+                #[cfg(feature = "object-store")]
+                reader::Error::UnableToOpenObjectStorePath { source, .. } => {
+                    matches!(source, object_store::Error::NotFound { .. })
+                }
+                #[cfg(feature = "object-store")]
+                reader::Error::UnableToParseObjectStorePath { .. } => false,
+            },
+            _ => false,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Spicepod {
     pub version: SpicepodVersion,
@@ -1407,6 +1435,31 @@ mod version_tests {
             .await
             .expect("load_from should find spicepod.yaml in a directory");
         assert_eq!(pod.name, "test_pod");
+    }
+
+    #[tokio::test]
+    async fn is_spicepod_missing_distinguishes_absent_from_unloadable() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+
+        let absent_in_dir = Spicepod::load_from(&reader::StdFileSystem, dir.path())
+            .await
+            .err()
+            .expect("an empty directory has no spicepod.yaml");
+        assert!(absent_in_dir.is_spicepod_missing());
+
+        let absent_file = Spicepod::load_from(&reader::StdFileSystem, dir.path().join("pod.yaml"))
+            .await
+            .err()
+            .expect("a named file that does not exist cannot load");
+        assert!(absent_file.is_spicepod_missing());
+
+        std::fs::write(dir.path().join("spicepod.yaml"), "version: v1\nkind: Spicepod\n")
+            .expect("write spicepod.yaml");
+        let malformed = Spicepod::load_from(&reader::StdFileSystem, dir.path())
+            .await
+            .err()
+            .expect("a spicepod.yaml with no name does not match the schema");
+        assert!(!malformed.is_spicepod_missing());
     }
 
     /// A directory with dots/dashes in its name (e.g. `my.app-sample`)


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

* Normally, Runtime will error and exit on startup if `spicepod.yaml` is missing. This makes installations from `spice connect --install` start crashlooping forever because no spicepod exists
* Updates Runtime so that when started with `--cloud-connect`, it tolerates a missing spicepod and starts up with an empty/default spicepod definition instead. It logs a warning when it detects no spicepod on startup, in case this is not expected.
