### PR TITLE
feat(cloud-connect): push metrics from adopted standalone instances

### DIFF
--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -534,7 +534,7 @@ impl SpicedRuntimeHandle {
             Err(join) => format!("identity persistence task panicked: {join}"),
         };
         tracing::warn!(
-            "Cloud Connect: could not persist the app id to {}: {error}; metrics stay attributed until this process exits, then are withheld until the next deploy",
+            "Spice Cloud Connect could not save the cloud app ID to {}. Metrics for this instance will not appear in Spice Cloud if the process restarts. Does the runtime have permission to write to that path? {error}",
             self.identity_path.display()
         );
     }
@@ -685,38 +685,41 @@ impl RuntimeHandle for SpicedRuntimeHandle {
         // not about the spicepod being valid. A rejected spicepod would otherwise
         // withhold metrics for a reason that has nothing to do with them.
         //
-        // Empty means the control plane named none. Leave any id already recorded
-        // in place rather than clearing it: the instance's app has not changed,
-        // and clearing would silence metrics that are correctly attributed.
-        if app_id.is_empty() {
-            let held = self.app_id.read().clone();
-            match held {
-                Some(held) => tracing::warn!(
-                    app_id = %held,
-                    "Cloud Connect: ApplySpicepod carried no app id; keeping the one already recorded, so metrics stay attributed"
-                ),
-                None => tracing::warn!(
-                    "Cloud Connect: ApplySpicepod carried no app id and none was recorded before, so metrics stay withheld. Either this instance is attached to no app, or the api that dispatched the deploy does not forward the app id"
-                ),
+        // Leave any id already recorded in place when the deployment names none:
+        // the instance's app has not changed, and clearing would silence metrics
+        // that are correctly attributed.
+        //
+        // Cloned out of the lock rather than read in the scrutinee: a scrutinee
+        // temporary lives until the match ends, so the read guard would still be
+        // held when an arm takes the write lock.
+        let held = self.app_id.read().clone();
+        match (app_id, held) {
+            (None, Some(held)) => tracing::debug!(
+                app_id = %held,
+                "Spice Cloud Connect: the Spicepod deployment named no cloud app; keeping the one already recorded"
+            ),
+            (None, None) => tracing::warn!(
+                "Spice Cloud Connect provided no app ID on Spicepod deployment. Metrics for this instance will not appear in Spice Cloud. Is this instance attached to an app?"
+            ),
+            (Some(app_id), held) => {
+                match held.as_deref() {
+                    Some(held) if held == app_id => tracing::debug!(
+                        app_id,
+                        "Spice Cloud Connect: the Spicepod deployment re-confirmed the cloud app metrics are attributed to"
+                    ),
+                    Some(previous) => tracing::debug!(
+                        app_id,
+                        previous,
+                        "Spice Cloud Connect: the Spicepod deployment moved this instance to a different cloud app; metrics follow it from the next export"
+                    ),
+                    None => tracing::debug!(
+                        app_id,
+                        "Spice Cloud Connect: metrics will be attributed to this cloud app from the next export"
+                    ),
+                }
+                *self.app_id.write() = Some(app_id.to_string());
+                self.persist_app_id(app_id).await;
             }
-        } else {
-            let previous = self.app_id.write().replace(app_id.to_string());
-            match previous.as_deref() {
-                Some(previous) if previous == app_id => tracing::debug!(
-                    app_id,
-                    "Cloud Connect: ApplySpicepod re-confirmed the app metrics are attributed to"
-                ),
-                Some(previous) => tracing::debug!(
-                    app_id,
-                    previous,
-                    "Cloud Connect: ApplySpicepod moved this instance to a different app; metrics follow it from the next export"
-                ),
-                None => tracing::debug!(
-                    app_id,
-                    "Cloud Connect: metrics will be attributed to this app from the next export"
-                ),
-            }
-            self.persist_app_id(app_id).await;
         }
 
         // Cloned out of the lock rather than compared under it: the guard must
@@ -983,7 +986,7 @@ impl RuntimeHandle for SpicedRuntimeHandle {
         let app_id = self.app_id.read().clone();
         let Some(app_id) = app_id else {
             tracing::debug!(
-                "Metrics export: withheld until the control plane names an app (deploy this instance's app to set one)"
+                "Spice Cloud Connect: metrics are withheld until Spice Cloud names an app for this instance; deploy the app it is attached to"
             );
             return Ok(None);
         };

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -65,6 +65,7 @@ use app::{App, AppBuilder};
 use async_trait::async_trait;
 use parking_lot::RwLock;
 use runtime::Runtime;
+use runtime::metrics_reader::MetricsReader;
 use runtime::status::ComponentStatus;
 use runtime_cloud_connect::config::{
     CLOUD_MANAGED_SPICEPOD_FILE, CloudConnectConfig, IDENTITY_FILE, PENDING_ADOPT_CODE_FILE,
@@ -238,6 +239,7 @@ pub async fn maybe_start(
     cloud_connect_flag: bool,
     delivered_secrets: Option<DeliveredSecretsState>,
     running_deployment: Option<CloudManagedSpicepod>,
+    metrics: Option<MetricsReader>,
 ) -> Option<CloudConnect> {
     let config = build_config(runtime_version);
 
@@ -246,8 +248,14 @@ pub async fn maybe_start(
     // rather than silently treating it as "not adopted", so a broken
     // identity file is visible to the operator instead of quietly
     // disabling Cloud Connect.
+    let mut persisted_app_id = None;
     let has_identity = match IdentityStore::load_optional(&config.identity_path) {
-        Ok(opt) => opt.is_some(),
+        Ok(opt) => {
+            // Restores the metrics attribution across a restart. Without it the
+            // instance exports nothing until its next deploy, which may be days.
+            persisted_app_id = opt.as_ref().and_then(|i| i.app_id.clone());
+            opt.is_some()
+        }
         Err(err) => {
             tracing::warn!(
                 "Spice Cloud Connect: could not read identity at {}: {err}; \
@@ -286,6 +294,16 @@ pub async fn maybe_start(
     // `GetLogs`. `None` if capture wasn't installed — the handler then
     // reports logs as unavailable rather than returning an empty blob.
     let logs = crate::log_capture::handle();
+
+    match &persisted_app_id {
+        Some(app_id) => tracing::debug!(
+            app_id,
+            "Spice Cloud Connect: metrics attribution restored from the stored identity"
+        ),
+        None => tracing::debug!(
+            "Spice Cloud Connect: the stored identity names no app; metrics are withheld until a deploy names one"
+        ),
+    }
 
     // Installed before `load_components()` by `restore_delivered_secrets`, so
     // the cached secrets were already in place when components resolved their
@@ -329,6 +347,8 @@ pub async fn maybe_start(
         identity_path,
         running_deployment,
         supervisor,
+        metrics,
+        persisted_app_id,
     ));
 
     match CloudConnect::start(config, handle).await {
@@ -454,6 +474,20 @@ struct SpicedRuntimeHandle {
     persisted: RwLock<Option<String>>,
     /// What will relaunch this process after a deployment exits it.
     supervisor: Supervisor,
+    /// Reader for the metrics pushed to the control plane. `None` when no
+    /// reader was attached to the meter provider, in which case this instance
+    /// reports nothing rather than an empty payload.
+    metrics: Option<MetricsReader>,
+    /// The app this instance's metrics are attributed to, learned from
+    /// `ApplySpicepod` and mirrored into the identity file so it survives a
+    /// restart. `None` until the control plane names one, and metrics are
+    /// withheld for as long as it is: a series with no `scp_app_id` is ingested
+    /// but matches no app dashboard, so exporting one spends the backend's quota
+    /// to produce something nothing can read.
+    ///
+    /// Guarded by a `parking_lot` lock held only for the brief read/write, never
+    /// across an `.await`.
+    app_id: RwLock<Option<String>>,
 }
 
 impl SpicedRuntimeHandle {
@@ -464,6 +498,8 @@ impl SpicedRuntimeHandle {
         identity_path: std::path::PathBuf,
         running_deployment: Option<CloudManagedSpicepod>,
         supervisor: Supervisor,
+        metrics: Option<MetricsReader>,
+        app_id: Option<String>,
     ) -> Self {
         let live = running_deployment.map_or_else(String::new, |running| running.spicepod_yaml);
         Self {
@@ -474,7 +510,33 @@ impl SpicedRuntimeHandle {
             live,
             persisted: RwLock::new(None),
             supervisor,
+            metrics,
+            app_id: RwLock::new(app_id),
         }
+    }
+
+    /// Record the app id alongside the credential so a restart keeps exporting.
+    ///
+    /// Runs on the blocking pool: the identity store is synchronous `std::fs`,
+    /// and this is called from the command dispatch loop.
+    ///
+    /// A failure is logged, not returned. The in-memory value is already set, so
+    /// metrics flow either way — all that is lost is durability across a
+    /// restart, and failing the deploy over that would be the wrong trade.
+    async fn persist_app_id(&self, app_id: &str) {
+        let path = self.identity_path.clone();
+        let app_id = app_id.to_string();
+        let result =
+            tokio::task::spawn_blocking(move || IdentityStore::store_app_id(&path, &app_id)).await;
+        let error = match result {
+            Ok(Ok(())) => return,
+            Ok(Err(err)) => err.to_string(),
+            Err(join) => format!("identity persistence task panicked: {join}"),
+        };
+        tracing::warn!(
+            "Cloud Connect: could not persist the app id to {}: {error}; metrics stay attributed until this process exits, then are withheld until the next deploy",
+            self.identity_path.display()
+        );
     }
 
     /// The local delivered-secrets cache key, read fresh from `identity.json`.
@@ -615,7 +677,47 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             config_dir,
             spicepod_yaml,
             delivered_secrets,
+            app_id,
         } = deployment;
+
+        // Recorded before staging, and independently of whether staging succeeds:
+        // which app this instance belongs to is a fact about the deploy's target,
+        // not about the spicepod being valid. A rejected spicepod would otherwise
+        // withhold metrics for a reason that has nothing to do with them.
+        //
+        // Empty means the control plane named none. Leave any id already recorded
+        // in place rather than clearing it: the instance's app has not changed,
+        // and clearing would silence metrics that are correctly attributed.
+        if app_id.is_empty() {
+            let held = self.app_id.read().clone();
+            match held {
+                Some(held) => tracing::warn!(
+                    app_id = %held,
+                    "Cloud Connect: ApplySpicepod carried no app id; keeping the one already recorded, so metrics stay attributed"
+                ),
+                None => tracing::warn!(
+                    "Cloud Connect: ApplySpicepod carried no app id and none was recorded before, so metrics stay withheld. Either this instance is attached to no app, or the api that dispatched the deploy does not forward the app id"
+                ),
+            }
+        } else {
+            let previous = self.app_id.write().replace(app_id.to_string());
+            match previous.as_deref() {
+                Some(previous) if previous == app_id => tracing::debug!(
+                    app_id,
+                    "Cloud Connect: ApplySpicepod re-confirmed the app metrics are attributed to"
+                ),
+                Some(previous) => tracing::debug!(
+                    app_id,
+                    previous,
+                    "Cloud Connect: ApplySpicepod moved this instance to a different app; metrics follow it from the next export"
+                ),
+                None => tracing::debug!(
+                    app_id,
+                    "Cloud Connect: metrics will be attributed to this app from the next export"
+                ),
+            }
+            self.persist_app_id(app_id).await;
+        }
 
         // Cloned out of the lock rather than compared under it: the guard must
         // not be held across the awaits below.
@@ -870,6 +972,24 @@ impl RuntimeHandle for SpicedRuntimeHandle {
                 "delivered_secrets_persisted": self.cache_key().is_some(),
             })),
         )
+    }
+
+    async fn collect_metrics(&self) -> Result<Option<Vec<u8>>, CommandError> {
+        let Some(reader) = &self.metrics else {
+            return Ok(None);
+        };
+        // Read and release: the collection below is CPU work, and the write side
+        // is an inbound ApplySpicepod that must not queue behind it.
+        let app_id = self.app_id.read().clone();
+        let Some(app_id) = app_id else {
+            tracing::debug!(
+                "Metrics export: withheld until the control plane names an app (deploy this instance's app to set one)"
+            );
+            return Ok(None);
+        };
+        reader
+            .collect_otlp_export(&app_id)
+            .map_err(|err| CommandError::internal(err.to_string()))
     }
 }
 

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -599,6 +599,21 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
         None
     };
 
+    // A reader of its own for the metrics Cloud Connect pushes to the control
+    // plane. Separate from the cluster reader above rather than shared: each
+    // reader registered with the meter provider gets its own pipeline and so
+    // sees every data point, whereas two consumers of one reader would divide
+    // them under delta temporality.
+    //
+    // Created here because readers are fixed when the meter provider is built,
+    // which happens well before Cloud Connect starts — so the decision is made
+    // from the same cheap on-disk/flag probe that gates log capture.
+    let cloud_connect_metrics = if cloud_connect::is_configured(args.cloud_connect) {
+        Some(runtime::metrics_reader::MetricsReader::new_cumulative())
+    } else {
+        None
+    };
+
     match resolved_cluster_config {
         Ok(resolved_cluster_config) => {
             // Validate that scheduler mode has state_location configured
@@ -782,8 +797,13 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
         .and_then(|c| c.otel_exporter.as_ref())
         .filter(|c| c.enabled);
 
-    let needs_metrics =
-        prometheus_registry.is_some() || otel_config.is_some() || metrics_reader.is_some();
+    // Cloud Connect counts: its reader only produces data once it is attached to
+    // the meter provider built below, and `spiced --cloud-connect` alone sets
+    // none of the other three signals.
+    let needs_metrics = prometheus_registry.is_some()
+        || otel_config.is_some()
+        || metrics_reader.is_some()
+        || cloud_connect_metrics.is_some();
 
     if needs_metrics {
         // Resolve secrets in OTEL exporter headers before initializing metrics
@@ -822,6 +842,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
             otel_config,
             resolved_otel_headers,
             metrics_reader,
+            cloud_connect_metrics.clone(),
             resource_attributes,
             metric_prefix,
         )
@@ -999,6 +1020,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
         cloud_connect_flag,
         delivered_secrets,
         running_deployment,
+        cloud_connect_metrics,
     )
     .await;
 
@@ -1260,6 +1282,7 @@ fn init_metrics(
     otel_config: Option<&app::spicepod::component::runtime::OtelExporterConfig>,
     resolved_otel_headers: std::collections::HashMap<String, String>,
     metrics_reader: Option<runtime::metrics_reader::MetricsReader>,
+    cloud_connect_metrics: Option<runtime::metrics_reader::MetricsReader>,
     resource_attributes: Vec<KeyValue>,
     metric_prefix: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -1337,6 +1360,13 @@ fn init_metrics(
     if let Some(reader) = metrics_reader {
         provider_builder = provider_builder.with_reader(reader);
         tracing::debug!("Cluster metrics reader enabled for on-demand OTLP collection");
+    }
+
+    // Case 2b: Cloud Connect push. Its own reader, so the cumulative totals it
+    // reports are unaffected by any other consumer collecting.
+    if let Some(reader) = cloud_connect_metrics {
+        provider_builder = provider_builder.with_reader(reader);
+        tracing::debug!("Cloud Connect metrics reader enabled for pushed OTLP export");
     }
 
     // Case 3: OTEL push exporter

--- a/crates/runtime-cloud-connect/proto/cloud_connect.proto
+++ b/crates/runtime-cloud-connect/proto/cloud_connect.proto
@@ -322,6 +322,13 @@ message Restart {
 message ApplySpicepod {
   string spicepod_yaml = 1;
   SealedSecretPayload sealed_secret_payload = 2;
+  // The app this instance's telemetry is attributed to. The control plane knows
+  // which app an instance is attached to and the instance cannot derive it, so
+  // it rides the same command that tells the instance what to run. The runtime
+  // stamps it as `scp_app_id`, the label the metrics backend's app dashboards
+  // filter on; empty means the control plane named none, and an instance that
+  // has never been given one exports no metrics rather than unattributed ones.
+  string app_id = 3;
 }
 
 message UpgradeRuntime {
@@ -443,7 +450,7 @@ message SecretPayload {
 //
 // Unsolicited: the runtime exports on its own cadence rather than answering a
 // command, so this rides on ClientMessage with no command_id and draws no
-// CommandResult. Nothing emits it yet.
+// CommandResult.
 //
 // `otlp_request` is a serialized
 // `opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest` in

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -659,11 +659,19 @@ impl ClientDriver {
         let met_runtime = Arc::clone(&runtime);
         let met_identifier = Arc::clone(&identifier);
         let met_interval = self.config.metrics_interval;
+        // Collecting metrics is CPU work the other periodic tasks do not do, so
+        // this one races the shutdown signal rather than relying on the `abort()`
+        // below: aborting resolves only at an await point, which can leave a
+        // collection running past the shutdown it was supposed to end.
+        let met_shutdown = Arc::clone(&self.shutdown);
         let met_handle = tokio::spawn(async move {
             let mut ticker = time::interval(met_interval);
             ticker.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
             loop {
-                ticker.tick().await;
+                tokio::select! {
+                    () = met_shutdown.wait() => break,
+                    _ = ticker.tick() => {}
+                }
                 // Every interval accounts for itself: one line per tick, whatever
                 // the outcome. An export path that silently stops is
                 // indistinguishable from a runtime with nothing to report, which
@@ -686,7 +694,7 @@ impl ClientDriver {
                     }
                     Err(err) => {
                         tracing::warn!(
-                            "Cloud Connect: could not collect metrics to export: {err}; skipping this interval"
+                            "Failed to export metrics to Spice Cloud: {err}. Runtime will retry the export on the next interval. Metrics may be delayed to appear in Spice Cloud"
                         );
                         continue;
                     }
@@ -712,7 +720,7 @@ impl ClientDriver {
                         tracing::warn!(
                             identifier = %id,
                             bytes,
-                            "Cloud Connect: metrics export dropped — the outbound queue is full. The next export carries the same cumulative totals, so no data is lost"
+                            "Failed to export metrics to Spice Cloud: the outbound queue is full. Runtime will retry the export on the next interval. Metrics may be delayed to appear in Spice Cloud"
                         );
                     }
                     Err(mpsc::error::TrySendError::Closed(_)) => break,
@@ -998,23 +1006,14 @@ impl ClientDriver {
         cmd: proto::ApplySpicepod,
         session_key: Option<&cloud_connect_crypto::EncryptionKeypair>,
     ) {
-        // Logged on arrival, before anything can fail: the app id rides this
-        // command and nothing else carries it, so whether one arrived is the
-        // first thing to know when metrics are being withheld.
-        if cmd.app_id.is_empty() {
-            tracing::warn!(
-                command_id,
-                yaml_bytes = cmd.spicepod_yaml.len(),
-                "Cloud Connect: ApplySpicepod received with no app id; metrics stay withheld because nothing can attribute them. The control plane sends one only if the instance is attached to an app"
-            );
-        } else {
-            tracing::debug!(
-                command_id,
-                app_id = %cmd.app_id,
-                yaml_bytes = cmd.spicepod_yaml.len(),
-                "Cloud Connect: ApplySpicepod received"
-            );
-        }
+        // The app id is not reported here. Whether one arrived only matters
+        // against what the handle already holds, which only the handle knows, so
+        // it is the handle that says what the deployment did to the attribution.
+        tracing::debug!(
+            command_id,
+            yaml_bytes = cmd.spicepod_yaml.len(),
+            "Spice Cloud Connect: received a Spicepod deployment"
+        );
 
         let delivered = match cmd.sealed_secret_payload.as_ref() {
             None => None,
@@ -1036,19 +1035,27 @@ impl ClientDriver {
                 config_dir: &self.config.config_dir,
                 spicepod_yaml: &cmd.spicepod_yaml,
                 delivered_secrets: delivered,
-                app_id: &cmd.app_id,
+                // An empty app id on the wire means the control plane named no
+                // app, which is a different thing from an app named "".
+                app_id: Some(cmd.app_id.as_str()).filter(|id| !id.is_empty()),
             })
             .await;
 
         let outcome = match outcome {
             Ok(outcome) => outcome,
             Err(err) => {
-                tracing::warn!(command_id, "Cloud Connect: ApplySpicepod failed: {err}");
+                tracing::warn!(
+                    command_id,
+                    "Failed to apply the Spicepod deployed from Spice Cloud: {err}. This instance keeps serving its current configuration; correct the Spicepod and deploy it again. See: https://spiceai.org/docs"
+                );
                 send_command_error(tx, command_id, &err).await;
                 return;
             }
         };
-        tracing::debug!(command_id, "Cloud Connect: ApplySpicepod applied");
+        tracing::debug!(
+            command_id,
+            "Spice Cloud Connect: applied the deployed Spicepod"
+        );
 
         send_ok_json(tx, command_id, &outcome.document).await;
 

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -428,6 +428,9 @@ impl ClientDriver {
             ca_bundle_pem: current.ca_bundle_pem,
             gateway_addr: current.gateway_addr,
             not_after_unix: Some(outcome.not_after_unix),
+            // The app attribution is not part of the credential and /renew
+            // does not re-send it, so it rides across the rotation unchanged.
+            app_id: current.app_id,
             // Seeded with the OUTGOING keypair and rotated by the call below,
             // which shifts it into `enc_previous_private_key_pem` — assigning
             // `material` here instead would leave the retained key equal to the
@@ -616,8 +619,8 @@ impl ClientDriver {
             }
         };
 
-        // Spawn periodic heartbeat + telemetry tasks. They emit through
-        // the same outbound channel. The identifier is shared by RwLock
+        // Spawn the periodic heartbeat, metrics, and telemetry tasks. They emit
+        // through the same outbound channel. The identifier is shared by RwLock
         // so a `Remove` can blank it for frames still in flight on the
         // draining stream.
         let runtime = Arc::clone(&self.runtime);
@@ -643,6 +646,76 @@ impl ClientDriver {
                 };
                 if hb_tx.send(msg).await.is_err() {
                     break;
+                }
+            }
+        });
+
+        // Metrics ride the same stream but not the same delivery guarantee. The
+        // payload carries cumulative totals, so a dropped export costs a data
+        // point and no data — whereas a late heartbeat is read as an instance
+        // going away. This task therefore offers its message and moves on
+        // instead of waiting for room behind one.
+        let met_tx = tx.clone();
+        let met_runtime = Arc::clone(&runtime);
+        let met_identifier = Arc::clone(&identifier);
+        let met_interval = self.config.metrics_interval;
+        let met_handle = tokio::spawn(async move {
+            let mut ticker = time::interval(met_interval);
+            ticker.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                // Every interval accounts for itself: one line per tick, whatever
+                // the outcome. An export path that silently stops is
+                // indistinguishable from a runtime with nothing to report, which
+                // is the failure this whole feature exists to remove.
+                let id = met_identifier.read().await.clone();
+                if id.is_empty() {
+                    tracing::debug!(
+                        "Cloud Connect: metrics export skipped — enrollment has not assigned an identifier yet, so nothing could attribute the payload"
+                    );
+                    continue;
+                }
+                let payload = match met_runtime.collect_metrics().await {
+                    Ok(Some(payload)) => payload,
+                    Ok(None) => {
+                        tracing::debug!(
+                            identifier = %id,
+                            "Cloud Connect: metrics export skipped — the runtime reported no metrics to send"
+                        );
+                        continue;
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            "Cloud Connect: could not collect metrics to export: {err}; skipping this interval"
+                        );
+                        continue;
+                    }
+                };
+                let bytes = payload.len();
+                let msg = proto::ClientMessage {
+                    body: Some(proto::client_message::Body::ExportMetrics(
+                        proto::ExportMetrics {
+                            identifier: id.clone(),
+                            otlp_request: payload,
+                        },
+                    )),
+                };
+                match met_tx.try_send(msg) {
+                    Ok(()) => {
+                        tracing::debug!(
+                            identifier = %id,
+                            bytes,
+                            "Cloud Connect: metrics export queued to the gateway"
+                        );
+                    }
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        tracing::warn!(
+                            identifier = %id,
+                            bytes,
+                            "Cloud Connect: metrics export dropped — the outbound queue is full. The next export carries the same cumulative totals, so no data is lost"
+                        );
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => break,
                 }
             }
         });
@@ -732,6 +805,7 @@ impl ClientDriver {
         // out-of-band exit.
         hb_handle.abort();
         tel_handle.abort();
+        met_handle.abort();
         drop(tx);
 
         Ok(exit_reason)
@@ -924,6 +998,24 @@ impl ClientDriver {
         cmd: proto::ApplySpicepod,
         session_key: Option<&cloud_connect_crypto::EncryptionKeypair>,
     ) {
+        // Logged on arrival, before anything can fail: the app id rides this
+        // command and nothing else carries it, so whether one arrived is the
+        // first thing to know when metrics are being withheld.
+        if cmd.app_id.is_empty() {
+            tracing::warn!(
+                command_id,
+                yaml_bytes = cmd.spicepod_yaml.len(),
+                "Cloud Connect: ApplySpicepod received with no app id; metrics stay withheld because nothing can attribute them. The control plane sends one only if the instance is attached to an app"
+            );
+        } else {
+            tracing::debug!(
+                command_id,
+                app_id = %cmd.app_id,
+                yaml_bytes = cmd.spicepod_yaml.len(),
+                "Cloud Connect: ApplySpicepod received"
+            );
+        }
+
         let delivered = match cmd.sealed_secret_payload.as_ref() {
             None => None,
             Some(payload) => match self
@@ -944,16 +1036,19 @@ impl ClientDriver {
                 config_dir: &self.config.config_dir,
                 spicepod_yaml: &cmd.spicepod_yaml,
                 delivered_secrets: delivered,
+                app_id: &cmd.app_id,
             })
             .await;
 
         let outcome = match outcome {
             Ok(outcome) => outcome,
             Err(err) => {
+                tracing::warn!(command_id, "Cloud Connect: ApplySpicepod failed: {err}");
                 send_command_error(tx, command_id, &err).await;
                 return;
             }
         };
+        tracing::debug!(command_id, "Cloud Connect: ApplySpicepod applied");
 
         send_ok_json(tx, command_id, &outcome.document).await;
 
@@ -1564,6 +1659,7 @@ mod tests {
             enc_public_key_pem: String::new(),
             enc_previous_private_key_pem: String::new(),
             cache_key_b64: String::new(),
+            app_id: None,
         }
     }
 

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -36,6 +36,12 @@ pub const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 /// Default cadence for `Telemetry` frames on an established stream.
 pub const DEFAULT_TELEMETRY_INTERVAL: Duration = Duration::from_mins(1);
 
+/// Default cadence for `ExportMetrics` frames on an established stream.
+///
+/// Matches the heartbeat cadence: the payload carries cumulative totals, so the
+/// interval sets chart resolution rather than what is or is not recorded.
+pub const DEFAULT_METRICS_INTERVAL: Duration = Duration::from_secs(30);
+
 /// File name (relative to `$SPICE_CONFIG_DIR`) where the cloud-managed
 /// spicepod is written when an `ApplySpicepod` command arrives.
 pub const CLOUD_MANAGED_SPICEPOD_FILE: &str = "spicepod-cloud-managed.yml";
@@ -157,6 +163,10 @@ pub struct CloudConnectConfig {
     /// Cadence for `Telemetry` frames once a stream is established.
     /// Defaults to [`DEFAULT_TELEMETRY_INTERVAL`].
     pub telemetry_interval: Duration,
+
+    /// Cadence for `ExportMetrics` frames once a stream is established.
+    /// Defaults to [`DEFAULT_METRICS_INTERVAL`].
+    pub metrics_interval: Duration,
 
     /// Lead time before the identity cert's `not_after` at which the
     /// client renews (fresh keypair + CSR against `/renew`). Defaults to
@@ -339,6 +349,7 @@ impl CloudConnectConfig {
             runtime_version: runtime_version.into(),
             heartbeat_interval: DEFAULT_HEARTBEAT_INTERVAL,
             telemetry_interval: DEFAULT_TELEMETRY_INTERVAL,
+            metrics_interval: DEFAULT_METRICS_INTERVAL,
             renewal_lead: DEFAULT_RENEWAL_LEAD,
         }
     }

--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -559,6 +559,7 @@ pub(crate) async fn acquire_identity(
         ca_bundle_pem: outcome.ca_bundle_pem,
         gateway_addr: outcome.gateway_addr,
         not_after_unix: Some(outcome.not_after_unix),
+        app_id: None,
         enc_private_key_pem: material.enc_private_key_pem,
         enc_public_key_pem: material.enc_public_key_pem,
         // A fresh enrollment has no prior key to retain.
@@ -920,6 +921,7 @@ mod tests {
             runtime_version: "v0-test".to_string(),
             heartbeat_interval: Duration::from_secs(30),
             telemetry_interval: Duration::from_mins(1),
+            metrics_interval: Duration::from_secs(30),
             renewal_lead: Duration::from_hours(12),
         }
     }

--- a/crates/runtime-cloud-connect/src/handlers.rs
+++ b/crates/runtime-cloud-connect/src/handlers.rs
@@ -205,6 +205,13 @@ pub struct SpicepodDeployment<'a> {
     /// `None` means the deployment carried none, which is distinct from an
     /// empty map — an app whose secrets were all removed.
     pub delivered_secrets: Option<DeliveredSecrets>,
+    /// The app this instance's telemetry is attributed to. It rides the
+    /// deployment because the instance cannot derive it and the control plane
+    /// already knows it; a handle that exports metrics records it and stamps it
+    /// as `scp_app_id`.
+    ///
+    /// Empty means the control plane named no app.
+    pub app_id: &'a str,
 }
 
 /// What the client must do once the result of an apply has been sent.
@@ -367,6 +374,9 @@ pub trait RuntimeHandle: Send + Sync + 'static {
     /// writing the spicepod and dropping them: an adapter that cannot apply
     /// secrets would otherwise report success and then fail every referencing
     /// component with a missing-parameter error that names nothing.
+    ///
+    /// [`SpicepodDeployment::app_id`] is ignored by the default implementation,
+    /// which has no metrics pipeline to attribute.
     async fn apply_spicepod(
         &self,
         deployment: SpicepodDeployment<'_>,
@@ -470,6 +480,21 @@ pub trait RuntimeHandle: Send + Sync + 'static {
             "GetStatus is not implemented in this build",
         ))
     }
+
+    /// The instance's current metrics, as a serialized OTLP
+    /// `ExportMetricsServiceRequest`.
+    ///
+    /// Not a [`Capability`]: the client pushes these on its own cadence rather
+    /// than answering a command, so there is nothing to advertise or dispatch.
+    ///
+    /// `Ok(None)` means this instance has nothing to report — either it does not
+    /// export metrics at all, which is the default, it has none yet, or it has not
+    /// been told which app to attribute them to (see [`Self::apply_spicepod`]). An
+    /// `Err` means collection was attempted and failed; the two are distinct so a
+    /// permanently broken collection cannot pass for an idle runtime.
+    async fn collect_metrics(&self) -> Result<Option<Vec<u8>>, CommandError> {
+        Ok(None)
+    }
 }
 
 /// The capabilities `runtime` advertises, as the wire names carried in
@@ -550,6 +575,7 @@ mod tests {
                 config_dir: &dir,
                 spicepod_yaml: "version: v2\nkind: Spicepod\nname: default-apply\n",
                 delivered_secrets: None,
+                app_id: "",
             })
             .await
             .expect("the default apply writes the spicepod");
@@ -584,6 +610,7 @@ mod tests {
                 config_dir: &dir,
                 spicepod_yaml: "version: v2\nkind: Spicepod\nname: refused\n",
                 delivered_secrets: Some(secrets),
+                app_id: "",
             })
             .await
             .expect_err("a handle that cannot apply secrets must refuse the deployment");

--- a/crates/runtime-cloud-connect/src/handlers.rs
+++ b/crates/runtime-cloud-connect/src/handlers.rs
@@ -210,8 +210,8 @@ pub struct SpicepodDeployment<'a> {
     /// already knows it; a handle that exports metrics records it and stamps it
     /// as `scp_app_id`.
     ///
-    /// Empty means the control plane named no app.
-    pub app_id: &'a str,
+    /// `None` when the control plane named no app.
+    pub app_id: Option<&'a str>,
 }
 
 /// What the client must do once the result of an apply has been sent.
@@ -575,7 +575,7 @@ mod tests {
                 config_dir: &dir,
                 spicepod_yaml: "version: v2\nkind: Spicepod\nname: default-apply\n",
                 delivered_secrets: None,
-                app_id: "",
+                app_id: None,
             })
             .await
             .expect("the default apply writes the spicepod");
@@ -610,7 +610,7 @@ mod tests {
                 config_dir: &dir,
                 spicepod_yaml: "version: v2\nkind: Spicepod\nname: refused\n",
                 delivered_secrets: Some(secrets),
-                app_id: "",
+                app_id: None,
             })
             .await
             .expect_err("a handle that cannot apply secrets must refuse the deployment");

--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -151,6 +151,22 @@ pub struct Identity {
     /// cache key yet and the cache is simply unavailable until one is minted.
     #[serde(default)]
     pub cache_key_b64: String,
+    /// The app this instance's telemetry is attributed to, as delivered by
+    /// `ApplySpicepod` and stamped on exported metrics as `scp_app_id`.
+    ///
+    /// The one field here that is not credential material. It lives alongside
+    /// the credential because it shares the credential's lifetime — both are
+    /// control-plane facts about this enrolled instance, and both are cleared
+    /// together when the instance is released.
+    ///
+    /// Persisted rather than held only in memory so a restart does not silence
+    /// the export until the next deploy: the runtime cannot derive the value,
+    /// nothing re-sends it on reconnect, and a deploy may be days away.
+    ///
+    /// `None` means no deploy has ever named an app for this instance, which is
+    /// the state a freshly enrolled instance starts in.
+    #[serde(default)]
+    pub app_id: Option<String>,
 }
 
 /// Read the persisted `not_after_unix`, mapping a missing, null, or `0` value
@@ -339,6 +355,31 @@ fn generate_cache_key_b64() -> std::result::Result<String, getrandom::Error> {
 #[derive(Debug, Clone)]
 pub struct IdentityStore;
 
+/// Serializes writers of the identity file.
+///
+/// [`atomic_write`] already makes any single write all-or-nothing, so no reader
+/// ever sees a half-file. What this adds is protection against a LOST UPDATE:
+/// [`IdentityStore::store_app_id`] reads the file, edits one field, and writes it
+/// back, while the renewal path writes the whole file from the identity it holds.
+/// Interleave those and the rotated credential is silently replaced by the copy
+/// the app-id update read a moment earlier — leaving on disk a key the cloud has
+/// already stopped accepting, which surfaces much later as a renewal that cannot
+/// authenticate.
+///
+/// Process-wide because both writers live in this process. Two `spiced`
+/// processes sharing one config directory would still race, but that is already
+/// unsupported for every other reason.
+///
+/// Poisoning is ignored: the guarded data is the file, not memory, and a panic
+/// mid-write leaves it either fully old or fully new thanks to the atomic
+/// rename. Refusing all later writes would turn a transient fault into a
+/// permanently unrenewable instance.
+fn write_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 impl IdentityStore {
     /// Read an identity file, returning `Ok(None)` if it does not exist.
     ///
@@ -369,6 +410,43 @@ impl IdentityStore {
     /// Returns an error if the parent directory cannot be created, the
     /// identity cannot be serialized, or the file cannot be written.
     pub fn store(path: &Path, identity: &Identity) -> Result<()> {
+        let _guard = write_lock();
+        Self::store_locked(path, identity)
+    }
+
+    /// Record the app this instance's telemetry belongs to, leaving every other
+    /// field as it is on disk.
+    ///
+    /// A read-modify-write, which is why it runs under [`write_lock`]: the
+    /// renewal path rewrites the whole file from the identity it holds in
+    /// memory, so an unsynchronized update here could be read before a renewal
+    /// and written after it, silently reverting the rotated credential. The
+    /// lock makes the two orderings the only possible ones.
+    ///
+    /// `Ok(())` with nothing written when the file does not exist. The app id
+    /// arrives over an established stream, which requires an identity, so this
+    /// means the identity was cleared concurrently (a `Remove`) — and
+    /// re-creating the file from a partial value would resurrect an instance the
+    /// control plane just released.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the existing file cannot be read or parsed, or if the
+    /// updated identity cannot be written.
+    pub fn store_app_id(path: &Path, app_id: &str) -> Result<()> {
+        let _guard = write_lock();
+        let Some(mut identity) = Self::load_optional(path)? else {
+            return Ok(());
+        };
+        if identity.app_id.as_deref() == Some(app_id) {
+            return Ok(());
+        }
+        identity.app_id = Some(app_id.to_string());
+        Self::store_locked(path, &identity)
+    }
+
+    /// The write itself, with the caller already holding [`write_lock`].
+    fn store_locked(path: &Path, identity: &Identity) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).context(IoSnafu {
                 path: parent.to_path_buf(),
@@ -628,6 +706,7 @@ mod tests {
                 .to_string(),
             gateway_addr: "gateway.test.spice.ai:443".to_string(),
             not_after_unix: None,
+            app_id: None,
             enc_private_key_pem:
                 "-----BEGIN PRIVATE KEY-----\nMOCKENC\n-----END PRIVATE KEY-----\n".to_string(),
             enc_public_key_pem: "-----BEGIN PUBLIC KEY-----\nMOCKENC\n-----END PUBLIC KEY-----\n"
@@ -676,6 +755,103 @@ mod tests {
         assert_eq!(loaded.public_key_pem, identity.public_key_pem);
         assert_eq!(loaded.ca_bundle_pem, identity.ca_bundle_pem);
         assert_eq!(loaded.gateway_addr, identity.gateway_addr);
+    }
+
+    /// `store_app_id` is a read-modify-write, and everything it does not touch
+    /// has to come back unchanged — most importantly the credential, since
+    /// overwriting that with a stale copy leaves a key the cloud has stopped
+    /// accepting.
+    #[test]
+    fn store_app_id_records_the_app_and_preserves_the_credential() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        let identity = sample_identity();
+        IdentityStore::store(&path, &identity).expect("store");
+
+        IdentityStore::store_app_id(&path, "4002").expect("store app id");
+
+        let loaded = IdentityStore::load_optional(&path)
+            .expect("load")
+            .expect("present");
+        assert_eq!(loaded.app_id.as_deref(), Some("4002"));
+        assert_eq!(loaded.identity_cert_pem, identity.identity_cert_pem);
+        assert_eq!(loaded.private_key_pem, identity.private_key_pem);
+        assert_eq!(loaded.enc_private_key_pem, identity.enc_private_key_pem);
+        assert_eq!(loaded.not_after_unix, identity.not_after_unix);
+    }
+
+    #[test]
+    fn store_app_id_replaces_a_previous_app() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        IdentityStore::store(&path, &sample_identity()).expect("store");
+
+        IdentityStore::store_app_id(&path, "4002").expect("first");
+        IdentityStore::store_app_id(&path, "3387").expect("second");
+
+        let loaded = IdentityStore::load_optional(&path)
+            .expect("load")
+            .expect("present");
+        assert_eq!(loaded.app_id.as_deref(), Some("3387"));
+    }
+
+    /// The app id arrives over an established stream, which requires an
+    /// identity — so a missing file means one was cleared concurrently by a
+    /// `Remove`. Writing a fresh file here would resurrect an instance the
+    /// control plane just released.
+    #[test]
+    fn store_app_id_does_not_create_an_identity() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+
+        IdentityStore::store_app_id(&path, "4002").expect("no-op on a missing identity");
+
+        assert!(
+            IdentityStore::load_optional(&path).expect("load").is_none(),
+            "a released instance must not be resurrected by a metrics label"
+        );
+    }
+
+    /// A renewal rewrites the whole file from the identity it holds in memory,
+    /// so the app id must ride across the rotation — otherwise every renewal
+    /// silently un-attributes the instance until its next deploy.
+    #[test]
+    fn a_rotation_carries_the_app_id_forward() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        IdentityStore::store(&path, &sample_identity()).expect("store");
+        IdentityStore::store_app_id(&path, "4002").expect("store app id");
+
+        let mut rotated = IdentityStore::load_optional(&path)
+            .expect("load")
+            .expect("present");
+        rotated.private_key_pem = "ROTATED-KEY".to_string();
+        rotated.identity_cert_pem = "ROTATED-CERT".to_string();
+        IdentityStore::store(&path, &rotated).expect("store rotated");
+
+        let loaded = IdentityStore::load_optional(&path)
+            .expect("load")
+            .expect("present");
+        assert_eq!(loaded.private_key_pem, "ROTATED-KEY");
+        assert_eq!(loaded.app_id.as_deref(), Some("4002"));
+    }
+
+    #[test]
+    fn load_tolerates_identity_without_an_app_id() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        let legacy = r#"{
+            "identifier": "inst_legacy",
+            "identity_cert_pem": "CERT",
+            "private_key_pem": "KEY",
+            "public_key_pem": "PUB"
+        }"#;
+        std::fs::write(&path, legacy).expect("write legacy identity");
+
+        let loaded = IdentityStore::load_optional(&path)
+            .expect("load")
+            .expect("present");
+        assert_eq!(loaded.app_id, None);
     }
 
     #[test]

--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -66,6 +66,9 @@ pub enum Error {
 
     #[snafu(display("Failed to generate enrollment encryption key material: {reason}"))]
     EncKeyGeneration { reason: String },
+
+    #[snafu(display("Failed to remove the identity file: {source}"))]
+    ClearTaskPanicked { source: tokio::task::JoinError },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -458,29 +461,43 @@ impl IdentityStore {
 
     /// Remove the identity file. No-op if it doesn't exist.
     ///
+    /// Takes [`write_lock`] for the same reason [`IdentityStore::store_app_id`]
+    /// does, and it is what makes a release final: an update that read the file
+    /// a moment before the removal would otherwise write it back afterwards,
+    /// resurrecting an instance the control plane just released. Under the lock
+    /// the removal either precedes the read — leaving nothing to update — or
+    /// follows the write, and removes it.
+    ///
     /// # Errors
     ///
     /// Returns an error if the file exists but cannot be removed.
     pub fn clear(path: &Path) -> Result<()> {
-        match std::fs::remove_file(path) {
-            Ok(()) => Ok(()),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(Error::Io {
-                path: path.to_path_buf(),
-                source: err,
-            }),
-        }
+        let _guard = write_lock();
+        Self::clear_locked(path)
     }
 
     /// Async variant of [`IdentityStore::clear`] for use on the Tokio driver
     /// task, where blocking on synchronous `std::fs` I/O would stall a worker
     /// thread. Same semantics: no-op if the file doesn't exist.
     ///
+    /// Runs on the blocking pool rather than awaiting `tokio::fs` directly: the
+    /// removal has to happen under the same [`write_lock`] every other writer
+    /// takes, and a std mutex must never be held across an `.await`.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the file exists but cannot be removed.
+    /// Returns an error if the file exists but cannot be removed, or if the
+    /// blocking task carrying the removal panicked.
     pub async fn clear_async(path: &Path) -> Result<()> {
-        match tokio::fs::remove_file(path).await {
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || Self::clear(&path))
+            .await
+            .map_err(|source| Error::ClearTaskPanicked { source })?
+    }
+
+    /// The removal itself, with the caller already holding [`write_lock`].
+    fn clear_locked(path: &Path) -> Result<()> {
+        match std::fs::remove_file(path) {
             Ok(()) => Ok(()),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(err) => Err(Error::Io {
@@ -809,6 +826,35 @@ mod tests {
         assert!(
             IdentityStore::load_optional(&path).expect("load").is_none(),
             "a released instance must not be resurrected by a metrics label"
+        );
+    }
+
+    /// A release racing app-id updates must win: `store_app_id` reads the file
+    /// and writes it back, so a removal landing between the two would be undone
+    /// and the instance would keep talking to a control plane that released it.
+    /// Both sides take the same writer lock, which leaves only the two orderings
+    /// where the file ends up gone.
+    #[test]
+    fn a_release_wins_over_concurrent_app_id_updates() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        IdentityStore::store(&path, &sample_identity()).expect("store");
+
+        std::thread::scope(|scope| {
+            let updater = scope.spawn(|| {
+                for i in 0..200 {
+                    IdentityStore::store_app_id(&path, &format!("400{i}")).expect("store app id");
+                }
+            });
+            IdentityStore::clear(&path).expect("clear");
+            updater.join().expect("updater thread");
+        });
+
+        // Updates that ran before the clear were removed with the rest of the
+        // identity; those that ran after found no file and did nothing.
+        assert!(
+            IdentityStore::load_optional(&path).expect("load").is_none(),
+            "a released instance must stay released"
         );
     }
 

--- a/crates/runtime-cloud-connect/src/release.rs
+++ b/crates/runtime-cloud-connect/src/release.rs
@@ -307,6 +307,7 @@ mod tests {
             ca_bundle_pem: String::new(),
             gateway_addr: String::new(),
             not_after_unix: None,
+            app_id: None,
             enc_private_key_pem: String::new(),
             enc_public_key_pem: String::new(),
             enc_previous_private_key_pem: String::new(),
@@ -405,6 +406,7 @@ mod tests {
             enc_public_key_pem: String::new(),
             enc_previous_private_key_pem: String::new(),
             cache_key_b64: String::new(),
+            app_id: None,
         };
         let public_key_pem = key_pair.public_key_pem();
         (identity, public_key_pem)

--- a/crates/runtime-cloud-connect/tests/adoption_flow.rs
+++ b/crates/runtime-cloud-connect/tests/adoption_flow.rs
@@ -136,7 +136,8 @@ impl CloudConnect for MockServer {
 }
 
 struct CapturedRuntime {
-    applied: Arc<Mutex<Option<(PathBuf, String)>>>,
+    /// The config dir, spicepod, and app id of the last apply.
+    applied: Arc<Mutex<Option<(PathBuf, String, String)>>>,
 }
 
 #[async_trait]
@@ -156,7 +157,11 @@ impl RuntimeHandle for CapturedRuntime {
             .map_err(|e| CommandError::failed(e.to_string()))?;
         std::fs::write(&path, deployment.spicepod_yaml)
             .map_err(|e| CommandError::failed(e.to_string()))?;
-        *self.applied.lock().await = Some((path.clone(), deployment.spicepod_yaml.to_string()));
+        *self.applied.lock().await = Some((
+            path.clone(),
+            deployment.spicepod_yaml.to_string(),
+            deployment.app_id.to_string(),
+        ));
         // `settled`, not `exit_to_apply`: this handle has no process to restart,
         // and asking the client to exit would take the test process with it.
         Ok(ApplyOutcome::settled(
@@ -270,6 +275,7 @@ fn enroll_config(
         runtime_version: "v0.0.0-test".to_string(),
         heartbeat_interval: Duration::from_secs(30),
         telemetry_interval: Duration::from_mins(1),
+        metrics_interval: Duration::from_secs(30),
         renewal_lead: Duration::from_mins(1),
     }
 }
@@ -472,6 +478,7 @@ async fn apply_spicepod_writes_file_and_acks() {
             proto::ApplySpicepod {
                 spicepod_yaml: yaml.to_string(),
                 sealed_secret_payload: None,
+                app_id: "4002".to_string(),
             },
         )),
     };
@@ -491,6 +498,7 @@ async fn apply_spicepod_writes_file_and_acks() {
         ca_bundle_pem: String::new(),
         gateway_addr: addr.to_string(),
         not_after_unix: None,
+        app_id: None,
         enc_private_key_pem: String::new(),
         enc_public_key_pem: String::new(),
         enc_previous_private_key_pem: String::new(),
@@ -519,6 +527,7 @@ async fn apply_spicepod_writes_file_and_acks() {
         runtime_version: "v0.0.0-test".to_string(),
         heartbeat_interval: Duration::from_secs(30),
         telemetry_interval: Duration::from_mins(1),
+        metrics_interval: Duration::from_secs(30),
         renewal_lead: Duration::from_hours(12),
     };
 
@@ -540,9 +549,12 @@ async fn apply_spicepod_writes_file_and_acks() {
         "runtime should have received ApplySpicepod within 5s"
     );
 
-    let (written_path, written_yaml) = captured.lock().await.clone().unwrap();
+    let (written_path, written_yaml, written_app_id) = captured.lock().await.clone().unwrap();
     assert_eq!(written_yaml, yaml);
     assert!(written_path.exists(), "file should be on disk");
+    // The runtime has no other way to learn its app, and withholds metrics
+    // entirely until this arrives.
+    assert_eq!(written_app_id, "4002");
 
     // Server should see the CommandResult for the apply. Poll for it with a
     // bounded timeout instead of a fixed sleep so the assertion does not race
@@ -643,6 +655,7 @@ async fn unknown_command_is_nacked_rather_than_dropped() {
         ca_bundle_pem: String::new(),
         gateway_addr: addr.to_string(),
         not_after_unix: None,
+        app_id: None,
         enc_private_key_pem: String::new(),
         enc_public_key_pem: String::new(),
         enc_previous_private_key_pem: String::new(),
@@ -663,6 +676,7 @@ async fn unknown_command_is_nacked_rather_than_dropped() {
         runtime_version: "v0.0.0-test".to_string(),
         heartbeat_interval: Duration::from_secs(30),
         telemetry_interval: Duration::from_mins(1),
+        metrics_interval: Duration::from_secs(30),
         renewal_lead: Duration::from_hours(12),
         adopt_app_name: None,
         adopt_create_app: false,

--- a/crates/runtime-cloud-connect/tests/adoption_flow.rs
+++ b/crates/runtime-cloud-connect/tests/adoption_flow.rs
@@ -137,7 +137,7 @@ impl CloudConnect for MockServer {
 
 struct CapturedRuntime {
     /// The config dir, spicepod, and app id of the last apply.
-    applied: Arc<Mutex<Option<(PathBuf, String, String)>>>,
+    applied: Arc<Mutex<Option<(PathBuf, String, Option<String>)>>>,
 }
 
 #[async_trait]
@@ -160,7 +160,7 @@ impl RuntimeHandle for CapturedRuntime {
         *self.applied.lock().await = Some((
             path.clone(),
             deployment.spicepod_yaml.to_string(),
-            deployment.app_id.to_string(),
+            deployment.app_id.map(str::to_string),
         ));
         // `settled`, not `exit_to_apply`: this handle has no process to restart,
         // and asking the client to exit would take the test process with it.
@@ -554,7 +554,7 @@ async fn apply_spicepod_writes_file_and_acks() {
     assert!(written_path.exists(), "file should be on disk");
     // The runtime has no other way to learn its app, and withholds metrics
     // entirely until this arrives.
-    assert_eq!(written_app_id, "4002");
+    assert_eq!(written_app_id.as_deref(), Some("4002"));
 
     // Server should see the CommandResult for the apply. Poll for it with a
     // bounded timeout instead of a fixed sleep so the assertion does not race

--- a/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
@@ -555,7 +555,8 @@ async fn spawn_gateway(server: GatewayServer, ca: &TestCa) -> SocketAddr {
 
 #[derive(Default)]
 struct E2eRuntimeState {
-    applied_spicepod: Option<(std::path::PathBuf, String)>,
+    /// The path, spicepod, and app id of the last apply.
+    applied_spicepod: Option<(std::path::PathBuf, String, String)>,
     /// Names of the secrets delivered with the last applied spicepod, never
     /// values. `None` when the deployment carried no payload at all.
     delivered_secret_names: Option<Vec<String>>,
@@ -616,7 +617,11 @@ impl RuntimeHandle for E2eRuntime {
             .await
             .map_err(|e| CommandError::failed(e.to_string()))?;
         self.state.lock().await.applied_spicepod =
-            Some((path.clone(), deployment.spicepod_yaml.to_string()));
+            Some((
+                path.clone(),
+                deployment.spicepod_yaml.to_string(),
+                deployment.app_id.to_string(),
+            ));
         Ok(ApplyOutcome::exit_to_apply(serde_json::json!({
             "path": path.display().to_string(),
             "applied": true,
@@ -694,6 +699,7 @@ impl Harness {
             // the periodic frame paths.
             heartbeat_interval: Duration::from_millis(150),
             telemetry_interval: Duration::from_millis(250),
+            metrics_interval: Duration::from_millis(200),
             renewal_lead,
         }
     }
@@ -1448,6 +1454,7 @@ async fn apply_spicepod_delivers_double_sealed_secrets() {
                 enc: outer_sealed.enc,
                 ciphertext: outer_sealed.ciphertext,
             }),
+            app_id: "4002".to_string(),
         }),
     ));
 
@@ -1524,6 +1531,7 @@ async fn apply_spicepod_refuses_an_unopenable_payload() {
                 enc: vec![0_u8; 32],
                 ciphertext: vec![0_u8; 64],
             }),
+            app_id: String::new(),
         }),
     ));
 
@@ -1571,6 +1579,7 @@ async fn apply_spicepod_persists_then_exits_to_restart() {
         proto::control_message::Body::ApplySpicepod(proto::ApplySpicepod {
             spicepod_yaml: yaml.to_string(),
             sealed_secret_payload: None,
+            app_id: "4002".to_string(),
         }),
     ));
 
@@ -1615,7 +1624,7 @@ async fn apply_spicepod_persists_then_exits_to_restart() {
 
     // The runtime persisted the YAML to the canonical cloud-managed path, which
     // is what the restart comes back up on.
-    let (path, written) = rt_state
+    let (path, written, app_id) = rt_state
         .lock()
         .await
         .applied_spicepod
@@ -1623,6 +1632,9 @@ async fn apply_spicepod_persists_then_exits_to_restart() {
         .expect("spicepod applied");
     assert_eq!(written, yaml);
     assert!(path.exists(), "spicepod file must be on disk");
+    // The app id rides the deploy: it is the only way the runtime learns which
+    // app to attribute its metrics to, and it exports none until it has one.
+    assert_eq!(app_id, "4002");
 
     handle.shutdown().await;
 }

--- a/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
@@ -556,7 +556,7 @@ async fn spawn_gateway(server: GatewayServer, ca: &TestCa) -> SocketAddr {
 #[derive(Default)]
 struct E2eRuntimeState {
     /// The path, spicepod, and app id of the last apply.
-    applied_spicepod: Option<(std::path::PathBuf, String, String)>,
+    applied_spicepod: Option<(std::path::PathBuf, String, Option<String>)>,
     /// Names of the secrets delivered with the last applied spicepod, never
     /// values. `None` when the deployment carried no payload at all.
     delivered_secret_names: Option<Vec<String>>,
@@ -620,7 +620,7 @@ impl RuntimeHandle for E2eRuntime {
             Some((
                 path.clone(),
                 deployment.spicepod_yaml.to_string(),
-                deployment.app_id.to_string(),
+                deployment.app_id.map(str::to_string),
             ));
         Ok(ApplyOutcome::exit_to_apply(serde_json::json!({
             "path": path.display().to_string(),
@@ -1634,7 +1634,7 @@ async fn apply_spicepod_persists_then_exits_to_restart() {
     assert!(path.exists(), "spicepod file must be on disk");
     // The app id rides the deploy: it is the only way the runtime learns which
     // app to attribute its metrics to, and it exports none until it has one.
-    assert_eq!(app_id, "4002");
+    assert_eq!(app_id.as_deref(), Some("4002"));
 
     handle.shutdown().await;
 }

--- a/crates/runtime/src/metrics_reader.rs
+++ b/crates/runtime/src/metrics_reader.rs
@@ -27,7 +27,7 @@ use std::sync::{Arc, Weak};
 use opentelemetry_proto::tonic::{
     collector::metrics::v1::ExportMetricsServiceRequest,
     common::v1::{AnyValue, KeyValue, any_value::Value},
-    metrics::v1::metric::Data,
+    metrics::v1::{Metric, metric::Data},
 };
 use opentelemetry_sdk::metrics::{
     InstrumentKind, ManualReader, Pipeline, Temporality, data::ResourceMetrics,
@@ -39,7 +39,7 @@ use snafu::prelude::*;
 /// Why an on-demand collection produced no payload.
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to collect the runtime's own metrics: {source}"))]
+    #[snafu(display("Failed to collect Runtime metrics: {source}"))]
     Collect {
         source: opentelemetry_sdk::error::OTelSdkError,
     },
@@ -284,14 +284,7 @@ fn summarize(request: &ExportMetricsServiceRequest) -> Summary {
             for metric in &scope_metrics.metrics {
                 metrics += 1;
                 names.insert(metric.name.clone());
-                data_points += match &metric.data {
-                    Some(Data::Gauge(gauge)) => gauge.data_points.len(),
-                    Some(Data::Sum(sum)) => sum.data_points.len(),
-                    Some(Data::Histogram(histogram)) => histogram.data_points.len(),
-                    Some(Data::ExponentialHistogram(histogram)) => histogram.data_points.len(),
-                    Some(Data::Summary(summary)) => summary.data_points.len(),
-                    None => 0,
-                };
+                data_points += data_point_count(metric);
             }
         }
     }
@@ -303,17 +296,37 @@ fn summarize(request: &ExportMetricsServiceRequest) -> Summary {
     }
 }
 
+/// How many data points `metric` carries, across every aggregation OTLP
+/// defines. A metric with no `data` arm carries none.
+fn data_point_count(metric: &Metric) -> usize {
+    match &metric.data {
+        Some(Data::Gauge(gauge)) => gauge.data_points.len(),
+        Some(Data::Sum(sum)) => sum.data_points.len(),
+        Some(Data::Histogram(histogram)) => histogram.data_points.len(),
+        Some(Data::ExponentialHistogram(histogram)) => histogram.data_points.len(),
+        Some(Data::Summary(summary)) => summary.data_points.len(),
+        None => 0,
+    }
+}
+
 /// Whether `request` carries any data point at all.
 ///
 /// Tested on the decoded shape rather than on the encoded length, because a
 /// request with no metrics still encodes its resource attributes and so is not
 /// empty on the wire.
+///
+/// A declared metric is not a reported one: an instrument registered but never
+/// recorded arrives as a `Metric` whose aggregation holds no points, and
+/// exporting that spends a round trip to say nothing. The check therefore
+/// descends to the points rather than stopping at the metric list.
 fn has_data_points(request: &ExportMetricsServiceRequest) -> bool {
     request.resource_metrics.iter().any(|resource_metrics| {
-        resource_metrics
-            .scope_metrics
-            .iter()
-            .any(|scope_metrics| !scope_metrics.metrics.is_empty())
+        resource_metrics.scope_metrics.iter().any(|scope_metrics| {
+            scope_metrics
+                .metrics
+                .iter()
+                .any(|metric| data_point_count(metric) > 0)
+        })
     })
 }
 
@@ -908,6 +921,33 @@ mod tests {
 
         let busy = request_with(&["service_name"], &["protocol"], true);
         assert!(has_data_points(&busy));
+    }
+
+    /// An instrument that was registered but never recorded arrives as a metric
+    /// whose aggregation holds no points. Counting the metric rather than its
+    /// points would export a payload the log line calls empty.
+    #[test]
+    fn a_metric_without_points_reports_nothing() {
+        use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics as OtlpRM, ScopeMetrics, Sum};
+
+        let declared_only = ExportMetricsServiceRequest {
+            resource_metrics: vec![OtlpRM {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: vec![Metric {
+                        name: "never_recorded".to_string(),
+                        data: Some(Data::Sum(Sum::default())),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        assert!(
+            !has_data_points(&declared_only),
+            "a metric carrying no points has nothing to report"
+        );
     }
 
     /// The export reader reports cumulative totals, which is what makes a

--- a/crates/runtime/src/metrics_reader.rs
+++ b/crates/runtime/src/metrics_reader.rs
@@ -26,13 +26,26 @@ use std::sync::{Arc, Weak};
 
 use opentelemetry_proto::tonic::{
     collector::metrics::v1::ExportMetricsServiceRequest,
-    common::v1::{AnyValue, any_value::Value},
+    common::v1::{AnyValue, KeyValue, any_value::Value},
+    metrics::v1::metric::Data,
 };
 use opentelemetry_sdk::metrics::{
     InstrumentKind, ManualReader, Pipeline, Temporality, data::ResourceMetrics,
     reader::MetricReader,
 };
 use prost::Message;
+use snafu::prelude::*;
+
+/// Why an on-demand collection produced no payload.
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to collect the runtime's own metrics: {source}"))]
+    Collect {
+        source: opentelemetry_sdk::error::OTelSdkError,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// A metrics reader that supports on-demand collection of OTLP metrics.
 ///
@@ -73,6 +86,74 @@ impl MetricsReader {
         Self {
             reader: Arc::new(ManualReader::builder().build()),
         }
+    }
+
+    /// Creates a reader that reports cumulative totals rather than per-interval
+    /// deltas.
+    ///
+    /// Pinned rather than inherited because a consumer that pushes on a timer
+    /// depends on it: with cumulative totals a skipped or dropped push loses a
+    /// data point but no data, since the next one carries the running total.
+    #[must_use]
+    pub fn new_cumulative() -> Self {
+        Self {
+            reader: Arc::new(
+                ManualReader::builder()
+                    .with_temporality(Temporality::Cumulative)
+                    .build(),
+            ),
+        }
+    }
+
+    /// Collects the current metrics as an OTLP payload.
+    ///
+    /// `Ok(None)` means there is nothing to report. That is deliberately a
+    /// different outcome from a failed collection: a caller exporting on a timer
+    /// has no one watching its return value, so conflating the two would let a
+    /// permanently broken collection look exactly like an idle runtime — which
+    /// is the symptom the export exists to remove.
+    ///
+    /// Every attribute the SDK aggregated on is carried through. Dropping a
+    /// label is an aggregation — the series that shared it have to be summed —
+    /// so it belongs where aggregation happens: an SDK view (which filters on the
+    /// key set *before* aggregating) or the metrics backend's own rollup rules.
+    /// Removing keys from an already-aggregated batch collapses distinct series
+    /// into label-identical duplicates whose values are never summed, which reads
+    /// downstream as a duplicate sample and silently loses the rest.
+    ///
+    /// `app_id` is attached as `scp_app_id`, the label the metrics backend's app
+    /// dashboards filter on. A parameter rather than reader state because a
+    /// runtime does not know it at boot — the control plane sends it — and taking
+    /// it here makes an export payload impossible to build without one.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Collect`] if the underlying reader cannot collect.
+    pub fn collect_otlp_export(&self, app_id: &str) -> Result<Option<Vec<u8>>> {
+        let mut rm = ResourceMetrics::default();
+        self.reader.collect(&mut rm).context(CollectSnafu)?;
+
+        let mut request = sdk_metrics_to_otlp(&rm);
+        clear_units(&mut request);
+        stamp_app_id(&mut request, app_id);
+
+        // The conversion always emits one ResourceMetrics, so an idle runtime
+        // encodes to a resource with no data points rather than to nothing.
+        // Sending that would spend a round trip to say nothing.
+        if !has_data_points(&request) {
+            tracing::debug!("Metrics export: nothing to report (no data points collected)");
+            return Ok(None);
+        }
+
+        let summary = summarize(&request);
+        let payload = request.encode_to_vec();
+        tracing::debug!(
+            metrics = summary.metrics,
+            data_points = summary.data_points,
+            names = %summary.names.join(","),
+            "Metrics export: contents"
+        );
+        Ok(Some(payload))
     }
 
     /// Collects the current metrics as OTLP protobuf bytes.
@@ -122,6 +203,118 @@ impl MetricReader for MetricsReader {
     fn temporality(&self, kind: InstrumentKind) -> Temporality {
         self.reader.temporality(kind)
     }
+}
+
+/// Clear the unit on every metric in `request`.
+///
+/// The runtime's Prometheus exporter is built `.without_units()`, so a metric
+/// scraped from `/metrics` is named `query_duration_ms` — the unit already lives
+/// in the name. A backend that ingests OTLP applies the `OpenTelemetry`
+/// Prometheus naming convention instead, expanding the unit and appending it, so
+/// the same instrument arrives as `query_duration_ms_milliseconds`. The name is
+/// then both duplicated and different from what the scrape path produces, and one
+/// dashboard query cannot serve both.
+///
+/// Clearing the unit applies the existing `.without_units()` decision to this
+/// export path too, so both of the runtime's paths name a metric identically
+/// whoever consumes them. No information is lost: the unit is in the name.
+///
+/// Unlike dropping an attribute, this cannot merge series — the unit is metadata
+/// and is not part of a metric's identity, so no aggregation is implied.
+fn clear_units(request: &mut ExportMetricsServiceRequest) {
+    for resource_metrics in &mut request.resource_metrics {
+        for scope_metrics in &mut resource_metrics.scope_metrics {
+            for metric in &mut scope_metrics.metrics {
+                metric.unit.clear();
+            }
+        }
+    }
+}
+
+/// Resource attribute naming the app a runtime's telemetry belongs to. The
+/// metrics backend's app dashboards filter on it, so a series without it is
+/// ingested and then invisible to everything that would read it.
+const APP_ID_ATTRIBUTE: &str = "scp_app_id";
+
+/// Attach `app_id` as [`APP_ID_ATTRIBUTE`] on every resource in `request`,
+/// replacing any value already there.
+///
+/// A resource attribute rather than a data-point one: it describes the emitting
+/// instance, not an individual measurement, so one copy per batch labels every
+/// series in it. That also matches how the collector attributes platform-managed
+/// workloads, keeping both ingest paths on one shape.
+///
+/// Replacing rather than appending matters — protobuf repeated fields permit
+/// duplicate keys, and two `scp_app_id` entries on one resource is not a
+/// well-defined series.
+fn stamp_app_id(request: &mut ExportMetricsServiceRequest, app_id: &str) {
+    for resource_metrics in &mut request.resource_metrics {
+        let resource = resource_metrics
+            .resource
+            .get_or_insert_with(Default::default);
+        resource.attributes.retain(|kv| kv.key != APP_ID_ATTRIBUTE);
+        resource.attributes.push(KeyValue {
+            key: APP_ID_ATTRIBUTE.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(app_id.to_string())),
+            }),
+            ..Default::default()
+        });
+    }
+}
+
+/// What a collected batch contains, for the export log line.
+struct Summary {
+    metrics: usize,
+    data_points: usize,
+    /// Metric names, deduplicated and ordered, for the debug-level breakdown.
+    names: Vec<String>,
+}
+
+/// Count what `request` carries, so an export can be logged by content rather
+/// than only by byte size — a payload that is the right size but the wrong
+/// shape is otherwise indistinguishable from a correct one.
+fn summarize(request: &ExportMetricsServiceRequest) -> Summary {
+    let mut metrics = 0usize;
+    let mut data_points = 0usize;
+    let mut names = std::collections::BTreeSet::new();
+
+    for resource_metrics in &request.resource_metrics {
+        for scope_metrics in &resource_metrics.scope_metrics {
+            for metric in &scope_metrics.metrics {
+                metrics += 1;
+                names.insert(metric.name.clone());
+                data_points += match &metric.data {
+                    Some(Data::Gauge(gauge)) => gauge.data_points.len(),
+                    Some(Data::Sum(sum)) => sum.data_points.len(),
+                    Some(Data::Histogram(histogram)) => histogram.data_points.len(),
+                    Some(Data::ExponentialHistogram(histogram)) => histogram.data_points.len(),
+                    Some(Data::Summary(summary)) => summary.data_points.len(),
+                    None => 0,
+                };
+            }
+        }
+    }
+
+    Summary {
+        metrics,
+        data_points,
+        names: names.into_iter().collect(),
+    }
+}
+
+/// Whether `request` carries any data point at all.
+///
+/// Tested on the decoded shape rather than on the encoded length, because a
+/// request with no metrics still encodes its resource attributes and so is not
+/// empty on the wire.
+fn has_data_points(request: &ExportMetricsServiceRequest) -> bool {
+    request.resource_metrics.iter().any(|resource_metrics| {
+        resource_metrics
+            .scope_metrics
+            .iter()
+            .any(|scope_metrics| !scope_metrics.metrics.is_empty())
+    })
 }
 
 /// Converts OpenTelemetry SDK `ResourceMetrics` to OTLP protobuf `ExportMetricsServiceRequest`.
@@ -534,6 +727,51 @@ mod tests {
         let _ = reader.collect_otlp();
     }
 
+    fn app_id_of(request: &ExportMetricsServiceRequest) -> Vec<String> {
+        request.resource_metrics[0]
+            .resource
+            .as_ref()
+            .expect("resource present")
+            .attributes
+            .iter()
+            .filter(|kv| kv.key == APP_ID_ATTRIBUTE)
+            .filter_map(|kv| match kv.value.as_ref()?.value.as_ref()? {
+                Value::StringValue(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn stamp_app_id_attaches_the_label_when_the_resource_has_none() {
+        let mut request = request_with(&[], &[], false);
+        stamp_app_id(&mut request, "4002");
+        assert_eq!(app_id_of(&request), vec!["4002".to_string()]);
+    }
+
+    /// Protobuf repeated fields permit duplicate keys, so appending a second
+    /// `scp_app_id` would leave the resource carrying two — not a well-defined
+    /// series. Stamping twice must still leave exactly one, with the new value.
+    #[test]
+    fn stamp_app_id_replaces_rather_than_appends() {
+        let mut request = request_with(&[], &[], false);
+        stamp_app_id(&mut request, "4002");
+        stamp_app_id(&mut request, "3387");
+        assert_eq!(app_id_of(&request), vec!["3387".to_string()]);
+    }
+
+    /// A resource that arrives with no `Resource` at all still has to end up
+    /// labelled — the backend drops what it cannot attribute.
+    #[test]
+    fn stamp_app_id_creates_a_missing_resource() {
+        use opentelemetry_proto::tonic::metrics::v1::ResourceMetrics as OtlpRM;
+        let mut request = ExportMetricsServiceRequest {
+            resource_metrics: vec![OtlpRM::default()],
+        };
+        stamp_app_id(&mut request, "4002");
+        assert_eq!(app_id_of(&request), vec!["4002".to_string()]);
+    }
+
     #[test]
     fn test_otel_value_to_proto_bool() {
         let value = opentelemetry::Value::Bool(true);
@@ -564,5 +802,142 @@ mod tests {
         let value = opentelemetry::Value::String("test".into());
         let proto = otel_value_to_proto(&value);
         assert!(matches!(proto, Value::StringValue(s) if s == "test"));
+    }
+
+    fn attribute(key: &str) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue("v".to_string())),
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// A request carrying a resource but no metrics, which is what an idle
+    /// runtime converts to.
+    fn request_with(
+        resource_keys: &[&str],
+        data_point_keys: &[&str],
+        with_metric: bool,
+    ) -> ExportMetricsServiceRequest {
+        use opentelemetry_proto::tonic::metrics::v1::{
+            Metric, NumberDataPoint, ResourceMetrics as OtlpRM, ScopeMetrics, Sum,
+        };
+        use opentelemetry_proto::tonic::resource::v1::Resource;
+
+        let metrics = if with_metric {
+            vec![Metric {
+                name: "m".to_string(),
+                data: Some(Data::Sum(Sum {
+                    data_points: vec![NumberDataPoint {
+                        attributes: data_point_keys.iter().copied().map(attribute).collect(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }]
+        } else {
+            Vec::new()
+        };
+
+        ExportMetricsServiceRequest {
+            resource_metrics: vec![OtlpRM {
+                resource: Some(Resource {
+                    attributes: resource_keys.iter().copied().map(attribute).collect(),
+                    ..Default::default()
+                }),
+                scope_metrics: vec![ScopeMetrics {
+                    metrics,
+                    ..Default::default()
+                }],
+                schema_url: String::new(),
+            }],
+        }
+    }
+
+    /// The exported payload carries no unit, matching the Prometheus exporter's
+    /// `.without_units()`. A backend that expanded `ms` into the metric name
+    /// would produce `query_duration_ms_milliseconds`, which is both a duplicated
+    /// unit and a different name from the one the scrape path publishes.
+    #[test]
+    fn units_are_cleared_so_a_backend_cannot_append_them_to_the_name() {
+        use opentelemetry_proto::tonic::metrics::v1::{
+            Metric, ResourceMetrics as OtlpRM, ScopeMetrics, Sum,
+        };
+
+        let mut request = ExportMetricsServiceRequest {
+            resource_metrics: vec![OtlpRM {
+                scope_metrics: vec![ScopeMetrics {
+                    metrics: vec![Metric {
+                        name: "query_duration_ms".to_string(),
+                        unit: "ms".to_string(),
+                        data: Some(Data::Sum(Sum::default())),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        clear_units(&mut request);
+
+        let metric = &request.resource_metrics[0].scope_metrics[0].metrics[0];
+        assert_eq!(metric.unit, "", "the unit must not reach the backend");
+        assert_eq!(
+            metric.name, "query_duration_ms",
+            "the name already carries the unit and must be untouched"
+        );
+    }
+
+    /// An idle runtime still converts to a request carrying its resource, so
+    /// emptiness has to be judged on data points rather than on encoded length.
+    #[test]
+    fn a_resource_without_metrics_has_no_data_points() {
+        let idle = request_with(&["service_name"], &[], false);
+        assert!(
+            !has_data_points(&idle),
+            "a resource-only request reports nothing"
+        );
+        assert!(
+            !idle.encode_to_vec().is_empty(),
+            "yet it is not empty on the wire, which is why length is the wrong test"
+        );
+
+        let busy = request_with(&["service_name"], &["protocol"], true);
+        assert!(has_data_points(&busy));
+    }
+
+    /// The export reader reports cumulative totals, which is what makes a
+    /// dropped push lose a data point rather than data.
+    #[test]
+    fn the_export_reader_is_cumulative() {
+        let reader = MetricsReader::new_cumulative();
+        assert_eq!(
+            reader.temporality(InstrumentKind::Counter),
+            Temporality::Cumulative
+        );
+    }
+
+    /// A collection that cannot run is an error, not silence.
+    ///
+    /// An unregistered reader is the reachable form of that failure, and it is
+    /// exactly the case the older accessor cannot express: it returns an empty
+    /// payload, indistinguishable from a runtime with nothing to say.
+    #[test]
+    fn a_failed_collection_is_not_reported_as_nothing_to_report() {
+        let reader = MetricsReader::new_cumulative();
+
+        reader
+            .collect_otlp_export("4002")
+            .expect_err("an unregistered reader cannot collect");
+
+        assert!(
+            reader.collect_otlp().is_empty(),
+            "the older accessor reports the same failure as emptiness, which is what the \
+             fallible one exists to separate"
+        );
     }
 }


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

An adopted standalone `spiced` now pushes its own metrics to Spice Cloud, so the portal's app dashboards work for instances the platform does not host.

The runtime collects its metrics on a timer and sends them to the gateway over the existing Cloud Connect stream as a serialized OTLP request. Totals are cumulative, so a dropped or skipped push loses a data point but never data — the next one carries the running total, and nothing needs buffering or retrying.

The dashboards filter on `scp_app_id`, and a runtime has no way to know which app it belongs to. The control plane does, so it sends the app id with the deploy (`ApplySpicepod`) and the runtime stamps it on what it exports. It is stored alongside the identity, so a restart keeps exporting rather than going quiet until the next deploy.

An instance that has never been told its app exports nothing at all. That is deliberate: a series with no `scp_app_id` is ingested but matches no dashboard, so sending it spends quota on something nothing can read — and does it silently.

The gateway remains the authority on tenancy. It stamps `scp_org_id` from the verified mTLS identity and overwrites whatever the client claimed, which is what keeps one org's metrics out of another's. `scp_app_id` is attribution within an org rather than a tenant boundary, so it stays the workload's to set.

Metric names match the `/metrics` scrape path, so one dashboard query serves both.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* See source PR: https://github.com/spiceai/spiceai/pull/12318
