### PR TITLE
fix(runtime): scope query jobs and active queries to the principal that submitted them

### DIFF
--- a/crates/runtime-datafusion/src/query_cancel_registry.rs
+++ b/crates/runtime-datafusion/src/query_cancel_registry.rs
@@ -45,6 +45,11 @@ pub struct ActiveQueryInfo {
     pub sql_preview: Arc<str>,
     pub protocol: Protocol,
     pub started_at_ms: u64,
+    /// The scope that submitted the query: the storage id of the submitting
+    /// request's cache namespace. Listing and cancellation are restricted to
+    /// this scope, so one principal cannot read another's in-flight SQL or
+    /// stop its work.
+    pub owner: Arc<str>,
 }
 
 struct ActiveQueryEntry {
@@ -77,6 +82,7 @@ impl QueryCancelRegistry {
         query_id: Uuid,
         sql: &str,
         protocol: Protocol,
+        owner: Arc<str>,
         token: CancellationToken,
     ) -> ActiveQueryGuard {
         let started_at_ms = SystemTime::now()
@@ -93,6 +99,7 @@ impl QueryCancelRegistry {
                     sql_preview: Self::truncate_sql_preview(sql),
                     protocol,
                     started_at_ms,
+                    owner,
                 },
                 token,
             },
@@ -103,16 +110,21 @@ impl QueryCancelRegistry {
         }
     }
 
-    /// Cancels the active query with the given id, if present. Returns `true`
-    /// if an entry existed and was signalled.
+    /// Cancels the active query with the given id when `caller` submitted it.
+    /// Returns `true` if a matching entry existed and was signalled.
+    ///
+    /// A query submitted by another scope reports the same `false` as an id
+    /// that does not exist, so a caller cannot probe for other principals'
+    /// query ids.
     #[must_use]
-    pub fn cancel(&self, query_id: Uuid) -> bool {
-        if let Some(entry) = self.entries.get(&query_id) {
+    pub fn cancel_owned(&self, query_id: Uuid, caller: &str) -> bool {
+        if let Some(entry) = self.entries.get(&query_id)
+            && entry.info.owner.as_ref() == caller
+        {
             entry.token.cancel();
-            true
-        } else {
-            false
+            return true;
         }
+        false
     }
 
     /// Cancels every active query in this registry. Returns the number of
@@ -127,13 +139,26 @@ impl QueryCancelRegistry {
         cancelled
     }
 
-    /// Returns a snapshot of all active queries.
+    /// Returns a snapshot of the active queries `caller` submitted.
     #[must_use]
-    pub fn list(&self) -> Vec<ActiveQueryInfo> {
+    pub fn list_for(&self, caller: &str) -> Vec<ActiveQueryInfo> {
+        self.list_matching(|info| info.owner.as_ref() == caller)
+    }
+
+    /// Returns a snapshot of every active query regardless of who submitted
+    /// it. For internal callers only — request-facing surfaces use
+    /// [`Self::list_for`].
+    #[must_use]
+    pub fn list_all(&self) -> Vec<ActiveQueryInfo> {
+        self.list_matching(|_| true)
+    }
+
+    fn list_matching(&self, predicate: impl Fn(&ActiveQueryInfo) -> bool) -> Vec<ActiveQueryInfo> {
         let mut entries: Vec<ActiveQueryInfo> = self
             .entries
             .iter()
             .map(|e| e.value().info.clone())
+            .filter(|info| predicate(info))
             .collect();
         entries.sort_by(|left, right| {
             left.started_at_ms
@@ -212,16 +237,24 @@ impl Drop for ActiveQueryGuard {
 mod tests {
     use super::*;
 
+    const OWNER: &str = "apikey:0123456789abcdef";
+    const OTHER: &str = "apikey:fedcba9876543210";
+
+    fn owner() -> Arc<str> {
+        Arc::from(OWNER)
+    }
+
     #[test]
     fn register_and_cancel_roundtrip() {
         let registry = Arc::new(QueryCancelRegistry::new());
         let token = CancellationToken::new();
         let query_id = Uuid::new_v4();
 
-        let _guard = registry.register(query_id, "SELECT 1", Protocol::Http, token.clone());
+        let _guard =
+            registry.register(query_id, "SELECT 1", Protocol::Http, owner(), token.clone());
 
         assert_eq!(registry.len(), 1);
-        assert!(registry.cancel(query_id));
+        assert!(registry.cancel_owned(query_id, OWNER));
         assert!(token.is_cancelled());
     }
 
@@ -234,6 +267,7 @@ mod tests {
                 query_id,
                 "SELECT 1",
                 Protocol::Http,
+                owner(),
                 CancellationToken::new(),
             );
             assert_eq!(registry.len(), 1);
@@ -244,7 +278,7 @@ mod tests {
     #[test]
     fn cancel_missing_returns_false() {
         let registry = Arc::new(QueryCancelRegistry::new());
-        assert!(!registry.cancel(Uuid::new_v4()));
+        assert!(!registry.cancel_owned(Uuid::new_v4(), OWNER));
     }
 
     #[test]
@@ -253,10 +287,20 @@ mod tests {
         let first = CancellationToken::new();
         let second = CancellationToken::new();
 
-        let _first_guard =
-            registry.register(Uuid::new_v4(), "SELECT 1", Protocol::Http, first.clone());
-        let _second_guard =
-            registry.register(Uuid::new_v4(), "SELECT 2", Protocol::Flight, second.clone());
+        let _first_guard = registry.register(
+            Uuid::new_v4(),
+            "SELECT 1",
+            Protocol::Http,
+            owner(),
+            first.clone(),
+        );
+        let _second_guard = registry.register(
+            Uuid::new_v4(),
+            "SELECT 2",
+            Protocol::Flight,
+            owner(),
+            second.clone(),
+        );
 
         assert_eq!(registry.cancel_all(), 2);
         assert!(first.is_cancelled());
@@ -271,16 +315,18 @@ mod tests {
             Uuid::from_u128(2),
             "SELECT 2",
             Protocol::Http,
+            owner(),
             CancellationToken::new(),
         );
         let _second_guard = registry.register(
             Uuid::from_u128(1),
             "SELECT 1",
             Protocol::Http,
+            owner(),
             CancellationToken::new(),
         );
 
-        let listed = registry.list();
+        let listed = registry.list_all();
         assert!(listed.windows(2).all(|window| {
             let left = &window[0];
             let right = &window[1];
@@ -298,11 +344,12 @@ mod tests {
             Uuid::new_v4(),
             &long_sql,
             Protocol::Http,
+            owner(),
             CancellationToken::new(),
         );
 
         let preview = registry
-            .list()
+            .list_all()
             .pop()
             .expect("registered query should be listed")
             .sql_preview
@@ -310,5 +357,58 @@ mod tests {
         assert_eq!(preview.chars().count(), SQL_PREVIEW_MAX_CHARS);
         assert!(preview.ends_with(SQL_PREVIEW_ELLIPSIS));
         assert!(long_sql.starts_with(preview.trim_end_matches(SQL_PREVIEW_ELLIPSIS)));
+    }
+
+    #[test]
+    fn cancel_owned_refuses_a_query_another_scope_submitted() {
+        let registry = Arc::new(QueryCancelRegistry::new());
+        let token = CancellationToken::new();
+        let query_id = Uuid::new_v4();
+        let _guard =
+            registry.register(query_id, "SELECT 1", Protocol::Http, owner(), token.clone());
+
+        assert!(
+            !registry.cancel_owned(query_id, OTHER),
+            "another scope must not cancel the query"
+        );
+        assert!(
+            !token.is_cancelled(),
+            "a refused cancellation must leave the query running"
+        );
+        assert!(
+            registry.cancel_owned(query_id, OWNER),
+            "the submitting scope may cancel its own query"
+        );
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn list_for_returns_only_the_callers_queries() {
+        let registry = Arc::new(QueryCancelRegistry::new());
+        let mine = Uuid::from_u128(1);
+        let theirs = Uuid::from_u128(2);
+        let _mine_guard = registry.register(
+            mine,
+            "SELECT mine",
+            Protocol::Http,
+            owner(),
+            CancellationToken::new(),
+        );
+        let _theirs_guard = registry.register(
+            theirs,
+            "SELECT theirs",
+            Protocol::Http,
+            Arc::from(OTHER),
+            CancellationToken::new(),
+        );
+
+        let listed = registry.list_for(OWNER);
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].query_id, mine);
+        assert!(
+            !listed.iter().any(|q| q.sql_preview.contains("theirs")),
+            "another scope's SQL must not be disclosed"
+        );
+        assert_eq!(registry.list_all().len(), 2);
     }
 }

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -176,7 +176,7 @@ async fn recover_orphaned_jobs(
     };
 
     let jobs = match job_executor
-        .list_jobs(Some(crate::jobs::JobStatus::Running))
+        .list_all_jobs(Some(crate::jobs::JobStatus::Running))
         .await
     {
         Ok(jobs) => jobs,

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1056,6 +1056,7 @@ impl Query {
             self.query_id,
             sql_preview.as_ref(),
             request_context.protocol(),
+            Arc::from(request_context.cache_namespace().storage_id()),
             query_cancel_token.clone(),
         );
         let query_id_str: Arc<str> = Arc::from(self.query_id.to_string());
@@ -3072,11 +3073,20 @@ mod tests {
         assert_eq!(cached_query.cache_status, CacheStatus::CacheHit);
         let registry = df.query_cancel_registry();
         assert!(
-            registry.list().iter().any(|info| info.query_id == query_id),
+            registry
+                .list_all()
+                .iter()
+                .any(|info| info.query_id == query_id),
             "cached query should remain registered while its stream is alive"
         );
 
-        assert!(registry.cancel(query_id));
+        let owner = registry
+            .list_all()
+            .into_iter()
+            .find(|info| info.query_id == query_id)
+            .map(|info| info.owner)
+            .expect("the registered query should expose its owning scope");
+        assert!(registry.cancel_owned(query_id, &owner));
         assert!(cancel_token.is_cancelled());
         let cancellation = cached_query
             .data
@@ -3089,7 +3099,10 @@ mod tests {
         );
         assert!(cached_query.data.next().await.is_none());
         assert!(
-            registry.list().iter().all(|info| info.query_id != query_id),
+            registry
+                .list_all()
+                .iter()
+                .all(|info| info.query_id != query_id),
             "cached query should be deregistered after the stream terminates"
         );
     }
@@ -3226,7 +3239,11 @@ mod tests {
         // a fixed sleep (which is flaky under slow CI). Bounded fallback (~5s).
         let registry = df.query_cancel_registry();
         for _ in 0..500 {
-            if registry.list().iter().any(|info| info.query_id == query_id) {
+            if registry
+                .list_all()
+                .iter()
+                .any(|info| info.query_id == query_id)
+            {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;

--- a/crates/runtime/src/flight/actions.rs
+++ b/crates/runtime/src/flight/actions.rs
@@ -250,7 +250,9 @@ async fn handle_cancel_query(body: &[u8]) -> Result<Vec<u8>, Status> {
     }
 
     let df = get_current_datafusion(&context);
-    let cancelled = df.query_cancel_registry().cancel(parsed);
+    let cancelled = df
+        .query_cancel_registry()
+        .cancel_owned(parsed, &crate::jobs::current_job_owner().await);
 
     let resp = CancelQueryResponse {
         query_id: req.query_id,

--- a/crates/runtime/src/flight/async_actions.rs
+++ b/crates/runtime/src/flight/async_actions.rs
@@ -261,7 +261,7 @@ pub async fn handle_submit_async_query(body: &[u8]) -> Result<Vec<u8>, Status> {
     let _ = super::check_read_only_sql(&context, &datafusion, &request.sql, None).await?;
 
     let state = executor
-        .submit(request, read_only)
+        .submit(request, read_only, crate::jobs::current_job_owner().await)
         .await
         .map_err(|e| Status::internal(format!("Failed to submit query: {e}")))?;
 
@@ -285,7 +285,10 @@ pub async fn handle_get_async_query_status(body: &[u8]) -> Result<Vec<u8>, Statu
     })?;
 
     let state = executor
-        .get_status(request.query_id.as_str())
+        .get_status(
+            request.query_id.as_str(),
+            &crate::jobs::current_job_owner().await,
+        )
         .await
         .map_err(|e| Status::not_found(format!("Query not found: {e}")))?;
 
@@ -307,8 +310,9 @@ pub async fn handle_get_async_query_result(body: &[u8]) -> Result<Vec<u8>, Statu
     })?;
 
     // Check job status first
+    let caller = crate::jobs::current_job_owner().await;
     let state = executor
-        .get_status(request.query_id.as_str())
+        .get_status(request.query_id.as_str(), &caller)
         .await
         .map_err(|e| Status::not_found(format!("Query not found: {e}")))?;
 
@@ -334,7 +338,7 @@ pub async fn handle_get_async_query_result(body: &[u8]) -> Result<Vec<u8>, Statu
 
     // Get the result chunk
     let batches = executor
-        .get_chunk(request.query_id.as_str(), request.chunk_index)
+        .get_chunk(request.query_id.as_str(), request.chunk_index, &caller)
         .await
         .map_err(|e| match &e {
             crate::jobs::Error::NoRowsReturned { .. }
@@ -355,14 +359,32 @@ pub async fn handle_cancel_async_query(body: &[u8]) -> Result<Vec<u8>, Status> {
     let executor = get_job_executor(&context)
         .ok_or_else(|| Status::unavailable("Async queries are only available in cluster mode"))?;
 
+    // Cancellation is a write. `POST /v1/queries/{id}/cancel` refuses a
+    // read-only principal, and this action must refuse it identically.
+    if super::is_auth_read_only(&context) {
+        return Err(Status::permission_denied(
+            "API key does not allow write access",
+        ));
+    }
+
     let request: CancelAsyncQueryRequest = serde_json::from_slice(body).map_err(|e| {
         Status::invalid_argument(format!("Failed to parse CancelAsyncQueryRequest: {e}"))
     })?;
 
     let state = executor
-        .cancel(request.query_id.as_str())
+        .cancel(
+            request.query_id.as_str(),
+            &crate::jobs::current_job_owner().await,
+        )
         .await
-        .map_err(|e| Status::internal(format!("Failed to cancel query: {e}")))?;
+        .map_err(|e| match &e {
+            // Mirrors the other async actions, and `POST
+            // /v1/queries/{id}/cancel`, so a job this caller cannot see reads
+            // as missing over both protocols instead of as a server error.
+            crate::jobs::Error::JobNotFound { .. }
+            | crate::jobs::Error::JobResultsExpired { .. } => Status::not_found(e.to_string()),
+            _ => Status::internal(format!("Failed to cancel query: {e}")),
+        })?;
 
     let response = CancelAsyncQueryResponse {
         query_id: QueryId::new(state.job_id),

--- a/crates/runtime/src/http/v1/queries.rs
+++ b/crates/runtime/src/http/v1/queries.rs
@@ -329,7 +329,9 @@ pub(crate) async fn submit(
         Ok(e) => e,
         Err(resp) => return resp,
     };
-    let result = executor.submit(request, read_only).await;
+    let result = executor
+        .submit(request, read_only, crate::jobs::current_job_owner().await)
+        .await;
 
     match result {
         Ok(state) => {
@@ -374,7 +376,8 @@ pub(crate) async fn get_query(
         Ok(e) => e,
         Err(resp) => return resp,
     };
-    let result = executor.get_status(&query_id).await;
+    let caller = crate::jobs::current_job_owner().await;
+    let result = executor.get_status(&query_id, &caller).await;
 
     match result {
         Ok(state) => {
@@ -382,7 +385,7 @@ pub(crate) async fn get_query(
 
             // If succeeded, include first chunk data
             if state.status == JobStatus::Succeeded
-                && let Ok(batches) = executor.get_chunk(&query_id, 0).await
+                && let Ok(batches) = executor.get_chunk(&query_id, 0, &caller).await
                 && let Some(result) = &state.result
             {
                 match build_chunk_response(&query_id, 0, &batches, result) {
@@ -425,7 +428,8 @@ pub(crate) async fn get_status(
         Ok(e) => e,
         Err(resp) => return resp,
     };
-    let result = executor.get_status(&query_id).await;
+    let caller = crate::jobs::current_job_owner().await;
+    let result = executor.get_status(&query_id, &caller).await;
 
     match result {
         Ok(state) => {
@@ -489,7 +493,8 @@ pub(crate) async fn get_results(
     }
 
     // First check the job state
-    let state = match executor.get_status(&query_id).await {
+    let caller = crate::jobs::current_job_owner().await;
+    let state = match executor.get_status(&query_id, &caller).await {
         Ok(s) => s,
         Err(e) => return error_to_response(&e),
     };
@@ -525,7 +530,7 @@ pub(crate) async fn get_results(
             .into_response();
     }
 
-    let result = executor.get_chunk(&query_id, partition).await;
+    let result = executor.get_chunk(&query_id, partition, &caller).await;
 
     match result {
         Ok(batches) => {
@@ -587,7 +592,8 @@ pub(crate) async fn get_chunk(
         Err(resp) => return resp,
     };
     // First check the job state to get manifest
-    let state = match executor.get_status(&query_id).await {
+    let caller = crate::jobs::current_job_owner().await;
+    let state = match executor.get_status(&query_id, &caller).await {
         Ok(s) => s,
         Err(e) => return error_to_response(&e),
     };
@@ -609,7 +615,7 @@ pub(crate) async fn get_chunk(
         return (status_code, Json(serde_json::json!({"error": error_msg}))).into_response();
     }
 
-    let result = executor.get_chunk(&query_id, chunk_index).await;
+    let result = executor.get_chunk(&query_id, chunk_index, &caller).await;
 
     match result {
         Ok(batches) => {
@@ -661,7 +667,8 @@ pub(crate) async fn cancel(
         Ok(e) => e,
         Err(resp) => return resp,
     };
-    let result = executor.cancel(&query_id).await;
+    let caller = crate::jobs::current_job_owner().await;
+    let result = executor.cancel(&query_id, &caller).await;
 
     match result {
         Ok(state) => {
@@ -712,7 +719,12 @@ pub(crate) async fn cancel_active(
         }
     };
 
-    if rt.df.query_cancel_registry().cancel(parsed_uuid) {
+    let caller = crate::jobs::current_job_owner().await;
+    if rt
+        .df
+        .query_cancel_registry()
+        .cancel_owned(parsed_uuid, &caller)
+    {
         return (
             StatusCode::OK,
             Json(CancelActiveQueryResponse {
@@ -751,9 +763,10 @@ pub(crate) async fn list_active(Extension(rt): Extension<Arc<Runtime>>) -> Respo
         return response;
     }
 
+    let caller = crate::jobs::current_job_owner().await;
     let registry = rt.df.query_cancel_registry();
     let queries: Vec<ActiveQuerySummary> = registry
-        .list()
+        .list_for(&caller)
         .into_iter()
         .map(|info| ActiveQuerySummary {
             query_id: info.query_id.to_string(),
@@ -808,7 +821,8 @@ pub(crate) async fn list(
         _ => None,
     });
 
-    match executor.list_jobs(status_filter).await {
+    let caller = crate::jobs::current_job_owner().await;
+    match executor.list_jobs(status_filter, &caller).await {
         Ok(jobs) => {
             let limit = query.limit.unwrap_or(100);
             let queries: Vec<QuerySummary> = jobs
@@ -1082,9 +1096,20 @@ mod tests {
         let query_id = Uuid::new_v4();
         let token = CancellationToken::new();
         let registry = rt.df.query_cancel_registry();
-        let _guard = registry.register(query_id, "SELECT 1", Protocol::Http, token.clone());
+        let _guard = registry.register(
+            query_id,
+            "SELECT 1",
+            Protocol::Http,
+            Arc::from(crate::jobs::PUBLIC_JOB_OWNER),
+            token.clone(),
+        );
 
-        let response = cancel_active(Extension(rt), Path(query_id.to_string())).await;
+        // Run the handler inside a real unauthenticated HTTP request context:
+        // outside any scope the runtime resolves to the internal `system`
+        // scope, which by design cannot reach a user-submitted query.
+        let response = Arc::new(RequestContextBuilder::new(Protocol::Http).build())
+            .scope(cancel_active(Extension(rt), Path(query_id.to_string())))
+            .await;
 
         assert_eq!(response.status(), StatusCode::OK);
         assert!(token.is_cancelled());
@@ -1105,16 +1130,20 @@ mod tests {
             long_query_id,
             &long_sql,
             Protocol::Http,
+            Arc::from(crate::jobs::PUBLIC_JOB_OWNER),
             CancellationToken::new(),
         );
         let _short_guard = registry.register(
             short_query_id,
             "SELECT 1",
             Protocol::Flight,
+            Arc::from(crate::jobs::PUBLIC_JOB_OWNER),
             CancellationToken::new(),
         );
 
-        let response = list_active(Extension(rt)).await;
+        let response = Arc::new(RequestContextBuilder::new(Protocol::Http).build())
+            .scope(list_active(Extension(rt)))
+            .await;
 
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_json(response).await;
@@ -1185,6 +1214,93 @@ mod tests {
         let values: Vec<i32> = (0..row_count).collect();
         arrow::array::RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(values))])
             .expect("to create batch")
+    }
+
+    /// A background/internal caller resolves to the `system` scope, which must
+    /// not reach a query submitted by a user request.
+    #[tokio::test]
+    async fn active_query_api_does_not_serve_user_queries_to_internal_callers() {
+        let rt = test_runtime().await;
+        let query_id = Uuid::new_v4();
+        let token = CancellationToken::new();
+        let registry = rt.df.query_cancel_registry();
+        let _guard = registry.register(
+            query_id,
+            "SELECT 1",
+            Protocol::Http,
+            Arc::from(crate::jobs::PUBLIC_JOB_OWNER),
+            token.clone(),
+        );
+
+        // No scope in force: `RequestContext::current` yields the internal
+        // context, whose cache namespace is `System`.
+        let response = cancel_active(Extension(rt), Path(query_id.to_string())).await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(!token.is_cancelled());
+    }
+
+    /// A write-capable principal must not see, or be able to stop, another
+    /// principal's in-flight query through the sync active-query API.
+    #[tokio::test]
+    async fn active_query_api_is_scoped_to_the_submitting_principal() {
+        let rt = test_runtime().await;
+        let registry = rt.df.query_cancel_registry();
+
+        let context = Arc::new(RequestContextBuilder::new(Protocol::Http).build());
+        context
+            .set_auth_principal(Arc::new(ApiKey::ReadWrite {
+                key: "writer-a".to_string(),
+            }) as AuthPrincipalRef)
+            .expect("auth principal should be set");
+        let caller_scope: Arc<str> = Arc::from(context.cache_namespace().storage_id());
+
+        let mine = Uuid::from_u128(1);
+        let theirs = Uuid::from_u128(2);
+        let their_token = CancellationToken::new();
+        let _mine_guard = registry.register(
+            mine,
+            "SELECT mine",
+            Protocol::Http,
+            Arc::clone(&caller_scope),
+            CancellationToken::new(),
+        );
+        let _theirs_guard = registry.register(
+            theirs,
+            "SELECT theirs",
+            Protocol::Http,
+            Arc::from("apikey:some-other-principal"),
+            their_token.clone(),
+        );
+
+        let listed = Arc::clone(&context)
+            .scope(list_active(Extension(Arc::clone(&rt))))
+            .await;
+        assert_eq!(listed.status(), StatusCode::OK);
+        let body = response_json(listed).await;
+        assert_eq!(body["total_count"], 1);
+        let rendered = body["queries"].to_string();
+        assert!(
+            rendered.contains("SELECT mine"),
+            "the caller must still see its own query: {rendered}"
+        );
+        assert!(
+            !rendered.contains("SELECT theirs"),
+            "another principal's SQL must not be disclosed: {rendered}"
+        );
+
+        let cancelled = context
+            .scope(cancel_active(Extension(rt), Path(theirs.to_string())))
+            .await;
+        assert_eq!(
+            cancelled.status(),
+            StatusCode::NOT_FOUND,
+            "another principal's query must read as missing, not as cancellable"
+        );
+        assert!(
+            !their_token.is_cancelled(),
+            "a refused cancellation must leave the other principal's query running"
+        );
     }
 
     #[test]

--- a/crates/runtime/src/jobs/executor.rs
+++ b/crates/runtime/src/jobs/executor.rs
@@ -78,8 +78,13 @@ impl JobExecutor {
     /// Submits a new query job for async execution.
     ///
     /// Returns the job state immediately. The query will be executed in the background.
-    pub async fn submit(&self, request: SubmitQueryRequest, read_only: bool) -> Result<JobState> {
-        let state = self.job_store.create_job(request, read_only).await?;
+    pub async fn submit(
+        &self,
+        request: SubmitQueryRequest,
+        read_only: bool,
+        owner: String,
+    ) -> Result<JobState> {
+        let state = self.job_store.create_job(request, read_only, owner).await?;
         let job_id = state.job_id.clone();
 
         // Create cancellation token for this job
@@ -181,26 +186,69 @@ impl JobExecutor {
         );
     }
 
-    /// Requests cancellation of a running job.
-    pub async fn cancel(&self, job_id: &str) -> Result<JobState> {
+    /// Requests cancellation of a running job submitted by `caller`.
+    pub async fn cancel(&self, job_id: &str, caller: &str) -> Result<JobState> {
+        // Resolve ownership before signalling: a caller that did not submit
+        // the job must not be able to stop it.
+        self.owned_job(job_id, caller).await?;
+
         // Signal cancellation to the running task
-        let active = self.active_jobs.read().await;
-        if let Some(info) = active.get(job_id) {
-            info.cancel_token.cancel();
+        {
+            let active = self.active_jobs.read().await;
+            if let Some(info) = active.get(job_id) {
+                info.cancel_token.cancel();
+            }
         }
 
         // Update job state
         self.job_store.cancel_job(job_id).await
     }
 
-    /// Gets the current state of a job.
-    pub async fn get_status(&self, job_id: &str) -> Result<JobState> {
-        self.job_store.get_job(job_id).await
+    /// Gets the current state of a job submitted by `caller`.
+    pub async fn get_status(&self, job_id: &str, caller: &str) -> Result<JobState> {
+        self.owned_job(job_id, caller).await
     }
 
-    /// Reads a result chunk for a completed job.
-    pub async fn get_chunk(&self, job_id: &str, chunk_index: usize) -> Result<Vec<RecordBatch>> {
-        let state = self.job_store.get_job(job_id).await?;
+    /// Reads a job's state and authorizes `caller` against it.
+    ///
+    /// Ownership is resolved before expiry so every job `caller` does not own
+    /// answers identically, whether it is live, expired, or absent.
+    async fn owned_job(&self, job_id: &str, caller: &str) -> Result<JobState> {
+        let state = self.job_store.get_job_ignoring_expiry(job_id).await?;
+        Self::require_owner(&state, caller)?;
+        if state.is_expired() {
+            return Err(super::error::Error::JobResultsExpired {
+                job_id: job_id.to_string(),
+            });
+        }
+        Ok(state)
+    }
+
+    /// Rejects access to a job `caller` did not submit.
+    ///
+    /// Reports the job as missing rather than forbidden so the API does not
+    /// confirm that a job id exists to a principal that cannot read it.
+    fn require_owner(state: &JobState, caller: &str) -> Result<()> {
+        if state.is_owned_by(caller) {
+            return Ok(());
+        }
+        tracing::debug!(
+            job_id = %state.job_id,
+            "Refusing access to a job submitted by a different principal"
+        );
+        Err(super::error::Error::JobNotFound {
+            job_id: state.job_id.clone(),
+        })
+    }
+
+    /// Reads a result chunk for a completed job submitted by `caller`.
+    pub async fn get_chunk(
+        &self,
+        job_id: &str,
+        chunk_index: usize,
+        caller: &str,
+    ) -> Result<Vec<RecordBatch>> {
+        let state = self.owned_job(job_id, caller).await?;
 
         if state.status != JobStatus::Succeeded {
             return Err(super::error::Error::JobNotComplete {
@@ -221,8 +269,24 @@ impl JobExecutor {
         self.job_store.read_chunk(job_id, chunk_index).await
     }
 
-    /// Lists all jobs, optionally filtered by status.
-    pub async fn list_jobs(&self, status_filter: Option<JobStatus>) -> Result<Vec<JobState>> {
+    /// Lists the jobs `caller` submitted, optionally filtered by status.
+    pub async fn list_jobs(
+        &self,
+        status_filter: Option<JobStatus>,
+        caller: &str,
+    ) -> Result<Vec<JobState>> {
+        let mut jobs = self.job_store.list_jobs(status_filter).await?;
+        jobs.retain(|job| job.is_owned_by(caller));
+        Ok(jobs)
+    }
+
+    /// Lists every job regardless of who submitted it.
+    ///
+    /// For internal schedulers only — the recovery sweep has to see jobs
+    /// across all principals to re-drive the ones orphaned by a lost peer.
+    /// Never reachable from a client request; API surfaces use
+    /// [`Self::list_jobs`], which is scoped to the caller.
+    pub async fn list_all_jobs(&self, status_filter: Option<JobStatus>) -> Result<Vec<JobState>> {
         self.job_store.list_jobs(status_filter).await
     }
 
@@ -394,5 +458,190 @@ impl JobExecutor {
             }
             QueryHandleError::JobNotFound { .. } => (JobErrorCode::NotFound, e.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataaccelerator::AcceleratorEngineRegistry;
+    use crate::datafusion::builder::DataFusionBuilder;
+    use crate::jobs::PUBLIC_JOB_OWNER;
+    use crate::status::RuntimeStatus;
+    use object_store::memory::InMemory;
+    use tokio::runtime::Handle;
+
+    const OWNER: &str = "apikey:0123456789abcdef";
+    const OTHER: &str = "apikey:fedcba9876543210";
+
+    fn executor(job_store: Arc<JobStore>) -> JobExecutor {
+        let df = Arc::new(
+            DataFusionBuilder::new(
+                RuntimeStatus::new(),
+                Arc::new(AcceleratorEngineRegistry::new()),
+                Handle::current(),
+            )
+            .build(),
+        );
+        JobExecutor::new(job_store, df)
+    }
+
+    /// Creates a job owned by `owner` directly through the store, so the test
+    /// exercises the read path without needing a live distributed executor.
+    async fn seed_job(job_store: &JobStore, owner: &str) -> String {
+        job_store
+            .create_job(
+                SubmitQueryRequest {
+                    sql: "SELECT 1".to_string(),
+                    parameters: None,
+                    timeout_seconds: None,
+                    maximum_size: None,
+                },
+                true,
+                owner.to_string(),
+            )
+            .await
+            .expect("job should be created")
+            .job_id
+    }
+
+    #[tokio::test]
+    async fn get_status_refuses_a_job_another_principal_submitted() {
+        let job_store = Arc::new(JobStore::new(Arc::new(InMemory::new()), "test", "node-1"));
+        let executor = executor(Arc::clone(&job_store));
+        let job_id = seed_job(&job_store, OWNER).await;
+
+        executor
+            .get_status(&job_id, OWNER)
+            .await
+            .expect("the submitting principal should read its own job");
+
+        let err = executor
+            .get_status(&job_id, OTHER)
+            .await
+            .expect_err("another principal must not read the job");
+        assert!(
+            matches!(err, super::super::error::Error::JobNotFound { .. }),
+            "a job owned by someone else must report as missing, not as forbidden: {err:?}"
+        );
+    }
+
+    /// Ownership is resolved before expiry, so a non-owner cannot tell an
+    /// expired job from one that never existed. Without this ordering the
+    /// expired job answers `JobResultsExpired` (HTTP 410) while a missing id
+    /// answers `JobNotFound` (404), which confirms someone else's job id.
+    #[tokio::test]
+    async fn an_expired_job_reads_as_missing_to_a_non_owner() {
+        let job_store = Arc::new(JobStore::new(Arc::new(InMemory::new()), "test", "node-1"));
+        let executor = executor(Arc::clone(&job_store));
+        let job_id = seed_job(&job_store, OWNER).await;
+
+        let mut state = job_store
+            .get_job(&job_id)
+            .await
+            .expect("the freshly created job should be readable");
+        state.expires_at_ms = Some(1);
+        job_store
+            .update_job(&mut state)
+            .await
+            .expect("the job should be marked expired");
+
+        let owner_err = executor
+            .get_status(&job_id, OWNER)
+            .await
+            .expect_err("the owner should be told its results expired");
+        assert!(
+            matches!(
+                owner_err,
+                super::super::error::Error::JobResultsExpired { .. }
+            ),
+            "the owner keeps the precise expiry error: {owner_err:?}"
+        );
+
+        let other_err = executor
+            .get_status(&job_id, OTHER)
+            .await
+            .expect_err("another principal must not read the job");
+        assert!(
+            matches!(other_err, super::super::error::Error::JobNotFound { .. }),
+            "an expired job must be indistinguishable from a missing one: {other_err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_chunk_refuses_a_job_another_principal_submitted() {
+        let job_store = Arc::new(JobStore::new(Arc::new(InMemory::new()), "test", "node-1"));
+        let executor = executor(Arc::clone(&job_store));
+        let job_id = seed_job(&job_store, OWNER).await;
+
+        let err = executor
+            .get_chunk(&job_id, 0, OTHER)
+            .await
+            .expect_err("another principal must not read result chunks");
+        assert!(
+            matches!(err, super::super::error::Error::JobNotFound { .. }),
+            "ownership must be resolved before the job's completion state: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_refuses_a_job_another_principal_submitted() {
+        let job_store = Arc::new(JobStore::new(Arc::new(InMemory::new()), "test", "node-1"));
+        let executor = executor(Arc::clone(&job_store));
+        let job_id = seed_job(&job_store, OWNER).await;
+
+        let err = executor
+            .cancel(&job_id, OTHER)
+            .await
+            .expect_err("another principal must not cancel the job");
+        assert!(
+            matches!(err, super::super::error::Error::JobNotFound { .. }),
+            "cancellation must be refused before the job is signalled: {err:?}"
+        );
+
+        let state = executor
+            .get_status(&job_id, OWNER)
+            .await
+            .expect("the job should still be readable by its owner");
+        assert_eq!(
+            state.status,
+            JobStatus::Pending,
+            "a refused cancellation must leave the job running"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_jobs_returns_only_the_callers_jobs() {
+        let job_store = Arc::new(JobStore::new(Arc::new(InMemory::new()), "test", "node-1"));
+        let executor = executor(Arc::clone(&job_store));
+        let mine = seed_job(&job_store, OWNER).await;
+        let theirs = seed_job(&job_store, OTHER).await;
+
+        let listed = executor
+            .list_jobs(None, OWNER)
+            .await
+            .expect("listing should succeed");
+        let ids: Vec<&str> = listed.iter().map(|j| j.job_id.as_str()).collect();
+        assert_eq!(ids, vec![mine.as_str()]);
+
+        let unauthenticated = executor
+            .list_jobs(None, PUBLIC_JOB_OWNER)
+            .await
+            .expect("listing should succeed");
+        assert!(
+            unauthenticated.is_empty(),
+            "the public scope must not see jobs submitted by a principal"
+        );
+
+        let all = executor
+            .list_all_jobs(None)
+            .await
+            .expect("internal listing should succeed");
+        assert_eq!(
+            all.len(),
+            2,
+            "the internal recovery sweep still sees every job"
+        );
+        assert!(all.iter().any(|j| j.job_id == theirs));
     }
 }

--- a/crates/runtime/src/jobs/mod.rs
+++ b/crates/runtime/src/jobs/mod.rs
@@ -27,8 +27,25 @@ mod executor;
 mod state;
 mod store;
 
+use runtime_request_context::{AsyncMarker, RequestContext};
+
 pub use error::{Error, Result};
 pub use executor::JobExecutor;
 pub use state::JobErrorCode;
-pub use state::{DEFAULT_CHUNK_SIZE, JobResult, JobResultManifest, JobSchema, JobState, JobStatus};
+pub use state::{
+    DEFAULT_CHUNK_SIZE, JobResult, JobResultManifest, JobSchema, JobState, JobStatus,
+    PUBLIC_JOB_OWNER,
+};
 pub use store::JobStore;
+
+/// The scope the calling request submits jobs under, and the only scope it may
+/// read or cancel jobs in.
+///
+/// This is the request's cache-namespace storage id, so job ownership follows
+/// exactly the principal boundary the caches already enforce: every request is
+/// `public` when no principal is authenticated, and each authenticated
+/// principal gets its own stable opaque scope.
+pub async fn current_job_owner() -> String {
+    let context = RequestContext::current(AsyncMarker::new().await);
+    context.cache_namespace().storage_id().to_string()
+}

--- a/crates/runtime/src/jobs/state.rs
+++ b/crates/runtime/src/jobs/state.rs
@@ -27,6 +27,14 @@ pub const DEFAULT_RESULT_TTL: Duration = Duration::from_hours(12);
 /// Default chunk size for results (10,000 rows)
 pub const DEFAULT_CHUNK_SIZE: usize = 10_000;
 
+/// Owner scope used when the runtime has no authenticated principal, and the
+/// scope a job persisted before [`JobState::owner`] existed is read back as.
+///
+/// Must stay equal to `CacheNamespace::Public.storage_id()` so an
+/// unauthenticated deployment keeps reaching its own jobs across upgrades;
+/// `public_owner_matches_public_cache_namespace` pins that.
+pub const PUBLIC_JOB_OWNER: &str = "public";
+
 /// The current status of a job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -192,6 +200,15 @@ pub struct JobState {
     /// Whether this job must execute only read-only SQL operations.
     #[serde(default)]
     pub read_only: bool,
+    /// The scope that submitted this job: the storage id of the submitting
+    /// request's cache namespace — [`PUBLIC_JOB_OWNER`] when no principal is
+    /// authenticated, or the principal's stable opaque id.
+    ///
+    /// `None` for jobs persisted before this field existed; those read back as
+    /// [`PUBLIC_JOB_OWNER`], so an authenticated principal cannot reach a job
+    /// submitted before the upgrade.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
     /// Object store version for conditional writes (e-tag tracking).
     /// This is not serialized - it's set after reading from object store.
     #[serde(skip)]
@@ -219,8 +236,23 @@ impl JobState {
             timeout_seconds: None,
             maximum_size: None,
             read_only: false,
+            owner: None,
             version: None,
         }
+    }
+
+    /// The scope that owns this job, resolving a job persisted before
+    /// [`Self::owner`] existed to [`PUBLIC_JOB_OWNER`].
+    #[must_use]
+    pub fn owner_scope(&self) -> &str {
+        self.owner.as_deref().unwrap_or(PUBLIC_JOB_OWNER)
+    }
+
+    /// Whether `caller` — the storage id of the requesting principal's cache
+    /// namespace — submitted this job and may therefore read or cancel it.
+    #[must_use]
+    pub fn is_owned_by(&self, caller: &str) -> bool {
+        self.owner_scope() == caller
     }
 
     /// Transitions job to running state.
@@ -281,6 +313,12 @@ impl JobState {
     }
 
     #[must_use]
+    pub(crate) fn with_owner(mut self, owner: String) -> Self {
+        self.owner = Some(owner);
+        self
+    }
+
+    #[must_use]
     pub(crate) fn with_timeout_seconds(mut self, timeout_seconds: Option<u64>) -> Self {
         self.timeout_seconds = timeout_seconds;
         self
@@ -304,5 +342,64 @@ fn now_ms_or_zero() -> u64 {
             tracing::warn!(error = %e, "System time is before Unix epoch, using 0 for timestamp");
             0
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runtime_request_context::CacheNamespace;
+
+    fn job() -> JobState {
+        JobState::new_pending("job-1".to_string(), "SELECT 1".to_string(), None)
+    }
+
+    /// The owner scope and the cache namespace must agree on the
+    /// unauthenticated scope, or an unauthenticated deployment stops seeing
+    /// its own jobs.
+    #[test]
+    fn public_owner_matches_public_cache_namespace() {
+        assert_eq!(PUBLIC_JOB_OWNER, CacheNamespace::Public.storage_id());
+    }
+
+    #[test]
+    fn owner_scope_defaults_to_public_for_a_job_stored_without_one() {
+        let state = job();
+        assert_eq!(state.owner, None);
+        assert_eq!(state.owner_scope(), PUBLIC_JOB_OWNER);
+        assert!(state.is_owned_by(PUBLIC_JOB_OWNER));
+        assert!(!state.is_owned_by("apikey:0123456789abcdef"));
+    }
+
+    #[test]
+    fn a_job_is_owned_only_by_its_submitting_scope() {
+        let state = job().with_owner("apikey:0123456789abcdef".to_string());
+        assert!(state.is_owned_by("apikey:0123456789abcdef"));
+        assert!(!state.is_owned_by("apikey:fedcba9876543210"));
+        assert!(!state.is_owned_by(PUBLIC_JOB_OWNER));
+    }
+
+    /// Job state persisted before `owner` existed must still deserialize, and
+    /// must read back as the public scope rather than as any principal's.
+    #[test]
+    fn state_persisted_without_an_owner_deserializes_as_public() {
+        let stored = serde_json::to_value(job()).expect("job state should serialize");
+        assert!(
+            stored.get("owner").is_none(),
+            "an absent owner must not be written out"
+        );
+
+        let state: JobState =
+            serde_json::from_value(stored).expect("legacy job state should deserialize");
+        assert_eq!(state.owner_scope(), PUBLIC_JOB_OWNER);
+    }
+
+    #[test]
+    fn owner_round_trips_through_serialization() {
+        let state = job().with_owner("mtls:dn:CN=client-1".to_string());
+        let encoded = serde_json::to_vec(&state).expect("job state should serialize");
+        let decoded: JobState =
+            serde_json::from_slice(&encoded).expect("job state should deserialize");
+        assert_eq!(decoded.owner_scope(), "mtls:dn:CN=client-1");
     }
 }

--- a/crates/runtime/src/jobs/store.rs
+++ b/crates/runtime/src/jobs/store.rs
@@ -136,9 +136,11 @@ impl JobStore {
         &self,
         request: SubmitQueryRequest,
         read_only: bool,
+        owner: String,
     ) -> Result<JobState> {
         let job_id = Self::generate_job_id();
         let mut state = JobState::new_pending(job_id, request.sql, request.parameters)
+            .with_owner(owner)
             .with_timeout_seconds(request.timeout_seconds)
             .with_maximum_size(request.maximum_size);
         state.read_only = read_only;
@@ -146,8 +148,24 @@ impl JobStore {
         Ok(state)
     }
 
-    /// Gets the current state of a job.
+    /// Gets the current state of a job, refusing one whose results expired.
     pub async fn get_job(&self, job_id: &str) -> Result<JobState> {
+        let state = self.get_job_ignoring_expiry(job_id).await?;
+        if state.is_expired() {
+            return Err(super::error::Error::JobResultsExpired {
+                job_id: job_id.to_string(),
+            });
+        }
+        Ok(state)
+    }
+
+    /// Gets the current state of a job without applying the expiry check.
+    ///
+    /// Callers that authorize by owner use this so ownership is resolved
+    /// before expiry: otherwise an expired job answers a non-owner with
+    /// `JobResultsExpired` while a missing one answers `JobNotFound`, which
+    /// tells a caller that someone else's job id exists.
+    pub async fn get_job_ignoring_expiry(&self, job_id: &str) -> Result<JobState> {
         let path = self.job_state_path(job_id);
         let result = self.store.get(&path).await.map_err(|e| match e {
             ObjectStoreError::NotFound { .. } => super::error::Error::JobNotFound {
@@ -167,13 +185,6 @@ impl JobStore {
 
         // Store the version for conditional writes
         state.version = Some(version);
-
-        // Check if expired
-        if state.is_expired() {
-            return Err(super::error::Error::JobResultsExpired {
-                job_id: job_id.to_string(),
-            });
-        }
 
         Ok(state)
     }
@@ -750,6 +761,10 @@ mod tests {
 
     use crate::http::v1::queries::SubmitQueryRequest;
 
+    fn test_owner() -> String {
+        crate::jobs::PUBLIC_JOB_OWNER.to_string()
+    }
+
     fn make_request(sql: impl Into<String>) -> SubmitQueryRequest {
         SubmitQueryRequest {
             sql: sql.into(),
@@ -765,7 +780,7 @@ mod tests {
         let job_store = JobStore::new(store, "test", "node-1");
 
         let state = job_store
-            .create_job(make_request("SELECT 1"), false)
+            .create_job(make_request("SELECT 1"), false, test_owner())
             .await
             .expect("to create job");
 
@@ -785,7 +800,7 @@ mod tests {
 
         // Create job
         let state = job_store
-            .create_job(make_request("SELECT * FROM test"), false)
+            .create_job(make_request("SELECT * FROM test"), false, test_owner())
             .await
             .expect("to create job");
         let job_id = state.job_id.clone();
@@ -828,7 +843,7 @@ mod tests {
         let job_store = JobStore::new(store, "test", "node-1");
 
         let state = job_store
-            .create_job(make_request("SELECT 1"), false)
+            .create_job(make_request("SELECT 1"), false, test_owner())
             .await
             .expect("to create job");
 
@@ -876,7 +891,11 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1");
 
             let state = job_store
-                .create_job(make_request("SELECT * FROM test WHERE 1=0"), false)
+                .create_job(
+                    make_request("SELECT * FROM test WHERE 1=0"),
+                    false,
+                    test_owner(),
+                )
                 .await
                 .expect("to create job");
 
@@ -909,7 +928,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(100);
 
             let state = job_store
-                .create_job(make_request("SELECT * FROM test"), false)
+                .create_job(make_request("SELECT * FROM test"), false, test_owner())
                 .await
                 .expect("to create job");
 
@@ -948,7 +967,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(100);
 
             let state = job_store
-                .create_job(make_request("SELECT * FROM test"), false)
+                .create_job(make_request("SELECT * FROM test"), false, test_owner())
                 .await
                 .expect("to create job");
 
@@ -987,7 +1006,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(2);
 
             let state = job_store
-                .create_job(make_request("SELECT * FROM test"), false)
+                .create_job(make_request("SELECT * FROM test"), false, test_owner())
                 .await
                 .expect("to create job");
 
@@ -1049,7 +1068,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1").with_chunk_size(2);
 
             let state = job_store
-                .create_job(make_request("SELECT * FROM test"), false)
+                .create_job(make_request("SELECT * FROM test"), false, test_owner())
                 .await
                 .expect("to create job");
 
@@ -1090,7 +1109,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1");
 
             let state = job_store
-                .create_job(make_request("SELECT * FROM test"), false)
+                .create_job(make_request("SELECT * FROM test"), false, test_owner())
                 .await
                 .expect("to create job");
 
@@ -1119,7 +1138,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1");
 
             let state = job_store
-                .create_job(make_request("SELECT * FROM test"), false)
+                .create_job(make_request("SELECT * FROM test"), false, test_owner())
                 .await
                 .expect("to create job");
 
@@ -1167,6 +1186,7 @@ mod tests {
                 .create_job(
                     make_request_with_maximum_size("SELECT * FROM test", Some(10_000)),
                     false,
+                    test_owner(),
                 )
                 .await
                 .expect("to create job");
@@ -1203,6 +1223,7 @@ mod tests {
                 .create_job(
                     make_request_with_maximum_size("SELECT * FROM test", Some(1)),
                     false,
+                    test_owner(),
                 )
                 .await
                 .expect("to create job");
@@ -1246,6 +1267,7 @@ mod tests {
                 .create_job(
                     make_request_with_maximum_size("SELECT * FROM test", Some(1)),
                     false,
+                    test_owner(),
                 )
                 .await
                 .expect("to create job");
@@ -1281,6 +1303,7 @@ mod tests {
                 .create_job(
                     make_request_with_maximum_size("SELECT * FROM test", None),
                     false,
+                    test_owner(),
                 )
                 .await
                 .expect("to create job");
@@ -1317,7 +1340,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1");
 
             let state = job_store
-                .create_job(make_request("SELECT 1"), false)
+                .create_job(make_request("SELECT 1"), false, test_owner())
                 .await
                 .expect("to create job");
 
@@ -1334,7 +1357,7 @@ mod tests {
             let job_store = JobStore::new(store, "test", "node-1");
 
             let created = job_store
-                .create_job(make_request("SELECT 1"), false)
+                .create_job(make_request("SELECT 1"), false, test_owner())
                 .await
                 .expect("to create job");
 
@@ -1357,7 +1380,7 @@ mod tests {
 
             // Create job
             let created = job_store
-                .create_job(make_request("SELECT 1"), false)
+                .create_job(make_request("SELECT 1"), false, test_owner())
                 .await
                 .expect("to create job");
             let job_id = created.job_id.clone();
@@ -1407,7 +1430,7 @@ mod tests {
 
             // Create job
             let created = job_store
-                .create_job(make_request("SELECT 1"), false)
+                .create_job(make_request("SELECT 1"), false, test_owner())
                 .await
                 .expect("to create job");
             let job_id = created.job_id.clone();
@@ -1440,7 +1463,7 @@ mod tests {
 
             // Create job
             let created = job_store
-                .create_job(make_request("SELECT 1"), false)
+                .create_job(make_request("SELECT 1"), false, test_owner())
                 .await
                 .expect("to create job");
             let job_id = created.job_id.clone();
@@ -1477,7 +1500,7 @@ mod tests {
 
             // Create first job and write chunks
             let state1 = job_store
-                .create_job(make_request("SELECT * FROM test"), false)
+                .create_job(make_request("SELECT * FROM test"), false, test_owner())
                 .await
                 .expect("to create first job");
 

--- a/crates/runtime/tests/cluster/job_store.rs
+++ b/crates/runtime/tests/cluster/job_store.rs
@@ -231,13 +231,14 @@ async fn test_simple_job_store() -> Result<(), anyhow::Error> {
                 .submit(
                     make_request("SELECT id, name, age, city, score FROM names ORDER BY id"),
                     false,
+                    runtime::jobs::PUBLIC_JOB_OWNER.to_string(),
                 )
                 .await
                 .expect("should submit job");
 
             for _ in 0..30 {
                 let job_status = job_executor
-                    .get_status(&result.job_id)
+                    .get_status(&result.job_id, runtime::jobs::PUBLIC_JOB_OWNER)
                     .await
                     .expect("should get job status");
                 println!("job state: {job_status:?}");
@@ -248,7 +249,7 @@ async fn test_simple_job_store() -> Result<(), anyhow::Error> {
             }
 
             let job_status = job_executor
-                .get_status(&result.job_id)
+                .get_status(&result.job_id, runtime::jobs::PUBLIC_JOB_OWNER)
                 .await
                 .expect("should get job status");
             assert!(
@@ -257,7 +258,7 @@ async fn test_simple_job_store() -> Result<(), anyhow::Error> {
             );
 
             let job_results = job_executor
-                .get_chunk(&result.job_id, 0)
+                .get_chunk(&result.job_id, 0, runtime::jobs::PUBLIC_JOB_OWNER)
                 .await
                 .expect("should get job results");
             let pretty = datafusion::arrow::util::pretty::pretty_format_batches(&job_results)

--- a/crates/runtime/tests/cluster/scheduler_failover.rs
+++ b/crates/runtime/tests/cluster/scheduler_failover.rs
@@ -333,7 +333,7 @@ where
     let start = Instant::now();
     loop {
         let state = je
-            .get_status(job_id)
+            .get_status(job_id, runtime::jobs::PUBLIC_JOB_OWNER)
             .await
             .map_err(|e| anyhow::Error::msg(format!("get_status: {e}")))?;
         if pred(&state) {
@@ -394,6 +394,7 @@ async fn run_failover(recovery_timeout: Duration) -> Result<(), anyhow::Error> {
                 maximum_size: None,
             },
             true,
+            runtime::jobs::PUBLIC_JOB_OWNER.to_string(),
         )
         .await
         .map_err(|e| anyhow::Error::msg(format!("submit: {e}")))?;
@@ -434,7 +435,7 @@ async fn run_failover(recovery_timeout: Duration) -> Result<(), anyhow::Error> {
 
     // Results are correct: COUNT(*) == NAMES_ROWS.
     let chunks = s2_je
-        .get_chunk(&job_id, 0)
+        .get_chunk(&job_id, 0, runtime::jobs::PUBLIC_JOB_OWNER)
         .await
         .map_err(|e| anyhow::Error::msg(format!("get_chunk: {e}")))?;
     let count: i64 = chunks


### PR DESCRIPTION
## What

Scope async query jobs and synchronous active queries to the principal that submitted them, across both HTTP and Flight.

## Why

Three authorization gaps, all from the same cause — a query-tracking surface that records no owner:

1. **Async jobs had no owner.** `JobExecutor::{get_status, get_chunk, cancel, list_jobs}` served any job to any caller. Over HTTP that is `GET /v1/queries` (which enumerates every job id with its SQL preview) plus the `{id}`, `/status`, `/results`, and `/results/chunks/{i}` routes; over Flight it is `GetAsyncQueryStatus` and `GetAsyncQueryResult`. Any authenticated principal could therefore read another principal's query text and full result set.
2. **The synchronous active-query API had the same shape.** `GET /v1/sql/active`, `POST /v1/sql/{id}/cancel`, and Flight `CancelQuery` checked only that the caller had write access, so any write-capable key could list every principal's in-flight SQL preview and cancel their work.
3. **Flight `CancelAsyncQuery` was missing a write-access gate.** Its HTTP twin `POST /v1/queries/{id}/cancel` calls `require_write_access()`, and the neighbouring Flight action `handle_cancel_query` refuses read-only principals — so a read-only key refused cancellation over HTTP could cancel any async query over Flight.

`JobExecutor::submit` already binds a job to the submitting request context so it *executes* as the caller's principal; the retrieval and cancellation paths simply never consulted it.

## How

Ownership uses the request's `CacheNamespace::storage_id()`, so it follows exactly the principal boundary the caches already enforce rather than inventing a second identity notion:

- `JobState` gains `owner` (serde-default, omitted when absent) plus `owner_scope()` / `is_owned_by()`; `QueryCancelRegistry`'s `ActiveQueryInfo` gains the same.
- Enforcement lives at the two choke points both protocols funnel through — `JobExecutor` (`require_owner`, `owned_job`) and `QueryCancelRegistry` (`list_for`, `cancel_owned`) — rather than being duplicated per route.
- **Ownership is resolved before expiry and before any side effect**, and a job the caller does not own reports as *missing*, not forbidden, so job ids are never confirmed to a principal that cannot read them.
- Internal callers keep full visibility through explicit, separately named entry points (`list_all_jobs`, `list_all`), so the scheduler recovery sweep still re-drives orphaned jobs.

**Compatibility.** An unauthenticated runtime is unchanged: every request shares the `public` scope, which is also how a job persisted before this field existed reads back. Authenticated principals fail closed against pre-upgrade jobs, bounded by the 12-hour result TTL. Internal/background traffic resolves to `system` and cannot reach user-submitted work.

## Tests

```
cargo test -p runtime --lib -- jobs:: http::v1::queries         # 42 passed
cargo test -p runtime-datafusion --lib query_cancel_registry    # 8 passed
cargo test -p runtime --lib -- jobs:: datafusion::query::tests  # 71 passed
cargo fmt --all -- --check
make lint-rust                                                  # clean
```

New coverage: a second principal is refused by `get_status`, `get_chunk`, and `cancel`; a refused cancel leaves the job running; `list_jobs` returns only the caller's jobs while `list_all_jobs` still sees every job; an expired job reads as missing to a non-owner while its owner still gets the precise expiry error; the HTTP active-query API is scoped to the submitting principal and does not serve user queries to internal callers; `JobState` owner serde round-trips and a legacy record without the field reads back as `public`.

## Risks

- Ownership for API keys derives from the key's stable id, so rotating a key makes its own in-flight jobs unreadable. This matches the documented `stable_id` contract and the existing cache behaviour.
- `list_jobs` filters after reading the store; fine at current job counts, worth a pushdown filter if it ever gets hot.
- Two pre-existing issues in this area are deliberately **not** addressed here and are better handled on their own: `complete_job` can overwrite a `Cancelled` state (a cancel/completion race), and `resume` re-drives a job under internal context — the persisted owner still governs all API access, so ownership holds either way.
