### PR TITLE
fix(ci): ask whether the runner can hold the build before starting one (fixes #12798)

### DIFF
--- a/.github/actions/build-spiced/action.yml
+++ b/.github/actions/build-spiced/action.yml
@@ -78,6 +78,56 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    # Ask whether the runner can hold the build before starting one, because the
+    # only other place to find out is inside the compiler: a volume at zero
+    # surfaces minutes later as `os error 28` against whichever crate happened to
+    # be writing, often behind a `cc-rs`/sccache frame that reads as a
+    # compiler-cache fault rather than a full disk (#12794).
+    #
+    # First step in the action, and it has to be: every later step writes to one
+    # of the volumes this measures, so any of them can die on a raw ENOSPC before
+    # the diagnostic runs. `Detect OS`, `Detect architecture` and `Check if
+    # sccache can be set up` append to `$GITHUB_OUTPUT`, `setup-sccache` appends
+    # to `$GITHUB_ENV` and writes its own config file, and `Resolve build paths`
+    # runs `mkdir -p` on the target directory — on a self-hosted runner the
+    # command files live under `RUNNER_TEMP`, beside `target/` on the same work
+    # volume. Nothing here needs those steps: the target is resolved from the
+    # input, and the script walks an absent path up to its nearest existing
+    # ancestor, which is on the volume the directory would be created on.
+    - name: Preflight disk space
+      shell: bash
+      env:
+        # Named separately from BUILD_MIN_FREE_GIB so an omitted input does not
+        # overwrite a caller's own setting with an empty step-level value —
+        # a step env key wins over the job's even when it is empty.
+        MIN_FREE_GIB_INPUT: ${{ inputs.min_free_gib }}
+        # Through the environment rather than interpolated into the script body,
+        # so a target directory containing a quote stays one argument instead of
+        # becoming shell syntax.
+        TARGET_DIR_INPUT: ${{ inputs.target_dir }}
+      run: |
+        if [ -n "$MIN_FREE_GIB_INPUT" ]; then
+          export BUILD_MIN_FREE_GIB="$MIN_FREE_GIB_INPUT"
+        fi
+
+        # target_dir is relative to bin/spiced, which is where the build steps
+        # resolve it from; an absolute value is used as given.
+        case "$TARGET_DIR_INPUT" in
+          /*|[A-Za-z]:[/\\]*) target_probe="$TARGET_DIR_INPUT" ;;
+          *) target_probe="bin/spiced/$TARGET_DIR_INPUT" ;;
+        esac
+
+        # Every volume #12794 observed at zero. RUNNER_TEMP and TMPDIR are named
+        # separately because they are not the same place on a self-hosted macOS
+        # runner: RUNNER_TEMP sits under the work volume beside target/, while
+        # TMPDIR is the per-user system temp directory sccache and cc-rs write
+        # through. The script reports one reading per volume, so naming all
+        # three costs nothing where they coincide.
+        bash "$GITHUB_ACTION_PATH/../../../scripts/preflight_build_disk.sh" \
+          "$target_probe" \
+          "${RUNNER_TEMP:-}" \
+          "${TMPDIR:-}"
+
     - name: Detect OS
       id: detect-os
       shell: bash
@@ -135,51 +185,6 @@ runs:
       with:
         minio_endpoint: ${{ inputs.minio_endpoint }}
         spiceio_endpoint: ${{ inputs.spiceio_endpoint }}
-
-    # Ask whether the runner can hold the build before starting one, because the
-    # only other place to find out is inside the compiler: a volume at zero
-    # surfaces minutes later as `os error 28` against whichever crate happened to
-    # be writing, often behind a `cc-rs`/sccache frame that reads as a
-    # compiler-cache fault rather than a full disk (#12794).
-    #
-    # Ahead of `Resolve build paths` rather than after it: that step's `mkdir -p`
-    # is itself a write to the volume in question, so on a volume at zero it can
-    # fail with a raw ENOSPC before this diagnostic ever runs. The script walks
-    # an absent path up to its nearest existing ancestor, which is on the volume
-    # the directory would be created on, so nothing is lost by measuring first.
-    - name: Preflight disk space
-      shell: bash
-      env:
-        # Named separately from BUILD_MIN_FREE_GIB so an omitted input does not
-        # overwrite a caller's own setting with an empty step-level value —
-        # a step env key wins over the job's even when it is empty.
-        MIN_FREE_GIB_INPUT: ${{ inputs.min_free_gib }}
-        # Through the environment rather than interpolated into the script body,
-        # so a target directory containing a quote stays one argument instead of
-        # becoming shell syntax.
-        TARGET_DIR_INPUT: ${{ inputs.target_dir }}
-      run: |
-        if [ -n "$MIN_FREE_GIB_INPUT" ]; then
-          export BUILD_MIN_FREE_GIB="$MIN_FREE_GIB_INPUT"
-        fi
-
-        # target_dir is relative to bin/spiced, which is where the build steps
-        # resolve it from; an absolute value is used as given.
-        case "$TARGET_DIR_INPUT" in
-          /*|[A-Za-z]:[/\\]*) target_probe="$TARGET_DIR_INPUT" ;;
-          *) target_probe="bin/spiced/$TARGET_DIR_INPUT" ;;
-        esac
-
-        # Every volume #12794 observed at zero. RUNNER_TEMP and TMPDIR are named
-        # separately because they are not the same place on a self-hosted macOS
-        # runner: RUNNER_TEMP sits under the work volume beside target/, while
-        # TMPDIR is the per-user system temp directory sccache and cc-rs write
-        # through. The script reports one reading per volume, so naming all
-        # three costs nothing where they coincide.
-        bash "$GITHUB_ACTION_PATH/../../../scripts/preflight_build_disk.sh" \
-          "$target_probe" \
-          "${RUNNER_TEMP:-}" \
-          "${TMPDIR:-}"
 
     - name: Resolve build paths
       id: resolve-build-paths

--- a/.github/actions/build-spiced/action.yml
+++ b/.github/actions/build-spiced/action.yml
@@ -56,6 +56,10 @@ inputs:
   spiceio_endpoint:
     description: 'Spiceio S3-compatible endpoint for sccache (macOS)'
     required: false
+  min_free_gib:
+    description: 'Free space (GiB) each volume the build writes to must have before it starts. Enforced only on self-hosted runners; GitHub-hosted images are reported and built anyway.'
+    required: false
+    default: '10'
 
 outputs:
   spiced_path:
@@ -153,6 +157,33 @@ runs:
         echo "target_subdir=$target_subdir" >> $GITHUB_OUTPUT
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
         echo "target_dir_relative=$target_dir_relative" >> $GITHUB_OUTPUT
+
+    # Ask whether the runner can hold the build before starting one, because the
+    # only other place to find out is inside the compiler: a volume at zero
+    # surfaces minutes later as `os error 28` against whichever crate happened to
+    # be writing, often behind a `cc-rs`/sccache frame that reads as a
+    # compiler-cache fault rather than a full disk (#12794). Placed after the
+    # paths are resolved so it measures the target directory the build will
+    # actually use, which CARGO_TARGET_DIR can put on another filesystem.
+    - name: Preflight disk space
+      shell: bash
+      env:
+        BUILD_MIN_FREE_GIB: ${{ inputs.min_free_gib }}
+        # Through the environment rather than interpolated into the script body,
+        # so a target directory containing a quote stays one argument instead of
+        # becoming shell syntax.
+        BUILD_TARGET_DIR: ${{ steps.resolve-build-paths.outputs.target_dir }}
+      run: |
+        # Every volume #12794 observed at zero. RUNNER_TEMP and TMPDIR are named
+        # separately because they are not the same place on a self-hosted macOS
+        # runner: RUNNER_TEMP sits under the work volume beside target/, while
+        # TMPDIR is the per-user system temp directory sccache and cc-rs write
+        # through. The script reports one reading per volume, so naming all
+        # three costs nothing where they coincide.
+        bash "$GITHUB_ACTION_PATH/../../../scripts/preflight_build_disk.sh" \
+          "${BUILD_TARGET_DIR:-}" \
+          "${RUNNER_TEMP:-}" \
+          "${TMPDIR:-}"
 
     - name: Build spiced (Makefile)
       if: inputs.use_makefile == 'true'

--- a/.github/actions/build-spiced/action.yml
+++ b/.github/actions/build-spiced/action.yml
@@ -57,9 +57,9 @@ inputs:
     description: 'Spiceio S3-compatible endpoint for sccache (macOS)'
     required: false
   min_free_gib:
-    description: 'Free space (GiB) each volume the build writes to must have before it starts. Enforced only on self-hosted runners; GitHub-hosted images are reported and built anyway.'
+    description: 'Free space (GiB) each volume the build writes to must have before it starts. Enforced only on self-hosted runners; GitHub-hosted images are reported and built anyway. Left empty, a caller-set BUILD_MIN_FREE_GIB applies, then the script default.'
     required: false
-    default: '10'
+    default: ''
 
 outputs:
   spiced_path:
@@ -136,6 +136,51 @@ runs:
         minio_endpoint: ${{ inputs.minio_endpoint }}
         spiceio_endpoint: ${{ inputs.spiceio_endpoint }}
 
+    # Ask whether the runner can hold the build before starting one, because the
+    # only other place to find out is inside the compiler: a volume at zero
+    # surfaces minutes later as `os error 28` against whichever crate happened to
+    # be writing, often behind a `cc-rs`/sccache frame that reads as a
+    # compiler-cache fault rather than a full disk (#12794).
+    #
+    # Ahead of `Resolve build paths` rather than after it: that step's `mkdir -p`
+    # is itself a write to the volume in question, so on a volume at zero it can
+    # fail with a raw ENOSPC before this diagnostic ever runs. The script walks
+    # an absent path up to its nearest existing ancestor, which is on the volume
+    # the directory would be created on, so nothing is lost by measuring first.
+    - name: Preflight disk space
+      shell: bash
+      env:
+        # Named separately from BUILD_MIN_FREE_GIB so an omitted input does not
+        # overwrite a caller's own setting with an empty step-level value —
+        # a step env key wins over the job's even when it is empty.
+        MIN_FREE_GIB_INPUT: ${{ inputs.min_free_gib }}
+        # Through the environment rather than interpolated into the script body,
+        # so a target directory containing a quote stays one argument instead of
+        # becoming shell syntax.
+        TARGET_DIR_INPUT: ${{ inputs.target_dir }}
+      run: |
+        if [ -n "$MIN_FREE_GIB_INPUT" ]; then
+          export BUILD_MIN_FREE_GIB="$MIN_FREE_GIB_INPUT"
+        fi
+
+        # target_dir is relative to bin/spiced, which is where the build steps
+        # resolve it from; an absolute value is used as given.
+        case "$TARGET_DIR_INPUT" in
+          /*|[A-Za-z]:[/\\]*) target_probe="$TARGET_DIR_INPUT" ;;
+          *) target_probe="bin/spiced/$TARGET_DIR_INPUT" ;;
+        esac
+
+        # Every volume #12794 observed at zero. RUNNER_TEMP and TMPDIR are named
+        # separately because they are not the same place on a self-hosted macOS
+        # runner: RUNNER_TEMP sits under the work volume beside target/, while
+        # TMPDIR is the per-user system temp directory sccache and cc-rs write
+        # through. The script reports one reading per volume, so naming all
+        # three costs nothing where they coincide.
+        bash "$GITHUB_ACTION_PATH/../../../scripts/preflight_build_disk.sh" \
+          "$target_probe" \
+          "${RUNNER_TEMP:-}" \
+          "${TMPDIR:-}"
+
     - name: Resolve build paths
       id: resolve-build-paths
       shell: bash
@@ -157,33 +202,6 @@ runs:
         echo "target_subdir=$target_subdir" >> $GITHUB_OUTPUT
         echo "target_dir=$target_dir" >> $GITHUB_OUTPUT
         echo "target_dir_relative=$target_dir_relative" >> $GITHUB_OUTPUT
-
-    # Ask whether the runner can hold the build before starting one, because the
-    # only other place to find out is inside the compiler: a volume at zero
-    # surfaces minutes later as `os error 28` against whichever crate happened to
-    # be writing, often behind a `cc-rs`/sccache frame that reads as a
-    # compiler-cache fault rather than a full disk (#12794). Placed after the
-    # paths are resolved so it measures the target directory the build will
-    # actually use, which CARGO_TARGET_DIR can put on another filesystem.
-    - name: Preflight disk space
-      shell: bash
-      env:
-        BUILD_MIN_FREE_GIB: ${{ inputs.min_free_gib }}
-        # Through the environment rather than interpolated into the script body,
-        # so a target directory containing a quote stays one argument instead of
-        # becoming shell syntax.
-        BUILD_TARGET_DIR: ${{ steps.resolve-build-paths.outputs.target_dir }}
-      run: |
-        # Every volume #12794 observed at zero. RUNNER_TEMP and TMPDIR are named
-        # separately because they are not the same place on a self-hosted macOS
-        # runner: RUNNER_TEMP sits under the work volume beside target/, while
-        # TMPDIR is the per-user system temp directory sccache and cc-rs write
-        # through. The script reports one reading per volume, so naming all
-        # three costs nothing where they coincide.
-        bash "$GITHUB_ACTION_PATH/../../../scripts/preflight_build_disk.sh" \
-          "${BUILD_TARGET_DIR:-}" \
-          "${RUNNER_TEMP:-}" \
-          "${TMPDIR:-}"
 
     - name: Build spiced (Makefile)
       if: inputs.use_makefile == 'true'

--- a/.github/workflows/build_disk_preflight_test.yml
+++ b/.github/workflows/build_disk_preflight_test.yml
@@ -1,0 +1,58 @@
+---
+name: Build Disk Preflight Tests
+
+# `scripts/preflight_build_disk.sh` decides whether a build job gets blamed on
+# the runner or left to fail as a broken branch, and both directions cost
+# something real. Under-reporting is the condition #12794 describes: an
+# out-of-disk host fails minutes in with `os error 28` on a crate the branch
+# never touched, and the merge queue freezes while the failure is triaged as a
+# compiler-cache fault. Over-reporting would refuse builds that pass today —
+# every GitHub-hosted image sits below any floor useful for the self-hosted
+# pool — so the "report but build anyway" paths are tested as carefully as the
+# refusal.
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - 'scripts/preflight_build_disk.sh'
+      - 'scripts/test_preflight_build_disk.sh'
+      - '.github/actions/build-spiced/action.yml'
+      - '.github/workflows/build_disk_preflight_test.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'scripts/preflight_build_disk.sh'
+      - 'scripts/test_preflight_build_disk.sh'
+      - '.github/actions/build-spiced/action.yml'
+      - '.github/workflows/build_disk_preflight_test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  test-build-disk-preflight:
+    name: Unit tests for the build disk preflight
+    # GitHub-hosted on purpose: this is a sub-second check and must not queue
+    # behind the self-hosted pool whose full disks it exists to report.
+    runs-on: ubuntu-24.04
+    # A checkout plus a local bash script against a stub `df` — the job reads
+    # the repository and nothing else, so it needs no write scope.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run tests
+        # Invoked through `bash` rather than as `./…` so the job does not depend
+        # on the script's executable bit surviving a checkout on every platform.
+        run: bash scripts/test_preflight_build_disk.sh

--- a/scripts/preflight_build_disk.sh
+++ b/scripts/preflight_build_disk.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Refuse a build the runner's volumes cannot hold, before `make` writes a byte.
+#
+# Without this the condition surfaces from inside the compiler, several minutes
+# in, as `No space left on device (os error 28)` against whichever crate was
+# writing at the time — usually one the branch never touched, and often behind a
+# `cc-rs`/sccache frame that reads as a compiler-cache fault instead (#12794).
+# `scripts/signoff` already refuses on the same grounds for the sign-off path;
+# this is the same reading for the build path, so a full host is reported the
+# same way whichever job lands on it.
+#
+# Fatal only on a self-hosted runner. GitHub-hosted images ship with far less
+# free space than a self-hosted host needs, and builds complete there today, so
+# a floor tuned for the pool must not fail them: hosted runners get the reading
+# and nothing else.
+#
+# Usage: scripts/preflight_build_disk.sh <path> [<path>...]
+#
+# Environment:
+#   BUILD_MIN_FREE_GIB   Free space (GiB) each measured volume must have before
+#                        the build starts (default: 10). A volume below this
+#                        cannot finish a release build of this workspace, so
+#                        the floor names a certainty rather than a preference.
+#                        Set it to 0 to report the readings and refuse nothing,
+#                        which is the escape hatch if the floor is ever wrong
+#                        for a host: it needs no change to this script.
+#   RUNNER_ENVIRONMENT   Set by Actions to `self-hosted` or `github-hosted`.
+#                        Anything else — an unset value, a local run — reports
+#                        without failing.
+
+set -uo pipefail
+
+readonly DEFAULT_MIN_FREE_GIB=10
+
+# Exit status for "the runner cannot hold this build". Distinct from 1 so a
+# caller can tell the refusal from this script failing to run at all.
+readonly EXIT_DISK_EXHAUSTED=70
+
+info() { printf '%s\n' "$*" >&2; }
+
+# "<device> <free_gib>" for the volume holding $1, from one `df`. Reporting both
+# together is what lets two of the build's paths on one volume be recognised as
+# one volume without asking twice.
+#
+# Fails rather than guessing: an unmeasurable volume must read as "unknown",
+# never as "full", because refusing a build on a reading we do not have is the
+# worse error.
+measure_volume() {
+  local path="$1" reading free
+  command -v df >/dev/null 2>&1 || return 1
+  # -P: POSIX one-line-per-filesystem output, so the fields are reliably placed
+  # even when a long device name would otherwise wrap.
+  # -k: 1024-byte blocks on macOS (whose df defaults to 512) as well as Linux.
+  reading=$(df -Pk "$path" 2>/dev/null | awk 'NR==2 { print $1, int($4 / 1048576) }') || return 1
+  free="${reading##* }"
+  [[ "$free" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$reading"
+}
+
+# Actions surfaces. Both no-op outside a workflow, so the script runs the same
+# way from a shell.
+annotate() {
+  echo "::error title=Runner out of disk::$*"
+}
+
+append_step_summary() {
+  [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
+  printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+}
+
+main() {
+  if [[ $# -eq 0 ]]; then
+    info "usage: ${0##*/} <path> [<path>...]"
+    return 2
+  fi
+
+  local min="${BUILD_MIN_FREE_GIB:-$DEFAULT_MIN_FREE_GIB}"
+  if [[ ! "$min" =~ ^[0-9]+$ ]]; then
+    info "warning: BUILD_MIN_FREE_GIB='${min}' is not an integer — using ${DEFAULT_MIN_FREE_GIB}"
+    min="$DEFAULT_MIN_FREE_GIB"
+  fi
+  # Force base 10: bash arithmetic reads a leading zero as octal, so a
+  # well-meaning `BUILD_MIN_FREE_GIB=08` is an arithmetic error rather than 8.
+  min=$((10#$min))
+
+  # Plain strings rather than arrays: this runs under whichever bash the runner
+  # provides, and bash 3.2 — still /bin/bash on macOS — errors on `${#arr[@]}`
+  # for an empty array under `set -u`.
+  local seen_ids="" detail="" short_count=0
+  local path reading free id
+
+  for path in "$@"; do
+    [[ -n "$path" ]] || continue
+    # Measure something that exists: a target directory the build has not
+    # created yet would otherwise report nothing, which is exactly the
+    # first-build-on-a-fresh-runner case. The nearest existing ancestor is on
+    # the same volume the directory will be created on.
+    while [[ ! -e "$path" && "$path" != "/" && "$path" != "." && "$path" != *: ]]; do
+      local parent="${path%/*}"
+      [[ "$parent" != "$path" ]] || break
+      path="${parent:-/}"
+    done
+
+    if ! reading=$(measure_volume "$path"); then
+      info "note: could not measure free space on ${path} — not treating that as full"
+      continue
+    fi
+    id="${reading%% *}"
+    free="${reading##* }"
+
+    # One physical volume reported once, however many of the build's paths land
+    # on it — the usual case, where target/ and TMPDIR share a disk.
+    case "${seen_ids}" in
+      *"|${id}|"*) continue ;;
+    esac
+    seen_ids="${seen_ids}|${id}|"
+
+    info "free space on ${path}: ${free} GiB (floor ${min} GiB)"
+    if (( free < min )); then
+      detail="${detail}${path} has ${free} GiB free; "
+      short_count=$((short_count + 1))
+    fi
+  done
+
+  if (( short_count == 0 )); then
+    return 0
+  fi
+
+  local runner="${RUNNER_NAME:-this runner}"
+  detail="${detail%; }"
+
+  # A hosted runner is reported and allowed through: its image is smaller than
+  # any floor a self-hosted host needs, and these builds pass there today.
+  if [[ "${RUNNER_ENVIRONMENT:-}" != "self-hosted" ]]; then
+    info "warning: below the ${min} GiB build floor (${detail}) — building anyway on a ${RUNNER_ENVIRONMENT:-non-self-hosted} runner"
+    return 0
+  fi
+
+  info "Not enough disk to build on ${runner}: ${detail}, below the ${min} GiB floor."
+  info "  The build did not start, so the branch was not evaluated."
+  info "  Reclaim space on this runner — stale _work checkouts, target/ trees and the local sccache directory accumulate, and several runner instances share the volume."
+  annotate "${detail}, below the ${min} GiB floor on ${runner}. The build did not start and the branch was not evaluated: reclaim space on this runner and re-run."
+  append_step_summary "### Preflight: not enough disk to build"$'\n'"On \`${runner}\`: ${detail}, below the **${min} GiB** floor, so the build did not start and **the branch was not evaluated**. This is an infrastructure failure, not a code failure: reclaim space on this runner (\`target/\` and the local sccache directory are shared across branches, and several runner instances share the volume) and re-run. Adjust the floor with \`BUILD_MIN_FREE_GIB\`."$'\n'
+  return "$EXIT_DISK_EXHAUSTED"
+}
+
+main "$@"

--- a/scripts/preflight_build_disk.sh
+++ b/scripts/preflight_build_disk.sh
@@ -52,7 +52,14 @@ measure_volume() {
   # -P: POSIX one-line-per-filesystem output, so the fields are reliably placed
   # even when a long device name would otherwise wrap.
   # -k: 1024-byte blocks on macOS (whose df defaults to 512) as well as Linux.
-  reading=$(df -Pk "$path" 2>/dev/null | awk 'NR==2 { print $1, int($4 / 1048576) }') || return 1
+  #
+  # awk checks that Available is a number before dividing, because it would
+  # otherwise coerce a non-numeric field to 0 — and a 0 that came from garbage
+  # is indistinguishable, downstream, from a volume genuinely at zero. That is
+  # the "unknown is never full" rule failing in the one direction that refuses
+  # a build it should not.
+  reading=$(df -Pk "$path" 2>/dev/null |
+    awk 'NR==2 && $4 ~ /^[0-9]+$/ { print $1, int($4 / 1048576) }') || return 1
   free="${reading##* }"
   [[ "$free" =~ ^[0-9]+$ ]] || return 1
   printf '%s\n' "$reading"
@@ -98,7 +105,11 @@ main() {
     # the same volume the directory will be created on.
     while [[ ! -e "$path" && "$path" != "/" && "$path" != "." && "$path" != *: ]]; do
       local parent="${path%/*}"
-      [[ "$parent" != "$path" ]] || break
+      # A relative path with no slash left — `target` — strips to itself, so
+      # walking further is a loop. Its parent is the working directory, which
+      # is the volume it would be created on, so ask about that rather than
+      # giving up and silently measuring nothing.
+      [[ "$parent" != "$path" ]] || { path="."; break; }
       path="${parent:-/}"
     done
 

--- a/scripts/test_preflight_build_disk.sh
+++ b/scripts/test_preflight_build_disk.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+#
+# Unit tests for `scripts/preflight_build_disk.sh`, the check that refuses a
+# build on a runner whose volumes cannot hold it.
+#
+# Both directions are load-bearing. Under-reporting leaves the condition to
+# surface from inside the compiler as `os error 28` on an unrelated crate, which
+# is how #12794 came to be triaged as a compiler-cache fault. Over-reporting is
+# worse: it would refuse builds that complete today — on a GitHub-hosted image,
+# or on any volume the script could not actually measure — and a floor tuned for
+# the self-hosted pool must never do that.
+#
+# No network, no runner, no real disk: a stub `df` on PATH reports whatever each
+# case needs, keyed by the path it is asked about, so a case can put two paths
+# on one volume or on two.
+#
+# Usage: scripts/test_preflight_build_disk.sh
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+subject="$script_dir/preflight_build_disk.sh"
+
+tests_run=0
+failures=0
+
+fail_test() {
+  failures=$((failures + 1))
+  echo "  FAIL: $1"
+}
+
+stub_dir="$(mktemp -d)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$stub_dir" "$work_dir"' EXIT
+
+# A `df` whose answers come from $STUB_MAP: one `path|device|free_kb` line per
+# path, with STUB_DEFAULT used for anything unlisted. STUB_DF_RC makes it fail
+# outright and STUB_DF_GARBAGE makes it print something unparseable — both are
+# "unknown free space", which must never read as "full".
+cat >"$stub_dir/df" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+[[ "${STUB_DF_RC:-0}" == "0" ]] || exit "${STUB_DF_RC}"
+if [[ -n "${STUB_DF_GARBAGE:-}" ]]; then
+  echo "df: something went sideways"
+  exit 0
+fi
+target="${*: -1}"
+device="/dev/disk1"
+free_kb="${STUB_DEFAULT:-104857600}"
+if [[ -n "${STUB_MAP:-}" ]]; then
+  while IFS='|' read -r map_path map_device map_free; do
+    [[ -n "$map_path" ]] || continue
+    if [[ "$target" == "$map_path" ]]; then
+      device="$map_device"
+      free_kb="$map_free"
+      break
+    fi
+  done <<<"${STUB_MAP}"
+fi
+echo "Filesystem 1024-blocks      Used Available Capacity Mounted on"
+echo "${device}   1000000000 500000000 ${free_kb}       50% /"
+STUB
+chmod +x "$stub_dir/df"
+
+gib_to_kb() { echo $(( $1 * 1048576 )); }
+
+# Runs the subject in a fresh bash with the stub `df` first on PATH. Every
+# variable the case wants set is passed in the environment, so no case can leak
+# state into the next. Echoes "<rc>|<output>", with stderr folded in because the
+# diagnostic the operator reads is written there.
+run_subject() {
+  local output rc
+  output=$(PATH="$stub_dir:$PATH" bash "$subject" "$@" 2>&1)
+  rc=$?
+  printf '%s|%s' "$rc" "$output"
+}
+
+expect_rc() {
+  local label="$1" want="$2" got="$3"
+  tests_run=$((tests_run + 1))
+  [[ "${got%%|*}" == "$want" ]] || fail_test "$label: expected rc ${want}, got ${got%%|*} (${got#*|})"
+}
+
+expect_contains() {
+  local label="$1" needle="$2" got="$3"
+  tests_run=$((tests_run + 1))
+  case "${got#*|}" in
+    *"$needle"*) ;;
+    *) fail_test "$label: expected output to contain '${needle}', got: ${got#*|}" ;;
+  esac
+}
+
+expect_not_contains() {
+  local label="$1" needle="$2" got="$3"
+  tests_run=$((tests_run + 1))
+  case "${got#*|}" in
+    *"$needle"*) fail_test "$label: expected output NOT to contain '${needle}', got: ${got#*|}" ;;
+  esac
+}
+
+echo "Testing scripts/preflight_build_disk.sh"
+
+# --- The refusal, and who it applies to ------------------------------------
+
+echo "- a self-hosted runner below the floor refuses the build"
+result=$(STUB_DEFAULT="$(gib_to_kb 3)" RUNNER_ENVIRONMENT=self-hosted RUNNER_NAME=mbp-runner-04-01 \
+  run_subject "$work_dir")
+expect_rc "self-hosted below floor" 70 "$result"
+expect_contains "self-hosted below floor" "3 GiB free" "$result"
+expect_contains "self-hosted names the runner" "mbp-runner-04-01" "$result"
+# The whole point of the diagnostic: an operator must not read this as a broken
+# branch, which is the mistake the raw compiler error invites.
+expect_contains "self-hosted says the branch was not evaluated" "the branch was not evaluated" "$result"
+expect_contains "self-hosted annotates the run" "::error title=Runner out of disk::" "$result"
+
+echo "- a GitHub-hosted runner below the floor reports and builds anyway"
+result=$(STUB_DEFAULT="$(gib_to_kb 3)" RUNNER_ENVIRONMENT=github-hosted \
+  run_subject "$work_dir")
+expect_rc "github-hosted below floor" 0 "$result"
+expect_contains "github-hosted warns" "building anyway" "$result"
+expect_not_contains "github-hosted does not annotate" "::error" "$result"
+
+echo "- an unset RUNNER_ENVIRONMENT reports and builds anyway"
+result=$(STUB_DEFAULT="$(gib_to_kb 3)" run_subject "$work_dir")
+expect_rc "no runner environment" 0 "$result"
+expect_contains "no runner environment warns" "building anyway" "$result"
+
+echo "- a self-hosted runner above the floor passes"
+result=$(STUB_DEFAULT="$(gib_to_kb 400)" RUNNER_ENVIRONMENT=self-hosted run_subject "$work_dir")
+expect_rc "self-hosted above floor" 0 "$result"
+expect_contains "self-hosted above floor reports the reading" "400 GiB" "$result"
+
+echo "- exactly at the floor passes"
+result=$(STUB_DEFAULT="$(gib_to_kb 10)" RUNNER_ENVIRONMENT=self-hosted run_subject "$work_dir")
+expect_rc "at the floor" 0 "$result"
+
+# --- Unknown is not full ----------------------------------------------------
+
+echo "- a df that fails does not refuse the build"
+result=$(STUB_DF_RC=1 RUNNER_ENVIRONMENT=self-hosted run_subject "$work_dir")
+expect_rc "df fails" 0 "$result"
+expect_contains "df fails says so" "could not measure" "$result"
+
+echo "- a df printing something unparseable does not refuse the build"
+result=$(STUB_DF_GARBAGE=1 RUNNER_ENVIRONMENT=self-hosted run_subject "$work_dir")
+expect_rc "df garbage" 0 "$result"
+expect_contains "df garbage says so" "could not measure" "$result"
+
+echo "- no df at all does not refuse the build"
+tests_run=$((tests_run + 1))
+empty_path_dir="$(mktemp -d)"
+# An absolute bash, because emptying PATH takes `bash` with it and the case is
+# about the subject finding no `df`, not about the harness finding no shell.
+bash_path="$(command -v bash)"
+output=$(PATH="$empty_path_dir" RUNNER_ENVIRONMENT=self-hosted "$bash_path" "$subject" "$work_dir" 2>&1)
+rc=$?
+rm -rf "$empty_path_dir"
+[[ "$rc" == "0" ]] || fail_test "no df: expected rc 0, got ${rc} (${output})"
+
+# --- Which volumes get measured --------------------------------------------
+
+echo "- two paths on one volume are reported once"
+result=$(STUB_MAP="${work_dir}|/dev/disk3s5|$(gib_to_kb 400)
+${work_dir}/tmp|/dev/disk3s5|$(gib_to_kb 400)" RUNNER_ENVIRONMENT=self-hosted \
+  run_subject "$work_dir" "$work_dir/tmp")
+expect_rc "one volume twice" 0 "$result"
+tests_run=$((tests_run + 1))
+lines=$(printf '%s' "${result#*|}" | grep -c "free space on" || true)
+[[ "$lines" == "1" ]] || fail_test "one volume twice: expected 1 reading, got ${lines}"
+
+echo "- a short second volume is caught even when the first is fine"
+# #12794 saw the work volume and the system temp directory fill separately, so
+# measuring only the target directory would have missed half the condition.
+mkdir -p "$work_dir/tmp"
+result=$(STUB_MAP="${work_dir}|/dev/disk3s5|$(gib_to_kb 400)
+${work_dir}/tmp|/dev/disk4s1|$(gib_to_kb 2)" RUNNER_ENVIRONMENT=self-hosted \
+  run_subject "$work_dir" "$work_dir/tmp")
+expect_rc "second volume short" 70 "$result"
+expect_contains "second volume named" "${work_dir}/tmp has 2 GiB free" "$result"
+expect_not_contains "healthy volume not blamed" "${work_dir} has 400 GiB free" "$result"
+
+echo "- a target directory that does not exist yet measures its nearest existing parent"
+# The first build on a fresh runner has no target/ — measuring nothing there
+# would silently disable the check exactly when the volume is most suspect.
+result=$(STUB_MAP="${work_dir}|/dev/disk3s5|$(gib_to_kb 1)" RUNNER_ENVIRONMENT=self-hosted \
+  run_subject "$work_dir/not/created/yet")
+expect_rc "absent target dir" 70 "$result"
+expect_contains "absent target dir measured the parent" "1 GiB free" "$result"
+
+# --- The floor --------------------------------------------------------------
+
+echo "- BUILD_MIN_FREE_GIB raises the floor"
+result=$(STUB_DEFAULT="$(gib_to_kb 20)" BUILD_MIN_FREE_GIB=50 RUNNER_ENVIRONMENT=self-hosted \
+  run_subject "$work_dir")
+expect_rc "raised floor" 70 "$result"
+expect_contains "raised floor named" "50 GiB floor" "$result"
+
+echo "- BUILD_MIN_FREE_GIB lowers the floor"
+result=$(STUB_DEFAULT="$(gib_to_kb 4)" BUILD_MIN_FREE_GIB=2 RUNNER_ENVIRONMENT=self-hosted \
+  run_subject "$work_dir")
+expect_rc "lowered floor" 0 "$result"
+
+echo "- a non-integer BUILD_MIN_FREE_GIB falls back to the default"
+result=$(STUB_DEFAULT="$(gib_to_kb 3)" BUILD_MIN_FREE_GIB=lots RUNNER_ENVIRONMENT=self-hosted \
+  run_subject "$work_dir")
+expect_rc "non-integer floor" 70 "$result"
+expect_contains "non-integer floor warns" "is not an integer" "$result"
+expect_contains "non-integer floor uses the default" "10 GiB floor" "$result"
+
+echo "- a zero floor reports the readings and refuses nothing"
+# The escape hatch: if the floor is ever wrong for a host, an operator turns the
+# refusal off from the workflow rather than waiting on a change to this script.
+result=$(STUB_DEFAULT="$(gib_to_kb 0)" BUILD_MIN_FREE_GIB=0 RUNNER_ENVIRONMENT=self-hosted \
+  run_subject "$work_dir")
+expect_rc "zero floor" 0 "$result"
+expect_contains "zero floor still reports" "free space on" "$result"
+
+echo "- a zero-padded BUILD_MIN_FREE_GIB is decimal, not octal"
+result=$(STUB_DEFAULT="$(gib_to_kb 7)" BUILD_MIN_FREE_GIB=08 RUNNER_ENVIRONMENT=self-hosted \
+  run_subject "$work_dir")
+expect_rc "zero-padded floor" 70 "$result"
+expect_contains "zero-padded floor is 8" "8 GiB floor" "$result"
+
+# --- Surfaces ---------------------------------------------------------------
+
+echo "- a refusal writes the step summary when one is available"
+tests_run=$((tests_run + 1))
+summary_file="$work_dir/summary.md"
+: >"$summary_file"
+PATH="$stub_dir:$PATH" STUB_DEFAULT="$(gib_to_kb 1)" RUNNER_ENVIRONMENT=self-hosted \
+  GITHUB_STEP_SUMMARY="$summary_file" bash "$subject" "$work_dir" >/dev/null 2>&1
+case "$(cat "$summary_file")" in
+  *"not enough disk to build"*) ;;
+  *) fail_test "step summary: expected the refusal to be written, got: $(cat "$summary_file")" ;;
+esac
+
+echo "- a passing preflight writes no step summary"
+tests_run=$((tests_run + 1))
+: >"$summary_file"
+PATH="$stub_dir:$PATH" STUB_DEFAULT="$(gib_to_kb 400)" RUNNER_ENVIRONMENT=self-hosted \
+  GITHUB_STEP_SUMMARY="$summary_file" bash "$subject" "$work_dir" >/dev/null 2>&1
+[[ ! -s "$summary_file" ]] || fail_test "step summary: expected nothing on a pass, got: $(cat "$summary_file")"
+
+echo "- no paths is a usage error, not a refusal"
+result=$(RUNNER_ENVIRONMENT=self-hosted run_subject)
+expect_rc "no arguments" 2 "$result"
+expect_contains "no arguments explains" "usage:" "$result"
+
+echo "- an empty path argument is skipped rather than measured"
+# The composite action passes TMPDIR straight through, and it is routinely unset.
+result=$(STUB_DEFAULT="$(gib_to_kb 400)" RUNNER_ENVIRONMENT=self-hosted run_subject "$work_dir" "")
+expect_rc "empty path" 0 "$result"
+
+echo
+if [[ "$failures" -eq 0 ]]; then
+  echo "All ${tests_run} assertions passed."
+  exit 0
+fi
+echo "${failures} of ${tests_run} assertions failed."
+exit 1

--- a/scripts/test_preflight_build_disk.sh
+++ b/scripts/test_preflight_build_disk.sh
@@ -45,6 +45,11 @@ if [[ -n "${STUB_DF_GARBAGE:-}" ]]; then
   echo "df: something went sideways"
   exit 0
 fi
+if [[ -n "${STUB_DF_NONNUMERIC:-}" ]]; then
+  echo "Filesystem 1024-blocks      Used Available Capacity Mounted on"
+  echo "map:autofs            0         0         -       -  /net"
+  exit 0
+fi
 target="${*: -1}"
 device="/dev/disk1"
 free_kb="${STUB_DEFAULT:-104857600}"
@@ -147,6 +152,14 @@ result=$(STUB_DF_GARBAGE=1 RUNNER_ENVIRONMENT=self-hosted run_subject "$work_dir
 expect_rc "df garbage" 0 "$result"
 expect_contains "df garbage says so" "could not measure" "$result"
 
+echo "- a df whose Available column is not a number does not refuse the build"
+# The dangerous shape: awk coerces a non-numeric field to 0, and a 0 that came
+# from garbage is indistinguishable downstream from a volume genuinely at zero.
+result=$(STUB_DF_NONNUMERIC=1 RUNNER_ENVIRONMENT=self-hosted run_subject "$work_dir")
+expect_rc "df non-numeric" 0 "$result"
+expect_contains "df non-numeric says so" "could not measure" "$result"
+expect_not_contains "df non-numeric is not read as zero" "0 GiB free" "$result"
+
 echo "- no df at all does not refuse the build"
 tests_run=$((tests_run + 1))
 empty_path_dir="$(mktemp -d)"
@@ -187,6 +200,17 @@ result=$(STUB_MAP="${work_dir}|/dev/disk3s5|$(gib_to_kb 1)" RUNNER_ENVIRONMENT=s
   run_subject "$work_dir/not/created/yet")
 expect_rc "absent target dir" 70 "$result"
 expect_contains "absent target dir measured the parent" "1 GiB free" "$result"
+
+echo "- an absent bare relative path falls back to the working directory"
+# `target` strips to itself, so walking parents is a loop. Giving up there would
+# silently measure nothing, which is the check quietly disabling itself.
+result=$(cd "$work_dir" && STUB_MAP=".|/dev/disk3s5|$(gib_to_kb 1)" RUNNER_ENVIRONMENT=self-hosted \
+  PATH="$stub_dir:$PATH" bash "$subject" "no-such-target" 2>&1; printf '|%s' "$?")
+tests_run=$((tests_run + 1))
+case "$result" in
+  *"free space on .: 1 GiB"*) ;;
+  *) fail_test "bare relative path: expected a reading for '.', got: ${result}" ;;
+esac
 
 # --- The floor --------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

A build job placed on a self-hosted runner whose volume is already full has no way to say so.
It compiles for several minutes and then dies inside whichever crate happened to be writing when
the volume hit zero — usually behind a `cc-rs` frame that shells out to `sccache`, so the failure
reads as a compiler-cache fault on a crate the branch never touched. In #12794 that froze the
merge queue for over twelve hours and was first triaged as an sccache problem.

`scripts/signoff` already refuses on these grounds for the sign-off path (`preflight_disk`, a
25 GiB floor). The build path — every job using `.github/actions/build-spiced`, including
`Build macOS aarch64 (Apple Silicon) binaries`, which gates `E2E Test CI` and therefore the merge
queue — had no equivalent, so the same host condition was reported one way on one path and not at
all on the other.

Fixes #12798

## Changes

- **`scripts/preflight_build_disk.sh`** (new) — measures the volumes a build writes to and, on a
  self-hosted runner below the floor, refuses with a diagnostic naming the runner, the reading,
  and the fact that the branch was not evaluated, plus an Actions annotation and a step summary,
  in the same shape `scripts/signoff` uses.
- **`.github/actions/build-spiced/action.yml`** — runs the preflight after the build paths are
  resolved, so it measures the target directory the build will actually use (`CARGO_TARGET_DIR`
  can put it on another filesystem) and both temp directories. A `min_free_gib` input carries the
  floor; the resolved paths are passed through the environment rather than interpolated into the
  script body.
- **`scripts/test_preflight_build_disk.sh`** + **`.github/workflows/build_disk_preflight_test.yml`**
  (new) — 40 assertions against a stub `df`, on a GitHub-hosted runner so a sub-second check never
  queues behind the self-hosted pool.

### What it does not do

Refusing a build is not itself a fix for a full disk. Reclaiming space on the affected hosts is an
operator action, and scheduled reclamation — follow-up 2 in #12794 — is a separate change with its
own blast radius on a volume several runner instances share. This is follow-up 1: make the
condition legible at the point it is detectable.

The floor is a start-of-job reading and cannot protect a build that runs the volume dry underneath
it. #12794 records a sign-off that cleared the same style of check with 26 GiB and then exhausted
the volume during a 350-minute run.

## Why these choices

**Self-hosted only.** A GitHub-hosted image ships with far less free space than a self-hosted host
needs, and these builds pass there today, so a floor tuned for the pool must not fail them. Hosted
runners get the reading and build anyway, gated on `RUNNER_ENVIRONMENT`.

**Unknown is never full.** A `df` that is absent, fails, or prints something unparseable leaves the
volume unmeasured and the build proceeds. Refusing on a reading we do not have is the worse error.

**10 GiB, and an escape hatch.** A volume below 10 GiB cannot finish a release build of this
workspace from cold, so the floor names a certainty rather than a preference — but the risk worth
stating is a *warm* `target/` on a self-hosted runner legitimately sitting under it, which this
would newly fail. `BUILD_MIN_FREE_GIB=0` (or the `min_free_gib` input) turns the refusal off from
the workflow without a change to the script, and the diagnostic says so.

**One reading per volume.** `target/`, `RUNNER_TEMP` and `TMPDIR` are named separately because they
are not the same place on a self-hosted macOS runner — #12794 observed the work volume and the
system temp directory at zero — and de-duplicated by device so naming all three costs nothing where
they coincide.

## Test plan

- [x] Added regression test for a self-hosted runner below the floor refusing the build with a
      named diagnostic, and for the GitHub-hosted and unset-environment cases building anyway
- [x] Added edge case tests for an unmeasurable volume (df absent, failing, unparseable), a target
      directory that does not exist yet, two paths on one volume, a short second volume behind a
      healthy first, exactly-at-the-floor, a raised/lowered/zero/non-integer/zero-padded floor,
      the step summary on refusal and its absence on a pass, no arguments, and an empty path
- [x] `bash scripts/test_preflight_build_disk.sh` — all 40 assertions pass
- [x] `shellcheck scripts/preflight_build_disk.sh scripts/test_preflight_build_disk.sh` — clean
- [x] `actionlint` — clean on the new workflow
- [x] `make lint` (workspace-wide `cargo fmt --all -- --check` + full clippy, never a per-crate
      invocation) — not applicable: this branch changes no Rust
- [x] `make test` — not applicable: this branch changes no Rust
- [x] `make signoff` run after the final push (`Attestation` check is green): not applicable —
      a branch with no Rust changes is not gated on `Attestation`
