### PR TITLE
fix(ci): recognise the Flight bind wording so a foreign ready cannot pass (fixes #12642)

### DIFF
--- a/.github/actions/wait-for-spice-ready/wait_for_ready.sh
+++ b/.github/actions/wait-for-spice-ready/wait_for_ready.sh
@@ -36,6 +36,33 @@ port_from_url() {
   esac
 }
 
+# The runtime reports a port collision in two different wordings, and a guard
+# that knows only one of them does not fire on the other (#12642):
+#
+#   - the HTTP server surfaces the OS error as-is —
+#     "Unable to bind to address: Address already in use (os error 48)"
+#   - the Flight server formats its own, with the address in the middle —
+#     "Address 127.0.0.1:50051 is already in use by another process."
+#     (crates/runtime/src/flight/mod.rs)
+#
+# Flight is the one that actually shows up on the self-hosted macOS pool, since
+# it binds :50051 while the collision is usually with a sibling runner's runtime
+# on the same machine. The same formatted variant covers the cluster listener.
+#
+# Two exact alternatives rather than `Address .*already in use`: tracing puts a
+# line's fields and its message together, so a wildcard between the two halves
+# could pair an `address` field with an unrelated "already in use" message — and
+# the runtime has several of those (a Postgres replication slot, a view name, a
+# schedule name). Neither alternative below matches any of them.
+BIND_FAILURE_PATTERN='Address already in use|Address [^[:space:]]+ is already in use'
+
+# True when our own runtime recorded that it could not bind. Authoritative over
+# whatever answers the readiness socket: on a shared machine that answer can come
+# from another job's runtime.
+own_runtime_failed_to_bind() {
+  [ -f "$LOG_FILE" ] && grep -Eq "$BIND_FAILURE_PATTERN" "$LOG_FILE" 2>/dev/null
+}
+
 # Runs only on the failure path, and is deliberately not itself time-bounded:
 # `lsof` can block on a wedged mount, and the job-level `timeout-minutes` is the
 # backstop for that. A step-level timeout is not an option — the inner steps of
@@ -82,7 +109,7 @@ diagnose() {
     cat "$LOG_FILE"
     # The single highest-value line: a port already held means a previous job on
     # this runner leaked its runtime, not that this job is broken.
-    if grep -q "Address already in use" "$LOG_FILE" 2>/dev/null; then
+    if grep -Eq "$BIND_FAILURE_PATTERN" "$LOG_FILE" 2>/dev/null; then
       echo
       echo "NOTE: the runtime could not bind its port because something else already held it."
       echo "      Two causes, and the process list above tells them apart:"
@@ -121,7 +148,7 @@ while :; do
     # runtime — and every test step after this would then run against it.
     # Failing to bind always leaves this line in our own log, so treat it as
     # authoritative over whatever answered the socket.
-    if [ -f "$LOG_FILE" ] && grep -q "Address already in use" "$LOG_FILE" 2>/dev/null; then
+    if own_runtime_failed_to_bind; then
       echo "Something on ${URL} reports ready, but it is not this job's runtime:"
       echo "${LOG_FILE} shows our own spiced failed to bind its port."
       diagnose "$last_body"

--- a/scripts/test_e2e_spice_lifecycle.sh
+++ b/scripts/test_e2e_spice_lifecycle.sh
@@ -393,6 +393,55 @@ assert_contains "says whose runtime it is not" "$out" "not this job's runtime"
 assert_not_contains "does not claim our runtime came up" "$out" "Runtime ready after"
 rm -f "$work_dir/spice.log"
 
+# Same case, in the wording the runtime actually uses on the pool (#12642). The
+# Flight server formats its own message with the address in the middle instead of
+# passing the OS error through, so a guard written against the HTTP wording alone
+# never fires on it — and :50051 is the port that collides, because it is Flight
+# that a sibling runner's runtime is already holding. Left unmatched, the wait
+# passes and the job instead goes red much later on a model that "did not return
+# expected response" — a model belonging to a different job's runtime.
+reset_state "201 spiced $THEIRS"
+printf 'ERROR spiced: Unable to start Spice Runtime servers: Unable to start Flight server: Address 127.0.0.1:50051 is already in use by another process. Either stop the existing process or change the address: https://spiceai.org/docs/cli/reference/run\n' \
+  > "$work_dir/spice.log"
+result="$(run_subject "$wait_script" STUB_READY_BODY=ready SPICE_READY_TIMEOUT=5 SPICE_READY_INTERVAL=1)"
+out="${result#*|}"
+assert_eq "refuses a ready when Flight lost the bind" "${result%%|*}" "1"
+assert_contains "recognises the Flight bind wording" "$out" "not this job's runtime"
+assert_not_contains "does not pass a Flight bind failure off as ready" "$out" "Runtime ready after"
+rm -f "$work_dir/spice.log"
+
+# ...and the timeout diagnosis has to recognise it too, so a contended port is
+# still described as a contended port rather than left to the reader.
+reset_state
+printf 'ERROR spiced: Unable to start Flight server: Address 127.0.0.1:50051 is already in use by another process.\n' \
+  > "$work_dir/spice.log"
+result="$(run_subject "$wait_script" SPICE_READY_TIMEOUT=2 SPICE_READY_INTERVAL=1 STUB_PORT_HOLDER=7777)"
+out="${result#*|}"
+assert_eq "times out non-zero on the Flight wording" "${result%%|*}" "1"
+assert_contains "explains the contended port for Flight too" "$out" "already held it"
+rm -f "$work_dir/spice.log"
+
+# A message that merely says something else is already in use must not be read as
+# a bind failure — the runtime says this about replication slots and view names,
+# and neither means our runtime lost a port.
+reset_state "101 spiced $OURS"
+printf "ERROR runtime: Catalog 'pg': replication slot 'spice_slot' is already in use by 12345.\n" \
+  > "$work_dir/spice.log"
+result="$(run_subject "$wait_script" STUB_READY_BODY=ready SPICE_READY_TIMEOUT=5)"
+assert_eq "an unrelated 'already in use' is not a bind failure" "${result%%|*}" "0"
+rm -f "$work_dir/spice.log"
+
+# ...including when the same line carries an address of its own. Tracing renders a
+# line's fields and its message together, so "Address" and "already in use" can
+# appear on one line without the line being about a bind at all. This is the case
+# that pins the two exact alternatives instead of a wildcard between the halves.
+reset_state "101 spiced $OURS"
+printf "ERROR runtime: Address 127.0.0.1:8090 bound. View name is already in use by a dataset.\n" \
+  > "$work_dir/spice.log"
+result="$(run_subject "$wait_script" STUB_READY_BODY=ready SPICE_READY_TIMEOUT=5)"
+assert_eq "an address plus an unrelated 'already in use' still passes" "${result%%|*}" "0"
+rm -f "$work_dir/spice.log"
+
 # ...but a genuine ready alongside an unrelated log must still pass, or the
 # guard above would fail every job whose log merely mentions the phrase.
 reset_state "101 spiced $OURS"


### PR DESCRIPTION
Fixes #12642

## The failure this fixes

`E2E Test CI` failed **9 times across 7 distinct branches** between 2026-08-04 and
2026-08-06, on both `merge_group` (dequeues) and `push` to `trunk`. Every one of
them was a `model (darwin-aarch64)` job on the shared self-hosted macOS pool, and
every one of them reported the wrong thing.

- https://github.com/spiceai/spiceai/actions/runs/31075749056 (`push` on `trunk`)
- https://github.com/spiceai/spiceai/actions/runs/31088421790
- https://github.com/spiceai/spiceai/actions/runs/31081140526
- https://github.com/spiceai/spiceai/actions/runs/31066186618

In the first of those, two runner instances on the **same physical machine**
(`...-mbp-runner-01-01` and `...-mbp-runner-01-02`) ran overlapping jobs. The openai
job's own `spice.log` — printed by `stop-spice` at the end of the job — says:

```
ERROR spiced: Unable to start Spice Runtime servers: Unable to start Flight server: Address 127.0.0.1:50051 is already in use by another process. ...
```

`Wait for Spice runtime is ready` passed anyway, because the sibling instance's
runtime answered `localhost:8090/v1/ready`. Four minutes later the job went red on
`Test chat` with `Model did not return expected response` — about a model
belonging to a different job's runtime.

## Root cause

`wait_for_ready.sh` already has a guard for exactly this: it treats a bind failure
in **our own** log as authoritative over whatever answered the socket. It matched
the literal `Address already in use`, which is only one of the runtime's two
wordings:

| listener | message | matched before? |
|---|---|---|
| HTTP | `Unable to bind to address: Address already in use (os error 48)` — the OS error passed through | yes |
| Flight / cluster | `Address 127.0.0.1:50051 is already in use by another process.` — `Error::AddressAlreadyInUse`, `crates/runtime/src/flight/mod.rs` | **no** |

Flight is the one that fires, because :50051 is the port a sibling runtime holds.
So the guard never ran. The existing unit tests only ever fed it the HTTP wording,
which is why the gap survived.

## The change

Match both wordings, as two exact alternatives:

```
'Address already in use|Address [^[:space:]]+ is already in use'
```

Two alternatives rather than `Address .*already in use` on purpose: tracing renders
a line's fields and its message together, so a wildcard spanning the halves could
pair an `address` field with an unrelated "already in use" message — and the
runtime has several of those (a Postgres replication slot, a view name, a schedule
name). Both false-positive shapes are now pinned by tests.

I checked the other listeners for wordings still missed: `Error::AddressAlreadyInUse`
is the shared variant for Flight (plain and TLS) and the cluster server, HTTP passes
the OS error through, and the cluster *executor* path deliberately falls back to a
dynamic port with `Unable to bind executor flight server to ..., using dynamic port ...`
— non-fatal, and correctly not matched.

## What this does not change

- The pass condition is otherwise untouched: a genuine `ready` with no bind failure
  in the log still passes, immediately.
- No timeout is lengthened, no assertion loosened, no retry added. This makes a
  failure **earlier and correctly attributed**; it does not make anything greener.
  A port collision now fails in the step that owns it, named as a collision.
- Making the collision impossible (per-job ports, or serialising the runtime-owning
  jobs across instances on one machine) is out of scope and noted in #12642.

## Test plan

- `scripts/test_e2e_spice_lifecycle.sh` grows 5 cases and now passes **64**:
  - the Flight wording must refuse a foreign `ready` (2 assertions);
  - the Flight wording must be named as a contended port in the timeout diagnosis;
  - an unrelated `... is already in use` (replication slot) must still pass;
  - a line carrying *both* an address and an unrelated `already in use` must still
    pass — the case that justifies the two alternatives over a wildcard.
- **The 4 load-bearing assertions fail against the pre-fix script** — verified by
  restoring `origin/trunk`'s `wait_for_ready.sh` under the new tests:
  `expected '1', got '0'` on the refusal, and the diagnosis note absent.
- `shellcheck .github/actions/wait-for-spice-ready/wait_for_ready.sh` — clean.
- `python .github/scripts/check_workflow_yaml.py` — OK, 108 definitions well-formed.
- `actionlint` — no new findings versus the unmodified tree.
- The diff touches no Rust and no workflow triggers, so the Rust gate has nothing to
  build; `E2E Lifecycle Scripts Test` is the check that exercises it, and its
  `paths:` filter already covers both changed files.

## Notes for reviewers

- Verified against the source, not just one log sample: `git grep 'already in use'`
  over `crates/` accounts for every message the pattern could see, and each is
  either the target or provably unmatched.
- The refactor into `own_runtime_failed_to_bind()` is behaviour-preserving — same
  `[ -f "$LOG_FILE" ] && grep ...` body, so a missing, empty, unreadable, or
  directory `$LOG_FILE` still returns false exactly as before.
- **No overlap with the other two PRs from this sweep.** #12643's fix touches only
  `e2e_test_ci.yml`'s `e2e-gate` job and #12644's only `test_openai_model`'s
  `timeout-minutes`; this touches neither file.
