### PR TITLE
fix(ci): build without the compiler cache when it cannot be reached (fixes #12770)

### DIFF
--- a/.github/actions/build-spiced/action.yml
+++ b/.github/actions/build-spiced/action.yml
@@ -113,16 +113,22 @@ runs:
             ;;
         esac
 
+    # Reports only whether an sccache endpoint was configured, which decides
+    # whether `setup-sccache` runs. It deliberately does not export a
+    # `RUSTC_WRAPPER` for the build steps to consume: whether rustc is actually
+    # wrapped depends on the cache answering, which only `setup-sccache` learns.
+    # It writes the verdict to `$GITHUB_ENV`, so the build steps must inherit it
+    # rather than pin a step-level `env: RUSTC_WRAPPER:` -- a step-level value
+    # outranks `$GITHUB_ENV` and would wrap rustc in a cache known to be
+    # unreachable, which is the failure this action exists to prevent.
     - name: Check if sccache can be set up
       id: check-sccache
       shell: bash
       run: |
         if [ -z "${{ inputs.minio_endpoint }}" ] && [ -z "${{ inputs.spiceio_endpoint }}" ]; then
           echo "SCCACHE_SETUP=false" >> $GITHUB_OUTPUT
-          echo "RUSTC_WRAPPER=" >> $GITHUB_OUTPUT
         else
           echo "SCCACHE_SETUP=true" >> $GITHUB_OUTPUT
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_OUTPUT
         fi
 
     - name: Set up sccache
@@ -158,7 +164,6 @@ runs:
       if: inputs.use_makefile == 'true'
       shell: bash
       env:
-        RUSTC_WRAPPER: ${{ steps.check-sccache.outputs.RUSTC_WRAPPER }}
         CARGO_TARGET_DIR: ${{ steps.resolve-build-paths.outputs.target_dir }}
         AWS_ACCESS_KEY_ID: ${{ inputs.minio_access_key }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.minio_secret_key }}
@@ -177,7 +182,6 @@ runs:
       if: inputs.use_makefile != 'true'
       shell: bash
       env:
-        RUSTC_WRAPPER: ${{ steps.check-sccache.outputs.RUSTC_WRAPPER }}
         AWS_ACCESS_KEY_ID: ${{ inputs.minio_access_key }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.minio_secret_key }}
         CARGO_INCREMENTAL: 0
@@ -196,7 +200,6 @@ runs:
       if: inputs.build_cli == 'true'
       shell: bash
       env:
-        RUSTC_WRAPPER: ${{ steps.check-sccache.outputs.RUSTC_WRAPPER }}
         CARGO_TARGET_DIR: ${{ steps.resolve-build-paths.outputs.target_dir }}
         AWS_ACCESS_KEY_ID: ${{ inputs.minio_access_key }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.minio_secret_key }}

--- a/.github/actions/build-spicepod-validator/action.yml
+++ b/.github/actions/build-spicepod-validator/action.yml
@@ -111,6 +111,14 @@ runs:
       if: (inputs.force_rebuild == 'true' || (steps.minio-download.outputs.found != 'true' && steps.cache-validator.outputs.cache-hit != 'true')) && steps.detect-os.outputs.os == 'linux'
       uses: ./.github/actions/setup-cc
 
+    # Reports only whether an sccache endpoint was configured, which decides
+    # whether `setup-sccache` runs. It deliberately does not export a
+    # `RUSTC_WRAPPER` for the build steps to consume: whether rustc is actually
+    # wrapped depends on the cache answering, which only `setup-sccache` learns.
+    # It writes the verdict to `$GITHUB_ENV`, so the build steps must inherit it
+    # rather than pin a step-level `env: RUSTC_WRAPPER:` -- a step-level value
+    # outranks `$GITHUB_ENV` and would wrap rustc in a cache known to be
+    # unreachable, which is the failure this action exists to prevent.
     - name: Check if sccache can be set up
       if: inputs.force_rebuild == 'true' || (steps.minio-download.outputs.found != 'true' && steps.cache-validator.outputs.cache-hit != 'true')
       id: check-sccache
@@ -118,10 +126,8 @@ runs:
       run: |
         if [ -z "${{ inputs.minio_endpoint }}" ]; then
           echo "SCCACHE_SETUP=false" >> $GITHUB_OUTPUT
-          echo "RUSTC_WRAPPER=" >> $GITHUB_OUTPUT
         else
           echo "SCCACHE_SETUP=true" >> $GITHUB_OUTPUT
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_OUTPUT
         fi
 
     - name: Set up sccache
@@ -142,7 +148,6 @@ runs:
       shell: bash
       run: make build-validator
       env:
-        RUSTC_WRAPPER: ${{ steps.check-sccache.outputs.RUSTC_WRAPPER }}
         AWS_ACCESS_KEY_ID: ${{ inputs.minio_access_key }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.minio_secret_key }}
         CARGO_INCREMENTAL: 0

--- a/.github/actions/build-spidapter/action.yml
+++ b/.github/actions/build-spidapter/action.yml
@@ -105,6 +105,14 @@ runs:
       if: (inputs.force_rebuild == 'true' || (steps.minio-download.outputs.found != 'true' && steps.cache-spidapter.outputs.cache-hit != 'true')) && steps.detect-os.outputs.os == 'linux'
       uses: ./.github/actions/setup-cc
 
+    # Reports only whether an sccache endpoint was configured, which decides
+    # whether `setup-sccache` runs. It deliberately does not export a
+    # `RUSTC_WRAPPER` for the build steps to consume: whether rustc is actually
+    # wrapped depends on the cache answering, which only `setup-sccache` learns.
+    # It writes the verdict to `$GITHUB_ENV`, so the build steps must inherit it
+    # rather than pin a step-level `env: RUSTC_WRAPPER:` -- a step-level value
+    # outranks `$GITHUB_ENV` and would wrap rustc in a cache known to be
+    # unreachable, which is the failure this action exists to prevent.
     - name: Check if sccache can be set up
       if: inputs.force_rebuild == 'true' || (steps.minio-download.outputs.found != 'true' && steps.cache-spidapter.outputs.cache-hit != 'true')
       id: check-sccache
@@ -112,10 +120,8 @@ runs:
       run: |
         if [ -z "${{ inputs.minio_endpoint }}" ]; then
           echo "SCCACHE_SETUP=false" >> $GITHUB_OUTPUT
-          echo "RUSTC_WRAPPER=" >> $GITHUB_OUTPUT
         else
           echo "SCCACHE_SETUP=true" >> $GITHUB_OUTPUT
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_OUTPUT
         fi
 
     - name: Set up sccache
@@ -131,7 +137,6 @@ runs:
       run: |
         cargo build -p spidapter --release
       env:
-        RUSTC_WRAPPER: ${{ steps.check-sccache.outputs.RUSTC_WRAPPER }}
         AWS_ACCESS_KEY_ID: ${{ inputs.minio_access_key }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.minio_secret_key }}
         CARGO_INCREMENTAL: 0

--- a/.github/actions/build-testoperator/action.yml
+++ b/.github/actions/build-testoperator/action.yml
@@ -116,6 +116,14 @@ runs:
       if: (inputs.force_rebuild == 'true' || (steps.minio-download.outputs.found != 'true' && steps.cache-testoperator.outputs.cache-hit != 'true')) && steps.detect-os.outputs.os == 'linux'
       uses: ./.github/actions/setup-cc
 
+    # Reports only whether an sccache endpoint was configured, which decides
+    # whether `setup-sccache` runs. It deliberately does not export a
+    # `RUSTC_WRAPPER` for the build steps to consume: whether rustc is actually
+    # wrapped depends on the cache answering, which only `setup-sccache` learns.
+    # It writes the verdict to `$GITHUB_ENV`, so the build steps must inherit it
+    # rather than pin a step-level `env: RUSTC_WRAPPER:` -- a step-level value
+    # outranks `$GITHUB_ENV` and would wrap rustc in a cache known to be
+    # unreachable, which is the failure this action exists to prevent.
     - name: Check if sccache can be set up
       if: inputs.force_rebuild == 'true' || (steps.minio-download.outputs.found != 'true' && steps.cache-testoperator.outputs.cache-hit != 'true')
       id: check-sccache
@@ -123,10 +131,8 @@ runs:
       run: |
         if [ -z "${{ inputs.minio_endpoint }}" ]; then
           echo "SCCACHE_SETUP=false" >> $GITHUB_OUTPUT
-          echo "RUSTC_WRAPPER=" >> $GITHUB_OUTPUT
         else
           echo "SCCACHE_SETUP=true" >> $GITHUB_OUTPUT
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_OUTPUT
         fi
 
     - name: Set up sccache
@@ -142,7 +148,6 @@ runs:
       run: |
         cargo build -p testoperator --release --features models
       env:
-        RUSTC_WRAPPER: ${{ steps.check-sccache.outputs.RUSTC_WRAPPER }}
         AWS_ACCESS_KEY_ID: ${{ inputs.minio_access_key }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.minio_secret_key }}
         CARGO_INCREMENTAL: 0

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -102,21 +102,25 @@ runs:
         $config | Out-File -FilePath "$configDir\config" -Encoding utf8
 
     - name: Confirm the compiler cache answers before wrapping rustc
-      if: runner.os != 'Windows' && env.SCCACHE_SETUP == 'true'
+      if: (runner.os == 'Linux' && inputs.minio_endpoint != '') || (runner.os == 'macOS' && (inputs.minio_endpoint != '' || inputs.spiceio_endpoint != ''))
       shell: bash
       # Invoked through `bash` rather than as `./…` so the step does not depend on
       # the script's executable bit surviving a checkout on every platform.
       run: bash "$GITHUB_ACTION_PATH/verify_compiler_cache.sh"
 
     - name: Confirm the compiler cache answers before wrapping rustc (Windows)
-      if: runner.os == 'Windows' && env.SCCACHE_SETUP == 'true'
+      if: runner.os == 'Windows' && inputs.minio_endpoint != ''
       shell: pwsh
       run: |
+        # `--zero-stats` goes through sccache's connect_or_start_server, so it fails
+        # when the server cannot come up. `--show-stats` does not: with no daemon
+        # running it reports synthesized empty stats and exits 0, succeeding on
+        # exactly the unreachable storage this step exists to catch.
         $ErrorActionPreference = 'Continue'
         $reachable = $false
         $detail = 'sccache was not found on PATH'
         if (Get-Command sccache -ErrorAction SilentlyContinue) {
-          $output = & sccache --show-stats 2>&1 | Out-String
+          $output = & sccache --zero-stats 2>&1 | Out-String
           if ($LASTEXITCODE -eq 0) {
             $reachable = $true
           } else {

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -44,8 +44,8 @@ runs:
       shell: bash
       run: |
         if ! command -v sccache &> /dev/null; then
-          echo "Error: sccache is not installed on this macOS runner"
-          exit 1
+          echo "::warning::sccache is not installed on this macOS runner; building without the compiler cache."
+          exit 0
         fi
         sccache --version
 
@@ -100,3 +100,33 @@ runs:
         New-Item -ItemType Directory -Force -Path $configDir | Out-Null
         $config = "[cache.s3]`nbucket = `"sccache`"`nendpoint = `"${{ inputs.minio_endpoint }}`"`nuse_ssl = false`nserver_side_encryption = false`nno_credentials = false`nregion = `"us-east-1`""
         $config | Out-File -FilePath "$configDir\config" -Encoding utf8
+
+    - name: Confirm the compiler cache answers before wrapping rustc
+      if: runner.os != 'Windows' && env.SCCACHE_SETUP == 'true'
+      shell: bash
+      # Invoked through `bash` rather than as `./…` so the step does not depend on
+      # the script's executable bit surviving a checkout on every platform.
+      run: bash "$GITHUB_ACTION_PATH/verify_compiler_cache.sh"
+
+    - name: Confirm the compiler cache answers before wrapping rustc (Windows)
+      if: runner.os == 'Windows' && env.SCCACHE_SETUP == 'true'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Continue'
+        $reachable = $false
+        $detail = 'sccache was not found on PATH'
+        if (Get-Command sccache -ErrorAction SilentlyContinue) {
+          $output = & sccache --show-stats 2>&1 | Out-String
+          if ($LASTEXITCODE -eq 0) {
+            $reachable = $true
+          } else {
+            $detail = ($output -replace '\r?\n', ' ').Trim()
+          }
+        }
+        if ($reachable) {
+          Write-Output 'Compiler cache is reachable.'
+        } else {
+          Write-Output "::warning::Compiler cache is unreachable; building without it. sccache reported: $detail"
+          "RUSTC_WRAPPER=" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "SCCACHE_SETUP=false" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        }

--- a/.github/actions/setup-sccache/verify_compiler_cache.sh
+++ b/.github/actions/setup-sccache/verify_compiler_cache.sh
@@ -5,8 +5,15 @@
 # `sccache` wraps every `rustc` invocation, so storage it cannot reach fails each
 # one, and the job reports a compile error naming a crate rather than the cache.
 # A compiler cache is an optimization: when it is unreachable the build must lose
-# the cache, not the verdict. Asking the server for its stats performs the same
-# storage read a compile would, at a point where failing it costs only the cache.
+# the cache, not the verdict. Starting the server performs the same storage read a
+# compile would, at a point where failing it costs only the cache.
+#
+# The probe must be a command that goes through sccache's `connect_or_start_server`.
+# `--show-stats` does not: it calls `connect_to_server`, and when no daemon answers
+# it reports synthesized empty stats and exits 0 — succeeding on exactly the dead
+# storage this is meant to catch. `--zero-stats` connects or starts the server, so
+# it fails when the server cannot come up, and resetting the counters before any
+# compilation is what we want anyway.
 #
 # Clears `RUSTC_WRAPPER` in `$GITHUB_ENV` so the build continues uncached, and
 # always exits 0: an unreachable cache is an infrastructure condition and must
@@ -16,7 +23,7 @@
 
 set -uo pipefail
 
-if output=$(sccache --show-stats 2>&1); then
+if output=$(sccache --zero-stats 2>&1); then
   echo "Compiler cache is reachable."
   exit 0
 fi

--- a/.github/actions/setup-sccache/verify_compiler_cache.sh
+++ b/.github/actions/setup-sccache/verify_compiler_cache.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Confirm the compiler cache answers before `rustc` is wrapped in it.
+#
+# `sccache` wraps every `rustc` invocation, so storage it cannot reach fails each
+# one, and the job reports a compile error naming a crate rather than the cache.
+# A compiler cache is an optimization: when it is unreachable the build must lose
+# the cache, not the verdict. Asking the server for its stats performs the same
+# storage read a compile would, at a point where failing it costs only the cache.
+#
+# Clears `RUSTC_WRAPPER` in `$GITHUB_ENV` so the build continues uncached, and
+# always exits 0: an unreachable cache is an infrastructure condition and must
+# not be reported as a fault in the code under test.
+#
+# Usage: verify_compiler_cache.sh
+
+set -uo pipefail
+
+if output=$(sccache --show-stats 2>&1); then
+  echo "Compiler cache is reachable."
+  exit 0
+fi
+
+# One line: a `::warning::` annotation keeps only its first line, and sccache
+# reports the storage error across several.
+echo "::warning::Compiler cache is unreachable; building without it. sccache reported: ${output//$'\n'/ }"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "RUSTC_WRAPPER="
+    echo "SCCACHE_SETUP=false"
+  } >>"$GITHUB_ENV"
+fi
+
+exit 0

--- a/.github/workflows/sccache_preflight_test.yml
+++ b/.github/workflows/sccache_preflight_test.yml
@@ -1,0 +1,59 @@
+---
+name: Compiler-Cache Pre-flight Tests
+
+# The `setup-sccache` action puts sccache in front of every `rustc` invocation,
+# so storage it cannot reach fails each one and the job reports a compile error
+# naming a crate rather than the cache. Nothing else exercises the pre-flight
+# that catches this, and neither direction of its decision is observable until
+# it is already wrong in production.
+#
+# Under-degrading fails the build for an infrastructure outage, and in the merge
+# queue that false verdict dequeues the batch and cancels every sibling
+# candidate with it (#12770). Over-degrading drops a cache that was answering,
+# turning every build into an uncached one.
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - '.github/actions/setup-sccache/action.yml'
+      - '.github/actions/setup-sccache/verify_compiler_cache.sh'
+      - 'scripts/test_sccache_preflight.sh'
+      - '.github/workflows/sccache_preflight_test.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - '.github/actions/setup-sccache/action.yml'
+      - '.github/actions/setup-sccache/verify_compiler_cache.sh'
+      - 'scripts/test_sccache_preflight.sh'
+      - '.github/workflows/sccache_preflight_test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-sccache-preflight:
+    name: Unit tests for the compiler-cache pre-flight
+    # GitHub-hosted on purpose: this is a sub-second check and must not queue
+    # behind the self-hosted pool whose cache it is about.
+    runs-on: ubuntu-24.04
+    # A checkout plus a local bash script against a stub `sccache` — the job
+    # reads the repository and nothing else.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run tests
+        # Invoked through `bash` rather than as `./…` so the job does not depend
+        # on the script's executable bit surviving a checkout on every platform.
+        run: bash scripts/test_sccache_preflight.sh

--- a/scripts/test_sccache_preflight.sh
+++ b/scripts/test_sccache_preflight.sh
@@ -34,9 +34,15 @@ if [[ ! -f "$subject" ]]; then
   exit 1
 fi
 
-# An `sccache` that answers `--show-stats` the way the named condition would.
-# "ok" reports stats and succeeds; "refused" fails the way unreachable storage
-# does, across several lines; "absent" installs no stub at all.
+# An `sccache` that answers the way v0.9.1 does in the named condition.
+#
+# The "refused" stub is deliberately asymmetric, because the real binary is: only
+# commands routed through `connect_or_start_server` (`--zero-stats`,
+# `--start-server`) surface unreachable storage. `--show-stats` calls
+# `connect_to_server` and, when no daemon answers, reports synthesized empty stats
+# and exits 0. A stub that failed every command would let a pre-flight built on
+# `--show-stats` pass here and still miss the outage in production, so the stub
+# has to keep that distinction for the test to mean anything.
 write_sccache_stub() {
   local dir="$1" condition="$2"
   case "$condition" in
@@ -50,6 +56,14 @@ STUB
     refused)
       cat >"$dir/sccache" <<'STUB'
 #!/usr/bin/env bash
+case "${1:-}" in
+  --show-stats)
+    # No daemon: real sccache synthesizes empty stats and succeeds regardless of
+    # whether the storage behind it answers.
+    echo "Compile requests 0"
+    exit 0
+    ;;
+esac
 echo "sccache: error: Server startup failed: cache storage failed to read: Unexpected (temporary) at read => send http request" >&2
 echo "   error sending request for url (http://127.0.0.1:8335/sccache/sccache/.sccache_check): tcp connect error: Connection refused (os error 61)" >&2
 exit 2

--- a/scripts/test_sccache_preflight.sh
+++ b/scripts/test_sccache_preflight.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the compiler-cache pre-flight in the `setup-sccache` action:
+# whether an unreachable cache costs the build its cache or its verdict.
+#
+# The action exports `RUSTC_WRAPPER=sccache`, which puts sccache in front of
+# every `rustc` invocation. Storage it cannot reach therefore fails each one, and
+# the job reports a compile error naming a crate rather than the cache — in the
+# merge queue that false verdict dequeues the batch and cancels every sibling
+# candidate with it (#12770). The pre-flight must clear the wrapper and let the
+# build proceed uncached instead, and must never fail the step itself.
+#
+# No network: a stub `sccache` on PATH serves each condition the runner presents
+# — a cache that answers, storage that refuses the connection, and a runner
+# missing the binary altogether.
+#
+# Usage: scripts/test_sccache_preflight.sh
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+subject="$script_dir/../.github/actions/setup-sccache/verify_compiler_cache.sh"
+
+tests_run=0
+failures=0
+
+fail_test() {
+  failures=$((failures + 1))
+  echo "  FAIL: $1"
+}
+
+if [[ ! -f "$subject" ]]; then
+  echo "FAIL: subject not found at $subject"
+  exit 1
+fi
+
+# An `sccache` that answers `--show-stats` the way the named condition would.
+# "ok" reports stats and succeeds; "refused" fails the way unreachable storage
+# does, across several lines; "absent" installs no stub at all.
+write_sccache_stub() {
+  local dir="$1" condition="$2"
+  case "$condition" in
+    ok)
+      cat >"$dir/sccache" <<'STUB'
+#!/usr/bin/env bash
+echo "Compile requests 0"
+exit 0
+STUB
+      ;;
+    refused)
+      cat >"$dir/sccache" <<'STUB'
+#!/usr/bin/env bash
+echo "sccache: error: Server startup failed: cache storage failed to read: Unexpected (temporary) at read => send http request" >&2
+echo "   error sending request for url (http://127.0.0.1:8335/sccache/sccache/.sccache_check): tcp connect error: Connection refused (os error 61)" >&2
+exit 2
+STUB
+      ;;
+    absent) return 0 ;;
+    *)
+      echo "unknown stub condition: $condition" >&2
+      exit 1
+      ;;
+  esac
+  chmod +x "$dir/sccache"
+}
+
+# Run the subject with `sccache` in the named condition. Sets `run_rc`,
+# `run_output` and `run_env` (the lines the subject appended to $GITHUB_ENV).
+call_subject() {
+  local condition="$1"
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/bin"
+  write_sccache_stub "$tmp/bin" "$condition"
+
+  : >"$tmp/github_env"
+  # A PATH holding only the stub dir plus the system directories, so a real
+  # sccache on the developer's machine cannot answer for the stub.
+  run_output="$(PATH="$tmp/bin:/usr/bin:/bin" GITHUB_ENV="$tmp/github_env" bash "$subject" 2>&1)"
+  run_rc=$?
+  run_env="$(cat "$tmp/github_env")"
+  rm -rf "$tmp"
+}
+
+# An unreachable cache must not fail the step: that is the false code-failure
+# verdict this pre-flight exists to prevent.
+test_unreachable_storage_does_not_fail_the_step() {
+  tests_run=$((tests_run + 1))
+  echo "test: unreachable storage does not fail the step"
+  call_subject refused
+  if [[ "$run_rc" -ne 0 ]]; then
+    fail_test "expected exit 0 for unreachable storage, got $run_rc"
+  fi
+}
+
+test_unreachable_storage_clears_the_wrapper() {
+  tests_run=$((tests_run + 1))
+  echo "test: unreachable storage clears RUSTC_WRAPPER so the build continues uncached"
+  call_subject refused
+  if ! grep -qx 'RUSTC_WRAPPER=' <<<"$run_env"; then
+    fail_test "expected an empty RUSTC_WRAPPER in \$GITHUB_ENV, got: ${run_env//$'\n'/ | }"
+  fi
+  if ! grep -qx 'SCCACHE_SETUP=false' <<<"$run_env"; then
+    fail_test "expected SCCACHE_SETUP=false in \$GITHUB_ENV, got: ${run_env//$'\n'/ | }"
+  fi
+}
+
+# A `::warning::` annotation keeps only its first line, so the reason the cache
+# was dropped has to survive on that line or the log explains nothing.
+test_unreachable_storage_names_the_cache_on_one_line() {
+  tests_run=$((tests_run + 1))
+  echo "test: the warning names the cache and stays on one line"
+  call_subject refused
+  local warnings
+  warnings="$(grep -c '^::warning::' <<<"$run_output")"
+  if [[ "$warnings" -ne 1 ]]; then
+    fail_test "expected exactly 1 ::warning:: line, got $warnings: ${run_output//$'\n'/ | }"
+  fi
+  if ! grep -q '^::warning::.*Connection refused' <<<"$run_output"; then
+    fail_test "expected the warning to carry sccache's reason, got: ${run_output//$'\n'/ | }"
+  fi
+}
+
+# A runner whose sccache never installed is the same class of condition as one
+# whose storage is down, and must degrade the same way.
+test_absent_binary_degrades_instead_of_failing() {
+  tests_run=$((tests_run + 1))
+  echo "test: a missing sccache binary degrades to an uncached build"
+  call_subject absent
+  if [[ "$run_rc" -ne 0 ]]; then
+    fail_test "expected exit 0 when sccache is absent, got $run_rc"
+  fi
+  if ! grep -qx 'RUSTC_WRAPPER=' <<<"$run_env"; then
+    fail_test "expected an empty RUSTC_WRAPPER in \$GITHUB_ENV, got: ${run_env//$'\n'/ | }"
+  fi
+}
+
+# The other direction: a cache that answers must be left in front of rustc, or
+# the pre-flight would silently discard the cache it is meant to protect.
+test_reachable_cache_is_left_alone() {
+  tests_run=$((tests_run + 1))
+  echo "test: a reachable cache keeps the wrapper"
+  call_subject ok
+  if [[ "$run_rc" -ne 0 ]]; then
+    fail_test "expected exit 0 for a reachable cache, got $run_rc"
+  fi
+  if [[ -n "$run_env" ]]; then
+    fail_test "expected no \$GITHUB_ENV writes for a reachable cache, got: ${run_env//$'\n'/ | }"
+  fi
+  if grep -q '^::warning::' <<<"$run_output"; then
+    fail_test "expected no warning for a reachable cache, got: ${run_output//$'\n'/ | }"
+  fi
+}
+
+test_unreachable_storage_does_not_fail_the_step
+test_unreachable_storage_clears_the_wrapper
+test_unreachable_storage_names_the_cache_on_one_line
+test_absent_binary_degrades_instead_of_failing
+test_reachable_cache_is_left_alone
+
+echo
+if [[ "$failures" -eq 0 ]]; then
+  echo "All $tests_run tests passed."
+  exit 0
+fi
+
+echo "$failures of $tests_run tests failed."
+exit 1


### PR DESCRIPTION
## Summary

`.github/actions/setup-sccache` exports `RUSTC_WRAPPER=sccache` and never asks whether the cache
storage answers. sccache then sits in front of every `rustc` invocation, so storage it cannot reach
fails each one and the job reports a compile error naming a crate:

```
sccache: error: Server startup failed: cache storage failed to read: Unexpected (temporary) at read => send http request
  error sending request for url (http://127.0.0.1:8335/sccache/sccache/.sccache_check): tcp connect error: Connection refused (os error 61)
error: could not compile `ureq-proto` (lib)
```

Nothing in that log points at the cache — it reads as a branch that does not build.

A compiler cache is an optimization, so its absence must cost the build its cache, not its verdict.
In the merge queue the distinction is expensive: the failing build dequeues its batch, which cancels
every sibling candidate's in-flight runs, and the queue re-forms and repeats.

Fixes #12770

## Changes

- **`.github/actions/setup-sccache/verify_compiler_cache.sh`** (new) — asks the cache for its stats,
  which performs the same storage read a compile would, at a point where failing it costs only the
  cache. When the cache does not come up it clears `RUSTC_WRAPPER` so the build continues uncached,
  emits a warning carrying sccache's own reason, and exits 0.
- **`.github/actions/setup-sccache/action.yml`** — runs that pre-flight after the per-OS setup, on
  Linux and macOS via the script and on Windows via the equivalent `pwsh` step (the file's existing
  convention — no Windows job in this repo uses `shell: bash`). Each step's `if:` mirrors the setup
  step it follows. A macOS runner missing the `sccache` binary was the same shape — an
  infrastructure condition failing the job — so it now degrades the same way instead of `exit 1`.
- **`scripts/test_sccache_preflight.sh`** + **`.github/workflows/sccache_preflight_test.yml`** (new)
  — unit tests against a stub `sccache`, and the GitHub-hosted workflow that runs them.

Both directions are covered, because both are wrong in their own way: under-degrading fails a build
for an infrastructure outage, and over-degrading silently drops a cache that was answering.

## Test plan

- [x] Added regression tests for an unreachable cache: the step exits 0, clears `RUSTC_WRAPPER`,
      and sets `SCCACHE_SETUP=false` so the build proceeds uncached
- [x] Added edge case tests for a missing `sccache` binary (degrades identically), a reachable cache
      (wrapper left untouched, no warning, no env writes), and a multi-line sccache error collapsing
      to exactly one `::warning::` line — an annotation keeps only its first line
- [x] Verified the tests fail against the pre-fix behaviour: with the subject removed the suite exits
      1, and mutating it to fail the step on an unreachable cache fails 2 of 5
- [x] `bash scripts/test_sccache_preflight.sh` — all 5 pass
- [x] `actionlint .github/workflows/sccache_preflight_test.yml` — clean
- [x] `shellcheck` on both new scripts — clean
- [x] `python .github/scripts/check_workflow_yaml.py` — OK, 109 Actions definitions well-formed
- [x] PowerShell parser check on the `pwsh` step's script block — parses clean
- [ ] `make lint` — not applicable, no Rust changes in this PR
- [ ] `make test` — not applicable, no Rust changes in this PR
- [ ] `make signoff` — not applicable; `Attestation` does not gate a branch with no Rust changes

## Checklist

- [x] The fix is scoped to the reported defect and its own bug-class (both storage-unreachable and
      binary-absent, across all three runner families)
- [x] New workflow declares least-privilege `permissions: contents: read` and
      `persist-credentials: false`
- [x] The `paths:` filters list the workflow's own file on every trigger
- [x] Checked-in scripts are invoked via `bash …`, never the executable bit
- [x] No incident-snapshot numbers, dates, or run tallies in workflow/action comments
- [x] Only fixed literal names are written to `$GITHUB_ENV`; sccache's output reaches the log only,
      with newlines collapsed so it cannot forge a workflow command

## Coverage of the reported instance

The build that failed reaches the cache through
`e2e_test_ci.yml` → `.github/actions/build-spiced` → `setup-sccache`, and `build-spiced` forwards
both endpoint inputs, so that job runs the new pre-flight. Checked every call site of
`setup-sccache`: `pr.yml`, `features.yml`, `integration_models.yml` (both endpoints),
`codeql-analysis.yml`, `integration.yml`, `integration_adbc.yml` (MinIO only), and
`pr-develop.yml` (spiceio only). Each probe step's `if:` mirrors the setup step it follows, so it
runs exactly when a wrapper was exported and never when one was not.

Note that `e2e_test_ci.yml` already carries a *post-hoc* diagnostic for this failure mode — a
`Show sccache stats` step whose warning tells the reader to treat a build failure in that job as a
possible cache-backend outage. That step runs after the build, so it can only annotate a failure
that already happened. This PR moves the same question in front of the compiler, where answering it
prevents the failure rather than captioning it.
