### PR TITLE
docs(ci): warn that re-running enforce-pull-with-spice replays a stale payload (fixes #12809)

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -30,6 +30,30 @@ on:
 # for every PR and would serialise unrelated PRs against each other; the PR number is
 # the correct key. A `merge_group` event carries no `pull_request`, and its `github.ref`
 # is the unique `gh-readonly-queue/...` branch, so it falls through to a group of its own.
+#
+# DO NOT RE-RUN THIS CHECK TO CLEAR A FAILURE — toggle a label instead:
+#
+#   gh pr edit <N> --repo spiceai/spiceai --add-label area/quality
+#   gh pr edit <N> --repo spiceai/spiceai --remove-label area/quality
+#
+# Re-running a run of this workflow replays the `pull_request_target` event payload as it
+# was frozen when the run was first created, so the action re-reads the PR's labels, title
+# and assignees *as they were then*. A re-run therefore cannot observe the metadata fix
+# that discharged the failure — it can only reproduce it — and because the re-run's
+# check-run is the newest one on the SHA, the stale `failure` sorts on top of the genuine
+# `success` that followed the fix. On 2026-08-08 that took four PRs red in one 17-second
+# burst of re-runs, every one of which already carried an assignee and both required label
+# prefixes. It is also self-perpetuating for any automation that sweeps for red required
+# checks and re-runs them: the sweep sees red, re-runs, gets red, and the PR never recovers.
+#
+# The reflex is normally right, which is what makes this trap worth naming: lint, build and
+# test re-read the tree, so re-running them is correct. This gate reads *mutable PR
+# metadata* rather than commit content, so for it a re-run is not idempotent — it is a time
+# machine. The label toggle above mints a new check-run against the PR's current state,
+# which is the whole reason `labeled` and `unlabeled` are in the trigger list.
+#
+# The durable fix is for the action to read the PR from the API rather than the event
+# payload — tracked in #12805, which belongs in `spiceai/pulls-with-spice-action`.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary (root cause)

`enforce-pull-with-spice` is a **required** status check that evaluates *mutable PR metadata* — labels, title, assignees — read from a `pull_request_target` event payload that is frozen when the run is created. Re-running one of its runs therefore replays that snapshot: the action re-reads the PR as it was, not as it is, so a re-run cannot observe the metadata fix that discharged the original failure. It can only reproduce it, and because the re-run's check-run is the newest one on the SHA, the stale `failure` sorts on top of the genuine `success` that followed the fix.

The reason this deserves a comment rather than a shrug is that the reflex it defeats is normally correct. For every other required check in this repo — `Rust Lint`, `Build and Test`, the integration suites — re-running a red check is exactly right, because those re-read the tree. This one is not idempotent under re-run; it is a time machine. And it is self-perpetuating for any automation that sweeps for red required checks and re-runs them: the sweep sees red, re-runs, gets red, and the PR never recovers. On 2026-08-08 that took four PRs red in a single 17-second burst, every one of which already carried an assignee and both required label prefixes.

The workflow header is where a reader already goes before touching this check — it explains the `concurrency` group, why `cancel-in-progress` is `false`, and why the trigger list is what it is. It said nothing about this.

Fixes #12809

## Changes

24 lines of comment in `.github/workflows/enforce-pulls-with-spice.yml`, recording:

- that re-running replays the frozen payload, with the four-PR incident as the concrete evidence
- the `gh pr edit --add-label` / `--remove-label` toggle as the way to clear a failed verdict, which is the reason `labeled`/`unlabeled` are already in the trigger list
- why this gate differs from the tree-reading checks, so the rule generalises instead of reading as a quirk
- a pointer to #12805 for the durable fix

**Nothing executable changed.** The trigger list, the `concurrency` group and every action input are byte-identical; `yaml.safe_load` returns the same `on`, `concurrency` and `jobs` structures before and after.

## Deliberately out of scope

#12805 stays open for the two remedies that are not ours to make: having the action read the PR from the API instead of the event payload, and closing the opening race so `attempt: 1` is rarely a failure. Both live in [`spiceai/pulls-with-spice-action`](https://github.com/spiceai/pulls-with-spice-action), which this account has no push access to. Remedy 1 is the only one that makes a re-run *correct* rather than merely discouraged.

Two things this deliberately does **not** do, since both are tempting and both are worse:

- **Does not drop the `opened` trigger** to avoid the spurious first failure. A PR opened with no labels and no assignee would then fire no `labeled`/`assigned` event at all, so the required check would never run — trading a self-healing red check for an absent one, which is the harder state to get out of.
- **Does not have the workflow re-fire its own trigger** on a re-run attempt. Making a required gate mint its own fresh evaluation is a branch-protection behaviour change and wants a maintainer's call, not a documentation PR.

## Test plan

- [x] `actionlint .github/workflows/enforce-pulls-with-spice.yml` passes
- [x] Verified the change is semantically inert: `yaml.safe_load` reports the same `jobs`, the same `pull_request_target` types list (`labeled, unlabeled, opened, edited, synchronize, assigned, unassigned`) and the same `concurrency` group with `cancel-in-progress: false`
- [x] `git diff --numstat` is `24 0` — insertions only, no line removed or altered; file stays LF-only and valid UTF-8
- [x] No Rust, no `Cargo.toml`, no `Cargo.lock` in the diff, so the sign-off fast-track applies and no `Attestation` sign-off is required — confirmed against `scripts/check_rust_gate_paths.py`'s fast-track path list

`make lint` and `make test` are not listed as run: this diff contains no Rust and cannot affect either, and the workspace gates cannot execute on the authoring machine in any case (`crates/runtime` fails on an `openssl-sys` build script under Git Bash, `bin/spice` needs `protoc`). If a reviewer would rather see the full gate anyway, say so and I will dispatch `make signoff-remote` against this branch.
