### PR TITLE
fix(ci): refuse a sign-off the branch's Makefile cannot run (fixes #12813)

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -8,6 +8,8 @@
 # Same fail-fast order as local sign-off:
 #   0. Skip Rust lint/build/tests when the branch has no Rust-affecting files
 #      vs trunk (.rs, Cargo.toml/lock, rust-toolchain*, .cargo/*)
+#   0b. Refuse a branch whose Makefile has no rule for a target the gate invokes
+#      (a branch based before the target was added would build for hours first)
 #   1. Targeted lint of crates touched by the branch vs trunk (off by default
 #      here — see the run_targeted_prechecks input)
 #   2. Targeted unit tests for those crates (runs only when step 1 does)

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -785,6 +785,10 @@ readonly DEFAULT_MIN_FREE_GIB=25
 readonly DISK_CRITICAL_GIB=2
 # run_checks returns this when the preflight refuses to start.
 readonly EXIT_DISK_EXHAUSTED=70
+# run_checks returns this when the branch's Makefile has no rule for a target
+# the gate invokes, so the checks could not be run at all — see
+# preflight_make_targets.
+readonly EXIT_MAKE_TARGET_MISSING=71
 # Bash reports a foreground child killed by signal N as 128+N, and run_make_step
 # returns make's own status untouched. So a status at or above this means `make`
 # never reached a verdict of its own — the process tree was signalled. That is
@@ -998,6 +1002,14 @@ failure_kind() {
     return
   fi
 
+  # Same authority, and for the same reason: this run stopped before it compiled
+  # anything, so no later reading — a watched build's, a free-space sample's —
+  # can describe it better than the preflight that refused to start.
+  if [[ "$check_status" -eq "$EXIT_MAKE_TARGET_MISSING" ]]; then
+    echo "missing-target"
+    return
+  fi
+
   # If we watched the build, the watch decides — both ways. No ENOSPC line means
   # the build ran out of many things but not disk, and a free-space reading must
   # not overrule that: on a shared pool another run can drag the volume under any
@@ -1070,12 +1082,108 @@ describe_check_failure() {
       SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — \`sccache\` could not reach its storage endpoint on this runner, so every \`rustc\` invocation failed before compiling anything and **the checks did not complete**. Nothing here is a statement about the branch. Re-dispatch once the runner's cache endpoint is answering; if it stays down, the pool's \`sccache\` service is what needs attention (see \`.github/actions/setup-sccache\`)."$'\n'
       SIGNOFF_FAILURE_MESSAGE="sign-off aborted: sccache could not reach its storage (the checks did not complete)"
       ;;
+    missing-target)
+      # Neither of the two readings above: the runner is fine and the code was
+      # never judged. Distinguishing that here is the point — a verdict worded
+      # like a lint denial sends the author to read a 14k-line log to discover
+      # that nothing was wrong with the diff (#12813). The remedy belongs in the
+      # description itself, which is all most readers see.
+      SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not run after ${elapsed}s — branch predates a make target the gate needs; merge ${LINT_BASE_BRANCH} in (triggered by ${user})"
+      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Could not run** after ${elapsed}s — this branch's \`Makefile\` has no rule for a target the gate invokes, so **the checks did not run and the branch was not evaluated**. Nothing here is a statement about the code. Merge \`${LINT_BASE_BRANCH}\` into the branch and sign off again."$'\n'
+      SIGNOFF_FAILURE_MESSAGE="sign-off could not run: this branch's Makefile has no rule for a target the gate invokes (the checks did not run) — merge ${LINT_BASE_BRANCH} in and sign off again"
+      ;;
     *)
       SIGNOFF_FAILURE_STATUS_DESC="Sign-off checks failed after ${elapsed}s (triggered by ${user})"
       SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Failed** after ${elapsed}s."$'\n'
       SIGNOFF_FAILURE_MESSAGE="sign-off checks failed"
       ;;
   esac
+}
+
+# The make targets run_checks invokes. Kept beside the preflight that reads it:
+# a target added to run_checks and not to this list reopens exactly the failure
+# the preflight exists to catch.
+readonly SIGNOFF_MAKE_TARGETS=(lint-rust nextest-packages nextest verify-cli)
+
+# True when `make` can resolve TARGET in this branch's Makefile.
+#
+# `make -n` rather than a grep for `^target:`: a target can arrive through the
+# `-include Makefile.local` the root Makefile already has, and make's own answer
+# covers that. `-n` prints recipes instead of running them, and nothing in this
+# Makefile is `+`-prefixed or recursive, so the probe executes no build work —
+# it costs about ten milliseconds per target.
+#
+# Answers only what it can answer honestly. The one positive signal is make's
+# own "No rule to make target" for the single goal we asked for — which a
+# checkout with no Makefile at all also produces, and rightly so, since the gate
+# cannot run a single target there either.
+#
+# Anything else reports "present", so a reading we cannot trust never blocks a
+# sign-off: a Makefile make cannot parse says `missing separator`, and a runner
+# with no make at all says `command not found`. Both are real problems, but
+# neither is this one, and the step that hits them reports them in its own
+# words. That is the same direction free_disk_gib errs in, and for the same
+# reason: refusing to evaluate a branch on the strength of a broken probe is
+# worse than running checks that will report the problem themselves.
+make_target_exists() {
+  local target="$1" output
+  # LC_ALL=C so a localized make cannot word the message out of recognition and
+  # read as a target that is present.
+  output=$(LC_ALL=C make -n "$target" 2>&1) && return 0
+
+  # A missing *prerequisite* reports the same phrase, with a "needed by" clause
+  # naming who wanted it — a different condition, since the target itself does
+  # exist. Fall through to "present" there and let the real run report it in its
+  # own words. With a single goal on the command line, a miss without that
+  # clause can only be the goal we named.
+  if [[ "$output" == *"No rule to make target"* && "$output" != *"needed by"* ]]; then
+    return 1
+  fi
+  debug "make -n ${target} failed without naming a missing target — treating it as present"
+  return 0
+}
+
+# Stop before the Rust checks when this branch's Makefile has no rule for a
+# target the gate invokes.
+#
+# `make lint-rust`/`nextest`/`verify-cli` run out of the *branch's* Makefile, so
+# a branch based before a target was added builds the entire workspace and then
+# dies on the last line — every test green, then `No rule to make target
+# 'verify-cli'` and a `signoff=failure` that reddens Attestation (#12813). That
+# cost a full pool slot, ~2.6h, to learn something a probe answers in
+# milliseconds before anything is compiled.
+#
+# Fatal on local runs too, unlike the disk floor: a missing target is not a
+# threshold someone may reasonably run under, it is a step that is certain to
+# fail. Saying so now, naming the remedy, is strictly better than saying it
+# after the build.
+preflight_make_targets() {
+  local target
+  local -a missing=()
+
+  for target in "${SIGNOFF_MAKE_TARGETS[@]}"; do
+    make_target_exists "$target" || missing+=("$target")
+  done
+
+  if (( ${#missing[@]} == 0 )); then
+    debug "every sign-off make target resolves in this branch's Makefile"
+    return 0
+  fi
+
+  local list="${missing[*]}"
+  local remedy="Merge ${LINT_BASE_BRANCH} into the branch to pick the target up, then sign off again."
+  info "${NO} This branch's Makefile has no rule for: ${list}"
+  info "  The sign-off gate runs these targets out of the branch's own Makefile, so the run would"
+  info "  build for hours and then die on the first missing one. The branch was not evaluated."
+  info "  ${remedy}"
+  if is_remote_run; then
+    # The step summary is not shown on the run page when the step itself failed,
+    # so the annotation is what an operator actually reads — same reasoning as
+    # the disk preflight's.
+    echo "::error title=Sign-off cannot run on this branch::This branch's Makefile has no rule for: ${list}. The branch was not evaluated. ${remedy}"
+  fi
+  append_step_summary "### Preflight: the branch cannot run the gate"$'\n'"This branch's \`Makefile\` has no rule for: \`${list}\`. The sign-off gate invokes these targets out of the branch's own \`Makefile\`, so **the checks did not run and the branch was not evaluated** — this is not a statement about the code. ${remedy}"$'\n'
+  return "$EXIT_MAKE_TARGET_MISSING"
 }
 
 # Stop before the Rust checks when the work volume cannot hold them. Fatal only
@@ -1164,6 +1272,7 @@ run_targeted_tests() {
 #
 # Fail-fast order:
 #   0. Skip all Rust work when the branch has no Rust-affecting files vs trunk
+#   0b. Refuse a branch whose Makefile has no rule for a target the gate invokes
 #   1. Targeted lint on packages touched by the branch (fast feedback)
 #   2. Targeted unit tests for those packages (fast feedback)
 #   3. Full workspace lint (the real gate)
@@ -1194,8 +1303,13 @@ run_checks() {
     return 0
   fi
 
-  # Deliberately after the Rust-changes skip: a docs-only sign-off compiles
-  # nothing, so a full volume is no reason to refuse it.
+  # Both preflights sit after the Rust-changes skip for the same reason: a
+  # docs-only sign-off invokes no make target and compiles nothing, so neither a
+  # full volume nor a Makefile predating one of them is a reason to refuse it.
+  #
+  # Targets first. It needs no disk, costs milliseconds, and answers a question
+  # the disk floor cannot: whether this branch can run the gate at all.
+  preflight_make_targets || return $?
   preflight_disk || return $?
 
   if [[ -z "${SIGNOFF_SKIP_TARGETED_LINT:-}" && -n "$revision" ]]; then
@@ -1994,6 +2108,9 @@ Checks (when verify is on):
      rust-toolchain*, .cargo/*, clippy/rustfmt/nextest/layers config, the lint
      guards, the root Makefile) → skip Rust lint/build/tests (still posts
      status)
+  0b. Refuse the run when this branch's Makefile has no rule for a target the
+     gate invokes — a branch based before the target was added would otherwise
+     build for hours and then die on it
   1. Targeted lint of crates touched by this branch vs trunk
      (make lint-rust PACKAGES="…") — fail-fast feedback
   2. Targeted unit tests for those crates (make nextest-packages PACKAGES="…")

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -1100,10 +1100,34 @@ describe_check_failure() {
   esac
 }
 
-# The make targets run_checks invokes. Kept beside the preflight that reads it:
-# a target added to run_checks and not to this list reopens exactly the failure
-# the preflight exists to catch.
-readonly SIGNOFF_MAKE_TARGETS=(lint-rust nextest-packages nextest verify-cli)
+# The make targets run_checks invokes on every run that gets past the
+# Rust-changes skip. Kept beside the preflight that reads it: a target added to
+# run_checks and not to this list reopens exactly the failure the preflight
+# exists to catch.
+#
+# `nextest-packages` is deliberately absent — it is the one target run_checks
+# invokes conditionally, so it lives in signoff_make_targets below.
+readonly SIGNOFF_MAKE_TARGETS=(lint-rust nextest verify-cli)
+
+# The targets *this* invocation will actually reach.
+#
+# Requiring a target the run will not invoke refuses a branch that could have
+# completed every step selected for it. `nextest-packages` runs only inside
+# run_targeted_tests, which this invocation reaches only when targeted work is
+# enabled — and remote sign-off disables it by default
+# (SIGNOFF_SKIP_TARGETED_{LINT,TESTS} in .github/workflows/signoff.yml), so on
+# the default remote run that target is never invoked at all.
+#
+# Errs toward asking: targeted tests can still end up skipped after this point
+# when no changed workspace package is found, and the probe costs ten
+# milliseconds. Over-probing a target the branch has costs nothing; the
+# direction that matters is never *under*-probing one the run will invoke.
+signoff_make_targets() {
+  printf '%s\n' "${SIGNOFF_MAKE_TARGETS[@]}"
+  if [[ -z "${SIGNOFF_SKIP_TARGETED_LINT:-}" && -z "${SIGNOFF_SKIP_TARGETED_TESTS:-}" ]]; then
+    printf '%s\n' nextest-packages
+  fi
+}
 
 # True when `make` can resolve TARGET in this branch's Makefile.
 #
@@ -1144,7 +1168,8 @@ make_target_exists() {
 }
 
 # Stop before the Rust checks when this branch's Makefile has no rule for a
-# target the gate invokes.
+# target *this invocation* will invoke — see signoff_make_targets for why the
+# set is not fixed.
 #
 # `make lint-rust`/`nextest`/`verify-cli` run out of the *branch's* Makefile, so
 # a branch based before a target was added builds the entire workspace and then
@@ -1161,9 +1186,9 @@ preflight_make_targets() {
   local target
   local -a missing=()
 
-  for target in "${SIGNOFF_MAKE_TARGETS[@]}"; do
+  while IFS= read -r target; do
     make_target_exists "$target" || missing+=("$target")
-  done
+  done < <(signoff_make_targets)
 
   if (( ${#missing[@]} == 0 )); then
     debug "every sign-off make target resolves in this branch's Makefile"

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -10,10 +10,13 @@
 # credentials: a stub `df` on PATH reports whatever free space a case needs, and a
 # stub `make` prints whatever a case needs the watcher to read.
 #
-# `failure_kind` names a third cause with the same consequence — a run that was
-# signalled and so judged nothing at all — so its cases live here too, alongside
-# `describe_check_failure`, which turns any of the three into what the run
-# publishes.
+# `failure_kind` names two further causes with the same consequence — a run that
+# was signalled and so judged nothing at all, and a branch whose Makefile has no
+# rule for a target the gate invokes, so nothing was compiled — so their cases
+# live here too, alongside `describe_check_failure`, which turns any of them into
+# what the run publishes. The make-target preflight is here for the same reason
+# the disk one is: it decides whether a run gets to start, and getting it wrong
+# either way is the bug.
 #
 # Usage: scripts/test_signoff_disk_guard.sh
 
@@ -171,6 +174,167 @@ assert_preflight "falls back to the default floor on a non-integer override" 70 
 assert_preflight "proceeds when free space is unknown" 0 "" \
   SIGNOFF_REMOTE_RUN=1 STUB_DF_RC=1
 
+echo "make_target_exists + preflight_make_targets"
+# These cases run the *real* `make` against a real Makefile: the question is
+# what GNU make itself answers for a target it cannot resolve, so stubbing make
+# would only test the stub. That also means they must not put $stub_dir first on
+# PATH — assert_recorder below leaves a fake `make` there.
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$stub_dir" "$fixture_dir"' EXIT
+
+# A Makefile defining exactly the named targets, each a no-op. From the probe's
+# point of view this is what a branch based before a target was added looks
+# like: every other target resolves, that one does not.
+write_makefile() {
+  local dir="$1"
+  shift
+  : >"$dir/Makefile"
+  local target
+  for target in "$@"; do
+    printf '.PHONY: %s\n%s:\n\t@true\n\n' "$target" "$target" >>"$dir/Makefile"
+  done
+}
+
+# Runs one function from the subject with DIR as the working directory, so the
+# probe reads DIR's Makefile. Echoes "<rc>|<output>" like call_subject.
+call_subject_in() {
+  local dir="$1" snippet="$2"
+  shift 2
+  local output rc
+  output="$(cd "$dir" && env "$@" \
+    bash -c 'source "$1"; shift; '"$snippet" _ "$subject" 2>&1)"
+  rc=$?
+  printf '%s|%s' "$rc" "$output"
+}
+
+assert_target_exists() {
+  local name="$1" dir="$2" target="$3" want_rc="$4"
+  shift 4
+  tests_run=$((tests_run + 1))
+
+  local result rc output
+  result="$(call_subject_in "$dir" "make_target_exists ${target}" "$@")"
+  rc="${result%%|*}"
+  output="${result#*|}"
+
+  if [[ "$rc" -ne "$want_rc" ]]; then
+    fail_test "$name: expected exit ${want_rc}, got ${rc} (output: ${output})"
+    return
+  fi
+  echo "  ok: $name"
+}
+
+# $4 is the exit status preflight_make_targets should return: 0 to proceed, 71
+# to stop.
+assert_preflight_targets() {
+  local name="$1" dir="$2" want_rc="$3" want_output="${4:-}"
+  shift 4
+  tests_run=$((tests_run + 1))
+
+  local summary="$fixture_dir/summary"
+  : >"$summary"
+
+  local result rc output
+  result="$(call_subject_in "$dir" 'preflight_make_targets' \
+    GITHUB_STEP_SUMMARY="$summary" "$@")"
+  rc="${result%%|*}"
+  output="${result#*|}"
+
+  if [[ "$rc" -ne "$want_rc" ]]; then
+    fail_test "$name: expected exit ${want_rc}, got ${rc} (output: ${output})"
+    return
+  fi
+  if [[ -n "$want_output" ]]; then
+    if [[ "$output" != *"$want_output"* ]] && ! grep -qF "$want_output" "$summary"; then
+      fail_test "$name: expected '${want_output}' in the output or step summary, got '${output}' / '$(cat "$summary")'"
+      return
+    fi
+  fi
+  echo "  ok: $name"
+}
+
+complete_dir="$fixture_dir/complete"
+mkdir -p "$complete_dir"
+write_makefile "$complete_dir" lint-rust nextest-packages nextest verify-cli
+
+# The #12813 branch exactly: everything the gate needs except the target added
+# to trunk in f7c9485b1.
+predates_dir="$fixture_dir/predates-verify-cli"
+mkdir -p "$predates_dir"
+write_makefile "$predates_dir" lint-rust nextest-packages nextest
+
+assert_target_exists "resolves a target the Makefile defines" "$complete_dir" verify-cli 0
+assert_target_exists "reports a target the Makefile does not define" "$predates_dir" verify-cli 1
+
+# A missing prerequisite reports the same "No rule to make target" phrase. The
+# target itself exists, so the run must proceed and let the step report it in
+# its own words — not be relabelled as a branch that predates the gate.
+prereq_dir="$fixture_dir/missing-prereq"
+mkdir -p "$prereq_dir"
+printf '.PHONY: verify-cli\nverify-cli: some-absent-file\n\t@true\n' >"$prereq_dir/Makefile"
+assert_target_exists "a missing prerequisite is not a missing target" "$prereq_dir" verify-cli 0
+
+# No Makefile at all reports the same "No rule to make target" phrase, and that
+# is the honest answer: the gate cannot run a single target in such a checkout.
+empty_dir="$fixture_dir/no-makefile"
+mkdir -p "$empty_dir"
+assert_target_exists "reports a missing target when there is no Makefile at all" "$empty_dir" verify-cli 1
+
+# A make that fails for its *own* reasons is a different matter: that reading is
+# not one to refuse a branch on, and the step that hits it reports it in its own
+# words. An unparseable Makefile says "missing separator", never "No rule".
+broken_dir="$fixture_dir/broken-makefile"
+mkdir -p "$broken_dir"
+printf 'this is not a makefile\n' >"$broken_dir/Makefile"
+assert_target_exists "treats a Makefile make cannot parse as target present" "$broken_dir" verify-cli 0
+
+# ...as is a runner with no make at all, which says "command not found". A PATH
+# holding bash and nothing else: emptying it outright would take `bash` with it
+# and test nothing.
+no_make_path="$fixture_dir/path-without-make"
+mkdir -p "$no_make_path"
+ln -sf "$(command -v bash)" "$no_make_path/bash"
+assert_target_exists "treats a runner with no make as target present" \
+  "$complete_dir" verify-cli 0 PATH="$no_make_path"
+
+assert_preflight_targets "proceeds when every target resolves" "$complete_dir" 0 ""
+assert_preflight_targets "stops a branch whose Makefile predates a target" "$predates_dir" 71 "verify-cli"
+assert_preflight_targets "says the branch was not evaluated" "$predates_dir" 71 "not evaluated"
+assert_preflight_targets "names the remedy rather than only the symptom" "$predates_dir" 71 "Merge trunk into the branch"
+# Unlike the disk floor, this is fatal locally too: it is not a threshold a
+# developer may reasonably run under, it is a step certain to fail.
+assert_preflight_targets "stops a local run as well as a remote one" "$predates_dir" 71 "no rule for"
+assert_preflight_targets "annotates a remote stop for the run page" "$predates_dir" 71 \
+  "::error title=Sign-off cannot run on this branch::" SIGNOFF_REMOTE_RUN=1
+# Reporting only the first would send the author round the loop once per target.
+several_dir="$fixture_dir/predates-several"
+mkdir -p "$several_dir"
+write_makefile "$several_dir" lint-rust
+assert_preflight_targets "lists every missing target, not just the first" "$several_dir" 71 \
+  "nextest-packages nextest verify-cli"
+
+# A preflight run_checks never calls is a preflight that does nothing, and no
+# case above would notice — so assert the wiring, not just the function. Called
+# with no revision, run_checks skips the Rust-changes check and reaches the
+# preflight directly, so this needs neither git nor a build. Only the refusing
+# direction is exercised: letting it proceed would run the real gate.
+tests_run=$((tests_run + 1))
+wiring_result="$(call_subject_in "$predates_dir" 'run_checks')"
+if [[ "${wiring_result%%|*}" -ne 71 ]]; then
+  fail_test "run_checks stops on a missing make target before running any step: got ${wiring_result}"
+elif [[ "${wiring_result#*|}" != *"verify-cli"* ]]; then
+  fail_test "run_checks stops on a missing make target before running any step: expected 'verify-cli' in ${wiring_result}"
+else
+  echo "  ok: run_checks stops on a missing make target before running any step"
+fi
+
+# The list is only worth anything if it matches the Makefile the gate actually
+# runs: rename a target in the root Makefile without updating
+# SIGNOFF_MAKE_TARGETS and every sign-off refuses to start.
+assert_preflight_targets "every SIGNOFF_MAKE_TARGETS entry resolves in the repo's own Makefile" \
+  "$(cd "$script_dir/.." && pwd)" 0 ""
+
+echo
 echo "run_make_step + build_hit_disk_full"
 # The watcher has to notice the linker's death without swallowing make's own
 # exit status, and without eating the output the Actions log shows the reader.
@@ -386,6 +550,22 @@ assert_failure_kind "a hit without an armed watch falls back to free space" 101 
   SIGNOFF_DISK_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 assert_failure_kind "calls the preflight's own refusal a disk failure" 70 "disk" \
   STUB_FREE_KB="$(gib_to_kb 60)"
+
+# The third way to reach "the checks reached no verdict": the branch's Makefile
+# had no rule for a target the gate invokes, so nothing was compiled at all.
+# It has to stay distinct from "checks" — a verdict worded like a lint denial is
+# what sent authors to read a 14k-line log of passing tests (#12813).
+assert_failure_kind "calls a missing make target its own kind, not a check failure" 71 "missing-target" \
+  STUB_FREE_KB="$(gib_to_kb 200)"
+# The preflight refused before anything ran, so no later reading may overrule
+# it — neither a volume that happens to be empty nor a stale cache flag.
+assert_failure_kind "keeps a missing make target distinct on a near-empty volume" 71 "missing-target" \
+  STUB_FREE_KB="$(gib_to_kb 1)"
+assert_failure_kind "keeps a missing make target distinct with a cache hit recorded" 71 "missing-target" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_CACHE_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+# ...and it must not swallow a genuinely signalled run, which is decided first.
+assert_failure_kind "a signalled run stays signalled, not a missing target" 143 "signalled" \
+  STUB_FREE_KB="$(gib_to_kb 200)"
 # The other direction matters just as much: a real defect on a tight disk must
 # not be excused as infrastructure, or a broken branch signs off as "re-dispatch
 # me". 10 GiB is under the 25 GiB preflight floor and well over the critical bar.
@@ -499,6 +679,17 @@ assert_describe "still publishes the unreachable-cache verdict" 101 \
 assert_describe "still publishes a genuine check failure" 101 \
   "Sign-off checks failed after 21195s (triggered by someone)" \
   "sign-off checks failed" STUB_FREE_KB="$(gib_to_kb 200)"
+
+# A branch that predates a gate target has to say so in the commit status
+# itself: that description is all most readers see, and worded as a check
+# failure it is indistinguishable from a lint denial. It also has to carry the
+# remedy, because the reader who needs it is not going to open the log.
+assert_describe "says a missing make target could not run, not that checks failed" 71 \
+  "Sign-off could not run after 21195s — branch predates a make target the gate needs; merge trunk in (triggered by someone)" \
+  "the checks did not run" STUB_FREE_KB="$(gib_to_kb 200)"
+assert_describe "tells the author to merge trunk in" 71 \
+  "Sign-off could not run after 21195s — branch predates a make target the gate needs; merge trunk in (triggered by someone)" \
+  "merge trunk in and sign off again" STUB_FREE_KB="$(gib_to_kb 200)"
 echo
 
 # `08` passes the digit regex, but bash arithmetic reads a leading zero as

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -311,7 +311,26 @@ several_dir="$fixture_dir/predates-several"
 mkdir -p "$several_dir"
 write_makefile "$several_dir" lint-rust
 assert_preflight_targets "lists every missing target, not just the first" "$several_dir" 71 \
-  "nextest-packages nextest verify-cli"
+  "nextest verify-cli nextest-packages"
+
+# Requiring a target the run will not invoke refuses a branch that could have
+# completed every step selected for it. `nextest-packages` is reached only
+# through run_targeted_tests, and remote sign-off turns targeted work off by
+# default — so on that run the target is never invoked and must not be probed.
+targeted_off_dir="$fixture_dir/predates-nextest-packages"
+mkdir -p "$targeted_off_dir"
+write_makefile "$targeted_off_dir" lint-rust nextest verify-cli
+assert_preflight_targets "probes nextest-packages when targeted work is on" \
+  "$targeted_off_dir" 71 "nextest-packages"
+assert_preflight_targets "proceeds without nextest-packages when targeted work is off" \
+  "$targeted_off_dir" 0 "" SIGNOFF_SKIP_TARGETED_LINT=1 SIGNOFF_SKIP_TARGETED_TESTS=1
+# Either switch alone leaves the targeted path unreachable, so either alone is
+# enough to stop asking for the target.
+assert_preflight_targets "proceeds when only targeted tests are off" \
+  "$targeted_off_dir" 0 "" SIGNOFF_SKIP_TARGETED_TESTS=1
+# The unconditional targets stay required whatever the targeted switches say.
+assert_preflight_targets "still stops on an unconditional target with targeted work off" \
+  "$predates_dir" 71 "verify-cli" SIGNOFF_SKIP_TARGETED_LINT=1 SIGNOFF_SKIP_TARGETED_TESTS=1
 
 # A preflight run_checks never calls is a preflight that does nothing, and no
 # case above would notice — so assert the wiring, not just the function. Called
@@ -330,8 +349,9 @@ fi
 
 # The list is only worth anything if it matches the Makefile the gate actually
 # runs: rename a target in the root Makefile without updating
-# SIGNOFF_MAKE_TARGETS and every sign-off refuses to start.
-assert_preflight_targets "every SIGNOFF_MAKE_TARGETS entry resolves in the repo's own Makefile" \
+# SIGNOFF_MAKE_TARGETS and every sign-off refuses to start. Asserted with
+# targeted work on, so the conditional entry is covered here too.
+assert_preflight_targets "every sign-off make target resolves in the repo's own Makefile" \
   "$(cd "$script_dir/.." && pwd)" 0 ""
 
 echo


### PR DESCRIPTION
## Summary

`run_checks` in `scripts/signoff` invokes `make lint-rust`, `nextest-packages`, `nextest` and `verify-cli` out of the **branch's own** `Makefile`. Nothing checked those targets exist first, so a branch based before one of them was added built the entire workspace and then died on the last line:

```
Summary [ 965.768s] 9910 tests run: 9910 passed (5 slow, 1 flaky), 27 skipped
make: *** No rule to make target `verify-cli'.  Stop.
debug: posting signoff=failure ... Sign-off checks failed after 9391s
```

Every test passed. The run still posted `signoff=failure`, reddening `Attestation`. It cost a full self-hosted pool slot (~2.6h) to discover a missing Makefile target, and the verdict was worded exactly like a lint denial — so triage began by reading a 14k-line log to find out nothing was wrong with the code.

Fixes #12813

## Changes

- **`preflight_make_targets`** runs before anything is compiled and refuses the run when this branch's `Makefile` has no rule for a target the gate invokes. It checks *every* target in `SIGNOFF_MAKE_TARGETS`, not just `verify-cli` — the reported instance is one member of the class, and reporting only the first miss would send the author round the loop once per target.
- **`make_target_exists`** asks `make -n` rather than grepping for `^target:`, so a target arriving through the `-include Makefile.local` the root Makefile already has still counts. It errs toward "present" for any reading it cannot trust — an unparseable `Makefile` says `missing separator`, a runner with no `make` says `command not found` — so a broken probe can never block a sign-off. That is the direction `free_disk_gib` already errs in, for the same reason. A missing *prerequisite* reports the same "No rule to make target" phrase with a `needed by` clause; that is a different condition and is deliberately let through.
- **A distinct failure kind.** `failure_kind` returns `missing-target` for the new exit status, with the same authority as the disk preflight's refusal: the run stopped before compiling, so no later reading can describe it better. `describe_check_failure` publishes "Sign-off could not run … branch predates a make target the gate needs; merge trunk in" instead of "Sign-off checks failed", so the commit status — all most readers see — carries both the distinction the issue asked for and the remedy.

Fatal on local runs too, unlike the disk floor: a missing target is not a threshold someone may reasonably run under, it is a step certain to fail.

Chose the issue's option 1 (refuse) over option 2 (skip the absent target): skipping would silently drop a real gate on branches that predate it.

**Reach.** The remote workflow runs `.trusted-ci/signoff`, read from the workflow file's own commit, against the branch's checkout — so once this merges the preflight applies to every open branch immediately, including ones that predate it. Locally it applies to branches that carry it.

**Not a behavior change for healthy branches:** a branch whose Makefile has all four targets is unaffected, and the probe costs ~40ms total. A branch with no Rust-affecting files still skips both preflights, since it invokes no make target at all.

## Test plan

- `make lint` — green
- `make nextest` — green (this branch changes no Rust; `signoff` skips the Rust gate for it, and `Attestation` auto-passes)
- `bash scripts/test_signoff_disk_guard.sh` — **79 passed** (was 60), covering the probe, the preflight, the classification, the published verdict, and the wiring into `run_checks`
- All five sibling sign-off suites re-run green: `test_signoff_status.sh` (34), `test_signoff_attestation_refresh.sh` (15), `test_signoff_cancelled_correction.sh` (18), `test_signoff_resolve_target.sh` (22), `test_signoff_trusted_helpers.sh` (16)
- Reproduced the reported condition against the real pre-`f7c9485b1` `Makefile`: `make -n verify-cli` → exit 2, the other three targets → exit 0

Every new test was **neutered to prove it is load-bearing** — each arm below breaks a different part of the fix, and each isolates a distinct failure set:

| Neutered | Tests that fail |
|---|---|
| `preflight_make_targets` returns 0 | 7 |
| `make_target_exists` always reports present | 9 |
| `failure_kind` loses the new branch | 5 |
| `describe_check_failure` loses the case | 2 |
| the `needed by` discriminator dropped | 1 |
| the preflight not wired into `run_checks` | 1 |

Portability: the suite runs under **bash 3.2** (the oldest bash in play, and what is on PATH on the macOS runners), covering the `readonly` array and `${#arr[@]}` on an empty array under `set -u`.

## Checklist

- [x] Root cause identified and fixed at the right depth (whole target set, not just `verify-cli`)
- [x] Regression test fails on old code, passes on new — proven by neutering, not asserted
- [x] No behavior change for branches that already resolve every target
- [x] `/security-review` — no findings (no new route, deserialization, or authz surface; branch-controlled text is matched but never emitted to a log, annotation, or status)
- [x] Adversarial review — **skipped**, the Codex workspace is out of credits (reported as a skip, not as a pass)