### PR TITLE
fix(ci): retry the sign-off status post, and say so when it never lands (fixes #12701)

### DIFF
--- a/scripts/signoff
+++ b/scripts/signoff
@@ -68,6 +68,12 @@ readonly VERSION="1.5.0"
 readonly STATUS_CONTEXT="signoff"
 readonly TARGET_BRANCH="${SIGNOFF_BRANCH:-trunk}"
 readonly TARGET_REMOTE="${SIGNOFF_REMOTE:-origin}"
+# Seconds to wait between attempts at a commit-status POST; the number of
+# attempts is one more than the number of entries. A verdict can cost hours of
+# runner time and exists nowhere but that POST, so one transient response must
+# not discard it. Empty means post once. Overridable so the unit tests do not
+# pay for the waits.
+readonly STATUS_POST_BACKOFF="${SIGNOFF_STATUS_POST_BACKOFF-5 15 30 60}"
 DEBUG="${SIGNOFF_DEBUG:-}"
 VCS=""
 JJ_REMOTE_URL=""
@@ -605,16 +611,68 @@ append_step_summary() {
   printf '%s\n' "$text" >>"$GITHUB_STEP_SUMMARY" 2>/dev/null || true
 }
 
+# A status post that never lands leaves the commit carrying whatever it had.
+# For a remote run that is the `pending` posted on the way in, which the
+# Attestation check renders as a failure and which every reader — `signoff
+# mine`, the PR-sweep tooling — takes for a run still in flight, so nobody
+# re-dispatches. That state is indistinguishable from a live run, and a warning
+# in the log of a finished job does not reach anyone looking at the PR.
+warn_status_not_recorded() {
+  local sha="$1" state="$2" attempts="$3"
+  info "warning: could not post ${STATUS_CONTEXT}=${state} on ${sha:0:12} after ${attempts} attempt(s)"
+
+  # A `pending` that fails to post strands nothing: the commit keeps whatever it
+  # had, and this run still has its own verdict to post later. It is the verdict
+  # failing that leaves a reader holding a `pending` they cannot tell from a run
+  # still going, so that is what the summary is for.
+  if [[ "$state" != "pending" ]]; then
+    append_step_summary \
+      "### Sign-off"$'\n'"**Verdict not recorded** on \`${sha:0:12}\` — the \`${STATUS_CONTEXT}=${state}\` status did not post after ${attempts} attempt(s). Any \`pending\` left on this commit is stale, not a run in flight: sign off again."$'\n'
+  fi
+}
+
 # Post a commit status for STATUS_CONTEXT. Used for pending/failure on remote
 # runs and the final success attestation.
+#
+# Retried with backoff: this call is the only place a verdict exists, and a
+# transient response — a 5xx, a network blip, a 401 from a job that has outlived
+# its token — would otherwise discard hours of runner time for good.
 post_commit_status() {
   local repo="$1" sha="$2" state="$3" description="$4"
   description="${description:0:140}"
   debug "posting ${STATUS_CONTEXT}=${state} on ${repo}@${sha}: ${description}"
-  gh api --method POST "repos/${repo}/statuses/${sha}" \
-    -f state="$state" \
-    -f context="${STATUS_CONTEXT}" \
-    -f "description=${description}" >/dev/null
+
+  local -a backoff=()
+  read -r -a backoff <<<"$STATUS_POST_BACKOFF" || true
+  local attempts=$((${#backoff[@]} + 1))
+
+  local attempt=1 response
+  while true; do
+    if response=$(gh api --method POST "repos/${repo}/statuses/${sha}" \
+      -f state="$state" \
+      -f context="${STATUS_CONTEXT}" \
+      -f "description=${description}" 2>&1); then
+      if (( attempt > 1 )); then
+        info "posted ${STATUS_CONTEXT}=${state} on ${sha:0:12} on attempt ${attempt}"
+      fi
+      return 0
+    fi
+
+    # Report the response, not just that the call failed: "Bad credentials" on a
+    # job that has outlived its token reads differently from a 5xx, and only the
+    # second is something retrying can fix. Which one it was decides whether the
+    # answer here is more attempts or a fresh token.
+    info "warning: posting ${STATUS_CONTEXT}=${state} on ${sha:0:12} failed (attempt ${attempt}/${attempts}): $(printf '%s' "$response" | tr '\n' ' ')"
+
+    if (( attempt >= attempts )); then
+      warn_status_not_recorded "$sha" "$state" "$attempts"
+      return 1
+    fi
+    # Never fatal: a backoff this cannot honour must not abort the run before
+    # the attempt that would have recorded the verdict.
+    sleep "${backoff[attempt - 1]}" || true
+    attempt=$((attempt + 1))
+  done
 }
 
 # The STATUS_CONTEXT state currently on a commit: success/pending/failure/error,

--- a/scripts/test_signoff_status.sh
+++ b/scripts/test_signoff_status.sh
@@ -11,6 +11,11 @@
 
 set -uo pipefail
 
+# Every assertion below that exercises a failing post wants one call and no
+# waiting; the retry is covered on its own by assert_post_retry, which sets the
+# backoff it needs.
+export SIGNOFF_STATUS_POST_BACKOFF=""
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 subject="$script_dir/signoff"
 
@@ -62,7 +67,22 @@ fi
 
 if [[ "$*" == *"--method POST"* ]]; then
   # A post that fails records nothing: the status never landed on the commit.
-  [[ "${STUB_POST_RC:-0}" == "0" ]] || exit "${STUB_POST_RC}"
+  # STUB_POST_FAILURES names a file holding how many of the next posts must
+  # fail; each failing attempt decrements it, so a caller that retries gets
+  # through once it reaches zero. The body is the one that stranded the verdict
+  # the retry exists for.
+  if [[ -n "${STUB_POST_FAILURES:-}" ]]; then
+    remaining="$(cat "$STUB_POST_FAILURES" 2>/dev/null)"
+    if (( "${remaining:-0}" > 0 )); then
+      printf '%s\n' "$(( remaining - 1 ))" >"$STUB_POST_FAILURES"
+      echo "gh: Bad credentials (HTTP 401)" >&2
+      exit 1
+    fi
+  fi
+  if [[ "${STUB_POST_RC:-0}" != "0" ]]; then
+    echo "gh: Bad credentials (HTTP 401)" >&2
+    exit "${STUB_POST_RC}"
+  fi
   state="" context="" description=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -300,6 +320,54 @@ assert_reruns() {
   echo "  ok: $name"
 }
 
+# Calls post_commit_status against an endpoint that fails its next $2 posts,
+# under a backoff of $3 (empty = one attempt). Checks the return code against
+# $4, that exactly $5 statuses landed on the commit, and that the output — the
+# log plus the job summary, which is where a reader who is not tailing the run
+# looks — carries $6.
+assert_post_retry() {
+  local name="$1" fail_times="$2" backoff="$3" want_rc="$4" want_posts="$5" want_output="${6:-}"
+  local state="${7:-failure}" unwanted_output="${8:-}"
+  tests_run=$((tests_run + 1))
+
+  # Not named `failures`: that is the suite's own counter, and shadowing it here
+  # makes fail_test's increment an arithmetic error, so a failing assertion
+  # reports nothing and the suite still claims every test passed.
+  local posts="$stub_dir/posts" failures_left="$stub_dir/failures" summary="$stub_dir/summary"
+  : >"$posts"
+  : >"$summary"
+  printf '%s\n' "$fail_times" >"$failures_left"
+
+  local output rc
+  output="$(PATH="$stub_dir:$PATH" STUB_POSTS="$posts" STUB_POST_FAILURES="$failures_left" \
+    SIGNOFF_STATUS_POST_BACKOFF="$backoff" GITHUB_STEP_SUMMARY="$summary" \
+    bash -c 'source "$1"; post_commit_status spiceai/spiceai "$2" "$3" "a canned verdict"' \
+    _ "$subject" "$fake_sha" "$state" 2>&1)"
+  rc=$?
+  output+=$'\n'"$(cat "$summary")"
+
+  if [[ "$rc" -ne "$want_rc" ]]; then
+    fail_test "$name: expected exit ${want_rc}, got ${rc} (output: ${output})"
+    return
+  fi
+
+  local landed
+  landed="$(grep -c . <"$posts")"
+  if [[ "$landed" -ne "$want_posts" ]]; then
+    fail_test "$name: expected ${want_posts} status(es) to land, got ${landed} (output: ${output})"
+    return
+  fi
+  if [[ -n "$want_output" && "$output" != *"$want_output"* ]]; then
+    fail_test "$name: expected the output to carry '${want_output}', got '${output}'"
+    return
+  fi
+  if [[ -n "$unwanted_output" && "$output" == *"$unwanted_output"* ]]; then
+    fail_test "$name: expected the output not to carry '${unwanted_output}', got '${output}'"
+    return
+  fi
+  echo "  ok: $name"
+}
+
 # The BASH_SOURCE guard that makes the subject sourceable must not stop it from
 # dispatching when it is executed — every other caller runs it that way.
 assert_dispatches_when_executed() {
@@ -398,6 +466,36 @@ assert_attestation_refresh "an in-flight Attestation is flagged, not promised, o
   "4242 in_progress null" force "" 0 "may have read the previous sign-off already"
 assert_attestation_refresh "an in-flight Attestation is not flagged on the success path" \
   "4242 in_progress null" "" "" 0 "it will evaluate the sign-off once it finishes"
+
+echo
+echo "scripts/signoff — recording the verdict"
+
+# The bug: post_commit_status made one unretried call, so a single transient
+# response discarded a verdict that had cost hours of runner time, and the
+# `pending` posted on the way in stayed on the commit as the only thing there —
+# a state no reader can tell from a run still in flight.
+assert_post_retry "a verdict survives a transient failure" 2 "0 0 0" 0 1
+assert_post_retry "a verdict survives failures up to the last attempt" 3 "0 0 0" 0 1
+
+# An expired token is beyond what retrying can fix. What it must not do is fail
+# where only the log of a finished job can see it.
+assert_post_retry "a verdict that never lands says the pending is stale" 9 "0 0 0" 1 0 \
+  "Verdict not recorded"
+
+# Which failure it was decides whether the answer is more attempts or a fresh
+# token, and only the response body tells them apart.
+assert_post_retry "the response body is reported, not just the failure" 9 "0 0 0" 1 0 \
+  "Bad credentials"
+
+# An empty backoff is the single call the endpoint used to get, so a caller that
+# opts out is not silently retried.
+assert_post_retry "an empty backoff posts exactly once" 1 "" 1 0 "attempt 1/1"
+
+# A pending that never posts strands nothing — the commit keeps what it had and
+# the run still has its verdict to post — so it must not raise the alarm that
+# belongs to a lost verdict.
+assert_post_retry "a lost pending does not claim a stale status" 9 "0 0 0" 1 0 \
+  "" pending "Verdict not recorded"
 
 echo
 echo "scripts/signoff clear-pending"


### PR DESCRIPTION
## Summary

`post_commit_status` in `scripts/signoff` made a single unretried `gh api` call. That call is the
only place a sign-off verdict exists, so one transient response discarded it permanently.

The sign-off for #12652 ([run 31133614812](https://github.com/spiceai/spiceai/actions/runs/31133614812))
ran the full gate for 10,089s, reached a real verdict, and got `gh: Bad credentials (HTTP 401)`
posting it. The `Resolve an incomplete sign-off` fallback posts through the same helper and hit the
same 401. The commit was left carrying only the `pending` posted on the way in — which `Attestation`
renders as a failure, and which `signoff mine` and the PR-sweep tooling read as a run still in
flight, so nothing re-dispatches. That is strictly worse than a plain failure, and it happens to
exactly the runs whose verdict cost the most to produce.

Fixes #12701

## Changes

All three in `post_commit_status`, so every caller is covered at once — the pending on the way in,
the failing verdict, the success attestation, and the `clear-pending` fallback that inherited the
same weakness by calling the same function.

- **Retry with backoff.** `SIGNOFF_STATUS_POST_BACKOFF` (default `5 15 30 60`) gives four waits and
  therefore five attempts over ~110s. Empty means post once, which is what the tests use.
- **Report the response body on every attempt.** The issue asks for this explicitly, and it is the
  only thing that separates the two diagnoses: `Bad credentials` on a job that outlived its token is
  beyond what retrying can fix and needs a fresh token, while a 5xx or a network blip is exactly
  what the retry is for. Without the body the log cannot tell you which of the two you are looking
  at, and this run's 401 is still unattributed for that reason.
- **Say it in the job summary when the post never lands** — `Verdict not recorded … Any pending left
  on this commit is stale, not a run in flight: sign off again`. A warning in the log of a finished
  job does not reach anyone reading the PR, which is where the misreading happens.

  A failed **pending** post deliberately does not raise this: it strands nothing, because the commit
  keeps whatever it had and the run still has its own verdict to post. Covered by a test so the two
  cannot drift together.

## What this does not fix

If the 401 was token **expiry** rather than a transient blip, five attempts over ~110s will not
recover it — the issue says as much. This change makes that case diagnosable (the body is now
logged) and loud (the summary says the pending is stale) instead of silent. Refreshing the token
mid-run is a separate change to the workflow, and which of the two it is should be read off the next
occurrence rather than assumed.

Worst case this adds ~110s to a run that is already failing, on the failure path only.

## Test plan

`bash scripts/test_signoff_status.sh` — 33 assertions, run locally, all pass. CI runs it via
`.github/workflows/signoff_script_test.yml`, which triggers on both files this PR touches.

Six new assertions, all driving the real `post_commit_status` against a `gh` stub that fails its
next N posts:

- a verdict survives a transient failure
- a verdict survives failures up to the last attempt
- a verdict that never lands says the pending is stale
- the response body is reported, not just the failure
- an empty backoff posts exactly once
- a lost pending does not claim a stale status

Verified against the previous `scripts/signoff`: 4 of the 6 fail on it and all 6 pass on this one.
(The response-body assertion also passes on the old code, which let the body leak to the terminal
untagged; it is kept to lock the behaviour in now that the body is captured and attributed.)

Also re-ran the sibling suites, all passing and unchanged: `test_signoff_attestation_refresh.sh`
(15), `test_signoff_cancelled_correction.sh` (18), `test_signoff_disk_guard.sh` (48),
`test_signoff_resolve_target.sh` (22). `shellcheck -S warning` is clean on both changed files.

While writing the tests, the first version of the new helper declared a local named `failures`,
shadowing the suite's own counter — `fail_test`'s increment became an arithmetic error, so failing
assertions reported nothing and the suite still printed "all 32 tests passed". That is what the
old-code check above caught. The local is renamed and carries a comment saying why.

## Checklist

- [x] Fixed in the shared helper, so the fallback path cannot inherit the weakness again
- [x] Regression assertions fail on the previous script
- [x] Sibling sign-off suites re-run
- [x] Non-Rust change: `scripts/signoff` is not in `RUST_AFFECTING_PATH_PATTERN`, so the Rust gate is skipped
