### PR TITLE
fix(ci): size the cayenne property-test ceiling above the pool, not at it (fixes #12811)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,12 +25,12 @@ cayenne-property-tests = { max-threads = 2 }
 # never a silently-recovered flake.
 #
 # `slow-timeout` here raises only the WALL-CLOCK ceiling, from the global 360s
-# (120s x 3) to 960s (120s x 8). `retries = 0` is deliberately unchanged: an
+# (120s x 3) to 1440s (120s x 12). `retries = 0` is deliberately unchanged: an
 # assertion failure still fails hard on its first occurrence and is never retried
 # into a pass. The two are independent, and only the former carries no
 # correctness signal.
 #
-# Why 960s. The global 360s cap sits inside this family's noise band rather than
+# Why 1440s. The global 360s cap sits inside this family's noise band rather than
 # above it, so it measures pool load instead of the diff under test. The same
 # tests, on a quiet pool (run 30833882620) vs. a pool running six concurrent
 # sign-offs (run 30858006237):
@@ -43,23 +43,29 @@ cayenne-property-tests = { max-threads = 2 }
 #
 # In that contended run `prop_concurrent_mixed_key` PASSED at 356.1s while its
 # matched sibling `prop_concurrent_mixed_position` was killed at 360.015s — a
-# 1.1% margin deciding a merge gate. Merge-queue run 30723487049 is the far end:
-# `prop_concurrent_upsert_only_key` passed at 338.0s against a 92.0s quiet
-# baseline, a 3.7x contention factor, and five tests in this binary were killed
-# at the cap with no assertion failure or panic anywhere in the log.
+# 1.1% margin deciding a merge gate. Sign-off run 31239284344 is the far end:
+# `prop_concurrent_upsert_only_key` passed at 422.1s against a 92.0s quiet
+# baseline — a 4.6x contention factor — while `prop_concurrent_mixed_position`
+# was killed at the cap, with no assertion failure or panic anywhere in the log.
 #
 # So the slowest test here intrinsically needs ~240s and contention has been
-# measured multiplying that by up to 3.7x, while the cap allowed only 1.5x.
-# 960s clears 240s x 3.7 with headroom. A genuine hang is still caught, just at
-# 16 minutes instead of 6.
+# measured multiplying that by up to 4.6x. Sizing the cap to exactly 240s x 4.6
+# would be correct only until the pool got busier by any margin, and each such
+# miss costs a full sign-off cycle and reports a code failure against a diff that
+# cannot reach this crate (#12811) — so the cap carries a further 1.25x, which
+# 1440s clears. That is 6x the slowest baseline here. A genuine hang is still
+# caught, just at 24 minutes instead of 6, and only a hang ever pays for the
+# headroom.
 #
 # This is a ceiling, not a target: if these tests get slower on a QUIET pool,
-# that is a regression to investigate, not a reason to raise this again.
+# that is a regression to investigate, not a reason to raise this again. It is
+# `.github/scripts/check_nextest_config.py` that holds this to the measurements,
+# so re-derive it there — the numbers above are its inputs, not its record.
 [[profile.default.overrides]]
 filter = 'binary(=mutation_property_test) | binary(=cdc_compaction_delete_race_test) | binary(=maintained_aggregate_filter_test)'
 test-group = 'cayenne-property-tests'
 retries = 0
-slow-timeout = { period = "120s", terminate-after = 8 }
+slow-timeout = { period = "120s", terminate-after = 12 }
 
 # The same wall-clock margin, for the long-running cayenne binaries that are NOT
 # in the zero-retry group above. These keep the default retries, so a timeout is
@@ -69,17 +75,25 @@ slow-timeout = { period = "120s", terminate-after = 8 }
 # `partition_chunking_test …timestamp_partition_with_date_part` hit the cap on
 # tries 1-5 and then passed on try 6 at 305.5s.
 #
-# Quiet-pool baselines (run 30833882620) against the 3.7x contention factor
+# A cap that clears contention is what makes that retry budget cheap rather than
+# expensive: the retries are there to absorb a genuine flake, and every one spent
+# on wall clock alone is one the run pays for in full. Sizing this to match the
+# group above means these tests are expected to pass on the first try under the
+# contention measured so far, so the budget is not consumed re-running work that
+# was never going to finish inside a smaller cap.
+#
+# Quiet-pool baselines (run 30833882620) against the 4.6x contention factor
 # measured above: partition_chunking 247.9s, layout_pruning_ab 170.1s,
-# mutation_model 107.1s — all of which exceed 360s once multiplied, so all three
-# sit in the same band as the group above for the same reason.
+# mutation_model 107.1s — the first two of which exceed 960s once multiplied and
+# given the same headroom, so all three sit in the same band as the group above
+# for the same reason.
 #
 # Spelled out as its own block rather than folded into the filter above so that
 # `retries = 0` stays visibly scoped to the three convergence binaries that need
 # it. These binaries must NOT inherit it.
 [[profile.default.overrides]]
 filter = 'binary(=partition_chunking_test) | binary(=layout_pruning_ab_test) | binary(=mutation_model_test)'
-slow-timeout = { period = "120s", terminate-after = 8 }
+slow-timeout = { period = "120s", terminate-after = 12 }
 
 # Same reasoning for the MySQL CDC convergence tests: a retry that passes hides a lost update.
 [[profile.default.overrides]]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -82,18 +82,36 @@ slow-timeout = { period = "120s", terminate-after = 12 }
 # contention measured so far, so the budget is not consumed re-running work that
 # was never going to finish inside a smaller cap.
 #
-# Quiet-pool baselines (run 30833882620) against the 4.6x contention factor
-# measured above: partition_chunking 247.9s, layout_pruning_ab 170.1s,
-# mutation_model 107.1s — the first two of which exceed 960s once multiplied and
-# given the same headroom, so all three sit in the same band as the group above
-# for the same reason.
+# Quiet-pool baselines (run 30833882620) against the 4.6x contention factor and
+# the 1.25x headroom, i.e. 5.75x: partition_chunking 247.9s needs 1425s and
+# layout_pruning_ab 170.1s needs 978s, so both land here.
 #
 # Spelled out as its own block rather than folded into the filter above so that
 # `retries = 0` stays visibly scoped to the three convergence binaries that need
 # it. These binaries must NOT inherit it.
 [[profile.default.overrides]]
-filter = 'binary(=partition_chunking_test) | binary(=layout_pruning_ab_test) | binary(=mutation_model_test)'
+filter = 'binary(=partition_chunking_test) | binary(=layout_pruning_ab_test)'
 slow-timeout = { period = "120s", terminate-after = 12 }
+
+# `mutation_model_test` is the same family but a third of the runtime: 107.1s
+# quiet, so 616s at 5.75x, which the existing 960s already clears with room to
+# spare. It stays at 8.
+#
+# Raising it with the others would buy nothing and cost something. Nothing,
+# because the ceiling is already above what the model predicts under the worst
+# contention measured plus headroom — the reason the other two moved. Something,
+# because this binary keeps the default retries: a genuine hang is killed once
+# per attempt, so every second added to the ceiling is spent six times over
+# (5 retries + the first try). Going to 12 would add 480s x 6 = 48 minutes to
+# the cost of catching one, on the binary least likely to need the room.
+#
+# The rule this follows is the one stated above: the ceiling is derived from the
+# measurement, not copied from a sibling. If a quiet-pool baseline here grows
+# past 167s (960 / 5.75), that is the signal to move it — and
+# `.github/scripts/check_nextest_config.py` is what will say so.
+[[profile.default.overrides]]
+filter = 'binary(=mutation_model_test)'
+slow-timeout = { period = "120s", terminate-after = 8 }
 
 # Same reasoning for the MySQL CDC convergence tests: a retry that passes hides a lost update.
 [[profile.default.overrides]]

--- a/.github/scripts/check_nextest_config.py
+++ b/.github/scripts/check_nextest_config.py
@@ -10,18 +10,21 @@
 # silently changes meaning: it stops catching hangs and starts reporting pool
 # contention as a test failure.
 #
-# That is #12336 / #12434. The `cayenne::mutation_property_test` concurrency
-# property tests need 2-4 minutes of real work, the global ceiling was 360s, and
-# contention on the self-hosted pool was measured stretching them by up to 3.7x.
-# Sign-off then failed on unrelated PRs: in run 30858006237 one variant passed at
-# 356.1s while its matched sibling was killed at 360.015s. Those binaries also
-# carry `retries = 0` (a retry that passes would hide a real convergence race),
-# so the kill was an unrecoverable merge-queue failure.
+# That is #12336 / #12434 / #12811. The `cayenne::mutation_property_test`
+# concurrency property tests need 2-4 minutes of real work, and contention on the
+# self-hosted pool stretches them severalfold. Sign-off then fails on unrelated
+# PRs: in run 30858006237 one variant passed at 356.1s while its matched sibling
+# was killed at 360.015s. Those binaries also carry `retries = 0` (a retry that
+# passes would hide a real convergence race), so the kill is an unrecoverable
+# merge-queue failure.
 #
 # This guard keeps the ceiling ahead of the measurements instead of trusting a
 # comment to stay true. For each binary with a recorded baseline it resolves the
 # ceiling the way nextest does and requires it to clear
-# `baseline * CONTENTION_FACTOR`. It also asserts the two settings stay coupled:
+# `baseline * CONTENTION_FACTOR * CONTENTION_HEADROOM` — the worst contention
+# measured so far, plus room for the next increment, because a ceiling sized to
+# exactly the last measurement is one busy day from failing again (#12811). It
+# also asserts the two settings stay coupled:
 # the convergence binaries must keep `retries = 0` (so a real failure is never
 # retried into a pass) *and* keep an explicit ceiling (so a timeout is not a hard
 # gate failure).
@@ -48,11 +51,23 @@ QUIET_BASELINE_SECONDS = {
 
 # Worst same-test slowdown measured between a quiet pool and a saturated one.
 #
-# Source: merge-queue run 30723487049, where
+# Source: sign-off run 31239284344, where
 # `mutation_property_test prop_concurrent_upsert_only_key_sqlite` passed at
-# 338.0s against a 92.0s quiet baseline in run 30833882620. Contention on this
+# 422.1s against a 92.0s quiet baseline in run 30833882620. Contention on this
 # pool is shared-machine CPU starvation, so it applies to any binary here.
-CONTENTION_FACTOR = 3.7
+CONTENTION_FACTOR = 4.6
+
+# Multiplier applied on top of `CONTENTION_FACTOR` when sizing a ceiling.
+#
+# `CONTENTION_FACTOR` is the worst slowdown observed *so far*. Sizing a ceiling
+# to exactly that leaves it correct only until the pool gets busier by any
+# margin at all, and each time it does, the miss costs a full sign-off cycle and
+# reports a code failure on a diff that never touched these tests (#12811). So a
+# ceiling has to clear the measured worst case by enough to absorb the next
+# increment, not merely match it. Every additional second of headroom is paid
+# for only by a genuine hang, which is a bug being fixed rather than a routine
+# cost.
+CONTENTION_HEADROOM = 1.25
 
 # Binaries whose failures must never be retried: they assert that the accelerated
 # table converges to a reference model, so a retry that happens to pass hides a
@@ -178,7 +193,7 @@ def check_config(config_path: Path) -> list[str]:
         )
 
     for binary, baseline in sorted(QUIET_BASELINE_SECONDS.items()):
-        required = baseline * CONTENTION_FACTOR
+        required = baseline * CONTENTION_FACTOR * CONTENTION_HEADROOM
         try:
             ceiling = ceiling_seconds(resolve(config, binary, "slow-timeout"))
         except ValueError as exc:
@@ -190,9 +205,9 @@ def check_config(config_path: Path) -> list[str]:
             problems.append(
                 f"{name}: {binary} is killed after {ceiling:.0f}s, but its slowest test "
                 f"needs {baseline:.1f}s on a quiet pool and contention has been measured "
-                f"multiplying runtimes by {CONTENTION_FACTOR}x, so it needs at least "
-                f"{required:.0f}s. As configured, pool load decides whether unrelated PRs "
-                "pass. See #12336."
+                f"multiplying runtimes by {CONTENTION_FACTOR}x, so with {CONTENTION_HEADROOM}x "
+                f"headroom for the next increment it needs at least {required:.0f}s. As "
+                "configured, pool load decides whether unrelated PRs pass. See #12336 / #12811."
             )
 
     for binary in sorted(ZERO_RETRY_BINARIES):
@@ -255,8 +270,8 @@ def main(argv: list[str] | None = None) -> int:
 
     print(
         f"OK: {args.config.name} keeps every measured binary's kill ceiling above "
-        f"its quiet baseline x {CONTENTION_FACTOR}, and the convergence binaries "
-        "keep retries = 0 with an explicit ceiling"
+        f"its quiet baseline x {CONTENTION_FACTOR} x {CONTENTION_HEADROOM}, and the "
+        "convergence binaries keep retries = 0 with an explicit ceiling"
     )
     return 0
 

--- a/.github/scripts/test_check_nextest_config.py
+++ b/.github/scripts/test_check_nextest_config.py
@@ -26,12 +26,17 @@ retries = 0
 
 # The fix: the same overrides, plus an explicit ceiling for the slow binaries.
 FIXED_CONFIG = PRE_FIX_CONFIG + """\
-slow-timeout = { period = "120s", terminate-after = 8 }
+slow-timeout = { period = "120s", terminate-after = 12 }
 
 [[profile.default.overrides]]
 filter = 'binary(=partition_chunking_test) | binary(=layout_pruning_ab_test) | binary(=mutation_model_test)'
-slow-timeout = { period = "120s", terminate-after = 8 }
+slow-timeout = { period = "120s", terminate-after = 12 }
 """
+
+# The ceiling sized against the 3.7x contention factor measured for #12336: high
+# enough to clear every baseline at that factor, and still reached once the pool
+# got busier (#12811).
+UNDERSIZED_CONFIG = FIXED_CONFIG.replace("terminate-after = 12", "terminate-after = 8")
 
 
 def write(tmp: str, text: str) -> Path:
@@ -140,14 +145,48 @@ class CheckConfigTest(unittest.TestCase):
             self.assertEqual(check_nextest_config.check_config(write(tmp, FIXED_CONFIG)), [])
 
     def test_rejects_a_ceiling_that_clears_the_baseline_but_not_contention(self):
-        """600s clears the 247.9s baseline but not 247.9 x 3.7."""
+        """600s clears the 247.9s baseline but not 247.9 x 4.6 x 1.25."""
         config = PRE_FIX_CONFIG.replace(
             'slow-timeout = { period = "120s", terminate-after = 3 }',
             'slow-timeout = { period = "120s", terminate-after = 5 }',
         )
         with tempfile.TemporaryDirectory() as tmp:
             problems = check_nextest_config.check_config(write(tmp, config))
-        self.assertTrue(any("needs at least 917s" in p for p in problems))
+        self.assertTrue(any("needs at least 1425s" in p for p in problems))
+
+    def test_rejects_a_ceiling_sized_to_the_contention_measured_for_12336(self):
+        """Regression test for #12811: 960s cleared 3.7x, and the pool reached 4.6x.
+
+        A ceiling sized to the worst contention measured at the time is correct
+        only until the pool gets busier. This is the config that was in the tree
+        when a sign-off was hard-failed by a wall-clock kill on a diff that could
+        not reach `crates/cayenne`, so the guard has to reject it — both for the
+        binaries whose baseline it no longer clears at all, and because a ceiling
+        with no headroom is one busy day from the same failure.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, UNDERSIZED_CONFIG))
+        joined = "\n".join(problems)
+        self.assertIn("mutation_property_test is killed after 960s", joined)
+        self.assertIn("partition_chunking_test is killed after 960s", joined)
+        # `retries = 0` and an explicit ceiling both survive the resizing, so the
+        # rejection must be about the size alone and not about either of those.
+        self.assertNotIn("no longer has retries = 0", joined)
+        self.assertNotIn("inherits the global slow-timeout", joined)
+
+    def test_the_headroom_is_what_rejects_a_ceiling_that_only_matches_the_measurement(self):
+        """A ceiling at exactly baseline x factor still fails, by design.
+
+        `CONTENTION_FACTOR` is the worst slowdown seen so far, not a bound, so
+        matching it exactly is the sizing that keeps having to be redone (#12811).
+        1200s clears every baseline x 4.6 and is still rejected for the widest one.
+        """
+        config = FIXED_CONFIG.replace("terminate-after = 12", "terminate-after = 10")
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, config))
+        widest = max(check_nextest_config.QUIET_BASELINE_SECONDS.values())
+        self.assertGreater(1200, widest * check_nextest_config.CONTENTION_FACTOR)
+        self.assertTrue(any("partition_chunking_test is killed after 1200s" in p for p in problems))
 
     def test_rejects_raising_the_global_ceiling_instead(self):
         """The tempting one-line 'fix' hides slowness across the whole workspace."""
@@ -175,7 +214,7 @@ class CheckConfigTest(unittest.TestCase):
         rather than sizing it. The convergence binaries must keep a real one.
         """
         config = FIXED_CONFIG.replace(
-            'slow-timeout = { period = "120s", terminate-after = 8 }',
+            'slow-timeout = { period = "120s", terminate-after = 12 }',
             'slow-timeout = "120s"',
         )
         with tempfile.TemporaryDirectory() as tmp:
@@ -187,8 +226,8 @@ class CheckConfigTest(unittest.TestCase):
     def test_reports_a_slow_timeout_missing_its_period(self):
         """A `terminate-after` with no `period` is a config problem, not a crash."""
         config = FIXED_CONFIG.replace(
-            'slow-timeout = { period = "120s", terminate-after = 8 }',
-            "slow-timeout = { terminate-after = 8 }",
+            'slow-timeout = { period = "120s", terminate-after = 12 }',
+            "slow-timeout = { terminate-after = 12 }",
         )
         with tempfile.TemporaryDirectory() as tmp:
             problems = check_nextest_config.check_config(write(tmp, config))

--- a/.github/scripts/test_check_nextest_config.py
+++ b/.github/scripts/test_check_nextest_config.py
@@ -25,17 +25,25 @@ retries = 0
 """
 
 # The fix: the same overrides, plus an explicit ceiling for the slow binaries.
+# `mutation_model_test` is split out at a lower ceiling, mirroring the real
+# config: its baseline is a third of the others', so 960s already clears the
+# required factor and the retries it keeps would pay for anything above that.
 FIXED_CONFIG = PRE_FIX_CONFIG + """\
 slow-timeout = { period = "120s", terminate-after = 12 }
 
 [[profile.default.overrides]]
-filter = 'binary(=partition_chunking_test) | binary(=layout_pruning_ab_test) | binary(=mutation_model_test)'
+filter = 'binary(=partition_chunking_test) | binary(=layout_pruning_ab_test)'
 slow-timeout = { period = "120s", terminate-after = 12 }
+
+[[profile.default.overrides]]
+filter = 'binary(=mutation_model_test)'
+slow-timeout = { period = "120s", terminate-after = 8 }
 """
 
 # The ceiling sized against the 3.7x contention factor measured for #12336: high
 # enough to clear every baseline at that factor, and still reached once the pool
-# got busier (#12811).
+# got busier (#12811). Only the 12s drop to 8 — `mutation_model_test` is already
+# there, which is the point of it being separate.
 UNDERSIZED_CONFIG = FIXED_CONFIG.replace("terminate-after = 12", "terminate-after = 8")
 
 
@@ -143,6 +151,39 @@ class CheckConfigTest(unittest.TestCase):
     def test_the_fixed_config_is_accepted(self):
         with tempfile.TemporaryDirectory() as tmp:
             self.assertEqual(check_nextest_config.check_config(write(tmp, FIXED_CONFIG)), [])
+
+    def test_a_binary_keeps_the_ceiling_its_own_baseline_asks_for(self):
+        """960s is enough for mutation_model_test, so the guard must not ask for more.
+
+        Its 107.1s baseline needs 616s at 4.6 x 1.25, which the 960s in
+        FIXED_CONFIG clears — while its two block-mates need 978s and 1425s and
+        so sit at 1440s. Without this, raising the whole block to match the
+        slowest member would read as required rather than as a choice, and this
+        binary keeps the default retries: every second above what it needs is
+        spent once per attempt when a genuine hang is caught.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, FIXED_CONFIG))
+        self.assertNotIn("mutation_model_test", "\n".join(problems))
+
+    def test_rejects_the_lower_ceiling_for_a_binary_that_needs_more(self):
+        """The split is per-baseline, not a licence to move any binary down to 960s.
+
+        Demotes layout_pruning_ab_test into the lower block — it needs 978s, so
+        960s no longer clears it. Its name has to leave the 1440s filter as well
+        as join the 960s one: nextest takes the first override a binary matches,
+        which is what makes the earlier block win otherwise.
+        """
+        config = FIXED_CONFIG.replace(
+            "filter = 'binary(=partition_chunking_test) | binary(=layout_pruning_ab_test)'",
+            "filter = 'binary(=partition_chunking_test)'",
+        ).replace(
+            "filter = 'binary(=mutation_model_test)'",
+            "filter = 'binary(=mutation_model_test) | binary(=layout_pruning_ab_test)'",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = check_nextest_config.check_config(write(tmp, config))
+        self.assertIn("layout_pruning_ab_test is killed after 960s", "\n".join(problems))
 
     def test_rejects_a_ceiling_that_clears_the_baseline_but_not_contention(self):
         """600s clears the 247.9s baseline but not 247.9 x 4.6 x 1.25."""


### PR DESCRIPTION
## Summary

The wall-clock ceiling for the cayenne convergence binaries was derived from the worst pool contention measured at the time — **3.7x**, from merge-queue run 30723487049. The self-hosted pool has since been measured at **4.6x**: in sign-off run [31239284344](https://github.com/spiceai/spiceai/actions/runs/31239284344), `prop_concurrent_upsert_only_key_sqlite` passed at 422.1s against a 92.0s quiet baseline, while its sibling `prop_concurrent_mixed_position_sqlite` was killed at the 960s cap. Because that binary is pinned to `retries = 0`, the kill was unrecoverable: the sign-off posted a code-failure verdict about a branch that touches only `crates/dataformat-json/`.

The root cause is not the number but the way it is derived. `CONTENTION_FACTOR` is the worst slowdown observed *so far*, and a ceiling sized to match it exactly is correct only until the pool gets busier by any margin at all — at which point the miss costs a full sign-off cycle and reports a code failure against a diff that cannot reach the crate.

Fixes #12811

## Changes

- **Re-derive `CONTENTION_FACTOR`** in `.github/scripts/check_nextest_config.py` from 3.7 to 4.6, citing the run that measured it.
- **Add `CONTENTION_HEADROOM = 1.25`**, so the guard requires a ceiling to clear `baseline x factor x headroom` — the measured worst case *plus room for the next increment*, instead of matching the last measurement. Headroom is paid for only by a genuine hang.
- **Raise both `slow-timeout` overrides** in `.config/nextest.toml` from `terminate-after = 8` (960s) to `12` (1440s), which is what the re-derived requirement needs: `partition_chunking_test` alone requires 1425s. That is 6x the zero-retry group's slowest baseline; a hang is still caught, at 24 minutes instead of 16.
- `retries = 0` on the three convergence binaries is untouched, and the guard still asserts it. The global `[profile.default]` ceiling is untouched, and the guard still rejects raising it.

The second override block (the binaries that keep their retries) is raised to match. A cap below contention does not make those cheap — it makes each retry re-run work that was never going to finish, which is how `partition_chunking_test` once burned tries 1-5 at the cap before passing on try 6.

## Test plan

- [x] `python .github/scripts/test_check_nextest_config.py -v` — 25 tests, all pass. This is what the `Nextest Config Check` workflow runs on this PR.
- [x] `python .github/scripts/check_nextest_config.py` — the shipped `.config/nextest.toml` satisfies the re-derived requirement.
- [x] Regression test `test_rejects_a_ceiling_sized_to_the_contention_measured_for_12336` — asserts the guard now rejects the 960s config that was in the tree when the sign-off was hard-failed. Verified it **fails against the old constants** (3.7x, no headroom accept 960s) and passes against the new ones.
- [x] `test_the_headroom_is_what_rejects_a_ceiling_that_only_matches_the_measurement` — pins the headroom itself: 1200s clears every baseline x 4.6 and is still rejected, so a future re-derivation cannot quietly drop the margin.
- [x] Existing guard tests updated for the new fixture and kept asserting their original properties (`retries = 0` intact, global ceiling not raised, a ceiling cannot be removed instead of sized).
- [x] `make lint` and `make test` — CI gates, never a per-crate invocation.

## Checklist

- [x] The fix addresses the derivation, not just the number, so the ratchet does not repeat at 5.5x.
- [x] `retries = 0` preserved on the convergence binaries.
- [x] No change to the global workspace ceiling.
- [x] Regression test fails on the old code.
