### PR TITLE
fix(deps): drop the unreferenced ctor dev-dependency from data_components (fixes #12664)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5620,17 +5620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
 dependencies = [
  "ctor-proc-macro",
- "dtor 0.1.1",
-]
-
-[[package]]
-name = "ctor"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
-dependencies = [
- "ctor-proc-macro",
- "dtor 0.3.0",
+ "dtor",
 ]
 
 [[package]]
@@ -5996,7 +5986,6 @@ dependencies = [
  "chrono",
  "connector-postgres-common",
  "criterion 0.7.0",
- "ctor 0.8.0",
  "dashmap",
  "dataformat-json",
  "datafusion",
@@ -7480,15 +7469,6 @@ name = "dtor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
 dependencies = [
  "dtor-proc-macro",
 ]
@@ -13716,7 +13696,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
 dependencies = [
- "ctor 0.6.3",
+ "ctor",
  "opendal-core",
  "opendal-layer-concurrent-limit",
  "opendal-layer-logging",

--- a/crates/data_components/Cargo.toml
+++ b/crates/data_components/Cargo.toml
@@ -198,7 +198,6 @@ aws-smithy-types = { workspace = true }
 brotli = "8.0.2"
 chrono = { workspace = true }
 criterion = { version = "0.7", features = ["async_tokio", "html_reports"] }
-ctor = "0.8.0"
 flate2 = "1.1.5"
 iceberg-storage-opendal.workspace = true
 iceberg_test_utils = { workspace = true, features = ["tests"] }


### PR DESCRIPTION
## Summary

`crates/data_components/Cargo.toml` declared `ctor = "0.8.0"` under `[dev-dependencies]`, but nothing in the crate referenced it.

Its only two uses were the `#[ctor] fn before_all()` / `#[dtor] fn after_all()` docker-compose lifecycle hooks in `crates/data_components/tests/hadoop_catalog_test.rs`. Those were removed when that harness was reworked (#12646, landed as #12665), and the manifest entry was left behind. A declared-but-unreferenced dev-dependency still enters the resolution graph, so it is fetched and version-pinned in `Cargo.lock` for no benefit.

Fixes #12664

## Root cause

The dependency edge outlived its last use site. Removing the entry was deferred at the time because the lock change is not local to the crate: `ctor 0.8.0` is the only thing pulling `dtor 0.3.0`, so both leave the graph together, and `ctor 0.6.3` then becomes the sole `ctor` — which makes cargo drop the version disambiguator on every `"ctor 0.6.3"` / `"dtor 0.1.1"` reference. `pr.yml` builds with `--locked` and then fails on a non-empty `git diff Cargo.lock`, so the manifest edit and a regenerated lock have to land in the same commit, from a toolchain run rather than a hand-edit.

## Changes

- `crates/data_components/Cargo.toml` — drop the unreferenced `ctor` dev-dependency.
- `Cargo.lock` — regenerated by the toolchain in the same commit. The cascade is exactly the one predicted above, and nothing else moved:
  - `ctor 0.8.0` and `dtor 0.3.0` leave the graph.
  - `ctor 0.6.3` becomes the only `ctor`, so its disambiguator is dropped (`"ctor 0.6.3"` -> `"ctor"`, `"dtor 0.1.1"` -> `"dtor"`) at its two remaining references.
  - `data_components` no longer lists `ctor` among its dependencies.

  Net: 2 insertions, 22 deletions. No version of any retained package changed.

## Verification

There is no runtime behaviour to unit-test here — the guard against this change is that the crate's own test targets are what used the dependency, so they are what proves it is gone:

- `cargo check -p data_components --tests --locked` compiles every test, bench, and example target in the crate with the entry removed. Had any use site survived, it would fail to resolve `ctor`.
- `cargo metadata --locked` resolves cleanly, confirming the committed lock matches the edited manifests — this is the condition `pr.yml` enforces with `cargo build -p testoperator --all-features --locked` followed by its `git diff Cargo.lock` check.
- Re-running the resolver is idempotent: it reproduces the committed lock byte-for-byte rather than drifting further.

## Test plan

- [ ] `make lint` (workspace-wide; never a per-crate invocation)
- [ ] `make test`

## Checklist

- [ ] Manifest declares only dependencies the crate uses
- [ ] `Cargo.lock` regenerated in the same commit, from a toolchain run
- [ ] No retained package changed version
- [ ] Crate test targets compile without the removed dependency
