### PR TITLE
fix(ci): leave an incomplete sign-off pending, not failed (fixes #12741)

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -475,11 +475,13 @@ jobs:
       # as a *failed step* rather than a cancellation, leaving this step the incomplete-run
       # cases and the handler above the externally-cancelled ones.
       #
-      # Both write `pending`, so the two agree on what they mean rather than racing to
-      # opposite verdicts. Budget expiry and external cancellation are the same epistemic
-      # state — no verdict was reached — and `failure` is the one state that reads as a
-      # defect in the diff instead (#12741). Only the description differs, naming which
-      # way the run ended. A `success` already on the commit is left untouched by both.
+      # Neither handler writes a verdict, so the two agree on the end state rather than
+      # racing to opposite ones: budget expiry and external cancellation are the same
+      # epistemic state — nothing judged the diff — and `failure` is the one state that
+      # reads as a defect in it instead (#12741). They act on different starting states.
+      # `correct-cancelled` above repairs a `failure`/`error` into `pending`, and leaves
+      # an already-`pending` status untouched; this step restates a `pending` with why
+      # the run ended. A `success` already on the commit is left alone by both.
       - name: Resolve an incomplete sign-off
         if: always() && !cancelled() && steps.sign_off.conclusion != 'success'
         run: |

--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -470,13 +470,16 @@ jobs:
       # it. A run that evicted this one re-posts its own `pending` after checkout and
       # setup (~25s), well after this step has run.
       #
-      # `!cancelled()` partitions this against the cancellation handler above, which
-      # would otherwise fight it: on a cancelled run that handler writes `pending` and
-      # this one would immediately rewrite that to `failure`, re-asserting the very
-      # verdict #12424 is about. The split is along the grain of #12343's own design —
-      # `timeout-minutes: 353` exists so budget expiry lands here as a *failed step*
-      # rather than a cancellation, leaving this step the incomplete-run cases and the
-      # handler above the externally-cancelled ones.
+      # `!cancelled()` partitions this against the cancellation handler above, along the
+      # grain of #12343's own design: `timeout-minutes: 353` makes budget expiry land here
+      # as a *failed step* rather than a cancellation, leaving this step the incomplete-run
+      # cases and the handler above the externally-cancelled ones.
+      #
+      # Both write `pending`, so the two agree on what they mean rather than racing to
+      # opposite verdicts. Budget expiry and external cancellation are the same epistemic
+      # state — no verdict was reached — and `failure` is the one state that reads as a
+      # defect in the diff instead (#12741). Only the description differs, naming which
+      # way the run ended. A `success` already on the commit is left untouched by both.
       - name: Resolve an incomplete sign-off
         if: always() && !cancelled() && steps.sign_off.conclusion != 'success'
         run: |

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -272,12 +272,22 @@ The checks run under a 353-minute budget, inside a 358-minute job budget, so a
 run that overruns fails as a failed step rather than being terminated at the
 runner pool's ~360-minute wall (which reports as `cancelled`, with no failed
 step and no chance to clean up). A run that ends without a verdict — budget
-expired, evicted by a re-dispatch, cancelled — replaces its own `pending` status
-with a failure; otherwise `scripts/signoff status` and `scripts/signoff mine`
-would keep showing a sign-off in progress for a run that is long gone.
-Re-dispatch against the same HEAD to try again.
+expired, evicted by a re-dispatch, cancelled — restates its own `pending` status,
+keeping it `pending` and replacing the "in progress" wording with why the run
+ended. Re-dispatch against the same HEAD to try again.
 
-That replacement is the workflow's job, not the dying script's. Being signalled is
+It stays `pending` because nothing judged the diff. `failure` is the one state
+that reads as a code failure: `pr.yml` rejects it, **Attestation** rejects it on
+the head commit ([#12362](https://github.com/spiceai/spiceai/issues/12362)), and a
+red `signoff` never self-clears, so the commit stays disqualified until someone
+re-dispatches by hand ([#12741](https://github.com/spiceai/spiceai/issues/12741)).
+`pending` reads as "not signed off yet" instead — Attestation stays red, because
+HEAD really is not signed off, but it points at re-running sign-off rather than at
+a defect in the diff. A dormant `pending` is still distinguishable from a live one:
+`scripts/signoff status` reports any non-success as not signed off, and
+`scripts/signoff mine` takes its ⟳ from the in-flight run list, not from the status.
+
+That restatement is the workflow's job, not the dying script's. Being signalled is
 how a run learns its budget expired: `run_checks` returns `make`'s status and bash
 reports a killed child as 128+N, so the script classifies that as reaching **no
 verdict** and publishes nothing at all, saying why in its step summary. Treating it

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -271,21 +271,33 @@ The Actions workflow:
 The checks run under a 353-minute budget, inside a 358-minute job budget, so a
 run that overruns fails as a failed step rather than being terminated at the
 runner pool's ~360-minute wall (which reports as `cancelled`, with no failed
-step and no chance to clean up). A run that ends without a verdict — budget
-expired, evicted by a re-dispatch, cancelled — restates its own `pending` status,
-keeping it `pending` and replacing the "in progress" wording with why the run
-ended. Re-dispatch against the same HEAD to try again.
+step and no chance to clean up). A run that ends without a verdict leaves the
+commit at `pending` either way, and never at a failure. Where the two endings
+differ is only which status the handler finds:
 
-It stays `pending` because nothing judged the diff. `failure` is the one state
-that reads as a code failure: `pr.yml` rejects it, **Attestation** rejects it on
-the head commit ([#12362](https://github.com/spiceai/spiceai/issues/12362)), and a
-red `signoff` never self-clears, so the commit stays disqualified until someone
+| Ending | Handler | Effect |
+| --- | --- | --- |
+| Budget expired, runner died | `Resolve an incomplete sign-off` → `clear-pending` | Restates the `pending`, replacing the "in progress" wording with why the run ended |
+| Externally cancelled, evicted by a re-dispatch | `Correct the sign-off status…` → `correct-cancelled` | Repairs a `failure`/`error` into `pending`; leaves an already-`pending` status as it is |
+
+Either way, re-dispatch against the same HEAD to try again.
+
+The state stays `pending` because nothing judged the diff. `failure` is the one
+state that reads as a code failure: `pr.yml` rejects it, **Attestation** rejects it
+on the head commit ([#12362](https://github.com/spiceai/spiceai/issues/12362)), and
+a red `signoff` never self-clears, so the commit stays disqualified until someone
 re-dispatches by hand ([#12741](https://github.com/spiceai/spiceai/issues/12741)).
-`pending` reads as "not signed off yet" instead — Attestation stays red, because
-HEAD really is not signed off, but it points at re-running sign-off rather than at
-a defect in the diff. A dormant `pending` is still distinguishable from a live one:
-`scripts/signoff status` reports any non-success as not signed off, and
-`scripts/signoff mine` takes its ⟳ from the in-flight run list, not from the status.
+
+`pr.yml` does not reject a `pending` — it is not a verdict — so Attestation decides
+on its own terms rather than being forced red by a dead run. For an ordinary head
+that means red, because HEAD really is not signed off, pointing at re-running
+sign-off instead of at a defect in the diff. A head that `pr.yml` already clears —
+a fast-tracked one, or one whose inheritance chain of verified base merges reaches
+a `success` — stays green, which is the same latitude a cancelled run has always had.
+
+A dormant `pending` is still distinguishable from a live one: `scripts/signoff
+status` reports any non-success as not signed off, and `scripts/signoff mine` takes
+its ⟳ from the in-flight run list, not from the status.
 
 That restatement is the workflow's job, not the dying script's. Being signalled is
 how a run learns its budget expired: `run_checks` returns `make`'s status and bash

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -25,7 +25,7 @@
 #   scripts/signoff --no-verify     Sign off without running the checks (honor system)
 #   scripts/signoff status          Show the sign-off status of HEAD
 #   scripts/signoff mine            Show attestation status for all your open PRs
-#   scripts/signoff clear-pending   Turn a left-behind pending status into a failure
+#   scripts/signoff clear-pending   Restate a left-behind pending status as incomplete
 #   scripts/signoff preflight-disk  Check the work volume's free space (CI: run
 #                                   before the toolchain setup steps)
 #   scripts/signoff check           Show whether trunk requires sign-off
@@ -1463,14 +1463,28 @@ cmd_correct_cancelled() {
   return 0
 }
 
-# Replace a `pending` sign-off status with a failure.
+# Restate a left-behind `pending` sign-off status as a run that reached no verdict.
 #
 # A remote run posts `pending` before it starts the checks, so a run that never
 # reaches a verdict — the job is terminated at its budget, the runner goes away —
-# leaves that `pending` on the commit for good. `status` and `mine` then render
-# the branch as a sign-off still in progress, which is the one thing it is not.
+# leaves that `pending` on the commit carrying its "in progress" wording, which
+# is the one thing the run is not.
 #
-# Only `pending` is replaced. A run that finished has already posted its own
+# The state stays `pending`; only the description changes. Nothing judged the diff,
+# so `failure` would assert what no check established — pr.yml reads it as a code
+# failure, Attestation rejects it on the head commit (#12362), and a red `signoff`
+# never self-clears, leaving the commit disqualified until someone re-dispatches by
+# hand. `pending` is what this run's own signalled path already leaves standing (see
+# `describe_check_failure`), and pr.yml reads it as "not signed off yet": Attestation
+# stays red, because HEAD really is not signed off, but points at re-running sign-off
+# rather than at a phantom defect in the diff. Same answer as `correct-cancelled`, for
+# the same reason — neither ending is evidence about the diff.
+#
+# A dormant `pending` stays distinguishable from a live one: `mine` takes its ⟳ from
+# the in-flight run list, not from this status, and `status` reports any non-success
+# as "not signed off". The description carries the rest.
+#
+# Only `pending` is rewritten. A run that finished has already posted its own
 # success or failure, and overwriting that would discard the real verdict; the
 # same guard makes this safe to run unconditionally at the end of a job.
 #
@@ -1495,7 +1509,7 @@ cmd_clear_pending() {
     return 0
   fi
 
-  post_commit_status "$repo" "$sha" failure "$reason" \
+  post_commit_status "$repo" "$sha" pending "$reason" \
     || fail "failed to post the sign-off status (do you have write access to ${repo}?)"
   append_step_summary "### Sign-off"$'\n'"**Incomplete** on \`${sha:0:12}\` — ${reason}"$'\n'
   echo "${NO} ${sha:0:12} — ${reason}"
@@ -1838,8 +1852,10 @@ Developers:
   scripts/signoff status       Show the sign-off status of HEAD
   scripts/signoff mine         Show attestation status for all your open PRs
   scripts/signoff clear-pending [reason]
-                               Replace a left-behind '${STATUS_CONTEXT}' pending status
-                               on HEAD with a failure (no-op for any other state)
+                               Restate a left-behind '${STATUS_CONTEXT}' pending status
+                               on HEAD as a run that reached no verdict: it stays
+                               pending, with [reason] as its description (no-op for
+                               any other state)
 
 CI (.github/workflows/signoff.yml):
   scripts/signoff correct-cancelled [<sha>] [<owner/repo>]

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -1475,10 +1475,15 @@ cmd_correct_cancelled() {
 # failure, Attestation rejects it on the head commit (#12362), and a red `signoff`
 # never self-clears, leaving the commit disqualified until someone re-dispatches by
 # hand. `pending` is what this run's own signalled path already leaves standing (see
-# `describe_check_failure`), and pr.yml reads it as "not signed off yet": Attestation
-# stays red, because HEAD really is not signed off, but points at re-running sign-off
-# rather than at a phantom defect in the diff. Same answer as `correct-cancelled`, for
-# the same reason — neither ending is evidence about the diff.
+# `describe_check_failure`), and pr.yml does not reject it: a pending is not a
+# verdict. Attestation then decides on its own terms — red for an ordinary head,
+# which really is not signed off, and pointing at re-running sign-off rather than at
+# a phantom defect; green only where pr.yml already allows it, on a fast-tracked head
+# or a verified inheritance chain, which a dead run is no reason to block.
+#
+# `correct-cancelled` reaches the same end state from the other direction: it repairs
+# a `failure`/`error` into `pending` and leaves an existing `pending` alone. Neither
+# handler ever writes a verdict, because neither ending is evidence about the diff.
 #
 # A dormant `pending` stays distinguishable from a live one: `mine` takes its ⟳ from
 # the in-flight run list, not from this status, and `status` reports any non-success

--- a/scripts/test_signoff_status.sh
+++ b/scripts/test_signoff_status.sh
@@ -402,10 +402,16 @@ assert_attestation_refresh "an in-flight Attestation is not flagged on the succe
 echo
 echo "scripts/signoff clear-pending"
 
-# The bug: a run terminated mid-check leaves the `pending` it posted on the
-# commit for good, so `status` and `mine` report a sign-off still in progress.
-assert_clear_pending "a pending status is replaced with a failure" \
-  pending failure "a canned reason"
+# A run terminated mid-check leaves the `pending` it posted on the commit with its
+# "in progress" wording, so the description is restated to say the run ended.
+#
+# The state stays `pending` and must not become `failure`: nothing judged the diff,
+# pr.yml reads `failure` as a code failure, Attestation rejects it on the head commit
+# (#12362), and a red `signoff` never self-clears, disqualifying the commit outright.
+# A budget expiry reaches this path as a failed step rather than a cancellation, so
+# `correct-cancelled` never fires to take such a verdict back (#12741).
+assert_clear_pending "an incomplete run is restated as pending, not failed" \
+  pending pending "a canned reason"
 
 # The run reached a verdict — that verdict is the one that counts.
 assert_clear_pending "a successful sign-off is left alone" success


### PR DESCRIPTION
## Summary

A remote sign-off that runs out its 353-minute step budget posts `signoff=failure` — a code-failure verdict — on a commit that nothing judged.

`scripts/signoff` already gets this right on its own: being signalled is how a run learns its budget expired, and `describe_check_failure` classifies that as reaching **no verdict** and publishes nothing, leaving the `pending` it posted on the way in standing. The workflow's `Resolve an incomplete sign-off` step then overwrites that `pending` with a `failure`.

Since #12362 Attestation rejects a failed sign-off on the head commit, so the PR goes red claiming its diff broke, and a red `signoff` never self-clears — the commit is disqualified until someone notices and re-dispatches by hand.

In the run this was diagnosed from (`31164822954`), the job reached `Starting 9947 tests across 188 binaries` and completed 2238 of them with **zero failures** before the budget expired. Nothing had failed when the axe fell.

## Changes

- `scripts/signoff` — `clear-pending` now keeps the state at `pending` and replaces the "in progress" wording with the reason the run ended, rather than overwriting it with `failure`. Only a `pending` is rewritten; a `success` or a real `failure` verdict is still left alone.
- `.github/workflows/signoff.yml` — the comment on `Resolve an incomplete sign-off` now records that both handlers write `pending` and why, instead of describing the old opposite-verdicts split.
- `scripts/test_signoff_status.sh` — the `clear-pending` regression test asserts `pending`, with the reasoning for why the state must not become a verdict.
- `docs/dev/ci_signoff.md` — the "run that ends without a verdict" paragraph matches the behaviour.

## Why `pending` is the right state

This is the answer `correct-cancelled` already gives for an externally-cancelled run. Budget expiry could not reuse it: `timeout-minutes: 353` makes expiry land as a *failed step* by #12343's own design, so the `cancelled()`-gated handler never fires. An incomplete run and a cancelled one are the same epistemic state — no verdict was reached — and neither is evidence about the diff.

`pr.yml` deliberately does not reject `pending` ("it is not a verdict"). The affirmative requirement is untouched: Attestation still requires a `success` on HEAD, or an inheritance chain of verified two-parent base merges ending at one. A commit carrying a real code push is not a two-parent merge, so it still fails with "Run make signoff on the pushed HEAD" — Attestation stays red, it just points at the documented remedy instead of a phantom defect.

The one behavioural difference beyond the wording: a HEAD that is a *pure base merge* over a validly signed commit now inherits that sign-off instead of being blocked by the dead run's `failure`. That is the case inheritance exists for, each merge result is verified, and `correct-cancelled` already permits it.

`mine` and `status` still distinguish a dormant `pending` from a live one — `mine` takes its ⟳ from the in-flight run list rather than from the status, and `status` reports any non-success as "not signed off".

## Not addressed here

The issue also notes the budget has only ~8 minutes of headroom over a measured 345-minute peak, so a contended pool converts capacity exhaustion into repeated no-verdict runs. The issue flags that as worth considering separately (it turns on why `make lint-rust` took 3h17m in that run, and whether the budget should be measured against a contended pool), and it is a runner-cost judgement rather than part of this correctness fix.

## Test plan

- `make lint`
- `make test`
- `scripts/test_signoff_status.sh` — 27 assertions. The `clear-pending` regression test was verified to **fail** against the pre-fix script (`expected a 'pending' status in the 'signoff' context, got 'failure'`, suite exits 1) and pass after.
- `scripts/test_signoff_cancelled_correction.sh` (18), `scripts/test_signoff_disk_guard.sh` (48), `scripts/test_signoff_attestation_refresh.sh` (15), `scripts/test_signoff_resolve_target.sh` (22) — all pass, confirming the sibling handlers are unaffected.
- `shellcheck -S warning scripts/signoff` and `actionlint` clean.

## Checklist

- [x] Regression test fails on the old code and passes on the new
- [x] Sibling sign-off suites still pass
- [x] Security review: no new input handling, credential use, or gate weakening — the affirmative `state === 'success'` requirement is untouched
- [ ] `make signoff` green and Attestation re-run

Fixes #12741
