### PR TITLE
fix(runtime): keep serving when the working directory cannot be walked (fixes #6301)

### DIFF
--- a/crates/runtime/src/podswatcher.rs
+++ b/crates/runtime/src/podswatcher.rs
@@ -113,6 +113,7 @@ fn watch_root(watcher: &mut notify::RecommendedWatcher, root_path: &Path) -> not
         return Err(err);
     }
 
+    unwatch_partial_registration(watcher, root_path)?;
     watcher.watch(root_path, RecursiveMode::NonRecursive)?;
 
     tracing::warn!(
@@ -121,6 +122,34 @@ fn watch_root(watcher: &mut notify::RecommendedWatcher, root_path: &Path) -> not
     );
 
     Ok(())
+}
+
+/// Drop whatever the failed recursive registration left behind, so the fallback starts from
+/// nothing.
+///
+/// A recursive `watch` is not atomic. `notify`'s inotify backend walks the tree and registers a
+/// watch per directory as it goes, propagating the first failure without unwinding, so every
+/// directory it reached before the error is still registered — with the kernel as well as in the
+/// backend's own map. Re-watching `root_path` non-recursively would only rewrite the root's
+/// entry, leaving those descendants in place: the `MaxFilesWatch` fallback would sit at the
+/// watch limit it was supposed to retreat from, and the permission-denied fallback would be a
+/// partially recursive watcher whose coverage nobody can predict — while the warning below says
+/// the directories underneath are not watched.
+///
+/// Unwatching the root is enough to clear them, because the backend recorded that entry as
+/// recursive and so removes every watch beneath it too. `WatchNotFound` is the expected answer
+/// when the walk failed on `root_path` itself, and on the backends that register a subtree in
+/// one operation and so leave nothing partial behind; neither is an error here. Anything else is
+/// the watcher refusing to give a registration back, which the fallback cannot paper over.
+fn unwatch_partial_registration(
+    watcher: &mut notify::RecommendedWatcher,
+    root_path: &Path,
+) -> notify::Result<()> {
+    match watcher.unwatch(root_path) {
+        Ok(()) => Ok(()),
+        Err(err) if matches!(err.kind, notify::ErrorKind::WatchNotFound) => Ok(()),
+        Err(err) => Err(err),
+    }
 }
 
 /// Whether `err` reports that the subtree below the watched directory could not be walked,
@@ -464,6 +493,45 @@ mod tests {
             Some(root_path.clone()),
             "a spicepod edit must still be reported after an unreadable neighbour is skipped"
         );
+    }
+
+    /// The fallback narrows the watch to `root_path`, which only means anything if the
+    /// registrations the failed recursive walk left behind are gone first — otherwise
+    /// `MaxFilesWatch` retreats to the limit it just hit, and the warning's claim that the
+    /// directories below are unwatched is false.
+    ///
+    /// Asserted by removing a registration that is known to exist and then removing it again:
+    /// the second call can only be `WatchNotFound`, so a version of this that quietly skipped
+    /// the `unwatch` would leave the registration in place and fail here.
+    #[test]
+    fn clearing_a_partial_registration_removes_it_and_tolerates_its_absence() {
+        let root = tempfile::tempdir().expect("failed to create temp dir");
+        std::fs::create_dir(root.path().join("nested")).expect("failed to create nested directory");
+
+        let mut watcher = notify::recommended_watcher(|_: notify::Result<notify::Event>| {})
+            .expect("failed to construct a platform watcher");
+        watcher
+            .watch(root.path(), RecursiveMode::Recursive)
+            .expect("failed to register the watch this test then clears");
+
+        unwatch_partial_registration(&mut watcher, root.path())
+            .expect("clearing a registered watch must succeed");
+        unwatch_partial_registration(&mut watcher, root.path())
+            .expect("clearing an already-cleared watch must be tolerated, not an error");
+    }
+
+    /// A walk that failed on `root_path` itself registered nothing, and the backends that
+    /// register a subtree in one operation leave nothing partial behind either. Neither is a
+    /// reason to refuse the fallback.
+    #[test]
+    fn clearing_a_registration_that_was_never_made_is_not_an_error() {
+        let root = tempfile::tempdir().expect("failed to create temp dir");
+
+        let mut watcher = notify::recommended_watcher(|_: notify::Result<notify::Event>| {})
+            .expect("failed to construct a platform watcher");
+
+        unwatch_partial_registration(&mut watcher, root.path())
+            .expect("an unwatched path must not stop the fallback");
     }
 
     #[test]

--- a/crates/runtime/src/podswatcher.rs
+++ b/crates/runtime/src/podswatcher.rs
@@ -85,11 +85,53 @@ impl PodsWatcher {
             },
         )?;
 
-        watcher.watch(&self.root_path, RecursiveMode::Recursive)?;
+        watch_root(&mut watcher, &self.root_path)?;
 
         self.watcher = Some(watcher);
 
         Ok(rx)
+    }
+}
+
+/// Watch `root_path` for Spicepod changes, covering the directory alone when its subtree
+/// cannot be walked.
+///
+/// A recursive watch registers every directory beneath `root_path`, which is the working
+/// directory the runtime was started in — not a Spice-owned tree. Anything unreadable under it
+/// (another user's files) or a tree large enough to exhaust the kernel's watch limit fails the
+/// whole registration, and the pods watcher runs as a runtime task whose failure stops the
+/// process. Serving a valid Spicepod must not depend on every unrelated neighbour of it being
+/// readable, so those two environmental failures fall back to watching `root_path` itself,
+/// which is where `spicepod.yaml` lives. Any other failure — including an unreadable
+/// `root_path` — still propagates, because then there is nothing left to watch.
+fn watch_root(watcher: &mut notify::RecommendedWatcher, root_path: &Path) -> notify::Result<()> {
+    let Err(err) = watcher.watch(root_path, RecursiveMode::Recursive) else {
+        return Ok(());
+    };
+
+    if !is_untraversable_subtree(&err) {
+        return Err(err);
+    }
+
+    watcher.watch(root_path, RecursiveMode::NonRecursive)?;
+
+    tracing::warn!(
+        "Watching {} for Spicepod changes, but not the directories below it: {err}. Edits to spicepod.yaml still reload; edits to files it references from subdirectories do not. Run Spice from a directory it can read in full, or raise the system's file-watch limit, to restore them.",
+        root_path.display()
+    );
+
+    Ok(())
+}
+
+/// Whether `err` reports that the subtree below the watched directory could not be walked,
+/// rather than that the directory itself cannot be watched.
+fn is_untraversable_subtree(err: &notify::Error) -> bool {
+    match &err.kind {
+        // A directory beneath the root that this process may not read.
+        notify::ErrorKind::Io(err) => err.kind() == std::io::ErrorKind::PermissionDenied,
+        // More directories beneath the root than the kernel will watch.
+        notify::ErrorKind::MaxFilesWatch => true,
+        _ => false,
     }
 }
 
@@ -308,6 +350,120 @@ mod tests {
 
         assert!(!updated);
         assert_eq!(*watch_paths.read(), current);
+    }
+
+    #[test]
+    fn an_unreadable_directory_in_the_subtree_is_untraversable() {
+        let err = notify::Error::new(notify::ErrorKind::Io(std::io::Error::from(
+            std::io::ErrorKind::PermissionDenied,
+        )));
+
+        assert!(is_untraversable_subtree(&err));
+    }
+
+    #[test]
+    fn exhausting_the_watch_limit_is_untraversable() {
+        let err = notify::Error::new(notify::ErrorKind::MaxFilesWatch);
+
+        assert!(is_untraversable_subtree(&err));
+    }
+
+    /// The fallback narrows what is watched, so it must not stand in for a root that cannot be
+    /// watched at all — there is nothing left to degrade to.
+    #[test]
+    fn a_missing_or_unreadable_root_is_not_untraversable() {
+        for kind in [
+            notify::ErrorKind::PathNotFound,
+            notify::ErrorKind::Io(std::io::Error::from(std::io::ErrorKind::NotFound)),
+            notify::ErrorKind::Generic("something else".to_string()),
+        ] {
+            let err = notify::Error::new(kind);
+
+            assert!(
+                !is_untraversable_subtree(&err),
+                "{err:?} must propagate rather than fall back"
+            );
+        }
+    }
+
+    /// A root that does not exist has to keep failing: the fallback watch is on the same path,
+    /// so swallowing this would leave a watcher that reports nothing, forever.
+    #[tokio::test]
+    async fn a_root_that_does_not_exist_still_fails() {
+        let root = tempfile::tempdir().expect("failed to create temp dir");
+        let missing = root.path().join("no-such-directory");
+
+        let err = PodsWatcher::new(&missing)
+            .watch()
+            .await
+            .expect_err("watching a non-existent directory must fail");
+
+        assert!(
+            !is_untraversable_subtree(&err),
+            "a missing root must not be treated as a walkable-subtree failure: {err:?}"
+        );
+    }
+
+    /// The reported bug: Spice started in a directory that merely *contains* something the
+    /// process cannot read (`~` with another application's files under it) exited, because the
+    /// recursive registration failed and the pods watcher is a runtime task.
+    ///
+    /// On Linux the recursive walk is what fails, so this exercises the fallback directly. On
+    /// macOS `FSEvents` does not walk the tree, so the recursive watch succeeds and this asserts
+    /// the same end state by the ordinary path — either way an unreadable neighbour must not
+    /// stop the watcher, and edits to `spicepod.yaml` must still arrive.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_unreadable_neighbour_directory_does_not_stop_the_watcher() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().expect("failed to create temp dir");
+        // The watcher matches event paths against the paths it was given, and the platform
+        // backend reports resolved ones — on macOS the temp dir is `/var/…`, a symlink to
+        // `/private/var/…`, so an unresolved root would match nothing and time out below.
+        let root_path = root
+            .path()
+            .canonicalize()
+            .expect("failed to resolve temp dir");
+
+        let spicepod = root_path.join("spicepod.yaml");
+        std::fs::write(&spicepod, "version: v1\nkind: Spicepod\nname: test\n")
+            .expect("failed to write spicepod");
+
+        let locked = root_path.join("unreadable");
+        std::fs::create_dir(&locked).expect("failed to create directory");
+        std::fs::create_dir(locked.join("nested")).expect("failed to create nested directory");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000))
+            .expect("failed to drop permissions");
+
+        // Root ignores the mode bits, which would make the fixture a no-op and the assertions
+        // below vacuous.
+        if std::fs::read_dir(&locked).is_ok() {
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755))
+                .expect("failed to restore permissions");
+            return;
+        }
+
+        let mut watcher = PodsWatcher::new(&root_path);
+        let mut rx = watcher
+            .watch()
+            .await
+            .expect("an unreadable neighbour must not stop the pods watcher");
+
+        std::fs::write(&spicepod, "version: v1\nkind: Spicepod\nname: changed\n")
+            .expect("failed to modify spicepod");
+
+        let changed = tokio::time::timeout(std::time::Duration::from_secs(30), rx.recv()).await;
+
+        // Restore before asserting so a failure still leaves the tree removable.
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755))
+            .expect("failed to restore permissions");
+
+        assert_eq!(
+            changed.expect("timed out waiting for the spicepod change"),
+            Some(root_path.clone()),
+            "a spicepod edit must still be reported after an unreadable neighbour is skipped"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Starting Spice in a directory that merely *contains* something the process cannot read took the whole runtime down.

`PodsWatcher::watch` registers a **recursive** watch on the working directory. That directory is wherever the user ran `spice` — not a Spice-owned tree — so the walk descends into every neighbour it has. One unreadable directory anywhere beneath it fails the entire registration:

```console
ERROR spiced: Unable to start Spice Runtime servers: Failed to start pods watcher: Permission denied (os error 13) about ["/home/owner/.steam/steam/steamapps/compatdata/282160/pfx/dosdevices/z:/run/initramfs"]
```

The pods watcher runs as a runtime task, so that error stops the process. A valid Spicepod became unservable because of a file that has nothing to do with Spice.

`ErrorKind::MaxFilesWatch` is the same defect reached another way: a working directory with more subdirectories than the kernel will watch fails identically, and also for a reason that says nothing about the Spicepod.

## Changes

`watch_root` degrades those two environmental failures to a non-recursive watch of the working directory itself, which is where `spicepod.yaml` lives, and warns that subdirectories are no longer covered:

> Watching {root} for Spicepod changes, but not the directories below it: {err}. Edits to spicepod.yaml still reload; edits to files it references from subdirectories do not. Run Spice from a directory it can read in full, or raise the system's file-watch limit, to restore them.

Every other failure still propagates. That distinction is load-bearing: the fallback watches the *same path*, so treating an unreadable or missing root as recoverable would leave a watcher that silently reports nothing forever rather than failing. `a_root_that_does_not_exist_still_fails` and `a_missing_or_unreadable_root_is_not_untraversable` pin it in both directions.

## Test plan

- `an_unreadable_directory_in_the_subtree_is_untraversable`, `exhausting_the_watch_limit_is_untraversable`, `a_missing_or_unreadable_root_is_not_untraversable` — classification, both directions.
- `a_root_that_does_not_exist_still_fails` — the fallback does not swallow a genuinely unwatchable root.
- `an_unreadable_neighbour_directory_does_not_stop_the_watcher` — the reported scenario end to end: an unreadable sibling directory, then an edit to `spicepod.yaml` that must still arrive. It asserts the fixture actually bites (skipping when running as root, where the mode bits are ignored and the test would be vacuous).

Neuter matrix, one arm per direction, run against the committed tree:

| Arm | Failures |
| --- | --- |
| classification always `true` (everything looks recoverable) | 2 — `a_missing_or_unreadable_root_is_not_untraversable`, `a_root_that_does_not_exist_still_fails` |
| classification always `false` (nothing is recoverable) | 2 — `an_unreadable_directory_in_the_subtree_is_untraversable`, `exhausting_the_watch_limit_is_untraversable` |
| drop the fallback watch entirely | 0 **on macOS** — see below |

Worth stating plainly: the third arm does not isolate on macOS, because FSEvents does not walk the subtree, so the recursive watch never fails there and the fallback branch is unreachable. On Linux inotify is what walks and fails, so `an_unreadable_neighbour_directory_does_not_stop_the_watcher` exercises the fallback directly — which is where CI runs it. The *decision* is pinned on every platform by the two classification arms.

- `make lint`
- `make test`

## Checklist

- [x] Tests added covering the reported failure and both directions of the classification
- [x] `make lint` passes
- [x] `make test` passes
- [x] No behaviour change for a working directory the runtime can read in full

Fixes #6301