### PR TITLE
fix(ci): name the E2E jobs that did not succeed (fixes #12643)

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -2343,11 +2343,53 @@ jobs:
       - graceful_shutdown_test_full
     steps:
       - name: Verify all E2E jobs succeeded
+        env:
+          # Read through the environment rather than interpolated into the script:
+          # the results are GitHub's own, but keeping workflow expressions out of
+          # `run:` bodies is the habit that stops the next one being attacker-
+          # controlled.
+          E2E_JOB_RESULTS: ${{ toJSON(needs) }}
         run: |
-          failure="${{ contains(needs.*.result, 'failure') }}"
-          cancelled="${{ contains(needs.*.result, 'cancelled') }}"
-          if [ "$failure" = "true" ] || [ "$cancelled" = "true" ]; then
-            echo "::error::One or more E2E Test CI jobs did not succeed"
+          set -uo pipefail
+
+          # `contains(needs.*.result, 'failure')` can answer only *whether*
+          # something went wrong, never which job it was, so this gate used to
+          # fail with a single line — "One or more E2E Test CI jobs did not
+          # succeed" — whichever of the jobs above it was. Since it is the required
+          # merge-queue context standing in for the whole matrix, that line is also
+          # the entire failure summary a dequeued PR gets: whoever triages it has
+          # to open the run and read down the job list to learn anything at all
+          # (#12643). Name the jobs instead. `toJSON(needs)` carries each one's
+          # result, so this needs no extra API call and no token.
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "::error::jq is not available on this runner, so this gate cannot read the E2E job results. Failing closed rather than reporting a pass it did not verify."
             exit 1
           fi
+
+          # A `jq` that dies must not be mistaken for "nothing failed" — that
+          # would turn this gate into a rubber stamp on exactly the runs it exists
+          # to catch. Hence the explicit status check before the emptiness test.
+          # Allow-list the two results that pass rather than deny-listing the two
+          # that fail: an entry whose result were absent, or some state GitHub
+          # adds later, would be silently ignored by a deny-list and this gate
+          # would report a pass it had not established.
+          if ! not_succeeded="$(printf '%s' "$E2E_JOB_RESULTS" | jq -r '
+                to_entries
+                | map(select((.value.result // "missing") as $r
+                             | $r != "success" and $r != "skipped")
+                      | "\(.key) (\(.value.result // "no result"))")
+                | join(", ")
+              ')"; then
+            echo "::error::Could not read the E2E job results, so this gate cannot tell whether the matrix passed. Failing closed."
+            exit 1
+          fi
+
+          if [ -n "$not_succeeded" ]; then
+            # `needs` keys are job ids, and a matrix job reports one result for
+            # the whole matrix — so this names the job to open, not the cell. That
+            # is still the difference between one click and twenty.
+            echo "::error::E2E Test CI jobs did not succeed: ${not_succeeded}"
+            exit 1
+          fi
+
           echo "All E2E Test CI jobs succeeded"

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -2343,6 +2343,10 @@ jobs:
       - graceful_shutdown_test_full
     steps:
       - name: Verify all E2E jobs succeeded
+        # Named rather than left to the runner default: this gate is the required
+        # merge-queue context, so the shell it reads `set -uo pipefail`, `command -v`
+        # and `$(…)` under must not depend on the image's default staying bash.
+        shell: bash
         env:
           # Read through the environment rather than interpolated into the script:
           # the results are GitHub's own, but keeping workflow expressions out of
@@ -2375,9 +2379,9 @@ jobs:
           # would report a pass it had not established.
           if ! not_succeeded="$(printf '%s' "$E2E_JOB_RESULTS" | jq -r '
                 to_entries
-                | map(select((.value.result // "missing") as $r
-                             | $r != "success" and $r != "skipped")
-                      | "\(.key) (\(.value.result // "no result"))")
+                | map((.value.result // "missing") as $r
+                      | select($r != "success" and $r != "skipped")
+                      | "\(.key) (\($r))")
                 | join(", ")
               ')"; then
             echo "::error::Could not read the E2E job results, so this gate cannot tell whether the matrix passed. Failing closed."


### PR DESCRIPTION
Fixes #12643

## The failure this fixes

`e2e-gate` (display name **E2E Test CI**) is the single required merge-queue context
standing in for the whole E2E matrix. It failed **9 times across 7 distinct
branches** between 2026-08-04 and 2026-08-06, on both `merge_group` and `push` to
`trunk`, and on every one of those the entire output was:

```
##[error]One or more E2E Test CI jobs did not succeed
```

- https://github.com/spiceai/spiceai/actions/runs/31088421790
- https://github.com/spiceai/spiceai/actions/runs/31081140526
- https://github.com/spiceai/spiceai/actions/runs/31075749056

For the last of those, the answer a reader wanted was `openai model
(darwin-aarch64)`. The gate had that fact and threw it away.

## Root cause

`contains(needs.*.result, 'failure')` collapses ~20 job results to one boolean, so
the step cannot name the job even in principle. And because this is the required
context, that one line is also the whole failure summary a dequeued PR gets:
triaging it means opening the run and reading down the job list, every time.

`toJSON(needs)` carries each job's result in the same context — no extra API call
and no token needed.

## The change

Parse `toJSON(needs)` and name the jobs that did not succeed:

```
##[error]E2E Test CI jobs did not succeed: openai model job id (failure), ...
```

Two deliberate properties:

- **It fails closed.** A gate that cannot read the results must not report a pass it
  did not establish, so a missing `jq` and an unparseable payload each exit 1 with
  their own message. `if ! var="$(... | jq ...)"` observes the pipeline's status
  (`pipefail` is set), which is what makes that check real rather than decorative —
  confirmed against malformed input.
- **The results that pass are allow-listed, not the results that fail deny-listed.**
  A deny-list on `failure`/`cancelled` would silently ignore an entry with no
  `result`, or any state GitHub adds later; the allow-list reports those instead of
  passing them.

## What this does not change

- **The pass condition is identical.** `success` and `skipped` pass, `failure` and
  `cancelled` fail. Nothing was removed from `needs`, no check became optional, and
  no green was bought — this PR only changes the diagnosis a red gate prints.
- `needs` keys are job **ids**, and a matrix job reports one result for the whole
  matrix, so the message names the job to open rather than the failing cell. That is
  still the difference between one click and twenty.
- `toJSON(needs)` reaches the step through `env:` rather than interpolated into the
  `run:` body, and only keys and `result` values are printed — job `outputs` are not
  echoed.

## Test plan

The step's shell was extracted verbatim and run against the real `toJSON(needs)`
shape (`{"job_id":{"result":"...","outputs":{}}}`), including the payload from
run 31075749056:

| input | expected | result |
|---|---|---|
| one `failure` among `success`/`skipped` | exit 1, names it | `E2E Test CI jobs did not succeed: test_openai_model (failure)` |
| all `success`/`skipped` | exit 0 | `All E2E Test CI jobs succeeded` |
| `cancelled` + `failure` | exit 1, names both | both listed with their results |
| entry with **no** `result` key | exit 1 (fail closed) | `a (no result)` |
| unknown result (`neutral`) | exit 1 (fail closed) | `a (neutral)` |
| `{}` | exit 0 | pass |
| malformed JSON | exit 1 (fail closed) | `Could not read the E2E job results ...` |
| `jq` absent from `PATH` | exit 1 (fail closed) | `jq is not available on this runner ...` |

- `python .github/scripts/check_workflow_yaml.py` — OK, 108 definitions well-formed.
- `actionlint .github/workflows/e2e_test_ci.yml` — no new findings versus the
  unmodified tree (the pre-existing self-hosted-label and SC2116 notices are
  unchanged and in untouched steps).

## Notes for reviewers

- `jq` is preinstalled on `ubuntu-latest`, where this job runs; the check exists so
  that stops being an unstated assumption rather than because it is expected to fire.
- **No overlap with the other two PRs from this sweep.** #12644 edits the same file
  but only `test_openai_model`'s `timeout-minutes` near the top; #12642's fix is in
  `.github/actions/wait-for-spice-ready/`. Whichever of this and #12644 merges second
  will need a base merge, nothing more.
