### PR TITLE
fix(cloud-connect): pin rustls where the release call presents its identity (fixes #12760)

### DIFF
--- a/crates/runtime-cloud-connect/src/release.rs
+++ b/crates/runtime-cloud-connect/src/release.rs
@@ -134,9 +134,14 @@ pub async fn release(
     let client_identity =
         reqwest::Identity::from_pem(client_pem.as_bytes()).context(IdentitySnafu)?;
 
+    // `reqwest::Identity::from_pem` builds a rustls identity, and the workspace
+    // compiles both TLS backends in, so the backend has to be pinned to match:
+    // a builder left on the default resolves to native-tls and rejects the
+    // identity outright. Every other `.identity()` call site pins it the same way.
     let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
+        .use_rustls_tls()
         .identity(client_identity);
     if let Some(ca_pem) = ca_cert_pem {
         for cert in reqwest::Certificate::from_pem_bundle(ca_pem.as_bytes()).context(CaCertSnafu)? {
@@ -263,5 +268,99 @@ mod tests {
         // A multi-byte char straddling the limit must not be split.
         let s = "aa\u{e9}bb";
         assert_eq!(bounded(s, 3), "aa");
+    }
+
+    /// A self-signed leaf plus its key, in the PEM shape an enrolled identity
+    /// holds them. The keypair is rcgen's default (ECDSA P-256, `aws_lc_rs`),
+    /// which is what `IdentityStore::generate_enrollment` produces, so the
+    /// identity here is presented over TLS exactly as a real one is.
+    fn self_signed_identity() -> Identity {
+        let key = rcgen::KeyPair::generate().expect("generate leaf keypair");
+        let params = rcgen::CertificateParams::new(vec!["localhost".to_string()])
+            .expect("leaf certificate params");
+        let cert = params.self_signed(&key).expect("self-sign the leaf");
+
+        Identity {
+            identifier: "inst_release_test".to_string(),
+            identity_cert_pem: cert.pem(),
+            private_key_pem: key.serialize_pem(),
+            public_key_pem: String::new(),
+            ca_bundle_pem: String::new(),
+            gateway_addr: String::new(),
+            not_after_unix: None,
+            enc_private_key_pem: String::new(),
+            enc_public_key_pem: String::new(),
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+        }
+    }
+
+    // Port 1 is privileged and unbound, so a connection to it is refused well
+    // inside the connect timeout instead of waiting it out.
+    const UNREACHABLE_ENDPOINT: &str = "https://127.0.0.1:1";
+
+    #[tokio::test]
+    async fn release_builds_its_mtls_client_from_a_real_identity() {
+        // `reqwest::Identity::from_pem` yields a rustls identity, and the
+        // workspace compiles native-tls in alongside rustls, so a client
+        // builder that does not pin rustls rejects the identity and the
+        // release fails before it ever reaches the network. Getting as far as
+        // a transport error is what proves the backend and the identity agree.
+        let identity = self_signed_identity();
+
+        let Err(err) = release(UNREACHABLE_ENDPOINT, &identity, None).await else {
+            panic!("release against an unbound port must not succeed");
+        };
+
+        assert!(
+            matches!(err, Error::Http { .. }),
+            "expected a transport error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn release_builds_its_mtls_client_with_extra_trust_roots() {
+        // The self-hosted path adds root certificates to the same builder, so
+        // it has to agree with the identity's backend too.
+        let ca_key = rcgen::KeyPair::generate().expect("generate CA keypair");
+        let mut ca_params =
+            rcgen::CertificateParams::new(Vec::<String>::new()).expect("CA certificate params");
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_pem = ca_params
+            .self_signed(&ca_key)
+            .expect("self-sign the CA")
+            .pem();
+
+        let identity = self_signed_identity();
+
+        let Err(err) = release(UNREACHABLE_ENDPOINT, &identity, Some(&ca_pem)).await else {
+            panic!("release against an unbound port must not succeed");
+        };
+
+        assert!(
+            matches!(err, Error::Http { .. }),
+            "expected a transport error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn release_reports_a_truncated_identity_distinctly() {
+        // An identity file missing its key block carries repair advice that the
+        // generic client-build failure does not, so the two must stay
+        // distinguishable. `Identity::from_pem` checks that a certificate block
+        // and a key block are both present, which is what this exercises; it
+        // does not inspect the key's contents, so a well-formed block holding
+        // nonsense is accepted here and only rejected at handshake time.
+        let mut identity = self_signed_identity();
+        identity.private_key_pem = String::new();
+
+        let Err(err) = release(UNREACHABLE_ENDPOINT, &identity, None).await else {
+            panic!("release with a truncated identity must not succeed");
+        };
+
+        assert!(
+            matches!(err, Error::Identity { .. }),
+            "expected the identity error, got: {err}"
+        );
     }
 }

--- a/crates/runtime-cloud-connect/src/release.rs
+++ b/crates/runtime-cloud-connect/src/release.rs
@@ -295,21 +295,23 @@ mod tests {
         }
     }
 
-    // Port 1 is privileged and unbound, so a connection to it is refused well
-    // inside the connect timeout instead of waiting it out.
-    const UNREACHABLE_ENDPOINT: &str = "https://127.0.0.1:1";
+    // A scheme-less endpoint. `release` builds the client before it hands the
+    // URL to reqwest, so the send fails on the URL itself and never opens a
+    // socket: the client build stays the only thing under test, and no listener
+    // that happens to be up on this host can answer in its place.
+    const UNSENDABLE_ENDPOINT: &str = "not-a-url";
 
     #[tokio::test]
     async fn release_builds_its_mtls_client_from_a_real_identity() {
         // `reqwest::Identity::from_pem` yields a rustls identity, and the
         // workspace compiles native-tls in alongside rustls, so a client
         // builder that does not pin rustls rejects the identity and the
-        // release fails before it ever reaches the network. Getting as far as
-        // a transport error is what proves the backend and the identity agree.
+        // release fails before it ever reaches the URL. Getting as far as the
+        // send is what proves the backend and the identity agree.
         let identity = self_signed_identity();
 
-        let Err(err) = release(UNREACHABLE_ENDPOINT, &identity, None).await else {
-            panic!("release against an unbound port must not succeed");
+        let Err(err) = release(UNSENDABLE_ENDPOINT, &identity, None).await else {
+            panic!("release against an unsendable endpoint must not succeed");
         };
 
         assert!(
@@ -333,8 +335,8 @@ mod tests {
 
         let identity = self_signed_identity();
 
-        let Err(err) = release(UNREACHABLE_ENDPOINT, &identity, Some(&ca_pem)).await else {
-            panic!("release against an unbound port must not succeed");
+        let Err(err) = release(UNSENDABLE_ENDPOINT, &identity, Some(&ca_pem)).await else {
+            panic!("release against an unsendable endpoint must not succeed");
         };
 
         assert!(
@@ -354,7 +356,7 @@ mod tests {
         let mut identity = self_signed_identity();
         identity.private_key_pem = String::new();
 
-        let Err(err) = release(UNREACHABLE_ENDPOINT, &identity, None).await else {
+        let Err(err) = release(UNSENDABLE_ENDPOINT, &identity, None).await else {
             panic!("release with a truncated identity must not succeed");
         };
 


### PR DESCRIPTION
## Summary

`release()` builds its mTLS client with `reqwest::Identity::from_pem`, which produces a **rustls** identity — but the builder never pinned a TLS backend.

`graph-rs-sdk` enables `reqwest`'s `native-tls` feature, and Cargo feature unification turns it on for the whole workspace's `reqwest 0.13.4`. With both backends compiled in, a builder that does not call `.use_rustls_tls()` resolves to native-tls and rejects the rustls identity outright:

```
ClientBuild { source: reqwest::Error { kind: Builder, source: "incompatible TLS identity type" } }
```

So every identity-bearing release failed before it reached the network. Because the trigger is backend unification rather than anything in `release.rs` itself, it is invisible to a narrowly-scoped build and only appears under the full feature set the sign-off gate uses.

`release.rs` was the only `.identity()` call site in the tree that did not pin the backend. The others already do — `crates/runtime/src/dataconnector/https.rs:879`, `crates/llms/src/provider.rs`, `crates/runtime/src/catalogconnector/spice_cloud.rs`, and the two mTLS test harnesses — so this makes it consistent rather than introducing a new convention.

Fixes #12760

## Changes

- `crates/runtime-cloud-connect/src/release.rs` — add `.use_rustls_tls()` to the release client builder, ahead of `.identity()`.
- Three regression tests that call the real `release()` rather than re-deriving its client setup.

## Verification of the mechanism

This host cannot build the crate (`build.rs` needs `protoc`, which is not installed), so the behaviour was verified in a standalone binary against the versions pinned in `Cargo.lock` — `reqwest 0.13.4`, `rcgen 0.14.8` — reproducing `release()`'s client construction exactly:

| Feature set | `.identity()` without `.use_rustls_tls()` | with `.use_rustls_tls()` |
| --- | --- | --- |
| `rustls` only | builds | builds |
| `rustls` + `native-tls` (what unification produces) | **builder error** | builds |

That is the bug and the fix, and it confirms the added tests fail on the unfixed code: under unification they get `Error::ClientBuild` where they assert `Error::Http`. The same harness ran all three assertions against a patched copy of `release()` — all pass.

Two things the probe corrected, which the tests now reflect:

- `Identity::from_pem` accepts rcgen's default ECDSA P-256 keypair, which is what `IdentityStore::generate_enrollment` produces — so the test identity is built the same way a real one is.
- `Identity::from_pem` validates PEM *structure*, not key contents: a well-formed block holding nonsense is accepted. The truncated-identity test therefore omits the key block entirely, which is what actually yields `Error::Identity`.

## Follow-up filed

#12763 — with rustls pinned here and `enroll`/`renew` still on the workspace default, the two paths validate the same endpoint against different trust roots (bundled `webpki-roots` vs the OS store). Only one configuration is affected — a self-hosted control plane that sets no `ca_cert_pem` and relies on an OS-installed CA — and it is not a regression, since `release()` previously failed in *every* configuration. Deciding the backend once for the crate is a deliberate trust-configuration change, so it is tracked separately rather than folded in here.

## Test plan

- [x] Added regression test for an identity-bearing release building its client (`release_builds_its_mtls_client_from_a_real_identity`)
- [x] Added edge case test for the extra-trust-roots branch (`release_builds_its_mtls_client_with_extra_trust_roots`)
- [x] Added edge case test for a truncated identity staying distinguishable from a client-build failure (`release_reports_a_truncated_identity_distinctly`)
- [x] `cargo fmt --all -- --check` passes
- [ ] `make lint` passes (workspace-wide fmt + full clippy) — runs as part of sign-off; `make` is not available on this host
- [ ] `make test` passes — runs as part of sign-off
- [ ] `make signoff` run after the final push (`Attestation` check is green)

The lint and test gates are the ones `make signoff` executes; they are checked off once the sign-off run reports green, not before.
