### PR TITLE
fix(tests): skip the Oracle cloud test when its credential is unusable (fixes #12758)

### DIFF
--- a/crates/runtime/tests/oracle/mod.rs
+++ b/crates/runtime/tests/oracle/mod.rs
@@ -24,7 +24,8 @@ use crate::oracle::common::{
     make_oracle_cloud_dataset, make_oracle_dataset, start_oracle_docker_container,
 };
 use crate::utils::{
-    register_test_connectors, runtime_ready_check, test_request_context, verify_env_secret_exists,
+    dataset_load_errors, register_test_connectors, runtime_ready_check,
+    runtime_ready_check_with_timeout_err, test_request_context, verify_env_secret_exists,
 };
 
 pub mod common;
@@ -298,6 +299,92 @@ async fn oracle_test_direct_connection() -> Result<(), anyhow::Error> {
         .await
 }
 
+/// The Oracle server errors that mean the test account's own credential cannot be used,
+/// whatever the runtime does with it. Each is paired with the condition to report.
+///
+/// `ORA-28002` ("the password will expire within N days") is deliberately absent: it accompanies
+/// a logon that *succeeded*, so reading it as unusable would skip a test that can still run.
+const UNUSABLE_CREDENTIAL_ERRORS: [(&str, &str); 3] = [
+    ("ORA-01017", "invalid username or password"),
+    ("ORA-28000", "the account is locked"),
+    ("ORA-28001", "the password has expired"),
+];
+
+/// Returns the credential condition `message` names, if it names one.
+///
+/// Only the conditions in [`UNUSABLE_CREDENTIAL_ERRORS`] skip the test. Every other failure,
+/// a near-expiry warning included, has to keep failing.
+fn unusable_oracle_credential(message: &str) -> Option<&'static str> {
+    UNUSABLE_CREDENTIAL_ERRORS
+        .iter()
+        .find(|(code, _)| names_oracle_code(message, code))
+        .map(|(_, condition)| *condition)
+}
+
+/// Whether `message` names `code` itself, rather than a longer number beginning with it.
+///
+/// The recorded status text is free-form, so the character after the code is checked: matching
+/// `ORA-28001` inside `ORA-280015` would report an unusable credential for a different error.
+fn names_oracle_code(message: &str, code: &str) -> bool {
+    message.match_indices(code).any(|(index, _)| {
+        !message[index + code.len()..]
+            .chars()
+            .next()
+            .is_some_and(|next| next.is_ascii_digit())
+    })
+}
+
+#[test]
+fn expired_password_is_an_unusable_credential() {
+    assert_eq!(
+        unusable_oracle_credential(
+            "Failed to connect to the Oracle Server. Failed to establish connection: \
+             OCI Error: ORA-28001: the password has expired"
+        ),
+        Some("the password has expired")
+    );
+}
+
+#[test]
+fn a_locked_account_and_bad_credentials_are_unusable_credentials() {
+    assert_eq!(
+        unusable_oracle_credential("OCI Error: ORA-28000: the account is locked"),
+        Some("the account is locked")
+    );
+    assert_eq!(
+        unusable_oracle_credential("OCI Error: ORA-01017: invalid username/password; logon denied"),
+        Some("invalid username or password")
+    );
+}
+
+/// `ORA-28002` reports a password nearing expiry on a logon that *succeeded*. The test can still
+/// run, so this must not be read as an unusable credential.
+#[test]
+fn a_password_nearing_expiry_is_not_an_unusable_credential() {
+    assert_eq!(
+        unusable_oracle_credential("OCI Error: ORA-28002: the password will expire within 7 days"),
+        None
+    );
+}
+
+/// A longer number beginning with a listed code is a different error.
+#[test]
+fn a_longer_code_sharing_a_prefix_is_not_an_unusable_credential() {
+    assert_eq!(unusable_oracle_credential("OCI Error: ORA-280015"), None);
+}
+
+/// Every other failure has to keep failing: a connector regression must not be filed away as
+/// somebody else's expired password.
+#[test]
+fn an_unrelated_failure_is_not_a_credential_problem() {
+    assert_eq!(
+        unusable_oracle_credential("ORA-12541: TNS:no listener"),
+        None
+    );
+    assert_eq!(unusable_oracle_credential("Timed out waiting"), None);
+    assert_eq!(unusable_oracle_credential(""), None);
+}
+
 #[tokio::test]
 async fn oracle_test_cloud_mtls() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("integration=debug,info"));
@@ -328,14 +415,49 @@ async fn oracle_test_cloud_mtls() -> Result<(), anyhow::Error> {
             let cloned_rt = Arc::new(rt.clone());
 
             // Set a timeout for the test
-            tokio::select! {
-                () = tokio::time::sleep(std::time::Duration::from_mins(1)) => {
-                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
-                }
-                () = cloned_rt.load_components() => {}
-            }
+            let loaded = tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_mins(1)) => false,
+                () = cloned_rt.load_components() => true,
+            };
 
-            runtime_ready_check(&rt).await;
+            let ready = loaded
+                && runtime_ready_check_with_timeout_err(&rt, std::time::Duration::from_mins(2))
+                    .await
+                    .is_ok();
+
+            // A dataset the connector could not authenticate never reports ready, and the reason
+            // is only in the status the runtime recorded for it. Read that status, so an
+            // unusable test credential is told apart from a connector that is actually broken.
+            if !ready {
+                let errors = dataset_load_errors(&rt);
+
+                if let Some(condition) = errors
+                    .iter()
+                    .find_map(|(_, message)| unusable_oracle_credential(message))
+                {
+                    eprintln!(
+                        "Skipping oracle_test_cloud_mtls: the ORACLE_CLOUD_* test credential is \
+                         unusable ({condition}). Rotate the Oracle Cloud test account's password \
+                         and update the CI secret to restore this coverage."
+                    );
+                    return Ok(());
+                }
+
+                let reported = errors
+                    .iter()
+                    .map(|(dataset, message)| format!("{dataset}: {message}"))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+
+                return Err(anyhow::Error::msg(format!(
+                    "Timed out waiting for datasets to load ({})",
+                    if reported.is_empty() {
+                        "no dataset recorded an error"
+                    } else {
+                        &reported
+                    }
+                )));
+            }
 
             run_and_snapshot_query(
                 &rt,

--- a/crates/runtime/tests/utils/mod.rs
+++ b/crates/runtime/tests/utils/mod.rs
@@ -29,7 +29,7 @@ use opentelemetry_sdk::{
     trace::{SdkTracerProvider, span_processor_with_async_runtime::BatchSpanProcessor},
 };
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
-use runtime::{Runtime, task_history::otel_exporter::TaskHistoryExporter};
+use runtime::{Runtime, status::ComponentStatus, task_history::otel_exporter::TaskHistoryExporter};
 use serde::Deserialize;
 use spicepod::component::runtime::{TaskHistoryCapturedContext, TaskHistoryCapturedOutput};
 use tracing::subscriber::DefaultGuard;
@@ -68,6 +68,25 @@ pub(crate) async fn runtime_ready_check_with_timeout_err(
     } else {
         Err(())
     }
+}
+
+/// Returns the error each dataset recorded when it failed to load, as `(dataset, message)`.
+///
+/// A connector that cannot initialize stores its error text in the dataset's component
+/// status, so a test that gave up waiting for readiness can report why readiness never
+/// arrived instead of only that it waited. Sorted, so the report reads the same way twice.
+pub(crate) fn dataset_load_errors(rt: &Runtime) -> Vec<(String, String)> {
+    let mut errors: Vec<(String, String)> = rt
+        .status()
+        .get_dataset_statuses()
+        .into_iter()
+        .filter_map(|(dataset, status)| match status {
+            ComponentStatus::Error(Some(message)) => Some((dataset.to_string(), message)),
+            _ => None,
+        })
+        .collect();
+    errors.sort();
+    errors
 }
 
 pub(crate) async fn wait_until_true<F, Fut>(max_wait: Duration, mut f: F) -> bool


### PR DESCRIPTION
## Summary

`oracle::oracle_test_cloud_mtls` connects to a real Oracle Cloud test account. That account's
password expired, so every run failed, `Integration Tests (part 2)` failed on every merge-queue
candidate, and each candidate was evicted. `trunk` did not advance for over 19 hours while 19
approved, fully green PRs sat in the queue.

Two things made an expired password able to halt the repository:

1. **The failure was undiagnosable.** The test raced `load_components()` against a one-minute
   sleep and reported `Timed out waiting for datasets to load`. The actual cause —
   `ORA-28001: the password has expired` — only ever appeared in a `WARN` line from
   `runtime::init::dataset`, so the test's own output never named it.
2. **An unusable credential failed a merge-queue-gating job.** A third-party account's password
   expiry became an availability dependency for merging anything.

The dataset already records the connector's error text in its component status
(`init/dataset.rs` stores `ComponentStatus::error_with_message(err.to_string())` before it
returns), so the test can read why readiness never arrived rather than only that it waited.

## Changes

- `tests/utils`: add `dataset_load_errors`, which returns the error each dataset recorded when it
  failed to load. Sorted, so the reported diagnosis reads the same way twice.
- `tests/oracle`: replace the blind timeout race with a bounded wait that, when the runtime never
  becomes ready, reads those recorded errors and decides from them:
  - an error naming a credential that cannot be used at all — `ORA-01017` (invalid credentials),
    `ORA-28000` (account locked), `ORA-28001` (password expired) — skips the test with a message
    naming the condition and the remediation;
  - **every other failure still fails**, now reporting the dataset error instead of a bare
    timeout.

The list is deliberately short. `ORA-28002` ("the password will expire within N days") accompanies
a logon that *succeeded*, so it is not on it — treating it as unusable would skip a test that can
still run. Matching also requires the code not be followed by another digit, since the recorded
status text is free-form and `ORA-28001` occurs inside `ORA-280015`. Both cases are tested.

The skip is deliberately narrow: it requires the server to have named a credential condition. If
no dataset recorded an error, the test fails rather than skips, so a connector regression cannot
be filed away as somebody else's expired password.

## What this does not do

It does not restore the coverage. The password still needs rotating and the CI secret updating —
a credential operation, not a code change. #12761 tracks that separately so it is not lost when
this closes. Because a passing test's output is captured, the skip is not visible in a green CI
run; #12761 is the tracker that keeps it visible.

Scope note: sibling credentialed suites (`github`, `sharepoint`, `cluster`, `models`) already skip
when a secret is *absent*, but none classify a secret that is present and *rejected*. Generalising
that needs a per-provider classifier (Oracle `ORA-` codes, HTTP 401/403, AWS error codes) and is
not folded in here.

## Test plan

- `make lint`
- `make nextest`
- New unit tests over the classifier, run as part of the Oracle integration test binary:
  - `expired_password_is_an_unusable_credential`
  - `a_locked_account_and_bad_credentials_are_unusable_credentials`
  - `a_password_nearing_expiry_is_not_an_unusable_credential` (`ORA-28002` accompanies a
    successful logon and must not skip the test)
  - `a_longer_code_sharing_a_prefix_is_not_an_unusable_credential`
  - `an_unrelated_failure_is_not_a_credential_problem` (a TNS error, a bare timeout, and an empty
    message all still fail)

## Checklist

- [x] Tests added for the new behaviour, including the direction that must keep failing
- [x] No production code paths changed — the diff is entirely within `crates/runtime/tests`
- [x] Follow-up tracker filed for the credential rotation (#12761)

Fixes #12758
