### PR TITLE
fix(ci): refuse to attest a run that is neither a pull request nor a queue entry (fixes #12679)

### DIFF
--- a/.github/scripts/test_pr_attestation_signoff.mjs
+++ b/.github/scripts/test_pr_attestation_signoff.mjs
@@ -385,6 +385,29 @@ const admittedSteps = (eventName) =>
 /** Whether a step fails the job rather than reporting success. */
 const stepFails = (stepName) => /(^|\n)\s*exit 1\s*(\n|$)/.test(stepLines(job, stepName).join('\n'));
 
+/**
+ * Whether a step admitted for `eventName` is certain to run, rather than merely
+ * able to.
+ *
+ * `admitsEvent` treats a `steps.*.outputs.*` term as possibly true, so an
+ * admitted step is only *maybe* reached. That over-approximation is the wrong
+ * direction for asserting that a trigger hits a step which fails the job: a
+ * refusal gated on some earlier step's output would satisfy the assertion while
+ * a real run skipped it and reported success. Requiring the condition to rest on
+ * `github.event_name` alone closes that gap.
+ */
+function certainlyRuns(stepName, eventName) {
+  const condition = stepCondition(job, stepName);
+  if (!admitsEvent(condition, eventName)) {
+    return false;
+  }
+  if (condition === null) {
+    return true;
+  }
+  const residue = condition.replace(/github\.event_name\s*(?:==|!=)\s*'[^']*'/g, '');
+  return !/steps\.|needs\.|inputs\.|github\./.test(residue);
+}
+
 test('the merge queue passthrough names merge_group instead of negating pull_request', () => {
   const condition = stepCondition(job, PASSTHROUGH_STEP);
   assert.match(
@@ -436,9 +459,9 @@ test('no other trigger can reach a green Attestation', () => {
       `a ${event} run reaches no step at all, so Attestation reports success for free`
     );
     assert.ok(
-      admitted.some((step) => stepFails(step)),
-      `a ${event} run reaches only [${admitted.join(', ')}], none of which fails the job, so ` +
-        `it posts a green required Attestation without inspecting any sign-off`
+      admitted.some((step) => stepFails(step) && certainlyRuns(step, event)),
+      `a ${event} run reaches only [${admitted.join(', ')}], none of which is certain to fail ` +
+        `the job, so it posts a green required Attestation without inspecting any sign-off`
     );
   }
 });

--- a/.github/scripts/test_pr_attestation_signoff.mjs
+++ b/.github/scripts/test_pr_attestation_signoff.mjs
@@ -300,6 +300,149 @@ test('an unsigned non-merge commit cannot inherit', async () => {
   assert.match(result.failed[0], /not a two-parent merge/);
 });
 
+// --- Which triggers can reach a green Attestation (#12679) ------------------
+//
+// Attestation is the only required quality gate on a PR, so a trigger that
+// reaches the end of this job without inspecting a sign-off mints that gate for
+// free. The steps above are gated on `pull_request`; the checks below assert
+// that every *other* trigger declared in `on:` is either the merge queue — whose
+// entry was itself gated on a green Attestation — or refused outright.
+
+const PASSTHROUGH_STEP = 'Merge queue passthrough';
+
+/** The event names declared in the workflow's `on:` block. */
+function triggers(workflow) {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex((line) => /^on:\s*$/.test(line));
+  assert.notEqual(start, -1, 'pr.yml no longer declares an `on:` block');
+
+  const names = [];
+  for (const line of lines.slice(start + 1)) {
+    // A key at column 0 ends the block.
+    if (/^[A-Za-z_]/.test(line)) {
+      break;
+    }
+    const match = /^ {2}([A-Za-z_][A-Za-z0-9_]*):/.exec(line);
+    if (match) {
+      names.push(match[1]);
+    }
+  }
+  assert.ok(names.length > 0, 'could not read any trigger out of the `on:` block');
+  return names;
+}
+
+/** A step's `if:` expression, or null when it is unconditional. */
+function stepCondition(jobLines, stepName) {
+  const line = stepLines(jobLines, stepName).find((candidate) => /^ {8}if: /.test(candidate));
+  return line === undefined ? null : line.replace(/^ {8}if: /, '').trim();
+}
+
+/** Every step name declared in the job, in order. */
+function stepNames(jobLines) {
+  return jobLines
+    .filter((line) => /^ {6}- name: /.test(line))
+    .map((line) => line.replace(/^ {6}- name: /, '').trim());
+}
+
+/**
+ * Whether a step's condition can hold for `eventName`.
+ *
+ * Only the `github.event_name` comparisons are modelled; every other term (a
+ * `steps.*.outputs.*` fast-track flag) is treated as possibly true, which is
+ * what makes this an over-approximation of what runs — the safe direction for
+ * asking "could this trigger reach a step that reports success?".
+ *
+ * The conditions in this job are pure conjunctions. A `||` would make that
+ * reading wrong, so it is rejected rather than guessed at.
+ */
+function admitsEvent(condition, eventName) {
+  if (condition === null) {
+    return true;
+  }
+  assert.doesNotMatch(
+    condition,
+    /\|\|/,
+    `this check cannot model the disjunction in \`${condition}\`; teach it the new shape`
+  );
+
+  for (const [, operator, value] of condition.matchAll(
+    /github\.event_name\s*(==|!=)\s*'([^']*)'/g
+  )) {
+    if (operator === '==' && value !== eventName) {
+      return false;
+    }
+    if (operator === '!=' && value === eventName) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** The steps that could run for `eventName`. */
+const admittedSteps = (eventName) =>
+  stepNames(job).filter((name) => admitsEvent(stepCondition(job, name), eventName));
+
+/** Whether a step fails the job rather than reporting success. */
+const stepFails = (stepName) => /(^|\n)\s*exit 1\s*(\n|$)/.test(stepLines(job, stepName).join('\n'));
+
+test('the merge queue passthrough names merge_group instead of negating pull_request', () => {
+  const condition = stepCondition(job, PASSTHROUGH_STEP);
+  assert.match(
+    condition,
+    /github\.event_name\s*==\s*'merge_group'/,
+    `"${PASSTHROUGH_STEP}" must name merge_group explicitly; its premise is that queue ` +
+      `entry already validated the sign-off, which no other trigger provides`
+  );
+  assert.doesNotMatch(
+    condition,
+    /github\.event_name\s*!=\s*'pull_request'/,
+    `"${PASSTHROUGH_STEP}" must not admit a trigger by negating pull_request`
+  );
+});
+
+test('a pull request still reaches the sign-off inspection', () => {
+  const admitted = admittedSteps('pull_request');
+  for (const step of [REJECT_STEP, INSPECT_STEP]) {
+    assert.ok(admitted.includes(step), `a pull_request must still reach "${step}"`);
+  }
+  assert.ok(
+    !admitted.includes(PASSTHROUGH_STEP),
+    `a pull_request must not reach "${PASSTHROUGH_STEP}"`
+  );
+});
+
+test('the merge queue passes through without inspecting a sign-off', () => {
+  const admitted = admittedSteps('merge_group');
+  assert.deepEqual(
+    admitted,
+    [PASSTHROUGH_STEP],
+    'a merge_group run must reach the passthrough and nothing else'
+  );
+});
+
+// The regression guard. On a workflow_dispatch every inspecting step is gated
+// out, so if the only step left standing reports success, the dispatch posts a
+// green required Attestation having verified nothing.
+test('no other trigger can reach a green Attestation', () => {
+  const others = triggers(workflow).filter(
+    (event) => event !== 'pull_request' && event !== 'merge_group'
+  );
+  assert.ok(others.length > 0, 'expected pr.yml to declare a trigger beyond pull_request/merge_group');
+
+  for (const event of others) {
+    const admitted = admittedSteps(event);
+    assert.ok(
+      admitted.length > 0,
+      `a ${event} run reaches no step at all, so Attestation reports success for free`
+    );
+    assert.ok(
+      admitted.some((step) => stepFails(step)),
+      `a ${event} run reaches only [${admitted.join(', ')}], none of which fails the job, so ` +
+        `it posts a green required Attestation without inspecting any sign-off`
+    );
+  }
+});
+
 let failures = 0;
 for (const { name, body } of tests) {
   try {

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -592,9 +592,31 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && steps.revert.outputs.fast_track == 'true' }}
         run: echo "Pure revert fast-tracked past sign-off; the full suite runs on the merged result in the merge queue."
 
+      # `merge_group` is named explicitly rather than negating `pull_request`,
+      # because the passthrough rests on a precondition only the queue has:
+      # entry into it is itself gated on a green Attestation, so the sign-off
+      # was already validated for this tree. No other trigger carries that
+      # precondition. See #12679.
       - name: Merge queue passthrough
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name == 'merge_group' }}
         run: echo "Sign-off was validated at queue entry; the full suite runs in this merge_group run."
+
+      # Every other trigger fails closed. Dispatching this workflow by hand is a
+      # legitimate way to run the heavy jobs below, but it establishes nothing
+      # about a sign-off: there is no pull_request payload to read a head SHA
+      # from, so no step above can inspect one, and nothing gates the dispatch
+      # the way queue entry gates a merge_group run. Since Attestation is a
+      # required check, letting a dispatch report success would post the one
+      # green check a PR needs onto a head commit nobody signed off — so this
+      # job must refuse rather than pass. A new trigger added to `on:` lands
+      # here too, and has to decide its own semantics before it can be attested.
+      - name: Refuse to attest a run that is neither a pull request nor a merge queue entry
+        if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          echo "::error::Attestation cannot be established by a ${EVENT_NAME} run: there is no pull request to read a head commit from, and no queue-entry gate behind it. Push to the pull request and run make signoff on the pushed HEAD; see docs/dev/ci_signoff.md."
+          exit 1
 
   # The jobs below run ONLY in the merge queue (merge_group) and on manual
   # dispatch — never on a pull request. They stay required, so the full suite

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -615,7 +615,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          echo "::error::Attestation cannot be established by a ${EVENT_NAME} run: there is no pull request to read a head commit from, and no queue-entry gate behind it. Push to the pull request and run make signoff on the pushed HEAD; see docs/dev/ci_signoff.md."
+          echo "::error::Attestation cannot be established by a ${EVENT_NAME} run: there is no pull request to read a head commit from, and no queue-entry gate behind it. The heavy jobs in this run still report their own results. To get a real verdict on a pull request, run make signoff on the pushed HEAD and re-run the Attestation check on the pull_request run; see docs/dev/ci_signoff.md."
           exit 1
 
   # The jobs below run ONLY in the merge queue (merge_group) and on manual


### PR DESCRIPTION
Fixes #12679

## Summary

The `attestation` job in `.github/workflows/pr.yml` gates every verifying step on
`github.event_name == 'pull_request'`, and its only other path is a passthrough gated on
`github.event_name != 'pull_request'` that succeeds unconditionally. That reasoning is right for
`merge_group` — entry into the queue is itself gated on a green `Attestation`, so the sign-off was
already validated for that tree — but `workflow_dispatch` takes the same path. `Attestation` is a
required check and the only quality gate on a PR, so dispatching `pr.yml` against a PR branch posts
the one green check that PR needs onto a head commit nobody signed off.

The condition `!= 'pull_request'` conflates "not a pull request" with "already verified".

### This is not theoretical

Dispatching `pr.yml` is what people reach for when a push did not start CI, which is exactly the
state a number of PRs were left in by the 2026-08-06 Actions incident. Confirmed on real runs:

- A `workflow_dispatch` run of `pr.yml` shows all eleven verifying steps `skipped` and only
  `Merge queue passthrough` `success`, so the job reports `success`
  ([run 30952600523](https://github.com/spiceai/spiceai/actions/runs/30952600523)).
- Three such dispatches landed during the incident recovery and each minted a green `Attestation`
  check-run on a PR head. Two of those PR heads carry no `signoff` status at all, so their required
  gate is currently green having inspected nothing.

## Changes

- **Name `merge_group` explicitly** in the passthrough instead of negating `pull_request`, so the
  queue-entry premise cannot be inherited by a trigger that does not have it.
- **Fail closed for every other trigger.** A new step refuses to attest a run that is neither a
  pull request nor a merge queue entry. A trigger added to `on:` later lands here too and has to
  decide its own semantics before it can be attested.
- **Regression test** in `.github/scripts/test_pr_attestation_signoff.mjs`, which already lifts this
  job's steps out of the workflow. It reads the `on:` block, models which steps each trigger can
  reach, and asserts that no trigger outside `pull_request`/`merge_group` reaches a step that
  reports success.

### Behaviour change worth knowing

A manual dispatch now reports a red `Attestation` rather than a green one. The heavy jobs in that
run still report their own results, and the error says how to get a real verdict. If a PR already
had a legitimate green `Attestation`, a later dispatch replaces it with a red one — recoverable by
re-running `Attestation` on the `pull_request` run. Failing closed is the deliberate trade: a check
that says "verified" without verifying is worse than one that says "cannot verify here".

Making a dispatch skip the job instead was considered and rejected — a skipped job counts as
success for a required check, which is the same defect.

### Scope note

The other `!= 'pull_request'` conditions in this file (`check_changes`, `Rust Lint`,
`Build and Test`, `Build (release profile)`) were swept and left alone: they gate whether heavy jobs
*run*, and running them on a manual dispatch is the point of the dispatch. Only the attestation
passthrough turned "not a pull request" into a verdict.

## Test plan

- `node .github/scripts/test_pr_attestation_signoff.mjs` — **16/16 pass** (12 pre-existing, 4 new).
  This is the suite CI runs for this file, via `.github/workflows/attestation_script_test.yml`.
- `python .github/scripts/check_workflow_yaml.py` — OK, 108 definitions well-formed.
- `python .github/scripts/test_check_workflow_yaml.py` — 42 tests, OK.
- **Neuter matrix, 7/7 caught.** Each direction of wrongness was injected and the suite re-run:
  reverting to the pre-fix state; negating `pull_request` again in the passthrough; deleting the
  refusal step; making the refusal report success; letting the refusal swallow `merge_group`;
  gating the sign-off inspection away from `pull_request`; and adding a `||` the condition model
  cannot represent. Every one is caught by a named assertion, and the matrix was re-run after the
  test was strengthened.
- `make lint` / `make nextest` are **not** applicable to this branch and were not run: it changes
  only `.github/**`, which matches no path in `RUST_AFFECTING_PATH_PATTERN` (`scripts/signoff`), so
  the Rust gate is a no-op and the branch takes the no-Rust fast-track.

## Checklist

- [x] Regression test fails on the old code and passes on the new
- [x] Workflow YAML validates against the repo's own linter
- [x] No Rust-affecting paths touched
- [x] `Attestation` green on this PR (no-Rust fast-track; the run was created and the check passed)

