### PR TITLE
fix(ci): recognise sccache's startup-timeout wording as an unusable cache (fixes #12622)

### DIFF
--- a/scripts/signoff
+++ b/scripts/signoff
@@ -818,26 +818,25 @@ readonly DISK_FULL_PATTERN='No space left on device|errno=28'
 # Anchored on sccache's own `error:` channel, which rustc, clippy and nextest
 # have no way to produce while reporting on the branch.
 #
-# The alternatives enumerate how sccache itself reports an unusable cache to a
-# wrapper invocation, taken from its source rather than from the spellings we
-# happen to have seen. `connect_or_start_server` — the whole of the path a
-# `RUSTC_WRAPPER=sccache` call takes — has exactly four outcomes, and the two
-# that abort the compile are `ServerStartup::Err`, which bails with
-# `Server startup failed: {reason}`, and `ServerStartup::TimedOut`, which bails
-# with `Timed out waiting for server startup`. `Ok` compiles and `AddrInUse`
-# retries, so neither can reach this channel. `main()` prints the first line of
-# that error as `sccache: error: {}` and every later cause as
-# `sccache: caused by: {}`, so the anchor belongs on the first line only.
+# The alternatives are taken from sccache's source rather than from the spellings
+# we happen to have seen, so the set is an enumeration and not a running tally.
+# `connect_or_start_server` is the whole of the path a `RUSTC_WRAPPER=sccache`
+# call takes, and it has four outcomes: `Ok` compiles and `AddrInUse` retries,
+# while `ServerStartup::Err` bails with `Server startup failed: {reason}` and
+# `ServerStartup::TimedOut` bails with `Timed out waiting for server startup`.
+# So those two are the ways an unusable cache reaches this channel, and the third
+# alternative below is the storage self-check's own `cache storage failed to
+# read: {…}`, for an invocation that reaches a live server and then cannot read
+# through it. sccache prints the first line of the error as `sccache: error: {}`
+# and every later cause as `sccache: caused by: {}`, so the anchor belongs on the
+# first line only.
 #
-# Hence three alternatives:
-#   - the startup failure, as observed on the pool;
-#   - the storage failure without the startup prefix, for an invocation that
-#     reaches a live server and then cannot read through it (sccache bails with
-#     `cache storage failed to read: {…}` from its storage self-check);
-#   - the startup timeout, matched on the prefix the two `TimedOut` bails share.
-#     sccache words it `Timed out waiting for server startup. Maybe the remote
-#     service is unreachable?` from the wrapper path and bare from
-#     `--start-server`, so the prefix covers both without pinning either.
+# The timeout is matched on the prefix its two bails share — sccache words it
+# `Timed out waiting for server startup. Maybe the remote service is
+# unreachable?` from the wrapper path and bare from `--start-server`. Keep it a
+# prefix: this string is an awk ERE, so the `?` ending the longer wording is a
+# quantifier, and spelling that sentence out here would match `unreachabl` plus
+# an optional `e` while reading as though it were deliberate.
 readonly CACHE_UNUSABLE_PATTERN='sccache: error: Server startup failed|sccache: error: cache storage failed|sccache: error: Timed out waiting for server startup'
 
 # Set to 1 on remote runs, where run_make_step watches build output for the

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -816,11 +816,29 @@ readonly DISK_FULL_PATTERN='No space left on device|errno=28'
 # so, exactly as the disk guard above does for a volume that filled.
 #
 # Anchored on sccache's own `error:` channel, which rustc, clippy and nextest
-# have no way to produce while reporting on the branch. Two spellings: the
-# startup failure observed on the pool, and the storage failure without the
-# startup prefix, for an invocation that reaches a live server and then cannot
-# read through it.
-readonly CACHE_UNUSABLE_PATTERN='sccache: error: Server startup failed|sccache: error: cache storage failed'
+# have no way to produce while reporting on the branch.
+#
+# The alternatives enumerate how sccache itself reports an unusable cache to a
+# wrapper invocation, taken from its source rather than from the spellings we
+# happen to have seen. `connect_or_start_server` — the whole of the path a
+# `RUSTC_WRAPPER=sccache` call takes — has exactly four outcomes, and the two
+# that abort the compile are `ServerStartup::Err`, which bails with
+# `Server startup failed: {reason}`, and `ServerStartup::TimedOut`, which bails
+# with `Timed out waiting for server startup`. `Ok` compiles and `AddrInUse`
+# retries, so neither can reach this channel. `main()` prints the first line of
+# that error as `sccache: error: {}` and every later cause as
+# `sccache: caused by: {}`, so the anchor belongs on the first line only.
+#
+# Hence three alternatives:
+#   - the startup failure, as observed on the pool;
+#   - the storage failure without the startup prefix, for an invocation that
+#     reaches a live server and then cannot read through it (sccache bails with
+#     `cache storage failed to read: {…}` from its storage self-check);
+#   - the startup timeout, matched on the prefix the two `TimedOut` bails share.
+#     sccache words it `Timed out waiting for server startup. Maybe the remote
+#     service is unreachable?` from the wrapper path and bare from
+#     `--start-server`, so the prefix covers both without pinning either.
+readonly CACHE_UNUSABLE_PATTERN='sccache: error: Server startup failed|sccache: error: cache storage failed|sccache: error: Timed out waiting for server startup'
 
 # Set to 1 on remote runs, where run_make_step watches build output for the
 # out-of-disk and unusable-cache signatures. Separates "watched, and it was

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -274,6 +274,32 @@ assert_recorder "records sccache failing to reach its storage" \
 assert_recorder "records a storage failure reported without the startup prefix" \
   'echo "sccache: error: cache storage failed to read: Unexpected (temporary)"; exit 101' \
   101 no "" yes
+# The third spelling (#12622). sccache reaches this one when the server it spawns
+# never comes up inside the startup timeout, which is how an endpoint that stops
+# answering during a run reads once the previous server has exited. Wording is
+# verbatim from sccache's `connect_or_start_server`; the second line is the same
+# bail's own continuation, unprefixed, and must not be what the guard matches.
+assert_recorder "records sccache timing out waiting for its server to start" \
+  'echo "sccache: error: Timed out waiting for server startup. Maybe the remote service is unreachable?"
+   echo "Run with SCCACHE_LOG=debug SCCACHE_NO_DAEMON=1 to get more information"
+   echo "error: process didn'"'"'t exit successfully: \`sccache /Users/runner/.rustup/toolchains/1.96.1-aarch64-apple-darwin/bin/rustc -vV\` (exit status: 2)"
+   exit 101' \
+  101 no "Timed out waiting for server startup" yes
+# `sccache --start-server` bails with the same sentence and no trailing advice,
+# so the guard anchors on the prefix the two share rather than on either whole
+# sentence — this case fails if the pattern ever pins the "Maybe the remote
+# service is unreachable?" suffix.
+assert_recorder "records the bare startup-timeout wording too" \
+  'echo "sccache: error: Timed out waiting for server startup"; exit 101' \
+  101 no "" yes
+# The other direction, as for the storage spellings: the sentence only counts on
+# sccache's own error channel. A build that merely prints it — a test asserting
+# on the wording, or a log echoed back — is still a failure about the branch.
+assert_recorder "leaves a failure unmarked when the timeout wording is only quoted" \
+  'echo "Timed out waiting for server startup"
+   echo "error[E0308]: mismatched types"
+   exit 101' \
+  101 no "E0308" no
 # The direction that matters: a genuine defect must not be excused because the
 # word sccache appeared. Only sccache's own `error:` channel counts.
 assert_recorder "leaves a compile failure unmarked when sccache merely ran" \


### PR DESCRIPTION
## Summary

The sign-off's compiler-cache guard recognised two of sccache's spellings for an
unusable cache and not the third. When the third one occurred, a run that
compiled nothing still published `signoff=failure` — a verdict *about the
branch* — so the author was sent to hunt a defect in a diff that was never
built, and the commit carried a status that disqualifies it outright.

That is the same mislabelling #12556 exists to prevent, reached through a
different wording:

```
sccache: error: Timed out waiting for server startup. Maybe the remote service is unreachable?
```

### Root cause

`CACHE_UNUSABLE_PATTERN` was assembled from the failures we had happened to
observe, so it was a running tally rather than an enumeration. This change
derives the set from sccache's source instead.

`connect_or_start_server` is the whole of the path a `RUSTC_WRAPPER=sccache`
call takes, and it has four outcomes — `Ok` compiles, `AddrInUse` retries, and
the two that abort the compile are:

| outcome | sccache bails with | matched before? |
|---|---|---|
| `ServerStartup::Err` | `Server startup failed: {reason}` | yes |
| `ServerStartup::TimedOut` | `Timed out waiting for server startup` | **no** |

The third existing alternative, `cache storage failed`, is the storage
self-check's own bail for an invocation that reaches a live server and then
cannot read through it. sccache prints the first line of an error as
`sccache: error: {}` and every later cause as `sccache: caused by: {}`, so the
guard's existing discipline of anchoring on the first line is correct and is
kept.

### Changes

- Add a third alternative to `CACHE_UNUSABLE_PATTERN` for the startup timeout.
  It is matched on the **prefix** the two `TimedOut` bails share: sccache words
  it with a trailing `Maybe the remote service is unreachable?` from the wrapper
  path and bare from `--start-server`, so the prefix covers both.
- Record why that must stay a prefix. The pattern is an awk ERE, so the `?`
  ending the longer wording is a quantifier — spelling that sentence out would
  match `unreachabl` plus an optional `e` while reading as though it were
  deliberate. Verified: `awk 'BEGIN{ if ("…unreachabl" ~ /…unreachable?/) …}'`
  matches.
- Rewrite the constant's comment to carry the enumeration and its source, so the
  next wording that turns up is checked against sccache's outcomes rather than
  appended to a list.

Behaviour is unchanged for every input the guard already classified.

### Scope

The `cache` verdict changes a failing run's *description*, never its pass/fail:
it still publishes a failure status, so nothing here can move a branch toward
`signoff=success`. The anchoring on sccache's own `error:` channel is what keeps
a genuine defect from being excused because the sentence appeared in the log,
and that direction is tested.

Not changed: `Server startup failed: Address in use`, which the existing first
alternative already matches. It is a parallel-bootstrap race rather than a cache
outage, but narrowing the alternative to exclude it would reopen the hole this
guard exists to close, and re-dispatch is the right remedy either way.

## Test plan

Four cases added to `scripts/test_signoff_disk_guard.sh`, all through the
existing `assert_recorder` harness, which feeds lines through the real watcher
in `run_make_step` and reads the verdict back the way `failure_kind` does:

- the wrapper-path wording, with its unprefixed continuation line and the
  following `process didn't exit successfully` line — recorded as a cache hit;
- the bare `--start-server` wording — recorded as a cache hit;
- the sentence quoted *without* sccache's `error:` channel alongside a real
  `E0308` — left unmarked, so a genuine defect is not excused;
- (the existing cases continue to prove the disk signature still outranks cache
  and does not cross-fire).

Neuter matrix, one arm per direction of wrongness, run against the committed
tree — every arm isolates cleanly and the pass+fail sum is constant at 61, so
nothing was destroyed rather than neutered:

| arm | expected | failures |
|---|---|---|
| revert to the two old alternatives | the two positive tests | exactly 2 |
| pin the wrapper-path suffix | the bare-wording test | exactly 1 |
| drop the `sccache: error:` anchor | the cross-fire test | exactly 1 |

- `bash scripts/test_signoff_disk_guard.sh` — **61/61** (was 57).
- The other five sign-off suites re-run unchanged: attestation-refresh 15,
  cancelled-correction 18, resolve-target 22, status 34, trusted-helpers 16.
- `bash -n scripts/signoff` clean.
- `make lint` and `make test` via `make signoff`.

`.github/workflows/signoff_disk_guard_test.yml` already triggers on both changed
paths, so these run in CI on this PR.

## Checklist

- [x] Enumerated the wordings from sccache's source, not from observed failures
- [x] Regression tests fail on the unfixed pattern and pass on the fixed one
- [x] The "genuine defect is not excused" direction is tested
- [x] No change to any input the guard already classified

Fixes #12622