### PR TITLE
fix(search): decide a compound index's write fatality per half, not by OR (fixes #12826)

### DIFF
--- a/crates/search/src/index/compound/mod.rs
+++ b/crates/search/src/index/compound/mod.rs
@@ -326,6 +326,52 @@ async fn compound_on_write_start(
 /// either combining rule — misclassifies one of them, as [`compound_on_write_start`] describes.
 pub(super) const COMPOUND_WRITE_START_FAILURE_IS_FATAL: bool = true;
 
+/// Finalize both indexes, applying each half's own [`Index::write_complete_failure_is_fatal`] to
+/// *that half's* failure.
+///
+/// Both completion callbacks always run — a failure on one half must not skip the other's
+/// finalize — and the primary's error is surfaced first. Fatality is then decided per half for the
+/// same reason [`compound_on_write_start`] decides it per half: one combined answer cannot say
+/// which half failed, so a fatal half turns the *other* half's best-effort finalize failure into a
+/// failed write. Elasticsearch's `_forcemerge` beside a tantivy primary is the live pairing —
+/// force-merge is a segment-count optimization the indexed rows do not depend on, but the tantivy
+/// half declares its own commit fatal, so the combined answer failed the write whenever
+/// force-merge did.
+async fn compound_on_write_complete(
+    primary: &dyn Index,
+    secondary: &dyn Index,
+) -> Result<(), DataFusionError> {
+    let (primary_result, secondary_result) =
+        futures::join!(primary.on_write_complete(), secondary.on_write_complete());
+    let primary_outcome = finalize_outcome("primary", primary, primary_result);
+    let secondary_outcome = finalize_outcome("secondary", secondary, secondary_result);
+    primary_outcome.and(secondary_outcome)
+}
+
+/// Keep `result` only if `index` declares its own finalize failure fatal; otherwise log it and
+/// report success — what the sink does with that same flag on a standalone index.
+fn finalize_outcome(
+    half: &str,
+    index: &dyn Index,
+    result: Result<(), DataFusionError>,
+) -> Result<(), DataFusionError> {
+    match result {
+        Err(err) if !index.write_complete_failure_is_fatal() => {
+            tracing::warn!(
+                "The {half} index of a compound search index failed to finalize a write: {err}. Reporting the write as successful, because that index's finalize is best-effort."
+            );
+            Ok(())
+        }
+        result => result,
+    }
+}
+
+/// What a compound index reports from [`Index::write_complete_failure_is_fatal`].
+///
+/// Always `true`, for the reason [`COMPOUND_WRITE_START_FAILURE_IS_FATAL`] is:
+/// [`compound_on_write_complete`] has already applied each half's own policy to its own failure.
+pub(super) const COMPOUND_WRITE_COMPLETE_FAILURE_IS_FATAL: bool = true;
+
 /// Delete `keys` from both indexes (full/both-scope, per [`Index::delete_by_keys`]'s contract).
 /// Both deletes run concurrently and both are driven to completion even if one fails, matching
 /// [`compound_on_write_start`]'s "neither index left inconsistent" approach.

--- a/crates/search/src/index/compound/mod.rs
+++ b/crates/search/src/index/compound/mod.rs
@@ -266,7 +266,7 @@ fn compound_required_columns(
 /// best-effort is logged and the write continues; one that declares it fatal returns the error,
 /// which the compound's [`Index::write_start_failure_is_fatal`] reports as fatal unconditionally.
 ///
-/// Both errors a single combined answer can give are wrong for one of the halves:
+/// Either answer a single combined flag can give is wrong for one of the halves:
 ///
 ///  - Answering "fatal" (a fatal half paired with a best-effort one) abandons the whole write
 ///    when the *best-effort* half's start fails — an Elasticsearch `refresh_interval` override

--- a/crates/search/src/index/compound/mod.rs
+++ b/crates/search/src/index/compound/mod.rs
@@ -257,21 +257,58 @@ fn compound_required_columns(
     columns
 }
 
-/// Start a bounded write window on both indexes. If the secondary fails to start after the
-/// primary already started, the primary's window is rolled back (best effort) so the two
-/// indexes never disagree about whether a write window is open.
+/// Start a bounded write window on both indexes, applying each half's own
+/// [`Index::write_start_failure_is_fatal`] to *that half's* failure.
+///
+/// A compound index has two halves that can classify their own start failure differently, and a
+/// single `write_start_failure_is_fatal` answer cannot say which half failed. So the decision is
+/// made here, where the failing half is known: a half that declares its own start failure
+/// best-effort is logged and the write continues; one that declares it fatal returns the error,
+/// which the compound's [`Index::write_start_failure_is_fatal`] reports as fatal unconditionally.
+///
+/// Both errors a single combined answer can give are wrong for one of the halves:
+///
+///  - Answering "fatal" (a fatal half paired with a best-effort one) abandons the whole write
+///    when the *best-effort* half's start fails — an Elasticsearch `refresh_interval` override
+///    the write does not depend on would fail the refresh it was only tuning.
+///  - Answering "best-effort" (two best-effort halves) rolls the primary's window back and then
+///    writes anyway, turning a staged [`WriteWindow::ReplaceAll`] into an in-place write: readers
+///    observe a partially rebuilt index and rows the source dropped are never cleared.
+///
+/// A half whose own start failed is never rolled back here: a start that fails partway owns its
+/// cleanup (`ElasticsearchIndexWriteMaintenance::abandon_write_cycle` is the example), and
+/// `on_write_failed` restores state set up by a *successful* start, so calling it could "restore"
+/// settings that were never overridden. That ownership is also what lets `on_write_failed` and
+/// `on_write_complete` keep fanning out to both halves after a best-effort start failure — the
+/// half that failed has already closed its own cycle, so its cleanup short-circuits.
 async fn compound_on_write_start(
     primary: &dyn SearchIndex,
     secondary: &dyn SearchIndex,
     window: WriteWindow,
 ) -> Result<(), DataFusionError> {
-    primary.on_write_start(window).await?;
+    let primary_started = match primary.on_write_start(window).await {
+        Ok(()) => true,
+        Err(primary_err) if primary.write_start_failure_is_fatal() => return Err(primary_err),
+        Err(primary_err) => {
+            tracing::warn!(
+                "The primary index of a compound search index failed to start a write: {primary_err}. Continuing with the write, because that index's start is best-effort."
+            );
+            false
+        }
+    };
+
     if let Err(secondary_err) = secondary.on_write_start(window).await {
-        // Roll back only the primary: the secondary's `on_write_start` is the call that
-        // failed, and `on_write_failed` restores state set up by a *successful*
-        // `on_write_start` — an implementation whose start fails partway owns its own
-        // cleanup. Calling it here could "restore" settings that were never overridden.
-        if let Err(rollback_err) = primary.on_write_failed().await {
+        if !secondary.write_start_failure_is_fatal() {
+            tracing::warn!(
+                "The secondary index of a compound search index failed to start a write: {secondary_err}. Continuing with the write, because that index's start is best-effort."
+            );
+            return Ok(());
+        }
+
+        // The write is being abandoned, so the primary's window has to close with it — but only
+        // if it opened. A primary whose own start failed owns its cleanup (see above), which is
+        // why `primary_started` is tested before the call and not after it.
+        if primary_started && let Err(rollback_err) = primary.on_write_failed().await {
             tracing::warn!(
                 "Failed to roll back the primary index of a compound search index after the secondary index failed to start a write: {rollback_err}"
             );
@@ -280,6 +317,14 @@ async fn compound_on_write_start(
     }
     Ok(())
 }
+
+/// What a compound index reports from [`Index::write_start_failure_is_fatal`].
+///
+/// Always `true`: [`compound_on_write_start`] has already applied each half's own policy to its
+/// own failure and swallowed the best-effort ones, so any error it *does* return came from a half
+/// that declares a start failure fatal. Answering from the two halves' flags instead — under
+/// either combining rule — misclassifies one of them, as [`compound_on_write_start`] describes.
+pub(super) const COMPOUND_WRITE_START_FAILURE_IS_FATAL: bool = true;
 
 /// Delete `keys` from both indexes (full/both-scope, per [`Index::delete_by_keys`]'s contract).
 /// Both deletes run concurrently and both are driven to completion even if one fails, matching

--- a/crates/search/src/index/compound/search_index.rs
+++ b/crates/search/src/index/compound/search_index.rs
@@ -29,9 +29,9 @@ use runtime_datafusion_index::{Index, WriteWindow};
 use crate::index::{SearchIndex, VectorIndex};
 
 use super::{
-    CompoundReadMode, CompoundVectorIndex, Error, compound_delete_by_keys, compound_on_write_start,
-    compound_required_columns, compound_write, fallback::fallback_on_empty_plan,
-    validate_compatibility,
+    COMPOUND_WRITE_START_FAILURE_IS_FATAL, CompoundReadMode, CompoundVectorIndex, Error,
+    compound_delete_by_keys, compound_on_write_start, compound_required_columns, compound_write,
+    fallback::fallback_on_empty_plan, validate_compatibility,
 };
 
 /// A [`SearchIndex`] that writes through to two compatible underlying indexes and serves
@@ -133,9 +133,7 @@ impl Index for CompoundSearchIndex {
     }
 
     fn write_start_failure_is_fatal(&self) -> bool {
-        // `compound_on_write_start` fails if either half fails to start, so either half
-        // treating that as fatal makes it fatal for this compound index.
-        self.primary.write_start_failure_is_fatal() || self.secondary.write_start_failure_is_fatal()
+        COMPOUND_WRITE_START_FAILURE_IS_FATAL
     }
 
     fn write_complete_failure_is_fatal(&self) -> bool {

--- a/crates/search/src/index/compound/search_index.rs
+++ b/crates/search/src/index/compound/search_index.rs
@@ -29,8 +29,9 @@ use runtime_datafusion_index::{Index, WriteWindow};
 use crate::index::{SearchIndex, VectorIndex};
 
 use super::{
-    COMPOUND_WRITE_START_FAILURE_IS_FATAL, CompoundReadMode, CompoundVectorIndex, Error,
-    compound_delete_by_keys, compound_on_write_start, compound_required_columns, compound_write,
+    COMPOUND_WRITE_COMPLETE_FAILURE_IS_FATAL, COMPOUND_WRITE_START_FAILURE_IS_FATAL,
+    CompoundReadMode, CompoundVectorIndex, Error, compound_delete_by_keys,
+    compound_on_write_complete, compound_on_write_start, compound_required_columns, compound_write,
     fallback::fallback_on_empty_plan, validate_compatibility,
 };
 
@@ -114,12 +115,7 @@ impl Index for CompoundSearchIndex {
     }
 
     async fn on_write_complete(&self) -> Result<(), DataFusionError> {
-        // As with `on_write_failed`: both completion callbacks must run.
-        let (primary_result, secondary_result) = futures::join!(
-            self.primary.on_write_complete(),
-            self.secondary.on_write_complete()
-        );
-        primary_result.and(secondary_result)
+        compound_on_write_complete(self.primary.as_ref(), self.secondary.as_ref()).await
     }
 
     async fn delete_by_keys(&self, keys: RecordBatch) -> DataFusionResult<()> {
@@ -137,9 +133,7 @@ impl Index for CompoundSearchIndex {
     }
 
     fn write_complete_failure_is_fatal(&self) -> bool {
-        // Either half failing to finalize leaves this compound index stale.
-        self.primary.write_complete_failure_is_fatal()
-            || self.secondary.write_complete_failure_is_fatal()
+        COMPOUND_WRITE_COMPLETE_FAILURE_IS_FATAL
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/search/src/index/compound/tests.rs
+++ b/crates/search/src/index/compound/tests.rs
@@ -607,46 +607,32 @@ fn write_complete_fatality_is_the_union_of_both_vector_halves() {
     }
 }
 
-/// `compound_on_write_start` fails if either half fails to start, so the start-fatality flag
-/// is the union of both halves rather than the trait default (#12421).
+/// `compound_on_write_start` applies each half's own start-fatality to that half's own failure
+/// and swallows the best-effort ones, so every error it returns is fatal — whatever the halves
+/// report individually. The trait default (`false`) would still downgrade a fatal half (#12421),
+/// which is why this is `true` rather than inherited.
 #[test]
-fn write_start_fatality_is_the_union_of_both_search_halves() {
+fn write_start_fatality_is_reported_for_the_compound_not_the_halves() {
     let events = Arc::new(Mutex::new(vec![]));
 
-    for (primary_fatal, secondary_fatal, expected) in [
-        (false, false, false),
-        (true, false, true),
-        (false, true, true),
-        (true, true, true),
-    ] {
+    for (primary_fatal, secondary_fatal) in
+        [(false, false), (true, false), (false, true), (true, true)]
+    {
         let mut primary = MockIndex::new("primary", &events);
         primary.write_start_fatal = primary_fatal;
         let mut secondary = MockIndex::new("secondary", &events);
         secondary.write_start_fatal = secondary_fatal;
 
         let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
-        assert_eq!(
+        assert!(
             idx.write_start_failure_is_fatal(),
-            expected,
             "primary_fatal={primary_fatal}, secondary_fatal={secondary_fatal}"
         );
         assert!(
             !idx.write_complete_failure_is_fatal(),
             "a fatal start must not be reported as a fatal finalize"
         );
-    }
-}
 
-#[test]
-fn write_start_fatality_is_the_union_of_both_vector_halves() {
-    let events = Arc::new(Mutex::new(vec![]));
-
-    for (primary_fatal, secondary_fatal, expected) in [
-        (false, false, false),
-        (true, false, true),
-        (false, true, true),
-        (true, true, true),
-    ] {
         let mut primary = MockIndex::new("primary", &events);
         primary.dimension = Some(4);
         primary.write_start_fatal = primary_fatal;
@@ -654,20 +640,19 @@ fn write_start_fatality_is_the_union_of_both_vector_halves() {
         secondary.dimension = Some(4);
         secondary.write_start_fatal = secondary_fatal;
 
-        let idx = CompoundVectorIndex::try_new(
+        let vector = CompoundVectorIndex::try_new(
             Arc::new(primary) as Arc<dyn VectorIndex>,
             Arc::new(secondary) as Arc<dyn VectorIndex>,
             CompoundReadMode::PrimaryOnly,
         )
         .expect("compatible vector indexes");
 
-        assert_eq!(
-            idx.write_start_failure_is_fatal(),
-            expected,
-            "primary_fatal={primary_fatal}, secondary_fatal={secondary_fatal}"
+        assert!(
+            vector.write_start_failure_is_fatal(),
+            "vector: primary_fatal={primary_fatal}, secondary_fatal={secondary_fatal}"
         );
         assert!(
-            !idx.write_complete_failure_is_fatal(),
+            !vector.write_complete_failure_is_fatal(),
             "a fatal start must not be reported as a fatal finalize"
         );
     }
@@ -721,22 +706,108 @@ fn partial_key_deletion_requires_both_halves() {
     }
 }
 
+/// A secondary whose *own* start failure is best-effort must not close the primary's window.
+/// The write runs anyway, so closing the window the primary staged silently downgrades a
+/// [`WriteWindow::ReplaceAll`] to an in-place write: readers observe a partially rebuilt index
+/// and rows the source dropped are never cleared (#12826).
 #[tokio::test]
-async fn on_write_start_rolls_back_primary_when_secondary_fails() {
+async fn on_write_start_keeps_the_primary_window_when_a_best_effort_secondary_fails() {
+    let events = Arc::new(Mutex::new(vec![]));
+    let mut primary = MockIndex::new("primary", &events);
+    primary.dimension = Some(4);
+    let mut secondary = MockIndex::new("secondary", &events);
+    secondary.dimension = Some(4);
+    secondary.fail_on_write_start = true;
+
+    let idx = CompoundVectorIndex::try_new(
+        Arc::new(primary) as Arc<dyn VectorIndex>,
+        Arc::new(secondary) as Arc<dyn VectorIndex>,
+        CompoundReadMode::PrimaryOnly,
+    )
+    .expect("compatible vector indexes");
+    idx.on_write_start(WriteWindow::ReplaceAll)
+        .await
+        .expect("a best-effort secondary start failure must not fail the start");
+
+    let events = events.lock().expect("event log mutex").clone();
+    assert!(
+        !events.contains(&"primary:on_write_failed".to_string()),
+        "the primary's staged window must stay open for the write that follows: {events:?}"
+    );
+}
+
+/// The mirror case: a secondary that declares its own start failure fatal *does* abandon the
+/// write, so the primary's window must close with it.
+#[tokio::test]
+async fn on_write_start_rolls_back_the_primary_when_a_fatal_secondary_fails() {
     let events = Arc::new(Mutex::new(vec![]));
     let primary = MockIndex::new("primary", &events);
     let mut secondary = MockIndex::new("secondary", &events);
     secondary.fail_on_write_start = true;
+    secondary.write_start_fatal = true;
 
     let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
     idx.on_write_start(WriteWindow::Append)
         .await
-        .expect_err("secondary start failure must propagate");
+        .expect_err("a fatal secondary start failure must propagate");
 
     let events = events.lock().expect("event log mutex").clone();
     assert!(
         events.contains(&"primary:on_write_failed".to_string()),
         "primary write window must be rolled back: {events:?}"
+    );
+}
+
+/// A best-effort *primary* start failure must not abandon the write either, even next to a
+/// fatal secondary. Reporting the union of the two flags escalated it: the sink saw "fatal"
+/// from the secondary and rejected a write only the primary's advisory tuning had failed
+/// (#12826).
+#[tokio::test]
+async fn on_write_start_continues_past_a_best_effort_primary_failure() {
+    let events = Arc::new(Mutex::new(vec![]));
+    let mut primary = MockIndex::new("primary", &events);
+    primary.fail_on_write_start = true;
+    let mut secondary = MockIndex::new("secondary", &events);
+    secondary.write_start_fatal = true;
+
+    let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
+    idx.on_write_start(WriteWindow::Append)
+        .await
+        .expect("a best-effort primary start failure must not fail the start");
+
+    let events = events.lock().expect("event log mutex").clone();
+    assert!(
+        events.contains(&"secondary:on_write_start:Append".to_string()),
+        "the secondary must still be started: {events:?}"
+    );
+    assert!(
+        !events.contains(&"primary:on_write_failed".to_string()),
+        "a start that failed partway owns its own cleanup: {events:?}"
+    );
+}
+
+/// A fatal primary start failure stops before the secondary is started at all.
+#[tokio::test]
+async fn on_write_start_stops_at_a_fatal_primary_failure() {
+    let events = Arc::new(Mutex::new(vec![]));
+    let mut primary = MockIndex::new("primary", &events);
+    primary.fail_on_write_start = true;
+    primary.write_start_fatal = true;
+    let secondary = MockIndex::new("secondary", &events);
+
+    let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
+    idx.on_write_start(WriteWindow::Append)
+        .await
+        .expect_err("a fatal primary start failure must propagate");
+
+    let events = events.lock().expect("event log mutex").clone();
+    assert!(
+        !events.contains(&"secondary:on_write_start:Append".to_string()),
+        "the secondary must not be started after a fatal primary failure: {events:?}"
+    );
+    assert!(
+        !events.contains(&"primary:on_write_failed".to_string()),
+        "a start that failed partway owns its own cleanup: {events:?}"
     );
 }
 

--- a/crates/search/src/index/compound/tests.rs
+++ b/crates/search/src/index/compound/tests.rs
@@ -725,6 +725,31 @@ async fn on_write_start_continues_past_a_best_effort_primary_failure() {
     );
 }
 
+/// Both halves failing to start is the only path that reaches the rollback branch with the
+/// primary's window never opened. The write is still abandoned — the secondary declares its own
+/// start failure fatal — but the primary must not be rolled back: a start that failed partway
+/// owns its cleanup, so `on_write_failed` would "restore" settings it never overrode (#12826).
+#[tokio::test]
+async fn on_write_start_does_not_roll_back_a_primary_whose_own_start_failed() {
+    let events = Arc::new(Mutex::new(vec![]));
+    let mut primary = MockIndex::new("primary", &events);
+    primary.fail_on_write_start = true;
+    let mut secondary = MockIndex::new("secondary", &events);
+    secondary.fail_on_write_start = true;
+    secondary.write_start_fatal = true;
+
+    let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
+    idx.on_write_start(WriteWindow::ReplaceAll)
+        .await
+        .expect_err("a fatal secondary start failure must propagate");
+
+    let events = events.lock().expect("event log mutex").clone();
+    assert!(
+        !events.contains(&"primary:on_write_failed".to_string()),
+        "a primary whose own start failed must not be rolled back: {events:?}"
+    );
+}
+
 /// The finalize hook has the same shape as the start hook: a half that declares its own finalize
 /// failure best-effort must not fail the write just because the *other* half declares its own
 /// fatal. Elasticsearch's `_forcemerge` beside a tantivy primary is the live pairing (#12826).

--- a/crates/search/src/index/compound/tests.rs
+++ b/crates/search/src/index/compound/tests.rs
@@ -56,6 +56,7 @@ struct MockIndex {
     write_output_rows: Option<usize>,
     fail_write: bool,
     fail_on_write_start: bool,
+    fail_on_write_complete: bool,
     /// What this mock reports from `Index::write_start_failure_is_fatal`.
     write_start_fatal: bool,
     /// What this mock reports from `Index::write_complete_failure_is_fatal`.
@@ -78,6 +79,7 @@ impl MockIndex {
             write_output_rows: None,
             fail_write: false,
             fail_on_write_start: false,
+            fail_on_write_complete: false,
             write_start_fatal: false,
             write_complete_fatal: false,
             deletes_partial_key: false,
@@ -172,6 +174,12 @@ impl Index for MockIndex {
 
     async fn on_write_complete(&self) -> Result<(), DataFusionError> {
         self.record("on_write_complete");
+        if self.fail_on_write_complete {
+            return Err(DataFusionError::Execution(format!(
+                "{} refuses to finalize a write",
+                self.label
+            )));
+        }
         Ok(())
     }
 
@@ -549,112 +557,43 @@ async fn replace_all_window_forwards_to_both_indexes() {
     }
 }
 
-/// A compound index is stale if *either* half fails to finalize, so the fatality flag
-/// must be the union of both halves rather than the trait default (#12038).
+/// A compound applies each half's own fatality to that half's own failure and swallows the
+/// best-effort ones, so every error it returns is already fatal — whatever the halves report
+/// individually. The trait default (`false`) would still downgrade a fatal half (#12421), which is
+/// why both are `true` rather than inherited (#12038 for the finalize half).
 #[test]
-fn write_complete_fatality_is_the_union_of_both_search_halves() {
-    let events = Arc::new(Mutex::new(vec![]));
-
-    for (primary_fatal, secondary_fatal, expected) in [
-        (false, false, false),
-        (true, false, true),
-        (false, true, true),
-        (true, true, true),
-    ] {
-        let mut primary = MockIndex::new("primary", &events);
-        primary.write_complete_fatal = primary_fatal;
-        let mut secondary = MockIndex::new("secondary", &events);
-        secondary.write_complete_fatal = secondary_fatal;
-
-        let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
-        assert_eq!(
-            idx.write_complete_failure_is_fatal(),
-            expected,
-            "primary_fatal={primary_fatal}, secondary_fatal={secondary_fatal}"
-        );
-    }
-}
-
-#[test]
-fn write_complete_fatality_is_the_union_of_both_vector_halves() {
-    let events = Arc::new(Mutex::new(vec![]));
-
-    for (primary_fatal, secondary_fatal, expected) in [
-        (false, false, false),
-        (true, false, true),
-        (false, true, true),
-        (true, true, true),
-    ] {
-        let mut primary = MockIndex::new("primary", &events);
-        primary.dimension = Some(4);
-        primary.write_complete_fatal = primary_fatal;
-        let mut secondary = MockIndex::new("secondary", &events);
-        secondary.dimension = Some(4);
-        secondary.write_complete_fatal = secondary_fatal;
-
-        let idx = CompoundVectorIndex::try_new(
-            Arc::new(primary) as Arc<dyn VectorIndex>,
-            Arc::new(secondary) as Arc<dyn VectorIndex>,
-            CompoundReadMode::PrimaryOnly,
-        )
-        .expect("compatible vector indexes");
-
-        assert_eq!(
-            idx.write_complete_failure_is_fatal(),
-            expected,
-            "primary_fatal={primary_fatal}, secondary_fatal={secondary_fatal}"
-        );
-    }
-}
-
-/// `compound_on_write_start` applies each half's own start-fatality to that half's own failure
-/// and swallows the best-effort ones, so every error it returns is fatal — whatever the halves
-/// report individually. The trait default (`false`) would still downgrade a fatal half (#12421),
-/// which is why this is `true` rather than inherited.
-#[test]
-fn write_start_fatality_is_reported_for_the_compound_not_the_halves() {
+fn fatality_is_reported_for_the_compound_not_the_halves() {
     let events = Arc::new(Mutex::new(vec![]));
 
     for (primary_fatal, secondary_fatal) in
         [(false, false), (true, false), (false, true), (true, true)]
     {
-        let mut primary = MockIndex::new("primary", &events);
-        primary.write_start_fatal = primary_fatal;
-        let mut secondary = MockIndex::new("secondary", &events);
-        secondary.write_start_fatal = secondary_fatal;
+        let mock = |label: &'static str, fatal: bool, dimension: Option<i32>| {
+            let mut idx = MockIndex::new(label, &events);
+            idx.dimension = dimension;
+            idx.write_start_fatal = fatal;
+            idx.write_complete_fatal = fatal;
+            idx
+        };
+        let case = format!("primary_fatal={primary_fatal}, secondary_fatal={secondary_fatal}");
 
-        let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
-        assert!(
-            idx.write_start_failure_is_fatal(),
-            "primary_fatal={primary_fatal}, secondary_fatal={secondary_fatal}"
+        let search = compound(
+            mock("primary", primary_fatal, None),
+            mock("secondary", secondary_fatal, None),
+            CompoundReadMode::PrimaryOnly,
         );
-        assert!(
-            !idx.write_complete_failure_is_fatal(),
-            "a fatal start must not be reported as a fatal finalize"
-        );
-
-        let mut primary = MockIndex::new("primary", &events);
-        primary.dimension = Some(4);
-        primary.write_start_fatal = primary_fatal;
-        let mut secondary = MockIndex::new("secondary", &events);
-        secondary.dimension = Some(4);
-        secondary.write_start_fatal = secondary_fatal;
+        assert!(search.write_start_failure_is_fatal(), "search: {case}");
+        assert!(search.write_complete_failure_is_fatal(), "search: {case}");
 
         let vector = CompoundVectorIndex::try_new(
-            Arc::new(primary) as Arc<dyn VectorIndex>,
-            Arc::new(secondary) as Arc<dyn VectorIndex>,
+            Arc::new(mock("primary", primary_fatal, Some(4))) as Arc<dyn VectorIndex>,
+            Arc::new(mock("secondary", secondary_fatal, Some(4))) as Arc<dyn VectorIndex>,
             CompoundReadMode::PrimaryOnly,
         )
         .expect("compatible vector indexes");
 
-        assert!(
-            vector.write_start_failure_is_fatal(),
-            "vector: primary_fatal={primary_fatal}, secondary_fatal={secondary_fatal}"
-        );
-        assert!(
-            !vector.write_complete_failure_is_fatal(),
-            "a fatal start must not be reported as a fatal finalize"
-        );
+        assert!(vector.write_start_failure_is_fatal(), "vector: {case}");
+        assert!(vector.write_complete_failure_is_fatal(), "vector: {case}");
     }
 }
 
@@ -783,6 +722,55 @@ async fn on_write_start_continues_past_a_best_effort_primary_failure() {
     assert!(
         !events.contains(&"primary:on_write_failed".to_string()),
         "a start that failed partway owns its own cleanup: {events:?}"
+    );
+}
+
+/// The finalize hook has the same shape as the start hook: a half that declares its own finalize
+/// failure best-effort must not fail the write just because the *other* half declares its own
+/// fatal. Elasticsearch's `_forcemerge` beside a tantivy primary is the live pairing (#12826).
+#[tokio::test]
+async fn on_write_complete_swallows_a_best_effort_half_failure() {
+    let events = Arc::new(Mutex::new(vec![]));
+    let mut primary = MockIndex::new("primary", &events);
+    primary.write_complete_fatal = true;
+    let mut secondary = MockIndex::new("secondary", &events);
+    secondary.fail_on_write_complete = true;
+
+    let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
+    idx.on_write_complete()
+        .await
+        .expect("a best-effort half's finalize failure must not fail the write");
+
+    let events = events.lock().expect("event log mutex").clone();
+    for side in ["primary", "secondary"] {
+        assert!(
+            events.contains(&format!("{side}:on_write_complete")),
+            "both halves must be finalized: {events:?}"
+        );
+    }
+}
+
+/// The mirror case: the half that declares its own finalize fatal does fail the write, and the
+/// other half is still finalized rather than skipped.
+#[tokio::test]
+async fn on_write_complete_reports_a_fatal_half_failure() {
+    let events = Arc::new(Mutex::new(vec![]));
+    let mut primary = MockIndex::new("primary", &events);
+    primary.fail_on_write_complete = true;
+    primary.write_complete_fatal = true;
+    let secondary = MockIndex::new("secondary", &events);
+
+    let idx = compound(primary, secondary, CompoundReadMode::PrimaryOnly);
+    let err = idx
+        .on_write_complete()
+        .await
+        .expect_err("a fatal half's finalize failure must fail the write");
+    assert!(err.to_string().contains("primary"), "{err}");
+
+    let events = events.lock().expect("event log mutex").clone();
+    assert!(
+        events.contains(&"secondary:on_write_complete".to_string()),
+        "the other half must still be finalized: {events:?}"
     );
 }
 

--- a/crates/search/src/index/compound/vector_index.rs
+++ b/crates/search/src/index/compound/vector_index.rs
@@ -29,9 +29,9 @@ use runtime_datafusion_index::{Index, WriteWindow};
 use crate::index::{SearchIndex, VectorIndex, primary_key_projection};
 
 use super::{
-    CompoundReadMode, Error, compound_delete_by_keys, compound_on_write_start,
-    compound_required_columns, compound_write, fallback::fallback_on_empty_plan,
-    validate_compatibility,
+    COMPOUND_WRITE_START_FAILURE_IS_FATAL, CompoundReadMode, Error, compound_delete_by_keys,
+    compound_on_write_start, compound_required_columns, compound_write,
+    fallback::fallback_on_empty_plan, validate_compatibility,
 };
 
 /// A [`VectorIndex`] counterpart of [`super::CompoundSearchIndex`]: writes through to two
@@ -200,9 +200,7 @@ impl Index for CompoundVectorIndex {
     }
 
     fn write_start_failure_is_fatal(&self) -> bool {
-        // `compound_on_write_start` fails if either half fails to start, so either half
-        // treating that as fatal makes it fatal for this compound index.
-        self.primary.write_start_failure_is_fatal() || self.secondary.write_start_failure_is_fatal()
+        COMPOUND_WRITE_START_FAILURE_IS_FATAL
     }
 
     fn write_complete_failure_is_fatal(&self) -> bool {

--- a/crates/search/src/index/compound/vector_index.rs
+++ b/crates/search/src/index/compound/vector_index.rs
@@ -29,7 +29,8 @@ use runtime_datafusion_index::{Index, WriteWindow};
 use crate::index::{SearchIndex, VectorIndex, primary_key_projection};
 
 use super::{
-    COMPOUND_WRITE_START_FAILURE_IS_FATAL, CompoundReadMode, Error, compound_delete_by_keys,
+    COMPOUND_WRITE_COMPLETE_FAILURE_IS_FATAL, COMPOUND_WRITE_START_FAILURE_IS_FATAL,
+    CompoundReadMode, Error, compound_delete_by_keys, compound_on_write_complete,
     compound_on_write_start, compound_required_columns, compound_write,
     fallback::fallback_on_empty_plan, validate_compatibility,
 };
@@ -181,12 +182,7 @@ impl Index for CompoundVectorIndex {
     }
 
     async fn on_write_complete(&self) -> Result<(), DataFusionError> {
-        // As with `on_write_failed`: both completion callbacks must run.
-        let (primary_result, secondary_result) = futures::join!(
-            self.primary.on_write_complete(),
-            self.secondary.on_write_complete()
-        );
-        primary_result.and(secondary_result)
+        compound_on_write_complete(self.primary.as_ref(), self.secondary.as_ref()).await
     }
 
     async fn delete_by_keys(&self, keys: RecordBatch) -> DataFusionResult<()> {
@@ -204,9 +200,7 @@ impl Index for CompoundVectorIndex {
     }
 
     fn write_complete_failure_is_fatal(&self) -> bool {
-        // Either half failing to finalize leaves this compound index stale.
-        self.primary.write_complete_failure_is_fatal()
-            || self.secondary.write_complete_failure_is_fatal()
+        COMPOUND_WRITE_COMPLETE_FAILURE_IS_FATAL
     }
 
     fn as_any(&self) -> &dyn Any {


### PR DESCRIPTION
## Summary

`CompoundSearchIndex`/`CompoundVectorIndex` ORed their two halves' fatality flags into the
single answer the sink consults after a lifecycle hook fails. That answer cannot say **which
half** failed, and both answers the OR can produce are wrong for one of the halves:

| Halves | OR says | What happens | Why it is wrong |
|---|---|---|---|
| fatal + best-effort | `fatal` | the whole write is abandoned/failed when the **best-effort** half fails | the half that failed declared its own step advisory, and the OR overrode it |
| best-effort + best-effort | `best-effort` | the primary's window is rolled back, then the write runs anyway | a staged `WriteWindow::ReplaceAll` silently degrades to an in-place write: readers observe a partially rebuilt index, and rows the source dropped are never cleared |

Both hooks that carry a fatality flag had this, and both misclassifications are reachable on
`trunk` today:

- **`on_write_start`** (the reported defect): a full-text compound pairs a tantivy primary
  (`write_start_failure_is_fatal() == true`) with an Elasticsearch secondary (default `false`),
  so a failed `refresh_interval` override — documented on the trait as *the* example of a start
  the write does not depend on — failed the entire refresh. In the other direction,
  `compound_on_write_start` rolled the primary back on *any* secondary start failure, including
  ones after which the write was going to proceed anyway.
- **`on_write_complete`**: the same tantivy primary beside an Elasticsearch secondary whose
  finalize runs `_forcemerge`, a segment-count optimization the indexed rows do not depend on.
  The OR turned a failed force-merge into a failed write.

Fixes #12826

## Changes

- `compound_on_write_start` and `compound_on_write_complete` apply each half's own flag to
  **that half's own** failure, at the call site where the failing half is known. A best-effort
  failure is logged and the write continues; a fatal one is returned.
- Both compounds report `write_start_failure_is_fatal()` and `write_complete_failure_is_fatal()`
  as `true` unconditionally, because every error they now return already came from a half that
  declared one fatal. This keeps the property #12421 and #12038 added — a fatal half is never
  downgraded to the trait default — and drops the misclassification in both directions.
- The primary is rolled back only when the write is genuinely being abandoned **and** the
  primary actually started. No half whose own start failed is rolled back: a start that fails
  partway owns its cleanup, which is what lets the existing `on_write_failed`/`on_write_complete`
  fan-out stay correct (`ElasticsearchIndexWriteMaintenance::on_write_failed` short-circuits on
  `write_cycle_active`, which its own `abandon_write_cycle` already cleared).
- `on_write_complete` still finalizes **both** halves before either result is inspected, and
  still surfaces the primary's error first.

The set of writes this rejects is a strict subset of what `trunk` rejects. The change never
newly fails a write; it only stops failing ones that a best-effort half's advisory work should
never have failed, and stops closing a window the write still depends on.

### Note for #12413 / #12823

This is the change #12826 asked for, so that the memory vector tier's staged replace window can
declare its start fatal without escalating the Elasticsearch secondary's best-effort failures.
That flag flip belongs to #12823, which is where the staged window lives; it is not in this PR.

## Test plan

- [x] `make lint`
- [x] `make test`

New cases in `crates/search/src/index/compound/tests.rs`. Each was run against the pre-fix
implementation as well as the new one, so the regression coverage is confirmed rather than
assumed:

| test | on the old code |
|---|---|
| `on_write_start_keeps_the_primary_window_when_a_best_effort_secondary_fails` (the reported defect, over `CompoundVectorIndex`) | **fails** |
| `on_write_start_continues_past_a_best_effort_primary_failure` (the escalation direction) | **fails** |
| `on_write_complete_swallows_a_best_effort_half_failure` (the finalize hook) | **fails** |
| `on_write_start_rolls_back_the_primary_when_a_fatal_secondary_fails` | passes (preserved) |
| `on_write_start_stops_at_a_fatal_primary_failure` | passes (preserved) |
| `on_write_complete_reports_a_fatal_half_failure` | passes (preserved) |

The four `write_{start,complete}_fatality_is_the_union_of_both_{search,vector}_halves` tests are
replaced by one `fatality_is_reported_for_the_compound_not_the_halves`, covering both hooks and
both compound kinds over all four flag combinations.

## Checklist

- [x] Regression tests confirmed failing on the old code and passing on the new
- [x] Lint clean over the changed crate's lib and test targets (`make lint` is the gate)
- [x] No behaviour change for a compound whose halves agree on fatality
- [x] `on_write_failed` is unchanged (the sink logs cleanup failures rather than classifying them,
      so it carries no fatality flag)
- [ ] Sign-off / Attestation green
