### PR TITLE
fix(ci): let release/2.1 schema runs push their snapshot updates

### DIFF
--- a/.github/workflows/testoperator_run_schema.yml
+++ b/.github/workflows/testoperator_run_schema.yml
@@ -259,29 +259,54 @@ jobs:
 
       - name: Upload schema snapshots to branch
         run: |
-          BRANCH_ID=${{ github.run_id }}
-          BRANCH_NAME="testoperator-snapshot-update/${BRANCH_ID}"
+          # One branch per source branch and spicepod, so a connector whose
+          # snapshots drift keeps updating its own open PR, and a trunk run
+          # never shares a branch with a release run of the same connector. A
+          # run-scoped name would make the "is a PR already open" check below
+          # unreachable, opening a new PR on every run.
+          SLUG="$(printf '%s' '${{ github.ref_name }}/${{ github.event.inputs.spicepod_path }}' \
+            | sed -e 's/\.[Yy][Aa][Mm][Ll]$//' -e 's/[^A-Za-z0-9]\{1,\}/-/g' -e 's/^-//' -e 's/-$//' \
+            | tr '[:upper:]' '[:lower:]')"
+          BRANCH_NAME="testoperator-snapshot-update/${SLUG}"
 
           git config --global user.name 'Spice Benchmark Snapshot Update Bot'
           git config --global user.email 'spiceaibot@spice.ai'
-          git checkout -b ${BRANCH_NAME}
+          git checkout -b "${BRANCH_NAME}"
+
+          # Continue that branch when it already exists, so the push
+          # fast-forwards onto it. Re-parenting the index onto the remote tip
+          # keeps the commit to the snapshots alone instead of replaying every
+          # trunk commit made since the branch was opened.
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}"; then
+            git fetch origin "${BRANCH_NAME}"
+            git reset --soft FETCH_HEAD
+            git reset --quiet FETCH_HEAD -- .
+          fi
+
           git add '*.snap'
           if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "fix: Update schema snapshots for: ${{ github.event.inputs.spicepod_path }}"
-            if git ls-remote --exit-code --heads origin ${BRANCH_NAME}; then
-              git pull --rebase origin ${BRANCH_NAME}
-            fi
-            git push origin ${BRANCH_NAME}
+            echo "Schema snapshots already up to date on ${BRANCH_NAME}"
+            exit 0
+          fi
 
-            PR_URL="$(gh pr list --head "${BRANCH_NAME}" --state open --json url --jq .[].url)"
-            if [[ -n "${PR_URL}" ]]; then
-              echo "PR already exists -> ${PR_URL}"
-              exit 0
-            else
-              gh pr create --title "fix: Update schema snapshots" --body "Updates schema snapshots" --base trunk --head ${BRANCH_NAME} --label kind/bug
-            fi
+          git commit -m "fix: Update schema snapshots for: ${{ github.event.inputs.spicepod_path }}"
+          # The checkout persists no credentials, so authenticate the push
+          # itself rather than leaving a token in the local git config for the
+          # rest of the job.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:${BRANCH_NAME}"
+
+          PR_URL="$(gh pr list --head "${BRANCH_NAME}" --state open --json url --jq .[].url)"
+          if [[ -n "${PR_URL}" ]]; then
+            echo "Updated the open PR -> ${PR_URL}"
+          else
+            # Target the branch the run was dispatched on: a release branch's
+            # snapshots describe that branch, not trunk.
+            gh pr create \
+              --title "fix: Update schema snapshots for ${{ github.event.inputs.spicepod_path }}" \
+              --body "Updates the schema snapshots for \`${{ github.event.inputs.spicepod_path }}\` on \`${{ github.ref_name }}\`." \
+              --base "${{ github.ref_name }}" \
+              --head "${BRANCH_NAME}" \
+              --label kind/bug
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> **Base is `release/2.1`, not `trunk`** — the bug only exists on the release branch; trunk was fixed by #12525 and this backports that fix verbatim.

## Evidence

Signature, from a sweep of 2,258 failed runs over 2026-08-02 → 2026-08-08:

```
fatal: could not read Username for 'https://github.com': No such device or address
##[error]Process completed with exit code 128.
```

- **18 of the 40 sampled `testoperator schema tests` failures (45%)** land on step `Upload schema snapshots to branch` — the single largest cluster in that workflow, larger than every genuine test failure combined.
- `testoperator schema tests` failed **78 times** in the window, **60 of them on `release/2.1`**.
- It fires on *every* connector, every night: `federated/mysql[catalog]`, `mssql[catalog]`, `databricks[catalog]`, `spicecloud[catalog]`, `iceberg[catalog]`, `oracle[catalog]`, … — the daily `testoperator dispatch` matrix runs the suite on both `trunk` and `release/2.1`.

Failing runs (all `release/2.1`, 2026-08-07):
- https://github.com/spiceai/spiceai/actions/runs/31178296696 — `federated/mysql[catalog].yaml`
- https://github.com/spiceai/spiceai/actions/runs/31178198558 — `federated/mssql[catalog].yaml`
- https://github.com/spiceai/spiceai/actions/runs/31178102016 — `federated/databricks[catalog].yaml`

## Root cause

The job checks out with `persist-credentials: false` (line 44) and the upload step then runs a bare `git push origin "${BRANCH_NAME}"`. `GH_TOKEN` is exported for `gh`, but git has no credential helper and no token in its config, so the push cannot authenticate. It is deterministic — not flaky, not environmental.

The ordering is what makes it expensive: the schema test **passes** first. In run 31178296696 the step commits `2 files changed, 748 insertions(+)` of fresh snapshots and *then* fails on the push. So each occurrence costs a full test run and, worse, **the snapshot update never lands** — which is precisely how the drift these tests exist to catch keeps accumulating on the release branch.

Two smaller defects come with it, both already corrected on trunk and both included here:

1. The update branch was keyed on `github.run_id`, so the "is a PR already open?" check below it could never match — every run would open a new PR.
2. `gh pr create --base trunk`, hard-coded, on a workflow that also runs from `release/2.1`. A release branch's schema snapshots describe that branch; proposing them against trunk is wrong.

## What changed

The `Upload schema snapshots to branch` step, replaced verbatim with trunk's version (#12525) so the two branches do not diverge:

- authenticate the push itself — `git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:${BRANCH_NAME}"` — rather than leaving a token in the local git config for the rest of the job
- key the update branch on `<source branch>/<spicepod>` so a connector keeps updating its own open PR instead of opening a new one per run, and a trunk run never collides with a release run of the same connector
- continue an existing update branch by re-parenting onto its remote tip, so the commit stays scoped to the snapshots
- `--base "${{ github.ref_name }}"` so the PR targets the branch the run came from

Nothing outside that one step is touched.

## What this does *not* weaken

- **No test is skipped, retried, or relaxed.** The schema assertions are untouched; a connector whose schema genuinely drifted still fails exactly as before.
- **This does not make snapshots auto-update where they previously did not.** The step already ran and already tried to push on every one of these runs — it just could not authenticate. The change is that the push now succeeds and lands in a PR a human reviews.
- **The `kind/bug` label on the generated PR is retained**, so snapshot updates keep arriving as reviewable changes rather than silently.

## Test plan

- [x] `yaml.safe_load` parses the modified workflow; the `Upload schema snapshots to branch` step is present with its `GH_TOKEN` env intact
- [x] Diffed the resulting step against `origin/trunk`'s — byte-identical, so this is a pure backport with no release-branch-only divergence
- [x] Ran the new branch-slug pipeline locally against the real inputs and validated the results with `git check-ref-format`: `release/2.1` + `federated/mysql[catalog].yaml` → `testoperator-snapshot-update/release-2-1-federated-mysql-catalog` (valid), and the `.YAML`-suffix and `trunk` cases likewise. The `[`/`]` in every spicepod name is what makes this worth checking rather than assuming.
- [ ] `make lint` / `make test` — not applicable: the diff touches no Rust and no `Cargo.*`
- [ ] Adversarial review — **skipped, engine unavailable**: this branch was written by Grok, so the cross-model engine is `codex`, and the local `codex` CLI returns *"Your workspace is out of credits."*
- [ ] Final proof is the next nightly `testoperator dispatch` on `release/2.1`: the `Upload schema snapshots to branch` cluster should go to zero and any real drift should arrive as a PR against `release/2.1`.

Found by the `harden-ci-workflows` sweep.

<!-- harden-ci-workflows: schema-snapshot-push-unauthenticated-release-branch -->
