### PR TITLE
fix(connectors): tell an ABFS or GCS timeout from an authentication failure (fixes #12793)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,9 +4202,11 @@ checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
 name = "connector-abfs"
 version = "2.2.0-unstable"
 dependencies = [
+ "app",
  "linkme",
  "object_store 0.13.2",
  "runtime",
+ "runtime-secrets",
  "secrecy",
  "snafu",
  "tokio",
@@ -4462,9 +4464,12 @@ dependencies = [
 name = "connector-gcs"
 version = "2.2.0-unstable"
 dependencies = [
+ "app",
  "linkme",
  "object_store 0.13.2",
  "runtime",
+ "runtime-secrets",
+ "secrecy",
  "snafu",
  "tokio",
  "url",

--- a/crates/data-connectors/connector-abfs/Cargo.toml
+++ b/crates/data-connectors/connector-abfs/Cargo.toml
@@ -16,5 +16,10 @@ tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 
+[dev-dependencies]
+app = { path = "../../app" }
+runtime-secrets = { path = "../../runtime-secrets", default-features = false }
+tokio = { workspace = true, features = ["sync"] }
+
 [lints]
 workspace = true

--- a/crates/data-connectors/connector-abfs/src/lib.rs
+++ b/crates/data-connectors/connector-abfs/src/lib.rs
@@ -340,6 +340,17 @@ impl ListingTableConnector for AzureBlobFS {
     ) -> DataConnectorError {
         match error {
             object_store::Error::Generic { source, .. } => {
+                // A timeout carries no information about the credentials, so it has to
+                // be recognised before the auth-shaped branches below.
+                if let Some(timeout) = self.object_store_timeout_error(
+                    dataset,
+                    source.as_ref(),
+                    self.params.get("client_timeout").expose().ok(),
+                    "Azure Blob Storage",
+                ) {
+                    return timeout;
+                }
+
                 // Try to provide more specific error messages based on auth method
                 let has_msi = self.params.get("msi_endpoint").expose().ok().is_some();
                 let has_use_cli = self
@@ -410,3 +421,149 @@ runtime::register_data_connector!(
     CONNECTOR_NAME,
     AzureBlobFSFactory
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use app::AppBuilder;
+    use object_store::client::{HttpError, HttpErrorKind};
+    use runtime::builder::RuntimeBuilder;
+    use runtime::component::dataset::builder::DatasetBuilder;
+    use runtime_secrets::Secrets;
+    use tokio::sync::RwLock;
+
+    fn create_test_connector(params: Parameters) -> AzureBlobFS {
+        AzureBlobFS {
+            params,
+            runtime: None,
+            tokio_io_runtime: Handle::current(),
+        }
+    }
+
+    async fn create_test_parameters(params: Vec<(String, secrecy::SecretString)>) -> Parameters {
+        Parameters::try_new(
+            "abfs_test",
+            params,
+            PREFIX,
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS.as_ref(),
+        )
+        .await
+        .expect("valid ABFS test parameters")
+    }
+
+    async fn create_test_dataset() -> Dataset {
+        DatasetBuilder::try_new("abfs://test-container/data/".to_string(), "test")
+            .expect("dataset builder should be created")
+            .with_app(Arc::new(AppBuilder::new("test").build()))
+            .with_runtime(Arc::new(RuntimeBuilder::new().build().await))
+            .build()
+            .expect("dataset should be built")
+    }
+
+    /// A body-read timeout, as it reaches the connector: `object_store` classifies it
+    /// as [`HttpErrorKind::Timeout`] and then flattens it into `Error::Generic`.
+    fn timeout_error() -> object_store::Error {
+        object_store::Error::Generic {
+            store: "MicrosoftAzure",
+            source: Box::new(HttpError::new(
+                HttpErrorKind::Timeout,
+                std::io::Error::new(std::io::ErrorKind::TimedOut, "request timed out"),
+            )),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_timeout_with_client_credentials_is_not_an_auth_failure() {
+        let params =
+            create_test_parameters(vec![("client_id".to_string(), "an-id".to_string().into())])
+                .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, timeout_error())
+            .to_string();
+
+        assert!(
+            message.contains("timed out") && message.contains("client_timeout"),
+            "a timeout should be reported as one, and name client_timeout, got: {message}"
+        );
+        assert!(
+            !message.contains("authentication failed"),
+            "a timeout must not be attributed to the configured credentials, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_timeout_with_sas_string_is_not_an_auth_failure() {
+        let params = create_test_parameters(vec![(
+            "sas_string".to_string(),
+            "sv=2022-11-02".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, timeout_error())
+            .to_string();
+
+        assert!(
+            !message.contains("authentication failed"),
+            "a timeout must not be attributed to the SAS token, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_timeout_surfaces_the_configured_client_timeout() {
+        let params = create_test_parameters(vec![
+            ("client_id".to_string(), "an-id".to_string().into()),
+            ("client_timeout".to_string(), "120s".to_string().into()),
+        ])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, timeout_error())
+            .to_string();
+
+        assert!(
+            message.contains("120s"),
+            "the timeout error should surface the configured client_timeout, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_timeout_still_reports_the_authentication_failure() {
+        let params =
+            create_test_parameters(vec![("client_id".to_string(), "an-id".to_string().into())])
+                .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        // A decode error is not a timeout: the credential-shaped diagnosis is the
+        // right one here, and must survive the timeout check placed ahead of it.
+        let error = object_store::Error::Generic {
+            store: "MicrosoftAzure",
+            source: Box::new(HttpError::new(
+                HttpErrorKind::Decode,
+                std::io::Error::other("malformed response body"),
+            )),
+        };
+
+        let message = connector
+            .handle_object_store_error(&dataset, error)
+            .to_string();
+
+        assert!(
+            message.contains("client credentials authentication failed"),
+            "a non-timeout failure should keep its credential diagnosis, got: {message}"
+        );
+        assert!(
+            !message.contains("client_timeout"),
+            "a non-timeout failure must not be reported as a timeout, got: {message}"
+        );
+    }
+}

--- a/crates/data-connectors/connector-gcs/Cargo.toml
+++ b/crates/data-connectors/connector-gcs/Cargo.toml
@@ -14,5 +14,11 @@ snafu.workspace = true
 tokio.workspace = true
 url.workspace = true
 
+[dev-dependencies]
+app = { path = "../../app" }
+runtime-secrets = { path = "../../runtime-secrets", default-features = false }
+secrecy.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+
 [lints]
 workspace = true

--- a/crates/data-connectors/connector-gcs/src/lib.rs
+++ b/crates/data-connectors/connector-gcs/src/lib.rs
@@ -242,6 +242,17 @@ impl ListingTableConnector for GoogleCloudStorage {
     ) -> DataConnectorError {
         match error {
             object_store::Error::Generic { source, .. } => {
+                // A timeout carries no information about the credentials, so it has to
+                // be recognised before the auth-shaped branches below.
+                if let Some(timeout) = self.object_store_timeout_error(
+                    dataset,
+                    source.as_ref(),
+                    self.params.get("client_timeout").expose().ok(),
+                    "GCS",
+                ) {
+                    return timeout;
+                }
+
                 let has_service_account_path = self
                     .params
                     .get("service_account_path")
@@ -312,3 +323,153 @@ runtime::register_data_connector!(
     CONNECTOR_NAME,
     GoogleCloudStorageFactory
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use app::AppBuilder;
+    use object_store::client::{HttpError, HttpErrorKind};
+    use runtime::builder::RuntimeBuilder;
+    use runtime::component::dataset::builder::DatasetBuilder;
+    use runtime_secrets::Secrets;
+    use tokio::sync::RwLock;
+
+    fn create_test_connector(params: Parameters) -> GoogleCloudStorage {
+        GoogleCloudStorage {
+            params,
+            runtime: None,
+            tokio_io_runtime: Handle::current(),
+        }
+    }
+
+    async fn create_test_parameters(params: Vec<(String, secrecy::SecretString)>) -> Parameters {
+        Parameters::try_new(
+            "gcs_test",
+            params,
+            PREFIX,
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS.as_ref(),
+        )
+        .await
+        .expect("valid GCS test parameters")
+    }
+
+    async fn create_test_dataset() -> Dataset {
+        DatasetBuilder::try_new("gs://test-bucket/data/".to_string(), "test")
+            .expect("dataset builder should be created")
+            .with_app(Arc::new(AppBuilder::new("test").build()))
+            .with_runtime(Arc::new(RuntimeBuilder::new().build().await))
+            .build()
+            .expect("dataset should be built")
+    }
+
+    /// A body-read timeout, as it reaches the connector: `object_store` classifies it
+    /// as [`HttpErrorKind::Timeout`] and then flattens it into `Error::Generic`.
+    fn timeout_error() -> object_store::Error {
+        object_store::Error::Generic {
+            store: "GoogleCloudStorage",
+            source: Box::new(HttpError::new(
+                HttpErrorKind::Timeout,
+                std::io::Error::new(std::io::ErrorKind::TimedOut, "request timed out"),
+            )),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_timeout_with_service_account_is_not_an_auth_failure() {
+        let params = create_test_parameters(vec![(
+            "service_account_key".to_string(),
+            "{}".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, timeout_error())
+            .to_string();
+
+        assert!(
+            message.contains("timed out") && message.contains("client_timeout"),
+            "a timeout should be reported as one, and name client_timeout, got: {message}"
+        );
+        assert!(
+            !message.contains("authentication failed"),
+            "a timeout must not be attributed to the service account, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_timeout_with_application_default_credentials_is_not_an_auth_failure() {
+        let params = create_test_parameters(vec![(
+            "application_default_credentials".to_string(),
+            "true".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, timeout_error())
+            .to_string();
+
+        assert!(
+            !message.contains("authentication failed"),
+            "a timeout must not be attributed to application default credentials, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_timeout_surfaces_the_configured_client_timeout() {
+        let params = create_test_parameters(vec![
+            ("service_account_key".to_string(), "{}".to_string().into()),
+            ("client_timeout".to_string(), "120s".to_string().into()),
+        ])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, timeout_error())
+            .to_string();
+
+        assert!(
+            message.contains("120s"),
+            "the timeout error should surface the configured client_timeout, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_timeout_still_reports_the_authentication_failure() {
+        let params = create_test_parameters(vec![(
+            "service_account_key".to_string(),
+            "{}".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        // A decode error is not a timeout: the credential-shaped diagnosis is the
+        // right one here, and must survive the timeout check placed ahead of it.
+        let error = object_store::Error::Generic {
+            store: "GoogleCloudStorage",
+            source: Box::new(HttpError::new(
+                HttpErrorKind::Decode,
+                std::io::Error::other("malformed response body"),
+            )),
+        };
+
+        let message = connector
+            .handle_object_store_error(&dataset, error)
+            .to_string();
+
+        assert!(
+            message.contains("service account authentication failed"),
+            "a non-timeout failure should keep its credential diagnosis, got: {message}"
+        );
+        assert!(
+            !message.contains("client_timeout"),
+            "a non-timeout failure must not be reported as a timeout, got: {message}"
+        );
+    }
+}

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -44,6 +44,7 @@ use datafusion_datasource::file_groups::FileGroup;
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::{FileExtensions, PartitionedFile, TableSchema};
 use futures::TryStreamExt;
+use object_store::client::{HttpError, HttpErrorKind};
 use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt, path::Path};
 use snafu::prelude::*;
 use url::Url;
@@ -1037,6 +1038,47 @@ pub trait ListingTableConnector: DataConnector {
         }
     }
 
+    /// Builds an actionable error when `source` — the payload of an
+    /// [`object_store::Error::Generic`] — carries a transport timeout, and returns
+    /// `None` for anything else.
+    ///
+    /// An implementation of [`Self::handle_object_store_error`] that chooses its
+    /// message from the configured credentials must consult this **first**. A timeout
+    /// says nothing about the credentials, so a credential-shaped branch reached with
+    /// one in hand reports an authentication failure for a working secret and never
+    /// names `client_timeout`, the one parameter that resolves it.
+    ///
+    /// `label` names the service in the message; the documentation link is derived
+    /// from the connector's own [`Display`], which is its URL scheme.
+    fn object_store_timeout_error(
+        &self,
+        dataset: &Dataset,
+        source: &(dyn std::error::Error + 'static),
+        client_timeout: Option<&str>,
+        label: &str,
+    ) -> Option<DataConnectorError>
+    where
+        Self: Display,
+    {
+        if object_store_http_error_kind(source) != Some(HttpErrorKind::Timeout) {
+            return None;
+        }
+
+        let client_timeout = client_timeout.unwrap_or("30s (default)");
+        Some(DataConnectorError::UnableToConnectInternal {
+            dataconnector: format!("{self}"),
+            connector_component: ConnectorComponent::from(dataset),
+            source: format!(
+                "{label} request timed out (client_timeout: {client_timeout}). This often \
+                 happens when many datasets are loaded concurrently and saturate the network \
+                 or I/O. Consider increasing the `client_timeout` parameter or reducing the \
+                 number of concurrent dataset loads. See \
+                 https://spiceai.org/docs/components/data-connectors/{self}#params for details."
+            )
+            .into(),
+        })
+    }
+
     async fn create_text_table(
         &self,
         dataset: &Dataset,
@@ -1341,6 +1383,26 @@ pub trait ListingTableConnector: DataConnector {
 
         Ok(Arc::new(new_schema))
     }
+}
+
+/// Walks an `object_store` error's source chain for the typed [`HttpError`].
+///
+/// `object_store` 0.13 classifies `reqwest`/`hyper`/I/O timeouts into
+/// [`HttpErrorKind::Timeout`] and then flattens the error into
+/// [`object_store::Error::Generic`], so the classification survives only as a typed
+/// error in the source chain and has to be recovered by downcast rather than by
+/// matching on the rendered message.
+fn object_store_http_error_kind(
+    source: &(dyn std::error::Error + 'static),
+) -> Option<HttpErrorKind> {
+    let mut next = Some(source);
+    while let Some(err) = next {
+        if let Some(http_error) = err.downcast_ref::<HttpError>() {
+            return Some(http_error.kind());
+        }
+        next = err.source();
+    }
+    None
 }
 
 #[async_trait]

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -30,7 +30,6 @@ use crate::{
     dataconnector::listing::{LISTING_TABLE_PARAMETERS, ObjectVersionType},
 };
 
-use object_store::client::{HttpError, HttpErrorKind};
 use snafu::prelude::*;
 use std::any::Any;
 use std::clone::Clone;
@@ -373,30 +372,15 @@ impl ListingTableConnector for S3 {
     ) -> DataConnectorError {
         match error {
             object_store::Error::Generic { source, .. } => {
-                // object_store 0.13 preserves the transport classification
-                // (reqwest/hyper/IO timeouts) as a typed `HttpError` in the source
-                // chain. Surface timeouts with an actionable message instead of the
-                // opaque "error decoding response body" that body-read timeouts
-                // otherwise produce when many datasets are loaded concurrently.
-                if object_store_http_error_kind(source.as_ref()) == Some(HttpErrorKind::Timeout) {
-                    let client_timeout = self
-                        .params
-                        .get("client_timeout")
-                        .expose()
-                        .ok()
-                        .unwrap_or("30s (default)");
-                    return DataConnectorError::UnableToConnectInternal {
-                        dataconnector: format!("{self}"),
-                        connector_component: ConnectorComponent::from(dataset),
-                        source: format!(
-                            "S3 request timed out (client_timeout: {client_timeout}). This often \
-                             happens when many datasets are loaded concurrently and saturate the \
-                             network or I/O. Consider increasing the `client_timeout` parameter or \
-                             reducing the number of concurrent dataset loads. See {S3_DOCS}#params \
-                             for details."
-                        )
-                        .into(),
-                    };
+                // A timeout carries no information about the credentials, so it has to
+                // be recognised before the auth-shaped branch below.
+                if let Some(timeout) = self.object_store_timeout_error(
+                    dataset,
+                    source.as_ref(),
+                    self.params.get("client_timeout").expose().ok(),
+                    "S3",
+                ) {
+                    return timeout;
                 }
 
                 if self.params.get("auth").expose().ok() == Some("iam_role") {
@@ -425,24 +409,6 @@ impl ListingTableConnector for S3 {
     }
 }
 
-/// Walks an `object_store` error's source chain for the typed `HttpError`.
-/// `object_store` 0.13 classifies `reqwest`/`hyper`/I/O timeouts into
-/// `HttpErrorKind::Timeout` before flattening the error into
-/// `object_store::Error::Generic`, so we can detect timeouts via a typed downcast
-/// rather than matching on the error message.
-fn object_store_http_error_kind(
-    source: &(dyn std::error::Error + 'static),
-) -> Option<HttpErrorKind> {
-    let mut next = Some(source);
-    while let Some(err) = next {
-        if let Some(http_error) = err.downcast_ref::<HttpError>() {
-            return Some(http_error.kind());
-        }
-        next = err.source();
-    }
-    None
-}
-
 register_data_connector!("s3", S3Factory);
 
 #[cfg(test)]
@@ -453,6 +419,7 @@ mod tests {
         component::dataset::{Dataset, builder::DatasetBuilder},
     };
     use app::AppBuilder;
+    use object_store::client::{HttpError, HttpErrorKind};
     use runtime_secrets::Secrets;
     use tokio::sync::RwLock;
 


### PR DESCRIPTION
## Summary

`ListingTableConnector::handle_object_store_error` classified an `object_store::Error::Generic` by **which auth parameters were configured**, not by what actually failed. S3 checked the source chain for a transport timeout first; its two siblings did not.

So on ABFS and GCS a request that timed out was reported as an authentication failure — and as `InvalidConfiguration` rather than a connection error:

> Azure client credentials authentication failed. Verify your `client_id`, `client_secret`, and `tenant_id` are correct.

The credentials are fine. The user is sent to rotate a working secret for a network timeout, and `client_timeout` — the one parameter that resolves it, which both connectors already declare — is never mentioned.

**Root cause.** `object_store` 0.13 classifies `reqwest`/`hyper`/I/O timeouts into `HttpErrorKind::Timeout` and then flattens the error into `Error::Generic`, so the classification survives only as a typed `HttpError` in the source chain. The walk that recovers it was a private free function in `s3.rs`, which is why the sibling connectors could not reuse it.

Fixes #12793

## Changes

- `crates/runtime/src/dataconnector/listing/connector.rs` — promotes the source-chain walk to the `ListingTableConnector` surface as `object_store_timeout_error`, which returns an actionable error for a timeout and `None` for anything else. The documentation link is derived from the connector's own `Display`, which is its URL scheme.
- `crates/runtime/src/dataconnector/s3.rs` — drops the private copy and calls the shared helper. The rendered message is unchanged.
- `crates/data-connectors/connector-abfs/src/lib.rs`, `crates/data-connectors/connector-gcs/src/lib.rs` — call the helper **before** the auth-shaped branches, which is the fix.

Connectors that inherit the trait default are deliberately left alone: as #12793 notes, they are not misattributed to auth, and most declare no `client_timeout` parameter, so the advice would name one that does not exist.

## Test plan

New unit tests in each sibling connector, each exercising the real `handle_object_store_error` with the error shape `object_store` actually produces (a `Timeout`-kinded `HttpError` flattened into `Error::Generic`), with credentials configured so the pre-fix code takes the auth branch:

- a timeout with client credentials / a service account configured is reported as a timeout naming `client_timeout`, and **not** as an authentication failure — fails on the old code
- a timeout with a SAS token / application default credentials configured is likewise not an auth failure
- the configured `client_timeout` value is surfaced in the message
- a non-timeout (`Decode`) failure still reports its credential diagnosis and is not reported as a timeout — guards the check that was placed ahead of it

The existing S3 timeout tests are unchanged and continue to cover the shared helper through `S3`.

- [x] `make lint`
- [x] `make test`

## Checklist

- [x] The fix is minimal and stays in scope
- [x] Regression tests fail on the old code and pass on the new
- [x] No behaviour change for non-timeout errors on any of the three connectors
