### PR TITLE
feat(cloud-connect): bounded ExecuteQuery over the control stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19339,6 +19339,7 @@ dependencies = [
  "connector-spiceai",
  "cpu-budget",
  "crash-handler",
+ "datafusion",
  "event_stream",
  "futures",
  "libc",

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -18,6 +18,7 @@ connector-adbc = { path = "../../crates/data-connectors/connector-adbc", optiona
 connector-kafka = { path = "../../crates/data-connectors/connector-kafka", optional = true }
 connector-clickhouse = { path = "../../crates/data-connectors/connector-clickhouse", optional = true }
 connector-cosmosdb = { path = "../../crates/data-connectors/connector-cosmosdb", optional = true }
+datafusion = { workspace = true }
 connector-databricks = { path = "../../crates/data-connectors/connector-databricks", optional = true }
 connector-delta-lake = { path = "../../crates/data-connectors/connector-delta-lake", optional = true }
 connector-dynamodb = { path = "../../crates/data-connectors/connector-dynamodb", optional = true }

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -595,7 +595,7 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             // The handle holds the runtime, so it can always plan and execute
             // a query against whatever the instance currently serves — an
             // empty catalog answers with an error, not an inability.
-            Capability::ApplySpicepod | Capability::GetStatus | Capability::RunQuery => true,
+            Capability::ApplySpicepod | Capability::GetStatus | Capability::ExecuteQuery => true,
             // Only when the log-capture layer was installed at startup;
             // otherwise there is no buffer to read from.
             Capability::GetLogs => self.logs.is_some(),
@@ -608,7 +608,7 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             Capability::Restart => "Restart is unsupported on standalone spiced: it is not a control the runtime offers on demand. A deployment already applies by restarting this instance onto the spicepod it validated; to restart it without deploying, use your process manager (systemd/Docker/Kubernetes). See: https://spiceai.org/docs".to_string(),
             Capability::UpgradeRuntime => "UpgradeRuntime is unsupported on standalone spiced: it cannot replace its own binary. Upgrade it the way you installed it (`spice upgrade`, your container image, or your package manager). See: https://spiceai.org/docs".to_string(),
             Capability::GetLogs => "Log capture is not enabled for this runtime: Spice Cloud Connect must be configured before startup for spiced to install the log-capture layer. See: https://spiceai.org/docs".to_string(),
-            Capability::ApplySpicepod | Capability::GetStatus | Capability::RunQuery => format!(
+            Capability::ApplySpicepod | Capability::GetStatus | Capability::ExecuteQuery => format!(
                 "{} is not supported by this instance",
                 capability.wire_name()
             ),
@@ -1005,7 +1005,7 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             .map_err(|err| CommandError::internal(err.to_string()))
     }
 
-    /// Execute a `RunQuery` against the in-process runtime.
+    /// Execute an `ExecuteQuery` against the in-process runtime.
     ///
     /// The query goes through the same `DataFusion` entry point the local SQL
     /// APIs use, so there is no HTTP hop and no second set of query semantics
@@ -1020,7 +1020,7 @@ impl RuntimeHandle for SpicedRuntimeHandle {
     /// `max_rows` is clamped again here rather than trusted: the caller already
     /// clamps it, and a limit enforced in exactly one place is a limit one
     /// refactor away from being gone.
-    async fn run_query(&self, sql: &str, max_rows: u32) -> Result<QueryOutcome, CommandError> {
+    async fn execute_query(&self, sql: &str, max_rows: u32) -> Result<QueryOutcome, CommandError> {
         let result = self
             .runtime
             .datafusion()
@@ -1430,7 +1430,7 @@ mod tests {
     }
 
     // ----------------------------------------------------------------------
-    // RunQuery: row cap, byte cap, and the Arrow IPC the caller decodes.
+    // ExecuteQuery: row cap, byte cap, and the Arrow IPC the caller decodes.
     // ----------------------------------------------------------------------
 
     /// One `Int32` column named `n`, the shape every query test below returns.

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -302,14 +302,15 @@ pub async fn maybe_start(
     // reports logs as unavailable rather than returning an empty blob.
     let logs = crate::log_capture::handle();
 
-    match &persisted_app_id {
-        Some(app_id) => tracing::debug!(
+    if let Some(app_id) = &persisted_app_id {
+        tracing::debug!(
             app_id,
             "Spice Cloud Connect: metrics attribution restored from the stored identity"
-        ),
-        None => tracing::debug!(
+        );
+    } else {
+        tracing::debug!(
             "Spice Cloud Connect: the stored identity names no app; metrics are withheld until a deploy names one"
-        ),
+        );
     }
 
     // Installed before `load_components()` by `restore_delivered_secrets`, so
@@ -347,16 +348,17 @@ pub async fn maybe_start(
     // The cache key is read from the identity on each write, not captured here:
     // an instance enrolling in this very process has no identity yet.
     let identity_path = config.identity_path.clone();
-    let handle: Arc<dyn RuntimeHandle> = Arc::new(SpicedRuntimeHandle::new(
-        runtime,
-        logs,
-        delivered_store,
-        identity_path,
-        running_deployment,
-        supervisor,
-        metrics,
-        persisted_app_id,
-    ));
+    let handle: Arc<dyn RuntimeHandle> =
+        Arc::new(SpicedRuntimeHandle::new(SpicedRuntimeHandleParts {
+            runtime,
+            logs,
+            delivered_secrets: delivered_store,
+            identity_path,
+            running_deployment,
+            supervisor,
+            metrics,
+            app_id: persisted_app_id,
+        }));
 
     match CloudConnect::start(config, handle).await {
         Ok(Some(client)) => Some(client),
@@ -497,17 +499,31 @@ struct SpicedRuntimeHandle {
     app_id: RwLock<Option<String>>,
 }
 
+/// What a [`SpicedRuntimeHandle`] is assembled from, before the deployment is
+/// reduced to the spicepod that is live and the mutable fields are wrapped.
+struct SpicedRuntimeHandleParts {
+    runtime: Arc<Runtime>,
+    logs: Option<LogRingBuffer>,
+    delivered_secrets: Arc<CloudDeliveredSecretStore>,
+    identity_path: std::path::PathBuf,
+    running_deployment: Option<CloudManagedSpicepod>,
+    supervisor: Supervisor,
+    metrics: Option<MetricsReader>,
+    app_id: Option<String>,
+}
+
 impl SpicedRuntimeHandle {
-    fn new(
-        runtime: Arc<Runtime>,
-        logs: Option<LogRingBuffer>,
-        delivered_secrets: Arc<CloudDeliveredSecretStore>,
-        identity_path: std::path::PathBuf,
-        running_deployment: Option<CloudManagedSpicepod>,
-        supervisor: Supervisor,
-        metrics: Option<MetricsReader>,
-        app_id: Option<String>,
-    ) -> Self {
+    fn new(parts: SpicedRuntimeHandleParts) -> Self {
+        let SpicedRuntimeHandleParts {
+            runtime,
+            logs,
+            delivered_secrets,
+            identity_path,
+            running_deployment,
+            supervisor,
+            metrics,
+            app_id,
+        } = parts;
         let live = running_deployment.map_or_else(String::new, |running| running.spicepod_yaml);
         Self {
             runtime,

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -59,20 +59,27 @@ limitations under the License.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use app::{App, AppBuilder};
+use arrow::error::ArrowError;
+use arrow::ipc::writer::StreamWriter;
 use async_trait::async_trait;
+use datafusion::error::DataFusionError;
+use datafusion::execution::SendableRecordBatchStream;
+use futures::StreamExt;
 use parking_lot::RwLock;
 use runtime::Runtime;
+use runtime::datafusion::query::Error as QueryError;
 use runtime::metrics_reader::MetricsReader;
 use runtime::status::ComponentStatus;
 use runtime_cloud_connect::config::{
     CLOUD_MANAGED_SPICEPOD_FILE, CloudConnectConfig, IDENTITY_FILE, PENDING_ADOPT_CODE_FILE,
 };
 use runtime_cloud_connect::handlers::{
-    ApplyOutcome, Capability, CommandError, RuntimeHandle, RuntimePhase, SpicepodDeployment,
-    StatusReport,
+    ApplyOutcome, Capability, CommandError, MAX_QUERY_RESULT_BYTES, QueryOutcome, RuntimeHandle,
+    RuntimePhase, SpicepodDeployment, StatusReport, effective_max_rows,
 };
 use runtime_cloud_connect::supervisor::Supervisor;
 use runtime_cloud_connect::{CloudConnect, identity::IdentityStore};
@@ -585,7 +592,10 @@ impl RuntimeHandle for SpicedRuntimeHandle {
     /// for a process that may have no supervisor to come back under.
     fn supports(&self, capability: Capability) -> bool {
         match capability {
-            Capability::ApplySpicepod | Capability::GetStatus => true,
+            // The handle holds the runtime, so it can always plan and execute
+            // a query against whatever the instance currently serves — an
+            // empty catalog answers with an error, not an inability.
+            Capability::ApplySpicepod | Capability::GetStatus | Capability::RunQuery => true,
             // Only when the log-capture layer was installed at startup;
             // otherwise there is no buffer to read from.
             Capability::GetLogs => self.logs.is_some(),
@@ -598,7 +608,7 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             Capability::Restart => "Restart is unsupported on standalone spiced: it is not a control the runtime offers on demand. A deployment already applies by restarting this instance onto the spicepod it validated; to restart it without deploying, use your process manager (systemd/Docker/Kubernetes). See: https://spiceai.org/docs".to_string(),
             Capability::UpgradeRuntime => "UpgradeRuntime is unsupported on standalone spiced: it cannot replace its own binary. Upgrade it the way you installed it (`spice upgrade`, your container image, or your package manager). See: https://spiceai.org/docs".to_string(),
             Capability::GetLogs => "Log capture is not enabled for this runtime: Spice Cloud Connect must be configured before startup for spiced to install the log-capture layer. See: https://spiceai.org/docs".to_string(),
-            Capability::ApplySpicepod | Capability::GetStatus => format!(
+            Capability::ApplySpicepod | Capability::GetStatus | Capability::RunQuery => format!(
                 "{} is not supported by this instance",
                 capability.wire_name()
             ),
@@ -994,6 +1004,198 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             .collect_otlp_export(&app_id)
             .map_err(|err| CommandError::internal(err.to_string()))
     }
+
+    /// Execute a `RunQuery` against the in-process runtime.
+    ///
+    /// The query goes through the same `DataFusion` entry point the local SQL
+    /// APIs use, so there is no HTTP hop and no second set of query semantics
+    /// to keep aligned.
+    ///
+    /// It runs **read-only**: the statement is planned and then rejected if it
+    /// carries DDL, DML, `COPY`, or a write-capable extension. This command
+    /// arrives from the control plane rather than from someone holding the
+    /// instance's own credentials, so it reads the instance and never changes
+    /// it.
+    ///
+    /// `max_rows` is clamped again here rather than trusted: the caller already
+    /// clamps it, and a limit enforced in exactly one place is a limit one
+    /// refactor away from being gone.
+    async fn run_query(&self, sql: &str, max_rows: u32) -> Result<QueryOutcome, CommandError> {
+        let result = self
+            .runtime
+            .datafusion()
+            .query_builder(sql)
+            .read_only(true)
+            .build()
+            .run()
+            .await
+            .map_err(|source| query_error(&source))?;
+        bounded_arrow_ipc(result.data, effective_max_rows(max_rows)).await
+    }
+}
+
+/// Classify a query failure so the portal can tell a bad statement from a
+/// struggling instance without reading the English.
+///
+/// A statement the engine could not parse, plan, or resolve is the caller's to
+/// fix and fails identically on retry — that is `INVALID_ARGUMENT`. An
+/// execution, resource, or I/O fault is the instance's, and may not recur, so
+/// it stays retryable.
+fn query_error(source: &QueryError) -> CommandError {
+    let caller_fault = match source {
+        QueryError::UnableToExecuteQuery { source } | QueryError::BindingParameters { source } => {
+            is_caller_error(source)
+        }
+        QueryError::TableAccessDisallowed { .. } => true,
+        _ => false,
+    };
+    classify(caller_fault, format!("Query failed: {source}"))
+}
+
+/// The same classification for a failure that arrives as a bare
+/// `DataFusionError` — mid-stream, after planning already succeeded.
+fn datafusion_error(source: &DataFusionError) -> CommandError {
+    classify(is_caller_error(source), format!("Query failed: {source}"))
+}
+
+fn classify(caller_fault: bool, message: String) -> CommandError {
+    if caller_fault {
+        CommandError::invalid_argument(message)
+    } else {
+        CommandError::failed(message)
+    }
+}
+
+/// Whether a `DataFusion` error blames the statement rather than the instance.
+fn is_caller_error(source: &DataFusionError) -> bool {
+    match source {
+        DataFusionError::SQL(..)
+        | DataFusionError::Plan(..)
+        | DataFusionError::SchemaError(..)
+        | DataFusionError::NotImplemented(..) => true,
+        // Wrappers that add context around the error that actually happened.
+        DataFusionError::Context(_, inner) | DataFusionError::Diagnostic(_, inner) => {
+            is_caller_error(inner)
+        }
+        DataFusionError::Shared(inner) => is_caller_error(inner),
+        // Only the caller's fault if nothing in the collection is the
+        // instance's: a set holding both blames the instance, since that is the
+        // half a retry might clear.
+        DataFusionError::Collection(errors) => {
+            !errors.is_empty() && errors.iter().all(is_caller_error)
+        }
+        _ => false,
+    }
+}
+
+/// An in-memory sink that refuses to grow past `limit`.
+///
+/// Bounding the *writer* is what makes an oversized result cheap: the encoder
+/// fails on the first write that would cross the cap, so the bytes are never
+/// materialized and then measured. A single row too large to fit trips it the
+/// same way a million small ones do.
+struct BoundedBuffer {
+    bytes: Vec<u8>,
+    limit: usize,
+    /// Set when a write was refused, so the caller can tell the cap apart from
+    /// a genuine encoding fault after the error has been laundered through
+    /// `ArrowError`.
+    overflowed: Arc<AtomicBool>,
+}
+
+impl std::io::Write for BoundedBuffer {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        if self.bytes.len().saturating_add(data.len()) > self.limit {
+            self.overflowed.store(true, Ordering::Relaxed);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "Cloud Connect query result limit exceeded",
+            ));
+        }
+        self.bytes.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Encode at most `max_rows` rows of `stream` as one complete Arrow IPC stream
+/// of at most [`MAX_QUERY_RESULT_BYTES`] bytes.
+///
+/// Truncation is by slicing, which shares the batch's buffers rather than
+/// copying, and the stream is dropped as soon as the row cap is reached so the
+/// rows past it are never fetched. An empty result still produces a valid
+/// stream carrying the schema, so the caller can tell "no rows" from "no
+/// answer".
+async fn bounded_arrow_ipc(
+    mut stream: SendableRecordBatchStream,
+    max_rows: u32,
+) -> Result<QueryOutcome, CommandError> {
+    let schema = stream.schema();
+    let limit = max_rows as usize;
+    let overflowed = Arc::new(AtomicBool::new(false));
+    let sink = BoundedBuffer {
+        bytes: Vec::new(),
+        limit: MAX_QUERY_RESULT_BYTES,
+        overflowed: Arc::clone(&overflowed),
+    };
+
+    let mut writer = StreamWriter::try_new(sink, &schema)
+        .map_err(|source| encode_error(&overflowed, &source))?;
+
+    let mut rows: usize = 0;
+    while rows < limit {
+        let Some(batch) = stream.next().await else {
+            break;
+        };
+        // A failure that surfaces here rather than at planning is usually the
+        // instance's — a federated source going away mid-scan — so it takes the
+        // same classification as one from `run()` rather than being blamed on
+        // the statement.
+        let batch = batch.map_err(|source| datafusion_error(&source))?;
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let take = (limit - rows).min(batch.num_rows());
+        let batch = if take == batch.num_rows() {
+            batch
+        } else {
+            batch.slice(0, take)
+        };
+        rows += take;
+        writer
+            .write(&batch)
+            .map_err(|source| encode_error(&overflowed, &source))?;
+    }
+
+    writer
+        .finish()
+        .map_err(|source| encode_error(&overflowed, &source))?;
+    let sink = writer
+        .into_inner()
+        .map_err(|source| encode_error(&overflowed, &source))?;
+
+    Ok(QueryOutcome {
+        arrow_ipc: sink.bytes,
+        row_count: rows as u64,
+    })
+}
+
+/// Classify an encoder failure: the byte cap, or a genuine fault.
+///
+/// Neither message repeats the query or a value from it.
+fn encode_error(overflowed: &AtomicBool, source: &ArrowError) -> CommandError {
+    if overflowed.load(Ordering::Relaxed) {
+        return CommandError::result_too_large(format!(
+            "The query result exceeds the {} MiB Cloud Connect limit and was not sent. Return fewer rows or columns (a smaller LIMIT, a narrower projection, or an aggregate) and run it again.",
+            MAX_QUERY_RESULT_BYTES / (1024 * 1024)
+        ));
+    }
+    CommandError::internal(format!(
+        "Failed to encode the query result as Arrow IPC: {source}"
+    ))
 }
 
 /// Validate a cloud-managed spicepod and persist it to disk.
@@ -1090,6 +1292,12 @@ async fn replace_canonical_spicepod(incoming: &Path, path: &Path) -> Result<(), 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use arrow::array::{Int32Array, RecordBatch, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+    use arrow::ipc::reader::StreamReader;
+    use datafusion::physical_plan::memory::MemoryStream;
+    use runtime_cloud_connect::handlers::MAX_QUERY_ROWS;
 
     /// Minimal valid spicepod (no components — an empty app is valid).
     const VALID_SPICEPOD: &str = "version: v2\nkind: Spicepod\nname: cloud-managed-test\n";
@@ -1219,5 +1427,260 @@ mod tests {
     #[test]
     fn a_runtime_with_no_deployment_applies_the_first_one() {
         assert_eq!(disposition("", None, VALID_SPICEPOD), Disposition::Apply);
+    }
+
+    // ----------------------------------------------------------------------
+    // RunQuery: row cap, byte cap, and the Arrow IPC the caller decodes.
+    // ----------------------------------------------------------------------
+
+    /// One `Int32` column named `n`, the shape every query test below returns.
+    fn int_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new("n", DataType::Int32, false)]))
+    }
+
+    /// A batch of `count` rows counting up from `start`.
+    fn int_batch(start: i32, count: i32) -> RecordBatch {
+        let values: Vec<i32> = (start..start + count).collect();
+        RecordBatch::try_new(int_schema(), vec![Arc::new(Int32Array::from(values))])
+            .expect("build int batch")
+    }
+
+    /// A batch of one row holding `bytes` bytes of string, for the byte-cap
+    /// tests.
+    fn wide_batch(bytes: usize) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("blob", DataType::Utf8, false)]));
+        let value = "x".repeat(bytes);
+        RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(vec![value]))])
+            .expect("build wide batch")
+    }
+
+    fn stream_of(schema: SchemaRef, batches: Vec<RecordBatch>) -> SendableRecordBatchStream {
+        Box::pin(MemoryStream::try_new(batches, schema, None).expect("memory stream"))
+    }
+
+    /// Decode an Arrow IPC stream back into batches — what the caller does, so
+    /// the assertion is on a real round trip rather than on a byte count.
+    fn decode(ipc: &[u8]) -> (SchemaRef, Vec<RecordBatch>) {
+        let reader = StreamReader::try_new(std::io::Cursor::new(ipc), None)
+            .expect("the payload must be a complete Arrow IPC stream");
+        let schema = reader.schema();
+        let batches = reader
+            .collect::<Result<Vec<_>, _>>()
+            .expect("every batch must decode");
+        (schema, batches)
+    }
+
+    fn total_rows(batches: &[RecordBatch]) -> usize {
+        batches.iter().map(RecordBatch::num_rows).sum()
+    }
+
+    #[tokio::test]
+    async fn a_query_result_round_trips_through_arrow_ipc() {
+        let outcome = bounded_arrow_ipc(
+            stream_of(int_schema(), vec![int_batch(0, 3), int_batch(3, 2)]),
+            MAX_QUERY_ROWS,
+        )
+        .await
+        .expect("a small result encodes");
+
+        assert_eq!(outcome.row_count, 5);
+        let (schema, batches) = decode(&outcome.arrow_ipc);
+        assert_eq!(schema.field(0).name(), "n");
+        assert_eq!(total_rows(&batches), 5);
+        let values: Vec<i32> = batches
+            .iter()
+            .flat_map(|b| {
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .expect("int column")
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert_eq!(values, vec![0, 1, 2, 3, 4], "values must survive the trip");
+    }
+
+    /// An empty result is a schema and zero rows, not an absent payload — the
+    /// caller must be able to tell "no rows" from "no answer".
+    #[tokio::test]
+    async fn an_empty_result_still_carries_the_schema() {
+        let outcome = bounded_arrow_ipc(stream_of(int_schema(), vec![]), MAX_QUERY_ROWS)
+            .await
+            .expect("an empty result encodes");
+
+        assert_eq!(outcome.row_count, 0);
+        assert!(
+            !outcome.arrow_ipc.is_empty(),
+            "an empty result must still be a valid stream"
+        );
+        let (schema, batches) = decode(&outcome.arrow_ipc);
+        assert_eq!(schema.field(0).name(), "n");
+        assert_eq!(total_rows(&batches), 0);
+    }
+
+    /// The row cap truncates, and it truncates *mid-batch* — a cap that only
+    /// worked on batch boundaries would return 600 rows for a 600-row batch.
+    #[tokio::test]
+    async fn the_row_cap_truncates_inside_a_batch() {
+        let outcome = bounded_arrow_ipc(
+            stream_of(int_schema(), vec![int_batch(0, 600)]),
+            MAX_QUERY_ROWS,
+        )
+        .await
+        .expect("a truncated result encodes");
+
+        assert_eq!(outcome.row_count, u64::from(MAX_QUERY_ROWS));
+        let (_, batches) = decode(&outcome.arrow_ipc);
+        assert_eq!(
+            total_rows(&batches),
+            MAX_QUERY_ROWS as usize,
+            "the encoded stream must carry no more rows than the cap"
+        );
+    }
+
+    /// The cap is a row count across the whole result, not per batch.
+    #[tokio::test]
+    async fn the_row_cap_spans_batches() {
+        let batches: Vec<RecordBatch> = (0..10).map(|i| int_batch(i * 100, 100)).collect();
+        let outcome = bounded_arrow_ipc(stream_of(int_schema(), batches), 250)
+            .await
+            .expect("a truncated result encodes");
+
+        assert_eq!(outcome.row_count, 250);
+        let (_, decoded) = decode(&outcome.arrow_ipc);
+        assert_eq!(total_rows(&decoded), 250);
+    }
+
+    /// A result over the byte cap fails outright. No partial stream comes back:
+    /// a truncated Arrow IPC payload would look to the caller like a complete,
+    /// smaller answer.
+    #[tokio::test]
+    async fn an_oversized_result_fails_without_partial_data() {
+        // Twenty rows of ~512 KiB each — well past 4 MiB in total, but each one
+        // fits, so the cap has to be enforced across the whole stream.
+        let schema = wide_batch(1).schema();
+        let batches: Vec<RecordBatch> = (0..20).map(|_| wide_batch(512 * 1024)).collect();
+
+        let err = bounded_arrow_ipc(stream_of(schema, batches), MAX_QUERY_ROWS)
+            .await
+            .expect_err("an oversized result must fail");
+        assert!(
+            matches!(err, CommandError::ResultTooLarge { .. }),
+            "an oversized result must be typed result-too-large, got {err:?}"
+        );
+    }
+
+    /// A single row too large to send takes the same path — the caller cannot
+    /// narrow a LIMIT out of it, so it must still be a typed refusal rather
+    /// than a truncated row.
+    #[tokio::test]
+    async fn a_single_oversized_row_fails_the_same_way() {
+        let batch = wide_batch(MAX_QUERY_RESULT_BYTES + 1024);
+        let schema = batch.schema();
+
+        let err = bounded_arrow_ipc(stream_of(schema, vec![batch]), MAX_QUERY_ROWS)
+            .await
+            .expect_err("an oversized row must fail");
+        assert!(
+            matches!(err, CommandError::ResultTooLarge { .. }),
+            "an oversized row must be typed result-too-large, got {err:?}"
+        );
+    }
+
+    /// The refusal names the limit and the way out, and repeats neither the
+    /// query nor a value from it.
+    #[test]
+    fn the_oversized_message_leaks_neither_sql_nor_values() {
+        let overflowed = AtomicBool::new(true);
+        let message = encode_error(
+            &overflowed,
+            &ArrowError::IoError(
+                "ignored".to_string(),
+                std::io::Error::other("Cloud Connect query result limit exceeded"),
+            ),
+        )
+        .to_string();
+        assert!(message.contains("4 MiB"), "must name the limit: {message}");
+        assert!(
+            message.contains("LIMIT"),
+            "must say how to get under it: {message}"
+        );
+    }
+
+    /// A statement the engine could not parse, plan, or resolve is the caller's
+    /// to fix; an execution or I/O fault is the instance's and may not recur.
+    /// Collapsing both into one code leaves the portal unable to tell "your SQL
+    /// is wrong" from "this instance is struggling".
+    #[test]
+    fn query_failures_are_classified_by_who_can_fix_them() {
+        let callers = [
+            DataFusionError::Plan("No field named foo".to_string()),
+            DataFusionError::NotImplemented("LATERAL".to_string()),
+            // The engine wraps planning errors in context/diagnostic layers;
+            // classification has to see through them.
+            DataFusionError::Context(
+                "while planning".to_string(),
+                Box::new(DataFusionError::Plan("bad".to_string())),
+            ),
+        ];
+        for source in callers {
+            assert!(
+                is_caller_error(&source),
+                "must blame the statement: {source}"
+            );
+        }
+
+        let instances = [
+            DataFusionError::Execution("scan failed".to_string()),
+            DataFusionError::ResourcesExhausted("out of memory".to_string()),
+            DataFusionError::Internal("bug".to_string()),
+            DataFusionError::Context(
+                "while scanning".to_string(),
+                Box::new(DataFusionError::Execution("source down".to_string())),
+            ),
+        ];
+        for source in instances {
+            assert!(
+                !is_caller_error(&source),
+                "must blame the instance: {source}"
+            );
+        }
+    }
+
+    /// The classification has to survive the `QueryError` wrapper the runtime
+    /// actually returns, not just a bare `DataFusionError`.
+    #[test]
+    fn a_planning_failure_reaches_the_wire_as_invalid_argument() {
+        let planning = QueryError::UnableToExecuteQuery {
+            source: DataFusionError::Plan("No field named foo".to_string()),
+        };
+        assert!(
+            matches!(query_error(&planning), CommandError::InvalidArgument { .. }),
+            "a planning failure is the caller's mistake"
+        );
+
+        let execution = QueryError::UnableToExecuteQuery {
+            source: DataFusionError::Execution("source unreachable".to_string()),
+        };
+        assert!(
+            matches!(query_error(&execution), CommandError::Failed { .. }),
+            "an execution failure is retryable, not the caller's mistake"
+        );
+    }
+
+    /// A result that fits must never be misreported as oversized.
+    #[tokio::test]
+    async fn a_result_just_under_the_cap_still_sends() {
+        let batch = wide_batch(MAX_QUERY_RESULT_BYTES / 2);
+        let schema = batch.schema();
+
+        let outcome = bounded_arrow_ipc(stream_of(schema, vec![batch]), MAX_QUERY_ROWS)
+            .await
+            .expect("a result under the cap must send");
+        assert_eq!(outcome.row_count, 1);
+        assert!(outcome.arrow_ipc.len() <= MAX_QUERY_RESULT_BYTES);
+        let (_, batches) = decode(&outcome.arrow_ipc);
+        assert_eq!(total_rows(&batches), 1);
     }
 }

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -838,13 +838,15 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
 
         init_metrics(
             &rt.datafusion(),
-            prometheus_registry.clone(),
-            otel_config,
-            resolved_otel_headers,
-            metrics_reader,
-            cloud_connect_metrics.clone(),
-            resource_attributes,
-            metric_prefix,
+            MetricsInit {
+                registry: prometheus_registry.clone(),
+                otel_config,
+                resolved_otel_headers,
+                metrics_reader,
+                cloud_connect_metrics: cloud_connect_metrics.clone(),
+                resource_attributes,
+                metric_prefix,
+            },
         )
         .context(UnableToInitializeMetricsSnafu)?;
 
@@ -1102,9 +1104,9 @@ impl DeploymentNote {
             Self::PodsWatcherDeclined => tracing::warn!(
                 "Spice Cloud Connect: --pods-watcher-enabled was ignored because this instance serves a deployed spicepod. Watching the local spicepod.yaml would replace the deployed configuration while the instance kept reporting the deployment as applied. Edit the app in Spice Cloud and deploy it instead."
             ),
-            Self::NoSpicepod => tracing::warn!(
-                "No existing spicepod was found. Starting Runtime without one."
-            ),
+            Self::NoSpicepod => {
+                tracing::warn!("No existing spicepod was found. Starting Runtime without one.");
+            }
         }
     }
 }
@@ -1276,16 +1278,36 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
 /// Caller is expected to short-circuit (not invoke this fn) when none of the
 /// three sources is configured — otherwise an empty `MeterProvider` would be
 /// installed.
+struct MetricsInit<'a> {
+    /// Prometheus scrape registry, when `/metrics` is served.
+    registry: Option<prometheus::Registry>,
+    /// OTEL push exporter, with the headers already resolved from secrets.
+    otel_config: Option<&'a app::spicepod::component::runtime::OtelExporterConfig>,
+    resolved_otel_headers: std::collections::HashMap<String, String>,
+    /// On-demand reader for cluster metrics collection.
+    metrics_reader: Option<runtime::metrics_reader::MetricsReader>,
+    /// On-demand reader for the metrics pushed over Cloud Connect.
+    cloud_connect_metrics: Option<runtime::metrics_reader::MetricsReader>,
+    /// `runtime.telemetry.properties`, as dimensions on every exported metric.
+    resource_attributes: Vec<KeyValue>,
+    /// `runtime.telemetry.metric_prefix`, applied as an SDK-level view.
+    metric_prefix: Option<String>,
+}
+
 fn init_metrics(
     df: &Arc<DataFusion>,
-    registry: Option<prometheus::Registry>,
-    otel_config: Option<&app::spicepod::component::runtime::OtelExporterConfig>,
-    resolved_otel_headers: std::collections::HashMap<String, String>,
-    metrics_reader: Option<runtime::metrics_reader::MetricsReader>,
-    cloud_connect_metrics: Option<runtime::metrics_reader::MetricsReader>,
-    resource_attributes: Vec<KeyValue>,
-    metric_prefix: Option<String>,
+    init: MetricsInit<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let MetricsInit {
+        registry,
+        otel_config,
+        resolved_otel_headers,
+        metrics_reader,
+        cloud_connect_metrics,
+        resource_attributes,
+        metric_prefix,
+    } = init;
+
     // Apply user-configured `runtime.telemetry.properties` as OpenTelemetry
     // resource attributes so they appear as dimensions/tags on every metric
     // exported by any of the readers attached below (Prometheus scrape,
@@ -1643,8 +1665,7 @@ mod tests {
     async fn missing_spicepod_error(dir: &std::path::Path) -> app::Error {
         AppBuilder::build_from_path(dir)
             .await
-            .err()
-            .expect("a directory with no spicepod.yaml must fail to load")
+            .expect_err("a directory with no spicepod.yaml must fail to load")
     }
 
     #[tokio::test]
@@ -1671,8 +1692,7 @@ mod tests {
         let path = dir.path().join("spicepod.yaml");
         let error = AppBuilder::build_from_path(&path)
             .await
-            .err()
-            .expect("a spicepod.yaml that does not exist must fail to load");
+            .expect_err("a spicepod.yaml that does not exist must fail to load");
 
         let args = Args::parse_from([
             std::ffi::OsStr::new("spiced"),
@@ -1695,8 +1715,7 @@ mod tests {
         .expect("write spicepod.yaml");
         let error = AppBuilder::build_from_path(dir.path())
             .await
-            .err()
-            .expect("a malformed spicepod.yaml must fail to load");
+            .expect_err("a malformed spicepod.yaml must fail to load");
 
         let args = Args::parse_from(["spiced", "--cloud-connect"]);
         assert!(!tolerates_missing_spicepod(&args, &error));

--- a/crates/runtime-cloud-connect/proto/cloud_connect.proto
+++ b/crates/runtime-cloud-connect/proto/cloud_connect.proto
@@ -94,6 +94,13 @@ enum ResultCode {
   RESULT_CODE_FAILED = 4;
   // The instance hit a fault of its own while handling the command.
   RESULT_CODE_INTERNAL = 5;
+  // A command of this kind is already in flight; this one was refused before
+  // any work started. Retryable once the first one finishes.
+  RESULT_CODE_BUSY = 6;
+  // The command ran but its result exceeds what the control stream carries.
+  // No partial payload accompanies this code — a narrower command may
+  // succeed, an identical retry will not.
+  RESULT_CODE_RESULT_TOO_LARGE = 7;
 }
 
 // Coarse runtime state. The single vocabulary for "how is this runtime
@@ -171,6 +178,7 @@ message ControlMessage {
     Pause pause = 13;
     ApplySecrets apply_secrets = 14;
     DeleteSecrets delete_secrets = 15;
+    RunQuery run_query = 18;
   }
 
   // Correlates the eventual `CommandResult`. Empty for an unsolicited
@@ -380,6 +388,42 @@ message Drain {}
 
 message Pause {
   PauseState state = 1;
+}
+
+// Run a SQL query against the instance's in-process runtime and return the
+// rows as a complete Arrow IPC stream in `CommandResult.binary`.
+//
+// READ-ONLY. The statement is planned and then refused if it carries DDL, DML,
+// COPY, or a write-capable extension: this command arrives from the control
+// plane rather than from someone holding the instance's own credentials, so it
+// reads the instance and never changes it.
+//
+// The instance holds the limits, not the caller: at most 500 rows and at most
+// 4 MiB of Arrow IPC in the single result, one query in flight at a time — a
+// second is answered RESULT_CODE_BUSY before it executes — and a deadline after
+// which the query is abandoned and the slot freed. An oversized result is
+// RESULT_CODE_RESULT_TOO_LARGE with no payload; there is no partial success and
+// no chunking.
+//
+// The SQL text and the result values never leave the instance except as this
+// command's own result: nothing about them reaches the control plane's logs,
+// traces, or metrics, which carry only the command id, duration, row count,
+// byte count, and outcome. The instance still records the statement in its own
+// local query history, the same as for a query it received directly.
+//
+// `CommandResult.message` is the one place caller-derived text rides the wire:
+// on RESULT_CODE_INVALID_ARGUMENT it carries the engine's diagnostic, without
+// which a rejected statement cannot be fixed. It goes to the caller who wrote
+// the query and is not to be logged or retained on the way.
+//
+// There is no cancellation command: a caller that stops waiting releases its
+// own waiter, and the query runs on inside the instance until it finishes or
+// hits the instance's deadline.
+message RunQuery {
+  string sql = 1;
+  // Requested row cap. Zero means the instance default; the effective cap is
+  // min(max_rows, 500) with zero mapping to 500.
+  uint32 max_rows = 2;
 }
 
 // Sealed secrets delivery. A secret value is sealed TWICE with HPKE

--- a/crates/runtime-cloud-connect/proto/cloud_connect.proto
+++ b/crates/runtime-cloud-connect/proto/cloud_connect.proto
@@ -178,7 +178,7 @@ message ControlMessage {
     Pause pause = 13;
     ApplySecrets apply_secrets = 14;
     DeleteSecrets delete_secrets = 15;
-    RunQuery run_query = 18;
+    ExecuteQuery execute_query = 18;
   }
 
   // Correlates the eventual `CommandResult`. Empty for an unsolicited
@@ -419,7 +419,7 @@ message Pause {
 // There is no cancellation command: a caller that stops waiting releases its
 // own waiter, and the query runs on inside the instance until it finishes or
 // hits the instance's deadline.
-message RunQuery {
+message ExecuteQuery {
   string sql = 1;
   // Requested row cap. Zero means the instance default; the effective cap is
   // min(max_rows, 500) with zero mapping to 500.

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -107,7 +107,7 @@ pub(crate) struct ClientDriver {
     /// paced by [`RENEW_RETRY_INTERVAL`] rather than spinning on a
     /// due-in-the-past `not_after`. Cleared on enrollment.
     renew_not_before: Option<time::Instant>,
-    /// The single `RunQuery` slot. Its one permit is taken by the spawned
+    /// The single `ExecuteQuery` slot. Its one permit is taken by the spawned
     /// query task and released when that task ends, so a second query is
     /// refused as busy before it executes. Held on the driver rather than the
     /// stream so a reconnect cannot hand out a second slot while the first
@@ -927,12 +927,12 @@ impl ClientDriver {
                     }
                 }
             }
-            proto::control_message::Body::RunQuery(cmd) => {
+            proto::control_message::Body::ExecuteQuery(cmd) => {
                 if self
-                    .supported(tx, &command_id, Capability::RunQuery, name)
+                    .supported(tx, &command_id, Capability::ExecuteQuery, name)
                     .await
                 {
-                    self.handle_run_query(tx, &command_id, cmd).await;
+                    self.handle_execute_query(tx, &command_id, cmd).await;
                 }
             }
             proto::control_message::Body::Adopt(cmd) => {
@@ -1008,11 +1008,11 @@ impl ClientDriver {
     /// The query is bounded by `query_deadline` rather than left to run: this
     /// contract has no cancellation command, so a query that never returns
     /// would hold the only slot for the life of the process.
-    async fn handle_run_query(
+    async fn handle_execute_query(
         &self,
         tx: &mpsc::Sender<proto::ClientMessage>,
         command_id: &str,
-        cmd: proto::RunQuery,
+        cmd: proto::ExecuteQuery,
     ) {
         if cmd.sql.trim().is_empty() {
             send_result(
@@ -1051,7 +1051,7 @@ impl ClientDriver {
             let _permit = permit;
 
             let started = time::Instant::now();
-            let outcome = time::timeout(deadline, runtime.run_query(&sql, max_rows)).await;
+            let outcome = time::timeout(deadline, runtime.execute_query(&sql, max_rows)).await;
             let elapsed_ms = started.elapsed().as_millis();
 
             let Ok(outcome) = outcome else {
@@ -1631,7 +1631,7 @@ fn command_name(body: &proto::control_message::Body) -> &'static str {
         Body::ApplySecrets(_) => "ApplySecrets",
         Body::DeleteSecrets(_) => "DeleteSecrets",
         Body::GetLogs(_) => "GetLogs",
-        Body::RunQuery(_) => "RunQuery",
+        Body::ExecuteQuery(_) => "ExecuteQuery",
     }
 }
 

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -53,7 +53,7 @@ use std::time::Duration;
 
 use crate::TransportSnafu;
 use snafu::ResultExt;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{RwLock, Semaphore, mpsc};
 use tokio::time;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Streaming;
@@ -62,8 +62,8 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint};
 use crate::config::CloudConnectConfig;
 use crate::enroll::{EnrollClient, RENEWAL_GRACE};
 use crate::handlers::{
-    Capability, CommandError, PostApply, RestartMode, RuntimeHandle, SpicepodDeployment,
-    advertised_capabilities,
+    Capability, CommandError, MAX_QUERY_RESULT_BYTES, PostApply, RestartMode, RuntimeHandle,
+    SpicepodDeployment, advertised_capabilities, effective_max_rows,
 };
 use crate::heartbeat::{build_heartbeat, build_telemetry, now_unix};
 use crate::identity::{Identity, IdentityStore};
@@ -107,6 +107,12 @@ pub(crate) struct ClientDriver {
     /// paced by [`RENEW_RETRY_INTERVAL`] rather than spinning on a
     /// due-in-the-past `not_after`. Cleared on enrollment.
     renew_not_before: Option<time::Instant>,
+    /// The single `RunQuery` slot. Its one permit is taken by the spawned
+    /// query task and released when that task ends, so a second query is
+    /// refused as busy before it executes. Held on the driver rather than the
+    /// stream so a reconnect cannot hand out a second slot while the first
+    /// query is still running.
+    query_slot: Arc<Semaphore>,
 }
 
 impl ClientDriver {
@@ -122,6 +128,7 @@ impl ClientDriver {
             shutdown,
             identity,
             renew_not_before: None,
+            query_slot: Arc::new(Semaphore::new(1)),
         }
     }
 
@@ -920,6 +927,14 @@ impl ClientDriver {
                     }
                 }
             }
+            proto::control_message::Body::RunQuery(cmd) => {
+                if self
+                    .supported(tx, &command_id, Capability::RunQuery, name)
+                    .await
+                {
+                    self.handle_run_query(tx, &command_id, cmd).await;
+                }
+            }
             proto::control_message::Body::Adopt(cmd) => {
                 self.handle_adopt(tx, &command_id, cmd, live_identifier)
                     .await;
@@ -978,6 +993,147 @@ impl ClientDriver {
         );
         send_unsupported(tx, command_id, &self.runtime.unsupported_reason(capability)).await;
         false
+    }
+
+    /// Take the query slot and run the query on its own task.
+    ///
+    /// The pump must stay free to answer heartbeats and other commands while a
+    /// query executes, so nothing here awaits the query: the slot permit moves
+    /// into the spawned task and is released when that task ends, which is
+    /// also what makes a concurrent second query busy rather than queued.
+    ///
+    /// An empty statement is refused before the slot is taken, so a caller
+    /// sending blank queries cannot keep a real one out.
+    ///
+    /// The query is bounded by `query_deadline` rather than left to run: this
+    /// contract has no cancellation command, so a query that never returns
+    /// would hold the only slot for the life of the process.
+    async fn handle_run_query(
+        &self,
+        tx: &mpsc::Sender<proto::ClientMessage>,
+        command_id: &str,
+        cmd: proto::RunQuery,
+    ) {
+        if cmd.sql.trim().is_empty() {
+            send_result(
+                tx,
+                command_id,
+                proto::ResultCode::InvalidArgument,
+                "The query is empty. Send a SQL statement to execute.",
+                None,
+            )
+            .await;
+            return;
+        }
+
+        let Ok(permit) = Arc::clone(&self.query_slot).try_acquire_owned() else {
+            send_result(
+                tx,
+                command_id,
+                proto::ResultCode::Busy,
+                "This instance is already running a query. Cloud Connect runs one query at a time — retry once the running query finishes.",
+                None,
+            )
+            .await;
+            return;
+        };
+
+        let max_rows = effective_max_rows(cmd.max_rows);
+        let sql = cmd.sql;
+        let runtime = Arc::clone(&self.runtime);
+        let tx = tx.clone();
+        let command_id = command_id.to_string();
+        let deadline = self.config.query_deadline;
+
+        tokio::spawn(async move {
+            // Held for the whole query so the slot frees only once the work is
+            // genuinely finished, panic or not.
+            let _permit = permit;
+
+            let started = time::Instant::now();
+            let outcome = time::timeout(deadline, runtime.run_query(&sql, max_rows)).await;
+            let elapsed_ms = started.elapsed().as_millis();
+
+            let Ok(outcome) = outcome else {
+                // Dropping the query future abandons the work and, with the
+                // permit, frees the slot. Without this a query that never
+                // returns would answer every later one as busy for the life of
+                // the process — there is no cancellation command to rescue it.
+                tracing::warn!(
+                    "Cloud Connect: query {command_id} exceeded the {}s deadline; abandoning the waiter and freeing the query slot",
+                    deadline.as_secs()
+                );
+                send_result(
+                    &tx,
+                    &command_id,
+                    proto::ResultCode::Failed,
+                    &format!(
+                        "The query exceeded this instance's {}s Cloud Connect limit and was abandoned; no result will follow. Narrow it, or run it against the instance directly.",
+                        deadline.as_secs()
+                    ),
+                    None,
+                )
+                .await;
+                return;
+            };
+
+            match outcome {
+                Ok(result) => {
+                    let bytes = result.arrow_ipc.len();
+                    // The handle serializes under the same caps, so these are
+                    // the contract boundary refusing to put an out-of-bounds
+                    // payload on the control stream rather than the primary
+                    // enforcement. A handle that miscounts or ignores the caps
+                    // is refused here instead of being forwarded.
+                    if bytes > MAX_QUERY_RESULT_BYTES {
+                        tracing::warn!(
+                            "Cloud Connect: query {command_id} produced {bytes} bytes, over the {MAX_QUERY_RESULT_BYTES} byte limit; answering result-too-large"
+                        );
+                        send_result(
+                            &tx,
+                            &command_id,
+                            proto::ResultCode::ResultTooLarge,
+                            &result_too_large_message(),
+                            None,
+                        )
+                        .await;
+                        return;
+                    }
+                    if result.row_count > u64::from(max_rows) {
+                        tracing::error!(
+                            "Cloud Connect: query {command_id} returned {} rows against a {max_rows} row limit; refusing the result",
+                            result.row_count
+                        );
+                        send_result(
+                            &tx,
+                            &command_id,
+                            proto::ResultCode::Internal,
+                            "The query result exceeded this instance's row limit and was not sent.",
+                            None,
+                        )
+                        .await;
+                        return;
+                    }
+                    tracing::debug!(
+                        "Cloud Connect: query {command_id} returned {} rows ({bytes} bytes) in {elapsed_ms}ms",
+                        result.row_count
+                    );
+                    send_ok(
+                        &tx,
+                        &command_id,
+                        Some(proto::command_result::Payload::Binary(result.arrow_ipc)),
+                    )
+                    .await;
+                }
+                Err(err) => {
+                    tracing::debug!(
+                        "Cloud Connect: query {command_id} failed after {elapsed_ms}ms: {}",
+                        result_code(&err).as_str_name()
+                    );
+                    send_command_error(&tx, &command_id, &err).await;
+                }
+            }
+        });
     }
 
     /// Handle an `ApplySpicepod`, opening any secrets that rode with it.
@@ -1475,7 +1631,18 @@ fn command_name(body: &proto::control_message::Body) -> &'static str {
         Body::ApplySecrets(_) => "ApplySecrets",
         Body::DeleteSecrets(_) => "DeleteSecrets",
         Body::GetLogs(_) => "GetLogs",
+        Body::RunQuery(_) => "RunQuery",
     }
+}
+
+/// What the control plane is told when a result will not fit on the control
+/// stream. Names the limit and the way out, and repeats neither the query nor
+/// any value from it.
+fn result_too_large_message() -> String {
+    format!(
+        "The query result exceeds the {} MiB Cloud Connect limit and was not sent. Return fewer rows or columns (a smaller LIMIT, a narrower projection, or an aggregate) and run it again.",
+        MAX_QUERY_RESULT_BYTES / (1024 * 1024)
+    )
 }
 
 /// Map the wire restart mode onto the handler-level one. A value a newer
@@ -1498,6 +1665,8 @@ fn result_code(err: &CommandError) -> proto::ResultCode {
         CommandError::InvalidArgument { .. } => proto::ResultCode::InvalidArgument,
         CommandError::Failed { .. } => proto::ResultCode::Failed,
         CommandError::Internal { .. } => proto::ResultCode::Internal,
+        CommandError::Busy { .. } => proto::ResultCode::Busy,
+        CommandError::ResultTooLarge { .. } => proto::ResultCode::ResultTooLarge,
     }
 }
 

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -48,7 +48,12 @@ pub const DEFAULT_METRICS_INTERVAL: Duration = Duration::from_secs(30);
 /// time, so a query that never finishes would hold the only slot for the life
 /// of the process and answer every later query as busy. The deadline is what
 /// bounds that: it releases the slot and abandons the work.
-pub const DEFAULT_QUERY_DEADLINE: Duration = Duration::from_mins(1);
+///
+/// It sits below the control plane's own command budget so the instance is the
+/// layer that gives up first. The slot is then free by the time the caller is
+/// told the query failed, and the retry it prompts is not answered busy by the
+/// query it is replacing.
+pub const DEFAULT_QUERY_DEADLINE: Duration = Duration::from_secs(25);
 
 /// File name (relative to `$SPICE_CONFIG_DIR`) where the cloud-managed
 /// spicepod is written when an `ApplySpicepod` command arrives.
@@ -375,6 +380,31 @@ mod tests {
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// The instance must be the layer that gives up first, because it is the
+    /// only one holding the query slot. If the control plane answers the caller
+    /// while the query runs on, the retry that answer invites is refused as busy
+    /// by the query it is replacing, and the deadline's own result code never
+    /// reaches anyone.
+    ///
+    /// Serializing the result is inside the deadline, not inside the margin:
+    /// the encode runs within the future the deadline wraps. The margin is what
+    /// putting the finished payload on the control stream costs, so the answer
+    /// lands inside the budget rather than exactly on it.
+    #[test]
+    fn the_query_deadline_expires_inside_the_control_plane_command_budget() {
+        /// The control plane's shared `DEFAULT_COMMAND_TIMEOUT`, which bounds
+        /// every command it dispatches rather than queries alone. Mirrored here
+        /// because it is the number this deadline has to fit inside; if it moves
+        /// there, it moves here, and this test is what notices.
+        const CONTROL_PLANE_COMMAND_BUDGET: Duration = Duration::from_secs(30);
+        const MARGIN: Duration = Duration::from_secs(5);
+
+        assert!(
+            DEFAULT_QUERY_DEADLINE.saturating_add(MARGIN) <= CONTROL_PLANE_COMMAND_BUDGET,
+            "the {DEFAULT_QUERY_DEADLINE:?} query deadline leaves under {MARGIN:?} of the {CONTROL_PLANE_COMMAND_BUDGET:?} command budget to return the result; lower it, or raise the budget first"
+        );
+    }
 
     #[test]
     fn default_config_dir_respects_env_var() {

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -42,7 +42,7 @@ pub const DEFAULT_TELEMETRY_INTERVAL: Duration = Duration::from_mins(1);
 /// interval sets chart resolution rather than what is or is not recorded.
 pub const DEFAULT_METRICS_INTERVAL: Duration = Duration::from_secs(30);
 
-/// Default ceiling on a single `RunQuery`.
+/// Default ceiling on a single `ExecuteQuery`.
 ///
 /// There is no cancellation command on this contract, and one query runs at a
 /// time, so a query that never finishes would hold the only slot for the life
@@ -182,7 +182,7 @@ pub struct CloudConnectConfig {
     /// renewal loop without waiting hours.
     pub renewal_lead: Duration,
 
-    /// How long a `RunQuery` may run before the instance abandons it and frees
+    /// How long an `ExecuteQuery` may run before the instance abandons it and frees
     /// the query slot. Defaults to [`DEFAULT_QUERY_DEADLINE`]; overridable so
     /// tests can exercise the deadline without waiting it out.
     pub query_deadline: Duration,

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -42,6 +42,14 @@ pub const DEFAULT_TELEMETRY_INTERVAL: Duration = Duration::from_mins(1);
 /// interval sets chart resolution rather than what is or is not recorded.
 pub const DEFAULT_METRICS_INTERVAL: Duration = Duration::from_secs(30);
 
+/// Default ceiling on a single `RunQuery`.
+///
+/// There is no cancellation command on this contract, and one query runs at a
+/// time, so a query that never finishes would hold the only slot for the life
+/// of the process and answer every later query as busy. The deadline is what
+/// bounds that: it releases the slot and abandons the work.
+pub const DEFAULT_QUERY_DEADLINE: Duration = Duration::from_mins(1);
+
 /// File name (relative to `$SPICE_CONFIG_DIR`) where the cloud-managed
 /// spicepod is written when an `ApplySpicepod` command arrives.
 pub const CLOUD_MANAGED_SPICEPOD_FILE: &str = "spicepod-cloud-managed.yml";
@@ -173,6 +181,11 @@ pub struct CloudConnectConfig {
     /// [`DEFAULT_RENEWAL_LEAD`]; overridable so tests can exercise the
     /// renewal loop without waiting hours.
     pub renewal_lead: Duration,
+
+    /// How long a `RunQuery` may run before the instance abandons it and frees
+    /// the query slot. Defaults to [`DEFAULT_QUERY_DEADLINE`]; overridable so
+    /// tests can exercise the deadline without waiting it out.
+    pub query_deadline: Duration,
 }
 
 impl CloudConnectConfig {
@@ -351,6 +364,7 @@ impl CloudConnectConfig {
             telemetry_interval: DEFAULT_TELEMETRY_INTERVAL,
             metrics_interval: DEFAULT_METRICS_INTERVAL,
             renewal_lead: DEFAULT_RENEWAL_LEAD,
+            query_deadline: DEFAULT_QUERY_DEADLINE,
         }
     }
 }

--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -923,6 +923,7 @@ mod tests {
             telemetry_interval: Duration::from_mins(1),
             metrics_interval: Duration::from_secs(30),
             renewal_lead: Duration::from_hours(12),
+            query_deadline: Duration::from_mins(1),
         }
     }
 

--- a/crates/runtime-cloud-connect/src/handlers.rs
+++ b/crates/runtime-cloud-connect/src/handlers.rs
@@ -114,14 +114,14 @@ impl CommandError {
     }
 }
 
-/// Most rows a [`RuntimeHandle::run_query`] result may carry.
+/// Most rows a [`RuntimeHandle::execute_query`] result may carry.
 pub const MAX_QUERY_ROWS: u32 = 500;
 
-/// Most bytes the complete Arrow IPC stream of a [`RuntimeHandle::run_query`]
+/// Most bytes the complete Arrow IPC stream of a [`RuntimeHandle::execute_query`]
 /// result may occupy on the control stream.
 pub const MAX_QUERY_RESULT_BYTES: usize = 4 * 1024 * 1024;
 
-/// The row cap a `RunQuery` actually gets: its own request bounded by
+/// The row cap an `ExecuteQuery` actually gets: its own request bounded by
 /// [`MAX_QUERY_ROWS`], with zero meaning the full default.
 #[must_use]
 pub fn effective_max_rows(requested: u32) -> u32 {
@@ -132,7 +132,7 @@ pub fn effective_max_rows(requested: u32) -> u32 {
     }
 }
 
-/// A bounded `RunQuery` result.
+/// A bounded `ExecuteQuery` result.
 #[derive(Debug, Clone)]
 pub struct QueryOutcome {
     /// A complete Arrow IPC stream — schema, record batches, end-of-stream —
@@ -169,17 +169,17 @@ pub enum Capability {
     /// Report runtime readiness.
     GetStatus,
     /// Execute a bounded SQL query through the in-process runtime.
-    RunQuery,
+    ExecuteQuery,
 }
 
 impl Capability {
     /// Every capability this client can advertise, in wire-name order.
     pub const ALL: &'static [Self] = &[
         Self::ApplySpicepod,
+        Self::ExecuteQuery,
         Self::GetLogs,
         Self::GetStatus,
         Self::Restart,
-        Self::RunQuery,
         Self::UpgradeRuntime,
     ];
 
@@ -193,7 +193,7 @@ impl Capability {
             Self::UpgradeRuntime => "upgrade_runtime",
             Self::GetLogs => "get_logs",
             Self::GetStatus => "get_status",
-            Self::RunQuery => "run_query",
+            Self::ExecuteQuery => "execute_query",
         }
     }
 }
@@ -574,10 +574,14 @@ pub trait RuntimeHandle: Send + Sync + 'static {
     /// statement fixable.
     ///
     /// The default reports the command as unsupported so a handle that cannot
-    /// query neither advertises `run_query` nor fabricates a result.
-    async fn run_query(&self, _sql: &str, _max_rows: u32) -> Result<QueryOutcome, CommandError> {
+    /// query neither advertises `execute_query` nor fabricates a result.
+    async fn execute_query(
+        &self,
+        _sql: &str,
+        _max_rows: u32,
+    ) -> Result<QueryOutcome, CommandError> {
         Err(CommandError::unsupported(
-            "RunQuery is not implemented in this build",
+            "ExecuteQuery is not implemented in this build",
         ))
     }
 }
@@ -644,30 +648,33 @@ mod tests {
             Err(CommandError::Unsupported { .. })
         ));
         assert!(matches!(
-            h.run_query("SELECT 1", MAX_QUERY_ROWS).await,
+            h.execute_query("SELECT 1", MAX_QUERY_ROWS).await,
             Err(CommandError::Unsupported { .. })
         ));
     }
 
-    /// A handle that can query advertises `run_query`; one that cannot must
+    /// A handle that can query advertises `execute_query`; one that cannot must
     /// not — the control plane rejects unsupported queries on the strength of
     /// this list without a round trip, so a false advertisement is worse than
     /// none.
     #[test]
-    fn run_query_is_advertised_only_by_a_handle_that_can_query() {
+    fn execute_query_is_advertised_only_by_a_handle_that_can_query() {
         struct QueryingHandle;
 
         #[async_trait]
         impl RuntimeHandle for QueryingHandle {
             fn supports(&self, capability: Capability) -> bool {
-                capability == Capability::RunQuery
+                capability == Capability::ExecuteQuery
             }
         }
 
-        assert_eq!(advertised_capabilities(&QueryingHandle), vec!["run_query"]);
+        assert_eq!(
+            advertised_capabilities(&QueryingHandle),
+            vec!["execute_query"]
+        );
         assert!(
-            !advertised_capabilities(&NoopRuntimeHandle).contains(&"run_query".to_string()),
-            "a handle that cannot query must not advertise run_query"
+            !advertised_capabilities(&NoopRuntimeHandle).contains(&"execute_query".to_string()),
+            "a handle that cannot query must not advertise execute_query"
         );
     }
 
@@ -767,7 +774,7 @@ mod tests {
                 | Capability::UpgradeRuntime
                 | Capability::GetLogs
                 | Capability::GetStatus
-                | Capability::RunQuery => {}
+                | Capability::ExecuteQuery => {}
             }
         }
         let names: BTreeSet<&str> = Capability::ALL.iter().map(|c| c.wire_name()).collect();
@@ -780,10 +787,10 @@ mod tests {
             names,
             BTreeSet::from([
                 "apply_spicepod",
+                "execute_query",
                 "get_logs",
                 "get_status",
                 "restart",
-                "run_query",
                 "upgrade_runtime",
             ])
         );

--- a/crates/runtime-cloud-connect/src/handlers.rs
+++ b/crates/runtime-cloud-connect/src/handlers.rs
@@ -58,6 +58,16 @@ pub enum CommandError {
     /// The instance hit a fault of its own while handling the command.
     #[snafu(display("{message}"))]
     Internal { message: String },
+
+    /// A command of this kind is already in flight and this one was refused
+    /// before any work started. Retryable once the first one finishes.
+    #[snafu(display("{message}"))]
+    Busy { message: String },
+
+    /// The command ran but its result exceeds what the control stream carries.
+    /// Never accompanied by a partial payload.
+    #[snafu(display("{message}"))]
+    ResultTooLarge { message: String },
 }
 
 impl CommandError {
@@ -88,6 +98,49 @@ impl CommandError {
             message: message.into(),
         }
     }
+
+    /// A command of this kind is already in flight.
+    pub fn busy(message: impl Into<String>) -> Self {
+        Self::Busy {
+            message: message.into(),
+        }
+    }
+
+    /// The result is too large to send on the control stream.
+    pub fn result_too_large(message: impl Into<String>) -> Self {
+        Self::ResultTooLarge {
+            message: message.into(),
+        }
+    }
+}
+
+/// Most rows a [`RuntimeHandle::run_query`] result may carry.
+pub const MAX_QUERY_ROWS: u32 = 500;
+
+/// Most bytes the complete Arrow IPC stream of a [`RuntimeHandle::run_query`]
+/// result may occupy on the control stream.
+pub const MAX_QUERY_RESULT_BYTES: usize = 4 * 1024 * 1024;
+
+/// The row cap a `RunQuery` actually gets: its own request bounded by
+/// [`MAX_QUERY_ROWS`], with zero meaning the full default.
+#[must_use]
+pub fn effective_max_rows(requested: u32) -> u32 {
+    if requested == 0 {
+        MAX_QUERY_ROWS
+    } else {
+        requested.min(MAX_QUERY_ROWS)
+    }
+}
+
+/// A bounded `RunQuery` result.
+#[derive(Debug, Clone)]
+pub struct QueryOutcome {
+    /// A complete Arrow IPC stream — schema, record batches, end-of-stream —
+    /// never a fragment and never chunked across results.
+    pub arrow_ipc: Vec<u8>,
+    /// How many rows `arrow_ipc` carries. Reported in telemetry; the values
+    /// themselves are not.
+    pub row_count: u64,
 }
 
 /// An optional command a [`RuntimeHandle`] may or may not implement.
@@ -115,6 +168,8 @@ pub enum Capability {
     GetLogs,
     /// Report runtime readiness.
     GetStatus,
+    /// Execute a bounded SQL query through the in-process runtime.
+    RunQuery,
 }
 
 impl Capability {
@@ -124,6 +179,7 @@ impl Capability {
         Self::GetLogs,
         Self::GetStatus,
         Self::Restart,
+        Self::RunQuery,
         Self::UpgradeRuntime,
     ];
 
@@ -137,6 +193,7 @@ impl Capability {
             Self::UpgradeRuntime => "upgrade_runtime",
             Self::GetLogs => "get_logs",
             Self::GetStatus => "get_status",
+            Self::RunQuery => "run_query",
         }
     }
 }
@@ -495,6 +552,34 @@ pub trait RuntimeHandle: Send + Sync + 'static {
     async fn collect_metrics(&self) -> Result<Option<Vec<u8>>, CommandError> {
         Ok(None)
     }
+
+    /// Execute `sql` through the in-process runtime and return at most
+    /// `max_rows` rows as a complete Arrow IPC stream.
+    ///
+    /// `max_rows` arrives already reduced by [`effective_max_rows`], so an
+    /// implementation caps at the value it is handed rather than re-deriving
+    /// the limit. Serialization must be bounded by
+    /// [`MAX_QUERY_RESULT_BYTES`]: a result that would exceed it returns
+    /// [`CommandError::ResultTooLarge`] rather than a truncated stream, and
+    /// the bytes are never materialized past the cap.
+    ///
+    /// Run it read-only. The command arrives from the control plane rather than
+    /// from someone holding the instance's own credentials, so an
+    /// implementation reads the instance and never changes it.
+    ///
+    /// `sql` and the values it returns are confidential: keep both out of logs,
+    /// traces, and metrics. The returned error message is the one exception —
+    /// it reaches the caller who wrote the query and nobody else, so it carries
+    /// the engine's diagnostic, which is the only thing that makes a rejected
+    /// statement fixable.
+    ///
+    /// The default reports the command as unsupported so a handle that cannot
+    /// query neither advertises `run_query` nor fabricates a result.
+    async fn run_query(&self, _sql: &str, _max_rows: u32) -> Result<QueryOutcome, CommandError> {
+        Err(CommandError::unsupported(
+            "RunQuery is not implemented in this build",
+        ))
+    }
 }
 
 /// The capabilities `runtime` advertises, as the wire names carried in
@@ -558,6 +643,46 @@ mod tests {
             h.status().await,
             Err(CommandError::Unsupported { .. })
         ));
+        assert!(matches!(
+            h.run_query("SELECT 1", MAX_QUERY_ROWS).await,
+            Err(CommandError::Unsupported { .. })
+        ));
+    }
+
+    /// A handle that can query advertises `run_query`; one that cannot must
+    /// not — the control plane rejects unsupported queries on the strength of
+    /// this list without a round trip, so a false advertisement is worse than
+    /// none.
+    #[test]
+    fn run_query_is_advertised_only_by_a_handle_that_can_query() {
+        struct QueryingHandle;
+
+        #[async_trait]
+        impl RuntimeHandle for QueryingHandle {
+            fn supports(&self, capability: Capability) -> bool {
+                capability == Capability::RunQuery
+            }
+        }
+
+        assert_eq!(advertised_capabilities(&QueryingHandle), vec!["run_query"]);
+        assert!(
+            !advertised_capabilities(&NoopRuntimeHandle).contains(&"run_query".to_string()),
+            "a handle that cannot query must not advertise run_query"
+        );
+    }
+
+    #[test]
+    fn zero_requested_rows_means_the_default_cap() {
+        assert_eq!(effective_max_rows(0), MAX_QUERY_ROWS);
+    }
+
+    #[test]
+    fn requested_rows_are_clamped_to_the_cap() {
+        assert_eq!(effective_max_rows(1), 1);
+        assert_eq!(effective_max_rows(MAX_QUERY_ROWS - 1), MAX_QUERY_ROWS - 1);
+        assert_eq!(effective_max_rows(MAX_QUERY_ROWS), MAX_QUERY_ROWS);
+        assert_eq!(effective_max_rows(MAX_QUERY_ROWS + 1), MAX_QUERY_ROWS);
+        assert_eq!(effective_max_rows(u32::MAX), MAX_QUERY_ROWS);
     }
 
     /// The default apply persists the spicepod but cannot make it live, so it
@@ -641,7 +766,8 @@ mod tests {
                 | Capability::Restart
                 | Capability::UpgradeRuntime
                 | Capability::GetLogs
-                | Capability::GetStatus => {}
+                | Capability::GetStatus
+                | Capability::RunQuery => {}
             }
         }
         let names: BTreeSet<&str> = Capability::ALL.iter().map(|c| c.wire_name()).collect();
@@ -657,6 +783,7 @@ mod tests {
                 "get_logs",
                 "get_status",
                 "restart",
+                "run_query",
                 "upgrade_runtime",
             ])
         );

--- a/crates/runtime-cloud-connect/src/lib.rs
+++ b/crates/runtime-cloud-connect/src/lib.rs
@@ -90,8 +90,9 @@ use tokio::task::JoinHandle;
 
 pub use config::CloudConnectConfig;
 pub use handlers::{
-    ApplyOutcome, Capability, CommandError, PostApply, RestartMode, RuntimeHandle, RuntimePhase,
-    SpicepodDeployment, StatusReport,
+    ApplyOutcome, Capability, CommandError, MAX_QUERY_RESULT_BYTES, MAX_QUERY_ROWS, PostApply,
+    QueryOutcome, RestartMode, RuntimeHandle, RuntimePhase, SpicepodDeployment, StatusReport,
+    effective_max_rows,
 };
 pub use identity::{Identity, IdentityStore};
 pub use supervisor::Supervisor;
@@ -99,9 +100,12 @@ pub use supervisor::Supervisor;
 /// Revision of the `spice.cloud.v1` contract this client implements,
 /// announced in `Hello.protocol_version`.
 ///
-/// Bump it when the contract gains a command, field, or enum variant a peer
-/// can only use once it knows the other side has it; the package name changes
-/// only for a break this number cannot bridge.
+/// Bump it only for a change neither absent-oneof tolerance nor
+/// `Hello.capabilities` can carry — a peer that would misread the stream
+/// without knowing. A purely additive command does not qualify: an older peer
+/// decodes it as an absent body and answers unsupported, and `capabilities`
+/// already says self-descriptively what this instance answers. The package
+/// name changes only for a break this number cannot bridge.
 pub const PROTOCOL_VERSION: u32 = 1;
 
 use shutdown::Shutdown;

--- a/crates/runtime-cloud-connect/tests/adoption_flow.rs
+++ b/crates/runtime-cloud-connect/tests/adoption_flow.rs
@@ -277,6 +277,7 @@ fn enroll_config(
         telemetry_interval: Duration::from_mins(1),
         metrics_interval: Duration::from_secs(30),
         renewal_lead: Duration::from_mins(1),
+        query_deadline: Duration::from_mins(1),
     }
 }
 
@@ -529,6 +530,7 @@ async fn apply_spicepod_writes_file_and_acks() {
         telemetry_interval: Duration::from_mins(1),
         metrics_interval: Duration::from_secs(30),
         renewal_lead: Duration::from_hours(12),
+        query_deadline: Duration::from_mins(1),
     };
 
     let handle = runtime_cloud_connect::CloudConnect::start(config, runtime)
@@ -678,6 +680,7 @@ async fn unknown_command_is_nacked_rather_than_dropped() {
         telemetry_interval: Duration::from_mins(1),
         metrics_interval: Duration::from_secs(30),
         renewal_lead: Duration::from_hours(12),
+        query_deadline: Duration::from_mins(1),
         adopt_app_name: None,
         adopt_create_app: false,
     };

--- a/crates/runtime-cloud-connect/tests/adoption_flow.rs
+++ b/crates/runtime-cloud-connect/tests/adoption_flow.rs
@@ -135,9 +135,16 @@ impl CloudConnect for MockServer {
     }
 }
 
+/// What the last apply wrote, as the handle saw it.
+#[derive(Clone)]
+struct AppliedSpicepod {
+    path: PathBuf,
+    spicepod_yaml: String,
+    app_id: Option<String>,
+}
+
 struct CapturedRuntime {
-    /// The config dir, spicepod, and app id of the last apply.
-    applied: Arc<Mutex<Option<(PathBuf, String, Option<String>)>>>,
+    applied: Arc<Mutex<Option<AppliedSpicepod>>>,
 }
 
 #[async_trait]
@@ -157,11 +164,11 @@ impl RuntimeHandle for CapturedRuntime {
             .map_err(|e| CommandError::failed(e.to_string()))?;
         std::fs::write(&path, deployment.spicepod_yaml)
             .map_err(|e| CommandError::failed(e.to_string()))?;
-        *self.applied.lock().await = Some((
-            path.clone(),
-            deployment.spicepod_yaml.to_string(),
-            deployment.app_id.map(str::to_string),
-        ));
+        *self.applied.lock().await = Some(AppliedSpicepod {
+            path: path.clone(),
+            spicepod_yaml: deployment.spicepod_yaml.to_string(),
+            app_id: deployment.app_id.map(str::to_string),
+        });
         // `settled`, not `exit_to_apply`: this handle has no process to restart,
         // and asking the client to exit would take the test process with it.
         Ok(ApplyOutcome::settled(
@@ -551,12 +558,12 @@ async fn apply_spicepod_writes_file_and_acks() {
         "runtime should have received ApplySpicepod within 5s"
     );
 
-    let (written_path, written_yaml, written_app_id) = captured.lock().await.clone().unwrap();
-    assert_eq!(written_yaml, yaml);
-    assert!(written_path.exists(), "file should be on disk");
+    let written = captured.lock().await.clone().unwrap();
+    assert_eq!(written.spicepod_yaml, yaml);
+    assert!(written.path.exists(), "file should be on disk");
     // The runtime has no other way to learn its app, and withholds metrics
     // entirely until this arrives.
-    assert_eq!(written_app_id.as_deref(), Some("4002"));
+    assert_eq!(written.app_id.as_deref(), Some("4002"));
 
     // Server should see the CommandResult for the apply. Poll for it with a
     // bounded timeout instead of a fixed sleep so the assertion does not race

--- a/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
@@ -636,7 +636,7 @@ impl RuntimeHandle for E2eRuntime {
 }
 
 // --------------------------------------------------------------------------
-// Runtime handle for the RunQuery path. Records what the client handed it and
+// Runtime handle for the ExecuteQuery path. Records what the client handed it and
 // returns a scripted outcome, so the tests below observe the client's own
 // behavior (clamping, the single slot, the byte cap) rather than a query
 // engine's.
@@ -655,9 +655,9 @@ struct QueryRuntimeState {
 struct QueryRuntime {
     state: Arc<Mutex<QueryRuntimeState>>,
     can_query: bool,
-    /// What `run_query` answers with.
+    /// What `execute_query` answers with.
     reply: Mutex<Option<Result<QueryOutcome, CommandError>>>,
-    /// Released to let an in-flight `run_query` return. `None` returns at once.
+    /// Released to let an in-flight `execute_query` return. `None` returns at once.
     release: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
 }
 
@@ -674,7 +674,7 @@ impl QueryRuntime {
         )
     }
 
-    /// A handle that can query but blocks inside `run_query` until the returned
+    /// A handle that can query but blocks inside `execute_query` until the returned
     /// sender fires — how a test holds the single query slot open.
     fn blocking() -> (
         Arc<Self>,
@@ -720,14 +720,14 @@ impl QueryRuntime {
 impl RuntimeHandle for QueryRuntime {
     fn supports(&self, capability: Capability) -> bool {
         match capability {
-            Capability::RunQuery => self.can_query,
+            Capability::ExecuteQuery => self.can_query,
             // GetRuntimeInfo needs no capability, so this keeps the handle to
             // exactly the one command under test.
             _ => false,
         }
     }
 
-    async fn run_query(&self, sql: &str, max_rows: u32) -> Result<QueryOutcome, CommandError> {
+    async fn execute_query(&self, sql: &str, max_rows: u32) -> Result<QueryOutcome, CommandError> {
         {
             let mut state = self.state.lock().await;
             state.max_rows_seen.push(max_rows);
@@ -753,7 +753,7 @@ async fn enroll_query_runtime(
     enroll_query_runtime_with_deadline(harness, runtime, Duration::from_mins(1)).await
 }
 
-/// As [`enroll_query_runtime`], with the `RunQuery` deadline set explicitly so
+/// As [`enroll_query_runtime`], with the `ExecuteQuery` deadline set explicitly so
 /// a test can exercise it without waiting out the production value.
 async fn enroll_query_runtime_with_deadline(
     harness: &Harness,
@@ -809,8 +809,8 @@ async fn advertised_capabilities(captured: &Arc<Mutex<Captured>>) -> Vec<String>
         .expect("a Hello must have been captured")
 }
 
-fn run_query(sql: &str, max_rows: u32) -> proto::control_message::Body {
-    proto::control_message::Body::RunQuery(proto::RunQuery {
+fn execute_query(sql: &str, max_rows: u32) -> proto::control_message::Body {
+    proto::control_message::Body::ExecuteQuery(proto::ExecuteQuery {
         sql: sql.to_string(),
         max_rows,
     })
@@ -820,7 +820,7 @@ fn run_query(sql: &str, max_rows: u32) -> proto::control_message::Body {
 /// runtime encoded — the client is a courier for the Arrow IPC stream, not a
 /// re-encoder of it.
 #[tokio::test]
-async fn run_query_returns_the_runtime_bytes_on_the_binary_arm() {
+async fn execute_query_returns_the_runtime_bytes_on_the_binary_arm() {
     let harness = Harness::new(24 * 60 * 60).await;
     let payload = b"ARROW-IPC-STREAM-BYTES".to_vec();
     let (runtime, state) = QueryRuntime::returning(payload.clone(), 3);
@@ -831,11 +831,11 @@ async fn run_query_returns_the_runtime_bytes_on_the_binary_arm() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-query", run_query("SELECT 1", 10)));
+        .push_back(ctrl_id("cmd-query", execute_query("SELECT 1", 10)));
 
     let result = await_result(&harness.gateway.captured, "cmd-query")
         .await
-        .expect("the client must answer a RunQuery");
+        .expect("the client must answer an ExecuteQuery");
     assert_eq!(
         result.code,
         proto::ResultCode::Ok as i32,
@@ -856,7 +856,7 @@ async fn run_query_returns_the_runtime_bytes_on_the_binary_arm() {
 /// request above the cap is clamped before the runtime ever sees it. A runtime
 /// handed 500 cannot return 100_000 rows even if the caller asked for them.
 #[tokio::test]
-async fn run_query_clamps_the_row_limit_before_the_runtime_runs() {
+async fn execute_query_clamps_the_row_limit_before_the_runtime_runs() {
     for (requested, expected) in [(0_u32, MAX_QUERY_ROWS), (10, 10), (100_000, MAX_QUERY_ROWS)] {
         let harness = Harness::new(24 * 60 * 60).await;
         let (runtime, state) = QueryRuntime::returning(b"rows".to_vec(), 1);
@@ -867,11 +867,11 @@ async fn run_query_clamps_the_row_limit_before_the_runtime_runs() {
             .outbound
             .lock()
             .await
-            .push_back(ctrl_id("cmd-clamp", run_query("SELECT 1", requested)));
+            .push_back(ctrl_id("cmd-clamp", execute_query("SELECT 1", requested)));
 
         await_result(&harness.gateway.captured, "cmd-clamp")
             .await
-            .expect("the client must answer a RunQuery");
+            .expect("the client must answer an ExecuteQuery");
         assert_eq!(
             state.lock().await.max_rows_seen,
             vec![expected],
@@ -885,7 +885,7 @@ async fn run_query_clamps_the_row_limit_before_the_runtime_runs() {
 /// A second query while one is in flight is refused before it executes — the
 /// runtime handle must be called exactly once, not queued behind the first.
 #[tokio::test]
-async fn run_query_answers_busy_without_executing_a_second_query() {
+async fn execute_query_answers_busy_without_executing_a_second_query() {
     let harness = Harness::new(24 * 60 * 60).await;
     let (runtime, state, release) = QueryRuntime::blocking();
     let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
@@ -895,7 +895,7 @@ async fn run_query_answers_busy_without_executing_a_second_query() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-first", run_query("SELECT 1", 10)));
+        .push_back(ctrl_id("cmd-first", execute_query("SELECT 1", 10)));
 
     // Wait until the first query is genuinely inside the handle, so the second
     // one races a held slot rather than an empty one.
@@ -911,7 +911,7 @@ async fn run_query_answers_busy_without_executing_a_second_query() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-second", run_query("SELECT 2", 10)));
+        .push_back(ctrl_id("cmd-second", execute_query("SELECT 2", 10)));
 
     let second = await_result(&harness.gateway.captured, "cmd-second")
         .await
@@ -960,7 +960,7 @@ async fn heartbeats_and_commands_stay_live_while_a_query_runs() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-slow", run_query("SELECT 1", 10)));
+        .push_back(ctrl_id("cmd-slow", execute_query("SELECT 1", 10)));
 
     let running = wait_until_async(Duration::from_secs(5), || {
         let state = Arc::clone(&state);
@@ -1001,7 +1001,7 @@ async fn heartbeats_and_commands_stay_live_while_a_query_runs() {
 /// payload at all — a partial result would look to the caller like the whole
 /// answer.
 #[tokio::test]
-async fn run_query_refuses_an_oversized_result_without_partial_data() {
+async fn execute_query_refuses_an_oversized_result_without_partial_data() {
     let harness = Harness::new(24 * 60 * 60).await;
     let oversized = vec![0_u8; MAX_QUERY_RESULT_BYTES + 1];
     let (runtime, _state) = QueryRuntime::returning(oversized, 1);
@@ -1012,7 +1012,7 @@ async fn run_query_refuses_an_oversized_result_without_partial_data() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-big", run_query("SELECT 1", 10)));
+        .push_back(ctrl_id("cmd-big", execute_query("SELECT 1", 10)));
 
     let result = await_result(&harness.gateway.captured, "cmd-big")
         .await
@@ -1037,7 +1037,7 @@ async fn run_query_refuses_an_oversized_result_without_partial_data() {
 /// forwarded — the whole point of holding the limits at the instance is that
 /// nothing downstream re-checks them.
 #[tokio::test]
-async fn run_query_refuses_a_result_with_more_rows_than_the_limit() {
+async fn execute_query_refuses_a_result_with_more_rows_than_the_limit() {
     let harness = Harness::new(24 * 60 * 60).await;
     // Small payload, but it claims far more rows than the 10 that were asked
     // for — an honest byte count with a dishonest row count.
@@ -1049,7 +1049,7 @@ async fn run_query_refuses_a_result_with_more_rows_than_the_limit() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-toomany", run_query("SELECT 1", 10)));
+        .push_back(ctrl_id("cmd-toomany", execute_query("SELECT 1", 10)));
 
     let result = await_result(&harness.gateway.captured, "cmd-toomany")
         .await
@@ -1069,10 +1069,10 @@ async fn run_query_refuses_a_result_with_more_rows_than_the_limit() {
     handle.shutdown().await;
 }
 
-/// A runtime that cannot query neither advertises `run_query` nor pretends to
+/// A runtime that cannot query neither advertises `execute_query` nor pretends to
 /// answer one — and the session survives the refusal.
 #[tokio::test]
-async fn run_query_is_unsupported_when_the_runtime_cannot_query() {
+async fn execute_query_is_unsupported_when_the_runtime_cannot_query() {
     let harness = Harness::new(24 * 60 * 60).await;
     let (runtime, state) = QueryRuntime::incapable();
     let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
@@ -1080,8 +1080,8 @@ async fn run_query_is_unsupported_when_the_runtime_cannot_query() {
     let captured = Arc::clone(&harness.gateway.captured);
     let advertised = advertised_capabilities(&captured).await;
     assert!(
-        !advertised.contains(&"run_query".to_string()),
-        "a runtime that cannot query must not advertise run_query: {advertised:?}"
+        !advertised.contains(&"execute_query".to_string()),
+        "a runtime that cannot query must not advertise execute_query: {advertised:?}"
     );
 
     harness
@@ -1089,7 +1089,7 @@ async fn run_query_is_unsupported_when_the_runtime_cannot_query() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-nope", run_query("SELECT 1", 10)));
+        .push_back(ctrl_id("cmd-nope", execute_query("SELECT 1", 10)));
 
     let result = await_result(&captured, "cmd-nope")
         .await
@@ -1118,11 +1118,11 @@ async fn run_query_is_unsupported_when_the_runtime_cannot_query() {
     handle.shutdown().await;
 }
 
-/// A capable runtime advertises `run_query` and announces the protocol revision
+/// A capable runtime advertises `execute_query` and announces the protocol revision
 /// that carries it. The gateway gates dispatch on the capability, so the two
 /// must appear together.
 #[tokio::test]
-async fn a_querying_runtime_advertises_run_query() {
+async fn a_querying_runtime_advertises_execute_query() {
     let harness = Harness::new(24 * 60 * 60).await;
     let (runtime, _state) = QueryRuntime::returning(b"rows".to_vec(), 1);
     let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
@@ -1130,8 +1130,8 @@ async fn a_querying_runtime_advertises_run_query() {
     let captured = Arc::clone(&harness.gateway.captured);
     let advertised = advertised_capabilities(&captured).await;
     assert!(
-        advertised.contains(&"run_query".to_string()),
-        "a querying runtime must advertise run_query: {advertised:?}"
+        advertised.contains(&"execute_query".to_string()),
+        "a querying runtime must advertise execute_query: {advertised:?}"
     );
     let protocol_version = captured
         .lock()
@@ -1143,7 +1143,7 @@ async fn a_querying_runtime_advertises_run_query() {
     assert_eq!(
         protocol_version,
         runtime_cloud_connect::PROTOCOL_VERSION,
-        "the announced revision must be the one that carries run_query"
+        "the announced revision must be the one that carries execute_query"
     );
 
     handle.shutdown().await;
@@ -1153,7 +1153,7 @@ async fn a_querying_runtime_advertises_run_query() {
 /// taken, so a stream of blank queries cannot lock the instance out of real
 /// ones.
 #[tokio::test]
-async fn run_query_rejects_an_empty_statement() {
+async fn execute_query_rejects_an_empty_statement() {
     let harness = Harness::new(24 * 60 * 60).await;
     let (runtime, state) = QueryRuntime::returning(b"rows".to_vec(), 1);
     let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
@@ -1163,7 +1163,7 @@ async fn run_query_rejects_an_empty_statement() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-empty", run_query("   \n\t ", 10)));
+        .push_back(ctrl_id("cmd-empty", execute_query("   \n\t ", 10)));
 
     let result = await_result(&harness.gateway.captured, "cmd-empty")
         .await
@@ -1185,7 +1185,7 @@ async fn run_query_rejects_an_empty_statement() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-real", run_query("SELECT 1", 10)));
+        .push_back(ctrl_id("cmd-real", execute_query("SELECT 1", 10)));
     let real = await_result(&harness.gateway.captured, "cmd-real")
         .await
         .expect("a real query must still run after an empty one");
@@ -1212,7 +1212,7 @@ async fn a_query_that_never_returns_is_abandoned_and_frees_the_slot() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-hang", run_query("SELECT 1", 10)));
+        .push_back(ctrl_id("cmd-hang", execute_query("SELECT 1", 10)));
 
     let hung = await_result(&harness.gateway.captured, "cmd-hang")
         .await
@@ -1231,7 +1231,7 @@ async fn a_query_that_never_returns_is_abandoned_and_frees_the_slot() {
         .outbound
         .lock()
         .await
-        .push_back(ctrl_id("cmd-after-hang", run_query("SELECT 2", 10)));
+        .push_back(ctrl_id("cmd-after-hang", execute_query("SELECT 2", 10)));
     let after = await_result(&harness.gateway.captured, "cmd-after-hang")
         .await
         .expect("a query after the deadline must be answered");
@@ -1254,7 +1254,7 @@ async fn a_query_that_never_returns_is_abandoned_and_frees_the_slot() {
 /// codes, so the portal can tell a bad statement from a busy instance from a
 /// broken one without reading the English.
 #[tokio::test]
-async fn run_query_maps_runtime_failures_onto_their_own_codes() {
+async fn execute_query_maps_runtime_failures_onto_their_own_codes() {
     for (error, expected) in [
         (
             CommandError::invalid_argument("Query failed: no such column"),
@@ -1282,7 +1282,7 @@ async fn run_query_maps_runtime_failures_onto_their_own_codes() {
             .outbound
             .lock()
             .await
-            .push_back(ctrl_id("cmd-err", run_query("SELECT 1", 10)));
+            .push_back(ctrl_id("cmd-err", execute_query("SELECT 1", 10)));
 
         let result = await_result(&harness.gateway.captured, "cmd-err")
             .await

--- a/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
@@ -79,7 +79,8 @@ use rcgen::{
 };
 use runtime_cloud_connect::config::CloudConnectConfig;
 use runtime_cloud_connect::handlers::{
-    ApplyOutcome, Capability, CommandError, RuntimeHandle, SpicepodDeployment,
+    ApplyOutcome, Capability, CommandError, MAX_QUERY_RESULT_BYTES, MAX_QUERY_ROWS, QueryOutcome,
+    RuntimeHandle, SpicepodDeployment,
 };
 use runtime_cloud_connect::identity::IdentityStore;
 use runtime_cloud_connect::proto;
@@ -616,12 +617,11 @@ impl RuntimeHandle for E2eRuntime {
         tokio::fs::write(&path, deployment.spicepod_yaml)
             .await
             .map_err(|e| CommandError::failed(e.to_string()))?;
-        self.state.lock().await.applied_spicepod =
-            Some((
-                path.clone(),
-                deployment.spicepod_yaml.to_string(),
-                deployment.app_id.map(str::to_string),
-            ));
+        self.state.lock().await.applied_spicepod = Some((
+            path.clone(),
+            deployment.spicepod_yaml.to_string(),
+            deployment.app_id.map(str::to_string),
+        ));
         Ok(ApplyOutcome::exit_to_apply(serde_json::json!({
             "path": path.display().to_string(),
             "applied": true,
@@ -632,6 +632,669 @@ impl RuntimeHandle for E2eRuntime {
 
     async fn exit_to_apply(&self) {
         self.state.lock().await.exit_requested = true;
+    }
+}
+
+// --------------------------------------------------------------------------
+// Runtime handle for the RunQuery path. Records what the client handed it and
+// returns a scripted outcome, so the tests below observe the client's own
+// behavior (clamping, the single slot, the byte cap) rather than a query
+// engine's.
+// --------------------------------------------------------------------------
+
+#[derive(Default)]
+struct QueryRuntimeState {
+    /// The `max_rows` value of every call, in order — the clamp is the
+    /// client's job, so this is what proves it happened before the handle ran.
+    max_rows_seen: Vec<u32>,
+    /// The SQL of every call, so a test can confirm the statement reached the
+    /// handle intact.
+    sql_seen: Vec<String>,
+}
+
+struct QueryRuntime {
+    state: Arc<Mutex<QueryRuntimeState>>,
+    can_query: bool,
+    /// What `run_query` answers with.
+    reply: Mutex<Option<Result<QueryOutcome, CommandError>>>,
+    /// Released to let an in-flight `run_query` return. `None` returns at once.
+    release: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+}
+
+impl QueryRuntime {
+    /// A handle that can query and answers every call with `bytes`.
+    fn returning(bytes: Vec<u8>, row_count: u64) -> (Arc<Self>, Arc<Mutex<QueryRuntimeState>>) {
+        Self::build(
+            true,
+            Some(Ok(QueryOutcome {
+                arrow_ipc: bytes,
+                row_count,
+            })),
+            None,
+        )
+    }
+
+    /// A handle that can query but blocks inside `run_query` until the returned
+    /// sender fires — how a test holds the single query slot open.
+    fn blocking() -> (
+        Arc<Self>,
+        Arc<Mutex<QueryRuntimeState>>,
+        tokio::sync::oneshot::Sender<()>,
+    ) {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let (runtime, state) = Self::build(
+            true,
+            Some(Ok(QueryOutcome {
+                arrow_ipc: b"held".to_vec(),
+                row_count: 1,
+            })),
+            Some(rx),
+        );
+        (runtime, state, tx)
+    }
+
+    /// A handle that cannot query at all.
+    fn incapable() -> (Arc<Self>, Arc<Mutex<QueryRuntimeState>>) {
+        Self::build(false, None, None)
+    }
+
+    fn build(
+        can_query: bool,
+        reply: Option<Result<QueryOutcome, CommandError>>,
+        release: Option<tokio::sync::oneshot::Receiver<()>>,
+    ) -> (Arc<Self>, Arc<Mutex<QueryRuntimeState>>) {
+        let state = Arc::new(Mutex::new(QueryRuntimeState::default()));
+        (
+            Arc::new(Self {
+                state: Arc::clone(&state),
+                can_query,
+                reply: Mutex::new(reply),
+                release: Mutex::new(release),
+            }),
+            state,
+        )
+    }
+}
+
+#[async_trait]
+impl RuntimeHandle for QueryRuntime {
+    fn supports(&self, capability: Capability) -> bool {
+        match capability {
+            Capability::RunQuery => self.can_query,
+            // GetRuntimeInfo needs no capability, so this keeps the handle to
+            // exactly the one command under test.
+            _ => false,
+        }
+    }
+
+    async fn run_query(&self, sql: &str, max_rows: u32) -> Result<QueryOutcome, CommandError> {
+        {
+            let mut state = self.state.lock().await;
+            state.max_rows_seen.push(max_rows);
+            state.sql_seen.push(sql.to_string());
+        }
+        if let Some(release) = self.release.lock().await.take() {
+            let _ = release.await;
+        }
+        self.reply
+            .lock()
+            .await
+            .take()
+            .unwrap_or_else(|| Err(CommandError::failed("no scripted reply left")))
+    }
+}
+
+/// Enroll a client whose handle is a [`QueryRuntime`], and return the running
+/// client plus the temp dir keeping its identity alive.
+async fn enroll_query_runtime(
+    harness: &Harness,
+    runtime: Arc<dyn RuntimeHandle>,
+) -> (runtime_cloud_connect::CloudConnect, tempfile::TempDir) {
+    enroll_query_runtime_with_deadline(harness, runtime, Duration::from_mins(1)).await
+}
+
+/// As [`enroll_query_runtime`], with the `RunQuery` deadline set explicitly so
+/// a test can exercise it without waiting out the production value.
+async fn enroll_query_runtime_with_deadline(
+    harness: &Harness,
+    runtime: Arc<dyn RuntimeHandle>,
+    query_deadline: Duration,
+) -> (runtime_cloud_connect::CloudConnect, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = harness.config(
+        dir.path().join("identity.json"),
+        dir.path().to_path_buf(),
+        Some(ADOPTION_CODE.to_string()),
+        Duration::from_hours(12),
+    );
+    config.query_deadline = query_deadline;
+    let (handle, _identity) = enroll(harness, &config, runtime).await;
+    (handle, dir)
+}
+
+/// Poll for the `CommandResult` correlated to `command_id`.
+async fn await_result(
+    captured: &Arc<Mutex<Captured>>,
+    command_id: &str,
+) -> Option<proto::CommandResult> {
+    let found = wait_until_async(Duration::from_secs(5), || {
+        let captured = Arc::clone(captured);
+        let command_id = command_id.to_string();
+        async move {
+            captured
+                .lock()
+                .await
+                .results
+                .iter()
+                .any(|r| r.command_id == command_id)
+        }
+    })
+    .await;
+    if !found {
+        return None;
+    }
+    let c = captured.lock().await;
+    c.results
+        .iter()
+        .find(|r| r.command_id == command_id)
+        .cloned()
+}
+
+/// The capability list on the most recent `Hello`.
+async fn advertised_capabilities(captured: &Arc<Mutex<Captured>>) -> Vec<String> {
+    let c = captured.lock().await;
+    c.hellos
+        .last()
+        .map(|(hello, _)| hello.capabilities.clone())
+        .expect("a Hello must have been captured")
+}
+
+fn run_query(sql: &str, max_rows: u32) -> proto::control_message::Body {
+    proto::control_message::Body::RunQuery(proto::RunQuery {
+        sql: sql.to_string(),
+        max_rows,
+    })
+}
+
+/// A successful query comes back on the `binary` arm, byte-for-byte what the
+/// runtime encoded — the client is a courier for the Arrow IPC stream, not a
+/// re-encoder of it.
+#[tokio::test]
+async fn run_query_returns_the_runtime_bytes_on_the_binary_arm() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    let payload = b"ARROW-IPC-STREAM-BYTES".to_vec();
+    let (runtime, state) = QueryRuntime::returning(payload.clone(), 3);
+    let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-query", run_query("SELECT 1", 10)));
+
+    let result = await_result(&harness.gateway.captured, "cmd-query")
+        .await
+        .expect("the client must answer a RunQuery");
+    assert_eq!(
+        result.code,
+        proto::ResultCode::Ok as i32,
+        "query must succeed: {}",
+        result.message
+    );
+    assert_eq!(
+        result.payload,
+        Some(proto::command_result::Payload::Binary(payload)),
+        "the Arrow IPC stream must ride on the binary arm, unmodified"
+    );
+    assert_eq!(state.lock().await.sql_seen, vec!["SELECT 1".to_string()]);
+
+    handle.shutdown().await;
+}
+
+/// The row cap is the client's to enforce: zero means the default, and a
+/// request above the cap is clamped before the runtime ever sees it. A runtime
+/// handed 500 cannot return 100_000 rows even if the caller asked for them.
+#[tokio::test]
+async fn run_query_clamps_the_row_limit_before_the_runtime_runs() {
+    for (requested, expected) in [(0_u32, MAX_QUERY_ROWS), (10, 10), (100_000, MAX_QUERY_ROWS)] {
+        let harness = Harness::new(24 * 60 * 60).await;
+        let (runtime, state) = QueryRuntime::returning(b"rows".to_vec(), 1);
+        let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+        harness
+            .gateway
+            .outbound
+            .lock()
+            .await
+            .push_back(ctrl_id("cmd-clamp", run_query("SELECT 1", requested)));
+
+        await_result(&harness.gateway.captured, "cmd-clamp")
+            .await
+            .expect("the client must answer a RunQuery");
+        assert_eq!(
+            state.lock().await.max_rows_seen,
+            vec![expected],
+            "a request for {requested} rows must reach the runtime as {expected}"
+        );
+
+        handle.shutdown().await;
+    }
+}
+
+/// A second query while one is in flight is refused before it executes — the
+/// runtime handle must be called exactly once, not queued behind the first.
+#[tokio::test]
+async fn run_query_answers_busy_without_executing_a_second_query() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    let (runtime, state, release) = QueryRuntime::blocking();
+    let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-first", run_query("SELECT 1", 10)));
+
+    // Wait until the first query is genuinely inside the handle, so the second
+    // one races a held slot rather than an empty one.
+    let running = wait_until_async(Duration::from_secs(5), || {
+        let state = Arc::clone(&state);
+        async move { !state.lock().await.max_rows_seen.is_empty() }
+    })
+    .await;
+    assert!(running, "the first query must reach the runtime handle");
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-second", run_query("SELECT 2", 10)));
+
+    let second = await_result(&harness.gateway.captured, "cmd-second")
+        .await
+        .expect("a concurrent query must be answered, not dropped");
+    assert_eq!(
+        second.code,
+        proto::ResultCode::Busy as i32,
+        "a concurrent query must be answered busy: {}",
+        second.message
+    );
+    assert!(
+        second.payload.is_none(),
+        "a busy answer carries no payload, got {:?}",
+        second.payload
+    );
+    assert_eq!(
+        state.lock().await.max_rows_seen.len(),
+        1,
+        "the second query must be refused BEFORE execution, not queued"
+    );
+
+    // Releasing the first query frees the slot again.
+    let _ = release.send(());
+    let first = await_result(&harness.gateway.captured, "cmd-first")
+        .await
+        .expect("the first query must still answer");
+    assert_eq!(first.code, proto::ResultCode::Ok as i32);
+
+    handle.shutdown().await;
+}
+
+/// Query work runs off the control-message pump.
+///
+/// The command dispatched mid-query is what proves it: awaiting the query in
+/// the pump stops every later command from being read at all. Heartbeats ride
+/// their own task and would survive a blocked pump, so they are asserted for
+/// the acceptance criterion rather than as evidence of where the query runs.
+#[tokio::test]
+async fn heartbeats_and_commands_stay_live_while_a_query_runs() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    let (runtime, state, release) = QueryRuntime::blocking();
+    let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-slow", run_query("SELECT 1", 10)));
+
+    let running = wait_until_async(Duration::from_secs(5), || {
+        let state = Arc::clone(&state);
+        async move { !state.lock().await.max_rows_seen.is_empty() }
+    })
+    .await;
+    assert!(running, "the query must reach the runtime handle");
+
+    let captured = Arc::clone(&harness.gateway.captured);
+    let before = captured.lock().await.heartbeats.len();
+
+    // An unrelated command dispatched while the query is stuck must still be
+    // answered by the pump.
+    harness.gateway.outbound.lock().await.push_back(ctrl_id(
+        "cmd-info",
+        proto::control_message::Body::GetRuntimeInfo(proto::GetRuntimeInfo {}),
+    ));
+    let info = await_result(&captured, "cmd-info")
+        .await
+        .expect("the pump must answer other commands while a query runs");
+    assert_eq!(info.code, proto::ResultCode::Ok as i32);
+
+    let beating = wait_until_async(Duration::from_secs(5), || {
+        let captured = Arc::clone(&captured);
+        async move { captured.lock().await.heartbeats.len() > before + 1 }
+    })
+    .await;
+    assert!(
+        beating,
+        "heartbeats must keep flowing while a query is in flight"
+    );
+
+    let _ = release.send(());
+    handle.shutdown().await;
+}
+
+/// A result over the byte cap is refused at the contract boundary with no
+/// payload at all — a partial result would look to the caller like the whole
+/// answer.
+#[tokio::test]
+async fn run_query_refuses_an_oversized_result_without_partial_data() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    let oversized = vec![0_u8; MAX_QUERY_RESULT_BYTES + 1];
+    let (runtime, _state) = QueryRuntime::returning(oversized, 1);
+    let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-big", run_query("SELECT 1", 10)));
+
+    let result = await_result(&harness.gateway.captured, "cmd-big")
+        .await
+        .expect("an oversized result must still be answered");
+    assert_eq!(
+        result.code,
+        proto::ResultCode::ResultTooLarge as i32,
+        "an oversized result must be typed, not a generic failure: {}",
+        result.message
+    );
+    assert!(
+        result.payload.is_none(),
+        "an oversized result must carry no partial payload, got {:?}",
+        result.payload
+    );
+
+    handle.shutdown().await;
+}
+
+/// The row cap is re-checked against what the handle actually returned. A
+/// handle that ignores the limit it was given must not have its result
+/// forwarded — the whole point of holding the limits at the instance is that
+/// nothing downstream re-checks them.
+#[tokio::test]
+async fn run_query_refuses_a_result_with_more_rows_than_the_limit() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    // Small payload, but it claims far more rows than the 10 that were asked
+    // for — an honest byte count with a dishonest row count.
+    let (runtime, _state) = QueryRuntime::returning(b"rows".to_vec(), 5_000);
+    let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-toomany", run_query("SELECT 1", 10)));
+
+    let result = await_result(&harness.gateway.captured, "cmd-toomany")
+        .await
+        .expect("an over-limit result must still be answered");
+    assert_eq!(
+        result.code,
+        proto::ResultCode::Internal as i32,
+        "a handle breaking the row cap is an instance fault: {}",
+        result.message
+    );
+    assert!(
+        result.payload.is_none(),
+        "an over-limit result must not be forwarded, got {:?}",
+        result.payload
+    );
+
+    handle.shutdown().await;
+}
+
+/// A runtime that cannot query neither advertises `run_query` nor pretends to
+/// answer one — and the session survives the refusal.
+#[tokio::test]
+async fn run_query_is_unsupported_when_the_runtime_cannot_query() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    let (runtime, state) = QueryRuntime::incapable();
+    let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+    let captured = Arc::clone(&harness.gateway.captured);
+    let advertised = advertised_capabilities(&captured).await;
+    assert!(
+        !advertised.contains(&"run_query".to_string()),
+        "a runtime that cannot query must not advertise run_query: {advertised:?}"
+    );
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-nope", run_query("SELECT 1", 10)));
+
+    let result = await_result(&captured, "cmd-nope")
+        .await
+        .expect("an unsupported query must still be answered");
+    assert_eq!(
+        result.code,
+        proto::ResultCode::Unsupported as i32,
+        "an unsupported query must be typed unsupported: {}",
+        result.message
+    );
+    assert!(
+        state.lock().await.max_rows_seen.is_empty(),
+        "an unsupported query must never reach the runtime handle"
+    );
+
+    // The refusal must not tear the session down: existing commands keep working.
+    harness.gateway.outbound.lock().await.push_back(ctrl_id(
+        "cmd-after",
+        proto::control_message::Body::GetRuntimeInfo(proto::GetRuntimeInfo {}),
+    ));
+    let after = await_result(&captured, "cmd-after")
+        .await
+        .expect("the session must survive an unsupported query");
+    assert_eq!(after.code, proto::ResultCode::Ok as i32);
+
+    handle.shutdown().await;
+}
+
+/// A capable runtime advertises `run_query` and announces the protocol revision
+/// that carries it. The gateway gates dispatch on the capability, so the two
+/// must appear together.
+#[tokio::test]
+async fn a_querying_runtime_advertises_run_query() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    let (runtime, _state) = QueryRuntime::returning(b"rows".to_vec(), 1);
+    let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+    let captured = Arc::clone(&harness.gateway.captured);
+    let advertised = advertised_capabilities(&captured).await;
+    assert!(
+        advertised.contains(&"run_query".to_string()),
+        "a querying runtime must advertise run_query: {advertised:?}"
+    );
+    let protocol_version = captured
+        .lock()
+        .await
+        .hellos
+        .last()
+        .map(|(hello, _)| hello.protocol_version)
+        .expect("a Hello must have been captured");
+    assert_eq!(
+        protocol_version,
+        runtime_cloud_connect::PROTOCOL_VERSION,
+        "the announced revision must be the one that carries run_query"
+    );
+
+    handle.shutdown().await;
+}
+
+/// An empty statement is the caller's mistake and is refused before the slot is
+/// taken, so a stream of blank queries cannot lock the instance out of real
+/// ones.
+#[tokio::test]
+async fn run_query_rejects_an_empty_statement() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    let (runtime, state) = QueryRuntime::returning(b"rows".to_vec(), 1);
+    let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-empty", run_query("   \n\t ", 10)));
+
+    let result = await_result(&harness.gateway.captured, "cmd-empty")
+        .await
+        .expect("an empty query must be answered");
+    assert_eq!(
+        result.code,
+        proto::ResultCode::InvalidArgument as i32,
+        "an empty query is the caller's mistake: {}",
+        result.message
+    );
+    assert!(
+        state.lock().await.max_rows_seen.is_empty(),
+        "an empty query must never reach the runtime handle"
+    );
+
+    // The slot was not consumed: a real query still runs.
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-real", run_query("SELECT 1", 10)));
+    let real = await_result(&harness.gateway.captured, "cmd-real")
+        .await
+        .expect("a real query must still run after an empty one");
+    assert_eq!(real.code, proto::ResultCode::Ok as i32);
+
+    handle.shutdown().await;
+}
+
+/// A query that never returns is abandoned at the deadline and, crucially,
+/// gives the slot back. Without the deadline the single in-flight slot would be
+/// held for the life of the process and every later query would answer busy —
+/// there is no cancellation command to rescue it.
+#[tokio::test]
+async fn a_query_that_never_returns_is_abandoned_and_frees_the_slot() {
+    let harness = Harness::new(24 * 60 * 60).await;
+    // The sender is dropped at the end of this scope, but `blocking()` holds
+    // the receiver, so the query never completes on its own.
+    let (runtime, state, release) = QueryRuntime::blocking();
+    let (handle, _dir) =
+        enroll_query_runtime_with_deadline(&harness, runtime, Duration::from_millis(300)).await;
+
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-hang", run_query("SELECT 1", 10)));
+
+    let hung = await_result(&harness.gateway.captured, "cmd-hang")
+        .await
+        .expect("a hung query must still be answered");
+    assert_eq!(
+        hung.code,
+        proto::ResultCode::Failed as i32,
+        "a query past the deadline is retryable, not the caller's mistake: {}",
+        hung.message
+    );
+    assert!(hung.payload.is_none(), "an abandoned query carries no data");
+
+    // The slot must be back: a second query runs rather than answering busy.
+    harness
+        .gateway
+        .outbound
+        .lock()
+        .await
+        .push_back(ctrl_id("cmd-after-hang", run_query("SELECT 2", 10)));
+    let after = await_result(&harness.gateway.captured, "cmd-after-hang")
+        .await
+        .expect("a query after the deadline must be answered");
+    assert_ne!(
+        after.code,
+        proto::ResultCode::Busy as i32,
+        "the deadline must free the query slot, but the next query was refused as busy"
+    );
+    assert_eq!(
+        state.lock().await.max_rows_seen.len(),
+        2,
+        "the second query must actually reach the runtime handle"
+    );
+
+    drop(release);
+    handle.shutdown().await;
+}
+
+/// The failure classes a query can produce reach the control plane as their own
+/// codes, so the portal can tell a bad statement from a busy instance from a
+/// broken one without reading the English.
+#[tokio::test]
+async fn run_query_maps_runtime_failures_onto_their_own_codes() {
+    for (error, expected) in [
+        (
+            CommandError::invalid_argument("Query failed: no such column"),
+            proto::ResultCode::InvalidArgument,
+        ),
+        (
+            CommandError::result_too_large("too big"),
+            proto::ResultCode::ResultTooLarge,
+        ),
+        (
+            CommandError::internal("encoder fault"),
+            proto::ResultCode::Internal,
+        ),
+        (
+            CommandError::failed("the source is unreachable"),
+            proto::ResultCode::Failed,
+        ),
+    ] {
+        let harness = Harness::new(24 * 60 * 60).await;
+        let (runtime, _state) = QueryRuntime::build(true, Some(Err(error)), None);
+        let (handle, _dir) = enroll_query_runtime(&harness, runtime).await;
+
+        harness
+            .gateway
+            .outbound
+            .lock()
+            .await
+            .push_back(ctrl_id("cmd-err", run_query("SELECT 1", 10)));
+
+        let result = await_result(&harness.gateway.captured, "cmd-err")
+            .await
+            .expect("a failing query must be answered");
+        assert_eq!(
+            result.code, expected as i32,
+            "unexpected code for {}: {}",
+            result.message, result.code
+        );
+        assert!(result.payload.is_none(), "a failure carries no payload");
+
+        handle.shutdown().await;
     }
 }
 
@@ -701,6 +1364,9 @@ impl Harness {
             telemetry_interval: Duration::from_millis(250),
             metrics_interval: Duration::from_millis(200),
             renewal_lead,
+            // Long enough that only the test that targets the deadline ever
+            // reaches it; that test sets its own.
+            query_deadline: Duration::from_mins(1),
         }
     }
 }


### PR DESCRIPTION
The SQL Playground cannot query a connected standalone instance: a standalone `spiced` has no data-plane connection, so there is no path from the portal to its query engine. This adds a bounded `ExecuteQuery` command to the Cloud Connect control stream as a temporary bridge until the standalone data plane serves queries directly.

## Wire contract

`spice.cloud.v1` gains `ExecuteQuery execute_query = 18` in the `ControlMessage.body` oneof, carrying `string sql = 1` and `uint32 max_rows = 2`. Addressing stays on the envelope, so the command message carries no `command_id` of its own. Two outcome classes join `ResultCode` — `RESULT_CODE_BUSY = 6` and `RESULT_CODE_RESULT_TOO_LARGE = 7`. Rows come back as a complete Arrow IPC stream on the existing `CommandResult.binary` arm; no new result envelope.

`Hello.protocol_version` stays at `1`. A revision exists for a change that neither absent-oneof tolerance nor `Hello.capabilities` can carry, and this is not one: an older peer decodes arm 18 as an absent body, answers `RESULT_CODE_UNSUPPORTED` against the envelope's `command_id`, and keeps serving the session. `Hello.capabilities` is the authoritative signal, and dispatch gates on the capability.

`spiceai/spiceai` holds the authoritative contract, so the gateway and operator mirrors follow these field numbers exactly.

## Read-only

The query runs read-only: the statement is planned and then refused if it carries DDL, DML, `COPY`, or a write-capable extension. This command arrives from the control plane rather than from someone holding the instance's own credentials, so it reads the instance and never changes it.

## Limits live in the runtime

The instance, not the caller, is what makes the limits real:

- **Rows**: `min(max_rows, 500)`, with `max_rows == 0` meaning the 500 default. The clamp happens in `runtime-cloud-connect` before the runtime handle runs, and the handle applies it again rather than trusting it. Truncation slices mid-batch and stops pulling from the stream, so rows past the cap are never fetched. A result that comes back over the cap anyway is refused rather than forwarded.
- **Bytes**: the complete Arrow IPC payload is capped at 4 MiB. `BoundedBuffer` refuses the first write that would cross the cap, so an oversized result is never materialized and then measured — it returns `RESULT_CODE_RESULT_TOO_LARGE` with no payload at all. A single row too large to send takes the same path. The client re-checks the size at the contract boundary before anything reaches the stream.
- **Concurrency**: one query in flight per runtime, held by a single-permit semaphore on the driver so a reconnect cannot hand out a second slot while the first query is still running. A second query is answered busy before it executes.
- **Time**: a 25s deadline, after which the query is abandoned, the slot is freed, and the answer is `RESULT_CODE_FAILED`. There is no cancellation command on this contract, so without a deadline a query that never returns would hold the only slot for the life of the process and answer every later query as busy. The deadline sits below the control plane's shared command budget so the instance is the layer that gives up first: the slot is free by the time the caller is told the query failed, and the retry that answer invites is not refused as busy by the query it is replacing. A unit test holds that nesting.

## Execution and responsiveness

`RuntimeHandle::execute_query` executes through the in-process `DataFusion` entry point the local SQL APIs already use — no HTTP hop, and no second set of query semantics to keep aligned. The query is spawned off the control-message pump, so heartbeats and other commands keep answering while it runs.

`spiced` advertises `execute_query` only when its handle can actually execute queries; the gateway rejects unsupported queries on the strength of that list without a round trip, so the advertisement and the dispatch check read the same `RuntimeHandle::supports`.

A failure is classified by who can fix it: a statement the engine could not parse, plan, or resolve is `RESULT_CODE_INVALID_ARGUMENT` and fails identically on retry, while an execution, resource, or I/O fault is `RESULT_CODE_FAILED` and may not recur. That holds for a failure surfacing mid-stream — a federated source going away during a scan — as much as one from planning.

SQL text and result values stay out of every log, trace, and metric on the control path; telemetry records the command id, duration, row count, byte count, and outcome code only. `CommandResult.message` is the one place caller-derived text rides the wire: on `RESULT_CODE_INVALID_ARGUMENT` it carries the engine's diagnostic, without which a rejected statement cannot be fixed. It reaches the caller who wrote the query and is not to be logged or retained on the way.

## Tests

`crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs` drives the whole path against the real mTLS gateway harness: the binary arm round trip, the row-limit clamp reaching the handle, busy without a second execution, other commands staying answerable while a query is stuck, the deadline abandoning a hung query and freeing the slot, an over-limit row count being refused, the oversized refusal carrying no payload, unsupported on a handle that cannot query (and the session surviving it), the empty statement, and each failure class mapping to its own code.

`bin/spiced/src/cloud_connect.rs` covers the encoder and the classifier: an Arrow IPC round trip, an empty result that still carries its schema, truncation inside a batch and across batches, an oversized result and an oversized single row, a result just under the cap that still sends, and planning-vs-execution failure classification through the `QueryError` wrapper.

Each new test was checked against a reverted implementation, so none of them pass for the wrong reason.

Closes spicehq/spiceai#1380
Part of spicehq/spiceai#1379

