### PR TITLE
fix(ci): give the openai model job a ceiling above its own setup (fixes #12644)

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -199,7 +199,19 @@ jobs:
 
   test_openai_model:
     name: 'openai model (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-    timeout-minutes: 5
+    # This ceiling is a backstop, not a budget, and at 5 minutes it was below the
+    # job's own floor on the self-hosted macOS pool: downloading the build artifact
+    # and installing the CLI can consume most of it before a test runs, and the
+    # steps below then wait on bounded timeouts of their own — 60s for readiness,
+    # plus the 30s/30s/60s waits inside the expect scripts. The job was therefore
+    # cancelled mid-setup and the E2E gate read the cancellation as a failure,
+    # dequeuing whatever was in the merge queue (#12644). Raising it hides no test
+    # regression — a hung runtime or model still fails on those inner timeouts,
+    # not here — but it does stay the *only* bound on the checkout, artifact
+    # download and install steps, which is why it moves to the sibling's value
+    # rather than somewhere roomier. `test_hf_model` has the same setup on the
+    # same runners and has always been 10.
+    timeout-minutes: 10
     runs-on: ${{ matrix.target.runner }}
     needs:
       - build

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -199,18 +199,10 @@ jobs:
 
   test_openai_model:
     name: 'openai model (${{ matrix.target.target_os }}-${{ matrix.target.target_arch }})'
-    # This ceiling is a backstop, not a budget, and at 5 minutes it was below the
-    # job's own floor on the self-hosted macOS pool: downloading the build artifact
-    # and installing the CLI can consume most of it before a test runs, and the
-    # steps below then wait on bounded timeouts of their own — 60s for readiness,
-    # plus the 30s/30s/60s waits inside the expect scripts. The job was therefore
-    # cancelled mid-setup and the E2E gate read the cancellation as a failure,
-    # dequeuing whatever was in the merge queue (#12644). Raising it hides no test
-    # regression — a hung runtime or model still fails on those inner timeouts,
-    # not here — but it does stay the *only* bound on the checkout, artifact
-    # download and install steps, which is why it moves to the sibling's value
-    # rather than somewhere roomier. `test_hf_model` has the same setup on the
-    # same runners and has always been 10.
+    # A backstop for the whole job, so it has to clear this job's own setup — artifact
+    # download and CLI install on the self-hosted pool — before the steps' bounded waits
+    # (60s readiness, then 30s/30s/60s inside the expect scripts) can report anything.
+    # Matches `test_hf_model`, which has the same setup on the same runners (#12644).
     timeout-minutes: 10
     runs-on: ${{ matrix.target.runner }}
     needs:


### PR DESCRIPTION
Fixes #12644

## The failure this fixes

`openai model (darwin-aarch64)` hit its 5-minute job ceiling repeatedly on
2026-08-06, and because `e2e-gate` counts a `cancelled` job as not-succeeded, each
one failed the required `E2E Test CI` check and dequeued whatever was in the merge
queue.

- https://github.com/spiceai/spiceai/actions/runs/31088421790
- https://github.com/spiceai/spiceai/actions/runs/31081140526
- https://github.com/spiceai/spiceai/actions/runs/31110027058

The step timeline of the first of those is the whole argument. Almost the entire
budget went to `download artifacts` and `Install spice`; `Test the expect scripts
driving the REPLs` started with seconds left and ended `##[error]The operation was
canceled.`; `Test vector search` and `Test chat` never ran at all (`skipped`).

## Root cause

The ceiling was below the job's own floor. Nothing about it is test time:

| phase | bounded by |
|---|---|
| checkout, `download-artifact`, `install-spice` | **nothing but this ceiling** |
| `Wait for Spice runtime is ready` | its own `timeout: 60` |
| `Test the expect scripts driving the REPLs` | each expect case's own `set timeout` |
| `Test vector search` (`search_01.exp`) | `set timeout 5` |
| `Test chat` (`chat_01.exp`) | `set timeout 30`, and 60 for the catalog-page turn |

`chat_01.exp` alone is entitled to about two minutes of bounded waiting, before any
setup. Five minutes for setup plus all of that was never enough.

This is **not** a job that got slower and is having its regression hidden: the fast
path finishes well inside the limit, and every cancellation was consumed by setup
with the tests getting seconds. The sibling `test_hf_model` — same runners, same
artifact download, same `install-spice`, and it additionally pulls a model — has
always been `timeout-minutes: 10` and does not hit it.

## The change

`test_openai_model`: `timeout-minutes: 5` → `10`, matching that sibling, with the
reasoning recorded at the declaration.

## What this does not change

- **No test bound is relaxed.** Readiness still fails at 60s and each expect script
  still bounds its own waits, so a hung runtime or a model that never answers still
  fails there — not on the job ceiling, and not later than it did before.
- The ceiling deliberately moves to the sibling's value rather than somewhere
  roomier, because it stays the *only* bound on the checkout, artifact download and
  install steps. It is a backstop, and it should be as tight as those steps allow.
- Nothing else in the job or the workflow changes.

## Test plan

- Sizing is from measurement, not guesswork: successful runs of this job in the same
  window finish comfortably inside 10 minutes, and the slowest success of the
  identically-shaped `test_hf_model` under its existing 10-minute ceiling was under
  8 minutes.
- The steps' inner bounds were read from the workflow and from
  `test/models/{chat_01,chat_01_simple,search_01}.exp` to confirm which waits are
  self-bounded and which are not — the table above.
- `python .github/scripts/check_workflow_yaml.py` — OK, 108 definitions well-formed.
- `actionlint .github/workflows/e2e_test_ci.yml` — no new findings versus the
  unmodified tree.
- The real confirmation is the next few `E2E Test CI` runs: this job should stop
  appearing as `cancelled`. If it starts hitting 10 minutes, that is a genuine
  slowdown and wants investigating rather than another bump.

## Notes for reviewers

- The unbounded setup steps are the deeper issue; giving `download-artifact` and
  `install-spice` their own bounds, or trimming them, would let this ceiling come
  back down. Out of scope here and left unfiled, since it is a change to shared
  actions used by many jobs.
- **No overlap with the other two PRs from this sweep.** #12649 edits the same file
  but only the `e2e-gate` job at the very bottom; #12648 is in
  `.github/actions/wait-for-spice-ready/`. Whichever of this and #12649 merges second
  will need a base merge, nothing more.
