### PR TITLE
fix(cache): count an invalidation as an eviction, and export the counters before one fires (fixes #12687)

### DIFF
--- a/crates/cache/benches/cache_throughput.rs
+++ b/crates/cache/benches/cache_throughput.rs
@@ -19,8 +19,8 @@ limitations under the License.
 #![allow(clippy::unit_arg)]
 
 use cache::{
-    AsTableRefs, CacheMetrics, CacheProvider, HashBuilder, LruCache, SimpleCache, Sizeable,
-    get_hash_builder,
+    AsTableRefs, CacheMetrics, CacheProvider, EvictionReason, HashBuilder, LruCache, SimpleCache,
+    Sizeable, get_hash_builder,
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion::sql::TableReference;
@@ -63,8 +63,9 @@ impl CacheMetrics for BenchValue {
     fn record_item_count(_count: u64) {}
     fn record_size(_size: u64) {}
     fn record_max_size(_size: u64) {}
-    fn record_eviction() {}
+    fn record_eviction(_reason: EvictionReason) {}
     fn update_hit_ratio(_hits: u64, _total: u64) {}
+    fn publish_counters_at_zero() {}
 }
 
 impl AsTableRefs for BenchValue {

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -51,6 +51,7 @@ pub use backend::PingoraBackend;
 
 pub use lru_cache::LruCache;
 pub use metrics::CacheMetrics;
+pub use metrics::EvictionReason;
 pub use simple_cache::SimpleCache;
 use spicepod::component::caching::SQLResultsCacheConfig;
 pub use utils::RESPONSE_STATUS_COLUMN;

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -23,12 +23,13 @@ use crate::Sizeable;
 use crate::TabledCacheProvider;
 use crate::backend::{CacheBackend, MokaBackend};
 use crate::key::PassthroughHashBuilder;
-use crate::metrics::CacheMetrics;
+use crate::metrics::{CacheMetrics, EvictionReason};
 use crate::{CacheProvider, get_hash_builder};
 use async_trait::async_trait;
 use byte_unit::Byte;
 use datafusion::sql::TableReference;
 use moka::future::Cache;
+use moka::notification::RemovalCause;
 use snafu::ResultExt;
 use spicepod::component::caching::{CacheConfig, CacheEngine, CachingPolicy};
 use std::fmt::Display;
@@ -238,6 +239,27 @@ pub fn build_from_config<V: Sizeable + CacheMetrics + Clone + Send + Sync + 'sta
     )))
 }
 
+/// Maps moka's removal cause onto the reason reported on `*_cache_evictions`,
+/// or `None` for a removal that did not take an entry out of the cache.
+///
+/// `moka`'s own `RemovalCause::was_evicted` covers only `Expired` and `Size`,
+/// which leaves out the cause that dominates an accelerated deployment:
+/// `invalidate_entries_if` — how a refresh or a DML write drops the entries
+/// referencing a table — delivers `Explicit`. An entry removed that way is just
+/// as gone as one reclaimed under size pressure, and a query that would have
+/// been served from it now misses, so it belongs on the counter.
+///
+/// `Replaced` is the one cause that is not an eviction: the key stays cached and
+/// only its value was rewritten, so nothing was lost.
+fn eviction_reason(cause: RemovalCause) -> Option<EvictionReason> {
+    match cause {
+        RemovalCause::Size => Some(EvictionReason::Size),
+        RemovalCause::Expired => Some(EvictionReason::Expired),
+        RemovalCause::Explicit => Some(EvictionReason::Invalidated),
+        RemovalCause::Replaced => None,
+    }
+}
+
 // Build the Moka cache (used for Moka backend or for table invalidation support)
 fn build_moka_cache<
     V: Sizeable + CacheMetrics + Clone + Send + Sync + 'static,
@@ -273,8 +295,8 @@ fn build_moka_cache<
         .eviction_policy(moka_eviction_policy)
         .support_invalidation_closures()
         .eviction_listener(|_key, _value, cause| {
-            if cause.was_evicted() {
-                V::record_eviction();
+            if let Some(reason) = eviction_reason(cause) {
+                V::record_eviction(reason);
             }
         })
         .build_with_hasher(PassthroughHashBuilder::new(hasher))
@@ -523,8 +545,13 @@ impl<
                 keys_to_remove
             });
 
+            // Nothing counts these for us: the eviction listener belongs to the
+            // moka cache, which this engine does not have, so a removal here is
+            // only observable if it is recorded at the call site.
             for key in keys_to_remove {
-                futures::executor::block_on(backend.remove(&key));
+                if futures::executor::block_on(backend.remove(&key)).is_some() {
+                    V::record_eviction(EvictionReason::Invalidated);
+                }
             }
         }
 
@@ -1275,6 +1302,153 @@ mod tests {
         assert!(
             cache.get_raw_key(&raw_cache_key).await.is_none(),
             "search result should be removed after table invalidation"
+        );
+    }
+
+    /// Regression test for #12687.
+    ///
+    /// A refresh drops its table's entries through `invalidate_entries_if`, which
+    /// moka reports as `Explicit` — the dominant removal cause on an accelerated
+    /// dataset. `RemovalCause::was_evicted` covers only `Expired` and `Size`, so
+    /// the mapping has to name `Explicit` itself for that removal to be counted.
+    #[test]
+    fn invalidation_is_an_eviction_but_a_replaced_value_is_not() {
+        assert_eq!(
+            eviction_reason(RemovalCause::Explicit),
+            Some(EvictionReason::Invalidated),
+            "a refresh or DML invalidation removes the entry, so it must be counted"
+        );
+        assert_eq!(
+            eviction_reason(RemovalCause::Size),
+            Some(EvictionReason::Size),
+            "size pressure must stay separable from invalidation"
+        );
+        assert_eq!(
+            eviction_reason(RemovalCause::Expired),
+            Some(EvictionReason::Expired)
+        );
+        assert_eq!(
+            eviction_reason(RemovalCause::Replaced),
+            None,
+            "a replaced value leaves the key cached, so nothing was evicted"
+        );
+    }
+
+    /// A cached value whose eviction reports are counted in-process, so a test
+    /// can assert what the cache actually reported without standing up an
+    /// `OpenTelemetry` pipeline. [`CacheMetrics`] is implemented on the type
+    /// rather than on an instance, so each test needs its own type to keep a
+    /// count only it can move.
+    macro_rules! counting_value {
+        ($name:ident, $counter:ident) => {
+            static $counter: AtomicU64 = AtomicU64::new(0);
+
+            #[derive(Clone)]
+            struct $name(CachedQueryResult);
+
+            impl Sizeable for $name {
+                fn get_memory_size(&self) -> usize {
+                    self.0.get_memory_size()
+                }
+            }
+
+            impl AsTableRefs for $name {
+                fn as_table_refs(&self) -> Arc<HashSet<TableReference>> {
+                    self.0.as_table_refs()
+                }
+            }
+
+            impl CacheMetrics for $name {
+                fn record_hit() {}
+                fn record_miss() {}
+                fn record_request() {}
+                fn record_item_count(_count: u64) {}
+                fn record_size(_size: u64) {}
+                fn record_max_size(_size: u64) {}
+                fn update_hit_ratio(_hits: u64, _total: u64) {}
+                fn publish_counters_at_zero() {}
+
+                fn record_eviction(reason: EvictionReason) {
+                    if reason == EvictionReason::Invalidated {
+                        $counter.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+        };
+    }
+
+    counting_value!(MokaCountedValue, MOKA_INVALIDATIONS);
+
+    /// Regression test for #12687: a refresh drops its table's entries through
+    /// `invalidate_entries_if`, which moka reports as `Explicit`. The removal that
+    /// dominates an accelerated dataset has to reach the eviction counter.
+    #[tokio::test]
+    async fn moka_invalidation_is_reported_as_an_eviction() {
+        let cache: LruCache<MokaCountedValue, _, _> = LruCache::new(
+            1024 * 1024,
+            Duration::from_mins(1),
+            RandomState::default(),
+            CachingPolicy::Lru,
+            CacheEngine::Moka,
+        );
+
+        let table_ref = TableReference::bare("counted_table");
+        let key = CacheKey::Query("counted_query", None).as_raw_key(cache.hasher());
+        let value = MokaCountedValue(create_test_cached_result_with_table(table_ref.clone()).await);
+        cache.put_raw_key(&key.as_u64(), value).await;
+
+        cache
+            .invalidate_for_table(table_ref)
+            .expect("should invalidate cache");
+        cache.checkpoint().await;
+
+        assert!(
+            cache.get_raw_key(&key.as_u64()).await.is_none(),
+            "the entry must actually be gone, or the count below proves nothing"
+        );
+        assert_eq!(
+            MOKA_INVALIDATIONS.load(Ordering::Relaxed),
+            1,
+            "invalidating the entry's table must report one eviction"
+        );
+    }
+
+    #[cfg(feature = "pingora")]
+    counting_value!(PingoraCountedValue, PINGORA_INVALIDATIONS);
+
+    /// The Pingora engine has no moka cache, so its invalidation removes each key
+    /// directly and never reaches an eviction listener. Without an explicit
+    /// record at that call site the removal is invisible on every engine build.
+    #[cfg(feature = "pingora")]
+    #[tokio::test]
+    async fn pingora_invalidation_is_reported_as_an_eviction() {
+        let cache: LruCache<PingoraCountedValue, _, _> = LruCache::new(
+            1024 * 1024,
+            Duration::from_mins(1),
+            RandomState::default(),
+            CachingPolicy::Lru,
+            CacheEngine::Pingora,
+        );
+
+        let table_ref = TableReference::bare("counted_table");
+        let key = CacheKey::Query("counted_query", None).as_raw_key(cache.hasher());
+        let value =
+            PingoraCountedValue(create_test_cached_result_with_table(table_ref.clone()).await);
+        cache.put_raw_key(&key.as_u64(), value).await;
+
+        cache
+            .invalidate_for_table(table_ref)
+            .expect("should invalidate cache");
+        cache.checkpoint().await;
+
+        assert!(
+            cache.get_raw_key(&key.as_u64()).await.is_none(),
+            "the entry must actually be gone, or the count below proves nothing"
+        );
+        assert_eq!(
+            PINGORA_INVALIDATIONS.load(Ordering::Relaxed),
+            1,
+            "the Pingora removal path must report the eviction itself"
         );
     }
 }

--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -17,13 +17,48 @@ limitations under the License.
 use std::sync::LazyLock;
 
 use opentelemetry::{
-    global,
+    KeyValue, global,
     metrics::{Counter, Gauge, Meter},
 };
 
 use crate::result::{
     embeddings::CachedEmbeddingResult, query::CachedQueryResult, search::CachedSearchResult,
 };
+
+/// Why an entry left the cache, reported as the `reason` attribute on
+/// `*_cache_evictions`.
+///
+/// The attribute is what lets the counter carry invalidation at all. On an
+/// accelerated dataset with a periodic refresh, [`EvictionReason::Invalidated`]
+/// is the dominant — often the only — cause, so folding it into an unlabelled
+/// total would swamp the size and expiry counts that indicate actual cache
+/// pressure. Split by reason, each stays readable on its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvictionReason {
+    /// The cache exceeded `max_size` and reclaimed an entry.
+    Size,
+    /// The entry outlived `item_ttl`.
+    Expired,
+    /// A refresh or a DML write dropped the entries referencing a table.
+    Invalidated,
+}
+
+impl EvictionReason {
+    /// Every variant, so a caller publishing the series up front cannot omit one.
+    pub const ALL: [Self; 3] = [Self::Size, Self::Expired, Self::Invalidated];
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Size => "size",
+            Self::Expired => "expired",
+            Self::Invalidated => "invalidated",
+        }
+    }
+
+    fn key_value(self) -> KeyValue {
+        KeyValue::new("reason", self.as_str())
+    }
+}
 
 macro_rules! generate_cache_metrics {
     ($prefix:literal, $name:ident) => {
@@ -116,6 +151,28 @@ macro_rules! generate_cache_metrics {
                         )
                         .build()
                 });
+
+            /// Publishes every counter in this module at zero.
+            ///
+            /// A `LazyLock` counter is only built — and so only registered with
+            /// the meter — when something first derefs it, so a counter that has
+            /// not yet fired exports no series at all, rather than a zero. An
+            /// absent series is indistinguishable from a broken exporter or a bad
+            /// scrape config (#12687). Adding zero builds the instrument and emits
+            /// the series.
+            ///
+            /// Living in the macro keeps this list from drifting away from the
+            /// counters declared beside it.
+            pub fn publish_counters_at_zero() {
+                REQUESTS.add(0, &[]);
+                HITS.add(0, &[]);
+                MISSES.add(0, &[]);
+                STALE_WHILE_REVALIDATE_SKIPPED.add(0, &[]);
+                STALE_WHILE_REVALIDATE_BACKGROUND_QUERIES.add(0, &[]);
+                for reason in EvictionReason::ALL {
+                    EVICTIONS.add(0, &[reason.key_value()]);
+                }
+            }
         }
     };
 }
@@ -132,6 +189,7 @@ pub trait CacheMetrics: Send + Sync {
         Self::record_item_count(0);
         Self::record_size(0);
         Self::record_max_size(0);
+        Self::publish_counters_at_zero();
     }
 
     fn record_hit()
@@ -152,10 +210,17 @@ pub trait CacheMetrics: Send + Sync {
     fn record_max_size(size: u64)
     where
         Self: Sized;
-    fn record_eviction()
+    fn record_eviction(reason: EvictionReason)
     where
         Self: Sized;
     fn update_hit_ratio(hits: u64, total: u64)
+    where
+        Self: Sized;
+    /// Emits every counter this cache owns at zero, so a runtime on which one has
+    /// never fired still exports its series rather than nothing at all. Each
+    /// implementation forwards to the like-named function in its metrics module,
+    /// which is generated alongside the counters it publishes.
+    fn publish_counters_at_zero()
     where
         Self: Sized;
 }
@@ -194,13 +259,17 @@ impl CacheMetrics for CachedSearchResult {
         search_results::MAX_SIZE_BYTES.record(size, &[]);
     }
 
-    fn record_eviction() {
-        search_results::EVICTIONS.add(1, &[]);
+    fn record_eviction(reason: EvictionReason) {
+        search_results::EVICTIONS.add(1, &[reason.key_value()]);
     }
 
     fn update_hit_ratio(hits: u64, total: u64) {
         let ratio = calculate_hit_ratio(hits, total);
         search_results::HIT_RATIO.record(ratio, &[]);
+    }
+
+    fn publish_counters_at_zero() {
+        search_results::publish_counters_at_zero();
     }
 }
 
@@ -229,13 +298,17 @@ impl CacheMetrics for CachedQueryResult {
         sql_results::MAX_SIZE_BYTES.record(size, &[]);
     }
 
-    fn record_eviction() {
-        sql_results::EVICTIONS.add(1, &[]);
+    fn record_eviction(reason: EvictionReason) {
+        sql_results::EVICTIONS.add(1, &[reason.key_value()]);
     }
 
     fn update_hit_ratio(hits: u64, total: u64) {
         let ratio = calculate_hit_ratio(hits, total);
         sql_results::HIT_RATIO.record(ratio, &[]);
+    }
+
+    fn publish_counters_at_zero() {
+        sql_results::publish_counters_at_zero();
     }
 }
 
@@ -264,12 +337,16 @@ impl CacheMetrics for CachedEmbeddingResult {
         embeddings::MAX_SIZE_BYTES.record(size, &[]);
     }
 
-    fn record_eviction() {
-        embeddings::EVICTIONS.add(1, &[]);
+    fn record_eviction(reason: EvictionReason) {
+        embeddings::EVICTIONS.add(1, &[reason.key_value()]);
     }
 
     fn update_hit_ratio(hits: u64, total: u64) {
         let ratio = calculate_hit_ratio(hits, total);
         embeddings::HIT_RATIO.record(ratio, &[]);
+    }
+
+    fn publish_counters_at_zero() {
+        embeddings::publish_counters_at_zero();
     }
 }

--- a/crates/runtime/tests/metrics.rs
+++ b/crates/runtime/tests/metrics.rs
@@ -35,6 +35,7 @@ use std::{
 };
 
 use app::AppBuilder;
+use cache::{metrics::CacheMetrics, result::query::CachedQueryResult};
 use futures::StreamExt;
 use opentelemetry::global;
 use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
@@ -58,6 +59,26 @@ const EXPECTED_MEMORY_METRICS: &[&str] = &[
     "process_resident_memory_bytes",
     "query_memory_pool_used_bytes",
     "cayenne_compaction_memory_pool_used_bytes",
+];
+
+/// Series the SQL results cache must export as soon as it is enabled, whether or
+/// not anything has been recorded on them yet.
+///
+/// Each instrument is a `LazyLock` that only registers with the meter when
+/// something first derefs it, so a counter that has not fired exports nothing at
+/// all — not a zero. On a healthy runtime `results_cache_evictions` and both
+/// stale-while-revalidate counters are exactly the ones that never fire, and an
+/// absent series reads as a broken exporter rather than as "nothing happened".
+const EXPECTED_RESULTS_CACHE_METRICS: &[&str] = &[
+    "results_cache_requests",
+    "results_cache_hits",
+    "results_cache_misses",
+    "results_cache_evictions",
+    "results_cache_stale_swr_count",
+    "results_cache_swr_background_query_count",
+    "results_cache_items_count",
+    "results_cache_size_bytes",
+    "results_cache_max_size_bytes",
 ];
 
 /// Small enough that the sort below cannot fit, large enough that the runtime
@@ -300,5 +321,31 @@ async fn a_mid_stream_pool_refusal_is_counted_as_resources_exhausted() {
         increment(&before, &after, "QueryExecutionError") < 1.0,
         "capacity must not also be counted as a generic execution failure; \
          counts went from {before:?} to {after:?}"
+    );
+}
+
+/// The runtime calls `init` for each configured cache at startup, and that is the
+/// only chance an instrument nothing has touched gets to appear on `/metrics`.
+#[test]
+fn cache_counters_are_exported_before_anything_is_recorded() {
+    let registry = &*PROMETHEUS;
+
+    // Exactly what `Runtime::init_cache_metrics` calls once `runtime.caching.sql_results`
+    // is configured. Nothing else in this test touches a cache instrument, so a series
+    // present afterwards was published by `init` rather than by a real cache event.
+    CachedQueryResult::init();
+
+    let reported = reported_metric_names(registry);
+    let missing: Vec<&str> = EXPECTED_RESULTS_CACHE_METRICS
+        .iter()
+        .copied()
+        .filter(|metric| !reported.contains(*metric))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "cache metrics {missing:?} were not exported after the cache was initialised, so an \
+         operator scraping a healthy runtime cannot tell them from a broken exporter; \
+         reported: {:?}",
+        sorted(&reported)
     );
 }


### PR DESCRIPTION
## Summary

`results_cache_evictions` is absent from `/metrics` on a healthy runtime, and the removal that dominates an accelerated deployment is never counted. Two independent root causes, both in `crates/cache`:

**1. A counter is not registered until it first fires.** Every cache instrument is a `LazyLock`, so it is only built — and therefore only registered with the meter — when something first derefs it. `CacheMetrics::init` published the three gauges at zero but no counter, so a cache that has never evicted exports no eviction series at all, rather than a zero. An absent series is indistinguishable from a broken exporter or a bad scrape config, which is how this surfaced. The same applied to both stale-while-revalidate counters.

**2. Invalidation was excluded from the count.** The moka eviction listener gated on `RemovalCause::was_evicted`, which is `matches!(self, Expired | Size)`. `invalidate_for_table` drops entries through `invalidate_entries_if`, which delivers `Explicit` — so a refresh or DML invalidation failed that test. On an accelerated dataset with a periodic refresh that is the dominant, often the only, removal cause. The Pingora engine compounds it: it has no moka cache, so it removes each key directly and reaches no listener at all, leaving its invalidations invisible on every build that ships the feature.

## Changes

- `EvictionReason` (`Size` / `Expired` / `Invalidated`) is reported as a `reason` attribute on `*_cache_evictions`; `record_eviction` now takes it.
- `eviction_reason` maps moka's `RemovalCause`, naming `Explicit` as `Invalidated`. `Replaced` deliberately stays uncounted — the key remains cached and only its value was rewritten, so nothing was lost.
- The Pingora invalidation path records each key it actually removes, since no listener will.
- `publish_counters_at_zero` publishes every counter at zero, and `CacheMetrics::init` calls it. It is generated inside the metrics macro, beside the counters it publishes, so the list cannot drift from them. This covers requests, hits, misses, both SWR counters, and one eviction series per reason, across all three caches.

## Why a `reason` attribute rather than a single total

Folding invalidation into an unlabelled counter would swamp the size and expiry counts that actually indicate cache pressure — on a refreshing dataset nearly every eviction would be an invalidation, and the signal operators alert on would be lost. Split by reason each stays readable on its own, and `sum(results_cache_evictions)` still gives the total.

## Compatibility

`results_cache_evictions` gains a `reason` label and now includes invalidations, so a panel plotting it as one series will show one line per reason. Queries that aggregate over the family (`sum`, `rate`) are unaffected. `reason` is a closed three-variant enum with no user-supplied input, so it introduces no label-cardinality risk.

## Verification

The mechanism the fix depends on was confirmed against the pinned `opentelemetry` 0.32 / `opentelemetry-prometheus` 0.32 / `prometheus` 0.14 stack rather than assumed: a counter that is only built exports nothing at all, while one recorded at zero exports its series — reproducing the reported symptom and confirming that publishing at zero is what fixes it.

Both new eviction tests were run against the previous behaviour first and fail there, reporting `0` where `1` is required, on each engine.

The `crates/runtime` test could not be built on this machine — the vendored OpenSSL build fails for want of a usable `perl`, which is unrelated to this change — so that one is verified by sign-off rather than locally.

## Follow-up

Publishing a series at zero also makes an *uncounted* removal path report a confident zero rather
than nothing, which is worse. The Pingora engine has exactly that gap: it removes an expired entry
inline inside `PingoraBackend::get` and records nothing, and it does not evict to `max_size` at all
(#12688). Filed as #12792 rather than fixed here — recording it needs a `CacheMetrics` bound on
`PingoraBackend<V>`, and #12694 is rewriting that file from the merge queue, so both belong in one
change after it lands. The invalidation path on that engine *is* fixed here, in `lru_cache.rs`.

## Test plan

- `make lint`
- `make test`

New tests:

- `cache::lru_cache::tests::invalidation_is_an_eviction_but_a_replaced_value_is_not` — the `RemovalCause` mapping, pinning both `Explicit` and `Replaced`.
- `cache::lru_cache::tests::moka_invalidation_is_reported_as_an_eviction` and `..::pingora_invalidation_is_reported_as_an_eviction` — end to end on each engine, asserting the entry is genuinely gone and that exactly one eviction was reported for it.
- `runtime/tests/metrics.rs::cache_counters_are_exported_before_anything_is_recorded` — scrapes the Prometheus registry after the cache is initialised and requires every results-cache series to be present, in the test binary that exists to catch metrics that never reach the operator pipeline.

## Checklist

- [x] Tests added, covering both defects and both cache engines
- [x] New tests confirmed to fail against the previous behaviour
- [x] Formatting and lints clean for the changed crate
- [x] No new label cardinality or user-supplied data on any metric attribute
- [ ] `make lint` / `make test` green via sign-off

Fixes #12687
