### PR TITLE
fix(search): leave the stored rows in place when a delete cannot be applied (fixes #12822)

### DIFF
--- a/crates/data_components/src/arrow/write.rs
+++ b/crates/data_components/src/arrow/write.rs
@@ -1077,7 +1077,9 @@ fn constraint_identifiers(rb: &[&RecordBatch], constraint_idx: &[usize]) -> Resu
 ///
 /// This is one part of `InsertOp::Replace` functionality, and still requires the new rows (with conflicting PKs), to be added.
 ///
-/// This function modifies `existing_batches` in place.
+/// This function modifies `existing_batches` in place. All-or-nothing: on `Err` it still
+/// holds exactly the batches it held before the call, so an overwrite that cannot be applied
+/// does not take the rows it was filtering with it.
 ///
 /// # Visibility
 /// This function is public for benchmarking purposes.
@@ -1105,10 +1107,15 @@ pub(crate) fn filter_existing<S: std::hash::BuildHasher>(
         None
     };
 
-    // Instead of concatenating, we can filter each batch individually
+    // Instead of concatenating, we can filter each batch individually.
+    //
+    // Read the batches rather than draining them: both steps below are fallible, and
+    // `existing_batches` is the table's only copy of these rows. Draining as we went would
+    // leave it empty on the error path, turning a failed overwrite into the loss of every
+    // row the table held.
     let mut filtered = Vec::with_capacity(existing_batches.len());
-    for batch in existing_batches.drain(..) {
-        let keys = extract_primary_keys_str(&batch, pk_indices_ordered)?;
+    for batch in existing_batches.iter() {
+        let keys = extract_primary_keys_str(batch, pk_indices_ordered)?;
 
         // Pre-allocate with exact capacity for better performance
         let mut keep_row_builder = BooleanBuilder::with_capacity(keys.len());
@@ -1127,12 +1134,13 @@ pub(crate) fn filter_existing<S: std::hash::BuildHasher>(
                 );
             }
         }
-        let filtered_batch = filter_record_batch(&batch, &keep_row_builder.finish())?;
+        let filtered_batch = filter_record_batch(batch, &keep_row_builder.finish())?;
         if filtered_batch.num_rows() > 0 {
             filtered.push(filtered_batch);
         }
     }
 
+    // Every fallible step is done, so the batches can be replaced without losing rows.
     *existing_batches = filtered;
     Ok(())
 }

--- a/crates/search/src/index/memory/store.rs
+++ b/crates/search/src/index/memory/store.rs
@@ -78,21 +78,28 @@ impl MemoryVectorStore {
     }
 
     /// Remove every stored row whose formatted primary key appears in `keys`.
+    ///
+    /// All-or-nothing: on `Err` the store still holds exactly the rows it held before the
+    /// call, so a delete that cannot be applied does not take the rows it was filtering
+    /// with it.
     pub(crate) fn delete_by_keys(&mut self, keys: &[String]) -> Result<(), DataFusionError> {
         if keys.is_empty() {
             return Ok(());
         }
 
         let delete_keys: HashSet<&str> = keys.iter().map(String::as_str).collect();
-        let mut retained = Vec::with_capacity(self.batches.len() + 1);
-        for stored in self.batches.drain(..) {
+
+        // Filter every overlapping batch before touching the stored ones. This store holds
+        // the only copy of the rows it is filtering, so a partially applied delete would
+        // lose the batches it had already consumed. `None` marks a batch with no overlap.
+        let mut filtered: Vec<Option<RecordBatch>> = Vec::with_capacity(self.batches.len());
+        for stored in &self.batches {
             if !stored
                 .keys
                 .iter()
                 .any(|key| delete_keys.contains(key.as_str()))
             {
-                // No overlap — keep the batch untouched (zero-copy).
-                retained.push(stored);
+                filtered.push(None);
                 continue;
             }
             let mask: BooleanArray = stored
@@ -100,9 +107,20 @@ impl MemoryVectorStore {
                 .iter()
                 .map(|key| Some(!delete_keys.contains(key.as_str())))
                 .collect();
-            let filtered = filter_record_batch(&stored.batch, &mask)
+            let kept = filter_record_batch(&stored.batch, &mask)
                 .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-            if filtered.num_rows() == 0 {
+            filtered.push(Some(kept));
+        }
+
+        // Every fallible step is done, so the store can be rebuilt without dropping rows.
+        let mut retained = Vec::with_capacity(self.batches.len());
+        for (stored, filtered) in self.batches.drain(..).zip(filtered) {
+            let Some(batch) = filtered else {
+                // No overlap — keep the batch untouched (zero-copy).
+                retained.push(stored);
+                continue;
+            };
+            if batch.num_rows() == 0 {
                 continue;
             }
             let kept_keys = stored
@@ -111,7 +129,7 @@ impl MemoryVectorStore {
                 .filter(|key| !delete_keys.contains(key.as_str()))
                 .collect::<Vec<_>>();
             retained.push(StoredBatch {
-                batch: filtered,
+                batch,
                 keys: kept_keys,
             });
         }
@@ -123,5 +141,151 @@ impl MemoryVectorStore {
     /// Cheap: Arrow buffers are shared, not copied.
     pub(crate) fn batches(&self) -> Vec<RecordBatch> {
         self.batches.iter().map(|s| s.batch.clone()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::array::{Array, Int64Array, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
+
+    use super::{MemoryVectorStore, RecordBatch, SchemaRef, StoredBatch};
+
+    fn schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("body", DataType::Utf8, false),
+        ]))
+    }
+
+    fn batch(ids: &[i64]) -> RecordBatch {
+        let bodies: Vec<String> = ids.iter().map(|id| format!("row-{id}")).collect();
+        RecordBatch::try_new(
+            schema(),
+            vec![
+                Arc::new(Int64Array::from(ids.to_vec())),
+                Arc::new(StringArray::from(bodies)),
+            ],
+        )
+        .expect("test columns match the test schema")
+    }
+
+    fn keys(ids: &[i64]) -> Vec<String> {
+        ids.iter().map(i64::to_string).collect()
+    }
+
+    /// A store holding one batch per slice, each with keys parallel to its rows.
+    fn store_of(batches: &[&[i64]]) -> MemoryVectorStore {
+        let mut store = MemoryVectorStore::new(schema());
+        for ids in batches {
+            store.batches.push(StoredBatch {
+                batch: batch(ids),
+                keys: keys(ids),
+            });
+        }
+        store
+    }
+
+    /// The ids the store currently holds, one inner `Vec` per batch.
+    fn stored_ids(store: &MemoryVectorStore) -> Vec<Vec<i64>> {
+        store
+            .batches()
+            .iter()
+            .map(|b| {
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("column 0 is the id column")
+                    .values()
+                    .to_vec()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_delete_removes_only_the_named_rows() {
+        let mut store = store_of(&[&[1, 2, 3], &[4, 5]]);
+
+        store
+            .delete_by_keys(&keys(&[2, 4]))
+            .expect("every batch's keys are parallel to its rows");
+
+        assert_eq!(stored_ids(&store), vec![vec![1, 3], vec![5]]);
+    }
+
+    #[test]
+    fn a_batch_a_delete_empties_is_dropped() {
+        let mut store = store_of(&[&[1], &[2, 3]]);
+
+        store
+            .delete_by_keys(&keys(&[1]))
+            .expect("every batch's keys are parallel to its rows");
+
+        assert_eq!(
+            stored_ids(&store),
+            vec![vec![2, 3]],
+            "a batch with no rows left should not be retained"
+        );
+    }
+
+    #[test]
+    fn an_empty_key_list_leaves_the_store_alone() {
+        let mut store = store_of(&[&[1, 2]]);
+
+        store
+            .delete_by_keys(&[])
+            .expect("deleting nothing succeeds");
+
+        assert_eq!(stored_ids(&store), vec![vec![1, 2]]);
+    }
+
+    /// A store whose third batch carries one more key than it has rows, so the mask built
+    /// from those keys is longer than the batch and `filter_record_batch` fails on it.
+    ///
+    /// Deliberately violates [`StoredBatch`]'s parallel-keys invariant: a length mismatch is
+    /// the only way to make Arrow's filter fail, and the point is what the store does when
+    /// it does — the first two batches must survive the failure of the third.
+    fn store_whose_third_batch_cannot_be_filtered() -> MemoryVectorStore {
+        let mut store = store_of(&[&[1, 2], &[3, 4]]);
+        store.batches.push(StoredBatch {
+            batch: batch(&[5, 6]),
+            keys: keys(&[5, 6, 7]),
+        });
+        store
+    }
+
+    #[test]
+    fn a_failed_delete_leaves_every_stored_row_in_place() {
+        let mut store = store_whose_third_batch_cannot_be_filtered();
+
+        // "3" overlaps the second batch, so it filters successfully before "5" reaches the
+        // third and fails — the case that used to leave the store empty.
+        store
+            .delete_by_keys(&keys(&[3, 5]))
+            .expect_err("a batch whose mask does not match its rows cannot be filtered");
+
+        assert_eq!(
+            stored_ids(&store),
+            vec![vec![1, 2], vec![3, 4], vec![5, 6]],
+            "a delete that could not be applied must not remove any row"
+        );
+    }
+
+    #[test]
+    fn a_failed_upsert_leaves_every_stored_row_in_place() {
+        let mut store = store_whose_third_batch_cannot_be_filtered();
+
+        // `upsert` deletes the superseded rows first, so it inherits the same failure.
+        store
+            .upsert(batch(&[5]), keys(&[5]))
+            .expect_err("a batch whose mask does not match its rows cannot be filtered");
+
+        assert_eq!(
+            stored_ids(&store),
+            vec![vec![1, 2], vec![3, 4], vec![5, 6]],
+            "an upsert that could not delete the rows it supersedes must not add its own"
+        );
     }
 }


### PR DESCRIPTION
Fixes #12822

## Summary (root cause)

`MemoryVectorStore::delete_by_keys` built its replacement list while draining the
list it was replacing:

```rust
for stored in self.batches.drain(..) {
    ...
    let filtered = filter_record_batch(&stored.batch, &mask)?;  // early return
    ...
    retained.push(...);
}
self.batches = retained;
```

`drain(..)` empties the store's vector as it iterates, and `Drop` for `Drain`
clears whatever the iteration never reached. So an error on batch *n* returned
before `retained` was written back: the batches already rewritten were dropped
with the local, and the ones not yet visited were dropped by the drain. **The
store was left empty** — a failed delete removed every indexed row instead of
none.

The memory vector tier is the primary read tier for a warm-index dataset, so
until the next full refresh repopulated it, search returned nothing for that
dataset. `Index::delete_by_keys` is on the DML delete path and the chunked-index
cleanup path, so an ordinary `DELETE` reaches it.

## Changes

`delete_by_keys` now filters every overlapping batch **before** it touches the
stored ones, and only rebuilds the store once nothing left can fail. Batches with
no overlap are still moved across untouched, so the zero-copy path for them is
unchanged. The guarantee is now written on the method: on `Err` the store holds
exactly what it held before the call.

### Same shape in the Arrow accelerator

`filter_existing` (`crates/data_components/src/arrow/write.rs`) — the `InsertOp::Replace`
path of the in-memory Arrow accelerator's `MemSink` — drained the table's own
`Vec<RecordBatch>` across two fallible steps (`extract_primary_keys_str` and
`filter_record_batch`), with the same consequence for the same reason. It now
reads the batches instead of draining them; the loop body already only borrowed
each batch, so this is the same computation with the input left intact.

Included because it is the same defect rather than a related one, and the change
is confined to how the loop obtains each batch. Worth flagging for review,
though: I could not construct an input that actually makes it fail today. The
common primary-key types are handled by `extract_primary_keys_str`'s direct
paths, and the fallback's `ScalarValue::try_from_array` accepted every exotic
type I tried, including run-end encoding. So that half is hardening against a
latent shape, not a reachable failure, and it carries no regression test. Happy
to split it out if you would rather keep this PR to the one crate.

## Performance impact

`delete_by_keys` now holds the filtered results alongside the originals until it
commits, where before it released each original as it was consumed. Untouched
batches cost nothing extra — they are never copied — so the additional transient
memory is bounded by the retained rows of the batches a delete actually overlaps.
A delete touching a few keys is unchanged in practice; one that removes a small
number of rows from every batch is the worst case, roughly doubling peak memory
for the duration of the call.

The alternative that keeps peak memory flat is to pre-check `keys.len() ==
batch.num_rows()` and rely on that making `filter_record_batch` infallible. I did
not take it: it encodes an Arrow implementation detail, and a future failure mode
would silently restore the data loss. Correctness of the only copy of the rows
seemed the right thing to spend the memory on.

## Test plan

- [x] `make lint`
- [x] `make test`
- New tests in `crates/search/src/index/memory/store.rs` (the file had none):
  - `a_failed_delete_leaves_every_stored_row_in_place` — the regression test. A
    store whose third batch carries one more key than it has rows, so the mask
    built from those keys is longer than the batch and Arrow's filter fails on
    it, after the second batch has already been filtered successfully.
  - `a_failed_upsert_leaves_every_stored_row_in_place` — `upsert` deletes the
    superseded rows first, so it inherits the same failure; asserts it neither
    drops the stored rows nor adds its own.
  - `a_delete_removes_only_the_named_rows`, `a_batch_a_delete_empties_is_dropped`,
    `an_empty_key_list_leaves_the_store_alone` — the success paths, so the
    reordering above is pinned as behaviour-preserving.

Both failure tests were confirmed to fail on the pre-fix code and pass on this
one. On the pre-fix code they report `left: []` against
`right: [[1, 2], [3, 4], [5, 6]]` — the store emptied — while the three
success-path tests still pass, which is the reported bug exactly.

## Notes for the reviewer

- The two failure tests deliberately violate `StoredBatch`'s documented
  parallel-keys invariant. A length mismatch is the only way to make Arrow's
  filter fail, and the point of the tests is what the store does when it does.
  The helper that builds that state says so.
- #12823 changes this same function to write through a replace window
  (`write_target()`), and will conflict here. That PR is mine and is not yet
  approved; I will take the conflict there rather than hold this one behind it,
  since the data loss is live on `trunk` today and the replace window is not.

## Checklist

- [x] Root cause identified and stated
- [x] Regression test fails on the old code, passes on the new
- [x] Success paths covered so the reordering is pinned
- [x] `cargo clippy --all-targets` clean on both crates
- [x] Same bug class swept for across the repo (`pk_index.rs`'s drain has an
      infallible body, so it is not affected)
