### PR TITLE
fix(connectors): report an object-store timeout as a timeout, not as bad credentials (fixes #12793)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,9 +4202,11 @@ checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
 name = "connector-abfs"
 version = "2.2.0-unstable"
 dependencies = [
+ "app",
  "linkme",
  "object_store 0.13.2",
  "runtime",
+ "runtime-secrets",
  "secrecy",
  "snafu",
  "tokio",
@@ -4462,9 +4464,12 @@ dependencies = [
 name = "connector-gcs"
 version = "2.2.0-unstable"
 dependencies = [
+ "app",
  "linkme",
  "object_store 0.13.2",
  "runtime",
+ "runtime-secrets",
+ "secrecy",
  "snafu",
  "tokio",
  "url",

--- a/crates/data-connectors/connector-abfs/Cargo.toml
+++ b/crates/data-connectors/connector-abfs/Cargo.toml
@@ -16,5 +16,9 @@ tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 
+[dev-dependencies]
+app = { path = "../../app" }
+runtime-secrets = { path = "../../runtime-secrets", default-features = false }
+
 [lints]
 workspace = true

--- a/crates/data-connectors/connector-abfs/src/lib.rs
+++ b/crates/data-connectors/connector-abfs/src/lib.rs
@@ -18,6 +18,7 @@ use runtime::Runtime;
 use runtime::component::dataset::Dataset;
 use runtime::dataconnector::listing::{
     LISTING_TABLE_PARAMETERS, ListingTableConnector, ObjectVersionType, build_fragments,
+    object_store_timeout_message,
 };
 use runtime::dataconnector::parameters::{
     Validator,
@@ -40,6 +41,8 @@ use tokio::runtime::Handle;
 use url::Url;
 
 static PREFIX: &str = "abfs";
+
+const ABFS_DOCS: &str = "https://spiceai.org/docs/components/data-connectors/abfs";
 
 static VALIDATORS: LazyLock<
     Vec<
@@ -340,6 +343,23 @@ impl ListingTableConnector for AzureBlobFS {
     ) -> DataConnectorError {
         match error {
             object_store::Error::Generic { source, .. } => {
+                // A timeout arrives in the same `Generic` variant as an authentication failure, so
+                // it is classified first: the auth checks below key off which credentials are
+                // configured, not off what failed, and would report a network timeout as a bad
+                // secret.
+                if let Some(message) = object_store_timeout_message(
+                    source.as_ref(),
+                    "Azure",
+                    self.params.get("client_timeout").expose().ok(),
+                    ABFS_DOCS,
+                ) {
+                    return DataConnectorError::UnableToConnectInternal {
+                        dataconnector: format!("{self}"),
+                        connector_component: ConnectorComponent::from(dataset),
+                        source: message.into(),
+                    };
+                }
+
                 // Try to provide more specific error messages based on auth method
                 let has_msi = self.params.get("msi_endpoint").expose().ok().is_some();
                 let has_use_cli = self
@@ -410,3 +430,154 @@ runtime::register_data_connector!(
     CONNECTOR_NAME,
     AzureBlobFSFactory
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use app::AppBuilder;
+    use object_store::client::{HttpError, HttpErrorKind};
+    use runtime::builder::RuntimeBuilder;
+    use runtime::component::dataset::builder::DatasetBuilder;
+    use runtime_secrets::Secrets;
+    use tokio::sync::RwLock;
+
+    fn create_test_connector(params: Parameters) -> AzureBlobFS {
+        AzureBlobFS {
+            params,
+            runtime: None,
+            tokio_io_runtime: Handle::current(),
+        }
+    }
+
+    /// Component parameters must be passed `abfs_`-prefixed and runtime parameters unprefixed —
+    /// `Parameters::try_new` silently drops a key on the wrong side of that rule, which would
+    /// leave a credential unset and quietly turn the tests below into no-ops.
+    async fn create_test_parameters(params: Vec<(String, secrecy::SecretString)>) -> Parameters {
+        Parameters::try_new(
+            "abfs_test",
+            params,
+            PREFIX,
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS.as_ref(),
+        )
+        .await
+        .expect("valid ABFS test parameters")
+    }
+
+    async fn create_test_dataset() -> Dataset {
+        DatasetBuilder::try_new("abfs://container/path/".to_string(), "test")
+            .expect("dataset builder should be created")
+            .with_app(Arc::new(AppBuilder::new("test").build()))
+            .with_runtime(Arc::new(RuntimeBuilder::new().build().await))
+            .build()
+            .expect("dataset should be built")
+    }
+
+    /// `object_store` flattens a transport failure into `Error::Generic`, keeping the
+    /// classification only as a typed `HttpError` in the source chain.
+    fn generic_error(kind: HttpErrorKind) -> object_store::Error {
+        object_store::Error::Generic {
+            store: "MicrosoftAzure",
+            source: Box::new(HttpError::new(
+                kind,
+                std::io::Error::other("upstream transport failure"),
+            )),
+        }
+    }
+
+    /// A timed-out request arrives in the same `Generic` variant an authentication failure does,
+    /// so classifying it by which credential is configured reports a working `client_id` as
+    /// broken and never names the parameter that resolves it (#12793).
+    #[tokio::test]
+    async fn a_timeout_is_not_reported_as_a_client_credentials_failure() {
+        let params = create_test_parameters(vec![(
+            "abfs_client_id".to_string(),
+            "00000000-0000-0000-0000-000000000000".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, generic_error(HttpErrorKind::Timeout))
+            .to_string();
+
+        assert!(
+            message.contains("client_timeout"),
+            "a timeout should point at client_timeout, got: {message}"
+        );
+        assert!(
+            !message.contains("authentication failed"),
+            "a timeout must not be reported as an authentication failure, got: {message}"
+        );
+    }
+
+    /// The same holds for the SAS and managed-identity branches: every credential the connector
+    /// keys off must lose to the timeout check, not just the first one.
+    #[tokio::test]
+    async fn a_timeout_is_not_reported_against_any_configured_credential() {
+        for credential in ["abfs_sas_string", "abfs_msi_endpoint"] {
+            let params =
+                create_test_parameters(vec![(credential.to_string(), "value".to_string().into())])
+                    .await;
+            let connector = create_test_connector(params);
+            let dataset = create_test_dataset().await;
+
+            let message = connector
+                .handle_object_store_error(&dataset, generic_error(HttpErrorKind::Timeout))
+                .to_string();
+
+            assert!(
+                message.contains("client_timeout") && !message.contains("authentication failed"),
+                "a timeout with {credential} configured must not be blamed on it, got: {message}"
+            );
+        }
+    }
+
+    /// The timeout check must not swallow the classification it runs ahead of: a `Generic` error
+    /// that is *not* a timeout is still reported against the configured credential.
+    #[tokio::test]
+    async fn a_non_timeout_error_still_reports_the_configured_auth_method() {
+        let params = create_test_parameters(vec![(
+            "abfs_client_id".to_string(),
+            "00000000-0000-0000-0000-000000000000".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, generic_error(HttpErrorKind::Decode))
+            .to_string();
+
+        assert!(
+            message.contains("client credentials authentication failed"),
+            "a non-timeout error should keep its auth classification, got: {message}"
+        );
+        assert!(
+            !message.contains("client_timeout"),
+            "a non-timeout error must not be reported as a timeout, got: {message}"
+        );
+    }
+
+    /// The message names the number to raise, not just the parameter.
+    #[tokio::test]
+    async fn a_timeout_surfaces_the_configured_client_timeout() {
+        let params = create_test_parameters(vec![(
+            "client_timeout".to_string(),
+            "120s".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, generic_error(HttpErrorKind::Timeout))
+            .to_string();
+
+        assert!(
+            message.contains("120s"),
+            "the configured client_timeout should be surfaced, got: {message}"
+        );
+    }
+}

--- a/crates/data-connectors/connector-gcs/Cargo.toml
+++ b/crates/data-connectors/connector-gcs/Cargo.toml
@@ -14,5 +14,10 @@ snafu.workspace = true
 tokio.workspace = true
 url.workspace = true
 
+[dev-dependencies]
+app = { path = "../../app" }
+runtime-secrets = { path = "../../runtime-secrets", default-features = false }
+secrecy.workspace = true
+
 [lints]
 workspace = true

--- a/crates/data-connectors/connector-gcs/src/lib.rs
+++ b/crates/data-connectors/connector-gcs/src/lib.rs
@@ -18,6 +18,7 @@ use runtime::Runtime;
 use runtime::component::dataset::Dataset;
 use runtime::dataconnector::listing::{
     LISTING_TABLE_PARAMETERS, ListingTableConnector, ObjectVersionType, build_fragments,
+    object_store_timeout_message,
 };
 use runtime::dataconnector::parameters::{Validator, gcs::GcsAuthValidator};
 use runtime::dataconnector::{
@@ -35,6 +36,8 @@ use tokio::runtime::Handle;
 use url::Url;
 
 static PREFIX: &str = "gcs";
+
+const GCS_DOCS: &str = "https://spiceai.org/docs/components/data-connectors/gcs";
 
 static VALIDATORS: LazyLock<
     Vec<
@@ -242,6 +245,23 @@ impl ListingTableConnector for GoogleCloudStorage {
     ) -> DataConnectorError {
         match error {
             object_store::Error::Generic { source, .. } => {
+                // A timeout arrives in the same `Generic` variant as an authentication failure, so
+                // it is classified first: the credential checks below key off which credentials
+                // are configured, not off what failed, and would report a network timeout as a bad
+                // service account.
+                if let Some(message) = object_store_timeout_message(
+                    source.as_ref(),
+                    "GCS",
+                    self.params.get("client_timeout").expose().ok(),
+                    GCS_DOCS,
+                ) {
+                    return DataConnectorError::UnableToConnectInternal {
+                        dataconnector: format!("{self}"),
+                        connector_component: ConnectorComponent::from(dataset),
+                        source: message.into(),
+                    };
+                }
+
                 let has_service_account_path = self
                     .params
                     .get("service_account_path")
@@ -312,3 +332,154 @@ runtime::register_data_connector!(
     CONNECTOR_NAME,
     GoogleCloudStorageFactory
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use app::AppBuilder;
+    use object_store::client::{HttpError, HttpErrorKind};
+    use runtime::builder::RuntimeBuilder;
+    use runtime::component::dataset::builder::DatasetBuilder;
+    use runtime_secrets::Secrets;
+    use tokio::sync::RwLock;
+
+    fn create_test_connector(params: Parameters) -> GoogleCloudStorage {
+        GoogleCloudStorage {
+            params,
+            runtime: None,
+            tokio_io_runtime: Handle::current(),
+        }
+    }
+
+    /// Component parameters must be passed `gcs_`-prefixed and runtime parameters unprefixed —
+    /// `Parameters::try_new` silently drops a key on the wrong side of that rule, which would
+    /// leave a credential unset and quietly turn the tests below into no-ops.
+    async fn create_test_parameters(params: Vec<(String, secrecy::SecretString)>) -> Parameters {
+        Parameters::try_new(
+            "gcs_test",
+            params,
+            PREFIX,
+            Arc::new(RwLock::new(Secrets::new())),
+            PARAMETERS.as_ref(),
+        )
+        .await
+        .expect("valid GCS test parameters")
+    }
+
+    async fn create_test_dataset() -> Dataset {
+        DatasetBuilder::try_new("gs://bucket/path/".to_string(), "test")
+            .expect("dataset builder should be created")
+            .with_app(Arc::new(AppBuilder::new("test").build()))
+            .with_runtime(Arc::new(RuntimeBuilder::new().build().await))
+            .build()
+            .expect("dataset should be built")
+    }
+
+    /// `object_store` flattens a transport failure into `Error::Generic`, keeping the
+    /// classification only as a typed `HttpError` in the source chain.
+    fn generic_error(kind: HttpErrorKind) -> object_store::Error {
+        object_store::Error::Generic {
+            store: "GoogleCloudStorage",
+            source: Box::new(HttpError::new(
+                kind,
+                std::io::Error::other("upstream transport failure"),
+            )),
+        }
+    }
+
+    /// A timed-out request arrives in the same `Generic` variant an authentication failure does,
+    /// so classifying it by which credential is configured reports a working service account as
+    /// broken and never names the parameter that resolves it (#12793).
+    #[tokio::test]
+    async fn a_timeout_is_not_reported_as_a_service_account_failure() {
+        let params = create_test_parameters(vec![(
+            "gcs_service_account_path".to_string(),
+            "/etc/gcp/service-account.json".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, generic_error(HttpErrorKind::Timeout))
+            .to_string();
+
+        assert!(
+            message.contains("client_timeout"),
+            "a timeout should point at client_timeout, got: {message}"
+        );
+        assert!(
+            !message.contains("authentication failed"),
+            "a timeout must not be reported as an authentication failure, got: {message}"
+        );
+    }
+
+    /// Application default credentials are a separate branch and must lose to the timeout check
+    /// for the same reason.
+    #[tokio::test]
+    async fn a_timeout_is_not_reported_against_application_default_credentials() {
+        let params = create_test_parameters(vec![(
+            "gcs_application_default_credentials".to_string(),
+            "true".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, generic_error(HttpErrorKind::Timeout))
+            .to_string();
+
+        assert!(
+            message.contains("client_timeout") && !message.contains("authentication failed"),
+            "a timeout with ADC configured must not be blamed on it, got: {message}"
+        );
+    }
+
+    /// The timeout check must not swallow the classification it runs ahead of: a `Generic` error
+    /// that is *not* a timeout is still reported against the configured credential.
+    #[tokio::test]
+    async fn a_non_timeout_error_still_reports_the_configured_auth_method() {
+        let params = create_test_parameters(vec![(
+            "gcs_service_account_path".to_string(),
+            "/etc/gcp/service-account.json".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, generic_error(HttpErrorKind::Decode))
+            .to_string();
+
+        assert!(
+            message.contains("service account authentication failed"),
+            "a non-timeout error should keep its auth classification, got: {message}"
+        );
+        assert!(
+            !message.contains("client_timeout"),
+            "a non-timeout error must not be reported as a timeout, got: {message}"
+        );
+    }
+
+    /// The message names the number to raise, not just the parameter.
+    #[tokio::test]
+    async fn a_timeout_surfaces_the_configured_client_timeout() {
+        let params = create_test_parameters(vec![(
+            "client_timeout".to_string(),
+            "120s".to_string().into(),
+        )])
+        .await;
+        let connector = create_test_connector(params);
+        let dataset = create_test_dataset().await;
+
+        let message = connector
+            .handle_object_store_error(&dataset, generic_error(HttpErrorKind::Timeout))
+            .to_string();
+
+        assert!(
+            message.contains("120s"),
+            "the configured client_timeout should be surfaced, got: {message}"
+        );
+    }
+}

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -44,6 +44,7 @@ use datafusion_datasource::file_groups::FileGroup;
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::{FileExtensions, PartitionedFile, TableSchema};
 use futures::TryStreamExt;
+use object_store::client::{HttpError, HttpErrorKind};
 use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt, path::Path};
 use snafu::prelude::*;
 use url::Url;
@@ -1022,6 +1023,11 @@ pub trait ListingTableConnector: DataConnector {
         Ok(())
     }
 
+    /// Turn an `object_store` error into the error the user sees.
+    ///
+    /// An implementation that inspects [`object_store::Error::Generic`] must call
+    /// [`object_store_timeout_message`] before classifying it any other way — see that function
+    /// for why.
     fn handle_object_store_error(
         &self,
         dataset: &Dataset,
@@ -1435,6 +1441,56 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
         ListingTableConnector::on_accelerated_table_registration(self, dataset, accelerated_table)
             .await
     }
+}
+
+/// Walks an `object_store` error's source chain for the typed `HttpError`.
+///
+/// `object_store` 0.13 classifies `reqwest`/`hyper`/I/O timeouts into `HttpErrorKind::Timeout`
+/// before flattening the error into `object_store::Error::Generic`, so a timeout is detectable by
+/// a typed downcast rather than by matching on the error message.
+fn object_store_http_error_kind(
+    source: &(dyn std::error::Error + 'static),
+) -> Option<HttpErrorKind> {
+    let mut next = Some(source);
+    while let Some(err) = next {
+        if let Some(http_error) = err.downcast_ref::<HttpError>() {
+            return Some(http_error.kind());
+        }
+        next = err.source();
+    }
+    None
+}
+
+/// The message for an object-store request that timed out, or `None` when `source` is not a
+/// transport timeout.
+///
+/// Every [`ListingTableConnector::handle_object_store_error`] that inspects
+/// [`object_store::Error::Generic`] must consult this **before** classifying the error any other
+/// way. `object_store` flattens a timeout into the same `Generic` variant an authentication
+/// failure arrives in, so a connector that classifies `Generic` by which credentials are
+/// configured reports a network timeout as bad credentials — sending the user to rotate a working
+/// secret while the parameter that actually resolves it goes unmentioned (#12793).
+///
+/// `client_timeout` is the connector's configured value. `None` reports `object_store`'s own
+/// default, which every connector inherits by forwarding the parameter unset.
+#[must_use]
+pub fn object_store_timeout_message(
+    source: &(dyn std::error::Error + 'static),
+    service: &str,
+    client_timeout: Option<&str>,
+    docs_url: &str,
+) -> Option<String> {
+    if object_store_http_error_kind(source) != Some(HttpErrorKind::Timeout) {
+        return None;
+    }
+
+    let client_timeout = client_timeout.unwrap_or("30s (default)");
+    Some(format!(
+        "{service} request timed out (client_timeout: {client_timeout}). This often happens when \
+         many datasets are loaded concurrently and saturate the network or I/O. Consider \
+         increasing the `client_timeout` parameter or reducing the number of concurrent dataset \
+         loads. See {docs_url}#params for details."
+    ))
 }
 
 fn refresh_skip_enabled(dataset: &Dataset) -> bool {

--- a/crates/runtime/src/dataconnector/listing/mod.rs
+++ b/crates/runtime/src/dataconnector/listing/mod.rs
@@ -21,7 +21,10 @@ use crate::parameters::{ParameterSpec, Parameters};
 
 mod connector;
 mod infer;
-pub use connector::{ListingTableConnector, ObjectVersionType, build_table_parquet_options};
+pub use connector::{
+    ListingTableConnector, ObjectVersionType, build_table_parquet_options,
+    object_store_timeout_message,
+};
 
 /// All [`super::DataConnectorFactory`] that create [`ListingTableConnector`]s should have at least these parameters returned from the associated [`super::DataConnectorFactory::parameters`].
 pub const LISTING_TABLE_PARAMETERS: &[ParameterSpec] = &[

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -30,7 +30,6 @@ use crate::{
     dataconnector::listing::{LISTING_TABLE_PARAMETERS, ObjectVersionType},
 };
 
-use object_store::client::{HttpError, HttpErrorKind};
 use snafu::prelude::*;
 use std::any::Any;
 use std::clone::Clone;
@@ -373,29 +372,19 @@ impl ListingTableConnector for S3 {
     ) -> DataConnectorError {
         match error {
             object_store::Error::Generic { source, .. } => {
-                // object_store 0.13 preserves the transport classification
-                // (reqwest/hyper/IO timeouts) as a typed `HttpError` in the source
-                // chain. Surface timeouts with an actionable message instead of the
-                // opaque "error decoding response body" that body-read timeouts
-                // otherwise produce when many datasets are loaded concurrently.
-                if object_store_http_error_kind(source.as_ref()) == Some(HttpErrorKind::Timeout) {
-                    let client_timeout = self
-                        .params
-                        .get("client_timeout")
-                        .expose()
-                        .ok()
-                        .unwrap_or("30s (default)");
+                // A timeout arrives in the same `Generic` variant as an authentication failure,
+                // so it is classified first — otherwise the `auth` check below attributes it to
+                // the configured credentials.
+                if let Some(message) = listing::object_store_timeout_message(
+                    source.as_ref(),
+                    "S3",
+                    self.params.get("client_timeout").expose().ok(),
+                    S3_DOCS,
+                ) {
                     return DataConnectorError::UnableToConnectInternal {
                         dataconnector: format!("{self}"),
                         connector_component: ConnectorComponent::from(dataset),
-                        source: format!(
-                            "S3 request timed out (client_timeout: {client_timeout}). This often \
-                             happens when many datasets are loaded concurrently and saturate the \
-                             network or I/O. Consider increasing the `client_timeout` parameter or \
-                             reducing the number of concurrent dataset loads. See {S3_DOCS}#params \
-                             for details."
-                        )
-                        .into(),
+                        source: message.into(),
                     };
                 }
 
@@ -425,24 +414,6 @@ impl ListingTableConnector for S3 {
     }
 }
 
-/// Walks an `object_store` error's source chain for the typed `HttpError`.
-/// `object_store` 0.13 classifies `reqwest`/`hyper`/I/O timeouts into
-/// `HttpErrorKind::Timeout` before flattening the error into
-/// `object_store::Error::Generic`, so we can detect timeouts via a typed downcast
-/// rather than matching on the error message.
-fn object_store_http_error_kind(
-    source: &(dyn std::error::Error + 'static),
-) -> Option<HttpErrorKind> {
-    let mut next = Some(source);
-    while let Some(err) = next {
-        if let Some(http_error) = err.downcast_ref::<HttpError>() {
-            return Some(http_error.kind());
-        }
-        next = err.source();
-    }
-    None
-}
-
 register_data_connector!("s3", S3Factory);
 
 #[cfg(test)]
@@ -453,6 +424,7 @@ mod tests {
         component::dataset::{Dataset, builder::DatasetBuilder},
     };
     use app::AppBuilder;
+    use object_store::client::{HttpError, HttpErrorKind};
     use runtime_secrets::Secrets;
     use tokio::sync::RwLock;
 


### PR DESCRIPTION
## Summary

`ListingTableConnector::handle_object_store_error` classifies an `object_store::Error::Generic` by **which auth parameters are configured**, not by what actually failed. `object_store` 0.13 flattens a transport timeout into that same `Generic` variant, keeping the classification only as a typed `HttpError` in the source chain — so ABFS and GCS, which never looked, attributed every `Generic` error to whichever credential happened to be set.

A request that timed out reached the user as:

> Azure client credentials authentication failed. Verify your `client_id`, `client_secret`, and `tenant_id` are correct.

The credentials were fine. The user was sent to rotate a working secret over a network timeout, and `client_timeout` — the one parameter that resolves it, and one both connectors already declare — was never mentioned. With no credential configured, the same failure produced the opaque generic error #5980 filed for S3.

S3 already classified the timeout first. This applies the same check to its two siblings, from one shared helper.

## Changes

- `crates/runtime/src/dataconnector/listing/connector.rs` — `object_store_timeout_message` (exported from `listing`) walks the source chain for `HttpErrorKind::Timeout` and returns the actionable message, or `None` when the error is not a timeout. It owns the default reported for an unset `client_timeout`, so the three connectors cannot drift on it. `handle_object_store_error`'s doc comment now states the ordering requirement.
- `crates/runtime/src/dataconnector/s3.rs` — uses the shared helper; the private `object_store_http_error_kind` moved into it. No behaviour change.
- `crates/data-connectors/connector-abfs/src/lib.rs`, `crates/data-connectors/connector-gcs/src/lib.rs` — consult the helper **before** the credential-based branches, so a timeout is never attributed to a credential.

## Test plan

- `make lint`
- `make test`

New unit tests in both connectors (neither crate had a test module before; `app` and `runtime-secrets` are added as dev-dependencies to build a `Dataset`, matching the existing S3 harness):

- a timeout with `client_id` / `service_account_path` configured names `client_timeout` and is **not** reported as an authentication failure — fails on the old code in both crates
- the same across every credential each connector branches on (`sas_string`, `msi_endpoint`; `application_default_credentials`), so the fix is not just ahead of the first branch
- a **non**-timeout `Generic` error still reports the configured auth method and is not mislabelled a timeout — pins the check against over-reach
- the configured `client_timeout` value is surfaced, so the message names the number to raise

The three existing S3 tests cover the refactored path unchanged.

## Checklist

- [x] Tests added and passing
- [x] `cargo clippy` clean on the touched crates (lib and `--tests`)
- [x] Error messages follow the repo's user-facing format (name the fix, link the docs)
- [x] No behaviour change on S3

Fixes #12793
