### PR TITLE
fix(lint): clear the byoc lint and formatter debt blocking make lint-rust (fixes #12726)

### DIFF
--- a/crates/runtime/src/metrics_reader.rs
+++ b/crates/runtime/src/metrics_reader.rs
@@ -928,7 +928,9 @@ mod tests {
     /// points would export a payload the log line calls empty.
     #[test]
     fn a_metric_without_points_reports_nothing() {
-        use opentelemetry_proto::tonic::metrics::v1::{ResourceMetrics as OtlpRM, ScopeMetrics, Sum};
+        use opentelemetry_proto::tonic::metrics::v1::{
+            ResourceMetrics as OtlpRM, ScopeMetrics, Sum,
+        };
 
         let declared_only = ExportMetricsServiceRequest {
             resource_metrics: vec![OtlpRM {

--- a/crates/spicepod/src/lib.rs
+++ b/crates/spicepod/src/lib.rs
@@ -1443,22 +1443,22 @@ mod version_tests {
 
         let absent_in_dir = Spicepod::load_from(&reader::StdFileSystem, dir.path())
             .await
-            .err()
-            .expect("an empty directory has no spicepod.yaml");
+            .expect_err("an empty directory has no spicepod.yaml");
         assert!(absent_in_dir.is_spicepod_missing());
 
         let absent_file = Spicepod::load_from(&reader::StdFileSystem, dir.path().join("pod.yaml"))
             .await
-            .err()
-            .expect("a named file that does not exist cannot load");
+            .expect_err("a named file that does not exist cannot load");
         assert!(absent_file.is_spicepod_missing());
 
-        std::fs::write(dir.path().join("spicepod.yaml"), "version: v1\nkind: Spicepod\n")
-            .expect("write spicepod.yaml");
+        std::fs::write(
+            dir.path().join("spicepod.yaml"),
+            "version: v1\nkind: Spicepod\n",
+        )
+        .expect("write spicepod.yaml");
         let malformed = Spicepod::load_from(&reader::StdFileSystem, dir.path())
             .await
-            .err()
-            .expect("a spicepod.yaml with no name does not match the schema");
+            .expect_err("a spicepod.yaml with no name does not match the schema");
         assert!(!malformed.is_spicepod_missing());
     }
 


### PR DESCRIPTION
## Summary

`make lint-rust` could not pass on `byoc`, for reasons unrelated to any change made on top of it.
`pr.yml` triggers only on `pull_request.branches: [trunk, release-*, release/*, feature-*]`, so a PR
into `byoc` runs essentially no CI and nothing ever reported the breakage. Each author on the branch
discovered it by running the gate locally, then had to establish the failures were not their own.
Each also correctly declined to fold a drive-by fix of unrelated crates into an unrelated PR — which
is exactly why it stayed broken.

Two independent failures, both introduced on the branch:

- **`clippy::err_expect`** — three `.err().expect(..)` calls in `crates/spicepod/src/lib.rs`, which
  arrived with #12640. The lint is warn-by-default, but `make lint-rust` passes `-Dwarnings`, which
  promotes it to `error: could not compile spicepod (lib test)`.
- **`cargo fmt --all --check`** — `crates/runtime/src/metrics_reader.rs` and
  `crates/spicepod/src/lib.rs`.

Both are confined to test modules (`mod tests`, `mod version_tests`). No shipping code path changes.

Fixes #12726

## Changes

**`expect_err(..)` rather than the `unwrap_err()` the issue proposed.** Three reasons:

1. It is the replacement `clippy::err_expect` itself suggests — the diagnostic reads
   `help: try: expect_err`.
2. It keeps all three descriptive messages (`"an empty directory has no spicepod.yaml"`, and the
   two others). `unwrap_err()` would discard them, and those messages are the only thing that says
   what the assertion is for.
3. `CLAUDE.md` bars a bare `unwrap` in tests in favour of `.expect("descriptive message")`, so
   `unwrap_err()` would trade one lint complaint for a house-style violation.

One semantic difference worth naming: `expect_err` requires `T: Debug`, where `.err().expect()` does
not, because it formats the `Ok` value into the panic message. `Spicepod` satisfies it (verified —
the crate compiles clean), and that text is only ever produced when the test *fails*, where naming
the unexpected value is strictly better diagnostics.

The two formatting hunks are rustfmt's own output, applied unedited.

## Scope

I checked whether the issue's scope was complete rather than assuming it. It is:

- **`err_expect`** — a repo-wide sweep for the pattern (multi-line aware; `.err()` and `.expect(`
  sit on separate lines of a method chain, so a single-line grep silently finds nothing) reports
  **0 remaining sites** across `crates/` and `bin/` after this change.
- **Formatter** — a direct `rustfmt --check` over all 1,996 tracked `.rs` files reports diffs in
  exactly these two files, plus `crates/datafusion-dml/src/merge_parser.rs` and four files under
  `vendor/`. Neither of those is reachable by the gate: `vendor/` is not a workspace member, and
  `merge_parser.rs` is not declared as a module (see below). Both are byte-identical on `trunk`,
  where the gate is green — which is the proof they are outside it, not new debt.

## Out of scope — filed separately

Two findings turned up while verifying this one. Both are pre-existing on `trunk`, unrelated to
this branch, and filed rather than folded in:

- **#12735** — `crates/datafusion-dml/src/merge_parser.rs` is never declared as a module, so its
  494 lines and **23 tests** have never compiled, linted, or run. It surfaced here because a direct
  `rustfmt` sweep sees it while `cargo fmt --all` cannot.
- **#12743** — `runtime`'s `test_try_from_maps_acceleration` needs the `postgres` feature but never
  declares it, so every scoped `nextest` run without an explicit `FEATURES` reports it red. See the
  test plan below for the two runs that isolate it.

## Test plan

- [x] **`make lint-rust` — passes.** This is the gate the issue is about. Both clippy passes
      completed clean (lib/bins 39m33s, `--tests` 59m41s), zero errors and zero warnings, plus the
      crate-layering and rust-gate-path guards (`139 crates, 6 tiers, no upward edges`).
- [x] `cargo fmt --all --check` — clean. This is the check that was failing.
- [x] `is_spicepod_missing_distinguishes_absent_from_unloadable` passes, along with the other 224
      tests in `spicepod`.
- [x] `make nextest-packages PACKAGES="spicepod runtime"` — the two crates this touches.
      **1842 tests, 1841 passed.** The one failure is
      `component::catalog::tests::test_try_from_maps_acceleration`, which is **not caused by this
      PR** and is now filed as **#12743**: it needs the `postgres` feature but never declares it,
      and a scoped `make nextest-packages` with no `FEATURES` builds `runtime` with *zero* features
      (`runtime` has no `[features] default`). Re-running the same crate as
      `make nextest-packages PACKAGES="runtime" FEATURES="postgres"` gives **1640 run, 1640 passed**,
      that test included. The file it lives in is byte-identical on `trunk` and untouched by `byoc`.

No new tests: this changes no behaviour. The three `expect_err` call sites *are* assertions in an
existing regression test, and they assert the same thing before and after. The `--tests` clippy pass
above compiles both changed test modules, which is what actually exercises a formatting-only edit.

**Note on CI:** because `pr.yml` does not trigger on a `byoc` base, this PR will show no
`Attestation` and no required checks — that absence is the very problem #12726 describes, not a
missing gate on this change. The local run above is the only gate that exists here, which is why it
was run in full rather than scoped to the touched crates.

## Checklist

- [x] Fix is minimal and in scope
- [x] No behaviour change
- [x] Lint gate passes on the branch
- [x] Out-of-scope findings filed rather than folded in (#12735, #12743)
