### PR TITLE
fix(ci): bound every E2E job, so a wedged build cannot hold the queue (fixes #12717)

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -61,6 +61,11 @@ jobs:
   check_changes:
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: spiceai-dev-runners
+    # Every job here is bounded, because on a `merge_group` run an unbounded one does not
+    # just waste a job: the queue candidate stays `AWAITING_CHECKS` for GitHub's 6-hour
+    # default and every entry behind it waits (#12717). A full-history checkout is the
+    # slow part of this one.
+    timeout-minutes: 10
     outputs:
       relevant_changes: ${{ steps.check.outputs.relevant_changes == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
@@ -76,6 +81,9 @@ jobs:
     name: Setup strategy matrix
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: spiceai-dev-runners
+    # One `github-script` step returning a literal, so anything past a minute is a stuck
+    # runner rather than slow work.
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.setup-matrix.outputs.result }}
 
@@ -109,6 +117,11 @@ jobs:
     runs-on: ${{ matrix.target.builder }}
     needs: [setup-matrix, check_changes]
     if: ${{ needs.check_changes.outputs.relevant_changes == 'true' }}
+    # A backstop above the longest step bound below, leaving room for the artifact upload
+    # and the post steps. The compile steps carry their own tighter bounds so that a
+    # wedged one is cut while the `always()` diagnostics after it can still run — a hung
+    # compile is exactly when the sccache stats are worth having.
+    timeout-minutes: 200
     env:
       HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
 
@@ -165,6 +178,11 @@ jobs:
 
       - name: Build spiced and spice CLI
         if: matrix.target.target_os != 'darwin'
+        # 65 minutes is the slowest this leg has taken across the last ten successful
+        # `merge_group` runs (44-65), so this is that worst case with room to spare. The
+        # spread is wide on a contended pool, and a bound tight enough to fail a
+        # legitimate build would be worse than the slow build it replaced.
+        timeout-minutes: 90
         uses: ./.github/actions/build-spiced
         with:
           features: 'tpc-extension,models,postgres-accel'
@@ -174,6 +192,12 @@ jobs:
 
       - name: Build spiced and spice CLI (macOS)
         if: matrix.target.target_os == 'darwin'
+        # This is the step that wedged for over 4.5 hours and held four queue candidates
+        # behind it (#12717). 138 minutes is its slowest successful `merge_group` run of
+        # the last ten (74-138); the self-hosted macOS pool puts several runner instances
+        # on one host, which is where that factor-of-two spread comes from, so the bound
+        # sits well clear of it rather than close to the median.
+        timeout-minutes: 180
         uses: ./.github/actions/build-spiced
         with:
           features: 'tpc-extension,models,postgres-accel,metal'
@@ -207,6 +231,7 @@ jobs:
     name: Setup model strategy matrix
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.setup-matrix.outputs.result }}
     steps:
@@ -2356,6 +2381,10 @@ jobs:
     name: E2E Test CI
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
+    # The gate only reads the results it already has. Bounding it matters because it is
+    # the required check: a stuck gate blocks the queue even when every job it summarises
+    # has finished.
+    timeout-minutes: 5
     needs:
       - check_changes
       - setup-matrix


### PR DESCRIPTION
## Summary

`e2e_test_ci.yml`'s `build` job declared no `timeout-minutes`, so a wedged compile was held for GitHub's default of **360 minutes**. On a `merge_group` run that is not merely a wasted job — the queue candidate stays `AWAITING_CHECKS` for the whole six hours, and every entry behind it waits.

Run [31144642239](https://github.com/spiceai/spiceai/actions/runs/31144642239) was sitting on step 12, `Build spiced and spice CLI (macOS)`, having started it at 04:19:27Z. Setup steps 1-10 had taken 12 seconds in total; nothing after step 12 could start. The queue behind it:

```
total=24
pos=1  AWAITING_CHECKS  #12534  enqueued 00:10   <- waiting on that job
pos=2  AWAITING_CHECKS  #12586  enqueued 00:10
pos=3  AWAITING_CHECKS  #12601  enqueued 00:10
pos=4  AWAITING_CHECKS  #12607  enqueued 00:10
pos=5..24  QUEUED
```

Every one of the workflow's ~17 test jobs was already bounded at 5-10 minutes. `build` and the four jobs around it were the only unbounded ones, and `build` is the one that takes hours.

## Changes

Bounds go on the **compile steps** rather than only the job, so that a wedged step is cut while the `always()` steps after it — `Show sccache stats`, `Kill spiceio`, `Upload spiceio logs` — still run. A hung compile is exactly when the sccache stats are worth having (#12420 made that step run on failure for the same reason). The job then carries a backstop above the longest step bound, with room for the artifact upload and the post steps.

| Scope | Bound | Observed on the last ten successful `merge_group` runs |
| --- | --- | --- |
| step: Build spiced and spice CLI (Linux) | 90m | 44, 44, 60, 60, 63, 63, 63, 64, 65 |
| step: Build spiced and spice CLI (macOS) | 180m | 74, 80, 85, 86, 90, 91, 138 |
| job: `build` | 200m | — backstop above the step bounds |
| job: `check_changes` | 10m | full-history checkout plus one composite action |
| job: `setup-matrix` / `setup-model-matrix` | 5m | one `github-script` step returning a literal |
| job: `e2e-gate` | 5m | reads results it already has |

Each build bound is the slowest observed success with clear room over it. The spread is wide — the same job varies by a factor of two — because the self-hosted macOS pool puts several runner instances on one host, so the bounds sit clear of the median rather than near it. A bound tight enough to fail a legitimate build would be worse than the slow build it replaced.

`e2e-gate` gets a bound despite doing no work because it is the *required* check: a stuck gate blocks the queue even when every job it summarises has finished.

## What this does not do

It does not stop the hang. The same job succeeds routinely on the same runners, its log blob is not retrievable while the step runs (`BlobNotFound`), and there is no output to attribute it from — a contended or stuck compile on a shared host is plausible without anything being wrong with the commit. It also does not rescue a run already wedged, since a run reads the workflow as of its own start.

What it does is turn "the queue is stalled for six hours" into "one candidate fails, is dequeued, and the rest proceed".

## Test plan

- `make lint`
- `make test`
- `actionlint .github/workflows/e2e_test_ci.yml` reports nothing on the added lines. Its existing output for this file (unknown self-hosted runner labels, shellcheck style notes, one duplicate matrix value) is unchanged, and is pre-existing.
- The diff is additive only — `timeout-minutes` keys and comments, no step, condition or command altered. Verified by filtering the diff for non-comment, non-`timeout-minutes` lines, which yields nothing.
- Parsed the result and asserted all 21 jobs now carry a `timeout-minutes`, and that the two compile steps carry 90 and 180.

A timeout cannot be exercised without deliberately wedging a build on the shared macOS pool, which would cost the queue the very stall this prevents. The values are therefore justified from measured run history above rather than from a test.

## Checklist

- [x] Root cause identified, with the live queue stall and the hung step named
- [x] Bounds derived from measured durations, not guessed
- [x] Step bounds placed so the `always()` diagnostics survive the cut
- [x] Every job in the workflow now bounded, including the required gate
- [x] Diff verified additive; no behaviour changed on a passing run
- [x] The limits of the fix stated rather than overclaimed
- [ ] `make lint` / `make test` via sign-off

Fixes #12717

Follow-up: the same shape exists in `pr.yml`, `integration.yml` and `integration_llms.yml`, whose long jobs are also unbounded (`Build and Test` 156m, `Rust Lint` 147m, `Build (release profile)` 134m, `Build Test Binary` 121m observed). Not folded in here: each needs its own measured values, and `pr.yml` and `integration_llms.yml` have open PRs against them (#12681, #12626). Tracked in #12718.
