### PR TITLE
test(cayenne): name the small-file compaction tests after the path they take (fixes #12612)

### DIFF
--- a/crates/cayenne/tests/small_files_compaction_test.rs
+++ b/crates/cayenne/tests/small_files_compaction_test.rs
@@ -87,10 +87,15 @@ fn aggressive_sorted_compaction_config() -> VortexConfig {
 ///
 /// Key deletion is *necessary* for the warm-subset rewrite but not sufficient:
 /// `subset_rewrite_eligibility` also requires the picker's candidate to be a
-/// proper subset of the current files, and this config's
-/// `compaction_max_files_per_pick` of 32 exceeds the file count every test here
-/// builds — so the picker takes them all and the rewrite is the full one.
-/// `p1_subset_path_test.rs` is where the subset path is driven and asserted.
+/// proper subset of the current files. This config does not settle which
+/// rewrite runs, and neither does its file count: `compaction_max_files_per_pick`
+/// caps the files taken from the single tier bucket that fired, not the
+/// snapshot, so a candidate is a proper subset — well under the cap of 32 —
+/// whenever any current file is already settled or sits in the other tier.
+///
+/// So the tests here assert delete/row semantics, never a rewrite path. The
+/// path is observable via `last_small_file_compact_path()`, and
+/// `p1_subset_path_test.rs` is where each one is driven and asserted.
 fn aggressive_key_deletion_compaction_config() -> VortexConfig {
     VortexConfig {
         deletion_mode: cayenne::metadata::DeletionMode::Key,
@@ -1277,11 +1282,12 @@ async fn key_delete_survives_compaction_and_reseed(
     // again. MoR must keep the deleted key hidden and the exact row total must
     // match what we inserted after the delete.
     //
-    // The rewrite this drives is the full one, not the warm subset: the picker's
-    // candidate is never a proper subset here (see
-    // `aggressive_key_deletion_compaction_config`). What the PK buys is the
-    // key-delete topology — a PK-less table resolves to position-based deletion
-    // and a different MoR path.
+    // Which rewrite this drives — full or warm subset — is deliberately not
+    // asserted: the candidate is a proper subset whenever a current file is
+    // settled or in the other tier, and the sizes here do not pin that down
+    // (see `aggressive_key_deletion_compaction_config`). What the PK buys is
+    // the key-delete topology — a PK-less table resolves to position-based
+    // deletion and a different MoR path.
     let schema = pk_schema();
     let (table, ctx, table_id) =
         build_append_only_key_delete_table(&fixture, "key_delete_survives", Arc::clone(&schema))

--- a/crates/cayenne/tests/small_files_compaction_test.rs
+++ b/crates/cayenne/tests/small_files_compaction_test.rs
@@ -83,8 +83,14 @@ fn aggressive_sorted_compaction_config() -> VortexConfig {
     }
 }
 
-/// Same as [`aggressive_compaction_config`] but forces key-based deletion so
-/// warm-subset compaction (not the position full-rewrite path) is exercised.
+/// Same as [`aggressive_compaction_config`] but forces key-based deletion.
+///
+/// Key deletion is *necessary* for the warm-subset rewrite but not sufficient:
+/// `subset_rewrite_eligibility` also requires the picker's candidate to be a
+/// proper subset of the current files, and this config's
+/// `compaction_max_files_per_pick` of 32 exceeds the file count every test here
+/// builds — so the picker takes them all and the rewrite is the full one.
+/// `p1_subset_path_test.rs` is where the subset path is driven and asserted.
 fn aggressive_key_deletion_compaction_config() -> VortexConfig {
     VortexConfig {
         deletion_mode: cayenne::metadata::DeletionMode::Key,
@@ -1083,13 +1089,19 @@ async fn compact_current_after_seed_then_more_preserves_all_rows(
             "explicit phase-B compact must reduce file count ({files_before} → {files_after})"
         );
     } else {
-        // Post-write already drained the backlog; require only that the
-        // snapshot is not still holding every phase-B append as its own file.
-        let total_appends = usize::try_from(seed_batches + more).expect("fits");
+        // Post-write already drained the backlog. The bound has to be what an
+        // un-consolidated phase B would leave — the files phase A settled on
+        // plus one per phase-B append, since each append clears
+        // `INLINE_MAX_ROWS` and is too small to shard. Comparing against the
+        // raw append total instead asserts nothing: phase A already proved
+        // `files_a < seed_batches`, so `files_a + more < seed_batches + more`
+        // holds by construction whether or not post-write consolidated.
+        let unconsolidated = files_a + usize::try_from(more).expect("fits");
         assert!(
-            files_before < total_appends,
+            files_before < unconsolidated,
             "without an explicit compact, post-write must have consolidated \
-             below {total_appends} files (found {files_before})"
+             below {unconsolidated} files (phase-A settled at {files_a}, \
+             +{more} appends; found {files_before})"
         );
     }
     assert_eq!(count_rows(&ctx, "two_phase_compact").await, expected);
@@ -1257,16 +1269,22 @@ async fn build_append_only_key_delete_table(
     (table, ctx, table_id)
 }
 
-test_with_backends!(warm_subset_preserves_key_deletes_and_rows);
-async fn warm_subset_preserves_key_deletes_and_rows(
+test_with_backends!(key_delete_survives_compaction_and_reseed);
+async fn key_delete_survives_compaction_and_reseed(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Append-only key-mode PK table: compact, DELETE one PK, re-seed, compact
     // again. MoR must keep the deleted key hidden and the exact row total must
     // match what we inserted after the delete.
+    //
+    // The rewrite this drives is the full one, not the warm subset: the picker's
+    // candidate is never a proper subset here (see
+    // `aggressive_key_deletion_compaction_config`). What the PK buys is the
+    // key-delete topology — a PK-less table resolves to position-based deletion
+    // and a different MoR path.
     let schema = pk_schema();
     let (table, ctx, table_id) =
-        build_append_only_key_delete_table(&fixture, "warm_subset_deletes", Arc::clone(&schema))
+        build_append_only_key_delete_table(&fixture, "key_delete_survives", Arc::clone(&schema))
             .await;
 
     let batch_rows: i64 = 1500;
@@ -1282,12 +1300,12 @@ async fn warm_subset_preserves_key_deletes_and_rows(
     let Some((_snap_a, files_a)) = wait_until_current_snapshot_compacts(
         &table,
         &fixture,
-        "warm_subset_deletes",
+        "key_delete_survives",
         usize::try_from(seed_batches).expect("fits"),
     )
     .await?
     else {
-        panic!("key-mode append-only table should produce a warm-subset compaction candidate");
+        panic!("key-mode append-only table should produce a small-file compaction candidate");
     };
     assert!(
         files_a < usize::try_from(seed_batches).expect("fits"),
@@ -1304,14 +1322,14 @@ async fn warm_subset_preserves_key_deletes_and_rows(
         .expect("run delete");
 
     assert_eq!(
-        count_rows_matching(&ctx, "warm_subset_deletes", "id = 10").await,
+        count_rows_matching(&ctx, "key_delete_survives", "id = 10").await,
         0,
         "delete must hide id=10"
     );
-    let before = count_rows(&ctx, "warm_subset_deletes").await;
+    let before = count_rows(&ctx, "key_delete_survives").await;
     let snap_after_delete = fixture
         .catalog
-        .get_table("warm_subset_deletes")
+        .get_table("key_delete_survives")
         .await?
         .current_snapshot_id;
 
@@ -1344,7 +1362,7 @@ async fn warm_subset_preserves_key_deletes_and_rows(
 
     let snap_after = fixture
         .catalog
-        .get_table("warm_subset_deletes")
+        .get_table("key_delete_survives")
         .await?
         .current_snapshot_id;
     let files_after = count_vortex_files(&fixture.data_path, &table_id, &snap_after).await;
@@ -1358,15 +1376,15 @@ async fn warm_subset_preserves_key_deletes_and_rows(
     // Exact expected total: rows before re-seed + more_batches * batch_rows.
     // (id=10 is already excluded from `before`.)
     let expected = before + batch_rows * more_batches;
-    let after = count_rows(&ctx, "warm_subset_deletes").await;
+    let after = count_rows(&ctx, "key_delete_survives").await;
     assert_eq!(
         after, expected,
         "exact row total after re-seed + compact (before={before}, more={more_batches}*{batch_rows})"
     );
     assert_eq!(
-        count_rows_matching(&ctx, "warm_subset_deletes", "id = 10").await,
+        count_rows_matching(&ctx, "key_delete_survives", "id = 10").await,
         0,
-        "deleted key must remain hidden after warm-subset compaction (MoR kept)"
+        "deleted key must remain hidden after compaction (MoR kept)"
     );
 
     Ok(())
@@ -1449,21 +1467,21 @@ async fn a_seed_is_consolidated_before_its_fanout_can_be_listed(
     Ok(())
 }
 
-test_with_backends!(warm_subset_reduces_small_file_fanout);
-async fn warm_subset_reduces_small_file_fanout(
+test_with_backends!(full_rewrite_reduces_small_file_fanout);
+async fn full_rewrite_reduces_small_file_fanout(
     fixture: common::TestFixture,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let schema = pk_schema();
     let (table, ctx, _table_id) = build_table(
         &fixture,
-        "warm_subset_fanout",
+        "full_rewrite_fanout",
         Arc::clone(&schema),
         None,
         // No primary key, so `DeletionMode::Key` resolves to position-based
         // deletion and `subset_rewrite_eligibility` rejects the subset rewrite
         // outright — what this exercises is the full-rewrite small-file path.
-        // `warm_subset_preserves_key_deletes_and_rows` builds a real PK table and
-        // is the one that covers subset rewrite.
+        // The subset rewrite is covered by `p1_subset_path_test.rs`, which
+        // asserts the recorded path rather than inferring it from the config.
         aggressive_key_deletion_compaction_config(),
     )
     .await;
@@ -1473,7 +1491,7 @@ async fn warm_subset_reduces_small_file_fanout(
     // read taken after the loop is not reliably the un-compacted one.
     let pre_snapshot = fixture
         .catalog
-        .get_table("warm_subset_fanout")
+        .get_table("full_rewrite_fanout")
         .await?
         .current_snapshot_id;
 
@@ -1496,7 +1514,7 @@ async fn warm_subset_reduces_small_file_fanout(
     let Some((post_snap, post_count)) = wait_until_current_snapshot_compacts(
         &table,
         &fixture,
-        "warm_subset_fanout",
+        "full_rewrite_fanout",
         seeded_appends,
     )
     .await?
@@ -1510,7 +1528,7 @@ async fn warm_subset_reduces_small_file_fanout(
         "compaction must strictly reduce fan-out (seeded={seeded_appends}, post={post_count})"
     );
     assert_eq!(
-        count_rows(&ctx, "warm_subset_fanout").await,
+        count_rows(&ctx, "full_rewrite_fanout").await,
         batch_rows * batches
     );
     Ok(())


### PR DESCRIPTION
## Summary

Two tests in `crates/cayenne/tests/small_files_compaction_test.rs` are named for the warm-subset
rewrite, and neither one observes it. The issue diagnosed the first; checking the gate against the
config shows the second is misnamed too, for a different reason.

`subset_rewrite_eligibility` (`crates/cayenne/src/provider/table.rs`) is:

```rust
if is_position_delete || has_sort_columns || protected_snapshot_count > 0 {
    return false;
}
candidate_paths < total_current_files && candidate_paths >= 2
```

- `warm_subset_reduces_small_file_fanout` builds a PK-less table, so
  `PkDeletionStrategy` resolves to `PositionBased` and the first arm rejects it outright —
  `DeletionMode::Key` in the config is not enough on its own. The commit that fixed #12602
  (#12613) already corrected this test's comment to say so; the name was left behind. This one
  provably cannot reach the subset path.
- `warm_subset_preserves_key_deletes_and_rows` does have a real PK, so it clears the first arm and
  the proper-subset arm is what decides. Nothing in the test pins that arm down: the candidate
  comes from the single tier bucket that fired, and `compaction_max_files_per_pick` caps *that
  bucket* rather than the snapshot (`pick_from_bucket` takes
  `max_files_per_pick.min(bucket.len())`, and files at or above `mid_max_bytes` are classified
  settled and never enter a bucket). A candidate is therefore a proper subset whenever any current
  file is settled or sits in the other tier, whatever the total file count. The test also never
  reads `last_small_file_compact_path()`, so whichever rewrite runs, it is not asserting one — its
  name claims coverage it does not have.

So neither name describes what its test checks, and the file's coverage is not what its names claim.

## Changes

Renamed both to say what they exercise, with the gate that decides it recorded next to the config:

- `warm_subset_reduces_small_file_fanout` -> `full_rewrite_reduces_small_file_fanout`
  (table `warm_subset_fanout` -> `full_rewrite_fanout`). This one is provably the full path.
- `warm_subset_preserves_key_deletes_and_rows` -> `key_delete_survives_compaction_and_reseed`
  (table `warm_subset_deletes` -> `key_delete_survives`). The new name is what the test actually
  asserts: a key delete stays hidden across compact/re-seed and the row total is exact. Its PK
  still matters and the comment now says why — it buys the key-delete MoR topology. The comment
  deliberately does not claim which rewrite path runs, because the test does not observe it.
- `aggressive_key_deletion_compaction_config`'s doc comment claimed it made warm-subset compaction
  "exercised". It now records that key deletion is necessary but not sufficient, that the config
  does not settle which rewrite runs (the per-pick cap bounds the tier bucket, not the snapshot),
  and that `p1_subset_path_test.rs` is where the paths are actually driven and asserted.

Fixed the vacuous assertion the issue flagged in `compact_current_after_seed_then_more_preserves_all_rows`:

```rust
let total_appends = usize::try_from(seed_batches + more).expect("fits");   // 22
assert!(files_before < total_appends, ...);
```

Phase A already asserted `files_a < seed_batches` (12), and phase B adds 10 appends, so
`files_before <= files_a + 10 < 22` holds by construction — the branch could not fail. It now
compares against `files_a + more`, which is exactly what an un-consolidated phase B would leave
(each append clears `INLINE_MAX_ROWS` and is too small to shard, so one file per append), and so
genuinely requires that post-write maintenance consolidated something.

## Why no subset-path test is added here

The issue suggests asserting `LastSmallFileCompactPath::Subset`. `crates/cayenne/tests/p1_subset_path_test.rs`
already does exactly that — it drives a PK table with a small `compaction_max_files_per_pick` and
asserts both `::Subset` and `::Full` on the recorded path, which is the regression guard the issue
is asking for. Adding a second copy here would duplicate it.

Pinning *these* tests to a known path would mean both asserting `last_small_file_compact_path()`
and constraining the tier layout they build — the latter via `compaction_max_files_per_pick` in
`aggressive_key_deletion_compaction_config`, which is shared with
`a_seed_is_consolidated_before_its_fanout_can_be_listed` and the `consolidated_seed` case, where it
would change how many passes those need to consolidate and what their fan-out assertions mean. That
is a coverage change to unrelated tests, so it is deliberately not bundled into a rename. Renaming
is what makes the file honest; `p1_subset_path_test.rs` is what makes the path covered.

## Behaviour

No production code changes. Test renames plus one strengthened assertion; no test is weakened and
no test is removed.

## Test plan

- `make lint`
- `make test`
- Confirmed no CI filter, exclusion list, or other source references the old test or table names,
  so the renames are self-contained (`test_with_backends!` derives `_sqlite` / `_turso` variants
  from the function name).

The `cayenne` crate does not build on this Windows machine: `cargo check -p cayenne --tests` fails
with 8 errors in the crate's own `src/` (`libc::fsync`, `as_raw_fd` — Unix-only), before it ever
reaches `tests/`. Those are pre-existing and unrelated to this diff, which touches no library
code. The compile and test verdict therefore comes from CI and sign-off rather than a local run.

## Checklist

- [ ] `make lint` passes
- [ ] `make test` passes
- [x] No production code changed
- [x] No assertion weakened

Fixes #12612
