### PR TITLE
fix(cloud-connect): pin rustls where the release call presents its identity

### DIFF
--- a/crates/runtime-cloud-connect/src/release.rs
+++ b/crates/runtime-cloud-connect/src/release.rs
@@ -207,9 +207,14 @@ pub async fn release(
             instance_id: identity.identifier.clone(),
         })?;
 
+    // `reqwest::Identity::from_pem` builds a rustls identity, and the workspace
+    // compiles both TLS backends in, so the backend has to be pinned to match:
+    // a builder left on the default resolves to native-tls and rejects the
+    // identity outright. Every other `.identity()` call site pins it the same way.
     let mut builder = reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
+        .use_rustls_tls()
         .identity(client_identity);
     if let Some(ca_pem) = ca_cert_pem {
         for cert in reqwest::Certificate::from_pem_bundle(ca_pem.as_bytes()).context(CaCertSnafu)? {


### PR DESCRIPTION
## The bug

`release` builds its mTLS client from `reqwest::Identity::from_pem`, which yields a **rustls** identity. The workspace compiles both TLS backends in, so a builder left on the default resolves to native-tls and rejects the identity at build time:

```
ClientBuild { source: reqwest::Error { kind: Builder, source: "incompatible TLS identity type" } }
```

The client fails to build before a socket is opened, so `spice connect remove` could never post its release on this branch.

## Why it matters beyond the feature

`release_posts_the_certificate_and_a_pop_signature_the_cloud_can_verify` already covers this path and fails **deterministically** — 6/6 nextest attempts, all at `release.rs:455` — so it fails the full test suite for **every PR based on `byoc`**. #12739 (byoc lint debt, a 2-file diff touching only `metrics_reader.rs` and `spicepod/src/lib.rs`) has been red on sign-off entirely because of this, having nothing to do with its own changes.

The test is `byoc`-only — it does not exist on `trunk` — which is why `trunk` sign-offs are unaffected.

## The fix

Pin the backend the way every other `.identity()` call site in the workspace does, e.g. [`crates/runtime/src/dataconnector/https.rs:879`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/https.rs#L879):

```rust
builder = builder.use_rustls_tls().identity(identity);
```

`release.rs` was the only `.identity()` site in the workspace that did not.

**No new test** — the existing test already proves it, and it is the one that has been failing.

Same root cause and same one-line fix as #12764 on `trunk`; this applies it to `byoc`'s own copy of `release.rs`, which diverged after #12629.

## Verification

`use_rustls_tls()` is available here: the workspace `reqwest` dep carries the `rustls` feature and this crate uses `reqwest = { workspace = true }`.

Remote sign-off dispatched (no local Rust toolchain on the authoring host).
