### PR TITLE
fix(cayenne): drop the partition-value guard that key encoding made unreachable (fixes #12616)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3602,7 +3602,6 @@ dependencies = [
  "object_store 0.13.2",
  "parking_lot",
  "paste",
- "regex",
  "roaring",
  "rstest 0.26.1",
  "runtime-datafusion",

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -14,7 +14,6 @@ arrow = { workspace = true }
 arrow_tools = { path = "../arrow_tools" }
 datafusion-ddl = { path = "../datafusion-ddl" }
 datafusion-dml = { path = "../datafusion-dml" }
-regex = "1.12.3"
 arrow-flight = { workspace = true }
 arrow-ipc = { workspace = true }
 arrow-schema = { workspace = true }

--- a/crates/cayenne/src/partition_creator.rs
+++ b/crates/cayenne/src/partition_creator.rs
@@ -728,6 +728,19 @@ mod tests {
 
         let hostile = ["abcdef#123", "a/b", "..", "x=y", "with space"];
         for value in hostile {
+            // The path the creator computes, before the filesystem sees it: a
+            // value that kept a separator would nest below the table directory
+            // rather than sit directly in it, and `read_dir` below could not
+            // tell the difference — it only ever reports the first component.
+            let partition_dir = creator
+                .partition_dir(&[bucket(value)])
+                .unwrap_or_else(|e| panic!("'{value}' must map to a partition directory: {e}"));
+            assert_eq!(
+                partition_dir.parent(),
+                Some(fixture.base_path.as_path()),
+                "'{value}' must name a direct child of the table directory, got {partition_dir:?}"
+            );
+
             creator
                 .create_partition(vec![bucket(value)])
                 .await

--- a/crates/cayenne/src/partition_creator.rs
+++ b/crates/cayenne/src/partition_creator.rs
@@ -18,7 +18,7 @@ limitations under the License.
 //! partitioned tables, creating and opening per-partition [`CayenneTableProvider`]s.
 
 use std::path::PathBuf;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::common::DFSchema;
@@ -29,7 +29,6 @@ use datafusion::logical_expr::TableProviderFilterPushDown;
 use datafusion::prelude::Expr;
 use datafusion::scalar::ScalarValue;
 use datafusion_table_providers::UnsupportedTypeAction;
-use regex::Regex;
 use runtime_table_partition::Partition;
 use runtime_table_partition::creator::filename::{
     encode_composite_key, encode_key, parse_partition_value, to_hive_partition_dir,
@@ -42,14 +41,6 @@ use crate::{
     CayenneContext, CayenneTableProviderBuilder, MetadataCatalog, PartitionMetadata,
     TimeRetentionFilterBuilder, metadata,
 };
-
-/// Partition values matching `.*#\d+` (e.g. `"abcdef#123"`) are only supported
-/// on S3 Express One Zone locations, not on local filesystem paths.
-static UNSUPPORTED_LOCAL_PARTITION_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| match Regex::new(r".*#\d+$") {
-        Ok(compiled) => compiled,
-        Err(e) => unreachable!("Unable to compile regexp: {e}"),
-    });
 
 /// Implements [`PartitionCreator`] for Cayenne-backed partitioned tables.
 ///
@@ -268,21 +259,6 @@ impl PartitionCreator for CayennePartitionCreator {
             .collect::<Result<Vec<_>, _>>()
             .boxed()
             .context(creator::CreatePartitionSnafu)?;
-
-        if self.object_store_config.is_none() {
-            for value in &partition_value_strings {
-                if UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match(value) {
-                    return Err(creator::Error::CreatePartition {
-                        source: format!(
-                            "Partition value '{value}' is not supported for local filesystem locations. \
-                             Values matching the pattern '*#<digits>' (e.g., 'abcdef#123') are only \
-                             supported for S3 Express One Zone locations."
-                        )
-                        .into(),
-                    });
-                }
-            }
-        }
 
         tracing::debug!("creating Cayenne partition at {partition_path}");
         tokio::fs::create_dir_all(&partition_dir)
@@ -740,31 +716,68 @@ mod tests {
         );
     }
 
-    /// The pattern gates on a `#` followed only by digits at the end of the
-    /// value; everything else is a legal local partition value.
-    #[test]
-    fn unsupported_local_partition_pattern_matches_only_a_trailing_hash_digits() {
-        for unsupported in ["abcdef#123", "test#1", "some_value#999999", "#0", "a#1"] {
+    /// A partition value is hex-encoded into a single path component before it
+    /// reaches the filesystem, so no character a user can write — a `#`, a path
+    /// separator, a parent-directory reference — can escape or split the
+    /// directory name. This is what makes every value legal on a local
+    /// filesystem, and it is the property to keep if the encoding ever changes.
+    #[tokio::test]
+    async fn a_path_hostile_partition_value_becomes_one_safe_directory_component() {
+        let fixture = fixture().await;
+        let creator = creator_for(&fixture);
+
+        let hostile = ["abcdef#123", "a/b", "..", "x=y", "with space"];
+        for value in hostile {
+            creator
+                .create_partition(vec![bucket(value)])
+                .await
+                .unwrap_or_else(|e| panic!("'{value}' must be a legal partition value: {e}"));
+        }
+
+        let partition_dirs: Vec<String> = std::fs::read_dir(&fixture.base_path)
+            .expect("the table directory is readable")
+            .map(|entry| {
+                entry
+                    .expect("the directory entry is readable")
+                    .file_name()
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .filter(|name| name.starts_with("bucket="))
+            .collect();
+        assert_eq!(
+            partition_dirs.len(),
+            hostile.len(),
+            "one directory per created partition, got {partition_dirs:?}"
+        );
+        for name in &partition_dirs {
+            let encoded = name
+                .strip_prefix("bucket=")
+                .expect("the directory name is Hive-style");
             assert!(
-                UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match(unsupported),
-                "'{unsupported}' must be treated as S3 Express One Zone only"
+                encoded
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'.' || byte == b'_'),
+                "'{name}' must be a single path-safe component"
             );
         }
-        for supported in [
-            "abcdef",
-            "test_123",
-            "2024-01-01",
-            "partition_value",
-            "123",
-            "abc#def",
-            "test#",
-            "test#abc",
-            "test#123abc",
-        ] {
-            assert!(
-                !UNSUPPORTED_LOCAL_PARTITION_PATTERN.is_match(supported),
-                "'{supported}' must be a legal local filesystem partition value"
-            );
-        }
+
+        let mut values: Vec<String> = creator
+            .infer_existing_partitions()
+            .await
+            .expect("partitions are inferred")
+            .iter()
+            .map(|partition| match partition.partition_values.as_slice() {
+                [ScalarValue::Utf8(Some(value))] => value.clone(),
+                other => panic!("expected one Utf8 partition value, got {other:?}"),
+            })
+            .collect();
+        values.sort();
+        let mut expected: Vec<String> = hostile.iter().map(ToString::to_string).collect();
+        expected.sort();
+        assert_eq!(
+            values, expected,
+            "every encoded value must read back exactly as written"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`CayennePartitionCreator::create_partition` refused partition values matching `.*#\d+$` when the table was on a local filesystem, on the grounds that such names are only supported on S3 Express One Zone. **The branch could not fire.** It tested the *encoded* partition keys, and `encode_key` emits `v1.<type_tag>.v<HEX>` or `v1.<type_tag>.n` for every supported type — the type tags are compile-time literals and the payload is uppercase hex, so the full alphabet is `.0123456789ABCDEF_abefgilmnorstuvw`. A `#` cannot appear in it for any input of any type.

The guard was live when it was written (#9312, 2026-02-05): at that commit `encode_key` returned the raw `Display` form, so it really did read the user-visible value. #11803 (2026-07-14) replaced that with the versioned hex codec and the guard became unreachable as collateral — nothing in that PR mentions it.

**Removing it is a runtime no-op.** `abcdef#123` — the guard's own example — is accepted today and stored as `bucket=v1.utf8.v61626364656623313233`; it stays accepted. Reinstating the check on the raw `ScalarValue` instead would be a real behaviour change and the wrong one: the encoding is precisely what makes those values safe on a filesystem.

Fixes #12616

## Changes

- Delete `UNSUPPORTED_LOCAL_PARTITION_PATTERN`, its use in `create_partition`, and the `regex`/`LazyLock` imports.
- Drop `regex` from `crates/cayenne/Cargo.toml` — that static was the whole crate's only use of it.
- Replace the pattern's unit test with one that locks in the property that *replaced* the guard: a `#`, a path separator, a parent-directory reference, an `=`, or a space in a partition value becomes one path-safe directory component and reads back unchanged through `infer_existing_partitions`.

`partition_value_strings` is still consumed by the catalog write below the deleted block, so it stays.

## Test plan

- `make lint`
- `make test`
- Targeted: `cargo test -p cayenne --features turso,partition-table-provider --lib partition_creator` -> 5 passed.

The crate's `partition_creator` module is behind the non-default `partition-table-provider` feature (enabled by `runtime`), so a default-feature check never compiles this file — every verification above pins `--features turso,partition-table-provider` to match how `runtime` consumes the crate.

### Neuter matrix

Two directions, each measured rather than assumed:

| Neuter | Result |
|---|---|
| `encode_key`'s `Utf8` arm returns the raw value instead of hex | **Only** the new test fails (`'bucket=abcdef#123' must be a single path-safe component`). The pre-existing round-trip test still passes — its `alpha`/`beta` values are path-safe either way — so the new test is not standing in for an existing one. |
| Re-add the deleted guard (re-expressed without `regex`) | **All 5 tests green.** This is the measurement that the guard is unobservable: its presence or absence changes no test and no behaviour. |

## Checklist

- [x] Fix is minimal and in scope
- [x] Regression coverage added, and proven to fail without the property it asserts
- [x] `cargo clippy -p cayenne --features turso,partition-table-provider --lib --bins` and `--tests` both exit 0
- [x] No behaviour change (see neuter matrix, row 2)
- [x] No `docs/cayenne/cayenne.md` update needed — the removed restriction was never documented there, and nothing about the engine's behaviour changes
