### PR TITLE
fix(json): end an array element where serde did, so bare scalars read (fixes #12782)

### DIFF
--- a/crates/dataformat-json/src/stream.rs
+++ b/crates/dataformat-json/src/stream.rs
@@ -172,9 +172,10 @@ impl<R: Read + Send> ArrayToNdjson<R> {
                         return Ok(());
                     }
                 }
-                // An I/O failure may still be transient, so only a genuine
-                // parse failure closes the reader for good.
-                self.malformed = e.classify() != Category::Io;
+                // The bytes serde read are gone from the inner reader and a
+                // second attempt would start mid-element, so no failure here
+                // is recoverable — including an I/O one.
+                self.malformed = true;
                 return Err(io::Error::new(io::ErrorKind::InvalidData, e));
             }
             None => {
@@ -194,6 +195,12 @@ impl<R: Read + Send> ArrayToNdjson<R> {
         let committed = committed.min(tee.buf.len());
         let slice = &tee.buf[..committed];
 
+        // The element is held back until its delimiter has been read, so that
+        // a row is only ever published as part of a well-formed `element,` or
+        // `element]`. Handing it to `pending` first would let a caller that
+        // reads on past the error collect it from there.
+        let mut element_out = VecDeque::new();
+
         // If the element is a JSON array (e.g. from SODA `/data`), convert it
         // to a JSON object with positional string keys ("0", "1", …) so that
         // Arrow's JSON reader can handle it (it requires objects, not arrays).
@@ -206,17 +213,17 @@ impl<R: Read + Send> ArrayToNdjson<R> {
                     .map(|(i, v)| (i.to_string(), v))
                     .collect();
                 if let Ok(serialized) = serde_json::to_string(&serde_json::Value::Object(obj)) {
-                    self.pending.extend(serialized.bytes());
-                    self.pending.push_back(b'\n');
+                    element_out.extend(serialized.bytes());
+                    element_out.push_back(b'\n');
                 } else {
-                    filter_element_bytes(slice, &mut self.pending);
+                    filter_element_bytes(slice, &mut element_out);
                 }
             } else {
-                filter_element_bytes(slice, &mut self.pending);
+                filter_element_bytes(slice, &mut element_out);
             }
         } else {
-            // Push the clean element (without internal newlines and carriage returns) plus newline to `pending`.
-            filter_element_bytes(slice, &mut self.pending);
+            // Push the clean element (without internal newlines and carriage returns) plus newline.
+            filter_element_bytes(slice, &mut element_out);
         }
 
         // Discard bytes we no longer need from tee.buf.
@@ -224,28 +231,35 @@ impl<R: Read + Send> ArrayToNdjson<R> {
 
         drop(tee);
 
+        // From here the element's bytes have left the inner reader, so nothing
+        // can be re-read and every failure is final.
+        let next = self.read_delimiter().inspect_err(|_| {
+            self.malformed = true;
+        })?;
+        if next == b']' {
+            self.eof = true;
+        }
+
+        self.pending.append(&mut element_out);
+        Ok(())
+    }
+
+    /// Consume the `,` or `]` that follows an element, and report which it was.
+    fn read_delimiter(&mut self) -> io::Result<u8> {
         let next = self.peek_next_non_ws_byte()?;
         match next {
-            b',' => {
-                self.consume_delimiter()?; // another element coming
-                // println!("Found comma, expecting another element")
-            }
-            b']' => {
+            b',' | b']' => {
                 self.consume_delimiter()?;
-                self.eof = true;
+                Ok(next)
             }
-            _ => {
-                self.malformed = true;
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "expected ',' or ']' but found '{char}'",
-                        char = next as char
-                    ),
-                ));
-            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "expected ',' or ']' but found '{char}'",
+                    char = next as char
+                ),
+            )),
         }
-        Ok(())
     }
 
     /// Read (and buffer) bytes until we find the first non-whitespace byte,
@@ -3682,32 +3696,67 @@ mod tests {
             }
         }
 
-        /// Reading an element assumes the tee buffer begins at that element. A
-        /// parse error breaks that, so a caller that keeps reading has to keep
-        /// getting errors rather than a row assembled from the leftovers.
-        #[test]
-        fn a_malformed_array_keeps_failing_instead_of_yielding_a_row() {
+        /// Read past the point where the reader reported a problem, the way a
+        /// consumer that logs an error and carries on would.
+        ///
+        /// Reading an element assumes the tee buffer begins at that element,
+        /// and any failure breaks that: the element's bytes have already left
+        /// the inner reader, so nothing can be re-read from the right place.
+        /// Every read from there on has to keep saying so.
+        fn assert_stays_failed(body: &[u8], reads_before_failure: usize) {
             let mut reader =
-                ArrayToNdjson::try_new(Cursor::new(br"[1,@ 2]".to_vec())).expect("array start");
-
+                ArrayToNdjson::try_new(Cursor::new(body.to_vec())).expect("array start");
             let mut buf = [0u8; 64];
-            let n = reader
-                .read(&mut buf)
-                .expect("the first element is well formed");
-            assert_eq!(&buf[..n], b"1\n");
 
-            // `@` is where the array stops making sense. Every read from here
-            // on has to say so; the ` 2` behind it is not an element.
+            for i in 0..reads_before_failure {
+                let n = reader.read(&mut buf).unwrap_or_else(|e| {
+                    panic!(
+                        "{}: read {i} should succeed: {e}",
+                        String::from_utf8_lossy(body)
+                    )
+                });
+                assert_ne!(
+                    n,
+                    0,
+                    "{}: read {i} ended early",
+                    String::from_utf8_lossy(body)
+                );
+            }
+
             for attempt in 0..3 {
                 match reader.read(&mut buf) {
                     Err(_) => {}
-                    Ok(0) => panic!("attempt {attempt} ended the array instead of reporting it"),
+                    Ok(0) => panic!(
+                        "{}: attempt {attempt} ended the array instead of reporting it",
+                        String::from_utf8_lossy(body)
+                    ),
                     Ok(n) => panic!(
-                        "attempt {attempt} yielded {:?}, which is not in the file",
+                        "{}: attempt {attempt} yielded {:?}, which is not in the file",
+                        String::from_utf8_lossy(body),
                         String::from_utf8_lossy(&buf[..n])
                     ),
                 }
             }
+        }
+
+        #[test]
+        fn a_malformed_array_keeps_failing_instead_of_yielding_a_row() {
+            // `[1,@ 2]` — `1` is a real element, then `@` is where the array
+            // stops making sense and ` 2` behind it is not an element.
+            assert_stays_failed(br"[1,@ 2]", 1);
+        }
+
+        /// An element whose delimiter never arrives is not a row: the reader
+        /// has no way to know it read the whole of it.
+        #[test]
+        fn an_element_with_no_delimiter_is_never_published() {
+            // `1` is followed by a byte that ends nothing, or by nothing at all.
+            for body in [&br"[1x]"[..], &br"[1"[..]] {
+                assert_stays_failed(body, 0);
+            }
+            // `1,` is a whole element, so it is published; `2` runs into the
+            // end of the input and is not.
+            assert_stays_failed(br"[1,2", 1);
         }
 
         /// A body larger than one read buffer drives `fill_pending` many times

--- a/crates/dataformat-json/src/stream.rs
+++ b/crates/dataformat-json/src/stream.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use serde_json::error::Category;
-use serde_json::{Deserializer, StreamDeserializer, de::IoRead, value::RawValue};
+use serde_json::{Deserializer, value::RawValue};
 use std::collections::VecDeque;
 use std::io::{self, BufRead, Read};
 use std::sync::{Arc, Mutex};
@@ -73,11 +73,13 @@ ArrayToNdjson – implements `BufRead` so downstream can pull NDJSON
 ///   consumers choke on embedded new‑lines.
 pub struct ArrayToNdjson<R: Read + Send> {
     shared: Arc<Mutex<Tee<R>>>, // rolling buffer
-    stream: StreamDeserializer<'static, IoRead<TeeReader<R>>, Box<RawValue>>, // serde iterator
-    drained: usize,             // bytes already drained from tee.buf
-    prev_off: usize,            // byte_offset() after previous element
     pending: VecDeque<u8>,      // data ready for BufRead
     eof: bool,
+    /// Set when the array is known to be malformed. Reading an element
+    /// requires the tee buffer to begin at the element, and a parse error
+    /// leaves whatever serde had read sitting in front of it, so a caller that
+    /// keeps reading would be handed those bytes as the next element.
+    malformed: bool,
 }
 
 impl<R: Read + Send> ArrayToNdjson<R> {
@@ -92,19 +94,12 @@ impl<R: Read + Send> ArrayToNdjson<R> {
 
         // Shared tee so we can inspect bytes that serde has read.
         let shared = Arc::new(Mutex::new(Tee::new(inner)));
-        let reader = TeeReader {
-            shared: Arc::clone(&shared),
-        };
-        // `from_reader` takes ownership of `reader` and wraps it in IoRead.
-        let stream = Deserializer::from_reader(reader).into_iter::<Box<RawValue>>();
 
         Ok(Self {
             shared,
-            stream,
-            drained: 0,
-            prev_off: 0,
             pending: VecDeque::new(),
             eof: false,
+            malformed: false,
         })
     }
 
@@ -116,10 +111,8 @@ impl<R: Read + Send> ArrayToNdjson<R> {
     /// Returns an error if the adapter cannot be consumed due to multiple outstanding
     /// references to the shared buffer.
     pub fn finish(self) -> Result<R, io::Error> {
-        // Drop the stream to release its reference to the shared Tee
-        drop(self.stream);
-
-        // Try to unwrap the Arc - this should succeed since we dropped the stream
+        // Each element is read through a short-lived deserializer, so nothing
+        // else holds the shared Tee by the time the adapter is consumed.
         let tee = Arc::try_unwrap(self.shared)
             .map_err(|_| {
                 io::Error::other("Failed to recover inner reader - multiple references still exist")
@@ -139,9 +132,34 @@ impl<R: Read + Send> ArrayToNdjson<R> {
         if !self.pending.is_empty() || self.eof {
             return Ok(());
         }
+        if self.malformed {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Failed to read JSON array: the array is malformed and cannot be read further",
+            ));
+        }
 
-        // Pull the next element from serde.
-        match self.stream.next() {
+        // Pull the next element through a deserializer built for this element
+        // alone.
+        //
+        // A value with no closing delimiter — a number, `true`, `false` or
+        // `null` — is only known to have ended once the byte after it is read,
+        // and inside an array that byte is the array's own `,` or `]`. serde
+        // holds it as lookahead, so a deserializer reused for the next element
+        // would be handed a delimiter where it expects a value. Building a
+        // fresh one drops the lookahead on serde's side; the byte itself is
+        // still in the tee buffer, where the delimiter scan below consumes it.
+        let reader = TeeReader {
+            shared: Arc::clone(&self.shared),
+        };
+        let mut stream = Deserializer::from_reader(reader).into_iter::<Box<RawValue>>();
+        let element = stream.next();
+        // `byte_offset` counts what serde committed to the element, which
+        // excludes any lookahead byte. Read it before the stream is dropped.
+        let committed = stream.byte_offset();
+        drop(stream);
+
+        match element {
             Some(Ok(_)) => {}
             Some(Err(e)) => {
                 // Check if this is an empty array case
@@ -154,6 +172,9 @@ impl<R: Read + Send> ArrayToNdjson<R> {
                         return Ok(());
                     }
                 }
+                // An I/O failure may still be transient, so only a genuine
+                // parse failure closes the reader for good.
+                self.malformed = e.classify() != Category::Io;
                 return Err(io::Error::new(io::ErrorKind::InvalidData, e));
             }
             None => {
@@ -168,8 +189,10 @@ impl<R: Read + Send> ArrayToNdjson<R> {
             Err(e) => e.into_inner(),
         };
 
-        let slice = &tee.buf[..];
-        let tee_buf_len = tee.buf.len();
+        // Anything past `committed` is the lookahead: it belongs to the array,
+        // not to the element, so it is neither emitted nor drained here.
+        let committed = committed.min(tee.buf.len());
+        let slice = &tee.buf[..committed];
 
         // If the element is a JSON array (e.g. from SODA `/data`), convert it
         // to a JSON object with positional string keys ("0", "1", …) so that
@@ -197,7 +220,7 @@ impl<R: Read + Send> ArrayToNdjson<R> {
         }
 
         // Discard bytes we no longer need from tee.buf.
-        tee.drain_front(tee_buf_len);
+        tee.drain_front(committed);
 
         drop(tee);
 
@@ -212,6 +235,7 @@ impl<R: Read + Send> ArrayToNdjson<R> {
                 self.eof = true;
             }
             _ => {
+                self.malformed = true;
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!(
@@ -233,17 +257,11 @@ impl<R: Read + Send> ArrayToNdjson<R> {
         };
         loop {
             /* -------- 1. look in the bytes we already have -------- */
-            {
-                // Everything read so far (but not yet drained) lives in tee.buf.
-                // We start scanning from the point just after the last element.
-                let mut i = self.prev_off - self.drained;
-                while i < tee.buf.len() {
-                    let b = tee.buf[i];
-                    if !b.is_ascii_whitespace() {
-                        return Ok(b); // found it – return without consuming
-                    }
-                    i += 1;
-                }
+            // The element's own bytes have already been drained, so whatever
+            // is left in tee.buf starts just after it: serde's lookahead, plus
+            // anything read here on an earlier pass.
+            if let Some(&b) = tee.buf.iter().find(|b| !b.is_ascii_whitespace()) {
+                return Ok(b); // found it – return without consuming
             }
 
             /* -------- 2. need more data: read one byte from the source -------- */
@@ -264,8 +282,8 @@ impl<R: Read + Send> ArrayToNdjson<R> {
     }
 
     /// Remove the comma (`','`) **or** closing bracket (`']'`) that we just
-    /// peeked, together with any preceding whitespace, and update the
-    /// `drained` / `prev_off` counters so slicing the next element works.
+    /// peeked, together with any preceding whitespace, leaving tee.buf empty
+    /// so the next element starts at its front.
     fn consume_delimiter(&mut self) -> io::Result<()> {
         let mut tee = match self.shared.lock() {
             Ok(tee) => tee,
@@ -278,8 +296,6 @@ impl<R: Read + Send> ArrayToNdjson<R> {
                 break;
             }
             tee.drain_front(1);
-            self.drained += 1;
-            self.prev_off += 1;
         }
 
         // 2️⃣  Now the first byte must be the delimiter itself.
@@ -290,8 +306,6 @@ impl<R: Read + Send> ArrayToNdjson<R> {
             ));
         }
         tee.drain_front(1); // discard ',' or ']'
-        self.drained += 1;
-        self.prev_off += 1;
 
         Ok(())
     }
@@ -3534,30 +3548,203 @@ mod tests {
             assert_eq!(lines[0], "{}");
         }
 
-        /// Array with null elements — `ArrayToNdjson` doesn't handle bare scalars,
-        /// so this exercises the error path
+        /// Array whose elements are all bare `null`
         #[test]
         fn test_auto_array_null_elements() {
             let input = br"[null,null,null]";
-            // ArrayToNdjson uses RawValue which doesn't handle bare scalars
-            let result = auto_detect_and_read(input);
-            assert!(
-                result.is_err(),
-                "bare null elements should fail in ArrayToNdjson"
-            );
+            let lines = auto_detect_and_read(input).expect("should read");
+            assert_eq!(lines, vec!["null", "null", "null"]);
         }
 
-        /// Array with numeric elements — `ArrayToNdjson` doesn't handle bare scalars,
-        /// so this exercises the error path
+        /// Array whose elements are bare numbers
         #[test]
         fn test_auto_array_numeric_elements() {
             let input = br"[1,2,3,4,5]";
-            // ArrayToNdjson uses RawValue which doesn't handle bare scalars
-            let result = auto_detect_and_read(input);
-            assert!(
-                result.is_err(),
-                "bare numeric elements should fail in ArrayToNdjson"
+            let lines = auto_detect_and_read(input).expect("should read");
+            assert_eq!(lines, vec!["1", "2", "3", "4", "5"]);
+        }
+    }
+
+    /// A value with no closing delimiter — a number, `true`, `false`, `null` —
+    /// only ends when the byte after it is read, and inside an array that byte
+    /// is the array's own `,` or `]`. The pull reader has to hand that byte to
+    /// its own delimiter scan rather than lose it to serde's lookahead.
+    mod bare_scalar_elements {
+        use super::*;
+
+        /// Drive `ArrayToNdjson` over a whole body and split the NDJSON it
+        /// produces into lines.
+        fn ndjson_lines(body: &[u8]) -> io::Result<Vec<String>> {
+            let mut out = String::new();
+            ArrayToNdjson::try_new(Cursor::new(body.to_vec()))?.read_to_string(&mut out)?;
+            Ok(out.lines().map(ToOwned::to_owned).collect())
+        }
+
+        #[test]
+        fn each_scalar_kind_reads_as_one_element() {
+            for (body, want) in [
+                (&br"[1,2,3]"[..], vec!["1", "2", "3"]),
+                (&br"[1]"[..], vec!["1"]),
+                (&br"[true]"[..], vec!["true"]),
+                (&br"[false,true]"[..], vec!["false", "true"]),
+                (&br"[null]"[..], vec!["null"]),
+                (&br"[1.5]"[..], vec!["1.5"]),
+                (&br"[-2.5e10,0]"[..], vec!["-2.5e10", "0"]),
+            ] {
+                let got = ndjson_lines(body).unwrap_or_else(|e| {
+                    panic!("{} should read: {e}", String::from_utf8_lossy(body))
+                });
+                assert_eq!(got, want, "for {}", String::from_utf8_lossy(body));
+            }
+        }
+
+        /// Scalars mixed with self-delimiting elements, in both orders: the
+        /// reader has to cope with a lookahead byte appearing for some
+        /// elements of an array and not others.
+        #[test]
+        fn scalars_mix_with_objects_strings_and_arrays() {
+            for (body, want) in [
+                (&br#"[{"a":1},2]"#[..], vec![r#"{"a":1}"#, "2"]),
+                (&br#"[1,{"a":2}]"#[..], vec!["1", r#"{"a":2}"#]),
+                (&br#"[1,"s",true]"#[..], vec!["1", r#""s""#, "true"]),
+                (&br#"["s",1]"#[..], vec![r#""s""#, "1"]),
+                // A nested array element is rewritten with positional keys for
+                // Arrow's benefit; the scalar after it must still be read.
+                (&br"[[1,2],3]"[..], vec![r#"{"0":1,"1":2}"#, "3"]),
+            ] {
+                let got = ndjson_lines(body).unwrap_or_else(|e| {
+                    panic!("{} should read: {e}", String::from_utf8_lossy(body))
+                });
+                assert_eq!(got, want, "for {}", String::from_utf8_lossy(body));
+            }
+        }
+
+        /// Whitespace may sit either side of a scalar, and serde's lookahead
+        /// may land on it instead of on the delimiter.
+        #[test]
+        fn whitespace_around_scalars_is_trimmed() {
+            for body in [
+                &br"[ 1 , 2 ]"[..],
+                &b"[\n  1,\n  2\n]"[..],
+                &b"[\r\n1,\r\n2\r\n]"[..],
+                &b"  [1, 2]  "[..],
+            ] {
+                let got = ndjson_lines(body).unwrap_or_else(|e| {
+                    panic!("{} should read: {e}", String::from_utf8_lossy(body))
+                });
+                assert_eq!(got, vec!["1", "2"], "for {}", String::from_utf8_lossy(body));
+            }
+        }
+
+        /// The shapes that already worked have to keep working: the fix moves
+        /// where the element ends, which is shared with every element kind.
+        #[test]
+        fn self_delimiting_elements_are_unchanged() {
+            for (body, want) in [
+                (
+                    &br#"[{"a":1},{"b":2}]"#[..],
+                    vec![r#"{"a":1}"#, r#"{"b":2}"#],
+                ),
+                (&br#"["s"]"#[..], vec![r#""s""#]),
+                (&br"[]"[..], vec![]),
+                (&br"[{},{}]"[..], vec!["{}", "{}"]),
+            ] {
+                let got = ndjson_lines(body).unwrap_or_else(|e| {
+                    panic!("{} should read: {e}", String::from_utf8_lossy(body))
+                });
+                assert_eq!(got, want, "for {}", String::from_utf8_lossy(body));
+            }
+        }
+
+        /// An element is only ever the bytes serde committed to it. A body
+        /// with a stray byte after the array must still yield `1`, not `1]` —
+        /// a row that is not valid JSON and is not in the file.
+        #[test]
+        fn a_trailing_byte_is_never_folded_into_the_element() {
+            let got = ndjson_lines(br"[1]]").expect("should read the closed array");
+            assert_eq!(got, vec!["1"]);
+        }
+
+        /// An array cut short mid-scalar has no closing `]`, and must be
+        /// reported rather than read as a complete one.
+        ///
+        /// A body ending on the separator instead — `[1,` — is the separate
+        /// truncation gap tracked by #12755, which the reader shares with
+        /// object elements (`[{"a":1},`) and is not scalar-specific.
+        #[test]
+        fn a_truncated_array_is_still_reported() {
+            for body in [&br"[1,2"[..], &br"[1"[..], &br"[1.5"[..]] {
+                assert!(
+                    ndjson_lines(body).is_err(),
+                    "{} has no closing ']' and must not read clean",
+                    String::from_utf8_lossy(body)
+                );
+            }
+        }
+
+        /// Reading an element assumes the tee buffer begins at that element. A
+        /// parse error breaks that, so a caller that keeps reading has to keep
+        /// getting errors rather than a row assembled from the leftovers.
+        #[test]
+        fn a_malformed_array_keeps_failing_instead_of_yielding_a_row() {
+            let mut reader =
+                ArrayToNdjson::try_new(Cursor::new(br"[1,@ 2]".to_vec())).expect("array start");
+
+            let mut buf = [0u8; 64];
+            let n = reader
+                .read(&mut buf)
+                .expect("the first element is well formed");
+            assert_eq!(&buf[..n], b"1\n");
+
+            // `@` is where the array stops making sense. Every read from here
+            // on has to say so; the ` 2` behind it is not an element.
+            for attempt in 0..3 {
+                match reader.read(&mut buf) {
+                    Err(_) => {}
+                    Ok(0) => panic!("attempt {attempt} ended the array instead of reporting it"),
+                    Ok(n) => panic!(
+                        "attempt {attempt} yielded {:?}, which is not in the file",
+                        String::from_utf8_lossy(&buf[..n])
+                    ),
+                }
+            }
+        }
+
+        /// A body larger than one read buffer drives `fill_pending` many times
+        /// over, so any per-element bookkeeping drift shows up here.
+        #[test]
+        fn a_long_run_of_scalars_stays_aligned() {
+            let count = 5_000;
+            let body = format!(
+                "[{}]",
+                (0..count)
+                    .map(|i| i.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",")
             );
+
+            let got = ndjson_lines(body.as_bytes()).expect("should read");
+            assert_eq!(got.len(), count);
+            assert_eq!(got.first().map(String::as_str), Some("0"));
+            assert_eq!(got.last().map(String::as_str), Some("4999"));
+        }
+
+        /// The `BufRead` side is what production drives, and it hands out one
+        /// element at a time rather than the whole body.
+        #[test]
+        fn the_bufread_side_yields_the_same_elements() {
+            let mut reader =
+                ArrayToNdjson::try_new(Cursor::new(br"[1,2,3]".to_vec())).expect("array start");
+
+            let mut lines = Vec::new();
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).expect("read a line") == 0 {
+                    break;
+                }
+                lines.push(line.trim_end().to_owned());
+            }
+            assert_eq!(lines, vec!["1", "2", "3"]);
         }
     }
 


### PR DESCRIPTION
## Summary

`ArrayToNdjson` — the pull-based reader selected for any JSON body whose first non-whitespace byte is `[` — could not read an array containing a bare scalar. `[1,2,3]` failed outright with `expected ',' or ']' but found '2'`, and `[1]`, `[true]`, `[null]`, `[1.5]` all failed with `EOF while peeking next byte`. Arrays of objects or strings read fine, which is the shape the tests covered.

### Root cause

A number, `true`, `false` or `null` has no closing delimiter, so `serde_json` only knows the value ended once it reads the byte *after* it — and inside an array that byte is the array's own `,` or `]`. The reader then drained its whole tee buffer, so the delimiter went with it, and the delimiter scan that followed either landed on the next element's first byte (`expected ',' or ']' but found '2'`) or ran off the end of the input (`EOF while peeking next byte`).

Two counters, `prev_off` and `drained`, were meant to track this — the field comment on `prev_off` even reads `byte_offset() after previous element` — but they were only ever incremented in lockstep, so `prev_off - drained` was always `0` and the element boundary was never actually consulted.

### The fix

Each element is now pulled through a deserializer built for that element alone, and `StreamDeserializer::byte_offset()` — which counts what serde *committed*, excluding lookahead — decides where the element ends:

- Only the committed bytes are emitted as the NDJSON row and drained from the tee buffer.
- The lookahead byte stays in the buffer, where the existing delimiter scan finds and consumes it.
- Rebuilding the deserializer per element drops serde's copy of that byte, so it is never handed a delimiter where it expects a value.

The two dead counters are removed along with the arithmetic that read them.

Reading an element this way requires the tee buffer to begin at that element, which a failure breaks — it leaves whatever serde had read sitting in front of the next one, and those bytes have already left the inner reader, so nothing can be re-read from the right place. Two things follow, and both are now enforced:

- An element is held back until its `,` or `]` has been read, so a row is only ever published as part of a well-formed `element,` or `element]`. Publishing it first would let a caller that reads on past the error collect it from `pending` regardless.
- Any failure once the element's bytes are consumed closes the reader for good, an I/O one included.

This also removes a case that produced a row the file never contained: `[1]]` returned `1]`, the element with the swallowed delimiter glued on. It now returns `1`.

## Changes

- `crates/dataformat-json/src/stream.rs` — `ArrayToNdjson::fill_pending` builds a per-element deserializer and splits the element from serde's lookahead at `byte_offset()`; `peek_next_non_ws_byte` and `consume_delimiter` drop the `prev_off`/`drained` bookkeeping; the `stream`, `drained` and `prev_off` fields go away.
- Two existing tests asserted the bug as intended behaviour (`bare numeric elements should fail in ArrayToNdjson`) and now assert the elements that are actually read.

## Scope

Two adjacent gaps are deliberately left alone, because both are behaviour changes for bodies that read clean today and both belong to a rule still in review on #12777:

- A body that ends on the separator — `[1,` — still reads clean rather than reporting the truncation. Not scalar-specific (the reader shares it with `[{"a":1},`), and tracked by #12755; a comment on the truncation test says so.
- Content after the closing `]` — `[{"a":1}]garbage` — is still accepted and dropped. Filed as **#12786**, to be done once #12777 lands so the pull reader reuses that check rather than growing a second wording of it.

This PR does not touch the push adapter, so it does not overlap #12777.

## Performance impact

One `serde_json::Deserializer` is constructed per array element instead of one per array. It wraps the reader in `IoRead`, whose scratch buffer is an unallocated `Vec::new()`, so the construction itself does not allocate; the per-element `Box<RawValue>` allocation that dominates this path is unchanged. A 5,000-element array of bare numbers is covered by a test and reads in the same order of time as the existing 10,000-element object test beside it.

## Test plan

New `bare_scalar_elements` module in `crates/dataformat-json/src/stream.rs`:

- `each_scalar_kind_reads_as_one_element` — every row of the issue's failing table: `[1,2,3]`, `[1]`, `[true]`, `[false,true]`, `[null]`, `[1.5]`, `[-2.5e10,0]`.
- `scalars_mix_with_objects_strings_and_arrays` — `[{"a":1},2]` and `[1,{"a":2}]` in both orders, plus a nested-array element (the SODA positional-key rewrite) followed by a scalar, so an array with lookahead on some elements and not others is covered.
- `whitespace_around_scalars_is_trimmed` — whitespace either side of a scalar, including `\r\n`, where serde's lookahead lands on whitespace rather than on the delimiter.
- `self_delimiting_elements_are_unchanged` — the object, string, empty-array and empty-object shapes that already worked.
- `a_trailing_byte_is_never_folded_into_the_element` — `[1]]` yields `1`, not `1]`.
- `a_truncated_array_is_still_reported` — `[1,2`, `[1`, `[1.5` stay errors.
- `a_malformed_array_keeps_failing_instead_of_yielding_a_row` — `[1,@ 2]` yields `1`, then reports the array on every subsequent read rather than emitting `@`.
- `an_element_with_no_delimiter_is_never_published` — `[1x]` and `[1` publish nothing at all, and `[1,2` publishes only `1`; each then keeps reporting across three further reads.
- `a_long_run_of_scalars_stays_aligned` — 5,000 scalars, so per-element bookkeeping drift would show.
- `the_bufread_side_yields_the_same_elements` — the `BufRead` path production drives, one element at a time.

Every one of these fails on the pre-fix reader. Commands run:

```
make lint
make test
```

## Checklist

- [x] Regression tests fail on the old code and pass on the new
- [x] Existing tests in the crate all pass (377 lib + 5 doc)
- [x] `cargo fmt --all` clean
- [x] Clippy clean with the repo's lint set, lib and tests
- [x] No behaviour change for arrays of objects, strings or nested arrays

Fixes #12782
