### PR TITLE
test(runtime): say which components were not ready when the wait times out (refs #12396)

### DIFF
--- a/crates/runtime/tests/utils/mod.rs
+++ b/crates/runtime/tests/utils/mod.rs
@@ -56,7 +56,33 @@ pub(crate) async fn runtime_ready_check(rt: &Runtime) {
 }
 
 pub(crate) async fn runtime_ready_check_with_timeout(rt: &Runtime, duration: Duration) {
-    assert!(wait_until_true(duration, || async { rt.status().is_ready() }).await);
+    assert!(
+        wait_until_true(duration, || async { rt.status().is_ready() }).await,
+        "the runtime did not become ready within {duration:?} — {}",
+        describe_component_statuses(rt)
+    );
+}
+
+/// Name every registered component and the state it is in.
+///
+/// The readiness wait elapses identically whether a component failed to load, is
+/// still initializing, or was never registered at all, so on its own it says only
+/// that the runtime is not ready. `ComponentStatus::Error` carries the message that
+/// put the component in that state, so naming the states turns the timeout into the
+/// reason for it.
+fn describe_component_statuses(rt: &Runtime) -> String {
+    let statuses = rt.status().get_all_statuses();
+    if statuses.is_empty() {
+        return "no components were registered".to_string();
+    }
+
+    let mut described: Vec<String> = statuses
+        .iter()
+        .map(|(component, status)| format!("{component}: {status:?}"))
+        .collect();
+    // `get_all_statuses` returns a `HashMap`, so sort for a stable message.
+    described.sort();
+    described.join(", ")
 }
 
 pub(crate) async fn runtime_ready_check_with_timeout_err(


### PR DESCRIPTION
## Summary

The shared integration-test readiness helper asserted on the wait alone:

```rust
assert!(wait_until_true(duration, || async { rt.status().is_ready() }).await);
```

so a timeout printed only that the assertion failed. That message is identical whether a
component failed to load, is still initializing, or was never registered, which leaves the
failure undiagnosable from its own output.

The daily `integration tests (models)` Bedrock job is the live example. All six embedding tests
fail on this assertion after ~121s, and the only other line the run carries is that both secret
references resolved — nothing says which component is not ready, or why.

`RuntimeStatus::is_ready` explains the silence: under the default `RuntimeReadyState::OnLoad` it
requires every registered component to have reached `Ready` at least once, and `Error` does not
satisfy that. A component that fails to load leaves the runtime permanently not-ready and the
wait simply elapses.

## Changes

`runtime_ready_check_with_timeout` now names every registered component and its status in the
panic message. `ComponentStatus::Error` carries the message that put the component in that
state, so the assertion reports the reason rather than only the timeout:

```
the runtime did not become ready within 120s — bedrock: Initializing, titan-v1: Error(Some("..."))
```

The statuses come from a `HashMap`, so they are sorted for a stable message, and an empty set
reports `no components were registered` rather than an empty list — that is a distinct
condition, and `is_ready` returns `false` for it.

The format arguments are only evaluated when the assertion fails, so a passing wait is unchanged.

## Scope

Refs #12396. This does **not** close it and does not make that workflow green — it makes the
daily failure state its cause, which is a prerequisite for fixing item 1a rather than a fix for
it.

While investigating I established that the issue's proposed item-1 fix (a `HAS_*_SECRET` guard
on `test-bedrock`) would be a **no-op**: the Bedrock credentials are present in the scheduled
run. The step's environment block renders both as `***`, which is the masking GitHub applies to
a registered secret with a non-empty value, and the runtime logs `all 2 secret reference(s)
resolved`. I have not opened that change, to avoid a diff that reads as a fix and moves nothing.
The full evidence is on the issue.

This is the same treatment #12730 received for the catalog readiness wait in #12731; that fix
landed only in `crates/runtime/tests/postgres/catalog_changes.rs`, so the shared helper still
asserted bare.

## Test plan

- [x] `make lint` (never a per-crate invocation)
- [ ] `make test`
- [x] Logic verified against a standalone probe reproducing the helper with stub types matching
      the verified signatures of `Runtime::status`, `RuntimeStatus::get_all_statuses` and
      `ComponentStatus`: empty set reports `no components were registered`, output is sorted,
      and an `Error` variant's message is surfaced.
- [x] `cargo fmt --all` clean.

Note: this crate cannot be compiled on the authoring machine (`crates/cayenne` does not build on
Windows, which aborts `runtime` with it), so the compile is verified by CI and the remote
sign-off rather than locally.

## Checklist

- [x] Comments describe why the code is the way it is, not how it used to work
- [x] No `.unwrap()` added
- [x] Change is test-only; no runtime behavior is affected
