### PR TITLE
fix(cayenne): fractional proptest scaling + batch timestamp-partition test inserts

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -822,6 +822,11 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
           INSTA_UPDATE: ${{ github.event.inputs.update_snapshots || 'no' }}
+          # Lighter Cayenne fuzz/race depth for the merge-queue gate (see
+          # crates/cayenne/tests/mutation_property_test.rs and common::env_scale);
+          # both knobs default to 1.0 (full depth) when unset.
+          CAYENNE_PROPTEST_SCALE: "0.25"
+          CAYENNE_PROPTEST_OPS_SCALE: "0.25"
 
       - name: Build testoperator
         if: needs.check_changes.outputs.relevant_changes == 'true'

--- a/crates/cayenne/tests/cdc_compaction_delete_race_test.rs
+++ b/crates/cayenne/tests/cdc_compaction_delete_race_test.rs
@@ -54,7 +54,9 @@ limitations under the License.
 //! It is timing-dependent (it provokes a real race), so it makes several
 //! attempts and uses a wide rewrite window to keep reproduction reliable; it is
 //! a *reproducer*, complemented by the broader randomized harness in
-//! `mutation_property_test.rs`.
+//! `mutation_property_test.rs`. The attempt count is scalable via
+//! `CAYENNE_PROPTEST_SCALE` (see `common::env_scale`), so CI can dial
+//! reproduction depth up or down without code changes.
 
 #![allow(clippy::expect_used)]
 #![allow(clippy::clone_on_ref_ptr)]
@@ -248,11 +250,24 @@ async fn run_once(fixture: &TestFixture, table_name: &str) -> TestResult<()> {
 
 async fn delete_during_full_rewrite_is_not_lost_impl(fixture: TestFixture) -> TestResult<()> {
     // A few independent attempts; a real timing race need only surface once to
-    // prove the hazard is reachable.
-    for attempt in 0..4 {
+    // prove the hazard is reachable. Scalable via `CAYENNE_PROPTEST_SCALE` for a
+    // lighter per-PR pass or a deeper nightly run; floored at 1 so the race is
+    // still exercised at least once.
+    for attempt in 0..attempt_count() {
         run_once(&fixture, &format!("race_{attempt}")).await?;
     }
     Ok(())
+}
+
+#[expect(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    reason = "common::env_scale() is always positive and the result is floored at 1.0 before casting"
+)]
+fn attempt_count() -> u64 {
+    (4.0 * common::env_scale("CAYENNE_PROPTEST_SCALE"))
+        .round()
+        .max(1.0) as u64
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -378,7 +393,7 @@ async fn run_once_position(fixture: &TestFixture, table_name: &str) -> TestResul
 async fn position_delete_during_full_rewrite_is_not_lost_impl(
     fixture: TestFixture,
 ) -> TestResult<()> {
-    for attempt in 0..4 {
+    for attempt in 0..attempt_count() {
         run_once_position(&fixture, &format!("pos_race_{attempt}")).await?;
     }
     Ok(())

--- a/crates/cayenne/tests/common/mod.rs
+++ b/crates/cayenne/tests/common/mod.rs
@@ -258,6 +258,20 @@ pub async fn poll_inlined_data_count_zero(
     }
 }
 
+/// Read `var` as a positive scale multiplier for fuzz/stress-test depth
+/// (iteration counts, attempt counts, deadlines). Accepts fractions below 1
+/// (e.g. `0.25` for a lighter per-PR pass); a missing, non-positive, or
+/// unparseable value is treated as `1.0` (the default, full-depth run).
+/// Mirrors `mutation_property_test`'s `env_scale`, shared here so every
+/// hand-rolled race/stress test can dial CI depth the same way.
+pub fn env_scale(var: &str) -> f64 {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|&v| v > 0.0)
+        .unwrap_or(1.0)
+}
+
 /// Extract the row count from insert result batches.
 fn extract_row_count(results: &[RecordBatch]) -> u64 {
     use arrow::datatypes::DataType;

--- a/crates/cayenne/tests/inline_with_pending_deletions_test.rs
+++ b/crates/cayenne/tests/inline_with_pending_deletions_test.rs
@@ -936,7 +936,11 @@ async fn assert_no_duplicate_pk_under_concurrent_upserts(
     // A regressed publish surfaces a duplicate within the first second under this
     // contention; 5s keeps a healthy safety margin while bounding CI time. A
     // shorter run can only reduce detection power, never cause a false failure.
-    const DEADLINE: Duration = Duration::from_secs(5);
+    // Scalable via `CAYENNE_PROPTEST_OPS_SCALE` (see `common::env_scale`) for a
+    // lighter per-PR pass or a deeper nightly run; floored at 500ms.
+    let deadline = Duration::from_secs(5)
+        .mul_f64(common::env_scale("CAYENNE_PROPTEST_OPS_SCALE"))
+        .max(Duration::from_millis(500));
 
     let schema = composite_pk_schema();
     let vortex_config = cayenne::metadata::VortexConfig {
@@ -980,7 +984,7 @@ async fn assert_no_duplicate_pk_under_concurrent_upserts(
         writers.push(tokio::spawn(async move {
             let start = Instant::now();
             let mut round: i64 = 1;
-            while !stop.load(Ordering::Relaxed) && start.elapsed() < DEADLINE {
+            while !stop.load(Ordering::Relaxed) && start.elapsed() < deadline {
                 let key = (writer_id + round * NUM_WRITERS) % NUM_KEYS;
                 let batch = RecordBatch::try_new(
                     Arc::clone(&schema),

--- a/crates/cayenne/tests/mutation_model_test.rs
+++ b/crates/cayenne/tests/mutation_model_test.rs
@@ -27,6 +27,14 @@ limitations under the License.
 //! This gives strong coverage for protected-snapshot ordering, deletion cache
 //! reloads, insert-record persistence, and mixed single-row / batch mutation
 //! histories.
+//!
+//! The live in-memory read is checked after every step (cheap); the reopen
+//! (from catalog metadata) durability check runs once per sequence, after the
+//! final step, rather than after every step — reopening is the expensive part
+//! of this harness, and a bug that only shows up on reopen after an
+//! intermediate step but "heals" itself by the final step would be unusual.
+//! This trades a small amount of step-level durability coverage for a
+//! substantial reduction in per-sequence reopen cost.
 
 #![allow(clippy::expect_used)]
 
@@ -504,8 +512,7 @@ fn apply_composite_model(model: &mut CompositeModel, op: &CompositeMutationOp) {
     }
 }
 
-async fn assert_int64_state(
-    fixture: &TestFixture,
+async fn assert_int64_live_state(
     ctx: &SessionContext,
     table_name: &str,
     expected: &Int64Model,
@@ -518,18 +525,25 @@ async fn assert_int64_state(
         live_rows, expected_rows,
         "live state mismatch for {table_name} at sequence {sequence_index}, step {step_index}"
     );
-
-    let reopened_rows = reopen_and_read_int64_rows(fixture, table_name).await?;
-    assert_eq!(
-        reopened_rows, expected_rows,
-        "reopened state mismatch for {table_name} at sequence {sequence_index}, step {step_index}"
-    );
-
     Ok(())
 }
 
-async fn assert_composite_state(
+async fn assert_int64_reopened_state(
     fixture: &TestFixture,
+    table_name: &str,
+    expected: &Int64Model,
+    sequence_index: usize,
+) -> TestResult<()> {
+    let expected_rows = expected_int64_rows(expected);
+    let reopened_rows = reopen_and_read_int64_rows(fixture, table_name).await?;
+    assert_eq!(
+        reopened_rows, expected_rows,
+        "reopened state mismatch for {table_name} at sequence {sequence_index} (final step)"
+    );
+    Ok(())
+}
+
+async fn assert_composite_live_state(
     ctx: &SessionContext,
     table_name: &str,
     expected: &CompositeModel,
@@ -542,13 +556,21 @@ async fn assert_composite_state(
         live_rows, expected_rows,
         "live state mismatch for {table_name} at sequence {sequence_index}, step {step_index}"
     );
+    Ok(())
+}
 
+async fn assert_composite_reopened_state(
+    fixture: &TestFixture,
+    table_name: &str,
+    expected: &CompositeModel,
+    sequence_index: usize,
+) -> TestResult<()> {
+    let expected_rows = expected_composite_rows(expected);
     let reopened_rows = reopen_and_read_composite_rows(fixture, table_name).await?;
     assert_eq!(
         reopened_rows, expected_rows,
-        "reopened state mismatch for {table_name} at sequence {sequence_index}, step {step_index}"
+        "reopened state mismatch for {table_name} at sequence {sequence_index} (final step)"
     );
-
     Ok(())
 }
 
@@ -563,16 +585,10 @@ async fn test_exhaustive_int64_single_row_sequences_impl(fixture: TestFixture) -
         for (step_index, op) in sequence.iter().enumerate() {
             apply_int64_mutation(&table, &schema, op).await?;
             apply_int64_model(&mut expected, op);
-            assert_int64_state(
-                &fixture,
-                &ctx,
-                &table_name,
-                &expected,
-                sequence_index,
-                step_index,
-            )
-            .await?;
+            assert_int64_live_state(&ctx, &table_name, &expected, sequence_index, step_index)
+                .await?;
         }
+        assert_int64_reopened_state(&fixture, &table_name, &expected, sequence_index).await?;
     }
 
     Ok(())
@@ -591,16 +607,10 @@ async fn test_exhaustive_int64_batch_sequences_impl(fixture: TestFixture) -> Tes
         for (step_index, op) in sequence.iter().enumerate() {
             apply_int64_batch_mutation(&table, &schema, op).await?;
             apply_int64_batch_model(&mut expected, op);
-            assert_int64_state(
-                &fixture,
-                &ctx,
-                &table_name,
-                &expected,
-                sequence_index,
-                step_index,
-            )
-            .await?;
+            assert_int64_live_state(&ctx, &table_name, &expected, sequence_index, step_index)
+                .await?;
         }
+        assert_int64_reopened_state(&fixture, &table_name, &expected, sequence_index).await?;
     }
 
     Ok(())
@@ -621,16 +631,10 @@ async fn test_exhaustive_composite_single_row_sequences_impl(
         for (step_index, op) in sequence.iter().enumerate() {
             apply_composite_mutation(&table, &schema, op).await?;
             apply_composite_model(&mut expected, op);
-            assert_composite_state(
-                &fixture,
-                &ctx,
-                &table_name,
-                &expected,
-                sequence_index,
-                step_index,
-            )
-            .await?;
+            assert_composite_live_state(&ctx, &table_name, &expected, sequence_index, step_index)
+                .await?;
         }
+        assert_composite_reopened_state(&fixture, &table_name, &expected, sequence_index).await?;
     }
 
     Ok(())

--- a/crates/cayenne/tests/mutation_property_test.rs
+++ b/crates/cayenne/tests/mutation_property_test.rs
@@ -36,8 +36,10 @@ limitations under the License.
 //!
 //! Coverage is env-scalable for CI without code changes (see `env_scale`):
 //! `CAYENNE_PROPTEST_SCALE` multiplies the seed count of every config, and
-//! `CAYENNE_PROPTEST_OPS_SCALE` multiplies the per-seed op count. Both default
-//! to 1 (a fast local run).
+//! `CAYENNE_PROPTEST_OPS_SCALE` multiplies the per-seed op count. Both accept
+//! fractional values (e.g. `0.25` for a lighter per-PR pass) and default to 1
+//! (the current fast local run). Scaling never drops a config below 1 seed/op,
+//! so every config still runs on every PR — only its depth changes.
 //!
 //! All configs currently converge — the convergence/resurrection defects this
 //! harness surfaced are fixed (see the PR description for the linked fixes). If
@@ -986,20 +988,45 @@ async fn run_workload(fixture: TestFixture, w: Workload) -> TestResult<()> {
 //   * `CAYENNE_PROPTEST_OPS_SCALE` — multiplies the per-seed OP count (longer
 //     sequences = deeper histories; costlier in the concurrent configs because
 //     each op carries a small real-time sleep, so scale this more gently).
-// Both default to 1 and accept any positive integer; a missing/zero/unparseable
-// value is treated as 1.
-fn env_scale(var: &str) -> u64 {
+// Both default to 1 and accept any positive number, including fractions below 1
+// (e.g. `0.25` for a lighter per-PR pass); a missing/non-positive/unparseable
+// value is treated as 1. The scaled result is always rounded up to at least 1,
+// so no config's seed/op count can be scaled away to 0 — every config still
+// runs, just shallower.
+fn env_scale(var: &str) -> f64 {
     std::env::var(var)
         .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .filter(|&v| v > 0)
-        .unwrap_or(1)
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|&v| v > 0.0)
+        .unwrap_or(1.0)
 }
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "base seed counts are small (<1_000); exact in f64"
+)]
+#[expect(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    reason = "env_scale() is always positive and the result is floored at 1.0 before casting"
+)]
 fn scaled_seeds(base: u64) -> u64 {
-    base * env_scale("CAYENNE_PROPTEST_SCALE")
+    ((base as f64) * env_scale("CAYENNE_PROPTEST_SCALE"))
+        .round()
+        .max(1.0) as u64
 }
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "base op counts are small (<1_000); exact in f64"
+)]
+#[expect(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    reason = "env_scale() is always positive and the result is floored at 1.0 before casting"
+)]
 fn scaled_ops(base: usize) -> usize {
-    base * usize::try_from(env_scale("CAYENNE_PROPTEST_OPS_SCALE")).expect("scale fits usize")
+    ((base as f64) * env_scale("CAYENNE_PROPTEST_OPS_SCALE"))
+        .round()
+        .max(1.0) as usize
 }
 
 // ============================================================================

--- a/crates/cayenne/tests/overwrite_concurrent_scan_atomicity_test.rs
+++ b/crates/cayenne/tests/overwrite_concurrent_scan_atomicity_test.rs
@@ -58,8 +58,21 @@ type TestResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 /// Stable key set every overwrite reinserts — a correct scan always sees this count.
 const KEY_COUNT: i64 = 256;
+
 /// Bounded concurrent iterations (enough to interleave; fast enough for CI).
-const ITERATIONS: usize = 200;
+/// Scalable via `CAYENNE_PROPTEST_OPS_SCALE` (see `common::env_scale`) for a
+/// lighter per-PR pass or a deeper nightly run; floored at 1 so the race is
+/// still exercised at least once.
+#[expect(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    reason = "common::env_scale() is always positive and the result is floored at 1.0 before casting"
+)]
+fn iterations() -> usize {
+    (200.0 * common::env_scale("CAYENNE_PROPTEST_OPS_SCALE"))
+        .round()
+        .max(1.0) as usize
+}
 
 async fn setup() -> TestResult<(SessionContext, TempDir, TempDir)> {
     let data_dir = TempDir::new()?;
@@ -134,13 +147,14 @@ async fn overwrite_finish_never_exposes_a_torn_snapshot_to_a_concurrent_scan() -
     // is narrow, and a shared barrier maximizes interleaving (cf.
     // shared_metastore_concurrency_test.rs).
     let start = Arc::new(Barrier::new(2));
+    let iterations = iterations();
 
     // Writer: repeatedly OVERWRITE with the same KEY_COUNT keys (count-invariant).
     let writer_ctx = ctx.clone();
     let writer_start = Arc::clone(&start);
     let writer = tokio::spawn(async move {
         writer_start.wait().await;
-        for iteration in 0..ITERATIONS {
+        for iteration in 0..iterations {
             let salt = i64::try_from(iteration % 7).expect("salt fits i64");
             writer_ctx
                 .sql(&format!(
@@ -161,7 +175,7 @@ async fn overwrite_finish_never_exposes_a_torn_snapshot_to_a_concurrent_scan() -
     let reader = tokio::spawn(async move {
         reader_start.wait().await;
         let mut torn_observations = 0_usize;
-        for _ in 0..ITERATIONS {
+        for _ in 0..iterations {
             if scan_count(&reader_ctx).await != KEY_COUNT {
                 torn_observations += 1;
             }

--- a/crates/cayenne/tests/partition_chunking_test.rs
+++ b/crates/cayenne/tests/partition_chunking_test.rs
@@ -376,48 +376,51 @@ async fn test_timestamp_partition_with_date_part_impl(
     println!("\n--- Inserting timestamped data ---");
 
     // January 2024 data (month="2024-01")
-    for i in 0..1000 {
-        let timestamp_ms = 1_704_067_200_000_i64 + (i * 3_600_000); // Jan 1, 2024 00:00:00 UTC + i hours
-        let month = "2024-01";
-        let value = i;
-
-        ctx.sql(&format!(
-            "INSERT INTO timestamp_partitioned_table VALUES ({i}, {timestamp_ms}, {value}, '{month}')",
-        ))
-        .await?
-        .collect()
-        .await?;
-    }
+    let rows = (0..1000)
+        .map(|i| {
+            let timestamp_ms = 1_704_067_200_000_i64 + (i * 3_600_000); // Jan 1, 2024 00:00:00 UTC + i hours
+            format!("({i}, {timestamp_ms}, {i}, '2024-01')")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    ctx.sql(&format!(
+        "INSERT INTO timestamp_partitioned_table SELECT * FROM (VALUES {rows})",
+    ))
+    .await?
+    .collect()
+    .await?;
     println!("✓ Inserted 1000 rows for January (month=2024-01)");
 
     // February 2024 data (month="2024-02")
-    for i in 1000..2000 {
-        let timestamp_ms = 1_706_745_600_000_i64 + ((i - 1000) * 3_600_000); // Feb 1, 2024 00:00:00 UTC
-        let month = "2024-02";
-        let value = i;
-
-        ctx.sql(&format!(
-            "INSERT INTO timestamp_partitioned_table VALUES ({i}, {timestamp_ms}, {value}, '{month}')",
-        ))
-        .await?
-        .collect()
-        .await?;
-    }
+    let rows = (1000..2000)
+        .map(|i| {
+            let timestamp_ms = 1_706_745_600_000_i64 + ((i - 1000) * 3_600_000); // Feb 1, 2024 00:00:00 UTC
+            format!("({i}, {timestamp_ms}, {i}, '2024-02')")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    ctx.sql(&format!(
+        "INSERT INTO timestamp_partitioned_table SELECT * FROM (VALUES {rows})",
+    ))
+    .await?
+    .collect()
+    .await?;
     println!("✓ Inserted 1000 rows for February (month=2024-02)");
 
     // March 2024 data (month="2024-03")
-    for i in 2000..2500 {
-        let timestamp_ms = 1_709_251_200_000_i64 + ((i - 2000) * 3_600_000); // Mar 1, 2024 00:00:00 UTC
-        let month = "2024-03";
-        let value = i;
-
-        ctx.sql(&format!(
-            "INSERT INTO timestamp_partitioned_table VALUES ({i}, {timestamp_ms}, {value}, '{month}')",
-        ))
-        .await?
-        .collect()
-        .await?;
-    }
+    let rows = (2000..2500)
+        .map(|i| {
+            let timestamp_ms = 1_709_251_200_000_i64 + ((i - 2000) * 3_600_000); // Mar 1, 2024 00:00:00 UTC
+            format!("({i}, {timestamp_ms}, {i}, '2024-03')")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    ctx.sql(&format!(
+        "INSERT INTO timestamp_partitioned_table SELECT * FROM (VALUES {rows})",
+    ))
+    .await?
+    .collect()
+    .await?;
     println!("✓ Inserted 500 rows for March (month=2024-03)");
 
     println!("\n--- Querying partitioned timestamp data ---");

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -1243,7 +1243,11 @@ run_checks() {
   # spiced, and the release install for real, so release-only breakage — and the
   # `-p spice` resolution this no longer exercises — is still caught before trunk.
   info "Running unit tests and verifying the CLI (make nextest verify-cli)…"
-  run_make_step nextest verify-cli || return $?
+  # Lighter Cayenne fuzz/race depth for the PR gate (see
+  # crates/cayenne/tests/mutation_property_test.rs and common::env_scale); both
+  # knobs default to 1.0 (full depth) when unset, so this only affects this gate.
+  CAYENNE_PROPTEST_SCALE=0.25 CAYENNE_PROPTEST_OPS_SCALE=0.25 \
+    run_make_step nextest verify-cli || return $?
 
   SIGNOFF_CHECK_SUMMARY="lint+test passed"
 }


### PR DESCRIPTION
## Summary
Save about 15% of `make nextest` time (11-12minutes) in merge queue and signoff.yaml by
1. Reducing the depth of cayenne fuzzing.
2. Fix some cayenne testing bugs .

Cayenne's fuzz/race integration tests had several hardcoded depth constants. We add env variables to dial them down in CI.

| Test | Knob | Env variable | Before (default) | New value at gate scale=0.25 |
|---|---|---|---|---|
| `mutation_property_test` (17 configs) | seed count per config | `CAYENNE_PROPTEST_SCALE` | 6–24 seeds (varies per config) | seeds × 0.25, floored at 1 |
| `mutation_property_test` (17 configs) | op count per config | `CAYENNE_PROPTEST_OPS_SCALE` | 50–400 ops (varies per config) | ops × 0.25, floored at 1 |
| `cdc_compaction_delete_race_test` (2 tests) | attempt count | `CAYENNE_PROPTEST_SCALE` | 4 attempts | 1 attempt |
| `overwrite_concurrent_scan_atomicity_test` | `ITERATIONS` | `CAYENNE_PROPTEST_OPS_SCALE` | 200 | 50 |
| `inline_with_pending_deletions_test` (2 tests) | `DEADLINE` | `CAYENNE_PROPTEST_OPS_SCALE` | 5s | 1.25s (floored at 500ms) |

Saves approx 500-550s. When env not set, default to 1.0 (i.e. behaviour before PR). 

**Also fixed some bugs that had latency impact:  save ~165s**
- `test_timestamp_partition_with_date_part_impl` issued 2,500 sequential single-row `INSERT` statements. Batched each month into one multi-row `INSERT ... SELECT * FROM (VALUES ...)`, matching the pattern already used elsewhere in this file. Same data, same assertions. Measured: ~59s → 0.84s.
- `mutation_model_test`: moved the reopen-from-catalog durability check from every step to once per sequence (after the final step) — reopening was the expensive part of this harness; the live in-memory check still runs every step. Measured: ~106s (3 tests) → 11.83s.
