### PR TITLE
fix(cayenne): give the Turso metastore sidecars one pool over cayenne.db (fixes #12727)

### DIFF
--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -666,12 +666,29 @@ async fn acceleration_connection(
                     .and_then(|a| a.params.get("cayenne_metastore"))
                     .map_or("sqlite", String::as_str);
                 if metastore_type == "turso" {
-                    let pool = super::turso::TursoConnectionPool::new(&metadata_db_path)
+                    // Take the pool from the registered accelerator's path-keyed cache
+                    // rather than constructing one. `cayenne.db` is opened by every
+                    // sidecar of every Cayenne dataset in the pod, and the lock that
+                    // serializes their DDL against each other's `BEGIN CONCURRENT`
+                    // writes lives on the pool instance — a pool of our own would hold
+                    // a lock no other sidecar observes.
+                    let turso_engine = registry
+                        .get_accelerator_engine(Engine::Turso)
                         .await
-                        .map_err(|e| Error::CayennePool {
-                            source: Box::new(e),
+                        .context(AcceleratorEngineUnavailableSnafu {
+                            engine: Engine::Turso,
                         })?;
-                    return Ok(AccelerationConnection::Turso(Arc::new(pool)));
+                    let turso_accelerator = turso_engine
+                        .as_any()
+                        .downcast_ref::<TursoAccelerator>()
+                        .context(DowncastFailedSnafu {
+                            target: "TursoAccelerator",
+                        })?;
+                    let pool = turso_accelerator
+                        .get_shared_pool_for_path(&metadata_db_path)
+                        .await
+                        .context(TursoConnectionSnafu)?;
+                    return Ok(AccelerationConnection::Turso(pool));
                 }
             }
 
@@ -779,5 +796,133 @@ mod tests {
         assert!(!is_shutdown_cancellation(boxed.as_ref()));
 
         assert!(!is_shutdown_cancellation(&Error::NoAccelerationConnection));
+    }
+
+    #[cfg(all(not(windows), feature = "sqlite", feature = "turso"))]
+    mod cayenne_turso_metastore {
+        use super::super::{
+            AccelerationConnection, AccelerationSource, AcceleratorEngineRegistry, OpenOption,
+            acceleration_connection,
+        };
+        use crate::component::dataset::acceleration::{Acceleration, Engine, Mode};
+        use datafusion::sql::TableReference;
+        use std::sync::Arc;
+
+        struct MockSource {
+            name: TableReference,
+            acceleration: Option<Acceleration>,
+        }
+
+        impl MockSource {
+            fn cayenne_with_turso_metastore(name: &str, metadata_dir: &str) -> Self {
+                let mut acceleration = Acceleration {
+                    engine: Engine::Cayenne,
+                    mode: Mode::File,
+                    ..Default::default()
+                };
+                acceleration
+                    .params
+                    .insert("cayenne_metadata_dir".to_string(), metadata_dir.to_string());
+                acceleration
+                    .params
+                    .insert("cayenne_metastore".to_string(), "turso".to_string());
+
+                Self {
+                    name: TableReference::bare(name.to_string()),
+                    acceleration: Some(acceleration),
+                }
+            }
+        }
+
+        impl AccelerationSource for MockSource {
+            fn clone_arc(&self) -> Arc<dyn AccelerationSource> {
+                Arc::new(Self {
+                    name: self.name.clone(),
+                    acceleration: self.acceleration.clone(),
+                })
+            }
+
+            fn is_file_accelerated(&self) -> bool {
+                true
+            }
+
+            fn app(&self) -> Arc<app::App> {
+                unimplemented!("acceleration_connection does not consult the app")
+            }
+
+            fn secrets(&self) -> Arc<tokio::sync::RwLock<crate::secrets::Secrets>> {
+                unimplemented!("acceleration_connection does not consult secrets")
+            }
+
+            fn acceleration(&self) -> Option<&Acceleration> {
+                self.acceleration.as_ref()
+            }
+
+            fn name(&self) -> &TableReference {
+                &self.name
+            }
+
+            fn connector_name(&self) -> Option<&str> {
+                None
+            }
+
+            fn time_column(&self) -> Option<&str> {
+                None
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+
+        /// Both `spice_sys` sidecars of one Cayenne dataset — the dataset checkpoint
+        /// and the checkpoint store — open the same `cayenne.db`, and both do DDL and
+        /// DML on it. The lock that stops one sidecar's `CREATE TABLE` from landing
+        /// inside the other's open `BEGIN CONCURRENT` write lives on the pool
+        /// instance, so serialization only happens if they are handed the same pool.
+        ///
+        /// Before #12727 this branch constructed a pool per call, so each sidecar took
+        /// a lock the others could not observe and the gate excluded nothing.
+        #[tokio::test]
+        async fn two_connections_for_one_dataset_share_a_pool() {
+            let metadata_dir = std::env::temp_dir().join("spice_cayenne_turso_metastore_12727");
+            let _ = std::fs::remove_dir_all(&metadata_dir);
+            std::fs::create_dir_all(&metadata_dir).expect("metadata directory should be creatable");
+            let metadata_dir = metadata_dir.to_string_lossy().to_string();
+
+            let source = MockSource::cayenne_with_turso_metastore("orders", &metadata_dir);
+
+            let registry = Arc::new(AcceleratorEngineRegistry::new());
+            registry.register_all().await;
+
+            let first = acceleration_connection(
+                &source,
+                Arc::clone(&registry),
+                OpenOption::CreateIfNotExists,
+            )
+            .await
+            .expect("the first sidecar should open the Turso metastore");
+            let second = acceleration_connection(
+                &source,
+                Arc::clone(&registry),
+                OpenOption::CreateIfNotExists,
+            )
+            .await
+            .expect("the second sidecar should open the Turso metastore");
+
+            let AccelerationConnection::Turso(first) = &first else {
+                panic!("`cayenne_metastore: turso` must connect through Turso");
+            };
+            let AccelerationConnection::Turso(second) = &second else {
+                panic!("`cayenne_metastore: turso` must connect through Turso");
+            };
+
+            assert!(
+                Arc::ptr_eq(first, second),
+                "both sidecars must share one pool over `cayenne.db`, or the schema lock serializes nothing"
+            );
+
+            let _ = std::fs::remove_dir_all(&metadata_dir);
+        }
     }
 }

--- a/crates/runtime/src/dataaccelerator/turso.rs
+++ b/crates/runtime/src/dataaccelerator/turso.rs
@@ -422,6 +422,44 @@ impl TursoAccelerator {
         Ok(pool)
     }
 
+    /// Returns the shared connection pool for the database file at `db_path`.
+    ///
+    /// Callers holding an [`AccelerationSource`] should use [`Self::get_shared_pool`],
+    /// which derives the path from the source and applies its timestamp format and
+    /// storage pragmas. This variant serves databases that belong to the runtime
+    /// rather than to a dataset — the Cayenne metastore's `cayenne.db` — where there
+    /// is a path but no source to derive one from.
+    ///
+    /// Going through the cache matters for more than saving a handle. The lock that
+    /// serializes DDL against an open `BEGIN CONCURRENT` write lives on the
+    /// [`TursoConnectionPool`] instance, so two pools over one file hold two
+    /// independent locks and exclude nothing.
+    pub async fn get_shared_pool_for_path(
+        &self,
+        db_path: &str,
+    ) -> Result<Arc<TursoConnectionPool>> {
+        let mut pools = self.pools.lock().await;
+        if let Some(pool) = pools.get(db_path) {
+            return Ok(Arc::clone(pool));
+        }
+
+        let pool = Arc::new(
+            TursoConnectionPool::new(db_path)
+                .await
+                .map_err(|e| match e {
+                    data_components::turso::Error::TursoDatabaseError { source } => {
+                        Error::TursoDatabaseError { source }
+                    }
+                    _ => Error::AccelerationCreationFailed {
+                        source: Box::new(e),
+                    },
+                })?,
+        );
+
+        pools.insert(db_path.to_string(), Arc::clone(&pool));
+        Ok(pool)
+    }
+
     /// Per-storage SQLite/Turso pragma overrides applied after pool creation.
     ///
     /// On EBS-class network-attached storage we bump the page cache to absorb
@@ -1787,5 +1825,45 @@ mod tests {
                 "TimestampNanosecond should round-trip correctly"
             );
         }
+    }
+
+    /// One database file gets one pool, because the lock that serializes DDL
+    /// against an open `BEGIN CONCURRENT` write lives on the pool instance.
+    /// Two pools over one file hold two independent locks and exclude nothing.
+    #[tokio::test]
+    async fn get_shared_pool_for_path_returns_one_pool_per_file() {
+        let dir = std::env::temp_dir().join("spice_turso_shared_pool_by_path");
+        std::fs::create_dir_all(&dir).expect("temp directory should be creatable");
+        let metastore = dir.join("cayenne.db").to_string_lossy().to_string();
+        let unrelated = dir.join("other.db").to_string_lossy().to_string();
+        cleanup_turso_test_files(&metastore);
+        cleanup_turso_test_files(&unrelated);
+
+        let accelerator = TursoAccelerator::new();
+
+        let first = accelerator
+            .get_shared_pool_for_path(&metastore)
+            .await
+            .expect("a pool should be created for a path with no acceleration source");
+        let second = accelerator
+            .get_shared_pool_for_path(&metastore)
+            .await
+            .expect("a second request for the same path should resolve");
+        let other = accelerator
+            .get_shared_pool_for_path(&unrelated)
+            .await
+            .expect("a pool should be created for a second path");
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "two requests for the same database file must share one pool"
+        );
+        assert!(
+            !Arc::ptr_eq(&first, &other),
+            "distinct database files must not share a pool"
+        );
+
+        cleanup_turso_test_files(&metastore);
+        cleanup_turso_test_files(&unrelated);
     }
 }


### PR DESCRIPTION
Fixes #12727

## Summary

A Cayenne dataset running with `cayenne_metastore: turso` has several `spice_sys`
sidecars, and all of them open the one `cayenne.db`. Each did so by constructing a
**fresh** `TursoConnectionPool`.

The lock that keeps one sidecar's DDL from landing inside another's open
`BEGIN CONCURRENT` write — `schema_lock` — lives on the pool instance. So every
sidecar took a lock none of the others could observe, and the gate added by #10940
serialized nothing. Concurrent dataset registration is the normal startup shape, so
this is the `Database schema conflict` failure class of #10874 reachable again
through a construction site that fix did not cover.

Two callers already exist per dataset (`DatasetCheckpoint::try_new` and
`checkpoint_store`), both doing DDL *and* DML on `cayenne.db`; the `kafka`,
`debezium_kafka`, `mongodb` and `mysql_binlog` sidecars add more, and each further
Cayenne dataset in the pod multiplies the whole set again.

## Changes

- `dataaccelerator/turso.rs`: add `TursoAccelerator::get_shared_pool_for_path`, a
  by-path entry into the accelerator's existing path-keyed pool cache. The runtime
  owns `cayenne.db` rather than a dataset, so there is a path but no
  `AccelerationSource` from which `get_shared_pool` could derive one.
- `dataaccelerator/spice_sys.rs`: the Turso metastore branch of the Cayenne arm now
  takes its pool from the registered `TursoAccelerator` through that cache, the way
  the sibling SQLite metastore branch (`get_or_init_instance`) and every other Turso
  caller in the tree already do.

One file, one pool, one schema lock.

### Notes for review

- **Connections are still per-caller.** Only the pool is shared; each sidecar still
  takes its own connection from it. Sharing the pool is what makes the lock mean
  something, and it also collapses N libSQL handles on one file down to one.
- **The pool now outlives the caller**, cached on the accelerator for the process
  lifetime — the same contract every dataset Turso pool already has. Net retention
  goes down, not up. `reload_from_snapshot` evicts by `turso_file_path(source)`,
  which is always a dataset path, so it cannot evict the metastore entry.
- **The branch now requires `Engine::Turso` to be registered.** It did not before.
  `AcceleratorEngineRegistry::register_all()` is called unconditionally at
  `builder.rs:338`, and the `Engine::Turso` arm of this same function already
  depends on it, so this adds no new startup ordering requirement.
- **Cache keys are paths.** A Turso-accelerated dataset explicitly pointed at a
  Cayenne metastore file would now share that pool instead of stamping a second one
  over it. That configuration is already broken today and the new behaviour is not
  worse, but the pool's timestamp format would then be whichever caller created the
  entry — the same order dependence `create_external_table` already has on this map.
- **No behaviour change without the `turso` feature**: the whole branch is
  `#[cfg(feature = "turso")]` and falls through to the SQLite pool exactly as before.

## Test plan

- [ ] `make lint`
- [ ] `make test`

New coverage:

- `spice_sys.rs` — `two_connections_for_one_dataset_share_a_pool`: two
  `acceleration_connection` calls for one Cayenne + `cayenne_metastore: turso`
  dataset must return the same `Arc<TursoConnectionPool>`. This is the issue's
  acceptance criterion, and it fails on the pre-fix call site, which returns two
  distinct pools.
- `turso.rs` — `get_shared_pool_for_path_returns_one_pool_per_file`: the same path
  resolves to one pool across calls, and distinct paths do not share one.

Both are gated to the platforms and features the code under test compiles on
(`not(windows)`, `sqlite`, `turso`).

Note on local verification: `crates/runtime` cannot be compiled on this machine —
`runtime-proto`'s build script requires `protoc`, which is not installed — so the
gate above is left unchecked until sign-off reports it, rather than claimed from a
local run that did not happen. `cargo fmt --all` was run locally.

## Checklist

- [x] Regression test fails on the old code and passes on the new
- [x] No behaviour change for the default (`sqlite`) metastore
- [x] No new startup ordering requirement
