### PR TITLE
fix(cloud-connect): use a fully-qualified PoP domain for spice connect remove

### DIFF
--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -741,7 +741,8 @@ pub(crate) fn sign_pop(current_private_key_pem: &str, csr_pem: &str) -> Result<S
 /// Sign an arbitrary proof-of-possession payload with an identity's private
 /// key: a DER-encoded ECDSA P-256/SHA-256 signature over `payload`,
 /// base64-encoded. `/renew` signs a CSR's DER bytes ([`sign_pop`]);
-/// `/release` signs its own domain-separated `release\n{instance_id}` payload.
+/// `/release` signs its own domain-separated
+/// `spice-cloud-connect/release/v1\n{instance_id}` payload.
 ///
 /// The error is the bare reason rather than a typed error so each flow names
 /// itself in the error it surfaces, instead of nesting one flow's message

--- a/crates/runtime-cloud-connect/src/release.rs
+++ b/crates/runtime-cloud-connect/src/release.rs
@@ -22,11 +22,12 @@ limitations under the License.
 //! proof-of-possession carried in the request body. The request presents the
 //! instance's current leaf (`cert_pem`), whose SPIFFE SAN names exactly one
 //! instance, together with a signature made by that leaf's private key
-//! (`pop_sig`) over `release\n{instance_id}`. A certificate is not a secret, so
-//! the signature — not the certificate — is what proves the caller is the
-//! instance; the `release` domain prefix keeps the signature from being
-//! replayable against another endpoint, and the instance id keeps it from being
-//! replayable for another instance.
+//! (`pop_sig`) over `spice-cloud-connect/release/v1\n{instance_id}`. A
+//! certificate is not a secret, so the signature — not the certificate — is
+//! what proves the caller is the instance; the
+//! `spice-cloud-connect/release/v1` domain prefix keeps the signature from
+//! being replayable against another endpoint, and the instance id keeps it from
+//! being replayable for another instance.
 //!
 //! The credential rides in the body rather than the TLS layer for the same
 //! reason `/renew` does: the presented leaf may already be expired, which is
@@ -52,7 +53,7 @@ use crate::identity::Identity;
 pub const RELEASE_PATH: &str = "/v1/cloud-connect/release";
 
 /// Domain-separation prefix of the release proof-of-possession payload.
-const POP_DOMAIN: &str = "release";
+const POP_DOMAIN: &str = "spice-cloud-connect/release/v1";
 
 /// Errors from the host-initiated release call.
 #[derive(Debug, Snafu)]
@@ -112,8 +113,9 @@ struct ReleaseRequest<'a> {
     pop_sig: &'a str,
 }
 
-/// The exact bytes a release proof-of-possession signs: the `release` domain
-/// prefix, a newline, and the instance id. The cloud rebuilds this string from
+/// The exact bytes a release proof-of-possession signs: the
+/// `spice-cloud-connect/release/v1` domain prefix, a newline, and the instance
+/// id. The cloud rebuilds this string from
 /// the presented certificate's SPIFFE SAN and verifies the signature against
 /// that certificate's public key, so the separator must be a real newline
 /// (0x0A) — an escaped `\n` would be two bytes the cloud never signs over.
@@ -334,14 +336,14 @@ mod tests {
     #[test]
     fn pop_payload_separates_the_domain_from_the_instance_with_one_real_newline() {
         let payload = pop_payload("inst_1");
-        assert_eq!(payload, "release\ninst_1");
+        assert_eq!(payload, "spice-cloud-connect/release/v1\ninst_1");
         // The cloud rebuilds these bytes and verifies the signature over them,
         // so the separator must be the single byte 0x0A. A literal backslash-n
         // would be two bytes the cloud never signs, and every release would
         // come back 401.
         assert_eq!(
             payload.as_bytes(),
-            b"release\x0Ainst_1",
+            b"spice-cloud-connect/release/v1\x0Ainst_1",
             "the domain separator must be a real newline byte"
         );
         assert!(!payload.contains('\\'), "the payload must carry no escapes");

--- a/crates/runtime-cloud-connect/src/release.rs
+++ b/crates/runtime-cloud-connect/src/release.rs
@@ -480,7 +480,10 @@ mod tests {
             p256_point_from_spki(spki.contents()),
         );
         key.verify(pop_payload(&identity.identifier).as_bytes(), &sig)
-            .expect("the release signature must verify over `release\\n{instance_id}`");
+            .expect(
+                "the release signature must verify over \
+                 `spice-cloud-connect/release/v1\\n{instance_id}`",
+            );
         // ...and must not verify over anything else, so a captured signature
         // cannot release a different instance.
         key.verify(pop_payload("inst_other").as_bytes(), &sig)


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

The release proof-of-possession for `spice connect remove` signed over the bare domain prefix `release`. That string is generic enough to collide with any other protocol that domain-separates the same way, which is the exact replay boundary the prefix exists to establish.

Qualify it to `spice-cloud-connect/release/v1`, so the signature is scoped to this endpoint and carries a version for future changes to the payload shape.

The payload is now `spice-cloud-connect/release/v1\n{instance_id}` (real `0x0A` separator, unchanged). No wire-format or API change beyond the signed bytes.

## Testing

- `pop_payload_separates_the_domain_from_the_instance_with_one_real_newline` — asserts the exact string and its bytes, including the single `0x0A`.
- `release_posts_the_certificate_and_a_pop_signature_the_cloud_can_verify` — signs, POSTs to an in-process mock endpoint, verifies the signature over the rebuilt payload, and asserts it does not verify for a different instance id.

Both updated for the new prefix; no new tests were needed, as the existing ones assert the payload exactly.