### PR TITLE
Add AttachApp runtime command and durable attachment state

### DIFF
--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -562,6 +562,30 @@ impl SpicedRuntimeHandle {
         );
     }
 
+    async fn persist_attachment(&self, app_id: Option<&str>) -> Result<(), CommandError> {
+        let path = self.identity_path.clone();
+        let app_id = app_id.map(str::to_string);
+        let result = tokio::task::spawn_blocking(move || {
+            IdentityStore::set_app_id(&path, app_id.as_deref())
+        })
+        .await
+        .map_err(|error| {
+            CommandError::failed(format!("Failed to save the cloud app attachment: {error}"))
+        })?
+        .map_err(|error| {
+            CommandError::failed(format!(
+                "Failed to save the cloud app attachment to {}: {error}. Check that the runtime can write this path and retry.",
+                self.identity_path.display()
+            ))
+        })?;
+        if !result {
+            return Err(CommandError::failed(
+                "Failed to save the cloud app attachment because the Cloud Connect identity is missing. Reconnect the instance and retry.",
+            ));
+        }
+        Ok(())
+    }
+
     /// The local delivered-secrets cache key, read fresh from `identity.json`.
     ///
     /// `None` when there is no identity yet, or it predates the cache key — in
@@ -611,7 +635,10 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             // The handle holds the runtime, so it can always plan and execute
             // a query against whatever the instance currently serves — an
             // empty catalog answers with an error, not an inability.
-            Capability::ApplySpicepod | Capability::GetStatus | Capability::ExecuteQuery => true,
+            Capability::ApplySpicepod
+            | Capability::AttachApp
+            | Capability::GetStatus
+            | Capability::ExecuteQuery => true,
             // Only when the log-capture layer was installed at startup;
             // otherwise there is no buffer to read from.
             Capability::GetLogs => self.logs.is_some(),
@@ -624,7 +651,10 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             Capability::Restart => "Restart is unsupported on standalone spiced: it is not a control the runtime offers on demand. A deployment already applies by restarting this instance onto the spicepod it validated; to restart it without deploying, use your process manager (systemd/Docker/Kubernetes). See: https://spiceai.org/docs".to_string(),
             Capability::UpgradeRuntime => "UpgradeRuntime is unsupported on standalone spiced: it cannot replace its own binary. Upgrade it the way you installed it (`spice upgrade`, your container image, or your package manager). See: https://spiceai.org/docs".to_string(),
             Capability::GetLogs => "Log capture is not enabled for this runtime: Spice Cloud Connect must be configured before startup for spiced to install the log-capture layer. See: https://spiceai.org/docs".to_string(),
-            Capability::ApplySpicepod | Capability::GetStatus | Capability::ExecuteQuery => format!(
+            Capability::ApplySpicepod
+            | Capability::AttachApp
+            | Capability::GetStatus
+            | Capability::ExecuteQuery => format!(
                 "{} is not supported by this instance",
                 capability.wire_name()
             ),
@@ -1012,13 +1042,19 @@ impl RuntimeHandle for SpicedRuntimeHandle {
         let app_id = self.app_id.read().clone();
         let Some(app_id) = app_id else {
             tracing::debug!(
-                "Spice Cloud Connect: metrics are withheld until Spice Cloud names an app for this instance; deploy the app it is attached to"
+                "Spice Cloud Connect: metrics are withheld because this instance is not attached to a Spice Cloud app"
             );
             return Ok(None);
         };
         reader
             .collect_otlp_export(&app_id)
             .map_err(|err| CommandError::internal(err.to_string()))
+    }
+
+    async fn attach_app(&self, app_id: Option<&str>) -> Result<serde_json::Value, CommandError> {
+        self.persist_attachment(app_id).await?;
+        *self.app_id.write() = app_id.map(str::to_string);
+        Ok(serde_json::json!({ "app_id": app_id }))
     }
 
     /// Execute an `ExecuteQuery` against the in-process runtime.

--- a/crates/runtime-cloud-connect/proto/cloud_connect.proto
+++ b/crates/runtime-cloud-connect/proto/cloud_connect.proto
@@ -179,6 +179,7 @@ message ControlMessage {
     ApplySecrets apply_secrets = 14;
     DeleteSecrets delete_secrets = 15;
     ExecuteQuery execute_query = 18;
+    AttachApp attach_app = 19;
   }
 
   // Correlates the eventual `CommandResult`. Empty for an unsolicited
@@ -424,6 +425,12 @@ message ExecuteQuery {
   // Requested row cap. Zero means the instance default; the effective cap is
   // min(max_rows, 500) with zero mapping to 500.
   uint32 max_rows = 2;
+}
+
+// The app this instance is attached to, as the control plane currently sees it.
+// Absent means detached. If present it must be non-empty.
+message AttachApp {
+  optional string app_id = 1;
 }
 
 // Sealed secrets delivery. A secret value is sealed TWICE with HPKE

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -462,7 +462,9 @@ impl ClientDriver {
         // persistence fails, the rotated identity must be used in memory
         // (the old key can no longer renew). `persist_identity` logs the
         // failure; the next successful renewal re-attempts the write.
-        self.persist_identity(&rotated).await;
+        rotated = self
+            .persist_identity_preserving_attachment(rotated, "renewed identity")
+            .await;
         tracing::info!(
             "Cloud Connect: identity renewed for {} (identity and encryption keypairs rotated, valid until {})",
             rotated.identifier,
@@ -498,6 +500,45 @@ impl ClientDriver {
             "Cloud Connect: failed to persist identity at {}: {error}; continuing with the in-memory identity (it will be lost on restart)",
             self.config.identity_path.display()
         );
+    }
+
+    /// Persist a full credential update while retaining the attachment most
+    /// recently written by a command handler.
+    async fn persist_identity_preserving_attachment(
+        &self,
+        identity: Identity,
+        update: &'static str,
+    ) -> Identity {
+        let path = self.config.identity_path.clone();
+        let fallback = identity.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            IdentityStore::store_credential_update(&path, &identity)
+        })
+        .await;
+        match result {
+            Ok(Ok(Some(merged))) => merged,
+            Ok(Ok(None)) => {
+                tracing::error!(
+                    "Cloud Connect: identity disappeared while the {update} was being persisted at {}; continuing with the updated in-memory identity",
+                    self.config.identity_path.display()
+                );
+                fallback
+            }
+            Ok(Err(error)) => {
+                tracing::error!(
+                    "Cloud Connect: failed to persist the {update} at {}: {error}; continuing with the updated in-memory identity (it will be lost on restart)",
+                    self.config.identity_path.display()
+                );
+                fallback
+            }
+            Err(error) => {
+                tracing::error!(
+                    "Cloud Connect: {update} persistence task failed at {}: {error}; continuing with the updated in-memory identity (it will be lost on restart)",
+                    self.config.identity_path.display()
+                );
+                fallback
+            }
+        }
     }
 
     /// Remove the staged pending-adoption-code file, if configured. A
@@ -888,6 +929,22 @@ impl ClientDriver {
                         .await;
                 }
             }
+            proto::control_message::Body::AttachApp(cmd) => {
+                if self
+                    .supported(tx, &command_id, Capability::AttachApp, name)
+                    .await
+                {
+                    let app_id = cmd.app_id.as_deref();
+                    let result = if app_id.is_some_and(str::is_empty) {
+                        Err(CommandError::invalid_argument(
+                            "AttachApp.app_id must be non-empty when present",
+                        ))
+                    } else {
+                        self.runtime.attach_app(app_id).await
+                    };
+                    reply_with_json(tx, &command_id, result).await;
+                }
+            }
             proto::control_message::Body::UpgradeRuntime(cmd) => {
                 if self
                     .supported(tx, &command_id, Capability::UpgradeRuntime, name)
@@ -1268,21 +1325,13 @@ impl ClientDriver {
         if crate::sealed_secrets::opened_with_current(&opened.inner_key_id, &keyring) {
             let mut updated = identity;
             if updated.retire_previous_enc_key() {
-                let path = self.config.identity_path.clone();
-                let to_store = updated.clone();
-                self.identity = Some(updated);
-                // Best-effort: a failed write only means the superseded key
-                // stays on disk until the next successful one.
-                if let Err(err) =
-                    tokio::task::spawn_blocking(move || IdentityStore::store(&path, &to_store))
-                        .await
-                        .map_err(|join| format!("identity persistence task panicked: {join}"))
-                        .and_then(|result| result.map_err(|err| err.to_string()))
-                {
-                    tracing::warn!(
-                        "Cloud Connect: could not persist the retirement of the previous encryption key: {err}"
-                    );
-                }
+                self.identity = Some(
+                    self.persist_identity_preserving_attachment(
+                        updated,
+                        "previous encryption-key retirement",
+                    )
+                    .await,
+                );
             }
         }
 
@@ -1620,6 +1669,7 @@ fn command_name(body: &proto::control_message::Body) -> &'static str {
         Body::GetRuntimeInfo(_) => "GetRuntimeInfo",
         Body::Restart(_) => "Restart",
         Body::ApplySpicepod(_) => "ApplySpicepod",
+        Body::AttachApp(_) => "AttachApp",
         Body::UpgradeRuntime(_) => "UpgradeRuntime",
         Body::Adopt(_) => "Adopt",
         Body::Remove(_) => "Remove",

--- a/crates/runtime-cloud-connect/src/handlers.rs
+++ b/crates/runtime-cloud-connect/src/handlers.rs
@@ -160,6 +160,8 @@ pub struct QueryOutcome {
 pub enum Capability {
     /// Apply cloud-managed Spicepod YAML.
     ApplySpicepod,
+    /// Apply the control plane's current app attachment state.
+    AttachApp,
     /// Restart the runtime process.
     Restart,
     /// Upgrade the runtime in place.
@@ -176,6 +178,7 @@ impl Capability {
     /// Every capability this client can advertise, in wire-name order.
     pub const ALL: &'static [Self] = &[
         Self::ApplySpicepod,
+        Self::AttachApp,
         Self::ExecuteQuery,
         Self::GetLogs,
         Self::GetStatus,
@@ -189,6 +192,7 @@ impl Capability {
     pub fn wire_name(self) -> &'static str {
         match self {
             Self::ApplySpicepod => "apply_spicepod",
+            Self::AttachApp => "attach_app",
             Self::Restart => "restart",
             Self::UpgradeRuntime => "upgrade_runtime",
             Self::GetLogs => "get_logs",
@@ -553,6 +557,16 @@ pub trait RuntimeHandle: Send + Sync + 'static {
         Ok(None)
     }
 
+    /// Apply the control plane's current app attachment state.
+    ///
+    /// `None` means detached. A present value is always non-empty; the client
+    /// rejects an empty present value before invoking the handle.
+    async fn attach_app(&self, _app_id: Option<&str>) -> Result<serde_json::Value, CommandError> {
+        Err(CommandError::unsupported(
+            "AttachApp is not implemented in this build",
+        ))
+    }
+
     /// Execute `sql` through the in-process runtime and return at most
     /// `max_rows` rows as a complete Arrow IPC stream.
     ///
@@ -645,6 +659,10 @@ mod tests {
         ));
         assert!(matches!(
             h.status().await,
+            Err(CommandError::Unsupported { .. })
+        ));
+        assert!(matches!(
+            h.attach_app(Some("4002")).await,
             Err(CommandError::Unsupported { .. })
         ));
         assert!(matches!(
@@ -770,6 +788,7 @@ mod tests {
         for capability in Capability::ALL {
             match capability {
                 Capability::ApplySpicepod
+                | Capability::AttachApp
                 | Capability::Restart
                 | Capability::UpgradeRuntime
                 | Capability::GetLogs
@@ -787,6 +806,7 @@ mod tests {
             names,
             BTreeSet::from([
                 "apply_spicepod",
+                "attach_app",
                 "execute_query",
                 "get_logs",
                 "get_status",

--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -154,8 +154,8 @@ pub struct Identity {
     /// cache key yet and the cache is simply unavailable until one is minted.
     #[serde(default)]
     pub cache_key_b64: String,
-    /// The app this instance's telemetry is attributed to, as delivered by
-    /// `ApplySpicepod` and stamped on exported metrics as `scp_app_id`.
+    /// The app this instance's telemetry is attributed to, as delivered by the
+    /// control plane and stamped on exported metrics as `scp_app_id`.
     ///
     /// The one field here that is not credential material. It lives alongside
     /// the credential because it shares the credential's lifetime — both are
@@ -163,11 +163,10 @@ pub struct Identity {
     /// together when the instance is released.
     ///
     /// Persisted rather than held only in memory so a restart does not silence
-    /// the export until the next deploy: the runtime cannot derive the value,
-    /// nothing re-sends it on reconnect, and a deploy may be days away.
+    /// the export before the next control-stream reconciliation.
     ///
-    /// `None` means no deploy has ever named an app for this instance, which is
-    /// the state a freshly enrolled instance starts in.
+    /// `None` means the instance is detached, which is also the state a freshly
+    /// enrolled instance starts in.
     #[serde(default)]
     pub app_id: Option<String>,
 }
@@ -362,8 +361,8 @@ pub struct IdentityStore;
 ///
 /// [`atomic_write`] already makes any single write all-or-nothing, so no reader
 /// ever sees a half-file. What this adds is protection against a LOST UPDATE:
-/// [`IdentityStore::store_app_id`] reads the file, edits one field, and writes it
-/// back, while the renewal path writes the whole file from the identity it holds.
+/// [`IdentityStore::set_app_id`] reads the file, edits one field, and writes it
+/// back, while the renewal path replaces the credential fields.
 /// Interleave those and the rotated credential is silently replaced by the copy
 /// the app-id update read a moment earlier — leaving on disk a key the cloud has
 /// already stopped accepting, which surfaces much later as a renewal that cannot
@@ -420,11 +419,10 @@ impl IdentityStore {
     /// Record the app this instance's telemetry belongs to, leaving every other
     /// field as it is on disk.
     ///
-    /// A read-modify-write, which is why it runs under [`write_lock`]: the
-    /// renewal path rewrites the whole file from the identity it holds in
-    /// memory, so an unsynchronized update here could be read before a renewal
-    /// and written after it, silently reverting the rotated credential. The
-    /// lock makes the two orderings the only possible ones.
+    /// A read-modify-write, which is why it runs under [`write_lock`]. Complete
+    /// credential updates use [`IdentityStore::store_credential_update`] under
+    /// the same lock and merge this field from disk, preventing either update
+    /// from reverting the other.
     ///
     /// `Ok(())` with nothing written when the file does not exist. The app id
     /// arrives over an established stream, which requires an identity, so this
@@ -437,15 +435,60 @@ impl IdentityStore {
     /// Returns an error if the existing file cannot be read or parsed, or if the
     /// updated identity cannot be written.
     pub fn store_app_id(path: &Path, app_id: &str) -> Result<()> {
+        Self::set_app_id(path, Some(app_id)).map(|_| ())
+    }
+
+    /// Set or clear the app this instance's telemetry belongs to, leaving every
+    /// credential field as it is on disk.
+    ///
+    /// Returns `Ok(false)` when the identity file no longer exists. Callers
+    /// handling a control command must not acknowledge a durable update in that
+    /// case; the identity may have been removed concurrently.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the existing file cannot be read or parsed, or if the
+    /// updated identity cannot be written.
+    pub fn set_app_id(path: &Path, app_id: Option<&str>) -> Result<bool> {
         let _guard = write_lock();
         let Some(mut identity) = Self::load_optional(path)? else {
-            return Ok(());
+            return Ok(false);
         };
-        if identity.app_id.as_deref() == Some(app_id) {
-            return Ok(());
+        if identity.app_id.as_deref() == app_id {
+            return Ok(true);
         }
-        identity.app_id = Some(app_id.to_string());
-        Self::store_locked(path, &identity)
+        identity.app_id = app_id.map(str::to_string);
+        Self::store_locked(path, &identity)?;
+        Ok(true)
+    }
+
+    /// Persist a complete identity update without overwriting an attachment
+    /// change made after the caller cloned its in-memory identity.
+    ///
+    /// Certificate renewal and encryption-key retirement both replace
+    /// credential material from the client's in-memory clone. The attachment
+    /// is owned by control commands and can be newer on disk, so every such
+    /// full identity update must merge it while holding [`write_lock`].
+    ///
+    /// Returns `Ok(None)` when the identity was removed before the write and
+    /// does not recreate it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the existing file cannot be read or parsed, or if the
+    /// merged identity cannot be written.
+    pub fn store_credential_update(
+        path: &Path,
+        credential_update: &Identity,
+    ) -> Result<Option<Identity>> {
+        let _guard = write_lock();
+        let Some(current) = Self::load_optional(path)? else {
+            return Ok(None);
+        };
+        let mut merged = credential_update.clone();
+        merged.app_id = current.app_id;
+        Self::store_locked(path, &merged)?;
+        Ok(Some(merged))
     }
 
     /// The write itself, with the caller already holding [`write_lock`].
@@ -461,7 +504,7 @@ impl IdentityStore {
 
     /// Remove the identity file. No-op if it doesn't exist.
     ///
-    /// Takes [`write_lock`] for the same reason [`IdentityStore::store_app_id`]
+    /// Takes [`write_lock`] for the same reason [`IdentityStore::set_app_id`]
     /// does, and it is what makes a release final: an update that read the file
     /// a moment before the removal would otherwise write it back afterwards,
     /// resurrecting an instance the control plane just released. Under the lock
@@ -812,6 +855,26 @@ mod tests {
         assert_eq!(loaded.app_id.as_deref(), Some("3387"));
     }
 
+    #[test]
+    fn set_app_id_clears_only_the_attachment() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        let identity = sample_identity();
+        IdentityStore::store(&path, &identity).expect("store");
+        IdentityStore::set_app_id(&path, Some("4002")).expect("attach");
+
+        let present = IdentityStore::set_app_id(&path, None).expect("detach");
+
+        assert!(present, "the identity still exists");
+        let loaded = IdentityStore::load_optional(&path)
+            .expect("load")
+            .expect("present");
+        assert_eq!(loaded.app_id, None);
+        assert_eq!(loaded.identity_cert_pem, identity.identity_cert_pem);
+        assert_eq!(loaded.private_key_pem, identity.private_key_pem);
+        assert_eq!(loaded.enc_private_key_pem, identity.enc_private_key_pem);
+    }
+
     /// The app id arrives over an established stream, which requires an
     /// identity — so a missing file means one was cleared concurrently by a
     /// `Remove`. Writing a fresh file here would resurrect an instance the
@@ -858,28 +921,51 @@ mod tests {
         );
     }
 
-    /// A renewal rewrites the whole file from the identity it holds in memory,
-    /// so the app id must ride across the rotation — otherwise every renewal
-    /// silently un-attributes the instance until its next deploy.
     #[test]
-    fn a_rotation_carries_the_app_id_forward() {
+    fn credential_update_merges_an_attachment_newer_than_its_identity_clone() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let path = dir.path().join("identity.json");
-        IdentityStore::store(&path, &sample_identity()).expect("store");
+        let mut identity = sample_identity();
+        identity.enc_previous_private_key_pem = "PREVIOUS-ENCRYPTION-KEY".to_string();
+        IdentityStore::store(&path, &identity).expect("store");
+        let mut rotated = IdentityStore::load_optional(&path)
+            .expect("load stale clone")
+            .expect("present");
         IdentityStore::store_app_id(&path, "4002").expect("store app id");
 
-        let mut rotated = IdentityStore::load_optional(&path)
-            .expect("load")
-            .expect("present");
         rotated.private_key_pem = "ROTATED-KEY".to_string();
         rotated.identity_cert_pem = "ROTATED-CERT".to_string();
-        IdentityStore::store(&path, &rotated).expect("store rotated");
+        rotated.enc_previous_private_key_pem.clear();
+        assert_eq!(
+            rotated.app_id, None,
+            "the renewal clone is stale by construction"
+        );
+        let merged = IdentityStore::store_credential_update(&path, &rotated)
+            .expect("store rotated")
+            .expect("identity still present");
 
         let loaded = IdentityStore::load_optional(&path)
             .expect("load")
             .expect("present");
         assert_eq!(loaded.private_key_pem, "ROTATED-KEY");
+        assert!(loaded.enc_previous_private_key_pem.is_empty());
         assert_eq!(loaded.app_id.as_deref(), Some("4002"));
+        assert_eq!(merged.app_id.as_deref(), Some("4002"));
+    }
+
+    #[test]
+    fn credential_update_does_not_recreate_a_removed_identity() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        let identity = sample_identity();
+        IdentityStore::store(&path, &identity).expect("store");
+        IdentityStore::clear(&path).expect("remove");
+
+        let stored = IdentityStore::store_credential_update(&path, &identity)
+            .expect("credential update is a no-op");
+
+        assert!(stored.is_none());
+        assert!(IdentityStore::load_optional(&path).expect("load").is_none());
     }
 
     #[test]

--- a/crates/runtime-cloud-connect/tests/adoption_flow.rs
+++ b/crates/runtime-cloud-connect/tests/adoption_flow.rs
@@ -147,6 +147,22 @@ struct CapturedRuntime {
     applied: Arc<Mutex<Option<AppliedSpicepod>>>,
 }
 
+struct AttachmentRuntime {
+    applied: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+#[async_trait]
+impl RuntimeHandle for AttachmentRuntime {
+    fn supports(&self, capability: Capability) -> bool {
+        capability == Capability::AttachApp
+    }
+
+    async fn attach_app(&self, app_id: Option<&str>) -> Result<serde_json::Value, CommandError> {
+        self.applied.lock().await.push(app_id.map(str::to_string));
+        Ok(serde_json::json!({ "app_id": app_id }))
+    }
+}
+
 #[async_trait]
 impl RuntimeHandle for CapturedRuntime {
     fn supports(&self, capability: Capability) -> bool {
@@ -596,6 +612,104 @@ async fn apply_spicepod_writes_file_and_acks() {
         result.message
     );
     drop(s);
+
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn attach_app_applies_complete_state_and_rejects_empty_ids() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let identity_path = dir.path().join("identity.json");
+    let commands = [Some("4002"), None, Some("3387"), Some("")]
+        .into_iter()
+        .enumerate()
+        .map(|(index, app_id)| proto::ControlMessage {
+            command_id: format!("cmd-attach-{index}"),
+            target: None,
+            body: Some(proto::control_message::Body::AttachApp(proto::AttachApp {
+                app_id: app_id.map(str::to_string),
+            })),
+        })
+        .collect();
+    let mock = MockServer::new(commands);
+    let mock_state = Arc::clone(&mock.state);
+    let addr = spawn_server(mock).await;
+    IdentityStore::store(
+        &identity_path,
+        &runtime_cloud_connect::identity::Identity {
+            identifier: "inst_attachment".to_string(),
+            identity_cert_pem: "CERT".to_string(),
+            private_key_pem: "KEY".to_string(),
+            public_key_pem: "PUB".to_string(),
+            ca_bundle_pem: String::new(),
+            gateway_addr: addr.to_string(),
+            not_after_unix: None,
+            app_id: None,
+            enc_private_key_pem: String::new(),
+            enc_public_key_pem: String::new(),
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+        },
+    )
+    .expect("store identity");
+
+    let applied = Arc::new(Mutex::new(Vec::new()));
+    let runtime: Arc<dyn RuntimeHandle> = Arc::new(AttachmentRuntime {
+        applied: Arc::clone(&applied),
+    });
+    let config = CloudConnectConfig {
+        enroll_endpoint: "http://127.0.0.1:9".to_string(),
+        gateway_endpoint: None,
+        ca_cert_pem: None,
+        insecure: true,
+        identity_path,
+        config_dir: dir.path().to_path_buf(),
+        adoption_code: None,
+        pending_adopt_code_path: None,
+        adopt_app_name: None,
+        adopt_create_app: false,
+        instance_region: None,
+        runtime_version: "v0.0.0-test".to_string(),
+        heartbeat_interval: Duration::from_secs(30),
+        telemetry_interval: Duration::from_mins(1),
+        metrics_interval: Duration::from_secs(30),
+        renewal_lead: Duration::from_hours(12),
+        query_deadline: Duration::from_mins(1),
+    };
+    let handle = runtime_cloud_connect::CloudConnect::start(config, runtime)
+        .await
+        .expect("start")
+        .expect("started");
+
+    for _ in 0..50 {
+        if mock_state
+            .lock()
+            .await
+            .last_result
+            .as_ref()
+            .is_some_and(|result| result.command_id == "cmd-attach-3")
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_eq!(
+        applied.lock().await.as_slice(),
+        [Some("4002".to_string()), None, Some("3387".to_string())]
+    );
+    let state = mock_state.lock().await;
+    assert_eq!(
+        state
+            .last_hello
+            .as_ref()
+            .expect("server saw Hello")
+            .capabilities,
+        ["attach_app".to_string()]
+    );
+    let result = state.last_result.as_ref().expect("server saw a result");
+    assert_eq!(result.command_id, "cmd-attach-3");
+    assert_eq!(result.code, proto::ResultCode::InvalidArgument as i32);
+    drop(state);
 
     handle.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- add the additive `AttachApp` cloud-connect command (oneof arm 19) and advertise `attach_app` only from runtimes that implement it
- persist attach, detach, and reattach state before updating the running runtime, while rejecting a present empty app ID
- preserve the latest persisted attachment across certificate renewal and previous encryption-key retirement so stale in-memory identity clones cannot overwrite it
- retain `ApplySpicepod.app_id` compatibility during rollout; retirement should follow after every control plane uses `AttachApp`

## Validation

- `make lint-rust`
- `cargo test -p runtime-cloud-connect --tests`
- `cargo clippy -p runtime-cloud-connect --tests -- -D warnings`
- mutation check: replacing the persisted attachment merge with the stale credential value fails `credential_update_merges_an_attachment_newer_than_its_identity_clone`
- independent Grok review: pass, no critical or high findings

Part of spicehq/spiceai#1390

Closes spiceai/spiceai#12716
