### PR TITLE
fix(runtime): measure the CDC prefetch backlog, and stop its byte counter wrapping

### DIFF
--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -1139,6 +1139,13 @@ impl ChangeBatch {
     /// a caller can retract from this batch alone; pairing each row with its `op`
     /// still tells it which rows are *meant* to retract.
     ///
+    /// So `op` is the only authority on what a row is. Do NOT infer the operation
+    /// from this batch: an all-null row means "the source sent no prior values"
+    /// *or* "every prior value was NULL", and the two are indistinguishable here
+    /// once the struct's validity has been pushed into the columns. `op` is
+    /// non-nullable in both change schemas precisely so this question never has
+    /// to be answered from the before-image.
+    ///
     /// Every field is reported nullable regardless of how the table declares it:
     /// a before-image is absent on insert, and a source may send only the key
     /// columns (`PostgreSQL` under `REPLICA IDENTITY DEFAULT` does exactly that),

--- a/crates/runtime-metrics/src/acceleration.rs
+++ b/crates/runtime-metrics/src/acceleration.rs
@@ -359,28 +359,35 @@ pub static CDC_PREFETCH_BUFFER_CAPACITY: LazyLock<Gauge<u64>> = LazyLock::new(||
         .build()
 });
 
-/// **Bytes** resident in the CDC prefetch channel, as distinct from the envelope
+/// Estimated **size** of the CDC prefetch backlog, as distinct from the envelope
 /// count next to it. The channel is bounded by count, not size, and an envelope
-/// carries a materialized batch whose width the bound says nothing about — so
-/// occupancy in envelopes can sit mid-range while the bytes behind it are large
-/// enough to matter to the process.
+/// carries a batch whose width the bound says nothing about — so occupancy in
+/// envelopes can sit mid-range while the backlog behind it is large enough to
+/// matter to the process.
 ///
-/// Nothing else measures this. The query and compaction pools account for their
-/// own reservations, the mem-tier budget accounts for applied rows, and the
-/// coalescing path is bounded by `cdc_max_coalesced_bytes` — but bytes *waiting*
-/// in this channel, ahead of apply, appear in none of them. At SF-1000 the
-/// declared budgets summed to under half the cgroup limit while the process ran
-/// at 95% of it, which is the gap this closes: not a bound, but the measurement
-/// a bound would need.
+/// Nothing else sizes this. The query and compaction pools account for their own
+/// reservations, the mem-tier budget accounts for applied rows, and the
+/// coalescing path is bounded by `cdc_max_coalesced_bytes` — but what *waits* in
+/// this channel, ahead of apply, appears in none of them. Reading it against a
+/// process total is what tells an operator whether this path is worth
+/// investigating at all: this measures, it does not bound.
 ///
-/// Summed from each envelope's `encoded_len()`, which is the same figure
-/// `cdc_max_coalesced_bytes` budgets against and does not force a deferred
-/// envelope to build. Labeled by `dataset`.
+/// **This is an estimate, not measured resident bytes.** It sums each envelope's
+/// `ChangeRows::encoded_len()`, the same decode-free figure
+/// `cdc_max_coalesced_bytes` budgets against, chosen so that sampling never
+/// forces a deferred envelope to build. What that figure means depends on the
+/// envelope: for one already built it is the Arrow footprint
+/// (`get_array_memory_size`); for one still deferred in wire form it is the
+/// source's proxy for the Arrow memory the envelope *will* occupy — `PostgreSQL`
+/// uses `max(wire_bytes, rows × fixed-width footprint)` — which can exceed what
+/// the queued object holds today. Read it as the backlog's size on the same
+/// scale the coalescing budget uses, not as this path's exact contribution to
+/// RSS. Labeled by `dataset`.
 pub static CDC_PREFETCH_BUFFER_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
     METER
         .u64_gauge("dataset_acceleration_cdc_prefetch_buffer_bytes")
         .with_description(
-            "Encoded bytes resident in the CDC source-reader→apply prefetch channel. The channel is bounded by envelope count, not bytes, and this memory is counted by no other budget.",
+            "Estimated encoded size of the CDC source-reader→apply prefetch backlog, summed from the same decode-free per-envelope estimate the coalescing byte budget uses (not measured resident bytes). The channel is bounded by envelope count, not size, and this backlog is counted by no other budget.",
         )
         .with_unit("By")
         .build()

--- a/crates/runtime-metrics/src/acceleration.rs
+++ b/crates/runtime-metrics/src/acceleration.rs
@@ -359,6 +359,33 @@ pub static CDC_PREFETCH_BUFFER_CAPACITY: LazyLock<Gauge<u64>> = LazyLock::new(||
         .build()
 });
 
+/// **Bytes** resident in the CDC prefetch channel, as distinct from the envelope
+/// count next to it. The channel is bounded by count, not size, and an envelope
+/// carries a materialized batch whose width the bound says nothing about — so
+/// occupancy in envelopes can sit mid-range while the bytes behind it are large
+/// enough to matter to the process.
+///
+/// Nothing else measures this. The query and compaction pools account for their
+/// own reservations, the mem-tier budget accounts for applied rows, and the
+/// coalescing path is bounded by `cdc_max_coalesced_bytes` — but bytes *waiting*
+/// in this channel, ahead of apply, appear in none of them. At SF-1000 the
+/// declared budgets summed to under half the cgroup limit while the process ran
+/// at 95% of it, which is the gap this closes: not a bound, but the measurement
+/// a bound would need.
+///
+/// Summed from each envelope's `encoded_len()`, which is the same figure
+/// `cdc_max_coalesced_bytes` budgets against and does not force a deferred
+/// envelope to build. Labeled by `dataset`.
+pub static CDC_PREFETCH_BUFFER_BYTES: LazyLock<Gauge<u64>> = LazyLock::new(|| {
+    METER
+        .u64_gauge("dataset_acceleration_cdc_prefetch_buffer_bytes")
+        .with_description(
+            "Encoded bytes resident in the CDC source-reader→apply prefetch channel. The channel is bounded by envelope count, not bytes, and this memory is counted by no other budget.",
+        )
+        .with_unit("By")
+        .build()
+});
+
 /// Counts applied CDC bursts by what ended coalescing (the flush `reason`):
 /// `deadline` (the `cdc_max_coalesce_age_ms` linger timer fired — the batch was
 /// held for freshness-cost time waiting for more rows), `envelope_cap`

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -1134,7 +1134,7 @@ impl RefreshTask {
                         let send_res = tx.send(item).await;
                         if send_res.is_err() {
                             // Nobody will receive it, so nobody will subtract it.
-                            reader_prefetch_bytes.fetch_sub(queued_bytes, Ordering::Relaxed);
+                            discharge_prefetch_bytes(&reader_prefetch_bytes, queued_bytes);
                         }
                         metrics::CDC_READER_SEND_WAIT_MS.record(elapsed_ms(send_start), send_labels);
                         if send_res.is_err() {
@@ -1300,8 +1300,13 @@ impl RefreshTask {
             // Discharge what this receive took out, before sampling, so the byte
             // gauge and the envelope occupancy below describe the same thing: the
             // backlog still queued, not counting the item now in hand.
-            if let Some(item) = next_item.as_ref() {
-                prefetch_bytes.fetch_sub(cdc_item_budget_bytes(item) as u64, Ordering::Relaxed);
+            //
+            // A CARRIED item is deliberately not discharged here: it left the
+            // channel on the previous iteration's `try_recv` and was discharged
+            // there. Charging it out twice drove the counter below zero, and an
+            // unsigned wrap made the gauge read ~1.8e19.
+            if !from_carried && let Some(item) = next_item.as_ref() {
+                discharge_prefetch_bytes(&prefetch_bytes, cdc_item_budget_bytes(item) as u64);
             }
             // Sample prefetch-channel occupancy at the moment the apply loop wakes
             // (the just-received `first` is out of the buffer; whatever remains is
@@ -1400,7 +1405,9 @@ impl RefreshTask {
                         let item_bytes = cdc_item_budget_bytes(&item);
                         // Out of the channel, so out of the channel's byte count —
                         // whether it joins this burst or is carried to the next.
-                        prefetch_bytes.fetch_sub(item_bytes as u64, Ordering::Relaxed);
+                        // A carried item is discharged HERE and not again when the
+                        // next iteration picks it up.
+                        discharge_prefetch_bytes(&prefetch_bytes, item_bytes as u64);
                         if burst_bytes > 0
                             && item_bytes > 0
                             && burst_bytes.saturating_add(item_bytes) > max_burst_bytes
@@ -1450,7 +1457,8 @@ impl RefreshTask {
                             let item_bytes = cdc_item_budget_bytes(&item);
                             // Out of the channel, so out of the channel's byte
                             // count — burst or carried, it is no longer queued.
-                            prefetch_bytes.fetch_sub(item_bytes as u64, Ordering::Relaxed);
+                            // A carried item is discharged HERE, once.
+                            discharge_prefetch_bytes(&prefetch_bytes, item_bytes as u64);
                             if burst_bytes > 0
                                 && item_bytes > 0
                                 && burst_bytes.saturating_add(item_bytes) > max_burst_bytes
@@ -3085,6 +3093,19 @@ fn cdc_item_budget_bytes(item: &Result<cdc::ChangeEnvelope, cdc::StreamError>) -
     // accumulates before applying; the real Arrow build is deferred to apply
     // time (`into_parts_offloaded_burst`), off the source's shared read path.
     item.as_ref().map_or(0, cdc::ChangeEnvelope::encoded_len)
+}
+
+/// Subtract from the CDC prefetch byte counter without wrapping.
+///
+/// Charge and discharge are meant to be symmetric, but `u64::fetch_sub` past
+/// zero wraps to ~1.8e19, which turns a small accounting slip into a reading no
+/// operator can interpret — and which looks nothing like "slightly wrong". A
+/// gauge that fails should fail toward zero, where the error stays proportional
+/// to the mistake, so saturate rather than wrap.
+fn discharge_prefetch_bytes(counter: &AtomicU64, bytes: u64) {
+    let _previous = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_sub(bytes))
+    });
 }
 
 fn elapsed_ms(start: Instant) -> f64 {

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -541,10 +541,11 @@ const CDC_PREFETCH_BUFFER_DEFAULT: usize = 128;
 // fixed per-batch publish cost (one EBS directory `sync_all()` per batch per table)
 // over more rows. `max_coalesced_bytes` (128 MiB default) bounds the burst DRAINED
 // from the channel — not what sits in it. The channel's bound is this envelope
-// count, and an envelope carries a materialized batch of any width, so the bytes
-// queued ahead of apply are bounded by nothing. `cdc_prefetch_buffer_bytes`
-// measures them; treat a large value as real process memory that no budget
-// accounts for. The drain never waits, so low-load latency is unchanged
+// count, and an envelope carries a batch of any width, so the size of what is
+// queued ahead of apply is bounded by nothing. `cdc_prefetch_buffer_bytes`
+// estimates it, on the same decode-free scale `max_coalesced_bytes` budgets
+// against; a large value means memory no budget accounts for and is worth
+// investigating. The drain never waits, so low-load latency is unchanged
 // (burst.len()==1).
 const CDC_PREFETCH_BUFFER_MAX: usize = 16384;
 const CDC_MAX_COALESCED_ENVELOPES_DEFAULT: usize = 256;
@@ -1073,8 +1074,9 @@ impl RefreshTask {
         // loop is the bottleneck, the reader parks on `send` and stops pulling.
         // That bounds the number of envelopes in flight, not their size — a full
         // channel holds `prefetch_buffer` batches of whatever width the source
-        // produces, which at a large scale factor is a substantial and otherwise
-        // unmeasured share of the process. `cdc_prefetch_buffer_bytes` reports it.
+        // produces, which at a large scale factor can be a substantial and
+        // otherwise unmeasured share of the process. `cdc_prefetch_buffer_bytes`
+        // estimates it.
         let (tx, mut rx) = tokio::sync::mpsc::channel::<
             Result<cdc::ChangeEnvelope, cdc::StreamError>,
         >(cdc_cfg.prefetch_buffer);
@@ -1085,14 +1087,23 @@ impl RefreshTask {
         // while the reader's real sender lives, so it can never resurrect a closed
         // channel.
         let tx_probe = tx.downgrade();
-        // Bytes resident in the channel above. The capacity bound counts
-        // envelopes, so this is not derivable from occupancy: a mid-range
-        // envelope count can hold anything from kilobytes to gigabytes depending
-        // on how wide the source's batches are. The reader adds an envelope's
-        // encoded size as it hands it over and the apply loop subtracts it on
-        // receipt, so the value tracks what is actually queued ahead of apply.
+        // Estimated size of what is queued in the channel above. The capacity
+        // bound counts envelopes, so this is not derivable from occupancy: a
+        // mid-range envelope count can hold anything from kilobytes to gigabytes
+        // depending on how wide the source's batches are. The reader adds an
+        // envelope's encoded size as it hands it over and the apply loop
+        // subtracts it on receipt, so the value tracks what is queued ahead of
+        // apply. `encoded_len` is a decode-free estimate, not measured resident
+        // bytes — see `CDC_PREFETCH_BUFFER_BYTES` for what it does and does not
+        // claim.
         let prefetch_bytes = Arc::new(AtomicU64::new(0));
         let reader_prefetch_bytes = Arc::clone(&prefetch_bytes);
+        // Zeroes the gauge once this stream is gone, however it goes (see
+        // `PrefetchBytesGaugeReset`). Held for the whole function so the reset
+        // also covers the finalize/commit drain below, not just the apply loop.
+        let _prefetch_gauge_reset = PrefetchBytesGaugeReset {
+            labels: metric_labels.clone(),
+        };
 
         let reader_dataset = dataset_name.clone();
         let reader_metric_labels = metric_labels.clone();
@@ -3093,6 +3104,28 @@ fn cdc_item_budget_bytes(item: &Result<cdc::ChangeEnvelope, cdc::StreamError>) -
     // accumulates before applying; the real Arrow build is deferred to apply
     // time (`into_parts_offloaded_burst`), off the source's shared read path.
     item.as_ref().map_or(0, cdc::ChangeEnvelope::encoded_len)
+}
+
+/// Zeroes `cdc_prefetch_buffer_bytes` for one dataset when the CDC stream that
+/// feeds it goes away.
+///
+/// The gauge is only ever recorded from inside the apply loop, so its last
+/// reading outlives that loop. Every exit — a `break` out to the finalize drain,
+/// or the whole future being dropped mid-`await` when the refresh task is
+/// cancelled — drops the receiver and everything still queued behind it, but
+/// leaves the exported value describing a backlog that no longer exists. An
+/// operator reading a torn-down dataset would see prefetch memory that was
+/// already freed, which is the same class of lie the gauge exists to stop
+/// telling. `Drop` is what covers the cancellation path; resetting at each
+/// `break` would not, since an aborted task never reaches one.
+struct PrefetchBytesGaugeReset {
+    labels: DatasetMetricLabels,
+}
+
+impl Drop for PrefetchBytesGaugeReset {
+    fn drop(&mut self) {
+        metrics::CDC_PREFETCH_BUFFER_BYTES.record(0, self.labels.dataset());
+    }
 }
 
 /// Subtract from the CDC prefetch byte counter without wrapping.

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -67,7 +67,7 @@ use snafu::OptionExt;
 use snafu::ResultExt;
 use std::collections::{HashMap, VecDeque};
 use std::hash::BuildHasherDefault;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 use tokio::sync::{Notify, RwLock};
@@ -539,8 +539,13 @@ const CDC_PREFETCH_BUFFER_DEFAULT: usize = 128;
 // buffered in this channel. With the old 1024 max the 4096 envelope cap never bound.
 // Raised 1024 -> 16384 so high-throughput tables form larger bursts, amortizing the
 // fixed per-batch publish cost (one EBS directory `sync_all()` per batch per table)
-// over more rows. `max_coalesced_bytes` (128 MiB default) still bounds peak burst memory,
-// and the drain never waits, so low-load latency is unchanged (burst.len()==1).
+// over more rows. `max_coalesced_bytes` (128 MiB default) bounds the burst DRAINED
+// from the channel — not what sits in it. The channel's bound is this envelope
+// count, and an envelope carries a materialized batch of any width, so the bytes
+// queued ahead of apply are bounded by nothing. `cdc_prefetch_buffer_bytes`
+// measures them; treat a large value as real process memory that no budget
+// accounts for. The drain never waits, so low-load latency is unchanged
+// (burst.len()==1).
 const CDC_PREFETCH_BUFFER_MAX: usize = 16384;
 const CDC_MAX_COALESCED_ENVELOPES_DEFAULT: usize = 256;
 // Raised 4096 -> 16384 to match the prefetch ceiling (otherwise it would re-clip the burst).
@@ -1065,8 +1070,11 @@ impl RefreshTask {
         // its source-side offset, the reader task can already be pulling and
         // decoding batch N+1 (network/CPU work that would otherwise be idle).
         // The bounded channel provides natural backpressure: when the apply
-        // loop is the bottleneck, the reader parks on `send` and stops
-        // pulling, so we never accumulate unbounded memory.
+        // loop is the bottleneck, the reader parks on `send` and stops pulling.
+        // That bounds the number of envelopes in flight, not their size — a full
+        // channel holds `prefetch_buffer` batches of whatever width the source
+        // produces, which at a large scale factor is a substantial and otherwise
+        // unmeasured share of the process. `cdc_prefetch_buffer_bytes` reports it.
         let (tx, mut rx) = tokio::sync::mpsc::channel::<
             Result<cdc::ChangeEnvelope, cdc::StreamError>,
         >(cdc_cfg.prefetch_buffer);
@@ -1077,6 +1085,14 @@ impl RefreshTask {
         // while the reader's real sender lives, so it can never resurrect a closed
         // channel.
         let tx_probe = tx.downgrade();
+        // Bytes resident in the channel above. The capacity bound counts
+        // envelopes, so this is not derivable from occupancy: a mid-range
+        // envelope count can hold anything from kilobytes to gigabytes depending
+        // on how wide the source's batches are. The reader adds an envelope's
+        // encoded size as it hands it over and the apply loop subtracts it on
+        // receipt, so the value tracks what is actually queued ahead of apply.
+        let prefetch_bytes = Arc::new(AtomicU64::new(0));
+        let reader_prefetch_bytes = Arc::clone(&prefetch_bytes);
 
         let reader_dataset = dataset_name.clone();
         let reader_metric_labels = metric_labels.clone();
@@ -1102,10 +1118,24 @@ impl RefreshTask {
                     }
                     item = stream.next() => {
                         let Some(item) = item else { return; };
+                        // Charge the envelope before handing it over: once `send`
+                        // returns the apply loop may already have taken it and
+                        // subtracted, and crediting afterwards could then drive
+                        // the counter negative. `encoded_len` does not force a
+                        // deferred envelope to build.
+                        let queued_bytes = match &item {
+                            Ok(envelope) => envelope.encoded_len() as u64,
+                            Err(_) => 0,
+                        };
+                        reader_prefetch_bytes.fetch_add(queued_bytes, Ordering::Relaxed);
                         // Time blocked on send: non-zero => the prefetch channel is
                         // full and the apply loop can't drain fast enough (apply-bound).
                         let send_start = Instant::now();
                         let send_res = tx.send(item).await;
+                        if send_res.is_err() {
+                            // Nobody will receive it, so nobody will subtract it.
+                            reader_prefetch_bytes.fetch_sub(queued_bytes, Ordering::Relaxed);
+                        }
                         metrics::CDC_READER_SEND_WAIT_MS.record(elapsed_ms(send_start), send_labels);
                         if send_res.is_err() {
                             tracing::debug!(
@@ -1267,6 +1297,12 @@ impl RefreshTask {
                 },
             };
             metrics::CDC_SOURCE_RECV_WAIT_MS.record(elapsed_ms(recv_start), recv_wait_labels);
+            // Discharge what this receive took out, before sampling, so the byte
+            // gauge and the envelope occupancy below describe the same thing: the
+            // backlog still queued, not counting the item now in hand.
+            if let Some(item) = next_item.as_ref() {
+                prefetch_bytes.fetch_sub(cdc_item_budget_bytes(item) as u64, Ordering::Relaxed);
+            }
             // Sample prefetch-channel occupancy at the moment the apply loop wakes
             // (the just-received `first` is out of the buffer; whatever remains is
             // the backlog the reader has queued ahead). Near capacity => apply-bound.
@@ -1275,6 +1311,11 @@ impl RefreshTask {
                 let occupancy = capacity.saturating_sub(tx.capacity() as u64);
                 metrics::CDC_PREFETCH_BUFFER_OCCUPANCY.record(occupancy, recv_wait_labels);
                 metrics::CDC_PREFETCH_BUFFER_CAPACITY.record(capacity, recv_wait_labels);
+                // Sampled next to the envelope count deliberately: read together
+                // they say whether a full channel is holding a little or a lot,
+                // which the count alone cannot.
+                metrics::CDC_PREFETCH_BUFFER_BYTES
+                    .record(prefetch_bytes.load(Ordering::Relaxed), recv_wait_labels);
             }
             let Some(first) = next_item else {
                 break;
@@ -1357,6 +1398,9 @@ impl RefreshTask {
                 match rx.try_recv() {
                     Ok(item) => {
                         let item_bytes = cdc_item_budget_bytes(&item);
+                        // Out of the channel, so out of the channel's byte count —
+                        // whether it joins this burst or is carried to the next.
+                        prefetch_bytes.fetch_sub(item_bytes as u64, Ordering::Relaxed);
                         if burst_bytes > 0
                             && item_bytes > 0
                             && burst_bytes.saturating_add(item_bytes) > max_burst_bytes
@@ -1404,6 +1448,9 @@ impl RefreshTask {
                     match tokio::time::timeout(remaining, rx.recv()).await {
                         Ok(Some(item)) => {
                             let item_bytes = cdc_item_budget_bytes(&item);
+                            // Out of the channel, so out of the channel's byte
+                            // count — burst or carried, it is no longer queued.
+                            prefetch_bytes.fetch_sub(item_bytes as u64, Ordering::Relaxed);
                             if burst_bytes > 0
                                 && item_bytes > 0
                                 && burst_bytes.saturating_add(item_bytes) > max_burst_bytes

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -3103,9 +3103,23 @@ fn cdc_item_budget_bytes(item: &Result<cdc::ChangeEnvelope, cdc::StreamError>) -
 /// gauge that fails should fail toward zero, where the error stays proportional
 /// to the mistake, so saturate rather than wrap.
 fn discharge_prefetch_bytes(counter: &AtomicU64, bytes: u64) {
-    let _previous = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+    let previous = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
         Some(current.saturating_sub(bytes))
     });
+    // Saturating in release is the right failure mode for a gauge, but it also
+    // HIDES the bug that motivated it: discharging one envelope twice used to
+    // wrap the counter to ~1.8e19, and saturation would instead quietly clamp to
+    // zero and look plausible. Every charge has exactly one discharge, so a
+    // discharge larger than the balance is a real accounting error - fail loudly
+    // where a test can see it, and stay soft where an operator would only see a
+    // gauge.
+    debug_assert!(
+        previous.is_ok_and(|balance| balance >= bytes),
+        "CDC prefetch byte counter underflowed: discharged {bytes} against a balance of \
+         {previous:?}. Each envelope must be discharged exactly once - a carried item \
+         is discharged at the try_recv that removed it, not again when the next \
+         iteration adopts it."
+    );
 }
 
 fn elapsed_ms(start: Instant) -> f64 {
@@ -6905,6 +6919,50 @@ mod tests {
             .expect("task join")
             .expect("changes stream should succeed");
         // Final invariant: every envelope was committed exactly once, in order.
+        assert_eq!(log.ids().await, vec![1, 2, 3, 4, 5, 6]);
+    }
+
+    /// Regression test for the CDC prefetch byte counter.
+    ///
+    /// An envelope pulled from the channel but deferred past the burst byte cap
+    /// is stashed in `carried_item` and adopted by the NEXT iteration. It leaves
+    /// the channel exactly once, at the `try_recv` that removed it, so it must be
+    /// discharged exactly once. Discharging it again when the outer receive
+    /// adopted it drove the counter below zero, and the unsigned wrap made
+    /// `cdc_prefetch_buffer_bytes` report ~1.8e19 for every table with carry-over
+    /// activity - which is how it was found, on a lab run rather than here.
+    ///
+    /// `max_coalesced_bytes: 1` puts every envelope after the first over budget,
+    /// so this drives the carry path on every iteration. The accounting invariant
+    /// is enforced by the `debug_assert!` in `discharge_prefetch_bytes`, which is
+    /// live in test builds: a double discharge panics here rather than saturating
+    /// quietly to zero and looking plausible.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn carried_envelopes_are_discharged_from_the_prefetch_counter_exactly_once() {
+        let task = make_refresh_task(make_mem_table() as Arc<dyn TableProvider>);
+        let log = CommitLog::new();
+
+        let envelopes: Vec<Result<ChangeEnvelope, CdcStreamError>> = (1..=6)
+            .map(|id| Ok(make_tracked_envelope(id, Arc::clone(&log), false)))
+            .collect();
+        let stream: ChangesStream = fstream::iter(envelopes).boxed();
+
+        let cfg = CdcConfig {
+            prefetch_buffer: 128,
+            max_coalesced_envelopes: 256,
+            // Every envelope after the first exceeds this, so each one is carried
+            // rather than folded into the burst - the path under test.
+            max_coalesced_bytes: 1,
+            max_coalesce_age_ms: 0,
+            commit_timeout: Duration::from_secs(30),
+            delete_subbatch_max: CDC_DELETE_SUBBATCH_MAX_DEFAULT,
+        };
+
+        run_changes_stream_with_config(&task, cfg, stream)
+            .await
+            .expect("changes stream should succeed");
+
+        // Carrying must not lose, duplicate, or reorder an envelope either.
         assert_eq!(log.ids().await, vec![1, 2, 3, 4, 5, 6]);
     }
 

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1751,7 +1751,23 @@ impl DataFusion {
         // controller tick, long enough that the sampling overhead is negligible.
         const SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
         handle.spawn(async move {
-            let mut ticker = tokio::time::interval(SAMPLE_INTERVAL);
+            // First tick deliberately one interval out, NOT immediate. These
+            // gauges are built lazily on first `record` and then cached, binding
+            // permanently to whatever meter provider is global at that moment —
+            // and this sampler is installed ~10ms BEFORE `init_metrics` brings up
+            // the Prometheus provider. `tokio::time::interval` fires its first
+            // tick immediately, which landed that first `record` inside the gap
+            // and bound `query_memory_pool_used_bytes` and
+            // `cayenne_compaction_memory_pool_used_bytes` to the noop meter for
+            // the life of the process: absent from `/metrics` exactly when an OOM
+            // needed them. (`process_resident_memory_bytes` escaped only because
+            // its `spawn_blocking` round-trip straddled the gap.) Delaying the
+            // first sample makes true the assumption the telemetry accessors
+            // already document.
+            let mut ticker = tokio::time::interval_at(
+                tokio::time::Instant::now() + SAMPLE_INTERVAL,
+                SAMPLE_INTERVAL,
+            );
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 ticker.tick().await;

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -1751,23 +1751,7 @@ impl DataFusion {
         // controller tick, long enough that the sampling overhead is negligible.
         const SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
         handle.spawn(async move {
-            // First tick deliberately one interval out, NOT immediate. These
-            // gauges are built lazily on first `record` and then cached, binding
-            // permanently to whatever meter provider is global at that moment —
-            // and this sampler is installed ~10ms BEFORE `init_metrics` brings up
-            // the Prometheus provider. `tokio::time::interval` fires its first
-            // tick immediately, which landed that first `record` inside the gap
-            // and bound `query_memory_pool_used_bytes` and
-            // `cayenne_compaction_memory_pool_used_bytes` to the noop meter for
-            // the life of the process: absent from `/metrics` exactly when an OOM
-            // needed them. (`process_resident_memory_bytes` escaped only because
-            // its `spawn_blocking` round-trip straddled the gap.) Delaying the
-            // first sample makes true the assumption the telemetry accessors
-            // already document.
-            let mut ticker = tokio::time::interval_at(
-                tokio::time::Instant::now() + SAMPLE_INTERVAL,
-                SAMPLE_INTERVAL,
-            );
+            let mut ticker = tokio::time::interval(SAMPLE_INTERVAL);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 ticker.tick().await;


### PR DESCRIPTION
Two memory-accounting defects, both found by taking the instruments to a SF-1000 lab arm and reading what they actually printed.

## 1. The CDC prefetch channel had no size measurement

The channel between the CDC source reader and the apply loop is bounded by envelope **count** (`cdc_prefetch_buffer`, 128 default, 16384 max), and an envelope carries a batch of whatever width the source produces. Two comments here asserted the opposite — that `cdc_max_coalesced_bytes` "still bounds peak burst memory", and that "we never accumulate unbounded memory". Both describe the burst drained *from* the channel; neither describes what sits *in* it.

Adds `dataset_acceleration_cdc_prefetch_buffer_bytes`, sampled beside the existing envelope-occupancy gauge so the two describe the same backlog and can be read together: occupancy says how full, this says how much. Both false comments corrected.

**What it is, precisely.** It sums each envelope's `encoded_len()` — the same decode-free figure `cdc_max_coalesced_bytes` already budgets against, chosen so that sampling never forces a deferred envelope to build (measuring must not materialize). That figure is an *estimate*, not measured resident bytes, and the gauge is documented as one: for an already-built envelope it is the Arrow footprint (`get_array_memory_size`); for one still deferred in wire form it is the source's proxy for the Arrow memory the envelope *will* occupy (PostgreSQL uses `max(wire_bytes, rows × fixed-width footprint)`), which can exceed what the queued object holds today. It sizes the backlog on the same scale the coalescing budget uses; it is not this path's exact contribution to RSS.

This measures; it does not enforce. Bounding the channel in bytes changes CDC backpressure on the hot path and wants its own design and benchmarks — and a bound needs a measurement to be set from.

**What it showed:** on a SF-1000 arm, `stock` and `order_line` sat at occupancy **128/128 — fully saturated** — while a full channel estimated only **0.281 GiB**. Saturated on count, negligible on size. That distinction is exactly what the count gauge could not make, and it cheaply and permanently rules this path out of memory investigations.

## 2. The byte counter wrapped

An envelope pulled from the channel but deferred past the burst byte cap is stashed in `carried_item` and adopted by the next iteration — so it was discharged **twice**: once at the `try_recv` that took it out, once more when the outer receive picked it up. `u64::fetch_sub` past zero wraps, and the gauge read `1.8e19` for every table with carry-over activity.

Skips the outer discharge for a carried item, and makes every discharge saturating: an observability counter should fail toward the floor, where the error stays proportional to the mistake, rather than to a number that looks nothing like "slightly wrong". A `debug_assert!` keeps the underflow loud in test builds, so saturation cannot quietly hide the next accounting slip.

The gauge is also reset to zero when the stream goes away. It is only ever recorded from inside the apply loop, so without that its last reading outlives the loop — an operator reading a torn-down dataset would see prefetch memory that was already freed. A `Drop` guard does it, because the dominant teardown path is the whole future being dropped mid-`await` on task cancellation, which never reaches a loop exit.

## Verification

Verified live on SF-1000 (`m3_jem_sf1000`), not just compiled:

| | before | after |
|---|---|---|
| `cdc_prefetch_buffer_bytes` | `18446744073507066000` | **46 MB / 132 MB / 498 MiB** |

## Also here

`data_components/src/cdc.rs` carries one unrelated doc paragraph, written alongside the before-image work this branch was stacked on and left behind when that merged separately: `before_batch()`'s contract now says outright that `op` is the only authority on what a row is, because an all-null before-image row means "the source sent no prior values" *or* "every prior value was NULL" and the two are indistinguishable once struct validity has been pushed into the columns. Documentation only, no behavior change; happy to split it out if a reviewer would rather it travelled on its own.

## Context

These instruments were what made #12668 diagnosable: ~84 GiB of RSS outside every declared budget at SF-1000, since attributed to Vortex buffers (50.3 GiB), DataFusion join hash maps (17.2 GiB), and the Cayenne PK keyset (14.5 GiB).

## Changed during review

An earlier revision of this branch also moved `spawn_mem_tier_repartition_sampler`'s first tick one interval out, to keep `query_memory_pool_used_bytes` and `cayenne_compaction_memory_pool_used_bytes` from binding to the noop meter during the ~10 ms window before `init_metrics` installs the Prometheus provider. #12754 has since landed the structural fix for that (#12667): `record_via_cached` withholds the cache until `seal_operator_meter_provider()`, so an early record is exported through whatever provider is current instead of freezing the instrument. That made the delay redundant — and it cost the first dynamic mem-tier repartition a 2 s delay — so it has been dropped and the sampler restored to an immediate first tick.
