### PR TITLE
fix(ci): let only the merge queue pass Attestation without a sign-off (fixes #12679)

### DIFF
--- a/.github/scripts/test_pr_attestation_signoff.mjs
+++ b/.github/scripts/test_pr_attestation_signoff.mjs
@@ -20,6 +20,8 @@ import { fileURLToPath } from 'node:url';
 const WORKFLOW = fileURLToPath(new URL('../workflows/pr.yml', import.meta.url));
 const REJECT_STEP = 'Reject a failed sign-off on the head commit';
 const INSPECT_STEP = 'Inspect developer sign-off';
+const QUEUE_PASSTHROUGH_STEP = 'Merge queue passthrough';
+const DISPATCH_REJECT_STEP = 'Reject an attestation asserted by dispatch';
 
 const HEAD = 'a'.repeat(40);
 const BASE = 'b'.repeat(40);
@@ -73,6 +75,47 @@ function stepLines(jobLines, stepName) {
     }
   }
   return jobLines.slice(start, end);
+}
+
+/** Every step name in the job, in declaration order. */
+function jobStepNames(jobLines) {
+  return jobLines
+    .filter((line) => /^ {6}- name: /.test(line))
+    .map((line) => line.replace(/^ {6}- name: /, '').trimEnd());
+}
+
+/** The trigger names in the workflow's `on:` block. */
+function declaredTriggers(workflow) {
+  const lines = workflow.split('\n');
+  const start = lines.indexOf('on:');
+  assert.notEqual(start, -1, 'pr.yml no longer declares an `on:` block');
+
+  const triggers = [];
+  for (const line of lines.slice(start + 1)) {
+    // A key back at column 0 ends the block.
+    if (/^[A-Za-z_]/.test(line)) break;
+    const match = /^ {2}([a-z_]+):/.exec(line);
+    if (match) triggers.push(match[1]);
+  }
+  assert.ok(triggers.length > 0, 'pr.yml declares no triggers');
+  return triggers;
+}
+
+/**
+ * A step's `if:` expression, with the `${{ }}` wrapper and surrounding space removed.
+ *
+ * The gating is as load-bearing as the script bodies below: a step that runs on the
+ * wrong trigger decides Attestation without inspecting anything (#12679).
+ */
+function stepIf(jobLines, stepName) {
+  const lines = stepLines(jobLines, stepName);
+  const condition = lines.find((line) => /^ *if: /.test(line));
+  assert.notEqual(condition, undefined, `step "${stepName}" has no \`if:\``);
+  return condition
+    .replace(/^ *if: /, '')
+    .trim()
+    .replace(/^\$\{\{\s*/, '')
+    .replace(/\s*\}\}$/, '');
 }
 
 /** The dedented body of a step's `script: |` block. */
@@ -239,6 +282,67 @@ test('the rejection runs before, and independently of, every fast-track', () => 
     /continue-on-error/,
     'the rejection is the gate; it cannot be best-effort'
   );
+});
+
+// --- Which triggers can decide the job (#12679) -----------------------------
+
+// The job has no job-level `if:`, so it runs for every trigger in the `on:` block and
+// every step decides for itself. A step gated on the *absence* of a trigger therefore
+// picks up triggers nobody weighed: `!= 'pull_request'` was written for the merge queue
+// and silently covered `workflow_dispatch` too, so dispatching pr.yml posted a green
+// Attestation — the only gate a PR has — having read no sign-off at all.
+test('every step gates on a named event, never on the absence of one', () => {
+  for (const stepName of jobStepNames(job)) {
+    const condition = stepIf(job, stepName);
+    assert.doesNotMatch(
+      condition,
+      /github\.event_name\s*!=/,
+      `"${stepName}" gates on the absence of a trigger, so a trigger added to \`on:\` ` +
+        'later would take this path without anyone deciding it should'
+    );
+    assert.match(
+      condition,
+      /github\.event_name\s*==\s*'[a-z_]+'/,
+      `"${stepName}" does not gate on a named event`
+    );
+  }
+});
+
+// The passthrough asserts the sign-off was already validated. That is true of the merge
+// queue, because entry into it is itself gated on a green Attestation, and it is true of
+// nothing else.
+test('the queue passthrough is reachable only from the merge queue', () => {
+  assert.equal(stepIf(job, QUEUE_PASSTHROUGH_STEP), "github.event_name == 'merge_group'");
+});
+
+test('a dispatch is rejected rather than passed through', () => {
+  assert.equal(stepIf(job, DISPATCH_REJECT_STEP), "github.event_name == 'workflow_dispatch'");
+
+  const declaration = stepLines(job, DISPATCH_REJECT_STEP).join('\n');
+  assert.match(
+    declaration,
+    /exit 1/,
+    `"${DISPATCH_REJECT_STEP}" must fail the job; a message alone still leaves it green`
+  );
+  assert.doesNotMatch(
+    declaration,
+    /continue-on-error/,
+    'a rejection that cannot fail the job is not a rejection'
+  );
+});
+
+// The bug was not that `workflow_dispatch` was handled wrongly — it was that nothing
+// handled it, so it inherited a path meant for something else. Any trigger added to
+// `on:` without its own verdict lands in exactly that position again.
+test('every declared trigger has a step that decides the job', () => {
+  const conditions = jobStepNames(job).map((stepName) => stepIf(job, stepName));
+  for (const trigger of declaredTriggers(workflow)) {
+    assert.ok(
+      conditions.some((condition) => condition.includes(`github.event_name == '${trigger}'`)),
+      `pr.yml runs on "${trigger}" but no attestation step gates on it, so the job ` +
+        'reports success for that trigger without reaching a verdict'
+    );
+  }
 });
 
 // --- Inheritance still works (regression guards) ----------------------------

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -592,9 +592,30 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && steps.revert.outputs.fast_track == 'true' }}
         run: echo "Pure revert fast-tracked past sign-off; the full suite runs on the merged result in the merge queue."
 
+      # Named rather than negated. Entry into the queue is itself gated on a green
+      # Attestation, so by the time a merge_group run exists the sign-off has already
+      # been validated — that precondition is what makes passing here sound. Any other
+      # non-pull_request trigger reaching this step would be borrowing an assumption it
+      # does not satisfy.
       - name: Merge queue passthrough
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name == 'merge_group' }}
         run: echo "Sign-off was validated at queue entry; the full suite runs in this merge_group run."
+
+      # A dispatch carries no pull_request payload, so every inspection above is
+      # unreachable: there is no head SHA to read a `signoff` status for, no base to
+      # walk the first-parent chain from, and no author or commit list for the
+      # fast-tracks. It has no queue-entry precondition either, so the passthrough
+      # above must not cover it. Since Attestation is the only gate a pull request has,
+      # a green one minted here would satisfy that gate having verified nothing, which
+      # makes failing the only honest verdict.
+      #
+      # This does not cost the dispatch its purpose: the heavy jobs below gate on
+      # `check_changes`, not on this job, so they still run.
+      - name: Reject an attestation asserted by dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "::error title=Attestation cannot be established by dispatch::A workflow_dispatch of pr.yml has no pull request payload, so no sign-off can be read and no verdict asserted. Dispatch this workflow only to run the heavy jobs. To report Attestation on a pull request whose checks are absent, re-run the pull_request-triggered 'pr' run for that head commit, or push to the branch so the pull_request event fires again."
+          exit 1
 
   # The jobs below run ONLY in the merge queue (merge_group) and on manual
   # dispatch — never on a pull request. They stay required, so the full suite

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -468,6 +468,14 @@ merge queue is still the real gate.
 | Remote | `make signoff-remote` | the same checks via the self-hosted `signoff.yml` workflow, without the targeted pre-checks (`run_targeted_prechecks=true` restores them); posts `signoff` |
 | Pull request | `pull_request` | **Attestation** (validates the sign-off, or auto-passes a branch with no Rust-affecting files, a pure revert, or a single-commit Dependabot bump) + PR hygiene; merge-queue check names report lightweight skipped/passthrough results |
 | Merge queue | `merge_group` | the full required suite (below) + advisory niche checks |
+| Manual dispatch of `pr.yml` | `workflow_dispatch` | the heavy jobs, and **`Attestation` fails on purpose** — a dispatch carries no pull request payload, so there is no sign-off to read and no verdict it can honestly reach |
+
+`Attestation` failing on a dispatch is deliberate: it is the only gate a pull
+request has, so a green one that inspected nothing would satisfy that gate
+outright. Do not dispatch `pr.yml` to report a missing `Attestation` on a PR —
+it cannot, and the failure it posts lands on that head commit. Push to the
+branch, or re-run the `pull_request`-triggered `pr` run, so the event fires with
+its payload. To re-run the *sign-off* itself, dispatch `signoff.yml` instead.
 
 Required checks in the merge queue (the `trunk` ruleset):
 


### PR DESCRIPTION
## Summary

`pr.yml`'s `attestation` job has no job-level `if:`, so it runs for every trigger in the `on:` block and each step decides for itself. Every step that inspects anything gates on `pull_request`. The only other path was:

```yaml
- name: Merge queue passthrough
  if: ${{ github.event_name != 'pull_request' }}
  run: echo "Sign-off was validated at queue entry; ..."
```

which succeeds unconditionally. That negation is sound for `merge_group` — entry into the queue is itself gated on a green `Attestation`, so the sign-off really was validated. It also covered `workflow_dispatch`, which has no such precondition.

`Attestation` is a required check on the `trunk` ruleset and the only quality gate a pull request has since #11776. So **a manual dispatch of `pr.yml` against a PR branch posted a green, required `Attestation` on that head commit without reading any sign-off** — the gate satisfied having verified nothing. Reachable in practice, not theoretical: dispatching a workflow is the usual remedy when a push did not trigger runs, which is exactly the state a number of PRs were in during the 2026-08-06 Actions incident.

Fixes #12679

## Changes

**`pr.yml`** — the passthrough now names `merge_group` rather than negating `pull_request`, so no other trigger can borrow the queue's assumption. A dispatch gets its own verdict: it carries no pull request payload, so there is no head SHA to read a `signoff` status for, no base to walk the first-parent chain from, and no author or commit list for the fast-tracks. Failing is the only honest answer, and the error names what to do instead. This costs the dispatch nothing it was for — the heavy jobs gate on `check_changes`, not on this job, so they still run.

**`test_pr_attestation_signoff.mjs`** — the existing harness lifts the job's `script:` blocks out of the workflow and runs them; it had no coverage of the *gating*, which is what broke. Four tests added, plus `stepIf` / `jobStepNames` / `declaredTriggers` helpers:

- every step gates on a named event, never on the absence of one
- the queue passthrough is reachable only from `merge_group`
- a dispatch is rejected, and the rejection actually fails the job
- **every trigger declared in `on:` has a step that decides the job** — the general guard. The bug was not that `workflow_dispatch` was handled wrongly, it was that nothing handled it, so it inherited a path meant for something else. A trigger added to `on:` later lands in exactly that position again, and this test is what catches it.

**`docs/dev/ci_signoff.md`** — a `workflow_dispatch` row in "What runs where", and an explicit note not to dispatch `pr.yml` to fix a missing `Attestation`, since that is the mistake the old behavior silently rewarded.

### Trade-off worth flagging

Failing closed means a dispatch now posts a **red** `Attestation` on that head commit, which will replace a legitimately green one if the PR already had it. That is the safe direction of error — it blocks rather than admits — and it is recoverable by pushing or re-running the `pull_request` run, which the error message says. The alternative of skipping the job on dispatch was rejected: a skipped required check can count as success, which would leave the false-green intact.

I did not take the issue's other suggested option (resolve the head SHA from the ref and run the real inspection on dispatch). It means reimplementing the whole `pull_request` path against a different payload shape, in the one job that decides whether anything may merge; the value is a convenience the docs now direct elsewhere.

## Test plan

Non-Rust branch — no Rust-affecting files, so no sign-off applies.

Ran locally:

- `python .github/scripts/check_workflow_yaml.py` — `OK: 108 GitHub Actions definitions are well-formed`
- `python .github/scripts/test_check_workflow_yaml.py` — 42 tests, `OK`

`node .github/scripts/test_pr_attestation_signoff.mjs` runs in **Attestation Script Tests**, which triggers on `pr.yml` changes. There is no Node on the machine this was written on, so I mirrored the four new assertions in Python against both revisions to confirm they are real regression tests rather than tautologies:

- this branch — 4/4 pass
- `trunk` — 0/4 pass, each for the right reason (`'Merge queue passthrough' gates on absence: github.event_name != 'pull_request'`; the dispatch step absent; `trigger 'merge_group' has no deciding step`)

## Checklist

- [x] The passthrough is reachable only from `merge_group`
- [x] A dispatch fails rather than passing, and the message says what to do instead
- [x] The heavy jobs still run on a dispatch (they gate on `check_changes`, not on `attestation`)
- [x] The `pull_request` path is untouched — its existing tests still pass unchanged
- [x] Sibling `!= 'pull_request'` conditions swept; the heavy jobs genuinely mean "queue or dispatch"
- [x] Regression tests fail on `trunk` and pass here
