### PR TITLE
fix(object-store): bound the FTP and SFTP session setup, and stop rejecting hostnames when client_timeout is set (fixes #12647)

### DIFF
--- a/crates/runtime-object-store/src/store/ftp.rs
+++ b/crates/runtime-object-store/src/store/ftp.rs
@@ -57,6 +57,23 @@ struct FTPConnectionManager {
     config: Arc<FTPClientConfig>,
 }
 
+/// Surfaces the pool's own connection failures, which it reports to a sink
+/// rather than to a caller. `bb8`'s default sink discards them, so a connection
+/// discarded in the background — including one abandoned at its deadline — would
+/// otherwise leave no trace of why.
+#[derive(Debug, Clone, Copy)]
+struct LogErrorSink;
+
+impl bb8::ErrorSink<object_store::Error> for LogErrorSink {
+    fn sink(&self, error: object_store::Error) {
+        tracing::warn!("FTP connection pool discarded a connection: {error}");
+    }
+
+    fn boxed_clone(&self) -> Box<dyn bb8::ErrorSink<object_store::Error>> {
+        Box::new(*self)
+    }
+}
+
 impl bb8::ManageConnection for FTPConnectionManager {
     type Connection = AsyncFtpStream;
     type Error = object_store::Error;
@@ -70,7 +87,8 @@ impl bb8::ManageConnection for FTPConnectionManager {
         &self,
         conn: &mut Self::Connection,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send {
-        let deadline = self.config.deadline();
+        let config = Arc::clone(&self.config);
+        let deadline = config.deadline();
         let noop_future = conn.noop();
         Box::pin(async move {
             match tokio::time::timeout(deadline, noop_future).await {
@@ -82,7 +100,8 @@ impl bb8::ManageConnection for FTPConnectionManager {
                 Err(_elapsed) => Err(object_store::Error::Generic {
                     store: STORE_NAME,
                     source: format!(
-                        "The FTP server did not answer a liveness check within {deadline:?}; discarding the connection."
+                        "FTP server ftp://{}:{} did not answer a liveness check within {deadline:?}; discarding the connection.",
+                        config.host, config.port
                     )
                     .into(),
                 }),
@@ -209,6 +228,7 @@ impl FTPInner {
                 };
                 Pool::builder()
                     .max_size(DEFAULT_POOL_SIZE)
+                    .error_sink(Box::new(LogErrorSink))
                     .build(manager)
                     .await
                     .map_err(|e| generic_error(STORE_NAME, e))
@@ -585,6 +605,7 @@ impl ObjectStore for FTPObjectStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bb8::ManageConnection;
     use chrono::Utc;
     use std::time::Instant;
 
@@ -614,6 +635,13 @@ mod tests {
         assert_eq!(cloned.port, "21");
     }
 
+    /// Bind a listener on an ephemeral loopback port.
+    fn loopback_listener() -> (std::net::TcpListener, u16) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        (listener, port)
+    }
+
     /// A peer that completes the TCP handshake and then never answers, so the
     /// FTP greeting and the `USER`/`PASS` exchange stall. Returns the port.
     ///
@@ -621,8 +649,7 @@ mod tests {
     /// `spawn_blocking`, because a blocking task that never returns also blocks
     /// the test runtime's shutdown.
     fn stalled_ftp_peer() -> u16 {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
-        let port = listener.local_addr().expect("local addr").port();
+        let (listener, port) = loopback_listener();
         std::thread::spawn(move || {
             // Hold every accepted connection open without writing a byte.
             let mut accepted = Vec::new();
@@ -638,8 +665,7 @@ mod tests {
     fn logged_in_then_quiet_peer() -> u16 {
         use std::io::{BufRead, BufReader, Write};
 
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
-        let port = listener.local_addr().expect("local addr").port();
+        let (listener, port) = loopback_listener();
         std::thread::spawn(move || {
             let mut held = Vec::new();
             while let Ok((stream, _)) = listener.accept() {
@@ -715,8 +741,6 @@ mod tests {
     /// stalled attempt cannot occupy a pool slot indefinitely.
     #[tokio::test]
     async fn pool_manager_gives_up_on_a_peer_that_never_answers() {
-        use bb8::ManageConnection;
-
         let port = stalled_ftp_peer();
         let manager = FTPConnectionManager {
             config: Arc::new(config_for(
@@ -779,8 +803,7 @@ mod tests {
     #[tokio::test]
     async fn a_refused_port_fails_without_waiting_for_the_deadline() {
         // Bind and drop, so the port is almost certainly unused.
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
-        let port = listener.local_addr().expect("local addr").port();
+        let (listener, port) = loopback_listener();
         drop(listener);
 
         let config = config_for("127.0.0.1", port.to_string(), Some(Duration::from_secs(30)));
@@ -822,8 +845,6 @@ mod tests {
     /// even after the server recovered.
     #[tokio::test]
     async fn a_liveness_check_against_a_quiet_server_invalidates_the_connection() {
-        use bb8::ManageConnection;
-
         let port = logged_in_then_quiet_peer();
         let manager = FTPConnectionManager {
             config: Arc::new(config_for(

--- a/crates/runtime-object-store/src/store/ftp.rs
+++ b/crates/runtime-object-store/src/store/ftp.rs
@@ -45,27 +45,16 @@ const STORE_NAME: &str = "FTP";
 const MAX_CONCURRENT_LISTINGS: usize = 4;
 /// Default connection pool size.
 const DEFAULT_POOL_SIZE: u32 = 4;
+/// Deadline applied to establishing a session when `client_timeout` is unset.
+/// Matches the documented default for the parameter, and sits inside `bb8`'s
+/// own 30s `connection_timeout` so a stuck attempt cannot outlive the pool's
+/// willingness to wait for it.
+const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Connection manager for bb8 connection pool.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct FTPConnectionManager {
-    user: String,
-    password: String,
-    host: String,
-    port: String,
-    timeout: Option<Duration>,
-}
-
-impl std::fmt::Debug for FTPConnectionManager {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FTPConnectionManager")
-            .field("user", &self.user)
-            .field("password", &"[REDACTED]")
-            .field("host", &self.host)
-            .field("port", &self.port)
-            .field("timeout", &self.timeout)
-            .finish()
-    }
+    config: Arc<FTPClientConfig>,
 }
 
 impl bb8::ManageConnection for FTPConnectionManager {
@@ -73,51 +62,32 @@ impl bb8::ManageConnection for FTPConnectionManager {
     type Error = object_store::Error;
 
     fn connect(&self) -> impl Future<Output = Result<Self::Connection, Self::Error>> + Send {
-        let user = self.user.clone();
-        let password = self.password.clone();
-        let host = self.host.clone();
-        let port = self.port.clone();
-        let timeout = self.timeout;
-
-        Box::pin(async move {
-            let mut client = match timeout {
-                Some(timeout) => {
-                    AsyncFtpStream::connect_timeout(
-                        format!("{host}:{port}").parse().map_err(
-                            |e: std::net::AddrParseError| object_store::Error::Generic {
-                                store: STORE_NAME,
-                                source: e.into(),
-                            },
-                        )?,
-                        timeout,
-                    )
-                    .await
-                }
-                None => AsyncFtpStream::connect(format!("{host}:{port}")).await,
-            }
-            .map_err(|e| object_store::Error::Generic {
-                store: STORE_NAME,
-                source: e.into(),
-            })?;
-
-            client
-                .login(&user, &password)
-                .await
-                .map_err(|e| object_store::Error::Generic {
-                    store: STORE_NAME,
-                    source: e.into(),
-                })?;
-
-            Ok(client)
-        })
+        let config = Arc::clone(&self.config);
+        Box::pin(async move { config.connect_and_login().await })
     }
 
     fn is_valid(
         &self,
         conn: &mut Self::Connection,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        let deadline = self.config.deadline();
         let noop_future = conn.noop();
-        Box::pin(async move { noop_future.await.map_err(|e| generic_error(STORE_NAME, e)) })
+        Box::pin(async move {
+            match tokio::time::timeout(deadline, noop_future).await {
+                Ok(result) => result.map_err(|e| generic_error(STORE_NAME, e)),
+                // Reporting the connection invalid has the pool discard it. Waiting
+                // instead would hand the same unresponsive connection back on every
+                // checkout, so a peer that goes quiet mid-session would keep the
+                // pool unusable after the server recovered.
+                Err(_elapsed) => Err(object_store::Error::Generic {
+                    store: STORE_NAME,
+                    source: format!(
+                        "The FTP server did not answer a liveness check within {deadline:?}; discarding the connection."
+                    )
+                    .into(),
+                }),
+            }
+        })
     }
 
     fn has_broken(&self, conn: &mut Self::Connection) -> bool {
@@ -166,41 +136,54 @@ impl FTPClientConfig {
         }
     }
 
-    fn create_pool_manager(&self) -> FTPConnectionManager {
-        FTPConnectionManager {
-            user: self.user.clone(),
-            password: self.password.clone(),
-            host: self.host.clone(),
-            port: self.port.clone(),
-            timeout: self.timeout,
+    /// Wall-clock deadline for establishing one usable session.
+    fn deadline(&self) -> Duration {
+        self.timeout.unwrap_or(DEFAULT_CLIENT_TIMEOUT)
+    }
+
+    /// Connect and log in, as one operation under a single deadline.
+    ///
+    /// The login is what a peer that completes the TCP handshake and then goes
+    /// quiet holds open, so bounding only the connect leaves the attempt able to
+    /// hang forever: the pool slot it occupies is never released and later
+    /// `Pool::get` calls stay suppressed even once the server recovers. One
+    /// deadline over both stages also stops them from each spending the budget.
+    async fn connect_and_login(&self) -> object_store::Result<AsyncFtpStream> {
+        let deadline = self.deadline();
+        let addr = format!("{}:{}", self.host, self.port);
+
+        // `AsyncFtpStream::connect` resolves `host:port`, so a hostname works
+        // here; `connect_timeout` takes an already-resolved `SocketAddr` and
+        // rejects one.
+        let established = tokio::time::timeout(deadline, async {
+            let mut client = AsyncFtpStream::connect(addr.as_str())
+                .await
+                .map_err(|e| generic_error(STORE_NAME, e))?;
+
+            client
+                .login(&self.user, &self.password)
+                .await
+                .map_err(|e| generic_error(STORE_NAME, e))?;
+
+            Ok(client)
+        })
+        .await;
+
+        match established {
+            Ok(result) => result,
+            Err(_elapsed) => Err(object_store::Error::Generic {
+                store: STORE_NAME,
+                source: format!(
+                    "Failed to connect to FTP server ftp://{addr}: the connection and login did not complete within {deadline:?}. The server may be unreachable, or accepting connections without answering. Increase 'client_timeout' if the server is simply slow to respond. See: https://spiceai.org/docs/components/data-connectors/ftp"
+                )
+                .into(),
+            }),
         }
     }
 
     /// Create a fresh non-pooled connection for operations that modify connection state.
     async fn get_fresh_client(&self) -> object_store::Result<AsyncFtpStream> {
-        let mut client = match self.timeout {
-            Some(timeout) => {
-                AsyncFtpStream::connect_timeout(
-                    format!("{}:{}", self.host, self.port).parse().map_err(
-                        |e: std::net::AddrParseError| object_store::Error::Generic {
-                            store: STORE_NAME,
-                            source: e.into(),
-                        },
-                    )?,
-                    timeout,
-                )
-                .await
-            }
-            None => AsyncFtpStream::connect(format!("{}:{}", self.host, self.port)).await,
-        }
-        .map_err(|e| generic_error(STORE_NAME, e))?;
-
-        client
-            .login(&self.user, &self.password)
-            .await
-            .map_err(|e| generic_error(STORE_NAME, e))?;
-
-        Ok(client)
+        self.connect_and_login().await
     }
 }
 
@@ -221,7 +204,9 @@ impl FTPInner {
     async fn get_pool(&self) -> object_store::Result<&Pool<FTPConnectionManager>> {
         self.pool
             .get_or_try_init(|| async {
-                let manager = self.config.create_pool_manager();
+                let manager = FTPConnectionManager {
+                    config: Arc::clone(&self.config),
+                };
                 Pool::builder()
                     .max_size(DEFAULT_POOL_SIZE)
                     .build(manager)
@@ -601,6 +586,7 @@ impl ObjectStore for FTPObjectStore {
 mod tests {
     use super::*;
     use chrono::Utc;
+    use std::time::Instant;
 
     #[test]
     fn test_ftp_object_store_display() {
@@ -626,6 +612,273 @@ mod tests {
         let cloned = config;
         assert_eq!(cloned.host, "localhost");
         assert_eq!(cloned.port, "21");
+    }
+
+    /// A peer that completes the TCP handshake and then never answers, so the
+    /// FTP greeting and the `USER`/`PASS` exchange stall. Returns the port.
+    ///
+    /// The accept loop runs on a detached OS thread rather than via
+    /// `spawn_blocking`, because a blocking task that never returns also blocks
+    /// the test runtime's shutdown.
+    fn stalled_ftp_peer() -> u16 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        std::thread::spawn(move || {
+            // Hold every accepted connection open without writing a byte.
+            let mut accepted = Vec::new();
+            while let Ok((stream, _)) = listener.accept() {
+                accepted.push(stream);
+            }
+        });
+        port
+    }
+
+    /// A peer that answers the greeting and the `USER`/`PASS` exchange, and then
+    /// never answers another command. Returns the port.
+    fn logged_in_then_quiet_peer() -> u16 {
+        use std::io::{BufRead, BufReader, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        std::thread::spawn(move || {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept() {
+                let mut writer = stream.try_clone().expect("clone stream");
+                let mut reader = BufReader::new(stream);
+                // The greeting, then one reply per credential line.
+                let exchange = [
+                    "220 ready\r\n",
+                    "331 need password\r\n",
+                    "230 logged in\r\n",
+                ];
+                let mut sent = 0;
+                while sent < exchange.len() {
+                    if writer.write_all(exchange[sent].as_bytes()).is_err() {
+                        break;
+                    }
+                    let _flushed = writer.flush();
+                    sent += 1;
+                    if sent < exchange.len() {
+                        let mut line = String::new();
+                        if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                            break;
+                        }
+                    }
+                }
+                // Hold the session open without answering anything further.
+                held.push(reader.into_inner());
+            }
+        });
+        port
+    }
+
+    fn config_for(host: &str, port: String, timeout: Option<Duration>) -> FTPClientConfig {
+        FTPClientConfig::new(
+            "user".to_string(),
+            "pass".to_string(),
+            host.to_string(),
+            port,
+            timeout,
+        )
+    }
+
+    /// Regression test for #12647: a stalled login must not hang forever.
+    #[tokio::test]
+    async fn fresh_client_gives_up_on_a_peer_that_never_answers() {
+        let port = stalled_ftp_peer();
+        let config = config_for(
+            "127.0.0.1",
+            port.to_string(),
+            Some(Duration::from_millis(250)),
+        );
+
+        let start = Instant::now();
+        let err = config
+            .get_fresh_client()
+            .await
+            .map(|_| ())
+            .expect_err("a peer that never answers must not produce a session");
+
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "connect+login should be abandoned at the deadline, took {:?}",
+            start.elapsed()
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("did not complete within"),
+            "error should name the deadline, got: {message}"
+        );
+    }
+
+    /// The pooled path shares the same deadline as the non-pooled one, so a
+    /// stalled attempt cannot occupy a pool slot indefinitely.
+    #[tokio::test]
+    async fn pool_manager_gives_up_on_a_peer_that_never_answers() {
+        use bb8::ManageConnection;
+
+        let port = stalled_ftp_peer();
+        let manager = FTPConnectionManager {
+            config: Arc::new(config_for(
+                "127.0.0.1",
+                port.to_string(),
+                Some(Duration::from_millis(250)),
+            )),
+        };
+
+        let start = Instant::now();
+        let err = manager
+            .connect()
+            .await
+            .map(|_| ())
+            .expect_err("a peer that never answers must not produce a session");
+
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "pooled connect should be abandoned at the deadline, took {:?}",
+            start.elapsed()
+        );
+        assert!(
+            err.to_string().contains("did not complete within"),
+            "error should name the deadline, got: {err}"
+        );
+    }
+
+    /// Regression test for #12654: setting `client_timeout` used to route the
+    /// connect through `connect_timeout`, which takes an already-resolved
+    /// `SocketAddr`, so any host given as a name failed with "invalid socket
+    /// address syntax" before a packet was sent.
+    #[tokio::test]
+    async fn a_hostname_is_resolved_when_client_timeout_is_set() {
+        let port = stalled_ftp_peer();
+        let config = config_for(
+            "localhost",
+            port.to_string(),
+            Some(Duration::from_millis(250)),
+        );
+
+        let err = config
+            .get_fresh_client()
+            .await
+            .map(|_| ())
+            .expect_err("the stalled peer cannot complete a login");
+
+        let message = err.to_string();
+        assert!(
+            !message.contains("invalid socket address syntax"),
+            "a hostname must be resolved, not parsed as an address: {message}"
+        );
+        assert!(
+            message.contains("did not complete within"),
+            "the connect should reach the peer and then hit the deadline, got: {message}"
+        );
+    }
+
+    /// Control: a refused port must surface as a connection failure quickly,
+    /// rather than being masked by the deadline.
+    #[tokio::test]
+    async fn a_refused_port_fails_without_waiting_for_the_deadline() {
+        // Bind and drop, so the port is almost certainly unused.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        drop(listener);
+
+        let config = config_for("127.0.0.1", port.to_string(), Some(Duration::from_secs(30)));
+
+        let start = Instant::now();
+        let err = config
+            .get_fresh_client()
+            .await
+            .map(|_| ())
+            .expect_err("nothing is listening");
+
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "a refused connect should fail immediately, took {:?}",
+            start.elapsed()
+        );
+        assert!(
+            !err.to_string().contains("did not complete within"),
+            "a refused connect is not a timeout: {err}"
+        );
+    }
+
+    /// The deadline must not cost the happy path: a server that answers still
+    /// yields a logged-in session.
+    #[tokio::test]
+    async fn connect_and_login_succeeds_against_a_server_that_answers() {
+        let port = logged_in_then_quiet_peer();
+        let config = config_for("127.0.0.1", port.to_string(), Some(Duration::from_secs(10)));
+
+        let client = config.connect_and_login().await;
+        assert!(
+            client.is_ok(),
+            "a server that completes the login should yield a session"
+        );
+    }
+
+    /// A connection that stops answering after login must be discarded rather
+    /// than handed back on every checkout, which would leave the pool unusable
+    /// even after the server recovered.
+    #[tokio::test]
+    async fn a_liveness_check_against_a_quiet_server_invalidates_the_connection() {
+        use bb8::ManageConnection;
+
+        let port = logged_in_then_quiet_peer();
+        let manager = FTPConnectionManager {
+            config: Arc::new(config_for(
+                "127.0.0.1",
+                port.to_string(),
+                Some(Duration::from_millis(250)),
+            )),
+        };
+        let mut conn = manager.connect().await.expect("the login is answered");
+
+        let start = Instant::now();
+        let err = manager
+            .is_valid(&mut conn)
+            .await
+            .expect_err("a quiet server cannot answer a liveness check");
+
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "the liveness check should be abandoned at the deadline, took {:?}",
+            start.elapsed()
+        );
+        assert!(err.to_string().contains("liveness check"), "got: {err}");
+    }
+
+    #[test]
+    fn an_unset_client_timeout_still_has_a_deadline() {
+        assert_eq!(
+            config_for("ftp.example.com", "21".to_string(), None).deadline(),
+            DEFAULT_CLIENT_TIMEOUT
+        );
+        assert_eq!(
+            config_for(
+                "ftp.example.com",
+                "21".to_string(),
+                Some(Duration::from_secs(3))
+            )
+            .deadline(),
+            Duration::from_secs(3)
+        );
+    }
+
+    #[test]
+    fn the_pool_manager_debug_output_redacts_the_password() {
+        let manager = FTPConnectionManager {
+            config: Arc::new(FTPClientConfig::new(
+                "user".to_string(),
+                "s3cr3t-value".to_string(),
+                "ftp.example.com".to_string(),
+                "21".to_string(),
+                None,
+            )),
+        };
+        let rendered = format!("{manager:?}");
+        assert!(rendered.contains("[REDACTED]"), "got: {rendered}");
+        assert!(!rendered.contains("s3cr3t-value"), "got: {rendered}");
     }
 
     #[test]

--- a/crates/runtime-object-store/src/store/sftp.rs
+++ b/crates/runtime-object-store/src/store/sftp.rs
@@ -114,7 +114,11 @@ impl SFTPClientConfig {
 /// `TcpStream::connect_timeout` takes an already-resolved `SocketAddr` and so
 /// cannot accept a hostname; resolving first keeps hostnames working while
 /// still bounding the connect. The deadline covers all resolved candidates
-/// together rather than resetting per candidate.
+/// together rather than resetting per candidate, so a host with several
+/// addresses cannot multiply the wait the operator asked for — at the cost of
+/// possibly not reaching a later address, which is why the error reports how
+/// many were tried. Name resolution itself is bounded by the system resolver,
+/// not by this deadline.
 fn connect_within(addr: &str, deadline: Duration) -> object_store::Result<TcpStream> {
     let start = Instant::now();
     let candidates: Vec<SocketAddr> = addr
@@ -126,16 +130,18 @@ fn connect_within(addr: &str, deadline: Duration) -> object_store::Result<TcpStr
             )
         })?
         .collect();
+    let total = candidates.len();
 
+    let mut tried = 0;
     let mut last_error: Option<String> = None;
     for candidate in candidates {
-        let Some(remaining) = deadline.checked_sub(start.elapsed()) else {
-            break;
-        };
-        // `connect_timeout` rejects a zero duration.
+        // `connect_timeout` rejects a zero duration, and an exhausted deadline
+        // is the answer anyway.
+        let remaining = deadline.saturating_sub(start.elapsed());
         if remaining.is_zero() {
             break;
         }
+        tried += 1;
         match TcpStream::connect_timeout(&candidate, remaining) {
             Ok(stream) => return Ok(stream),
             Err(e) => last_error = Some(format!("{candidate}: {e}")),
@@ -146,7 +152,7 @@ fn connect_within(addr: &str, deadline: Duration) -> object_store::Result<TcpStr
     Err(generic_error(
         STORE_NAME,
         format!(
-            "Failed to connect to SFTP server sftp://{addr}: {detail}. Increase 'client_timeout' if the server is simply slow to respond. See: https://spiceai.org/docs/components/data-connectors/sftp"
+            "Failed to connect to SFTP server sftp://{addr}: {detail} (tried {tried} of {total} resolved addresses within {deadline:?}). Increase 'client_timeout' if the server is simply slow to respond. See: https://spiceai.org/docs/components/data-connectors/sftp"
         ),
     ))
 }
@@ -457,11 +463,17 @@ mod tests {
         assert!(config.timeout.is_some());
     }
 
+    /// Bind a listener on an ephemeral loopback port.
+    fn loopback_listener() -> (std::net::TcpListener, u16) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        (listener, port)
+    }
+
     /// A peer that completes the TCP handshake and then never sends the SSH
     /// banner. Returns the port; the accepted sockets are held by the thread.
     fn stalled_ssh_peer() -> u16 {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
-        let port = listener.local_addr().expect("local addr").port();
+        let (listener, port) = loopback_listener();
         std::thread::spawn(move || {
             let mut accepted = Vec::new();
             while let Ok((stream, _)) = listener.accept() {
@@ -541,8 +553,7 @@ mod tests {
     /// rather than being masked by the deadline.
     #[test]
     fn a_refused_port_fails_without_waiting_for_the_deadline() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
-        let port = listener.local_addr().expect("local addr").port();
+        let (listener, port) = loopback_listener();
         drop(listener);
 
         let config = config_for("127.0.0.1", port.to_string(), Some(Duration::from_secs(30)));

--- a/crates/runtime-object-store/src/store/sftp.rs
+++ b/crates/runtime-object-store/src/store/sftp.rs
@@ -16,9 +16,9 @@ limitations under the License.
 
 use std::{
     io::{Read, Seek, SeekFrom},
-    net::TcpStream,
+    net::{SocketAddr, TcpStream, ToSocketAddrs},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use async_trait::async_trait;
@@ -38,6 +38,9 @@ use super::common::{
 };
 
 const STORE_NAME: &str = "SFTP";
+/// Deadline applied to establishing a session when `client_timeout` is unset.
+/// Matches the documented default for the parameter.
+const DEFAULT_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 struct SFTPClientConfig {
@@ -77,23 +80,25 @@ impl SFTPClientConfig {
         }
     }
 
+    /// Wall-clock deadline for establishing one usable session.
+    fn deadline(&self) -> Duration {
+        self.timeout.unwrap_or(DEFAULT_CLIENT_TIMEOUT)
+    }
+
     fn connect(&self) -> object_store::Result<Session> {
-        let stream = match self.timeout {
-            Some(timeout) => TcpStream::connect_timeout(
-                &format!("{}:{}", self.host, self.port).parse().map_err(
-                    |e: std::net::AddrParseError| object_store::Error::Generic {
-                        store: "SFTP",
-                        source: e.into(),
-                    },
-                )?,
-                timeout,
-            )
-            .map_err(handle_error)?,
-            None => {
-                TcpStream::connect(format!("{}:{}", self.host, self.port)).map_err(handle_error)?
-            }
-        };
+        let deadline = self.deadline();
+        let addr = format!("{}:{}", self.host, self.port);
+        let stream = connect_within(&addr, deadline)?;
+
         let mut session = Session::new().map_err(handle_error)?;
+        // The SSH banner exchange and the password exchange are what a peer that
+        // completes the TCP handshake and then goes quiet holds open, so bounding
+        // only the connect leaves this blocking-pool thread parked forever. This
+        // bounds every blocking libssh2 wait, including the handshake, the
+        // authentication, and later SFTP reads on the returned session — libssh2
+        // applies it per wait for the socket to become ready, so a transfer that
+        // keeps making progress is not cut off.
+        session.set_timeout(u32::try_from(deadline.as_millis()).unwrap_or(u32::MAX));
         session.set_tcp_stream(stream);
         session.handshake().map_err(handle_error)?;
         session
@@ -102,6 +107,48 @@ impl SFTPClientConfig {
 
         Ok(session)
     }
+}
+
+/// Resolve `host:port` and connect within `deadline`.
+///
+/// `TcpStream::connect_timeout` takes an already-resolved `SocketAddr` and so
+/// cannot accept a hostname; resolving first keeps hostnames working while
+/// still bounding the connect. The deadline covers all resolved candidates
+/// together rather than resetting per candidate.
+fn connect_within(addr: &str, deadline: Duration) -> object_store::Result<TcpStream> {
+    let start = Instant::now();
+    let candidates: Vec<SocketAddr> = addr
+        .to_socket_addrs()
+        .map_err(|e| {
+            generic_error(
+                STORE_NAME,
+                format!("Failed to resolve SFTP server {addr}: {e}"),
+            )
+        })?
+        .collect();
+
+    let mut last_error: Option<String> = None;
+    for candidate in candidates {
+        let Some(remaining) = deadline.checked_sub(start.elapsed()) else {
+            break;
+        };
+        // `connect_timeout` rejects a zero duration.
+        if remaining.is_zero() {
+            break;
+        }
+        match TcpStream::connect_timeout(&candidate, remaining) {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last_error = Some(format!("{candidate}: {e}")),
+        }
+    }
+
+    let detail = last_error.unwrap_or_else(|| format!("no address answered within {deadline:?}"));
+    Err(generic_error(
+        STORE_NAME,
+        format!(
+            "Failed to connect to SFTP server sftp://{addr}: {detail}. Increase 'client_timeout' if the server is simply slow to respond. See: https://spiceai.org/docs/components/data-connectors/sftp"
+        ),
+    ))
 }
 
 #[derive(Debug, Clone)]
@@ -408,6 +455,160 @@ mod tests {
         );
         assert_eq!(config.host, "localhost");
         assert!(config.timeout.is_some());
+    }
+
+    /// A peer that completes the TCP handshake and then never sends the SSH
+    /// banner. Returns the port; the accepted sockets are held by the thread.
+    fn stalled_ssh_peer() -> u16 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        std::thread::spawn(move || {
+            let mut accepted = Vec::new();
+            while let Ok((stream, _)) = listener.accept() {
+                accepted.push(stream);
+            }
+        });
+        port
+    }
+
+    fn config_for(host: &str, port: String, timeout: Option<Duration>) -> SFTPClientConfig {
+        SFTPClientConfig::new(
+            "user".to_string(),
+            "pass".to_string(),
+            host.to_string(),
+            port,
+            timeout,
+        )
+    }
+
+    /// Regression test for #12647: the SSH banner exchange and the password
+    /// exchange must be bounded, not just the TCP connect. Without a session
+    /// timeout this parks a blocking-pool thread for as long as the peer stays
+    /// quiet, and the thread cannot be reclaimed.
+    #[test]
+    fn connect_gives_up_on_a_peer_that_never_sends_a_banner() {
+        let port = stalled_ssh_peer();
+        let config = config_for(
+            "127.0.0.1",
+            port.to_string(),
+            Some(Duration::from_millis(250)),
+        );
+
+        let start = Instant::now();
+        let err = config
+            .connect()
+            .map(|_| ())
+            .expect_err("a peer that never answers must not produce a session");
+
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "the handshake should be abandoned at the deadline, took {:?}",
+            start.elapsed()
+        );
+        // libssh2 reports its own timeout, so assert on the outcome rather than
+        // on wording it owns.
+        assert!(
+            format!("{err}").contains("SFTP"),
+            "the error should name the store, got: {err}"
+        );
+    }
+
+    /// Regression test for #12654: setting `client_timeout` used to route the
+    /// connect through `TcpStream::connect_timeout`, which takes an
+    /// already-resolved `SocketAddr`, so any host given as a name failed with
+    /// "invalid socket address syntax" before a packet was sent.
+    #[test]
+    fn a_hostname_is_resolved_when_client_timeout_is_set() {
+        let port = stalled_ssh_peer();
+        let config = config_for(
+            "localhost",
+            port.to_string(),
+            Some(Duration::from_millis(250)),
+        );
+
+        let err = config
+            .connect()
+            .map(|_| ())
+            .expect_err("the stalled peer cannot complete a handshake");
+
+        assert!(
+            !format!("{err}").contains("invalid socket address syntax"),
+            "a hostname must be resolved, not parsed as an address: {err}"
+        );
+    }
+
+    /// Control: a refused port must surface as a connection failure quickly,
+    /// rather than being masked by the deadline.
+    #[test]
+    fn a_refused_port_fails_without_waiting_for_the_deadline() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        drop(listener);
+
+        let config = config_for("127.0.0.1", port.to_string(), Some(Duration::from_secs(30)));
+
+        let start = Instant::now();
+        let err = config
+            .connect()
+            .map(|_| ())
+            .expect_err("nothing is listening");
+
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "a refused connect should fail immediately, took {:?}",
+            start.elapsed()
+        );
+        assert!(
+            format!("{err}").contains("Failed to connect to SFTP server"),
+            "a refused connect should name the server, got: {err}"
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_host_is_reported_as_a_resolution_failure() {
+        // `.invalid` is reserved by RFC 2606 and never resolves.
+        let config = config_for(
+            "no-such-host.invalid",
+            "22".to_string(),
+            Some(Duration::from_millis(250)),
+        );
+
+        let err = config
+            .connect()
+            .map(|_| ())
+            .expect_err("the host cannot resolve");
+        assert!(
+            format!("{err}").contains("Failed to resolve SFTP server"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn an_unset_client_timeout_still_has_a_deadline() {
+        assert_eq!(
+            config_for("sftp.example.com", "22".to_string(), None).deadline(),
+            DEFAULT_CLIENT_TIMEOUT
+        );
+        assert_eq!(
+            config_for(
+                "sftp.example.com",
+                "22".to_string(),
+                Some(Duration::from_secs(3))
+            )
+            .deadline(),
+            Duration::from_secs(3)
+        );
+    }
+
+    #[test]
+    fn an_exhausted_deadline_stops_trying_candidates() {
+        let port = stalled_ssh_peer();
+        let err = connect_within(&format!("127.0.0.1:{port}"), Duration::ZERO)
+            .expect_err("a zero deadline cannot connect");
+        assert!(
+            format!("{err}").contains("no address answered within"),
+            "got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The FTP and SFTP object stores bounded only the TCP connect, and only when
`client_timeout` was set. Nothing bounded the part a stalled peer actually holds
open — the FTP `USER`/`PASS` exchange, and the SFTP banner and password
exchange — so a peer that completed the TCP handshake and then went quiet parked
the attempt indefinitely:

- **FTP**: `bb8` consults its own `connection_timeout` only *after*
  `ManageConnection::connect` returns, and its replenishment task calls
  `connect()` with no deadline at all. An attempt that never returns is never
  abandoned, its pool slot is never released, and later `Pool::get` calls stay
  suppressed even once the server recovers. `get_fresh_client`, the non-pooled
  path, had the identical gap.
- **SFTP**: `handshake()` and `userauth_password()` are blocking `libssh2`
  calls, so a quiet peer consumed a blocking-pool thread that could not be
  reclaimed.

The timed branch also could not address a host by *name*. It reached
`connect_timeout` — which takes an already-resolved `SocketAddr` — by
`parse()`-ing `"{host}:{port}"`, and `SocketAddr`'s `FromStr` accepts only
numeric addresses. So setting `client_timeout` failed every hostname with
`invalid socket address syntax` before a packet was sent, which is why the
missing deadline went unnoticed: the only bounded path was unusable. Observed
directly against the private helper before the fix:

```
PROBE hostname+timeout  => Some("Generic FTP error: invalid socket address syntax")
PROBE stalled peer (client_timeout=200ms) => returned=false elapsed=3.0s  (never returns)
```

`client_timeout` is documented for `ftp` and `sftp` as "stop waiting for a
response from the data source after the specified duration", with a default of
30 seconds. Neither connector applied a default at all, and neither applied the
configured value beyond the TCP connect.

Fixes #12647
Fixes #12654

## Changes

- One deadline covers connect **and** login together, so neither stage can spend
  the whole budget, defaulting to the documented 30s when `client_timeout` is
  unset rather than to no bound.
- FTP connects by name and lets the library resolve. SFTP resolves first, then
  bounds each candidate against one shared deadline.
- The pooled and non-pooled FTP paths now share a single `connect_and_login`, so
  a call site cannot reach an unbounded variant. `FTPConnectionManager` holds the
  config instead of duplicating its five fields and its redacting `Debug` impl.
- An SFTP session timeout bounds every blocking `libssh2` wait, including later
  reads on the returned session. `libssh2` applies it per wait for socket
  readiness, so a transfer that keeps making progress is not cut off.
- A liveness check (`is_valid`) against a server that went quiet now invalidates
  the connection instead of waiting, so the pool discards it rather than handing
  the same dead connection back on every checkout — a pool that survives an
  outage instead of staying unusable after it.
- The SFTP connect error names how many resolved addresses were tried, and a
  `tracing` error sink makes an invalidated FTP connection visible (bb8's
  default sink drops it silently).

Not changed: the NFS store, which already documents that the `libnfs` bindings
expose no timeout configuration, and the SMB store, which already bounds its
negotiate/session-setup reads via `read_timeout` with a 30s default — that
sibling is the in-repo precedent for the shape this PR gives FTP and SFTP.

## Behavior change

A server slower than the deadline now fails where it previously blocked until it
eventually answered. Two cases:

- `client_timeout` unset: previously unbounded, now the documented 30s default.
- `client_timeout` set: previously covered only the TCP connect, now covers the
  whole session setup, and for SFTP also later blocking reads.

Both directions make the parameter mean what it is documented to mean. The error
message names the deadline and says to raise `client_timeout` if the server is
simply slow.

## Test plan

- [x] `make lint` — clean
- [x] `make test` — green
- [x] `cargo fmt --all`
- [x] 14 new tests in `crates/runtime-object-store/src/store/{ftp,sftp}.rs`
      (72 in the crate's lib suite, all passing), against loopback peers:
  - a peer that accepts TCP and never answers: the FTP non-pooled path, the FTP
    pooled path, and the SFTP handshake each give up at the deadline
  - a hostname (`localhost`) with `client_timeout` set no longer fails with
    `invalid socket address syntax` — the regression test for #12654
  - happy path: a peer that answers the greeting and the `USER`/`PASS`
    exchange still yields a logged-in session, so the deadline does not cost
    the working case
  - a peer that logs in and then goes quiet: the liveness check invalidates the
    connection at the deadline
  - controls: a refused port fails immediately rather than being masked by the
    deadline; an unresolvable host is reported as a resolution failure
  - an unset `client_timeout` still has a deadline; an exhausted deadline stops
    trying candidates; the pooled manager's `Debug` output still redacts the
    password
- [x] Neuter matrix — each piece of the fix reverted in turn, confirming a named
      test catches it (results in the PR discussion)

## Checklist

- [x] Tests added, including a regression test that fails on the old code
- [x] No `.unwrap()` / `.expect()` in production code
- [x] Error messages name the resource and an actionable fix, with a docs link
- [x] No blocking calls added to an async context; the SFTP path stays inside
      `spawn_blocking`
- [x] No new dependencies
