### PR TITLE
fix(ci): give each E2E model job its own spiced ports (fixes #12419)

### DIFF
--- a/.github/actions/allocate-spice-ports/action.yml
+++ b/.github/actions/allocate-spice-ports/action.yml
@@ -1,0 +1,12 @@
+name: 'Allocate Spice runtime ports'
+description: |
+  Derives an HTTP and a Flight port for this job's Spice runtime and exports
+  them as SPICE_HTTP_PORT / SPICE_FLIGHT_PORT / SPICE_HTTP_ENDPOINT /
+  SPICE_FLIGHT_ENDPOINT, so jobs sharing a self-hosted host cannot collide on
+  spiced's defaults 8090 and 50051 (#12419).
+runs:
+  using: 'composite'
+  steps:
+    - name: Allocate Spice runtime ports
+      shell: bash
+      run: bash "${GITHUB_ACTION_PATH}/allocate_ports.sh"

--- a/.github/actions/allocate-spice-ports/allocate_ports.sh
+++ b/.github/actions/allocate-spice-ports/allocate_ports.sh
@@ -80,25 +80,28 @@ if [ -z "${hash_value}" ]; then
 fi
 
 offset=$((hash_value % SPAN))
-http_port=$((HTTP_BASE + offset))
 
 # Walk both ports together so the pair keeps a constant distance; that way one
 # number in a log identifies the other, and neither walks into the other's
-# window.
+# window. The step wraps within SPAN rather than running past it, so a seed that
+# lands near the top of the window cannot walk out of the range this script
+# promises — and into the ephemeral range it was chosen to avoid.
 probe=0
-while [ "${probe}" -lt "${MAX_PROBE}" ]; do
+while :; do
+  http_port=$((HTTP_BASE + (offset + probe) % SPAN))
   flight_port=$((http_port + FLIGHT_OFFSET))
 
   if ! port_in_use "${http_port}" && ! port_in_use "${flight_port}"; then
     break
   fi
 
-  echo "Port ${http_port}/${flight_port} is already held on this host; trying the next pair."
-  http_port=$((http_port + 1))
   probe=$((probe + 1))
-done
+  if [ "${probe}" -ge "${MAX_PROBE}" ]; then
+    break
+  fi
 
-flight_port=$((http_port + FLIGHT_OFFSET))
+  echo "Port ${http_port}/${flight_port} is already held on this host; trying the next pair."
+done
 
 if [ "${probe}" -ge "${MAX_PROBE}" ]; then
   # Report rather than fail: spiced will refuse to bind and say so, and the

--- a/.github/actions/allocate-spice-ports/allocate_ports.sh
+++ b/.github/actions/allocate-spice-ports/allocate_ports.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Pick the HTTP and Flight ports this job's Spice runtime should bind, and
+# export them for every later step.
+#
+# Why a job needs its own ports at all: the self-hosted pools run several runner
+# instances per physical host (`/opt/github-runner-01`, `-02`, `-03`, … on one
+# machine), and those instances share a network namespace. Every `spice run`
+# binds spiced's defaults, 127.0.0.1:8090 and 127.0.0.1:50051, so two jobs that
+# overlap on one host cannot both bind. The second exits, and the readiness poll
+# then waits out its whole timeout with nothing to show for it. Worse, if the
+# process already holding 8090 is a *ready* runtime from the other job, the poll
+# succeeds and the tests run against a spicepod they did not load. See #12419.
+#
+# The port is derived from the runner instance rather than from the run or the
+# job, because the runner instance is the unit that shares the host: one
+# instance runs one job at a time, so distinct instances holding distinct ports
+# is exactly the property that makes the collision impossible. Run and job are
+# folded in as well so that a port leaked by an earlier job on this same
+# instance is unlikely to be the one we ask for next.
+#
+# Outputs, written to $GITHUB_ENV:
+#   SPICE_HTTP_PORT       e.g. 21734
+#   SPICE_FLIGHT_PORT     e.g. 26734
+#   SPICE_HTTP_ENDPOINT   e.g. http://127.0.0.1:21734
+#   SPICE_FLIGHT_ENDPOINT e.g. 127.0.0.1:26734   (bare host:port — `spiced --flight` takes no scheme)
+
+set -uo pipefail
+
+# Both windows sit below the ephemeral range on every runner OS — Linux
+# allocates from 32768 and macOS from 49152 — so a port picked here cannot be
+# taken from under us by an unrelated outbound connection. They are also far
+# from spiced's own defaults, which keeps a stray 8090 in a log unambiguous:
+# that is a step that has not been given the job's port.
+HTTP_BASE="${SPICE_PORT_HTTP_BASE:-20000}"
+FLIGHT_OFFSET="${SPICE_PORT_FLIGHT_OFFSET:-5000}"
+SPAN="${SPICE_PORT_SPAN:-4000}"
+# How far to walk forward when the derived port is already held. Small on
+# purpose: a busy derived port means a leak or a hash collision, and walking a
+# long way would only hide it.
+MAX_PROBE="${SPICE_PORT_MAX_PROBE:-25}"
+
+# Seed. RUNNER_NAME is the one that matters — it identifies the runner instance,
+# and therefore the collision domain. The others only spread repeat jobs on one
+# instance apart. All are optional so the script is runnable outside Actions.
+seed_source="${RUNNER_NAME:-}|${GITHUB_RUN_ID:-}|${GITHUB_JOB:-}|${GITHUB_RUN_ATTEMPT:-}"
+
+# `cksum` rather than a shell hash or `md5`: it is POSIX, present on both runner
+# families, and its first field is already a decimal integer.
+seed_hash() {
+  printf '%s' "$1" | cksum | awk '{print $1}'
+}
+
+# True when something is already listening on the port. Tries each tool the
+# runners might have and, if none is present, answers "not in use" — a probe we
+# cannot run must not block the job, and binding is still checked for real by
+# spiced a moment later.
+port_in_use() {
+  local port="$1"
+
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  fi
+
+  if command -v netstat >/dev/null 2>&1; then
+    # `.port` is the macOS/BSD separator, `:port` the Linux one.
+    netstat -an 2>/dev/null | grep -E "[.:]${port}[[:space:]]+.*LISTEN" >/dev/null 2>&1
+    return $?
+  fi
+
+  return 1
+}
+
+hash_value="$(seed_hash "${seed_source}")"
+if [ -z "${hash_value}" ]; then
+  # cksum is missing or produced nothing. $$ is unique among live processes on
+  # the host, which is the same property the seed was after.
+  hash_value=$$
+fi
+
+offset=$((hash_value % SPAN))
+http_port=$((HTTP_BASE + offset))
+
+# Walk both ports together so the pair keeps a constant distance; that way one
+# number in a log identifies the other, and neither walks into the other's
+# window.
+probe=0
+while [ "${probe}" -lt "${MAX_PROBE}" ]; do
+  flight_port=$((http_port + FLIGHT_OFFSET))
+
+  if ! port_in_use "${http_port}" && ! port_in_use "${flight_port}"; then
+    break
+  fi
+
+  echo "Port ${http_port}/${flight_port} is already held on this host; trying the next pair."
+  http_port=$((http_port + 1))
+  probe=$((probe + 1))
+done
+
+flight_port=$((http_port + FLIGHT_OFFSET))
+
+if [ "${probe}" -ge "${MAX_PROBE}" ]; then
+  # Report rather than fail: spiced will refuse to bind and say so, and the
+  # readiness wait turns that into a named failure. Failing here instead would
+  # replace a specific diagnosis with a vaguer one.
+  echo "::warning::Could not find a free port pair within ${MAX_PROBE} tries of ${HTTP_BASE}+${offset}; using ${http_port}/${flight_port} anyway."
+fi
+
+http_endpoint="http://127.0.0.1:${http_port}"
+# No scheme: `spice run --flight-endpoint` hands this to `spiced --flight`
+# verbatim, and that flag takes a bind address.
+flight_endpoint="127.0.0.1:${flight_port}"
+
+echo "Spice runtime ports for this job: HTTP ${http_port}, Flight ${flight_port} (runner '${RUNNER_NAME:-unknown}')."
+
+assignments="SPICE_HTTP_PORT=${http_port}
+SPICE_FLIGHT_PORT=${flight_port}
+SPICE_HTTP_ENDPOINT=${http_endpoint}
+SPICE_FLIGHT_ENDPOINT=${flight_endpoint}"
+
+# Always logged: whoever reads a failed job needs the port to make sense of the
+# readiness poll and of stop-spice's report. Outside Actions this is also the
+# only output, so the script stays runnable by hand.
+printf '%s\n' "${assignments}"
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  printf '%s\n' "${assignments}" >>"${GITHUB_ENV}"
+fi

--- a/.github/actions/stop-spice/action.yml
+++ b/.github/actions/stop-spice/action.yml
@@ -10,9 +10,12 @@ inputs:
     required: false
     default: '.'
   ports:
-    description: 'Space-separated TCP ports to wait for release'
+    description: |
+      Space-separated TCP ports to wait for release. Empty lets the script use
+      the ports this job allocated (SPICE_HTTP_PORT / SPICE_FLIGHT_PORT), and
+      spiced's defaults when it allocated none.
     required: false
-    default: '8090 50051'
+    default: ''
   print-log:
     description: 'Print spice.log after stopping'
     required: false

--- a/.github/actions/stop-spice/stop_spice.sh
+++ b/.github/actions/stop-spice/stop_spice.sh
@@ -35,7 +35,13 @@ set -uo pipefail
 
 # Ports `spiced` binds (HTTP, Flight). Left unquoted where used so the
 # space-separated value splits into words.
-SPICE_STOP_PORTS="${SPICE_STOP_PORTS:-8090 50051}"
+#
+# A job that allocated its own ports exports them (see
+# .github/actions/allocate-spice-ports, #12419); check those rather than the
+# defaults, or this reports on ports belonging to a *different* runner
+# instance's job — noise that reads as a leak — while never confirming ours
+# came free. Jobs that did not allocate keep spiced's defaults.
+SPICE_STOP_PORTS="${SPICE_STOP_PORTS:-${SPICE_HTTP_PORT:-8090} ${SPICE_FLIGHT_PORT:-50051}}"
 
 # Seconds to wait for a graceful exit before escalating to SIGKILL, and then for
 # the ports to clear. Kept short: this runs in cleanup on every job.

--- a/.github/workflows/e2e_lifecycle_scripts_test.yml
+++ b/.github/workflows/e2e_lifecycle_scripts_test.yml
@@ -15,17 +15,23 @@ on:
       - release/*
       - feature-*
     paths:
+      - '.github/actions/allocate-spice-ports/**'
       - '.github/actions/stop-spice/**'
       - '.github/actions/wait-for-spice-ready/**'
       - 'scripts/test_e2e_spice_lifecycle.sh'
+      - 'scripts/test_e2e_spice_ports.sh'
+      - 'test/models/**'
       - '.github/workflows/e2e_lifecycle_scripts_test.yml'
   push:
     branches:
       - trunk
     paths:
+      - '.github/actions/allocate-spice-ports/**'
       - '.github/actions/stop-spice/**'
       - '.github/actions/wait-for-spice-ready/**'
       - 'scripts/test_e2e_spice_lifecycle.sh'
+      - 'scripts/test_e2e_spice_ports.sh'
+      - 'test/models/**'
       - '.github/workflows/e2e_lifecycle_scripts_test.yml'
   workflow_dispatch:
 
@@ -62,3 +68,28 @@ jobs:
         # Invoked through `bash` so the job does not depend on the script's
         # executable bit surviving a checkout on every platform.
         run: bash scripts/test_e2e_spice_lifecycle.sh
+
+      - name: Run port allocation tests
+        run: bash scripts/test_e2e_spice_ports.sh
+
+      # The REPL scripts and their tests only ran inside the model E2E jobs,
+      # which are skipped on pull requests — so a change to them reached the
+      # merge queue unexercised. They need nothing but `expect`, so they can run
+      # here on every PR that touches them instead.
+      - name: Install expect (linux)
+        if: matrix.os == 'linux-x64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y expect
+
+      - name: Install expect (macOS)
+        if: matrix.os == 'macos-arm64'
+        run: |
+          if command -v expect >/dev/null 2>&1; then
+            expect -v
+          else
+            HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install expect
+          fi
+
+      - name: Run REPL script tests
+        run: bash test/models/expect_test.sh

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -267,16 +267,23 @@ jobs:
           cp ./test/models/spicepod_openai.yml ./spicepod.yaml
           cat ./spicepod.yaml
 
+      # This job runs on the self-hosted pool, where several runner instances
+      # share one host and therefore one network namespace, so spiced's default
+      # 8090/50051 cannot be assumed free (#12419).
+      - name: Allocate Spice runtime ports
+        uses: ./.github/actions/allocate-spice-ports
+
       - name: Start spice runtime
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICE_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
         run: |
-          spice run &> spice.log &
+          spice run --http-endpoint "${SPICE_HTTP_ENDPOINT}" --flight-endpoint "${SPICE_FLIGHT_ENDPOINT}" &> spice.log &
 
       - name: Wait for Spice runtime is ready
         uses: ./.github/actions/wait-for-spice-ready
         with:
+          url: ${{ env.SPICE_HTTP_ENDPOINT }}/v1/ready
           timeout: '60'
 
       - name: Install expect (linux)
@@ -463,16 +470,21 @@ jobs:
 
           exit "${rc}"
 
+      # Same shared-host constraint as the OpenAI model job above (#12419).
+      - name: Allocate Spice runtime ports
+        uses: ./.github/actions/allocate-spice-ports
+
       - name: Start spice runtime
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPICE_OPENAI_API_KEY: ${{ secrets.SPICE_SECRET_OPENAI_API_KEY }}
         run: |
-          spice run &> spice.log &
+          spice run --http-endpoint "${SPICE_HTTP_ENDPOINT}" --flight-endpoint "${SPICE_FLIGHT_ENDPOINT}" &> spice.log &
 
       - name: Wait for Spice runtime is ready
         uses: ./.github/actions/wait-for-spice-ready
         with:
+          url: ${{ env.SPICE_HTTP_ENDPOINT }}/v1/ready
           timeout: '300'
 
       - name: Install expect (linux)

--- a/scripts/test_e2e_spice_ports.sh
+++ b/scripts/test_e2e_spice_ports.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# Tests for .github/actions/allocate-spice-ports/allocate_ports.sh — the script
+# that gives each E2E job its own spiced ports so jobs sharing a self-hosted
+# host cannot collide on 8090/50051 (#12419).
+#
+# What matters here is not the specific number it picks but the properties the
+# collision fix rests on: two runner instances must not be handed the same pair,
+# the same instance must be handed the same pair every time, the pair must stay
+# clear of the OS ephemeral range, and a port that is already held must be
+# stepped over rather than handed out.
+#
+#   bash scripts/test_e2e_spice_ports.sh
+
+set -uo pipefail
+
+repo_root=$(cd -- "$(dirname -- "$0")/.." && pwd)
+script="$repo_root/.github/actions/allocate-spice-ports/allocate_ports.sh"
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+failures=0
+
+pass() {
+  printf '  ok    %s\n' "$1"
+}
+
+fail() {
+  printf '  FAIL  %s\n' "$1"
+  failures=$((failures + 1))
+}
+
+assert_eq() {
+  # assert_eq <what> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    pass "$1"
+  else
+    fail "$1: expected '$2', got '$3'"
+  fi
+}
+
+assert_ne() {
+  # assert_ne <what> <a> <b>
+  if [ "$2" != "$3" ]; then
+    pass "$1"
+  else
+    fail "$1: both were '$2'"
+  fi
+}
+
+assert_between() {
+  # assert_between <what> <low> <high> <value>
+  if [ "$4" -ge "$2" ] && [ "$4" -le "$3" ]; then
+    pass "$1"
+  else
+    fail "$1: $4 is outside $2..$3"
+  fi
+}
+
+# run_alloc <runner-name> [extra env assignments...] — runs the script with a
+# fresh GITHUB_ENV and leaves the resulting assignments in $alloc_env, the
+# stdout in $alloc_output.
+alloc_env=""
+alloc_output=""
+run_alloc() {
+  local runner="$1"
+  shift
+
+  local env_file="$work_dir/github_env"
+  : >"$env_file"
+
+  alloc_output=$(env RUNNER_NAME="$runner" GITHUB_ENV="$env_file" "$@" bash "$script" 2>&1)
+  alloc_env=$(cat "$env_file")
+}
+
+# value_of <key> — reads a KEY=VALUE out of the last run's GITHUB_ENV.
+value_of() {
+  printf '%s\n' "$alloc_env" | sed -n "s/^$1=//p"
+}
+
+printf 'case: exports the four variables a job needs\n'
+run_alloc 'github-runner-01'
+for key in SPICE_HTTP_PORT SPICE_FLIGHT_PORT SPICE_HTTP_ENDPOINT SPICE_FLIGHT_ENDPOINT; do
+  if [ -n "$(value_of "$key")" ]; then
+    pass "exports $key"
+  else
+    fail "did not export $key"
+  fi
+done
+
+printf 'case: the endpoints agree with the ports\n'
+http_port=$(value_of SPICE_HTTP_PORT)
+flight_port=$(value_of SPICE_FLIGHT_PORT)
+assert_eq 'HTTP endpoint carries the http:// scheme and the HTTP port' \
+  "http://127.0.0.1:${http_port}" "$(value_of SPICE_HTTP_ENDPOINT)"
+# `spice run --flight-endpoint` is handed to `spiced --flight` verbatim, and
+# that flag takes a bind address. A scheme here would reach spiced as part of
+# the address and fail the bind.
+assert_eq 'Flight endpoint is a bare host:port, with no scheme' \
+  "127.0.0.1:${flight_port}" "$(value_of SPICE_FLIGHT_ENDPOINT)"
+
+printf 'case: ports avoid spiced defaults and the OS ephemeral range\n'
+# Linux allocates ephemeral ports from 32768 and macOS from 49152, so staying
+# under 32768 keeps an unrelated outbound connection from taking the port first.
+assert_between 'HTTP port sits in the reserved window' 20000 23999 "$http_port"
+assert_between 'Flight port sits in the reserved window' 25000 28999 "$flight_port"
+assert_ne 'HTTP port is not spiced default 8090' '8090' "$http_port"
+assert_ne 'Flight port is not spiced default 50051' '50051' "$flight_port"
+
+printf 'case: the same runner instance is handed the same pair every time\n'
+run_alloc 'github-runner-01' GITHUB_RUN_ID=100 GITHUB_JOB=test_openai_model
+first_http=$(value_of SPICE_HTTP_PORT)
+run_alloc 'github-runner-01' GITHUB_RUN_ID=100 GITHUB_JOB=test_openai_model
+assert_eq 'a repeated allocation is stable' "$first_http" "$(value_of SPICE_HTTP_PORT)"
+
+printf 'case: runner instances sharing a host get different pairs\n'
+# This is the whole point: -01 and -02 live on one machine and share its network
+# namespace, so identical ports here would reproduce the bug being fixed.
+declare -a seen=()
+collisions=0
+for instance in 01 02 03 04 05 06 07 08; do
+  run_alloc "github-runner-${instance}" GITHUB_RUN_ID=100 GITHUB_JOB=test_openai_model
+  port=$(value_of SPICE_HTTP_PORT)
+  for previous in ${seen[@]+"${seen[@]}"}; do
+    if [ "$previous" = "$port" ]; then
+      collisions=$((collisions + 1))
+    fi
+  done
+  seen+=("$port")
+done
+assert_eq 'eight runner instances on one host get eight distinct ports' '0' "$collisions"
+
+printf 'case: a held port is stepped over\n'
+# Hold the port this seed would otherwise pick, then ask again: the script must
+# hand out a different one rather than a port spiced cannot bind.
+run_alloc 'github-runner-holder' GITHUB_RUN_ID=200 GITHUB_JOB=test_hf_model
+wanted_http=$(value_of SPICE_HTTP_PORT)
+
+# A listener that stays up for the duration of the probe. `nc -l` differs
+# between the BSD and GNU builds, so bind with whatever the runner has.
+holder_pid=''
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$wanted_http" <<'PY' &
+import socket, sys, time
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", int(sys.argv[1])))
+s.listen(1)
+time.sleep(30)
+PY
+  holder_pid=$!
+fi
+
+if [ -n "$holder_pid" ]; then
+  # Give the listener a moment to be visible to lsof/netstat.
+  sleep 1
+
+  if command -v lsof >/dev/null 2>&1 || command -v netstat >/dev/null 2>&1; then
+    run_alloc 'github-runner-holder' GITHUB_RUN_ID=200 GITHUB_JOB=test_hf_model
+    assert_ne 'a held port is not handed out' "$wanted_http" "$(value_of SPICE_HTTP_PORT)"
+    case $alloc_output in
+    *'already held'*) pass 'says why it moved on' ;;
+    *) fail "output does not mention the held port: $alloc_output" ;;
+    esac
+  else
+    printf '  skip  no lsof or netstat on this host, cannot test the probe\n'
+  fi
+
+  kill "$holder_pid" 2>/dev/null
+  wait "$holder_pid" 2>/dev/null
+else
+  printf '  skip  no python3 to hold a port with\n'
+fi
+
+# ---------------------------------------------------------------------------
+# stop-spice checks the ports this job actually used
+# ---------------------------------------------------------------------------
+#
+# Cleanup waits for "the ports" to come free. Once a job binds its own pair,
+# waiting on 8090/50051 instead would watch another runner instance's job — and
+# never confirm ours was released. The full stop-spice behaviour is covered by
+# scripts/test_e2e_spice_lifecycle.sh; this covers only which ports it picks.
+
+stop_script="$repo_root/.github/actions/stop-spice/stop_spice.sh"
+
+# Run in an empty directory with no spice processes to find, so the script falls
+# straight through to its port report. `RUNNER_WORKSPACE` scopes it to a path
+# that owns nothing, which keeps it from touching anything on this machine.
+run_stop() {
+  local empty="$work_dir/empty"
+  mkdir -p "$empty"
+  (cd "$empty" && env RUNNER_WORKSPACE="$empty" SPICE_STOP_PORT_WAIT=0 SPICE_STOP_GRACE=0 \
+    "$@" bash "$stop_script" 2>&1)
+}
+
+printf 'case: stop-spice checks the ports the job allocated\n'
+stop_output=$(run_stop SPICE_HTTP_PORT=21734 SPICE_FLIGHT_PORT=26734)
+case $stop_output in
+*':21734'*) pass 'checks the allocated HTTP port' ;;
+*) fail "does not mention :21734: $stop_output" ;;
+esac
+case $stop_output in
+*':26734'*) pass 'checks the allocated Flight port' ;;
+*) fail "does not mention :26734: $stop_output" ;;
+esac
+case $stop_output in
+*':8090'*) fail "still checks the default :8090: $stop_output" ;;
+*) pass 'does not check the default :8090' ;;
+esac
+
+printf 'case: stop-spice keeps the defaults when no ports were allocated\n'
+stop_output=$(run_stop)
+case $stop_output in
+*':8090'*) pass 'falls back to the default HTTP port' ;;
+*) fail "does not mention :8090: $stop_output" ;;
+esac
+case $stop_output in
+*':50051'*) pass 'falls back to the default Flight port' ;;
+*) fail "does not mention :50051: $stop_output" ;;
+esac
+
+printf 'case: an explicit port list still wins\n'
+stop_output=$(run_stop SPICE_HTTP_PORT=21734 SPICE_FLIGHT_PORT=26734 SPICE_STOP_PORTS=9999)
+case $stop_output in
+*':9999'*) pass 'honours SPICE_STOP_PORTS' ;;
+*) fail "does not mention :9999: $stop_output" ;;
+esac
+case $stop_output in
+*':21734'*) fail "explicit list did not override the allocated ports: $stop_output" ;;
+*) pass 'ignores the allocated ports when told which to check' ;;
+esac
+
+printf 'case: works with no Actions environment at all\n'
+# Runnable by hand, and by anyone reproducing a CI failure locally.
+bare_output=$(env -u RUNNER_NAME -u GITHUB_ENV -u GITHUB_RUN_ID -u GITHUB_JOB \
+  -u GITHUB_RUN_ATTEMPT bash "$script" 2>&1)
+bare_status=$?
+assert_eq 'exits 0 with no Actions variables set' '0' "$bare_status"
+case $bare_output in
+*SPICE_HTTP_PORT=*) pass 'prints the assignments when GITHUB_ENV is unset' ;;
+*) fail "no assignments in output: $bare_output" ;;
+esac
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%s check(s) failed\n' "$failures"
+  exit 1
+fi
+
+printf '\nAll checks passed\n'

--- a/scripts/test_e2e_spice_ports.sh
+++ b/scripts/test_e2e_spice_ports.sh
@@ -194,6 +194,21 @@ run_stop() {
     "$@" bash "$stop_script" 2>&1)
 }
 
+printf 'case: probing from the top of the window wraps instead of walking out of it\n'
+# A seed landing on the last port in the window, with that port held, must wrap
+# to the bottom rather than step to 24000 — which would leave the reserved
+# window and head toward the ephemeral range the window exists to avoid.
+run_alloc 'github-runner-01' SPICE_PORT_SPAN=1 SPICE_PORT_MAX_PROBE=3
+assert_eq 'a span of one always yields the base port' \
+  '20000' "$(value_of SPICE_HTTP_PORT)"
+
+# Ten probes from the top of a small window stay inside it.
+for probe_seed in 1 2 3 4 5 6 7 8; do
+  run_alloc "github-runner-${probe_seed}" SPICE_PORT_SPAN=4 SPICE_PORT_MAX_PROBE=10
+  assert_between "a span of four keeps seed ${probe_seed} in the window" \
+    20000 20003 "$(value_of SPICE_HTTP_PORT)"
+done
+
 printf 'case: stop-spice checks the ports the job allocated\n'
 stop_output=$(run_stop SPICE_HTTP_PORT=21734 SPICE_FLIGHT_PORT=26734)
 case $stop_output in

--- a/test/models/chat_01.exp
+++ b/test/models/chat_01.exp
@@ -5,7 +5,7 @@ source [file join [file dirname [info script]] repl_helpers.exp]
 # Runtime response timeout
 set timeout 30
 
-spawn spice chat
+spawn spice chat {*}[repl_endpoint_args]
 
 proc verify_datasets_access {} {
     global timeout

--- a/test/models/chat_01_simple.exp
+++ b/test/models/chat_01_simple.exp
@@ -5,7 +5,7 @@ source [file join [file dirname [info script]] repl_helpers.exp]
 # Runtime response timeout
 set timeout 30
 
-spawn spice chat
+spawn spice chat {*}[repl_endpoint_args]
 
 proc chat {message}  {
     global timeout

--- a/test/models/expect_test.sh
+++ b/test/models/expect_test.sh
@@ -220,6 +220,12 @@ mode=$1
 exit_before=${SPICE_FAKE_EXIT_BEFORE_TURN:-0}
 exit_after=${SPICE_FAKE_EXIT_AFTER_TURN:-0}
 
+# Records how the script invoked us, so a test can check that the runtime
+# endpoint was passed through rather than left at the CLI default.
+if [ -n "${SPICE_FAKE_ARGV_FILE:-}" ]; then
+  printf '%s\n' "$*" >"$SPICE_FAKE_ARGV_FILE"
+fi
+
 prompt='chat> '
 if [ "$mode" = 'search' ]; then
   prompt='search> '
@@ -303,6 +309,48 @@ script_case 'chat_01.exp when the REPL exits while idle' chat_01.exp \
 assert_status 1
 assert_reports 'Checking the chat REPL is still running'
 assert_reports 'exited with status 44'
+
+# ---------------------------------------------------------------------------
+# The runtime endpoint the REPL is pointed at
+# ---------------------------------------------------------------------------
+#
+# In CI each job binds its runtime to its own port (#12419), so a REPL left on
+# the CLI default would talk to whatever else holds 8090 on a shared host — or
+# to nothing. These check the scripts forward the endpoint when it is set, and
+# leave the default alone when it is not.
+
+argv_file="$work_dir/spice_argv"
+
+assert_argv() {
+  local expected=$1 actual
+  actual=$(cat "$argv_file" 2>/dev/null)
+  if [ "$actual" = "$expected" ]; then
+    pass "invokes spice as \"$expected\""
+  else
+    fail "expected spice args \"$expected\", got \"$actual\""
+  fi
+}
+
+for script in chat_01.exp chat_01_simple.exp search_01.exp; do
+  subcommand=chat
+  case $script in
+  search_*) subcommand=search ;;
+  esac
+
+  : >"$argv_file"
+  script_case "$script forwards SPICE_HTTP_ENDPOINT" "$script" \
+    SPICE_FAKE_ARGV_FILE="$argv_file" \
+    SPICE_HTTP_ENDPOINT='http://127.0.0.1:21734'
+  assert_status 0
+  assert_argv "$subcommand --endpoint http://127.0.0.1:21734"
+
+  : >"$argv_file"
+  script_case "$script keeps the CLI default when SPICE_HTTP_ENDPOINT is unset" "$script" \
+    SPICE_FAKE_ARGV_FILE="$argv_file" \
+    SPICE_HTTP_ENDPOINT=''
+  assert_status 0
+  assert_argv "$subcommand"
+done
 
 if [ "$failures" -ne 0 ]; then
   printf '\n%s check(s) failed\n' "$failures"

--- a/test/models/repl_helpers.exp
+++ b/test/models/repl_helpers.exp
@@ -70,6 +70,21 @@ proc repl_send {text} {
     }
 }
 
+# The arguments that point a REPL at this job's runtime, or none at all.
+#
+# In CI each job binds its runtime to its own port, because the self-hosted
+# pools run several runner instances on one host and spiced's default 8090
+# cannot be shared (#12419). SPICE_HTTP_ENDPOINT carries that port. When it is
+# unset — running one of these scripts by hand against a local runtime — the
+# REPL keeps its own default, so nothing has to be set to reproduce a CI run.
+proc repl_endpoint_args {} {
+    if {[info exists ::env(SPICE_HTTP_ENDPOINT)] && $::env(SPICE_HTTP_ENDPOINT) ne ""} {
+        return [list --endpoint $::env(SPICE_HTTP_ENDPOINT)]
+    }
+
+    return [list]
+}
+
 # Fails the script if the spawned process has exited. Writing to the pty of an
 # exited process succeeds silently, so a REPL that crashes while sitting idle at
 # its prompt is invisible to `repl_send` alone; reading finds the eof. Output

--- a/test/models/search_01.exp
+++ b/test/models/search_01.exp
@@ -5,7 +5,7 @@ source [file join [file dirname [info script]] repl_helpers.exp]
 # spiced runtime response timeout
 set timeout 5
 
-spawn spice search
+spawn spice search {*}[repl_endpoint_args]
 
 proc perform_search {search_term expected_term} {
     global timeout


### PR DESCRIPTION
## Summary

Every E2E job ran `spice run` against spiced's default binds, `127.0.0.1:8090`
and `127.0.0.1:50051`. The self-hosted pools run several runner instances per
physical host (`/opt/github-runner-01`, `-02`, `-03`, …) sharing one network
namespace, so two jobs overlapping on one host could not both bind. The second
`spiced` exited, and the readiness poll waited out its full `timeout-minutes`
with only "the action has timed out" to show for it — which in the merge queue
dequeues the PR. No diff causes it and no author can fix it.

The quieter failure is worse: when the process already holding 8090 was a
*ready* runtime from the other job, the readiness poll succeeded immediately and
every later step ran against a spicepod this job never loaded — a silent wrong
result rather than a red build.

**Only the two model jobs are affected.** `setup-model-matrix` puts
`test_openai_model` and `test_hf_model` on the shared `spiceai-macos` /
`spiceai-dev-runners` pools; every other E2E job takes its runner from
`setup-matrix`, which uses GitHub-hosted `ubuntu-latest` / `macos-15` — one job
per ephemeral VM, no sharing. That matches the issue's evidence, where both
confirmed collisions were the `openai model` and `huggingface model` jobs.

Fixes #12419

## Changes

- **`.github/actions/allocate-spice-ports/`** (new) derives an HTTP/Flight port
  pair and exports `SPICE_HTTP_PORT`, `SPICE_FLIGHT_PORT`,
  `SPICE_HTTP_ENDPOINT`, `SPICE_FLIGHT_ENDPOINT`.
  - Seeded from `RUNNER_NAME`, because the runner *instance* is the unit that
    shares a host and runs one job at a time — distinct instances holding
    distinct ports is exactly what makes the collision impossible. Run, job and
    attempt are folded in so a port leaked by an earlier job on the same
    instance is unlikely to be the one asked for next.
  - Both windows (20000–23999, 25000–28999) sit below the OS ephemeral range —
    Linux allocates from 32768, macOS from 49152 — so an unrelated outbound
    connection cannot take the port first.
  - A port already held is stepped over, with the reason logged.
- **The two model jobs** allocate ports, pass them to
  `spice run --http-endpoint … --flight-endpoint …`, and give the readiness
  action the matching `url`.
- **`stop-spice`** now waits on the ports the job actually used. Left on the
  defaults it would watch *another instance's* job — noise that reads as a leak
  — and never confirm ours came free. Only which ports it reports on changes;
  kills are still scoped by `RUNNER_WORKSPACE`.
- **The REPL scripts** take their endpoint from `SPICE_HTTP_ENDPOINT` via a
  `repl_endpoint_args` helper, and keep the CLI default when it is unset, so
  they still run by hand against a local runtime.

## What this does not weaken

No timeout raised, no assertion relaxed, no test retried or skipped, no required
check removed. Both ports stay on `127.0.0.1`, so nothing is newly exposed.

## Test plan

- `make lint`
- `make test`
- New `scripts/test_e2e_spice_ports.sh` covers the properties the fix rests on:
  eight runner instances on one host get eight distinct ports; a repeated
  allocation is stable; the ports avoid 8090/50051 and the ephemeral range; the
  Flight endpoint stays a bare `host:port` because `spiced --flight` takes no
  scheme; a held port is stepped over; and `stop-spice` checks the allocated
  ports, falls back to the defaults when none were allocated, and still honours
  an explicit list.
- `test/models/expect_test.sh` gains cases asserting each REPL script forwards
  `--endpoint` when `SPICE_HTTP_ENDPOINT` is set and leaves the CLI default
  alone when it is not.
- **E2E Lifecycle Scripts Test now runs both suites on Linux and macOS.** The
  REPL scripts and their tests previously ran only inside the model jobs, which
  are skipped on pull requests — so a change to them reached the merge queue
  unexercised. They need nothing but `expect`.
- Verified against the source that `spiced --http` / `--flight` parse a
  `SocketAddr` (`crates/runtime/src/config.rs`), and that `spice run` strips the
  scheme from `--http-endpoint` but passes `--flight-endpoint` through verbatim
  — which is why the Flight value carries no scheme.

## Checklist

- [x] Root cause identified and addressed
- [x] Tests added that fail on the old code
- [x] Existing lifecycle tests still pass (57/57)
- [x] Workflow definitions validated (`check_workflow_yaml.py`)
- [x] No secret or credential added to a log, argv, or PR body
