### PR TITLE
fix(telemetry): keep a startup-recorded gauge on the operator meter, so it reaches /metrics (fixes #12667)

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -878,6 +878,18 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
         runtime::dataaccelerator::cayenne::register_cayenne_telemetry();
     }
 
+    // The global meter provider is now final: either `init_metrics` replaced the
+    // startup noop provider above, or metrics are not configured and the noop one
+    // stands. Operator instruments may cache from here on.
+    //
+    // This is outside the `needs_metrics` block on purpose. A deployment that
+    // exports nothing still records into these instruments, and leaving the seal
+    // off would make every such record rebuild its instrument forever rather than
+    // once. Sealing after `init_metrics` — rather than relying on the first record
+    // landing late enough — is what keeps a startup-time sampler's gauges on the
+    // operator's provider (#12667).
+    telemetry::seal_operator_meter_provider();
+
     let (tls_config, client_auth_mode) = tls::load_tls_config(
         &args,
         spicepod_tls_config.as_ref(),

--- a/crates/runtime/tests/metrics.rs
+++ b/crates/runtime/tests/metrics.rs
@@ -226,8 +226,15 @@ fn memory_gauges_are_exported_to_the_operator_metrics_pipeline() {
 /// `tokio::time::interval` fires its first tick immediately, so
 /// `spawn_mem_tier_repartition_sampler` records before `init_metrics` installs
 /// the Prometheus provider. An instrument cached at that moment binds to the
-/// startup noop provider for the life of the process, which is what kept these
-/// three gauges off `/metrics` entirely — regression test for #12667.
+/// startup noop provider for the life of the process, which is what kept
+/// `query_memory_pool_used_bytes` and `cayenne_compaction_memory_pool_used_bytes`
+/// off `/metrics` entirely — regression test for #12667.
+///
+/// `process_resident_memory_bytes` is asserted alongside them even though it was
+/// scrapable, because it was only ever scrapable by accident: it is recorded
+/// after a `spawn_blocking(...).await` in the same loop iteration, and that
+/// round-trip happened to outlast the window. Nothing holds that ordering, so it
+/// is pinned here rather than left to survive on timing.
 ///
 /// [`memory_gauges_are_exported_to_the_operator_metrics_pipeline`] cannot catch
 /// that: it forces [`PROMETHEUS`] first, so it only ever records after the

--- a/crates/runtime/tests/metrics.rs
+++ b/crates/runtime/tests/metrics.rs
@@ -220,6 +220,53 @@ fn memory_gauges_are_exported_to_the_operator_metrics_pipeline() {
     );
 }
 
+/// The sampler's first sample lands before the operator's provider exists, and
+/// the gauge must still reach `/metrics` afterwards.
+///
+/// `tokio::time::interval` fires its first tick immediately, so
+/// `spawn_mem_tier_repartition_sampler` records before `init_metrics` installs
+/// the Prometheus provider. An instrument cached at that moment binds to the
+/// startup noop provider for the life of the process, which is what kept these
+/// three gauges off `/metrics` entirely — regression test for #12667.
+///
+/// [`memory_gauges_are_exported_to_the_operator_metrics_pipeline`] cannot catch
+/// that: it forces [`PROMETHEUS`] first, so it only ever records after the
+/// install. This test records *before* it, which under `cargo nextest` — one
+/// process per test, the gate's runner — means the global provider really is
+/// the noop one at that point. Under `cargo test` a sibling thread may have
+/// installed it already, which costs the test its teeth but not its safety: the
+/// seal below always follows the install, never precedes it.
+#[test]
+fn a_gauge_recorded_before_the_provider_is_installed_still_reaches_metrics() {
+    // Deliberately ahead of `&*PROMETHEUS`: this is the sampler's first tick.
+    telemetry::track_process_resident_memory_bytes(1_024, &[]);
+    telemetry::cayenne::track_query_memory_pool_used_bytes(2_048, &[]);
+    telemetry::cayenne::track_compaction_memory_pool_used_bytes(4_096, &[]);
+
+    // `init_metrics` installing the operator's provider, then declaring it final.
+    let registry = &*PROMETHEUS;
+    telemetry::seal_operator_meter_provider();
+
+    // The sampler's next tick, two seconds later in production.
+    telemetry::track_process_resident_memory_bytes(8_192, &[]);
+    telemetry::cayenne::track_query_memory_pool_used_bytes(16_384, &[]);
+    telemetry::cayenne::track_compaction_memory_pool_used_bytes(32_768, &[]);
+
+    let reported = reported_metric_names(registry);
+    let missing: Vec<&str> = EXPECTED_MEMORY_METRICS
+        .iter()
+        .copied()
+        .filter(|metric| !reported.contains(*metric))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "memory gauges {missing:?} were recorded before the meter provider was installed and \
+         never recovered; a gauge cached against the startup noop provider never reaches \
+         /metrics. Reported: {:?}",
+        sorted(&reported)
+    );
+}
+
 /// Reads the resident set size directly and touches no instrument, so it needs
 /// no meter provider.
 #[test]

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -18,6 +18,7 @@ pub use opentelemetry::KeyValue;
 use opentelemetry::global;
 use opentelemetry::metrics::{Counter, Histogram};
 use opentelemetry::metrics::{Gauge, UpDownCounter};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{sync::OnceLock, time::Duration};
 
 #[cfg(feature = "anonymous_telemetry")]
@@ -76,6 +77,52 @@ pub const CONTENTION_MS_HISTOGRAM_BUCKETS: [f64; 17] = [
     0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0,
     10000.0, 30000.0,
 ];
+
+/// Whether the process has finished choosing the `OpenTelemetry` global meter
+/// provider that operator-facing instruments bind to.
+static OPERATOR_METER_PROVIDER_SEALED: AtomicBool = AtomicBool::new(false);
+
+/// Declares that the global meter provider will not be replaced again, so an
+/// instrument built from it may be cached for the life of the process.
+///
+/// `spiced` installs a noop provider at startup and replaces it during
+/// `init_metrics` with the one carrying the operator's Prometheus `/metrics`
+/// and OTLP readers. Call this once the choice is final — after `init_metrics`
+/// when metrics are configured, and also when they are not, so a deployment
+/// that exports nothing still caches (against noop) rather than rebuilding an
+/// instrument on every record.
+pub fn seal_operator_meter_provider() {
+    OPERATOR_METER_PROVIDER_SEALED.store(true, Ordering::Release);
+}
+
+/// Records through a lazily built, cached instrument — except before
+/// [`seal_operator_meter_provider`], where the instrument is built, used and
+/// dropped instead of being cached.
+///
+/// An instrument binds permanently to the provider that was global when it was
+/// built, so caching one built during startup freezes it to the noop provider
+/// and it never reaches `/metrics`. That is not hypothetical: the memory
+/// sampler's first `tokio::time::interval` tick fires immediately, ahead of
+/// the `init_metrics` that installs the real provider, which is what kept
+/// `query_memory_pool_used_bytes` and
+/// `cayenne_compaction_memory_pool_used_bytes` off `/metrics` entirely
+/// (#12667).
+///
+/// Deferring construction to the first record is not enough on its own,
+/// because "the first record" is exactly what a startup-time sampler makes
+/// early. Gating the *cache* rather than the record keeps every early sample
+/// exported through whatever provider is current, and costs a single
+/// [`OnceLock::get`] once the seal is in place — the same steady-state path as
+/// caching unconditionally.
+fn record_via_cached<I>(cell: &OnceLock<I>, build: impl FnOnce() -> I, record: impl FnOnce(&I)) {
+    if let Some(instrument) = cell.get() {
+        record(instrument);
+    } else if OPERATOR_METER_PROVIDER_SEALED.load(Ordering::Acquire) {
+        record(cell.get_or_init(build));
+    } else {
+        record(&build());
+    }
+}
 
 static QUERY_COUNT: OnceLock<Counter<u64>> = OnceLock::new();
 
@@ -307,12 +354,16 @@ static PROCESS_RESIDENT_MEMORY_BYTES: OnceLock<Gauge<u64>> = OnceLock::new();
 /// the anonymous-telemetry [`meter::METER`], which would never reach an
 /// operator's dashboard. The meter handle is fetched fresh rather than cached,
 /// for the reason `cayenne::operational_meter` documents: caching binds
-/// permanently to whatever provider is global at first access, so the `OnceLock`
-/// holds only the built gauge, whose construction is deferred to the first
-/// record — always after `init_metrics` on this 2s sampling path.
+/// permanently to whatever provider is global at first access.
+///
+/// The built gauge goes through `record_via_cached`, which withholds the
+/// cache until the provider is sealed. Deferring construction to the first
+/// record is not sufficient on its own: the sampler that records this gauge
+/// takes its first sample before `init_metrics` runs.
 pub fn track_process_resident_memory_bytes(bytes: u64, dimensions: &[KeyValue]) {
-    PROCESS_RESIDENT_MEMORY_BYTES
-        .get_or_init(|| {
+    record_via_cached(
+        &PROCESS_RESIDENT_MEMORY_BYTES,
+        || {
             global::meter("process")
                 .u64_gauge("process_resident_memory_bytes")
                 .with_description(
@@ -320,8 +371,9 @@ pub fn track_process_resident_memory_bytes(bytes: u64, dimensions: &[KeyValue]) 
                 )
                 .with_unit("By")
                 .build()
-        })
-        .record(bytes, dimensions);
+        },
+        |gauge| gauge.record(bytes, dimensions),
+    );
 }
 
 static QUERY_SPILLED_ROWS: OnceLock<Counter<u64>> = OnceLock::new();
@@ -810,6 +862,11 @@ pub mod cayenne {
     /// installed. Fetching it fresh defers binding to each instrument's first record
     /// (inside the `get_or_init` closures below), which on the scan/write paths
     /// always runs after `init_metrics`.
+    ///
+    /// An instrument whose first record can happen at *startup* needs more than
+    /// that, because the deferred build then still lands on the noop provider.
+    /// Those cache through `record_via_cached`, which withholds the cache until
+    /// `seal_operator_meter_provider`.
     fn operational_meter() -> Meter {
         global::meter("cayenne")
     }
@@ -1055,42 +1112,52 @@ pub mod cayenne {
 
     static QUERY_MEMORY_POOL_USED_BYTES: OnceLock<Gauge<u64>> = OnceLock::new();
 
-    /// Build-once accessor for the live query-pool usage gauge.
-    fn query_memory_pool_used_bytes() -> &'static Gauge<u64> {
-        QUERY_MEMORY_POOL_USED_BYTES.get_or_init(|| {
-            operational_meter()
-                .u64_gauge("query_memory_pool_used_bytes")
-                .with_description(
-                    "Live bytes reserved in the query memory pool, excluding the in-memory CDC tier's mirror account.",
-                )
-                .with_unit("By")
-                .build()
-        })
+    /// Builds the live query-pool usage gauge against the current global provider.
+    fn build_query_memory_pool_used_bytes() -> Gauge<u64> {
+        operational_meter()
+            .u64_gauge("query_memory_pool_used_bytes")
+            .with_description(
+                "Live bytes reserved in the query memory pool, excluding the in-memory CDC tier's mirror account.",
+            )
+            .with_unit("By")
+            .build()
     }
 
     /// Records live query-pool usage. Sampled by the mem-tier repartition loop,
     /// which already reads the pool on an interval; without this gauge the value
     /// is computed every two seconds and visible nowhere.
+    ///
+    /// That loop takes its first sample before `init_metrics` installs the
+    /// operator's provider, so the gauge is cached through `record_via_cached`
+    /// rather than a bare `get_or_init` — otherwise the cache freezes it to the
+    /// noop provider and it never reaches `/metrics` (#12667).
     pub fn track_query_memory_pool_used_bytes(bytes: u64, dimensions: &[KeyValue]) {
-        query_memory_pool_used_bytes().record(bytes, dimensions);
+        super::record_via_cached(
+            &QUERY_MEMORY_POOL_USED_BYTES,
+            build_query_memory_pool_used_bytes,
+            |gauge| gauge.record(bytes, dimensions),
+        );
     }
 
     static COMPACTION_MEMORY_POOL_USED_BYTES: OnceLock<Gauge<u64>> = OnceLock::new();
 
-    /// Build-once accessor for the live compaction-pool usage gauge.
-    fn compaction_memory_pool_used_bytes() -> &'static Gauge<u64> {
-        COMPACTION_MEMORY_POOL_USED_BYTES.get_or_init(|| {
-            operational_meter()
-                .u64_gauge("cayenne_compaction_memory_pool_used_bytes")
-                .with_description("Live bytes reserved in the dedicated compaction memory pool.")
-                .with_unit("By")
-                .build()
-        })
+    /// Builds the live compaction-pool usage gauge against the current global provider.
+    fn build_compaction_memory_pool_used_bytes() -> Gauge<u64> {
+        operational_meter()
+            .u64_gauge("cayenne_compaction_memory_pool_used_bytes")
+            .with_description("Live bytes reserved in the dedicated compaction memory pool.")
+            .with_unit("By")
+            .build()
     }
 
-    /// Records live compaction-pool usage, sampled alongside the query pool.
+    /// Records live compaction-pool usage, sampled alongside the query pool —
+    /// and cached under the same seal, for the same reason.
     pub fn track_compaction_memory_pool_used_bytes(bytes: u64, dimensions: &[KeyValue]) {
-        compaction_memory_pool_used_bytes().record(bytes, dimensions);
+        super::record_via_cached(
+            &COMPACTION_MEMORY_POOL_USED_BYTES,
+            build_compaction_memory_pool_used_bytes,
+            |gauge| gauge.record(bytes, dimensions),
+        );
     }
 
     static COMPACTION_MEMORY_EXHAUSTED: OnceLock<Counter<u64>> = OnceLock::new();


### PR DESCRIPTION
## Summary

`query_memory_pool_used_bytes` and `cayenne_compaction_memory_pool_used_bytes` never appeared on `/metrics`, so the two gauges added to explain a memory ceiling were missing from exactly the runs they exist for.

**Root cause.** An OpenTelemetry instrument binds permanently to whichever meter provider is global when it is *built*. Both gauges are built lazily on first `record` and cached in a `OnceLock`, and the comment on `cayenne::operational_meter` justifies that as safe because "the first record always runs after `init_metrics`".

That does not hold for the memory sampler. `tokio::time::interval` fires its first tick **immediately**, and `spawn_mem_tier_repartition_sampler` is installed before `init_metrics` replaces the startup noop provider. The first `record()` therefore lands inside that window and both gauges cache against the noop meter for the life of the process. `process_resident_memory_bytes` escaped only because its `spawn_blocking(...).await` round-trip happens to straddle the gap — an accident, not a design, so it is fixed here too.

## Changes

- `crates/telemetry/src/lib.rs`
  - `seal_operator_meter_provider()` — declares that the global meter provider will not be replaced again.
  - `record_via_cached()` — records through the cached instrument once sealed; **before** the seal it builds, uses and drops the instrument instead of caching it. Every early sample still exports through whatever provider is current, and the steady-state path stays a single `OnceLock::get`.
  - The three gauges the startup sampler records — `query_memory_pool_used_bytes`, `cayenne_compaction_memory_pool_used_bytes`, `process_resident_memory_bytes` — now go through it.
- `bin/spiced/src/lib.rs` — seals once the provider choice is final. Deliberately **outside** the `needs_metrics` block: a deployment that exports nothing still records into these instruments, and leaving the seal off would make every such record rebuild its instrument forever instead of once.

Gating the *cache* rather than the *record* is what makes this an elimination rather than a mitigation. Delaying the first tick (`interval_at`) only widens the window; reordering the sampler's spawn fixes one call site and leaves the hazard for the next instrument that acquires a startup-time recorder.

## Test plan

- `make lint`
- `make test`
- New regression test `a_gauge_recorded_before_the_provider_is_installed_still_reaches_metrics` in the `metrics` test binary: records all three gauges **before** the Prometheus provider is installed, installs it, seals, records again, and asserts all three are scrapable. It fails on the pre-fix code (the first record caches a noop-bound gauge, so the registry stays empty) and passes after.
- The existing `memory_gauges_are_exported_to_the_operator_metrics_pipeline` cannot catch this — it forces the provider first, so it only ever records after the install. Both tests are kept: one pins the wiring, the other pins the ordering.

Note on runners: under `cargo nextest` (the gate's runner) each test gets its own process, so the pre-install record is genuinely pre-install. Under `cargo test` a sibling thread may have installed the provider already, which costs the test its teeth but not its safety — the seal always follows the install, never precedes it.

## Checklist

- [x] Root cause identified and addressed, not worked around
- [x] Regression test fails on the old code and passes on the new
- [x] `cargo fmt` / `cargo clippy -p telemetry --all-targets` clean
- [x] No behavior change when metrics are configured normally — only the binding window is closed

Fixes #12667
