### PR TITLE
fix(ci): take stale build output off the runners, not just report a full one (fixes #12800)

### DIFF
--- a/.github/workflows/reclaim_runner_disk.yml
+++ b/.github/workflows/reclaim_runner_disk.yml
@@ -1,0 +1,105 @@
+---
+name: Reclaim Runner Disk
+
+# Takes stale build output and dead workspaces off the self-hosted runners.
+#
+# The pool's hosts are long-lived and nothing ever removed anything from them,
+# so free space only moved one way. #12794 is where that ends: two volumes below
+# the 25 GiB sign-off floor at the same time while two other hosts in the same
+# pool sat at 163 and 536 GiB, every merge-queue candidate failing its build,
+# and an operator deleting files by hand to get the queue moving again.
+#
+# The preflight checks added since (`scripts/preflight_build_disk.sh` for the
+# build path, `scripts/signoff` for the sign-off path) report a full volume at
+# the point it is detectable rather than minutes later from inside the compiler.
+# Neither reclaims anything. This is the other half.
+#
+# What it does not do is bound a single run — one host went 26 GiB to 1 GiB in
+# 6.2 hours of building, which no periodic sweep prevents. See #12800.
+
+on:
+  schedule:
+    # Off the hour, where scheduled runs are least likely to be delayed behind
+    # the on-the-hour crowd. Six-hourly rather than daily because each run
+    # sweeps whichever instances happen to be idle, so the pool is covered by
+    # repetition rather than by any one run (see `slot` below).
+    - cron: '41 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what would be removed without removing it'
+        type: boolean
+        default: false
+      max_age_days:
+        description: 'Leave anything modified within this many days'
+        type: string
+        default: '7'
+      free_gib:
+        description: 'Leave build output alone on a host with at least this many GiB free'
+        type: string
+        default: '100'
+
+concurrency:
+  group: ${{ github.workflow }}
+  # Queued rather than cancelled: a sweep interrupted mid-`rm` leaves a
+  # half-removed tree, and there is no hurry that would justify it.
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  reclaim:
+    name: Reclaim (${{ matrix.pool }} slot ${{ matrix.slot }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both self-hosted pools. `spiceai-macos` is the one #12794 names, but
+        # `spiceai-dev-runners` hosts are equally long-lived and accumulate the
+        # same way.
+        pool: [spiceai-macos, spiceai-dev-runners]
+        # A runner instance runs one job at a time, so N concurrent jobs on one
+        # label occupy N distinct instances — which is the only way to address
+        # individual instances behind a shared label. It is coverage by
+        # repetition, not a guarantee: a busier instance is idle less often and
+        # is swept on a later run instead.
+        slot: [1, 2, 3, 4]
+    runs-on: ${{ matrix.pool }}
+    # The sweep is a bounded directory walk and some deletes. Anything past this
+    # is wedged, and a wedged job on a self-hosted pool holds a slot until
+    # GitHub's 6-hour default expires it (#12717).
+    timeout-minutes: 30
+    permissions:
+      # Reads the repository to get the script, and nothing else.
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Reclaim stale space
+        shell: bash
+        env:
+          # Through the environment rather than interpolated into the script
+          # body, so a value carrying shell syntax cannot become shell syntax.
+          DRY_RUN_INPUT: ${{ inputs.dry_run }}
+          MAX_AGE_DAYS_INPUT: ${{ inputs.max_age_days }}
+          FREE_GIB_INPUT: ${{ inputs.free_gib }}
+        run: |
+          # On a scheduled run every input is empty, so each flag is omitted and
+          # the script's own defaults apply -- including "not a dry run", which
+          # is what a sweep that reclaims nothing would quietly become.
+          args=()
+          if [ "$DRY_RUN_INPUT" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          if [ -n "$MAX_AGE_DAYS_INPUT" ]; then
+            args+=(--max-age-days "$MAX_AGE_DAYS_INPUT")
+          fi
+          if [ -n "$FREE_GIB_INPUT" ]; then
+            args+=(--free-gib "$FREE_GIB_INPUT")
+          fi
+
+          # Invoked through `bash` rather than as `./…` so the job does not
+          # depend on the executable bit surviving a checkout.
+          bash scripts/reclaim_runner_disk.sh ${args[@]+"${args[@]}"}

--- a/.github/workflows/reclaim_runner_disk.yml
+++ b/.github/workflows/reclaim_runner_disk.yml
@@ -76,6 +76,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # `clean` defaults to true, which runs `git clean -ffdx` in this
+          # workspace before the sweep starts -- and `-x` takes the ignored
+          # `target/` with it. That is the one directory the free-space gate
+          # below exists to protect: on a host above the floor the script keeps
+          # every cache, then the checkout deletes this workspace's anyway, and
+          # the before/after report never sees it because it happened first.
+          # The script decides what comes off this volume, and nothing else.
+          clean: false
 
       - name: Reclaim stale space
         shell: bash

--- a/.github/workflows/reclaim_runner_disk_test.yml
+++ b/.github/workflows/reclaim_runner_disk_test.yml
@@ -42,10 +42,21 @@ permissions: {}
 
 jobs:
   test-reclaim-runner-disk:
-    name: Unit tests for the runner disk sweep
+    name: Unit tests for the runner disk sweep (${{ matrix.os }})
     # GitHub-hosted on purpose: a sub-second check must not queue behind the
     # self-hosted pool whose full disks it exists to keep from recurring.
-    runs-on: ubuntu-24.04
+    #
+    # Both families, because the sweep ships to both self-hosted pools and the
+    # subject leans on `find` predicates whose availability differs between GNU
+    # and BSD userlands. `spiceai-macos` is the pool #12794 names, so a BSD
+    # regression would land exactly where the sweep matters most and nowhere the
+    # suite could see it. macOS runners here are GitHub-hosted, so this reads
+    # the same `find` the self-hosted Macs ship without touching that pool.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-15]
+    runs-on: ${{ matrix.os }}
     permissions:
       # A checkout and a local bash script against temporary directories.
       contents: read

--- a/.github/workflows/reclaim_runner_disk_test.yml
+++ b/.github/workflows/reclaim_runner_disk_test.yml
@@ -1,0 +1,61 @@
+---
+name: Reclaim Runner Disk Tests
+
+# `scripts/reclaim_runner_disk.sh` deletes things on a shared, long-lived volume
+# where several runner instances live side by side, and both directions of a
+# mistake are expensive. Removing too little leaves the condition #12794
+# describes: a host that only fills, until every job landing on it fails on a
+# write. Removing too much takes a live build out from under the job using it,
+# or throws away the warm cache that is the difference between an incremental
+# sign-off finishing in minutes and one taking hours.
+#
+# So the exclusions are tested as closely as the removals, and the suite refuses
+# to grade the subject on an environment where `find` cannot run — there, every
+# removal case would report a false pass.
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - 'scripts/reclaim_runner_disk.sh'
+      - 'scripts/test_reclaim_runner_disk.sh'
+      - '.github/workflows/reclaim_runner_disk.yml'
+      - '.github/workflows/reclaim_runner_disk_test.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'scripts/reclaim_runner_disk.sh'
+      - 'scripts/test_reclaim_runner_disk.sh'
+      - '.github/workflows/reclaim_runner_disk.yml'
+      - '.github/workflows/reclaim_runner_disk_test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  test-reclaim-runner-disk:
+    name: Unit tests for the runner disk sweep
+    # GitHub-hosted on purpose: a sub-second check must not queue behind the
+    # self-hosted pool whose full disks it exists to keep from recurring.
+    runs-on: ubuntu-24.04
+    permissions:
+      # A checkout and a local bash script against temporary directories.
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run tests
+        # Invoked through `bash` rather than as `./…` so the job does not depend
+        # on the executable bit surviving a checkout.
+        run: bash scripts/test_reclaim_runner_disk.sh

--- a/scripts/reclaim_runner_disk.sh
+++ b/scripts/reclaim_runner_disk.sh
@@ -242,24 +242,31 @@ reclaim_stale_build_output() {
     info "could not measure free space — pruning stale build output anyway"
   fi
 
-  local -a swept=()
-  local -i pruned=0
-
+  # Collected in full before any of it is swept, rather than filtered as it
+  # arrives. `find` emits a directory's entries in the order the filesystem
+  # returns them, not sorted and not ancestors-first: a nested target directory
+  # is reported before its ancestor whenever `package/` happens to precede
+  # `CACHEDIR.TAG` in the parent's listing. Deciding nesting against a partial
+  # list therefore sweeps the same files twice and reports two directories where
+  # there is one.
+  local -a found=()
   while IFS= read -r tag; do
     [[ -n "$tag" ]] || continue
     target_dir=$(dirname "$tag")
     is_cargo_target_dir "$target_dir" || continue
+    found+=("$target_dir")
+  done < <(find "$root" -type f -name CACHEDIR.TAG 2>/dev/null)
 
-    # A target directory nested inside one already swept -- cargo puts one under
-    # `target/package/` for a packaged crate, and a vendored checkout can carry
-    # its own -- is already covered by the sweep of its ancestor. Skipping it
-    # keeps the count honest rather than reporting the same files twice.
+  local -i pruned=0
+  for target_dir in ${found[@]+"${found[@]}"}; do
+    # Nested inside another one found anywhere in the sweep -- cargo puts one
+    # under `target/package/` for a packaged crate, and a vendored checkout can
+    # carry its own -- so it is already covered by its ancestor.
     local nested=0
-    for accepted in ${swept[@]+"${swept[@]}"}; do
+    for accepted in ${found[@]+"${found[@]}"}; do
       [[ "$target_dir" == "$accepted"/* ]] && { nested=1; break; }
     done
     (( nested )) && continue
-    swept+=("$target_dir")
 
     if [[ "$DRY_RUN" == "1" ]]; then
       local count
@@ -275,10 +282,7 @@ reclaim_stale_build_output() {
     # and cargo recreates whatever it needs.
     find "$target_dir" -mindepth 1 -type d -empty -delete 2>/dev/null
     pruned+=1
-    # `find` walks a directory before its contents, so an ancestor target
-    # directory is always read before any nested one -- which is what the
-    # nesting check above relies on.
-  done < <(find "$root" -type f -name CACHEDIR.TAG 2>/dev/null)
+  done
 
   info "build output directories swept: ${pruned}"
 }

--- a/scripts/reclaim_runner_disk.sh
+++ b/scripts/reclaim_runner_disk.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+#
+# Reclaim stale space on a self-hosted runner's work volume.
+#
+# The pool's hosts are long-lived and nothing ever takes anything off them, so
+# free space only moves one way. #12794 is what that looks like when it lands:
+# two volumes below the sign-off floor at the same time (26 GiB then 1 GiB, and
+# 5 GiB) while two other hosts in the same pool sat at 163 and 536 GiB. The
+# recovery was an operator deleting things by hand.
+#
+# The preflight checks that already exist -- `scripts/preflight_build_disk.sh`
+# for the build path, `scripts/signoff` for the sign-off path -- report a full
+# volume at the point it is detectable instead of minutes later from inside the
+# compiler. Neither reclaims anything. This does.
+#
+# What it does NOT do is bound a single run: `/opt/github-runner-01` went from
+# 26 GiB to 1 GiB in 6.2 hours of active building, and no periodic sweep
+# prevents that. This bounds the baseline a long-lived host accumulates between
+# runs, which is a different problem with the same symptom.
+#
+# ## Why deleting here is safe when deleting by path alone is not
+#
+# Several runner instances share one volume, so a sweep that walks the volume
+# can delete a live build out from under a sibling. Two rules avoid it, and
+# every candidate below satisfies both:
+#
+#   1. Nothing outside this runner instance's own work root is ever a
+#      candidate. A job owns its instance for its whole duration, so while this
+#      runs, that instance has no other job. Sibling instances keep their own
+#      work roots on the same volume and are never walked.
+#   2. Nothing modified within the age threshold is ever a candidate. The
+#      workspace this job is using is rewritten by the checkout that put this
+#      script there, so an age filter cannot select it -- but the rule is
+#      enforced explicitly as well rather than relying on that.
+#
+# Usage: scripts/reclaim_runner_disk.sh [--dry-run] [--root <dir>]
+#                                       [--max-age-days <n>] [--free-gib <n>]
+#
+# Environment:
+#   RUNNER_WORKSPACE     Set by Actions to <work-root>/<repo>. Its parent is the
+#                        work root, and it is itself the one workspace this job
+#                        is using, so it is excluded by name.
+#   RUNNER_TEMP          This job's scratch directory. Excluded by name for the
+#                        same reason.
+#   RECLAIM_MAX_AGE_DAYS Default age threshold in days (default: 7), overridden
+#                        by --max-age-days. A week keeps the warm build cache
+#                        that makes an incremental sign-off finish in minutes
+#                        rather than hours, and drops what no branch built on
+#                        this host has needed since.
+#   RECLAIM_FREE_GIB     Free space (GiB) at or above which build output is left
+#                        alone entirely (default: 100), overridden by
+#                        --free-gib. See `reclaim_stale_build_output`.
+
+set -uo pipefail
+
+readonly DEFAULT_MAX_AGE_DAYS=7
+
+# Free space at or above which a host's build output is left alone entirely.
+#
+# Taken from the spread #12794 measured across one pool at one moment: 536 and
+# 163 GiB on the healthy hosts, 26 then 1 GiB and 5 GiB on the two that broke.
+# A floor between those populations reclaims where it matters and touches
+# nothing where it does not -- which is the point, because a pruned cache is not
+# free. Sign-offs on this pool run 2-5 hours against a 353-minute step budget,
+# and a budget expiry publishes `signoff=failure`, disqualifying the commit as
+# if the branch were broken. Trading that risk for space a host already has
+# would be a bad trade in both directions.
+readonly DEFAULT_FREE_GIB=100
+
+# Exit status for a usage error, distinct from 1 so a caller can tell "this
+# script was invoked wrongly" from "the sweep hit a problem".
+readonly EXIT_USAGE=64
+
+# The signature line every `cargo` target directory carries in its
+# CACHEDIR.TAG, per the Cache Directory Tagging Specification. Requiring it is
+# what makes pruning inside a workspace precise: a directory holding this file
+# is build output by cargo's own declaration, so a name-based guess about which
+# directories are `target/` -- and the chance of walking into source under a
+# directory that merely happens to be called `target` -- does not arise.
+readonly CACHEDIR_SIGNATURE='Signature: 8a477f597d28d172789f06886806bc55'
+
+info() { printf '%s\n' "$*" >&2; }
+
+# Report rather than remove. Set by --dry-run; defaulted here so the unit tests,
+# which source this file to reach one function at a time, never meet it unset.
+DRY_RUN="${DRY_RUN:-0}"
+
+# Free space in GiB on the volume holding "$1". Prints an integer; returns
+# non-zero when `df` is absent or unparseable, so a host whose df cannot be read
+# still gets swept -- the reading is for the report, not for a decision.
+free_gib() {
+  local path="$1" free
+  command -v df >/dev/null 2>&1 || return 1
+  # -k for 1024-byte blocks on both macOS (whose df defaults to 512) and Linux.
+  free=$(df -Pk "$path" 2>/dev/null | awk 'NR==2 { print int($4 / 1048576) }') || return 1
+  [[ "$free" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$free"
+}
+
+# The work root to sweep: the parent of RUNNER_WORKSPACE. Actions sets that to
+# <work-root>/<repo>, so its parent is the directory holding every workspace,
+# `_temp`, and the rest of the instance's state.
+work_root_from_env() {
+  local workspace="${RUNNER_WORKSPACE:-}"
+  [[ -n "$workspace" ]] || return 1
+  printf '%s\n' "$(dirname "$workspace")"
+}
+
+# True when the directory is a cargo target directory, by its own CACHEDIR.TAG.
+is_cargo_target_dir() {
+  local dir="$1"
+  local tag="$dir/CACHEDIR.TAG"
+  [[ -d "$dir" && -f "$tag" ]] || return 1
+  grep -qF "$CACHEDIR_SIGNATURE" "$tag" 2>/dev/null
+}
+
+# The workspace this job is running out of, which must survive the sweep
+# whatever its age. RUNNER_WORKSPACE names it on a runner; away from one -- an
+# operator running this by hand with --root -- the script's own location does,
+# and answering nothing there would leave the one tree we are certain is in use
+# protected only by its mtimes.
+live_workspace() {
+  local from_env="${RUNNER_WORKSPACE:-}"
+  if [[ -n "$from_env" ]]; then
+    printf '%s\n' "${from_env%/}"
+    return 0
+  fi
+  # <repo-checkout>/scripts/this-script -> the directory holding the checkout,
+  # which is what a work root lists.
+  local script_dir
+  script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd) || return 1
+  printf '%s\n' "$(dirname "$(dirname "$script_dir")")"
+}
+
+# True when nothing in the top few levels of "$1" has been modified within
+# "$2" days -- i.e. no job has used this workspace recently.
+#
+# Depth-limited on purpose. A checkout rewrites the repository root on every job
+# that uses a workspace, so recent use is always visible within a few levels,
+# and probing that far costs a directory read rather than a walk of a target
+# directory holding hundreds of thousands of files.
+workspace_is_stale() {
+  local dir="$1" days="$2" recent
+  [[ -d "$dir" ]] || return 1
+  recent=$(find "$dir" -maxdepth 3 -mtime "-${days}" -print 2>/dev/null | head -n 1)
+  [[ -z "$recent" ]]
+}
+
+# Remove "$1", or report it under --dry-run. Prints one line either way so the
+# run log names everything the sweep touched.
+remove_path() {
+  local path="$1" reason="$2"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    info "would remove (${reason}): ${path}"
+    return 0
+  fi
+  info "removing (${reason}): ${path}"
+  rm -rf "$path"
+}
+
+# Orphaned job scratch. Actions clears `_temp` between jobs on a healthy run, so
+# what survives past the threshold is what a killed or timed-out job left --
+# and #12794's hosts have had plenty of both.
+reclaim_temp() {
+  local root="$1" days="$2" entry
+  # Assigned separately from `root`: bash declares every name in one `local`
+  # before assigning any of them, so a later initialiser reading an earlier name
+  # sees it unset and aborts the function under `set -u`.
+  local temp_dir="$root/_temp"
+  [[ -d "$temp_dir" ]] || return 0
+
+  local live_temp="${RUNNER_TEMP:-}"
+  live_temp="${live_temp%/}"
+
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    # Whatever this job is using, whatever its age. On stock Actions RUNNER_TEMP
+    # *is* `_temp`, so no entry beneath it can equal it and the age filter is
+    # what actually protects the running job -- its files were written minutes
+    # ago. The name check covers the other layout, where RUNNER_TEMP points at a
+    # per-job directory inside `_temp`: there an idle-then-resumed runner really
+    # can present the live scratch as old, and only this catches it.
+    if [[ -n "$live_temp" ]]; then
+      [[ "${entry%/}" == "$live_temp" || "$live_temp" == "${entry%/}"/* ]] && continue
+    fi
+    remove_path "$entry" "orphaned job scratch"
+  done < <(find "$temp_dir" -mindepth 1 -maxdepth 1 -mtime "+${days}" 2>/dev/null)
+}
+
+# Whole workspaces for repositories nobody has built on this host lately. Each
+# one holds a full checkout and its build output, so this is where a host that
+# has served several repositories keeps most of its dead weight.
+reclaim_workspaces() {
+  local root="$1" days="$2" entry base
+  local live
+  live=$(live_workspace) || live=""
+
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    base=$(basename "$entry")
+    # Runner-internal state: `_temp` is handled above with its own exclusion,
+    # and `_actions`/`_tool` hold checkouts and toolchains a running job
+    # resolves lazily, so an old-but-in-use entry is reachable there in a way it
+    # is not for a workspace. Left alone.
+    [[ "$base" == _* ]] && continue
+    [[ -n "$live" && "${entry%/}" == "$live" ]] && continue
+    workspace_is_stale "$entry" "$days" || continue
+    remove_path "$entry" "workspace unused for ${days}d"
+  done < <(find "$root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+}
+
+# Stale build output inside the workspaces that survive, which on this pool is
+# where the space actually is: the sweep above cannot touch the workspace this
+# job is using, and that is the one holding the target directory every sign-off
+# has been writing into.
+#
+# Pruning by file age is what `cargo sweep` does and what cargo is built to
+# tolerate: a missing artifact or fingerprint is rebuilt, so the cost of being
+# wrong here is a rebuild, never a wrong build. Files newer than the threshold
+# stay, so the cache that makes an incremental build fast survives the sweep.
+#
+# Gated on free space, unlike the two above. Job scratch a killed job orphaned
+# and a workspace nobody has built in a week are dead weight on any host, but a
+# target directory is the warm cache an incremental build depends on, and
+# pruning it on a host with 536 GiB free buys space nobody needed at the cost of
+# a colder build -- which on this pool is measured in hours against a step
+# budget that publishes a code-failure verdict when it expires. So a host above
+# the floor keeps its cache, and one below it does not.
+reclaim_stale_build_output() {
+  local root="$1" days="$2" floor="$3" tag target_dir accepted
+  local free
+  if free=$(free_gib "$root"); then
+    if (( free >= floor )); then
+      info "free space is ${free} GiB, at or above the ${floor} GiB floor — leaving build output alone"
+      return 0
+    fi
+    info "free space is ${free} GiB, below the ${floor} GiB floor — pruning stale build output"
+  else
+    # No reading is not a reason to skip: the hosts this exists for are the ones
+    # whose volume is in trouble, and a host whose `df` cannot be read is not
+    # evidence of a healthy one.
+    info "could not measure free space — pruning stale build output anyway"
+  fi
+
+  local -a swept=()
+  local -i pruned=0
+
+  while IFS= read -r tag; do
+    [[ -n "$tag" ]] || continue
+    target_dir=$(dirname "$tag")
+    is_cargo_target_dir "$target_dir" || continue
+
+    # A target directory nested inside one already swept -- cargo puts one under
+    # `target/package/` for a packaged crate, and a vendored checkout can carry
+    # its own -- is already covered by the sweep of its ancestor. Skipping it
+    # keeps the count honest rather than reporting the same files twice.
+    local nested=0
+    for accepted in ${swept[@]+"${swept[@]}"}; do
+      [[ "$target_dir" == "$accepted"/* ]] && { nested=1; break; }
+    done
+    (( nested )) && continue
+    swept+=("$target_dir")
+
+    if [[ "$DRY_RUN" == "1" ]]; then
+      local count
+      count=$(find "$target_dir" -type f -mtime "+${days}" 2>/dev/null | wc -l | tr -d ' ')
+      info "would prune ${count} file(s) older than ${days}d from: ${target_dir}"
+      pruned+=1
+      continue
+    fi
+
+    info "pruning files older than ${days}d from: ${target_dir}"
+    find "$target_dir" -type f -mtime "+${days}" -delete 2>/dev/null
+    # Directories the prune emptied. Left behind they cost nothing but noise,
+    # and cargo recreates whatever it needs.
+    find "$target_dir" -mindepth 1 -type d -empty -delete 2>/dev/null
+    pruned+=1
+    # `find` walks a directory before its contents, so an ancestor target
+    # directory is always read before any nested one -- which is what the
+    # nesting check above relies on.
+  done < <(find "$root" -type f -name CACHEDIR.TAG 2>/dev/null)
+
+  info "build output directories swept: ${pruned}"
+}
+
+usage() {
+  info "usage: $0 [--dry-run] [--root <dir>] [--max-age-days <n>] [--free-gib <n>]"
+}
+
+main() {
+  DRY_RUN=0
+  local root=""
+  local days="${RECLAIM_MAX_AGE_DAYS:-$DEFAULT_MAX_AGE_DAYS}"
+  local floor="${RECLAIM_FREE_GIB:-$DEFAULT_FREE_GIB}"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run) DRY_RUN=1; shift ;;
+      --root) root="${2:-}"; shift 2 ;;
+      --max-age-days) days="${2:-}"; shift 2 ;;
+      --free-gib) floor="${2:-}"; shift 2 ;;
+      -h|--help) usage; return 0 ;;
+      *) info "unknown argument: $1"; usage; return "$EXIT_USAGE" ;;
+    esac
+  done
+
+  if [[ ! "$days" =~ ^[0-9]+$ ]]; then
+    info "--max-age-days must be a non-negative integer, got: ${days}"
+    return "$EXIT_USAGE"
+  fi
+
+  if [[ ! "$floor" =~ ^[0-9]+$ ]]; then
+    info "--free-gib must be a non-negative integer, got: ${floor}"
+    return "$EXIT_USAGE"
+  fi
+
+  if [[ -z "$root" ]]; then
+    if ! root=$(work_root_from_env); then
+      info "no work root: pass --root, or run where RUNNER_WORKSPACE is set"
+      return "$EXIT_USAGE"
+    fi
+  fi
+
+  if [[ ! -d "$root" ]]; then
+    info "work root is not a directory: ${root}"
+    return "$EXIT_USAGE"
+  fi
+
+  local before after
+  before=$(free_gib "$root") || before=""
+  [[ -n "$before" ]] && info "free space before: ${before} GiB"
+  info "sweeping ${root} for entries older than ${days}d (dry-run: ${DRY_RUN})"
+
+  reclaim_temp "$root" "$days"
+  reclaim_workspaces "$root" "$days"
+  reclaim_stale_build_output "$root" "$days" "$floor"
+
+  after=$(free_gib "$root") || after=""
+  if [[ -n "$before" && -n "$after" ]]; then
+    info "free space after: ${after} GiB (reclaimed $((after - before)) GiB)"
+  elif [[ -n "$after" ]]; then
+    info "free space after: ${after} GiB"
+  fi
+
+  return 0
+}
+
+# Sourced by the unit tests to reach one function at a time; run as a program
+# everywhere else.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/reclaim_runner_disk.sh
+++ b/scripts/reclaim_runner_disk.sh
@@ -140,9 +140,24 @@ live_workspace() {
 # and probing that far costs a directory read rather than a walk of a target
 # directory holding hundreds of thousands of files.
 workspace_is_stale() {
-  local dir="$1" days="$2" recent
+  local dir="$1" days="$2" recent rc
   [[ -d "$dir" ]] || return 1
-  recent=$(find "$dir" -maxdepth 3 -mtime "-${days}" -print 2>/dev/null | head -n 1)
+
+  # Not piped to `head`, deliberately. Cutting the walk short would be the
+  # obvious optimisation, but with `pipefail` set the SIGPIPE that closing the
+  # pipe sends `find` is indistinguishable from the walk having failed -- and
+  # the two must not be confused, per below. A depth-3 listing is a few
+  # thousand lines at worst.
+  recent=$(find "$dir" -maxdepth 3 -mtime "-${days}" -print 2>/dev/null)
+  rc=$?
+
+  # Fail closed: a walk that errored produces no output, which is byte-for-byte
+  # what "nothing here is recent" looks like, and the caller deletes the whole
+  # workspace on that answer. An unreadable directory must keep its workspace,
+  # not lose it -- the age rule is a safety rule, so its unknown case belongs on
+  # the safe side.
+  (( rc == 0 )) || return 1
+
   [[ -z "$recent" ]]
 }
 
@@ -230,7 +245,11 @@ reclaim_stale_build_output() {
   local root="$1" days="$2" floor="$3" tag target_dir accepted
   local free
   if free=$(free_gib "$root"); then
-    if (( free >= floor )); then
+    # `10#` forces base 10 on both operands. Bash arithmetic reads a leading
+    # zero as octal, so a floor of `08` is an arithmetic error rather than
+    # 8 GiB, and `0100` would silently mean 64 -- a wrong floor decides whether
+    # a host keeps its build cache.
+    if (( 10#$free >= 10#$floor )); then
       info "free space is ${free} GiB, at or above the ${floor} GiB floor — leaving build output alone"
       return 0
     fi
@@ -300,9 +319,24 @@ main() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --dry-run) DRY_RUN=1; shift ;;
-      --root) root="${2:-}"; shift 2 ;;
-      --max-age-days) days="${2:-}"; shift 2 ;;
-      --free-gib) floor="${2:-}"; shift 2 ;;
+      # The operand count is checked before consuming it. `shift 2` on a
+      # one-element list fails, and with no `errexit` that leaves the argument
+      # in place and the loop spinning on it until the job's timeout kills it --
+      # a flag typed last on a dispatch would hang the sweep rather than
+      # correct it.
+      --root|--max-age-days|--free-gib)
+        if [[ $# -lt 2 ]]; then
+          info "$1 needs a value"
+          usage
+          return "$EXIT_USAGE"
+        fi
+        case "$1" in
+          --root) root="$2" ;;
+          --max-age-days) days="$2" ;;
+          --free-gib) floor="$2" ;;
+        esac
+        shift 2
+        ;;
       -h|--help) usage; return 0 ;;
       *) info "unknown argument: $1"; usage; return "$EXIT_USAGE" ;;
     esac

--- a/scripts/reclaim_runner_disk.sh
+++ b/scripts/reclaim_runner_disk.sh
@@ -50,6 +50,15 @@
 #   RECLAIM_FREE_GIB     Free space (GiB) at or above which build output is left
 #                        alone entirely (default: 100), overridden by
 #                        --free-gib. See `reclaim_stale_build_output`.
+#
+# Exit status:
+#   0   the sweep completed; everything it selected came off
+#   1   the sweep ran to the end but at least one removal failed
+#   64  invoked wrongly -- no work root, a bad flag, a bad value
+#
+# 1 rather than stopping at the first failure: one unremovable entry says
+# nothing about the rest of the volume, so the run carries on and reports at the
+# end. See SWEEP_FAILURES.
 
 set -uo pipefail
 
@@ -96,6 +105,17 @@ info() { printf '%s\n' "$*" >&2; }
 # Report rather than remove. Set by --dry-run; defaulted here so the unit tests,
 # which source this file to reach one function at a time, never meet it unset.
 DRY_RUN="${DRY_RUN:-0}"
+
+# Removals that failed. Counted rather than fatal: a permission or I/O error on
+# one entry says nothing about the rest of the volume, and the run that stops at
+# the first one reclaims less than the run that carries on. But a sweep that
+# reclaimed nothing must not report success -- the whole point of the schedule
+# is that nobody watches it, so green has to mean the space was actually taken
+# back. `main` returns 1 when this is non-zero, which `EXIT_USAGE` already
+# distinguishes from "the script was invoked wrongly".
+#
+# Defaulted like DRY_RUN so a test sourcing one function never meets it unset.
+SWEEP_FAILURES="${SWEEP_FAILURES:-0}"
 
 # Free space in GiB on the volume holding "$1". Prints an integer; returns
 # non-zero when `df` is absent or unparseable, so a host whose df cannot be read
@@ -213,7 +233,14 @@ remove_path() {
     return 0
   fi
   info "removing (${reason}): ${path}"
-  rm -rf "$path"
+  # `rm -rf` is silent about a path that was never there, so a non-zero status
+  # here is a real failure to remove something that is: a permission denial, a
+  # busy file, an I/O error. Report it and keep going.
+  if ! rm -rf "$path"; then
+    info "failed to remove: ${path}"
+    SWEEP_FAILURES=$((SWEEP_FAILURES + 1))
+    return 1
+  fi
 }
 
 # Orphaned job scratch. Actions clears `_temp` between jobs on a healthy run, so
@@ -345,10 +372,18 @@ reclaim_stale_build_output() {
     fi
 
     info "pruning files older than ${days}d from: ${target_dir}"
-    find "$target_dir" -type f -mtime "+${days}" -delete 2>/dev/null
+    # stderr is dropped -- a walk this wide reports every unreadable entry and
+    # the log is for an operator, not a debugger -- so the exit status is the
+    # only signal that the prune did not do what the line above just announced.
+    if ! find "$target_dir" -type f -mtime "+${days}" -delete 2>/dev/null; then
+      info "failed to prune some files from: ${target_dir}"
+      SWEEP_FAILURES=$((SWEEP_FAILURES + 1))
+    fi
     # Directories the prune emptied. Left behind they cost nothing but noise,
-    # and cargo recreates whatever it needs.
-    find "$target_dir" -mindepth 1 -type d -empty -delete 2>/dev/null
+    # and cargo recreates whatever it needs. Not counted as a sweep failure:
+    # the space was already reclaimed by the prune above, and an empty directory
+    # that survives costs an inode.
+    find "$target_dir" -mindepth 1 -type d -empty -delete 2>/dev/null || true
     pruned+=1
   done
 
@@ -361,6 +396,7 @@ usage() {
 
 main() {
   DRY_RUN=0
+  SWEEP_FAILURES=0
   local root=""
   local days="${RECLAIM_MAX_AGE_DAYS:-$DEFAULT_MAX_AGE_DAYS}"
   local floor="${RECLAIM_FREE_GIB:-$DEFAULT_FREE_GIB}"
@@ -427,6 +463,13 @@ main() {
     info "free space after: ${after} GiB (reclaimed $((after - before)) GiB)"
   elif [[ -n "$after" ]]; then
     info "free space after: ${after} GiB"
+  fi
+
+  # After the report, not instead of it: an operator reading a failed run still
+  # needs to know how much the parts that did work reclaimed.
+  if (( SWEEP_FAILURES > 0 )); then
+    info "sweep incomplete: ${SWEEP_FAILURES} removal(s) failed"
+    return 1
   fi
 
   return 0

--- a/scripts/reclaim_runner_disk.sh
+++ b/scripts/reclaim_runner_disk.sh
@@ -79,6 +79,18 @@ readonly EXIT_USAGE=64
 # directory that merely happens to be called `target` -- does not arise.
 readonly CACHEDIR_SIGNATURE='Signature: 8a477f597d28d172789f06886806bc55'
 
+# The producer line cargo writes beneath the signature. Required as well,
+# because the signature alone is the *specification's* marker rather than
+# cargo's: it is a fixed string every tool implementing the spec writes, so
+# `restic`, `borg` and others tag their caches with the identical first line.
+# Discovery walks the whole work root, so matching the signature alone would
+# hand any of their caches to a prune whose safety argument -- that a rebuild
+# is the worst case -- is an argument about cargo and holds for nothing else.
+#
+# Failing this match is the safe direction: a cargo that reworded its tag would
+# leave build output unswept, which is the condition the host was already in.
+readonly CARGO_PRODUCER_LINE='# This file is a cache directory tag created by cargo.'
+
 info() { printf '%s\n' "$*" >&2; }
 
 # Report rather than remove. Set by --dry-run; defaulted here so the unit tests,
@@ -107,11 +119,14 @@ work_root_from_env() {
 }
 
 # True when the directory is a cargo target directory, by its own CACHEDIR.TAG.
+# Both lines are required: the signature says the directory is a cache, and the
+# producer line says whose. Only the second one narrows this to cargo.
 is_cargo_target_dir() {
   local dir="$1"
   local tag="$dir/CACHEDIR.TAG"
   [[ -d "$dir" && -f "$tag" ]] || return 1
-  grep -qF "$CACHEDIR_SIGNATURE" "$tag" 2>/dev/null
+  grep -qF "$CACHEDIR_SIGNATURE" "$tag" 2>/dev/null || return 1
+  grep -qF "$CARGO_PRODUCER_LINE" "$tag" 2>/dev/null
 }
 
 # The workspace this job is running out of, which must survive the sweep
@@ -161,6 +176,34 @@ workspace_is_stale() {
   [[ -z "$recent" ]]
 }
 
+# True when nothing anywhere beneath "$1" has been modified within "$2" days.
+#
+# `-mtime` on an entry answers for that entry alone, and a directory's own mtime
+# moves only when something is added to or removed from it -- not when a file
+# already inside it is rewritten. So scratch last restructured a fortnight ago,
+# holding a file the running job overwrote a minute ago, still presents as old.
+# `reclaim_temp` selects by the entry's own mtime and then deletes recursively,
+# so without this the live-scratch exclusion its comments promise does not hold
+# on the stock layout, where the name check cannot fire.
+#
+# Unbounded depth, unlike `workspace_is_stale`: that one can stop at the level a
+# checkout is guaranteed to rewrite, whereas job scratch has no such layer and
+# is small enough to walk whole.
+tree_is_stale() {
+  local dir="$1" days="$2" recent rc
+  [[ -e "$dir" ]] || return 1
+
+  recent=$(find "$dir" -mtime "-${days}" -print 2>/dev/null)
+  rc=$?
+
+  # Fail closed, for the reason `workspace_is_stale` does: a walk that errored
+  # prints nothing, which is byte-for-byte what "nothing here is recent" looks
+  # like, and the caller deletes on that answer.
+  (( rc == 0 )) || return 1
+
+  [[ -z "$recent" ]]
+}
+
 # Remove "$1", or report it under --dry-run. Prints one line either way so the
 # run log names everything the sweep touched.
 remove_path() {
@@ -190,14 +233,20 @@ reclaim_temp() {
   while IFS= read -r entry; do
     [[ -n "$entry" ]] || continue
     # Whatever this job is using, whatever its age. On stock Actions RUNNER_TEMP
-    # *is* `_temp`, so no entry beneath it can equal it and the age filter is
-    # what actually protects the running job -- its files were written minutes
-    # ago. The name check covers the other layout, where RUNNER_TEMP points at a
-    # per-job directory inside `_temp`: there an idle-then-resumed runner really
-    # can present the live scratch as old, and only this catches it.
+    # *is* `_temp`, so no entry beneath it can equal it and the age rule is what
+    # actually protects the running job. The name check covers the other layout,
+    # where RUNNER_TEMP points at a per-job directory inside `_temp`: there an
+    # idle-then-resumed runner really can present the live scratch as old, and
+    # only this catches it.
     if [[ -n "$live_temp" ]]; then
       [[ "${entry%/}" == "$live_temp" || "$live_temp" == "${entry%/}"/* ]] && continue
     fi
+    # The walk below matched this entry's own mtime, which says nothing about
+    # what is inside it -- and the removal is recursive. On the stock layout,
+    # where the name check above cannot fire, this is the only thing standing
+    # between a file the running job just rewrote and an `rm -rf` of the
+    # directory holding it.
+    tree_is_stale "$entry" "$days" || continue
     remove_path "$entry" "orphaned job scratch"
   done < <(find "$temp_dir" -mindepth 1 -maxdepth 1 -mtime "+${days}" 2>/dev/null)
 }

--- a/scripts/test_reclaim_runner_disk.sh
+++ b/scripts/test_reclaim_runner_disk.sh
@@ -148,6 +148,21 @@ result="$(env bash -c 'source "$1"; is_cargo_target_dir "$2"' _ "$subject" "$tmp
 pass_or_fail "rejects a CACHEDIR.TAG some other tool wrote" \
   "$([[ "$result" == *"rc=1" ]] && echo 1 || echo 0)" "got: $result"
 
+# The realistic collision, and the one the wrong-signature case above does not
+# reach: the signature is the Cache Directory Tagging Specification's, not
+# cargo's, so every tool implementing the spec writes that exact first line.
+# Discovery walks the whole work root, so accepting on the signature alone hands
+# a `restic` or `borg` cache to a prune justified by cargo's rebuild semantics.
+mkdir -p "$tmp/other-tool-cache"
+printf '%s\n' \
+  'Signature: 8a477f597d28d172789f06886806bc55' \
+  '# This file is a cache directory tag automatically created by restic.' \
+  >"$tmp/other-tool-cache/CACHEDIR.TAG"
+
+result="$(env bash -c 'source "$1"; is_cargo_target_dir "$2"' _ "$subject" "$tmp/other-tool-cache" 2>&1; echo "rc=$?")"
+pass_or_fail "rejects another tool's cache carrying the same spec signature" \
+  "$([[ "$result" == *"rc=1" ]] && echo 1 || echo 0)" "got: $result"
+
 echo "workspace_is_stale"
 
 mkdir -p "$tmp/stale-ws/repo/src"
@@ -207,6 +222,22 @@ env "RUNNER_TEMP=$root/_temp" bash -c 'source "$1"; reclaim_temp "$2" "$3"' _ "$
 pass_or_fail "still sweeps when RUNNER_TEMP names the whole _temp directory" \
   "$([[ ! -e "$root/_temp/from-a-dead-job" ]] && echo 1 || echo 0)" \
   "the sweep spared everything because RUNNER_TEMP is _temp itself"
+
+# A directory's own mtime moves when an entry is added to or removed from it,
+# not when a file already inside it is rewritten -- so scratch whose structure
+# last changed a month ago, holding a file this job just overwrote, matches the
+# `+days` walk and would be removed recursively. On the stock layout the name
+# check cannot fire, so nothing else stands in the way.
+mkdir -p "$root/_temp/old-dir-live-file"
+touch "$root/_temp/old-dir-live-file/in-use.sock"
+age_tree "$root/_temp/old-dir-live-file" 30
+touch "$root/_temp/old-dir-live-file/in-use.sock"   # rewritten by the running job
+age_path "$root/_temp/old-dir-live-file" 30         # the directory itself stays old
+
+env "RUNNER_TEMP=$root/_temp" bash -c 'source "$1"; reclaim_temp "$2" "$3"' _ "$subject" "$root" 7 >/dev/null 2>&1
+pass_or_fail "keeps old scratch holding a file the running job rewrote" \
+  "$([[ -e "$root/_temp/old-dir-live-file/in-use.sock" ]] && echo 1 || echo 0)" \
+  "an in-use file was deleted because only the directory's own mtime was checked"
 
 echo "reclaim_workspaces"
 

--- a/scripts/test_reclaim_runner_disk.sh
+++ b/scripts/test_reclaim_runner_disk.sh
@@ -352,6 +352,47 @@ pass_or_fail "still names what it would remove" \
   "$([[ "$output" == *"would remove"* && "$output" == *"would prune"* ]] && echo 1 || echo 0)" \
   "got: $output"
 
+echo "reporting a sweep that could not remove what it found"
+
+# Nobody watches a scheduled run, so its exit status is the whole signal. A
+# permission or I/O failure that leaves the job green reports a host as swept
+# while it is still filling up — which is the condition #12794 was.
+#
+# `rm` is stubbed rather than the tree made read-only: a runner executing this
+# as root would delete straight through a `chmod`, so the interesting case would
+# silently stop being tested on exactly the hosts it is written for.
+stub_bin="$tmp/stub-bin"
+mkdir -p "$stub_bin"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$stub_bin/rm"
+chmod +x "$stub_bin/rm"
+
+undeletable="$tmp/undeletable"
+mkdir -p "$undeletable/_temp/orphan" "$undeletable/spiceai/spiceai"
+age_tree "$undeletable" 30
+
+result="$(env "RUNNER_WORKSPACE=$undeletable/spiceai" "PATH=$stub_bin:$PATH" \
+  bash "$subject" --root "$undeletable" --free-gib "$ALWAYS_PRUNE_FLOOR" 2>&1; echo "rc=$?")"
+
+pass_or_fail "fails the run when a removal did not happen" \
+  "$([[ "$result" == *"rc=1" ]] && echo 1 || echo 0)" "got: $result"
+pass_or_fail "names the path it could not remove" \
+  "$([[ "$result" == *"failed to remove: $undeletable/_temp/orphan"* ]] && echo 1 || echo 0)" \
+  "got: $result"
+pass_or_fail "still reports the disk before returning non-zero" \
+  "$([[ "$result" == *"free space after:"* ]] && echo 1 || echo 0)" "got: $result"
+
+# The other direction: an ordinary sweep must not start failing the schedule.
+clean_sweep="$tmp/clean-sweep"
+mkdir -p "$clean_sweep/_temp/orphan" "$clean_sweep/staleworkspace/repo" "$clean_sweep/spiceai/spiceai"
+make_cargo_target "$clean_sweep/spiceai/spiceai/target"
+touch "$clean_sweep/staleworkspace/repo/Cargo.toml" "$clean_sweep/spiceai/spiceai/target/old.rlib"
+age_tree "$clean_sweep" 30
+
+result="$(env "RUNNER_WORKSPACE=$clean_sweep/spiceai" \
+  bash "$subject" --root "$clean_sweep" --free-gib "$ALWAYS_PRUNE_FLOOR" 2>&1; echo "rc=$?")"
+pass_or_fail "succeeds when everything it found came off" \
+  "$([[ "$result" == *"rc=0" ]] && echo 1 || echo 0)" "got: $result"
+
 echo "argument handling"
 
 result="$(env "RUNNER_WORKSPACE=" bash "$subject" 2>&1; echo "rc=$?")"

--- a/scripts/test_reclaim_runner_disk.sh
+++ b/scripts/test_reclaim_runner_disk.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+#
+# Unit tests for `scripts/reclaim_runner_disk.sh`.
+#
+# The sweep deletes things on a shared, long-lived volume, so both directions
+# are the bug. Deleting too little leaves the condition #12794 describes -- a
+# host that only ever fills, until every job that lands on it fails on a write.
+# Deleting too much takes a live build out from under the job using it, or
+# throws away the warm cache that is the difference between a sign-off finishing
+# in minutes and one taking hours. The exclusions are therefore tested as
+# closely as the removals: this job's own scratch, this job's own workspace,
+# anything modified inside the threshold, and anything a cargo target directory
+# has not disowned.
+#
+# No runner and no network: every case is a temporary directory tree with mtimes
+# set to whatever the case needs.
+#
+# Usage: scripts/test_reclaim_runner_disk.sh
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+subject="$script_dir/reclaim_runner_disk.sh"
+
+tests_run=0
+# Deliberately not named `failures`: a helper that shadows the suite's own
+# counter makes it report "all N passed" while cases fail underneath it.
+failed_assertions=0
+
+fail_test() {
+  failed_assertions=$((failed_assertions + 1))
+  echo "  FAIL: $1"
+}
+
+# The subject reads the tree through `find` and swallows its stderr, because a
+# host whose walk fails should not take the sweep down with it. That is right
+# for the runner and wrong for a test: an environment where `find` cannot run
+# would report every removal case as "nothing was removed" -- which is exactly
+# what a broken sweep looks like -- and every exclusion case as passing. Refuse
+# to grade the subject on an environment that cannot exercise it.
+if ! find "$script_dir" -maxdepth 0 -print >/dev/null 2>&1; then
+  echo "cannot run: 'find' is unavailable here, and without it every case would report a false pass" >&2
+  exit 1
+fi
+
+pass_or_fail() {
+  local name="$1" ok="$2" detail="$3"
+  tests_run=$((tests_run + 1))
+  if [[ "$ok" == "1" ]]; then
+    echo "  ok: $name"
+  else
+    fail_test "$name: $detail"
+  fi
+}
+
+# A timestamp `touch -t` accepts, "$1" days in the past. GNU and BSD `date`
+# spell relative arithmetic differently and the suite has to run on both: CI is
+# Linux, a developer reproducing a case is often not.
+days_ago_stamp() {
+  local days="$1"
+  date -u -d "${days} days ago" +%Y%m%d%H%M 2>/dev/null ||
+    date -u -v-"${days}"d +%Y%m%d%H%M 2>/dev/null
+}
+
+age_path() {
+  local path="$1" days="$2" stamp
+  stamp=$(days_ago_stamp "$days")
+  [[ -n "$stamp" ]] || { echo "could not compute a timestamp ${days} days ago" >&2; exit 1; }
+  touch -t "$stamp" "$path"
+}
+
+# Ages every entry in a tree, deepest first so that aging a directory is not
+# undone by a later write inside it.
+age_tree() {
+  local root="$1" days="$2" entry
+  while IFS= read -r entry; do
+    age_path "$entry" "$days"
+  done < <(find "$root" -depth 2>/dev/null)
+}
+
+make_cargo_target() {
+  local dir="$1"
+  mkdir -p "$dir"
+  printf '%s\n' \
+    'Signature: 8a477f597d28d172789f06886806bc55' \
+    '# This file is a cache directory tag created by cargo.' >"$dir/CACHEDIR.TAG"
+}
+
+# Runs one function from the subject in a fresh shell. Sourcing reaches a single
+# function without running the argument parsing a real invocation would.
+# Echoes "<rc>|<output>".
+call_subject() {
+  local snippet="$1"
+  shift
+  local output rc
+  # `env` rather than an assignment prefix: these come from "$@", and a word
+  # that only looks like an assignment after expansion is read as the command.
+  output="$(env "$@" bash -c 'source "$1"; shift; '"$snippet" _ "$subject" 2>&1)"
+  rc=$?
+  printf '%s|%s' "$rc" "$output"
+}
+
+echo "work_root_from_env"
+
+result="$(call_subject 'work_root_from_env' "RUNNER_WORKSPACE=/opt/github-runner-01/_work/spiceai")"
+pass_or_fail "derives the work root from RUNNER_WORKSPACE" \
+  "$([[ "$result" == "0|/opt/github-runner-01/_work" ]] && echo 1 || echo 0)" \
+  "got: $result"
+
+result="$(call_subject 'work_root_from_env' "RUNNER_WORKSPACE=")"
+pass_or_fail "fails when RUNNER_WORKSPACE is unset" \
+  "$([[ "${result%%|*}" != "0" ]] && echo 1 || echo 0)" \
+  "expected a non-zero exit, got: $result"
+
+echo "live_workspace"
+
+result="$(call_subject 'live_workspace' "RUNNER_WORKSPACE=/opt/github-runner-01/_work/spiceai/")"
+pass_or_fail "normalises a trailing slash, so the exclusion still matches" \
+  "$([[ "$result" == "0|/opt/github-runner-01/_work/spiceai" ]] && echo 1 || echo 0)" \
+  "got: $result"
+
+# Off a runner there is no RUNNER_WORKSPACE, and answering nothing would leave
+# the one tree we are certain is in use protected only by its mtimes.
+result="$(call_subject 'live_workspace' "RUNNER_WORKSPACE=")"
+pass_or_fail "falls back to the checkout this script lives in" \
+  "$([[ "$result" == "0|$(dirname "$(dirname "$script_dir")")" ]] && echo 1 || echo 0)" \
+  "got: $result"
+
+echo "is_cargo_target_dir"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+make_cargo_target "$tmp/real-target"
+mkdir -p "$tmp/named-target"
+mkdir -p "$tmp/wrong-signature"
+printf 'Signature: not-the-cargo-one\n' >"$tmp/wrong-signature/CACHEDIR.TAG"
+
+result="$(env bash -c 'source "$1"; is_cargo_target_dir "$2"' _ "$subject" "$tmp/real-target" 2>&1; echo "rc=$?")"
+pass_or_fail "accepts a directory carrying cargo's CACHEDIR.TAG" \
+  "$([[ "$result" == *"rc=0" ]] && echo 1 || echo 0)" "got: $result"
+
+result="$(env bash -c 'source "$1"; is_cargo_target_dir "$2"' _ "$subject" "$tmp/named-target" 2>&1; echo "rc=$?")"
+pass_or_fail "rejects a directory that is merely named like one" \
+  "$([[ "$result" == *"rc=1" ]] && echo 1 || echo 0)" "got: $result"
+
+result="$(env bash -c 'source "$1"; is_cargo_target_dir "$2"' _ "$subject" "$tmp/wrong-signature" 2>&1; echo "rc=$?")"
+pass_or_fail "rejects a CACHEDIR.TAG some other tool wrote" \
+  "$([[ "$result" == *"rc=1" ]] && echo 1 || echo 0)" "got: $result"
+
+echo "workspace_is_stale"
+
+mkdir -p "$tmp/stale-ws/repo/src"
+touch "$tmp/stale-ws/repo/src/lib.rs" "$tmp/stale-ws/repo/Cargo.toml"
+age_tree "$tmp/stale-ws" 30
+
+mkdir -p "$tmp/fresh-ws/repo/src"
+touch "$tmp/fresh-ws/repo/src/lib.rs"
+age_tree "$tmp/fresh-ws" 30
+# One recent file at the depth a checkout rewrites, which is the whole signal.
+touch "$tmp/fresh-ws/repo/Cargo.toml"
+
+result="$(env bash -c 'source "$1"; workspace_is_stale "$2" "$3"' _ "$subject" "$tmp/stale-ws" 7 2>&1; echo "rc=$?")"
+pass_or_fail "a workspace untouched for longer than the threshold is stale" \
+  "$([[ "$result" == *"rc=0" ]] && echo 1 || echo 0)" "got: $result"
+
+result="$(env bash -c 'source "$1"; workspace_is_stale "$2" "$3"' _ "$subject" "$tmp/fresh-ws" 7 2>&1; echo "rc=$?")"
+pass_or_fail "one recent file keeps a workspace off the list" \
+  "$([[ "$result" == *"rc=1" ]] && echo 1 || echo 0)" "got: $result"
+
+echo "reclaim_temp"
+
+root="$tmp/work"
+mkdir -p "$root/_temp/orphan" "$root/_temp/live" "$root/_temp/recent"
+touch "$root/_temp/orphan/leftover.log"
+age_tree "$root/_temp/orphan" 30
+age_tree "$root/_temp/live" 30
+
+env "RUNNER_TEMP=$root/_temp/live" bash -c 'source "$1"; reclaim_temp "$2" "$3"' _ "$subject" "$root" 7 >/dev/null 2>&1
+
+pass_or_fail "removes scratch a killed job orphaned" \
+  "$([[ ! -e "$root/_temp/orphan" ]] && echo 1 || echo 0)" "orphan survived"
+pass_or_fail "keeps this job's own scratch however old it looks" \
+  "$([[ -d "$root/_temp/live" ]] && echo 1 || echo 0)" "RUNNER_TEMP was removed"
+pass_or_fail "keeps scratch inside the threshold" \
+  "$([[ -d "$root/_temp/recent" ]] && echo 1 || echo 0)" "recent scratch was removed"
+
+# On stock Actions RUNNER_TEMP *is* `_temp`, not a directory inside it. Nothing
+# beneath it may be spared on that basis -- sparing the whole directory would
+# make the sweep a no-op on every real runner, which is the shape of bug that
+# passes its own tests while reclaiming nothing.
+mkdir -p "$root/_temp/from-a-dead-job"
+age_tree "$root/_temp/from-a-dead-job" 30
+env "RUNNER_TEMP=$root/_temp" bash -c 'source "$1"; reclaim_temp "$2" "$3"' _ "$subject" "$root" 7 >/dev/null 2>&1
+pass_or_fail "still sweeps when RUNNER_TEMP names the whole _temp directory" \
+  "$([[ ! -e "$root/_temp/from-a-dead-job" ]] && echo 1 || echo 0)" \
+  "the sweep spared everything because RUNNER_TEMP is _temp itself"
+
+echo "reclaim_workspaces"
+
+mkdir -p "$root/otherrepo/otherrepo" "$root/spiceai/spiceai" "$root/busyrepo/busyrepo" "$root/_actions/some/action"
+touch "$root/otherrepo/otherrepo/Cargo.toml" "$root/spiceai/spiceai/Cargo.toml" "$root/busyrepo/busyrepo/Cargo.toml"
+age_tree "$root/otherrepo" 30
+age_tree "$root/busyrepo" 30
+age_tree "$root/_actions" 30
+# The live workspace is aged too, to prove the exclusion is by name and does not
+# lean on the checkout that would refresh it in a real run.
+age_tree "$root/spiceai" 30
+touch "$root/busyrepo/busyrepo/Cargo.toml"
+
+env "RUNNER_WORKSPACE=$root/spiceai" bash -c 'source "$1"; reclaim_workspaces "$2" "$3"' _ "$subject" "$root" 7 >/dev/null 2>&1
+
+pass_or_fail "removes a workspace no job has used inside the threshold" \
+  "$([[ ! -e "$root/otherrepo" ]] && echo 1 || echo 0)" "stale workspace survived"
+pass_or_fail "keeps the workspace this job is using, whatever its age" \
+  "$([[ -d "$root/spiceai/spiceai" ]] && echo 1 || echo 0)" "the live workspace was removed"
+pass_or_fail "keeps a workspace something touched inside the threshold" \
+  "$([[ -d "$root/busyrepo/busyrepo" ]] && echo 1 || echo 0)" "a recently used workspace was removed"
+pass_or_fail "leaves runner-internal state alone" \
+  "$([[ -d "$root/_actions/some/action" ]] && echo 1 || echo 0)" "_actions was removed"
+
+echo "reclaim_stale_build_output"
+
+target="$root/spiceai/spiceai/target"
+make_cargo_target "$target"
+mkdir -p "$target/debug/deps" "$target/package/inner-crate"
+touch "$target/debug/deps/old.rlib" "$target/debug/deps/fresh.rlib"
+make_cargo_target "$target/package/inner-crate/target"
+touch "$target/package/inner-crate/target/old.rlib"
+
+# A directory named `target` that no cargo ever wrote: source, not build output.
+mkdir -p "$root/spiceai/spiceai/crates/target"
+touch "$root/spiceai/spiceai/crates/target/mod.rs"
+
+age_tree "$target/debug" 30
+age_tree "$target/package" 30
+age_tree "$root/spiceai/spiceai/crates/target" 30
+touch "$target/debug/deps/fresh.rlib"
+
+# A floor no real volume reaches, so every host counts as below it and the prune
+# always runs: the free-space gate has its own cases below, and these are about
+# which files the prune selects.
+readonly ALWAYS_PRUNE_FLOOR=999999999
+output="$(env bash -c 'source "$1"; reclaim_stale_build_output "$2" "$3" "$4"' _ "$subject" "$root" 7 "$ALWAYS_PRUNE_FLOOR" 2>&1)"
+
+pass_or_fail "prunes build output older than the threshold" \
+  "$([[ ! -e "$target/debug/deps/old.rlib" ]] && echo 1 || echo 0)" "stale artifact survived"
+pass_or_fail "keeps build output inside the threshold, so the cache stays warm" \
+  "$([[ -f "$target/debug/deps/fresh.rlib" ]] && echo 1 || echo 0)" "warm artifact was pruned"
+pass_or_fail "never walks a directory merely named target" \
+  "$([[ -f "$root/spiceai/spiceai/crates/target/mod.rs" ]] && echo 1 || echo 0)" "source under crates/target was deleted"
+pass_or_fail "sweeps a nested target directory only through its ancestor" \
+  "$([[ "$output" == *"build output directories swept: 1"* ]] && echo 1 || echo 0)" "got: $output"
+
+echo "free-space gate on build output"
+
+# A host with room to spare keeps its cache. The point of the gate: a pruned
+# target directory costs a colder build, and on this pool a colder build is
+# measured against a step budget whose expiry publishes a code-failure verdict.
+gated="$tmp/gated"
+make_cargo_target "$gated/spiceai/spiceai/target"
+touch "$gated/spiceai/spiceai/target/old.rlib"
+age_tree "$gated" 30
+
+output="$(env bash -c 'source "$1"; reclaim_stale_build_output "$2" "$3" "$4"' _ "$subject" "$gated" 7 0 2>&1)"
+pass_or_fail "leaves build output alone on a host above the floor" \
+  "$([[ -f "$gated/spiceai/spiceai/target/old.rlib" ]] && echo 1 || echo 0)" \
+  "the cache was pruned on a host with room"
+pass_or_fail "says why it left it alone" \
+  "$([[ "$output" == *"leaving build output alone"* ]] && echo 1 || echo 0)" "got: $output"
+
+output="$(env bash -c 'source "$1"; reclaim_stale_build_output "$2" "$3" "$4"' _ "$subject" "$gated" 7 "$ALWAYS_PRUNE_FLOOR" 2>&1)"
+pass_or_fail "prunes on a host below the floor" \
+  "$([[ ! -e "$gated/spiceai/spiceai/target/old.rlib" ]] && echo 1 || echo 0)" \
+  "the cache survived on a host that is out of room"
+
+# A volume whose `df` cannot be read is not evidence of a healthy one -- and the
+# hosts this exists for are the ones in trouble.
+stub_dir="$(mktemp -d)"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$stub_dir/df"
+chmod +x "$stub_dir/df"
+
+unreadable="$tmp/unreadable"
+make_cargo_target "$unreadable/repo/target"
+touch "$unreadable/repo/target/old.rlib"
+age_tree "$unreadable" 30
+
+output="$(env "PATH=$stub_dir:$PATH" bash -c 'source "$1"; reclaim_stale_build_output "$2" "$3" "$4"' _ "$subject" "$unreadable" 7 100 2>&1)"
+pass_or_fail "prunes when free space cannot be measured" \
+  "$([[ ! -e "$unreadable/repo/target/old.rlib" ]] && echo 1 || echo 0)" \
+  "an unreadable df was treated as a healthy host"
+
+echo "dry run"
+
+dry="$tmp/dryrun"
+mkdir -p "$dry/_temp/orphan" "$dry/staleworkspace/repo" "$dry/spiceai/spiceai"
+make_cargo_target "$dry/spiceai/spiceai/target"
+touch "$dry/staleworkspace/repo/Cargo.toml" "$dry/spiceai/spiceai/target/old.rlib"
+age_tree "$dry" 30
+
+output="$(env "RUNNER_WORKSPACE=$dry/spiceai" "DRY_RUN=1" bash -c \
+  'source "$1"; reclaim_temp "$2" "$3"; reclaim_workspaces "$2" "$3"; reclaim_stale_build_output "$2" "$3" "$4"' \
+  _ "$subject" "$dry" 7 "$ALWAYS_PRUNE_FLOOR" 2>&1)"
+
+pass_or_fail "removes nothing" \
+  "$([[ -d "$dry/_temp/orphan" && -d "$dry/staleworkspace" && -f "$dry/spiceai/spiceai/target/old.rlib" ]] && echo 1 || echo 0)" \
+  "a dry run deleted something"
+pass_or_fail "still names what it would remove" \
+  "$([[ "$output" == *"would remove"* && "$output" == *"would prune"* ]] && echo 1 || echo 0)" \
+  "got: $output"
+
+echo "argument handling"
+
+result="$(env "RUNNER_WORKSPACE=" bash "$subject" 2>&1; echo "rc=$?")"
+pass_or_fail "refuses to guess a work root" \
+  "$([[ "$result" == *"rc=64" ]] && echo 1 || echo 0)" "got: $result"
+
+result="$(bash "$subject" --root "$tmp" --max-age-days notanumber 2>&1; echo "rc=$?")"
+pass_or_fail "rejects a non-numeric age" \
+  "$([[ "$result" == *"rc=64" ]] && echo 1 || echo 0)" "got: $result"
+
+result="$(bash "$subject" --root "$tmp" --free-gib lots 2>&1; echo "rc=$?")"
+pass_or_fail "rejects a non-numeric free-space floor" \
+  "$([[ "$result" == *"rc=64" ]] && echo 1 || echo 0)" "got: $result"
+
+result="$(bash "$subject" --root "$tmp/does-not-exist" 2>&1; echo "rc=$?")"
+pass_or_fail "rejects a work root that is not there" \
+  "$([[ "$result" == *"rc=64" ]] && echo 1 || echo 0)" "got: $result"
+
+result="$(bash "$subject" --root "$tmp" --unknown-flag 2>&1; echo "rc=$?")"
+pass_or_fail "rejects an unknown argument rather than sweeping with a default" \
+  "$([[ "$result" == *"rc=64" ]] && echo 1 || echo 0)" "got: $result"
+
+echo
+if [[ "$failed_assertions" -eq 0 ]]; then
+  echo "all ${tests_run} checks passed"
+  exit 0
+fi
+echo "${failed_assertions} of ${tests_run} checks failed"
+exit 1

--- a/scripts/test_reclaim_runner_disk.sh
+++ b/scripts/test_reclaim_runner_disk.sh
@@ -168,6 +168,18 @@ result="$(env bash -c 'source "$1"; workspace_is_stale "$2" "$3"' _ "$subject" "
 pass_or_fail "one recent file keeps a workspace off the list" \
   "$([[ "$result" == *"rc=1" ]] && echo 1 || echo 0)" "got: $result"
 
+# A walk that errored prints nothing, which is byte-for-byte what "nothing here
+# is recent" looks like — and the caller deletes the whole workspace on that
+# answer. The unknown case has to land on the safe side.
+failing_find_dir="$(mktemp -d)"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$failing_find_dir/find"
+chmod +x "$failing_find_dir/find"
+
+result="$(env "PATH=$failing_find_dir:$PATH" bash -c 'source "$1"; workspace_is_stale "$2" "$3"' _ "$subject" "$tmp/stale-ws" 7 2>&1; echo "rc=$?")"
+pass_or_fail "a workspace whose walk failed is not called stale" \
+  "$([[ "$result" == *"rc=1" ]] && echo 1 || echo 0)" \
+  "an unreadable directory was reported as safe to delete: $result"
+
 echo "reclaim_temp"
 
 root="$tmp/work"
@@ -330,6 +342,29 @@ pass_or_fail "rejects a work root that is not there" \
 result="$(bash "$subject" --root "$tmp" --unknown-flag 2>&1; echo "rc=$?")"
 pass_or_fail "rejects an unknown argument rather than sweeping with a default" \
   "$([[ "$result" == *"rc=64" ]] && echo 1 || echo 0)" "got: $result"
+
+# A value-taking flag typed last used to leave `shift 2` failing with the
+# argument still in place, so the parser spun on it until the job timeout —
+# a mistyped dispatch input hung the sweep instead of correcting it. Each case
+# is bounded so a regression fails the suite rather than hanging it.
+for flag in --root --max-age-days --free-gib; do
+  result="$(bash "$subject" "$flag" 2>&1 & pid=$!; ( sleep 10; kill -9 "$pid" 2>/dev/null ) & watchdog=$!; wait "$pid"; rc=$?; kill "$watchdog" 2>/dev/null; echo "rc=$rc")"
+  pass_or_fail "$flag with no value exits rather than looping" \
+    "$([[ "$result" == *"rc=64" ]] && echo 1 || echo 0)" "got: $result"
+done
+
+# Bash arithmetic reads a leading zero as octal, so an unnormalised `08` is an
+# arithmetic error and `0100` would quietly mean 64 — a wrong floor decides
+# whether a host keeps its build cache.
+octal="$tmp/octal"
+make_cargo_target "$octal/repo/target"
+touch "$octal/repo/target/old.rlib"
+age_tree "$octal" 30
+
+output="$(env bash -c 'source "$1"; reclaim_stale_build_output "$2" "$3" "$4"' _ "$subject" "$octal" 7 08 2>&1)"
+pass_or_fail "a zero-padded floor is read as decimal, not octal" \
+  "$([[ "$output" != *"error"* && "$output" != *"value too great"* && "$output" == *"GiB"* ]] && echo 1 || echo 0)" \
+  "got: $output"
 
 echo
 if [[ "$failed_assertions" -eq 0 ]]; then


### PR DESCRIPTION
Fixes #12800

## Summary

Nothing ever reclaimed space on the self-hosted runner work volumes. The hosts are long-lived, several runner instances share a volume, and every job that lands on one writes into it — so free space only ever went down until a job failed on it. #12794 is where that ends: two volumes below the 25 GiB sign-off floor at the same time while two other hosts in the same pool sat at 163 and 536 GiB, every merge-queue candidate failing its build, and an operator deleting files by hand to get the queue moving.

The preflights added since — `scripts/preflight_build_disk.sh` for the build path (#12799), `scripts/signoff` for the sign-off path — report a full volume at the point it is detectable rather than minutes later from inside the compiler. Neither reclaims anything. Both are doors; this takes something out of the room. It is follow-up 2 from the end of #12794, the one those changes explicitly do not cover.

## Why deleting here is safe when deleting by path alone is not

A sweep that walks the volume can delete a live build out from under a sibling instance. Two rules avoid it, and every candidate satisfies both:

1. **Nothing outside this runner instance's own work root is walked.** A job owns its instance for its whole duration, so while the sweep runs that instance has no other job. Sibling instances keep their own work roots on the same volume and are never reached.
2. **Nothing modified inside the age threshold is a candidate** — one week by default.

## Changes

`scripts/reclaim_runner_disk.sh` sweeps three categories, and they are not treated alike:

| category | swept where |
|---|---|
| job scratch a killed job orphaned | any host |
| workspaces for repositories nobody has built here lately | any host |
| stale files inside cargo target directories | only a host **below** a free-space floor |

The first two are worth nothing to a future build. A target directory is not: it is the warm cache an incremental build depends on. Taking it from a host with 536 GiB free buys space nobody needed and pays in build time — and on this pool a build runs 2–5 hours against a 353-minute step budget whose expiry publishes a `signoff=failure` verdict against the branch. The 100 GiB default floor sits between the two populations #12794 measured (536/163 healthy, 26/5/1 broken), so the sweep reclaims where it matters and leaves healthy hosts alone.

A target directory is identified by **cargo's own `CACHEDIR.TAG` signature**, not by a directory named `target` — so source under a path called `target` is never walked, and pruning by file age is what `cargo sweep` does and what cargo is built to tolerate: a missing artifact or fingerprint is rebuilt, so being wrong costs a rebuild, never a wrong build.

`.github/workflows/reclaim_runner_disk.yml` runs it six-hourly across both self-hosted pools, with `--dry-run`, `--max-age-days` and `--free-gib` available on `workflow_dispatch`. A runner instance runs one job at a time, so N concurrent jobs on one label occupy N distinct instances — which is the only way to address individual instances behind a shared label. That is coverage by repetition, not a guarantee, and the workflow says so: a busier instance is idle less often and gets swept on a later run.

## What this does not do

It bounds the **baseline** a long-lived host accumulates. It does **not** bound a single run: `/opt/github-runner-01` went 26 GiB to 1 GiB in 6.2 hours of active building, and no periodic sweep prevents that — a mid-run headroom check is the shape of guard that would, and it is not this change. The script and the issue both say so rather than leaving the next reader to infer a fix that is not here.

An alternative worth naming: reclaiming after each build (a `cargo sweep` step in `build-spiced`) would be more immediate and more precise, at the cost of time on every build, and it would still not collect what a crashed job orphaned. A periodic sweep was what #12794's follow-up asked for; the two are complementary rather than exclusive.

## Test plan

- [x] Added unit tests covering each selection rule and, as closely, each exclusion: this job's own scratch, this job's own workspace, anything inside the threshold, a directory merely *named* `target`, a `CACHEDIR.TAG` some other tool wrote, and a nested target directory swept only through its ancestor
- [x] Added cases for the free-space gate in all three states — above the floor (cache kept), below it (pruned), and `df` unreadable (pruned, because an unreadable volume is not evidence of a healthy one)
- [x] Added a case pinning the real `RUNNER_TEMP` layout: on stock Actions it *is* `_temp`, not a directory inside it, so an exclusion written for the other shape would silently spare everything and reclaim nothing
- [x] The suite refuses to run where `find` is unavailable rather than reporting a false pass — the subject swallows `find`'s stderr, which is right on a runner and would grade every removal case as passing here
- [x] `shellcheck` (warning level) and `bash -n` clean on both scripts; `actionlint` clean on both workflows apart from the two custom self-hosted labels, which no workflow in this repo declares
- [x] No Rust files changed, so the workspace Rust gate (`make lint` / `make test` — never a per-crate invocation) has nothing to check here: nothing in this diff matches the `rustAffecting` pattern in `pr.yml`, so `Attestation` fast-tracks and no sign-off applies. The full suite still runs in the merge queue.

## Note on review coverage

The cross-model adversarial pass could not run — the Codex engine returns `Your workspace is out of credits`. That pass was done by hand instead, and it is what produced the free-space gate: the first draft pruned build output unconditionally, which would have traded a runner's spare disk for a colder build and a real chance of a false `signoff=failure` on a 353-minute budget. Two further defects it found are fixed here: a `local a="$1" b="$a/x"` initialiser that aborts the function under `set -u` (bash declares every name before assigning any), and the `RUNNER_TEMP` exclusion described above.
