### PR TITLE
fix(ci): take the trusted sign-off helpers from the workflow's own commit (fixes #12657)

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -41,9 +41,10 @@
 # PR/run lookups) at the fork instead of this repo.
 #
 # scripts/signoff and the setup-* composite actions below are also saved to
-# .trusted-ci/ from this repo *before* any fork commit is checked out, and
-# every later step references those copies (literal `.trusted-ci/...` paths)
-# rather than the working tree. This runs unconditionally, not just for fork
+# .trusted-ci/, read out of the object database at this workflow file's own
+# commit (github.sha) *before* any fork commit is checked out, and every later
+# step references those copies (literal `.trusted-ci/...` paths) rather than
+# the working tree. This runs unconditionally, not just for fork
 # PRs, so every step downstream has one fixed path to depend on instead of
 # branching on is_fork — `uses:` can't read a step output (the `steps`
 # context isn't available there), so a per-case path chosen at runtime
@@ -326,21 +327,59 @@ jobs:
         # would otherwise resolve to whatever the fork shipped — e.g. a fork
         # could ship a scripts/signoff that unconditionally posts "success"
         # regardless of whether checks passed, or a setup-rust action that
-        # exfiltrates secrets. Copying them out now, from this repo's
-        # checkout, and pointing every later step at these copies keeps the
-        # checks/decision/status-post logic trusted even though the code
-        # being built/linted/tested may be the fork's. Unconditional (not
-        # just for forks) so every later step has one fixed path regardless
-        # of is_fork — see the top-of-file comment. This directory is
-        # untracked, so the fork checkout below (which only touches tracked
-        # paths) leaves it alone.
+        # exfiltrates secrets. Materialising them now, and pointing every
+        # later step at these copies, keeps the checks/decision/status-post
+        # logic trusted even though the code being built/linted/tested may be
+        # the fork's. Unconditional (not just for forks) so every later step
+        # has one fixed path regardless of is_fork — see the top-of-file
+        # comment. This directory is untracked, so the fork checkout below
+        # (which only touches tracked paths) leaves it alone.
+        #
+        # Read out of the object database at ${{ github.sha }} rather than
+        # copied from the working tree. The call sites for these helpers are
+        # in this workflow file, which always comes from github.sha, while the
+        # same-repo checkout above is at the *branch under test* — so copying
+        # from the tree let a branch present an older helper to newer call
+        # sites. A branch predating `scripts/signoff correct-cancelled`
+        # (#12432) supplied a script without it, so the `if: cancelled()` step
+        # below died on "unknown command" and the cancelled run kept the
+        # `signoff=failure` it had already posted — a red Attestation on code
+        # that was never judged (#12657). Taking both helpers from one commit
+        # makes that skew unrepresentable.
+        #
+        # It also closes the same-repo half of the trust boundary the fork
+        # case already had: the branch under test no longer supplies the
+        # script that decides its own sign-off. github.sha is always a commit
+        # in this repo (workflow_dispatch can only target this repo's refs),
+        # and reading the object database rather than the tree means the fork
+        # overlay below cannot reach these files even in principle.
+        #
+        # To exercise a branch's *own* helper changes, dispatch on that branch
+        # (`gh workflow run signoff.yml --ref <branch> …`): github.sha is then
+        # the branch, so workflow and helpers agree there instead.
+        env:
+          TRUSTED_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          # actions/checkout fetches only the ref it checks out, even at
+          # fetch-depth: 0, so github.sha is usually absent in the same-repo
+          # case and already present in the fork case (where it is the ref
+          # checked out). No fallback to the working tree if this fails: the
+          # silent version skew is the bug, so an unresolvable trusted commit
+          # has to stop the run.
+          if ! git cat-file -e "${TRUSTED_SHA}^{commit}" 2>/dev/null; then
+            echo "Fetching this workflow's own commit ${TRUSTED_SHA} for the trusted helpers…"
+            git fetch --no-tags origin "$TRUSTED_SHA"
+          fi
+          rm -rf .trusted-ci
           mkdir -p .trusted-ci
-          cp -R .github/actions .trusted-ci/actions
-          cp scripts/signoff .trusted-ci/signoff
+          # --strip-components=1 drops the leading `.github/`, so the tree
+          # lands at .trusted-ci/actions/… — the path every `uses:` below
+          # names.
+          git archive "$TRUSTED_SHA" .github/actions | tar -x -C .trusted-ci --strip-components=1
+          git show "${TRUSTED_SHA}:scripts/signoff" > .trusted-ci/signoff
           chmod +x .trusted-ci/signoff
-          echo "Saved trusted CI helpers from $(git rev-parse --short HEAD) to .trusted-ci/"
+          echo "Saved trusted CI helpers from ${TRUSTED_SHA} (this workflow file's own commit) to .trusted-ci/"
 
       - name: Fetch and check out fork head commit
         if: needs.resolve.outputs.is_fork == 'true'

--- a/.github/workflows/signoff_trusted_helpers_test.yml
+++ b/.github/workflows/signoff_trusted_helpers_test.yml
@@ -1,0 +1,69 @@
+---
+name: Sign-off Trusted Helpers Tests
+
+# `signoff.yml`'s `Save trusted CI helpers` step decides which commit's
+# `scripts/signoff` and `.github/actions/**` the sign-off job actually runs.
+# Both properties it carries fail silently if it regresses: taking them from the
+# checked-out tree instead of the workflow's own commit lets a branch present an
+# older helper to newer call sites (a cancelled run then kept a `signoff=failure`
+# it could not withdraw — #12657), and it lets the code under test supply the
+# script that decides its own sign-off. Neither shows up as a red check; the
+# sign-off run just does the wrong thing.
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - '.github/workflows/signoff.yml'
+      - 'scripts/test_signoff_trusted_helpers.sh'
+      - '.github/workflows/signoff_trusted_helpers_test.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - '.github/workflows/signoff.yml'
+      - 'scripts/test_signoff_trusted_helpers.sh'
+      - '.github/workflows/signoff_trusted_helpers_test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-signoff-trusted-helpers:
+    name: Unit tests for the sign-off trusted-helper materialisation
+    # GitHub-hosted on purpose: this is a sub-second check and must not queue
+    # behind the saturated self-hosted pool the sign-off job runs on.
+    runs-on: ubuntu-24.04
+    # A checkout plus a local bash script against local git fixtures — the job
+    # reads the repository and nothing else, so it needs no write scope.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        # The test extracts the step under test from signoff.yml rather than
+        # keeping a copy, so it needs a YAML parser.
+        #
+        # `python -m pip`, not a bare `pip`: it installs into the interpreter
+        # setup-python just put on PATH, rather than whichever `pip` the runner
+        # image happens to resolve first.
+        run: python -m pip install pyyaml
+
+      - name: Run tests
+        # Invoked through `bash` rather than as `./…` so the job does not depend
+        # on the script's executable bit surviving a checkout on every platform.
+        run: bash scripts/test_signoff_trusted_helpers.sh

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -365,6 +365,19 @@ If you see `signoff=pending` with "Remote sign-off was cancelled", nothing is
 wrong with the branch: dispatch sign-off again. `scripts/test_signoff_cancelled_correction.sh`
 covers both directions.
 
+The correction runs through `.trusted-ci/signoff`, so it can only work if that copy
+understands the subcommand the workflow calls. Both trusted helpers are therefore read
+out of the object database at the workflow file's own commit (`github.sha`) rather than
+copied from the checked-out tree — the tree is the *branch under test*, which for a
+branch older than the helper is a script the workflow's own call sites have outrun. That
+is what left cancelled runs on older branches with a `signoff=failure` they could not
+withdraw (#12657). One consequence worth knowing: a branch that changes `scripts/signoff`
+or `.github/actions/**` is still signed off with the dispatch ref's version of them. To
+exercise a branch's own helper changes, dispatch on that branch —
+`gh workflow run signoff.yml --ref <branch> -f branch=<branch>` — which puts the workflow
+and the helpers on the same commit again. `scripts/test_signoff_trusted_helpers.sh` covers
+the extraction.
+
 ### Jujutsu workspaces
 
 `make signoff` also works in non-colocated JJ workspaces (where there is a

--- a/scripts/test_signoff_trusted_helpers.sh
+++ b/scripts/test_signoff_trusted_helpers.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the `Save trusted CI helpers` step of
+# `.github/workflows/signoff.yml` — the step that materialises
+# `.trusted-ci/signoff` and `.trusted-ci/actions/`, the copies every later step
+# in the sign-off job runs instead of the working tree's.
+#
+# Two properties are load-bearing, and both are about *which commit* the copies
+# come from:
+#
+#   1. Version agreement. The call sites for these helpers live in the workflow
+#      file, which always comes from `github.sha`. The same-repo checkout is at
+#      the branch under test, so copying from the tree let a branch present an
+#      older helper to newer call sites: a branch predating
+#      `scripts/signoff correct-cancelled` (#12432) supplied a script without
+#      it, the `if: cancelled()` step died on "unknown command", and the
+#      cancelled run kept the `signoff=failure` it had already posted — a red
+#      Attestation on code nothing judged (#12657).
+#
+#   2. Trust. The copies must not be reachable by the code under test. For a
+#      fork PR that is the whole point of `.trusted-ci/`; for a same-repo PR it
+#      means the branch cannot supply the script that decides its own sign-off.
+#
+# The step is inline YAML rather than a function in scripts/signoff, and it has
+# to stay that way: extracting it to a file in the repo would make the *saver*
+# itself come from the branch under test, which is the bug. So this extracts the
+# real `run:` block from the workflow and executes it. Extracting (rather than
+# copying it here) is what makes the test bind to the shipping definition.
+#
+# No network and no credentials: the fixtures are local git repositories, and
+# `origin` is a second local repository on disk.
+#
+# Usage: scripts/test_signoff_trusted_helpers.sh
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+workflow="$repo_root/.github/workflows/signoff.yml"
+
+tests_run=0
+failures=0
+
+fail_test() {
+  failures=$((failures + 1))
+  echo "  FAIL: $1"
+}
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 not found — required to extract the step"; exit 1; }
+command -v git >/dev/null 2>&1 || { echo "git not found — the step under test uses it"; exit 1; }
+command -v tar >/dev/null 2>&1 || { echo "tar not found — the step under test uses it"; exit 1; }
+# Checked separately from python3 itself: without this the extraction below
+# fails as an ImportError traceback, which reads like a bug in the test rather
+# than a missing dependency.
+python3 -c 'import yaml' 2>/dev/null \
+  || { echo "python3 cannot import yaml — required to extract the step (pip install pyyaml)"; exit 1; }
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+subject="$work_dir/save_trusted_helpers.sh"
+
+# Pull the step's `run:` script out of the workflow by name, and with it the
+# `env:` keys it declares — asserting those are exactly the one this test
+# supplies, so a new input added to the step cannot be silently untested.
+#
+# Any `${{ }}` left in the body is a hard error: it would mean the step reads a
+# template this test does not model, and letting it through would exercise a
+# script that is not the one CI runs.
+python3 - "$workflow" "$subject" <<'PY' || exit 1
+import io, re, sys
+import yaml
+
+workflow_path, out_path = sys.argv[1], sys.argv[2]
+doc = yaml.safe_load(io.open(workflow_path, encoding="utf-8"))
+
+steps = doc["jobs"]["sign-off"]["steps"]
+matches = [s for s in steps if s.get("name") == "Save trusted CI helpers"]
+if len(matches) != 1:
+    sys.exit(f"expected exactly 1 'Save trusted CI helpers' step in the sign-off job, found {len(matches)}")
+step = matches[0]
+
+declared = sorted(step.get("env", {}))
+expected = ["TRUSTED_SHA"]
+if declared != expected:
+    sys.exit(f"step env keys changed: expected {expected}, found {declared} — update this test")
+
+body = step["run"]
+leftover = re.findall(r"\$\{\{.*?\}\}", body)
+if leftover:
+    sys.exit(f"step body has unmodelled template expressions: {leftover} — update this test")
+
+io.open(out_path, "w", encoding="utf-8", newline="\n").write("#!/usr/bin/env bash\n" + body)
+PY
+chmod +x "$subject"
+
+git_quiet() { git "$@" >/dev/null 2>&1; }
+
+# Build the pair of repositories the step sees on a runner:
+#
+#   origin/   a bare-ish repo standing in for spiceai/spiceai, holding both the
+#             OLD commit (a branch predating the helper change) and the NEW one
+#             (the workflow file's own commit).
+#   clone/    the workspace, checked out at OLD — i.e. actions/checkout at
+#             `ref: <branch under test>`, which does not fetch other refs.
+#
+# Returns the two SHAs in $old_sha / $new_sha and the workspace in $clone.
+#
+# `$1` selects what the clone fetches, so the "already present" and "must be
+# fetched" paths can both be exercised: `shallow-refs` clones only the old
+# branch (the realistic same-repo case), `all-refs` clones everything (the fork
+# case, where github.sha is the ref already checked out).
+build_fixture() {
+  local fetch_mode="$1"
+  local root="$work_dir/fixture"
+  rm -rf "$root"
+  mkdir -p "$root"
+  origin="$root/origin"
+  clone="$root/clone"
+
+  mkdir -p "$origin"
+  (
+    cd "$origin" || exit 1
+    git_quiet init -b trunk
+    git_quiet config user.email test@example.com
+    git_quiet config user.name "Test"
+    mkdir -p scripts .github/actions/setup-rust
+
+    # The OLD helper: no `correct-cancelled`, exactly the shape that produced
+    # #12657.
+    printf '#!/usr/bin/env bash\necho OLD-SIGNOFF\n' >scripts/signoff
+    chmod +x scripts/signoff
+    printf 'name: setup-rust\n# OLD-ACTION\n' >.github/actions/setup-rust/action.yml
+    git_quiet add -A
+    git_quiet commit -m "old"
+    git_quiet branch branch-under-test
+
+    # The NEW helper, on trunk: this is what github.sha points at.
+    printf '#!/usr/bin/env bash\ncase "${1:-}" in correct-cancelled) echo NEW-SIGNOFF;; esac\n' >scripts/signoff
+    printf 'name: setup-rust\n# NEW-ACTION\n' >.github/actions/setup-rust/action.yml
+    git_quiet add -A
+    git_quiet commit -m "new"
+  ) || return 1
+
+  old_sha="$(git -C "$origin" rev-parse branch-under-test)"
+  new_sha="$(git -C "$origin" rev-parse trunk)"
+
+  if [[ "$fetch_mode" == "all-refs" ]]; then
+    git_quiet clone "$origin" "$clone"
+  else
+    git_quiet clone --branch branch-under-test --single-branch "$origin" "$clone"
+  fi
+  git -C "$clone" checkout --detach "$old_sha" >/dev/null 2>&1
+  git -C "$clone" config user.email test@example.com
+  git -C "$clone" config user.name "Test"
+}
+
+# Run the extracted step in the fixture workspace with the given TRUSTED_SHA.
+# Sets: rc, out.
+run_step() {
+  local trusted_sha="$1"
+  out=$(cd "$clone" && TRUSTED_SHA="$trusted_sha" bash "$subject" 2>&1)
+  rc=$?
+}
+
+assert_contains() {
+  local label="$1" needle="$2" file="$3"
+  tests_run=$((tests_run + 1))
+  if [[ ! -f "$file" ]]; then
+    fail_test "$label: $file does not exist"
+    return
+  fi
+  grep -q -- "$needle" "$file" || fail_test "$label: expected '$needle' in $file, got: $(cat "$file")"
+}
+
+assert_absent() {
+  local label="$1" needle="$2" file="$3"
+  tests_run=$((tests_run + 1))
+  if [[ ! -f "$file" ]]; then
+    fail_test "$label: $file does not exist"
+    return
+  fi
+  ! grep -q -- "$needle" "$file" || fail_test "$label: '$needle' must not appear in $file"
+}
+
+echo "Testing the sign-off trusted-helper materialisation step"
+echo
+
+# --- the regression test for #12657 -----------------------------------------
+# The workspace is at a branch whose scripts/signoff has no `correct-cancelled`.
+# The trusted copy must still be the one the workflow's call sites expect.
+echo "the trusted script comes from the workflow's commit, not the checked-out branch"
+build_fixture shallow-refs || { echo "fixture setup failed"; exit 1; }
+run_step "$new_sha"
+tests_run=$((tests_run + 1))
+[[ $rc -eq 0 ]] || fail_test "step exited $rc; output: $out"
+assert_contains "trusted signoff" "NEW-SIGNOFF" "$clone/.trusted-ci/signoff"
+assert_contains "trusted signoff carries the subcommand the workflow calls" \
+  "correct-cancelled" "$clone/.trusted-ci/signoff"
+assert_absent "the branch's script must not be what runs" "OLD-SIGNOFF" "$clone/.trusted-ci/signoff"
+
+# The composite actions run with this job's secrets in scope, so they are held
+# to the same rule as the script.
+echo "the trusted composite actions come from the same commit"
+assert_contains "trusted action" "NEW-ACTION" "$clone/.trusted-ci/actions/setup-rust/action.yml"
+assert_absent "the branch's action must not be what runs" "OLD-ACTION" \
+  "$clone/.trusted-ci/actions/setup-rust/action.yml"
+
+# Later steps invoke `.trusted-ci/signoff` directly, so the bit has to survive
+# the extraction — `git show` writes a plain file, unlike the `cp` this replaced.
+echo "the trusted script is executable"
+tests_run=$((tests_run + 1))
+[[ -x "$clone/.trusted-ci/signoff" ]] || fail_test "expected .trusted-ci/signoff to be executable"
+
+# The working tree is deliberately left alone: the fork overlay that follows
+# checks out tracked paths over it, and the sign-off run itself lints and tests
+# the branch's code. Only the .trusted-ci/ copies are pinned.
+echo "the working tree is left at the branch under test"
+assert_contains "working tree untouched" "OLD-SIGNOFF" "$clone/scripts/signoff"
+
+# --- the fork case: github.sha is the ref already checked out ----------------
+# Nothing to fetch, and the same copies must land. Asserting the step does not
+# depend on the fetch succeeding keeps the common path honest.
+echo "it works when the trusted commit is already present"
+build_fixture all-refs || { echo "fixture setup failed"; exit 1; }
+run_step "$new_sha"
+tests_run=$((tests_run + 1))
+[[ $rc -eq 0 ]] || fail_test "step exited $rc; output: $out"
+assert_contains "trusted signoff (no fetch needed)" "NEW-SIGNOFF" "$clone/.trusted-ci/signoff"
+
+# --- no silent fallback ------------------------------------------------------
+# An unresolvable trusted commit has to stop the run. Falling back to the
+# working tree would restore exactly the skew this step exists to prevent, and
+# it would do it invisibly — the run would go on to sign the branch off with the
+# branch's own script.
+echo "an unresolvable trusted commit fails the step rather than falling back"
+build_fixture shallow-refs || { echo "fixture setup failed"; exit 1; }
+run_step "0000000000000000000000000000000000000000"
+tests_run=$((tests_run + 1))
+[[ $rc -ne 0 ]] || fail_test "expected a non-zero exit for an unresolvable trusted commit; output: $out"
+tests_run=$((tests_run + 1))
+if [[ -f "$clone/.trusted-ci/signoff" ]]; then
+  fail_test "expected no .trusted-ci/signoff after a failed resolve, found: $(cat "$clone/.trusted-ci/signoff")"
+fi
+
+# --- a stale .trusted-ci/ from a previous run on the same workspace ----------
+# Self-hosted runners reuse the workspace. actions/checkout's clean removes
+# untracked files, but the step must not depend on that having happened: a
+# leftover copy of a *different* commit's helpers is the same skew by another
+# route.
+echo "a leftover .trusted-ci/ from a previous run is replaced, not merged into"
+build_fixture shallow-refs || { echo "fixture setup failed"; exit 1; }
+mkdir -p "$clone/.trusted-ci/actions/setup-rust"
+printf '#!/usr/bin/env bash\necho STALE-SIGNOFF\n' >"$clone/.trusted-ci/signoff"
+printf 'name: setup-rust\n# STALE-ACTION\n' >"$clone/.trusted-ci/actions/setup-rust/action.yml"
+printf 'stale\n' >"$clone/.trusted-ci/actions/leftover.yml"
+run_step "$new_sha"
+tests_run=$((tests_run + 1))
+[[ $rc -eq 0 ]] || fail_test "step exited $rc; output: $out"
+assert_absent "stale script replaced" "STALE-SIGNOFF" "$clone/.trusted-ci/signoff"
+assert_absent "stale action replaced" "STALE-ACTION" "$clone/.trusted-ci/actions/setup-rust/action.yml"
+tests_run=$((tests_run + 1))
+[[ ! -e "$clone/.trusted-ci/actions/leftover.yml" ]] \
+  || fail_test "expected the leftover .trusted-ci/actions/leftover.yml to be removed"
+
+echo
+if [[ $failures -eq 0 ]]; then
+  echo "All $tests_run assertions passed"
+  exit 0
+fi
+echo "$failures of $tests_run assertions failed"
+exit 1


### PR DESCRIPTION
## Summary

The sign-off job runs `.trusted-ci/signoff` and `.trusted-ci/actions/**` rather than the
working tree's copies, so that the code under test cannot supply the script that decides
its own sign-off. Those copies were made with `cp` from the checked-out tree — but for a
same-repo PR the tree is the **branch under test**, while the call sites live in the
workflow file, which always comes from `github.sha` (the dispatch ref; `make signoff-remote`
does not pass `--ref`, so that is the default branch).

So a branch older than a helper change presented an older helper to newer call sites. A
branch predating `scripts/signoff correct-cancelled` (#12432) supplied a script without it,
so the `if: cancelled()` step died on `unknown command: correct-cancelled` and the cancelled
run kept the `signoff=failure` it had already posted. That is a red `Attestation` on code
nothing ever judged, and the population that cannot repair its own cancelled status is
exactly the population that needs the repair. Confirmed on the branch from the run in the
issue: trunk's `scripts/signoff` has 2 occurrences of `correct-cancelled`,
`fix/12588-cli-response-read-data-loss` has 0.

It also closes the same-repo half of the trust boundary the fork case already had: a branch
under test no longer supplies the script that judges it.

Fixes #12657

## Changes

- **`.github/workflows/signoff.yml`** — `Save trusted CI helpers` reads both helpers out of
  the object database at `${{ github.sha }}` (`git archive` / `git show`) instead of copying
  the working tree, fetching that commit first if the checkout did not bring it.
  `actions/checkout` fetches only the ref it checks out even at `fetch-depth: 0`, so the
  commit is usually absent in the same-repo case and already present in the fork case (where
  it *is* the ref checked out). The SHA is passed through `env:` rather than interpolated
  into the shell body. The step still runs before the fork overlay, and reading the ODB means
  the overlay cannot reach these files even in principle.
- **`scripts/test_signoff_trusted_helpers.sh`** — new. Extracts the real `run:` block from
  the workflow and executes it against local git fixtures (no network, no credentials).
- **`.github/workflows/signoff_trusted_helpers_test.yml`** — runs it on GitHub-hosted
  `ubuntu-24.04`, paths-filtered, `contents: read` only.
- **`docs/dev/ci_signoff.md`** — documents where the trusted helpers come from and the
  consequence below.

The step stays inline in the workflow rather than moving to `scripts/`: a saver script in the
repo would itself be read from the branch under test, which is the bug. That is why the test
extracts the step instead of keeping a copy — it binds to the shipping definition.

## Behaviour change worth knowing

A branch that changes `scripts/signoff` or `.github/actions/**` is now signed off with the
**dispatch ref's** version of those, not its own. That is the point, but it means such a
branch can no longer self-serve a fix to a broken helper. The escape hatch is one flag —
dispatch on the branch, which puts the workflow and the helpers back on one commit:

```bash
gh workflow run signoff.yml --ref <branch> -f branch=<branch>
```

This is documented in the step comment and in `docs/dev/ci_signoff.md`. Three open PRs touch
`scripts/signoff` (#12557, #12392, #12383); none is blocked by this, but they are the
population the note is for.

An unresolvable trusted commit **fails the step** rather than falling back to the tree. A
silent fallback would restore the exact skew this fixes, and would do it invisibly — the run
would go on to sign the branch off with the branch's own script. A transient fetch failure
here would have broken the `Fetch trunk for targeted pre-lint` step immediately after anyway.

## Test plan

This branch touches no Rust — `.github/**`, `scripts/test_*`, and `docs/**` are outside the
Rust gate's path filter, so `Attestation` auto-passes and no `make lint` / `make nextest` run
is applicable to it. What was run:

- `bash scripts/test_signoff_trusted_helpers.sh` — **16/16 assertions pass**. Covers: the
  trusted script and composite actions come from the workflow's commit and not from the
  checked-out branch; the branch's own copies do not appear; the `correct-cancelled`
  subcommand the workflow calls is present in the trusted copy (the #12657 regression); the
  executable bit survives; the working tree is left at the branch under test; the
  already-present (fork) path needs no fetch; an unresolvable commit fails rather than falls
  back; a stale `.trusted-ci/` from a previous run on a reused workspace is replaced, not
  merged into.
- **Neuter matrix, 5/5 caught**, each by the test named for it: (1) `cp` the script from the
  tree — the original bug; (2) `cp -R` the actions from the tree; (3) drop the `chmod +x`;
  (4) drop the `rm -rf` of a stale `.trusted-ci/`; (5) tolerate an unresolvable commit and
  fall back to the tree.
- `python3 .github/scripts/check_workflow_yaml.py` — `OK: 109 GitHub Actions definitions are
  well-formed`.
- `tar --strip-components` is exercised on both implementations: the sign-off job runs on
  `spiceai-macos` (bsdtar), which the local run of the test above used, and the new test
  workflow runs on `ubuntu-24.04` (GNU tar).

## Checklist

- [x] Root cause identified and confirmed against the run in the issue
- [x] Regression test that fails on the old step and passes on the new one
- [x] Neuter matrix run; every test proven to catch its own defect
- [x] No credentials, secrets, or internal details added to logs, errors, or this body
- [x] Trust boundary reviewed: narrowed, not widened
- [x] Docs updated