### PR TITLE
fix(runtime): stop a superseded scheduler incarnation from claiming the heartbeat key

### DIFF
--- a/crates/runtime/src/cluster/heartbeat.rs
+++ b/crates/runtime/src/cluster/heartbeat.rs
@@ -296,6 +296,15 @@ impl SchedulerHeartbeatStore {
         // supersession, which the caller reconciles against membership — so a
         // brief write-error burst cannot consume consecutive ticks and let a
         // healthy scheduler's TTL lapse.
+        // Retries back off, and the whole sequence is capped well inside one
+        // heartbeat interval (a third of the TTL): retrying a fast-failing store
+        // with no delay would burn every attempt within a few milliseconds and
+        // give this path none of the burst tolerance the unconditional write has.
+        let retry_budget = Duration::from_millis(ttl_ms / 9);
+        let mut backoff = FibonacciBackoffBuilder::new()
+            .max_retries(Some(MAX_HEARTBEAT_ATTEMPTS))
+            .max_duration(Some(retry_budget))
+            .build();
         let mut attempt = 0usize;
         loop {
             attempt += 1;
@@ -322,12 +331,22 @@ impl SchedulerHeartbeatStore {
                         source,
                     });
                 }
-                Err(source) => tracing::warn!(
-                    path = %path,
-                    attempt,
-                    error = %source,
-                    "Conditional heartbeat write failed; retrying with the same predicate"
-                ),
+                Err(source) => {
+                    let Some(delay) = backoff.next_duration() else {
+                        return Err(Error::Write {
+                            path: path.to_string(),
+                            source,
+                        });
+                    };
+                    tracing::warn!(
+                        path = %path,
+                        attempt,
+                        error = %source,
+                        retry_in_ms = delay.as_millis(),
+                        "Conditional heartbeat write failed; retrying with the same predicate"
+                    );
+                    tokio::time::sleep(delay).await;
+                }
             }
         }
     }

--- a/crates/runtime/src/cluster/heartbeat.rs
+++ b/crates/runtime/src/cluster/heartbeat.rs
@@ -141,14 +141,16 @@ impl SchedulerHeartbeatStore {
         Path::from(format!("{}{}.json", self.prefix, scheduler_id))
     }
 
-    /// Writes (or overwrites) the heartbeat for a scheduler.
+    /// Writes (or overwrites) the heartbeat for a scheduler, returning the
+    /// version written where the store reports one. Callers keep that version so
+    /// a later write can stay conditional even if the object cannot be read.
     pub async fn heartbeat(
         &self,
         scheduler_id: &str,
         instance_id: Uuid,
         now_ms: u64,
         ttl_ms: u64,
-    ) -> Result<()> {
+    ) -> Result<Option<UpdateVersion>> {
         let beat = SchedulerHeartbeat {
             scheduler_id: scheduler_id.to_string(),
             instance_id,
@@ -173,7 +175,9 @@ impl SchedulerHeartbeatStore {
                 )
                 .await
             {
-                Ok(_) => return Ok(()),
+                Ok(result) => {
+                    return Ok(Self::usable_version_of(result.e_tag, result.version));
+                }
                 Err(source) => {
                     let Some(delay) = backoff.next_duration() else {
                         return Err(Error::RetryExhausted {

--- a/crates/runtime/src/cluster/heartbeat.rs
+++ b/crates/runtime/src/cluster/heartbeat.rs
@@ -238,16 +238,33 @@ impl SchedulerHeartbeatStore {
         }
     }
 
+    /// A version is only usable as a write predicate when it actually carries an
+    /// identifier. Some stores return neither an `ETag` nor a version, and passing
+    /// an empty predicate would assert a condition the store cannot check.
+    fn usable_version_of(e_tag: Option<String>, version: Option<String>) -> Option<UpdateVersion> {
+        if e_tag.is_none() && version.is_none() {
+            return None;
+        }
+        Some(UpdateVersion { e_tag, version })
+    }
+
     /// Writes the heartbeat only if the stored object is still the one the
     /// caller observed (`expected`), or is still absent when `expected` is
     /// `None`.
     ///
     /// The key is shared by every incarnation of a `scheduler_id`, so an
     /// unconditional write lets a superseded process clobber the incarnation
-    /// that replaced it. Making the write conditional turns "I am still the
-    /// registered incarnation" into part of the write itself: if anyone else
-    /// wrote in between, this fails with
-    /// [`Error::HeartbeatSupersededDuringWrite`] instead of overwriting them.
+    /// that replaced it. A conditional write means that if anyone else wrote in
+    /// between, this fails with [`Error::HeartbeatSupersededDuringWrite`]
+    /// instead of overwriting them.
+    ///
+    /// This is **not** an ownership fence. It proves only that the object has
+    /// not changed since `expected` was observed; it says nothing about whether
+    /// the caller is still the registered incarnation. Callers that need
+    /// ownership must check membership separately, as `write_heartbeat` does.
+    ///
+    /// Returns the version of the object just written, so a caller can keep
+    /// writing conditionally even while reads are failing.
     pub async fn heartbeat_if_unchanged(
         &self,
         scheduler_id: &str,
@@ -255,7 +272,7 @@ impl SchedulerHeartbeatStore {
         now_ms: u64,
         ttl_ms: u64,
         expected: Option<&UpdateVersion>,
-    ) -> Result<()> {
+    ) -> Result<Option<UpdateVersion>> {
         let beat = SchedulerHeartbeat {
             scheduler_id: scheduler_id.to_string(),
             instance_id,
@@ -269,21 +286,45 @@ impl SchedulerHeartbeatStore {
             None => PutMode::Create,
         };
 
-        match self
-            .store
-            .put_opts(&path, payload.into(), PutOptions::from(mode))
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(ObjectStoreError::Precondition { .. } | ObjectStoreError::AlreadyExists { .. }) => {
-                Err(Error::HeartbeatSupersededDuringWrite {
-                    scheduler_id: scheduler_id.to_string(),
-                })
+        // Transient write failures are retried with the *same* predicate, as the
+        // unconditional path does. If a retried attempt turns out to have
+        // already landed, the next one fails its precondition and surfaces as
+        // supersession, which the caller reconciles against membership — so a
+        // brief write-error burst cannot consume consecutive ticks and let a
+        // healthy scheduler's TTL lapse.
+        let mut attempt = 0usize;
+        loop {
+            attempt += 1;
+            match self
+                .store
+                .put_opts(
+                    &path,
+                    payload.clone().into(),
+                    PutOptions::from(mode.clone()),
+                )
+                .await
+            {
+                Ok(result) => return Ok(Self::usable_version_of(result.e_tag, result.version)),
+                Err(
+                    ObjectStoreError::Precondition { .. } | ObjectStoreError::AlreadyExists { .. },
+                ) => {
+                    return Err(Error::HeartbeatSupersededDuringWrite {
+                        scheduler_id: scheduler_id.to_string(),
+                    });
+                }
+                Err(source) if attempt >= MAX_HEARTBEAT_ATTEMPTS => {
+                    return Err(Error::Write {
+                        path: path.to_string(),
+                        source,
+                    });
+                }
+                Err(source) => tracing::warn!(
+                    path = %path,
+                    attempt,
+                    error = %source,
+                    "Conditional heartbeat write failed; retrying with the same predicate"
+                ),
             }
-            Err(source) => Err(Error::Write {
-                path: path.to_string(),
-                source,
-            }),
         }
     }
 

--- a/crates/runtime/src/cluster/heartbeat.rs
+++ b/crates/runtime/src/cluster/heartbeat.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::StreamExt;
+use object_store::UpdateVersion;
 use object_store::path::Path;
 use object_store::{Error as ObjectStoreError, ObjectStore, ObjectStoreExt, PutMode, PutOptions};
 use serde::{Deserialize, Serialize};
@@ -73,6 +74,11 @@ pub enum Error {
     },
     #[snafu(display("Failed to (de)serialize heartbeat: {source}"))]
     Serde { source: serde_json::Error },
+    #[snafu(display(
+        "Heartbeat for {scheduler_id} was written by another incarnation during this write"
+    ))]
+    HeartbeatSupersededDuringWrite { scheduler_id: String },
+
     #[snafu(display("Heartbeat write for {scheduler_id} exhausted retries: {source}"))]
     RetryExhausted {
         scheduler_id: String,
@@ -186,6 +192,84 @@ impl SchedulerHeartbeatStore {
                     tokio::time::sleep(delay).await;
                 }
             }
+        }
+    }
+
+    /// Reads the heartbeat together with the object version needed to write it
+    /// back conditionally. `None` means the object does not exist yet.
+    pub async fn read_versioned(
+        &self,
+        scheduler_id: &str,
+    ) -> Result<Option<(SchedulerHeartbeat, UpdateVersion)>> {
+        let path = self.path_for(scheduler_id);
+        match self.store.get(&path).await {
+            Ok(result) => {
+                let version = UpdateVersion {
+                    e_tag: result.meta.e_tag.clone(),
+                    version: result.meta.version.clone(),
+                };
+                let bytes = result.bytes().await.map_err(|source| Error::Read {
+                    path: path.to_string(),
+                    source,
+                })?;
+                let beat: SchedulerHeartbeat =
+                    serde_json::from_slice(&bytes).context(SerdeSnafu)?;
+                Ok(Some((beat, version)))
+            }
+            Err(ObjectStoreError::NotFound { .. }) => Ok(None),
+            Err(source) => Err(Error::Read {
+                path: path.to_string(),
+                source,
+            }),
+        }
+    }
+
+    /// Writes the heartbeat only if the stored object is still the one the
+    /// caller observed (`expected`), or is still absent when `expected` is
+    /// `None`.
+    ///
+    /// The key is shared by every incarnation of a `scheduler_id`, so an
+    /// unconditional write lets a superseded process clobber the incarnation
+    /// that replaced it. Making the write conditional turns "I am still the
+    /// registered incarnation" into part of the write itself: if anyone else
+    /// wrote in between, this fails with
+    /// [`Error::HeartbeatSupersededDuringWrite`] instead of overwriting them.
+    pub async fn heartbeat_if_unchanged(
+        &self,
+        scheduler_id: &str,
+        instance_id: Uuid,
+        now_ms: u64,
+        ttl_ms: u64,
+        expected: Option<&UpdateVersion>,
+    ) -> Result<()> {
+        let beat = SchedulerHeartbeat {
+            scheduler_id: scheduler_id.to_string(),
+            instance_id,
+            last_heartbeat_ms: now_ms,
+            ttl_ms,
+        };
+        let payload = serde_json::to_vec(&beat).context(SerdeSnafu)?;
+        let path = self.path_for(scheduler_id);
+        let mode = match expected {
+            Some(version) => PutMode::Update(version.clone()),
+            None => PutMode::Create,
+        };
+
+        match self
+            .store
+            .put_opts(&path, payload.into(), PutOptions::from(mode))
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(ObjectStoreError::Precondition { .. } | ObjectStoreError::AlreadyExists { .. }) => {
+                Err(Error::HeartbeatSupersededDuringWrite {
+                    scheduler_id: scheduler_id.to_string(),
+                })
+            }
+            Err(source) => Err(Error::Write {
+                path: path.to_string(),
+                source,
+            }),
         }
     }
 

--- a/crates/runtime/src/cluster/heartbeat.rs
+++ b/crates/runtime/src/cluster/heartbeat.rs
@@ -290,64 +290,28 @@ impl SchedulerHeartbeatStore {
             None => PutMode::Create,
         };
 
-        // Transient write failures are retried with the *same* predicate, as the
-        // unconditional path does. If a retried attempt turns out to have
-        // already landed, the next one fails its precondition and surfaces as
-        // supersession, which the caller reconciles against membership — so a
-        // brief write-error burst cannot consume consecutive ticks and let a
-        // healthy scheduler's TTL lapse.
-        // Retries back off, and the whole sequence is capped well inside one
-        // heartbeat interval (a third of the TTL): retrying a fast-failing store
-        // with no delay would burn every attempt within a few milliseconds and
-        // give this path none of the burst tolerance the unconditional write has.
-        let retry_budget = Duration::from_millis(ttl_ms / 9);
-        let mut backoff = FibonacciBackoffBuilder::new()
-            .max_retries(Some(MAX_HEARTBEAT_ATTEMPTS))
-            .max_duration(Some(retry_budget))
-            .build();
-        let mut attempt = 0usize;
-        loop {
-            attempt += 1;
-            match self
-                .store
-                .put_opts(
-                    &path,
-                    payload.clone().into(),
-                    PutOptions::from(mode.clone()),
-                )
-                .await
-            {
-                Ok(result) => return Ok(Self::usable_version_of(result.e_tag, result.version)),
-                Err(
-                    ObjectStoreError::Precondition { .. } | ObjectStoreError::AlreadyExists { .. },
-                ) => {
-                    return Err(Error::HeartbeatSupersededDuringWrite {
-                        scheduler_id: scheduler_id.to_string(),
-                    });
-                }
-                Err(source) if attempt >= MAX_HEARTBEAT_ATTEMPTS => {
-                    return Err(Error::Write {
-                        path: path.to_string(),
-                        source,
-                    });
-                }
-                Err(source) => {
-                    let Some(delay) = backoff.next_duration() else {
-                        return Err(Error::Write {
-                            path: path.to_string(),
-                            source,
-                        });
-                    };
-                    tracing::warn!(
-                        path = %path,
-                        attempt,
-                        error = %source,
-                        retry_in_ms = delay.as_millis(),
-                        "Conditional heartbeat write failed; retrying with the same predicate"
-                    );
-                    tokio::time::sleep(delay).await;
-                }
+        // Deliberately a single attempt. Retrying a *conditional* write after an
+        // ambiguous failure is what makes a lost acknowledgement dangerous: the
+        // retry's precondition fails against a write that may have been our own,
+        // which cannot be distinguished from a successor's. The caller treats an
+        // unknown outcome as "the retained version can no longer be trusted"
+        // instead, and the store's own retry policy still covers transport
+        // errors.
+        match self
+            .store
+            .put_opts(&path, payload.into(), PutOptions::from(mode))
+            .await
+        {
+            Ok(result) => Ok(Self::usable_version_of(result.e_tag, result.version)),
+            Err(ObjectStoreError::Precondition { .. } | ObjectStoreError::AlreadyExists { .. }) => {
+                Err(Error::HeartbeatSupersededDuringWrite {
+                    scheduler_id: scheduler_id.to_string(),
+                })
             }
+            Err(source) => Err(Error::Write {
+                path: path.to_string(),
+                source,
+            }),
         }
     }
 

--- a/crates/runtime/src/cluster/heartbeat.rs
+++ b/crates/runtime/src/cluster/heartbeat.rs
@@ -197,10 +197,15 @@ impl SchedulerHeartbeatStore {
 
     /// Reads the heartbeat together with the object version needed to write it
     /// back conditionally. `None` means the object does not exist yet.
+    /// The version is what a conditional write needs; the payload is only used
+    /// to see *whose* beat it is. An unparsable payload therefore yields
+    /// `Some((None, version))` rather than an error: failing here would stop a
+    /// healthy scheduler from ever repairing its own key, where the previous
+    /// unconditional write self-healed.
     pub async fn read_versioned(
         &self,
         scheduler_id: &str,
-    ) -> Result<Option<(SchedulerHeartbeat, UpdateVersion)>> {
+    ) -> Result<Option<(Option<SchedulerHeartbeat>, UpdateVersion)>> {
         let path = self.path_for(scheduler_id);
         match self.store.get(&path).await {
             Ok(result) => {
@@ -212,8 +217,17 @@ impl SchedulerHeartbeatStore {
                     path: path.to_string(),
                     source,
                 })?;
-                let beat: SchedulerHeartbeat =
-                    serde_json::from_slice(&bytes).context(SerdeSnafu)?;
+                let beat = match serde_json::from_slice::<SchedulerHeartbeat>(&bytes) {
+                    Ok(beat) => Some(beat),
+                    Err(err) => {
+                        tracing::warn!(
+                            path = %path,
+                            error = %err,
+                            "Unparsable heartbeat payload; treating the holder as unknown"
+                        );
+                        None
+                    }
+                };
                 Ok(Some((beat, version)))
             }
             Err(ObjectStoreError::NotFound { .. }) => Ok(None),

--- a/crates/runtime/src/cluster/heartbeat.rs
+++ b/crates/runtime/src/cluster/heartbeat.rs
@@ -303,11 +303,20 @@ impl SchedulerHeartbeatStore {
             .await
         {
             Ok(result) => Ok(Self::usable_version_of(result.e_tag, result.version)),
-            Err(ObjectStoreError::Precondition { .. } | ObjectStoreError::AlreadyExists { .. }) => {
-                Err(Error::HeartbeatSupersededDuringWrite {
-                    scheduler_id: scheduler_id.to_string(),
-                })
-            }
+            // `NotFound` belongs with the conflict cases: a conditional update
+            // whose target has been deleted since it was read has lost the same
+            // race, and some stores report it that way rather than as a
+            // precondition failure. Treating it as a hard error would abort
+            // registration *after* membership was committed, leaving a registered
+            // entry with no running registry, where the caller can simply re-read
+            // and create the key instead.
+            Err(
+                ObjectStoreError::Precondition { .. }
+                | ObjectStoreError::AlreadyExists { .. }
+                | ObjectStoreError::NotFound { .. },
+            ) => Err(Error::HeartbeatSupersededDuringWrite {
+                scheduler_id: scheduler_id.to_string(),
+            }),
             Err(source) => Err(Error::Write {
                 path: path.to_string(),
                 source,

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -62,6 +62,20 @@ const DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
 const JOB_RECOVERY_INTERVAL: Duration = Duration::from_secs(10);
 const HEARTBEAT_DIVISOR: u64 = 3;
 
+/// What this tick could prove about who owns the scheduler id.
+///
+/// A conditional write can only prove "the object did not change since I read
+/// it" — it cannot prove "I am the registered incarnation". That distinction is
+/// what keeps a superseded incarnation from refreshing over its successor when
+/// membership is merely unreadable, so it is carried explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Membership {
+    /// A successful read showed this incarnation registered.
+    ConfirmedSelf,
+    /// Membership could not be read. Not evidence either way.
+    Unknown,
+}
+
 /// Compare-and-set attempts for one heartbeat before skipping this beat.
 /// Contention means another incarnation is writing the same key, which is
 /// resolved by re-reading membership rather than by writing harder.
@@ -373,97 +387,118 @@ impl SchedulerRegistryRunner {
         // keeps overwriting the key with its own `instance_id`, `list_alive`
         // filters the *registered* incarnation out as an orphan, and peers
         // re-drive jobs it is still running.
-
         if self.superseded.load(Ordering::Relaxed) {
             return Ok(());
         }
 
-        // Only a *successful* read is evidence of supersession. Heartbeats
-        // deliberately live outside `cluster.json` so the high-frequency write
-        // path does not depend on that document; making emission conditional
-        // on reading it would mean a slow or failing GET silently suppresses
-        // beats and self-evicts a healthy scheduler — producing exactly the
-        // false-dead job re-drive this change exists to prevent. So fail open
-        // on a read error and only decline on a definitive observation.
-        // Bound the read. Failing open covers an *erroring* store, but a hung
-        // or very slow GET would block this loop before the heartbeat write,
-        // and once that exceeds the TTL peers reap this healthy scheduler and
-        // re-drive its jobs — the exact failure the fail-open behaviour exists
-        // to prevent. A timeout is treated exactly like an error: heartbeat
-        // anyway.
+        match self.read_membership().await {
+            Some(true) => self.write_heartbeat(Membership::ConfirmedSelf).await,
+            Some(false) => {
+                // A successful read proved someone else owns the id. Retire.
+                self.superseded.store(true, Ordering::Relaxed);
+                tracing::warn!(
+                    scheduler_id = %self.scheduler_id,
+                    instance_id = %self.instance_id,
+                    "This scheduler incarnation is no longer registered; it will stop heartbeating"
+                );
+                Ok(())
+            }
+            // Membership unreadable. Heartbeats deliberately live outside
+            // `cluster.json` so emission does not depend on that document:
+            // suppressing beats here would self-evict a healthy scheduler.
+            // The write path still refuses to overwrite *another*
+            // incarnation's beat without proof, so failing open cannot clobber
+            // a successor.
+            None => self.write_heartbeat(Membership::Unknown).await,
+        }
+    }
+
+    /// `Some(true)` when a successful, bounded read shows this incarnation
+    /// registered, `Some(false)` when it shows someone else (or nobody), and
+    /// `None` when membership could not be read at all.
+    async fn read_membership(&self) -> Option<bool> {
         let read_timeout = membership_check_timeout(self.entry.ttl_ms);
-        let membership = match tokio::time::timeout(read_timeout, self.cluster.read()).await {
-            Ok(result) => result,
+        match tokio::time::timeout(read_timeout, self.cluster.read()).await {
+            Ok(Ok(state)) => Some(
+                state
+                    .schedulers
+                    .get(&self.scheduler_id)
+                    .map(|entry| entry.instance_id)
+                    == Some(self.instance_id),
+            ),
+            Ok(Err(err)) => {
+                tracing::warn!(
+                    scheduler_id = %self.scheduler_id,
+                    error = %err,
+                    "Could not confirm cluster membership; heartbeating anyway"
+                );
+                None
+            }
             Err(_elapsed) => {
                 tracing::warn!(
                     scheduler_id = %self.scheduler_id,
                     timeout_ms = read_timeout.as_millis(),
                     "Timed out confirming cluster membership; heartbeating anyway"
                 );
-                return self.write_heartbeat().await;
-            }
-        };
-        match membership {
-            Ok(state) => {
-                let registered = state
-                    .schedulers
-                    .get(&self.scheduler_id)
-                    .map(|entry| entry.instance_id);
-                if registered != Some(self.instance_id) {
-                    self.superseded.store(true, Ordering::Relaxed);
-                    tracing::warn!(
-                        scheduler_id = %self.scheduler_id,
-                        instance_id = %self.instance_id,
-                        registered = ?registered,
-                        "This scheduler incarnation is no longer registered; it will stop heartbeating"
-                    );
-                    return Ok(());
-                }
-            }
-            Err(err) => {
-                tracing::warn!(
-                    scheduler_id = %self.scheduler_id,
-                    error = %err,
-                    "Could not confirm cluster membership; heartbeating anyway"
-                );
+                None
             }
         }
-
-        self.write_heartbeat().await
     }
-
-    /// Writes the heartbeat, but only over the object this incarnation just
-    /// observed.
+    /// Writes the heartbeat without ever overwriting another incarnation's.
     ///
-    /// The membership check and the write cannot be one operation — they touch
-    /// different objects — so a successor can register and publish between
-    /// them. Making the write conditional closes that: if anyone else wrote in
-    /// between, the put fails its precondition and this incarnation re-checks
-    /// membership rather than clobbering the successor. Whoever is actually
-    /// registered wins, and a superseded incarnation retires instead of
-    /// retrying.
-    async fn write_heartbeat(&self) -> Result<()> {
+    /// A conditional write proves only "the object did not change since I read
+    /// it" — it cannot prove "I am the registered incarnation". The two are
+    /// therefore combined: the version predicate closes the window between
+    /// checking membership and writing, while `membership` decides whether
+    /// writing over a *foreign* beat is permitted at all.
+    ///
+    /// - Our own beat, or none yet: refresh it. Safe even when membership is
+    ///   unreadable, and refusing would self-evict a healthy scheduler.
+    /// - A foreign beat: overwrite only with a successful membership read
+    ///   proving we are registered. Without that proof, skip the beat — a
+    ///   superseded incarnation must not refresh over its successor merely
+    ///   because `cluster.json` was slow.
+    async fn write_heartbeat(&self, membership: Membership) -> Result<()> {
         for _ in 0..MAX_HEARTBEAT_CAS_ATTEMPTS {
-            // The conditional write needs the current object version, so this
-            // path now reads as well as writes. Bound that read the same way as
-            // the membership read: a store whose reads hang must not wedge the
-            // registry loop. Skipping a beat costs slack against the TTL, which
-            // tolerates several missed beats; hanging costs the loop entirely.
             let read_timeout = membership_check_timeout(self.entry.ttl_ms);
-            let Ok(observed) = tokio::time::timeout(
+            let observed = match tokio::time::timeout(
                 read_timeout,
                 self.heartbeats.read_versioned(&self.scheduler_id),
             )
             .await
-            else {
+            {
+                Ok(result) => result.context(HeartbeatSnafu)?,
+                Err(_elapsed) => {
+                    // The current beat is unknown. With membership confirmed we
+                    // are entitled to the key, so write unconditionally rather
+                    // than skip: skipping repeatedly would let the TTL lapse and
+                    // get this healthy scheduler reaped. Without that proof,
+                    // skip — writing blind could clobber a successor.
+                    if membership == Membership::ConfirmedSelf {
+                        return self.overwrite_heartbeat().await;
+                    }
+                    tracing::warn!(
+                        scheduler_id = %self.scheduler_id,
+                        timeout_ms = read_timeout.as_millis(),
+                        "Timed out reading the heartbeat with membership unconfirmed; skipping this beat"
+                    );
+                    return Ok(());
+                }
+            };
+
+            if let Some((beat, _)) = observed.as_ref()
+                && beat.instance_id != self.instance_id
+                && membership != Membership::ConfirmedSelf
+            {
                 tracing::warn!(
                     scheduler_id = %self.scheduler_id,
-                    timeout_ms = read_timeout.as_millis(),
-                    "Timed out reading the current heartbeat; skipping this beat"
+                    instance_id = %self.instance_id,
+                    holder = %beat.instance_id,
+                    "Another incarnation holds the heartbeat and membership is unconfirmed; skipping this beat"
                 );
                 return Ok(());
-            };
-            let observed = observed.context(HeartbeatSnafu)?;
+            }
+
             let expected = observed.as_ref().map(|(_, version)| version.clone());
             let now = now_ms()?;
             match self
@@ -479,10 +514,21 @@ impl SchedulerRegistryRunner {
             {
                 Ok(()) => return Ok(()),
                 Err(heartbeat::Error::HeartbeatSupersededDuringWrite { .. }) => {
-                    // Someone else wrote. Re-read membership: if they took the
-                    // id over we must stop; otherwise retry over their object.
-                    if self.observe_supersession().await {
-                        return Ok(());
+                    // Someone else wrote between the read and the write. Only a
+                    // fresh membership read decides retry versus retire.
+                    match self.read_membership().await {
+                        // Still ours: fall through to the next attempt.
+                        Some(true) => {}
+                        Some(false) => {
+                            self.superseded.store(true, Ordering::Relaxed);
+                            tracing::warn!(
+                                scheduler_id = %self.scheduler_id,
+                                instance_id = %self.instance_id,
+                                "Lost the heartbeat to the registered incarnation; retiring"
+                            );
+                            return Ok(());
+                        }
+                        None => return Ok(()),
                     }
                 }
                 Err(source) => return Err(Error::Heartbeat { source }),
@@ -495,29 +541,12 @@ impl SchedulerRegistryRunner {
         Ok(())
     }
 
-    /// Returns true when a successful membership read shows this incarnation
-    /// is no longer the registered one, recording that decision as sticky.
-    async fn observe_supersession(&self) -> bool {
-        let read_timeout = membership_check_timeout(self.entry.ttl_ms);
-        let Ok(Ok(state)) = tokio::time::timeout(read_timeout, self.cluster.read()).await else {
-            // Unknown, not evidence: fail open and let the caller retry.
-            return false;
-        };
-        let registered = state
-            .schedulers
-            .get(&self.scheduler_id)
-            .map(|entry| entry.instance_id);
-        if registered == Some(self.instance_id) {
-            return false;
-        }
-        self.superseded.store(true, Ordering::Relaxed);
-        tracing::warn!(
-            scheduler_id = %self.scheduler_id,
-            instance_id = %self.instance_id,
-            registered = ?registered,
-            "Another incarnation owns this scheduler id; retiring this one's heartbeat"
-        );
-        true
+    async fn overwrite_heartbeat(&self) -> Result<()> {
+        let now = now_ms()?;
+        self.heartbeats
+            .heartbeat(&self.scheduler_id, self.instance_id, now, self.entry.ttl_ms)
+            .await
+            .context(HeartbeatSnafu)
     }
 
     async fn refresh_peers(&self) -> Result<()> {
@@ -1050,6 +1079,152 @@ mod tests {
         let beat: crate::cluster::heartbeat::SchedulerHeartbeat =
             serde_json::from_slice(&bytes).expect("parse");
         assert_eq!(beat.instance_id, instance_id);
+    }
+
+    /// A conditional write proves only that the object did not change — not
+    /// that the writer owns the id. So when membership is unreadable and the
+    /// heartbeat belongs to a *successor*, the beat must be skipped: otherwise a
+    /// superseded incarnation refreshes over the live one every tick for as
+    /// long as `cluster.json` stays slow.
+    #[tokio::test]
+    async fn an_unconfirmed_incarnation_does_not_overwrite_a_successors_heartbeat() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store: Arc<dyn ObjectStore> = Arc::new(HangingReads(Arc::clone(&inner)));
+        // Seed membership and the successor's heartbeat through the inner store,
+        // so the wrapper only affects later cluster reads.
+        let seed_cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        seed_cluster.bootstrap().await.expect("bootstrap");
+
+        let instance_id = Uuid::new_v4();
+        let successor = Uuid::new_v4();
+        heartbeats
+            .heartbeat("test:50051", successor, 20_000, 30_000)
+            .await
+            .expect("successor heartbeat");
+
+        let entry = SchedulerEntry {
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            advertise_address: "test:50051".to_string(),
+            grpc_address: "test:50051".to_string(),
+            http_address: "test:8090".to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        };
+        let job_store = crate::jobs::JobStore::new(Arc::clone(&inner), "", instance_id.to_string());
+        let df = DataFusionBuilder::new(
+            status::RuntimeStatus::new(),
+            Arc::new(AcceleratorEngineRegistry::default()),
+            Handle::current(),
+        )
+        .build();
+        let job_executor = Arc::new(crate::jobs::JobExecutor::new(
+            Arc::new(job_store),
+            Arc::new(df),
+        ));
+        let runner = SchedulerRegistryRunner {
+            // Cluster reads go through the hanging wrapper: membership unknown.
+            cluster: Arc::new(ClusterStateStore::new(Arc::clone(&store), "")),
+            heartbeats: Arc::clone(&heartbeats),
+            reaper: Reaper::new(
+                Arc::new(ClusterStateStore::new(Arc::clone(&store), "")),
+                Arc::clone(&heartbeats),
+            ),
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            entry,
+            peers: Arc::new(RwLock::new(HashMap::new())),
+            job_executor,
+            superseded: Arc::new(AtomicBool::new(false)),
+        };
+
+        runner
+            .send_heartbeat()
+            .await
+            .expect("an unconfirmed beat must not fail the loop");
+
+        let beat = heartbeats
+            .read("test:50051")
+            .await
+            .expect("read hb")
+            .expect("heartbeat present");
+        assert_eq!(
+            beat.instance_id, successor,
+            "an incarnation that cannot prove membership must not overwrite a successor's heartbeat"
+        );
+        assert_eq!(beat.last_heartbeat_ms, 20_000);
+    }
+
+    /// The mirror case: our *own* beat with membership unreadable must still be
+    /// refreshed. Skipping here would let the TTL lapse and get a healthy
+    /// scheduler reaped — the failure this whole change exists to prevent.
+    #[tokio::test]
+    async fn an_unconfirmed_incarnation_still_refreshes_its_own_heartbeat() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store: Arc<dyn ObjectStore> = Arc::new(HangingReads(Arc::clone(&inner)));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+
+        let instance_id = Uuid::new_v4();
+        heartbeats
+            .heartbeat("test:50051", instance_id, 1_000, 30_000)
+            .await
+            .expect("own heartbeat");
+
+        let entry = SchedulerEntry {
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            advertise_address: "test:50051".to_string(),
+            grpc_address: "test:50051".to_string(),
+            http_address: "test:8090".to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        };
+        let job_store = crate::jobs::JobStore::new(Arc::clone(&inner), "", instance_id.to_string());
+        let df = DataFusionBuilder::new(
+            status::RuntimeStatus::new(),
+            Arc::new(AcceleratorEngineRegistry::default()),
+            Handle::current(),
+        )
+        .build();
+        let job_executor = Arc::new(crate::jobs::JobExecutor::new(
+            Arc::new(job_store),
+            Arc::new(df),
+        ));
+        let runner = SchedulerRegistryRunner {
+            cluster: Arc::new(ClusterStateStore::new(Arc::clone(&store), "")),
+            heartbeats: Arc::clone(&heartbeats),
+            reaper: Reaper::new(
+                Arc::new(ClusterStateStore::new(Arc::clone(&store), "")),
+                Arc::clone(&heartbeats),
+            ),
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            entry,
+            peers: Arc::new(RwLock::new(HashMap::new())),
+            job_executor,
+            superseded: Arc::new(AtomicBool::new(false)),
+        };
+
+        runner
+            .send_heartbeat()
+            .await
+            .expect("refreshing our own beat must succeed");
+
+        let beat = heartbeats
+            .read("test:50051")
+            .await
+            .expect("read hb")
+            .expect("heartbeat present");
+        assert_eq!(beat.instance_id, instance_id);
+        assert!(
+            beat.last_heartbeat_ms > 1_000,
+            "our own heartbeat must be refreshed even when membership is unreadable"
+        );
     }
 
     /// A superseded incarnation must not delete the heartbeat key on the way

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -460,7 +460,7 @@ impl SchedulerRegistryRunner {
     ///   proving we are registered. Without that proof, skip the beat — a
     ///   superseded incarnation must not refresh over its successor merely
     ///   because `cluster.json` was slow.
-    async fn write_heartbeat(&self, membership: Membership) -> Result<()> {
+    async fn write_heartbeat(&self, mut membership: Membership) -> Result<()> {
         for _ in 0..MAX_HEARTBEAT_CAS_ATTEMPTS {
             let read_timeout = membership_check_timeout(self.entry.ttl_ms);
             let observed = match tokio::time::timeout(
@@ -544,8 +544,11 @@ impl SchedulerRegistryRunner {
                     // Someone else wrote between the read and the write. Only a
                     // fresh membership read decides retry versus retire.
                     match self.read_membership().await {
-                        // Still ours: fall through to the next attempt.
-                        Some(true) => {}
+                        // Still ours. Remember that: this read is proof of
+                        // ownership, and without promoting it a retry would
+                        // still refuse a foreign beat and leave the rightful
+                        // owner unable to reclaim its key.
+                        Some(true) => membership = Membership::ConfirmedSelf,
                         Some(false) => {
                             self.superseded.store(true, Ordering::Relaxed);
                             tracing::warn!(

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -484,25 +484,18 @@ impl SchedulerRegistryRunner {
             }
         };
 
-        // The heartbeat object is keyed by scheduler id alone, so a superseded
-        // incarnation deleting it would remove the *successor's* liveness and
-        // make it look orphaned until its next tick — the same false-orphan
-        // window this change exists to close. The object store has no
-        // conditional delete, so only delete when we just removed our own
-        // membership entry, which proves we still owned the id. Otherwise
-        // leave it: with our entry gone the stale object is inert, and it is
-        // overwritten by whoever owns the id next.
-        if owned_the_entry {
-            if let Err(err) = self.heartbeats.delete(&self.scheduler_id).await {
-                tracing::warn!("Failed to delete heartbeat on shutdown: {err}");
-            }
-        } else {
-            tracing::debug!(
-                scheduler_id = %self.scheduler_id,
-                instance_id = %self.instance_id,
-                "Not deleting the heartbeat: this incarnation no longer owns the scheduler id"
-            );
-        }
+        // Deliberately do not delete the heartbeat object. It is keyed by
+        // scheduler id alone, and there is no conditional delete, so any
+        // delete races a successor: between the mutation above committing and
+        // the delete landing, a successor can register and publish its
+        // heartbeat, and this process would then erase the new incarnation's
+        // liveness — the false-orphan window this change exists to close.
+        //
+        // Removing the membership entry is sufficient. `list_alive` only
+        // reports a heartbeat that matches a registered entry, so with the
+        // entry gone the object is inert, and whoever takes the id next
+        // overwrites it.
+        let _ = owned_the_entry;
     }
 }
 
@@ -603,8 +596,14 @@ mod tests {
         runner.shutdown().await;
         let snap = cluster.read().await.expect("read");
         assert!(!snap.schedulers.contains_key("test:50051"));
-        let beat = heartbeats.read("test:50051").await.expect("read hb");
-        assert!(beat.is_none());
+        // Shutdown removes membership and deliberately leaves the heartbeat
+        // object alone: deleting a key shared with a possible successor races
+        // that successor. With no registered entry the object is inert.
+        let alive = heartbeats
+            .list_alive(1_000, &snap)
+            .await
+            .expect("list alive");
+        assert!(!alive.contains_key("test:50051"));
     }
 
     /// A superseded incarnation must stop claiming the shared heartbeat key.

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -62,6 +62,11 @@ const DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
 const JOB_RECOVERY_INTERVAL: Duration = Duration::from_secs(10);
 const HEARTBEAT_DIVISOR: u64 = 3;
 
+/// Compare-and-set attempts for one heartbeat before skipping this beat.
+/// Contention means another incarnation is writing the same key, which is
+/// resolved by re-reading membership rather than by writing harder.
+const MAX_HEARTBEAT_CAS_ATTEMPTS: usize = 3;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to initialize scheduler state object store: {source}"))]
@@ -427,12 +432,92 @@ impl SchedulerRegistryRunner {
         self.write_heartbeat().await
     }
 
+    /// Writes the heartbeat, but only over the object this incarnation just
+    /// observed.
+    ///
+    /// The membership check and the write cannot be one operation — they touch
+    /// different objects — so a successor can register and publish between
+    /// them. Making the write conditional closes that: if anyone else wrote in
+    /// between, the put fails its precondition and this incarnation re-checks
+    /// membership rather than clobbering the successor. Whoever is actually
+    /// registered wins, and a superseded incarnation retires instead of
+    /// retrying.
     async fn write_heartbeat(&self) -> Result<()> {
-        let now = now_ms()?;
-        self.heartbeats
-            .heartbeat(&self.scheduler_id, self.instance_id, now, self.entry.ttl_ms)
+        for _ in 0..MAX_HEARTBEAT_CAS_ATTEMPTS {
+            // The conditional write needs the current object version, so this
+            // path now reads as well as writes. Bound that read the same way as
+            // the membership read: a store whose reads hang must not wedge the
+            // registry loop. Skipping a beat costs slack against the TTL, which
+            // tolerates several missed beats; hanging costs the loop entirely.
+            let read_timeout = membership_check_timeout(self.entry.ttl_ms);
+            let Ok(observed) = tokio::time::timeout(
+                read_timeout,
+                self.heartbeats.read_versioned(&self.scheduler_id),
+            )
             .await
-            .context(HeartbeatSnafu)
+            else {
+                tracing::warn!(
+                    scheduler_id = %self.scheduler_id,
+                    timeout_ms = read_timeout.as_millis(),
+                    "Timed out reading the current heartbeat; skipping this beat"
+                );
+                return Ok(());
+            };
+            let observed = observed.context(HeartbeatSnafu)?;
+            let expected = observed.as_ref().map(|(_, version)| version.clone());
+            let now = now_ms()?;
+            match self
+                .heartbeats
+                .heartbeat_if_unchanged(
+                    &self.scheduler_id,
+                    self.instance_id,
+                    now,
+                    self.entry.ttl_ms,
+                    expected.as_ref(),
+                )
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(heartbeat::Error::HeartbeatSupersededDuringWrite { .. }) => {
+                    // Someone else wrote. Re-read membership: if they took the
+                    // id over we must stop; otherwise retry over their object.
+                    if self.observe_supersession().await {
+                        return Ok(());
+                    }
+                }
+                Err(source) => return Err(Error::Heartbeat { source }),
+            }
+        }
+        tracing::warn!(
+            scheduler_id = %self.scheduler_id,
+            "Heartbeat contended by another incarnation; skipping this beat"
+        );
+        Ok(())
+    }
+
+    /// Returns true when a successful membership read shows this incarnation
+    /// is no longer the registered one, recording that decision as sticky.
+    async fn observe_supersession(&self) -> bool {
+        let read_timeout = membership_check_timeout(self.entry.ttl_ms);
+        let Ok(Ok(state)) = tokio::time::timeout(read_timeout, self.cluster.read()).await else {
+            // Unknown, not evidence: fail open and let the caller retry.
+            return false;
+        };
+        let registered = state
+            .schedulers
+            .get(&self.scheduler_id)
+            .map(|entry| entry.instance_id);
+        if registered == Some(self.instance_id) {
+            return false;
+        }
+        self.superseded.store(true, Ordering::Relaxed);
+        tracing::warn!(
+            scheduler_id = %self.scheduler_id,
+            instance_id = %self.instance_id,
+            registered = ?registered,
+            "Another incarnation owns this scheduler id; retiring this one's heartbeat"
+        );
+        true
     }
 
     async fn refresh_peers(&self) -> Result<()> {
@@ -739,6 +824,94 @@ mod tests {
         }
     }
 
+    /// The exact interleaving the conditional write exists for: a successor
+    /// takes the id over and publishes *after* this incarnation has confirmed
+    /// membership but *before* its write lands. The write must fail its
+    /// precondition and retire rather than clobber the successor.
+    #[tokio::test]
+    async fn a_successor_publishing_mid_write_is_not_clobbered() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+
+        let instance_id = Uuid::new_v4();
+        let successor = Uuid::new_v4();
+        let entry = SchedulerEntry {
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            advertise_address: "test:50051".to_string(),
+            grpc_address: "test:50051".to_string(),
+            http_address: "test:8090".to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        };
+        let job_store = crate::jobs::JobStore::new(Arc::clone(&store), "", instance_id.to_string());
+        let df = DataFusionBuilder::new(
+            status::RuntimeStatus::new(),
+            Arc::new(AcceleratorEngineRegistry::default()),
+            Handle::current(),
+        )
+        .build();
+        let job_executor = Arc::new(crate::jobs::JobExecutor::new(
+            Arc::new(job_store),
+            Arc::new(df),
+        ));
+        let runner = SchedulerRegistryRunner {
+            cluster: Arc::clone(&cluster),
+            heartbeats: Arc::clone(&heartbeats),
+            reaper: Reaper::new(Arc::clone(&cluster), Arc::clone(&heartbeats)),
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            entry: entry.clone(),
+            peers: Arc::new(RwLock::new(HashMap::new())),
+            job_executor,
+            superseded: Arc::new(AtomicBool::new(false)),
+        };
+        runner.register_self().await.expect("register");
+
+        // Simulate the interleaving: membership still names this incarnation
+        // when it checks, and the successor registers *and* publishes before
+        // the write lands. Writing the successor's heartbeat here changes the
+        // object version the old incarnation observed at registration time.
+        let mut successor_entry = entry;
+        successor_entry.instance_id = successor;
+        cluster
+            .mutate(|state| {
+                state
+                    .schedulers
+                    .insert("test:50051".to_string(), successor_entry.clone());
+                MutationOutcome::Apply
+            })
+            .await
+            .expect("successor takes over");
+        heartbeats
+            .heartbeat("test:50051", successor, 20_000, 30_000)
+            .await
+            .expect("successor heartbeat");
+
+        runner
+            .send_heartbeat()
+            .await
+            .expect("a contended heartbeat must not fail the loop");
+
+        let beat = heartbeats
+            .read("test:50051")
+            .await
+            .expect("read hb")
+            .expect("heartbeat present");
+        assert_eq!(
+            beat.instance_id, successor,
+            "the successor's heartbeat must survive a concurrent write by the old incarnation"
+        );
+        assert!(
+            runner.superseded.load(Ordering::Relaxed),
+            "losing the write must make the old incarnation observe it was superseded"
+        );
+    }
+
     /// Object store whose `get` never returns, standing in for a hung backend.
     /// Everything else delegates to an in-memory store so the heartbeat write
     /// under test still works.
@@ -755,10 +928,16 @@ mod tests {
     impl ObjectStore for HangingReads {
         async fn get_opts(
             &self,
-            _location: &object_store::path::Path,
-            _options: object_store::GetOptions,
+            location: &object_store::path::Path,
+            options: object_store::GetOptions,
         ) -> object_store::Result<object_store::GetResult> {
-            std::future::pending().await
+            // Hang only on the cluster document. The heartbeat path reads its
+            // own object to write conditionally, and hanging that too would
+            // test a different failure than the one under examination.
+            if location.as_ref().contains("cluster.json") {
+                return std::future::pending().await;
+            }
+            self.0.get_opts(location, options).await
         }
         async fn put_opts(
             &self,

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -60,6 +60,20 @@ fn membership_check_timeout(ttl_ms: u64) -> Duration {
     let interval = Duration::from_millis(ttl_ms.saturating_div(HEARTBEAT_DIVISOR).max(1));
     (interval / 2).min(MEMBERSHIP_CHECK_TIMEOUT_CAP)
 }
+
+/// Deadline for one whole heartbeat tick.
+///
+/// Individual reads have their own deadlines, but a tick can perform several of
+/// them — a membership read, then per retry a beat read, an ownership
+/// re-confirmation, and a post-conflict re-read — and bounding each one says
+/// nothing about their sum. Against a uniformly slow store those deadlines stack
+/// into far more than one interval, which delays every other duty on the same
+/// task and, for a short TTL, can exceed the TTL itself while the scheduler is
+/// healthy. Capping the tick at one interval means a slow tick can postpone the
+/// next beat by at most one slot, and the staleness tolerance absorbs that.
+fn heartbeat_tick_budget(ttl_ms: u64) -> Duration {
+    Duration::from_millis(ttl_ms.saturating_div(HEARTBEAT_DIVISOR).max(1))
+}
 const DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
 const JOB_RECOVERY_INTERVAL: Duration = Duration::from_secs(10);
 const HEARTBEAT_DIVISOR: u64 = 3;
@@ -405,6 +419,22 @@ impl SchedulerRegistryRunner {
             return Ok(());
         }
 
+        let budget = heartbeat_tick_budget(self.entry.ttl_ms);
+        match tokio::time::timeout(budget, self.heartbeat_tick()).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                tracing::warn!(
+                    scheduler_id = %self.scheduler_id,
+                    budget_ms = budget.as_millis(),
+                    "Heartbeat tick exceeded its budget; skipping this beat"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// One heartbeat tick, run under the deadline imposed by `send_heartbeat`.
+    async fn heartbeat_tick(&self) -> Result<()> {
         match self.read_membership().await {
             Some(false) => {
                 // A successful read proved someone else owns the id. Retire.
@@ -1073,6 +1103,127 @@ mod tests {
         );
     }
 
+    /// Store whose heartbeat writes never complete. Reads carry their own
+    /// deadlines but writes do not, so this is what an unbounded tick stalls on
+    /// indefinitely.
+    #[derive(Debug)]
+    struct HangingBeatWrites {
+        inner: Arc<dyn ObjectStore>,
+        /// Set after registration, so only the tick's own write hangs.
+        armed: std::sync::atomic::AtomicBool,
+    }
+
+    impl std::fmt::Display for HangingBeatWrites {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "HangingBeatWrites")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for HangingBeatWrites {
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            if location.as_ref().contains("heartbeats/")
+                && self.armed.load(std::sync::atomic::Ordering::Relaxed)
+            {
+                return std::future::pending().await;
+            }
+            self.inner.put_opts(location, payload, opts).await
+        }
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<
+                'static,
+                object_store::Result<object_store::path::Path>,
+            >,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
+        {
+            self.inner.delete_stream(locations)
+        }
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// Individual reads carry deadlines; the write does not. Bounding the parts
+    /// therefore says nothing about the whole, so the tick itself is bounded —
+    /// otherwise a store that accepts a write and never answers stalls the task
+    /// that also drives discovery, recovery and the reaper.
+    #[tokio::test]
+    async fn a_hanging_write_cannot_stall_a_tick_past_its_budget() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wrapper = Arc::new(HangingBeatWrites {
+            inner: Arc::clone(&inner),
+            armed: std::sync::atomic::AtomicBool::new(false),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+
+        let instance_id = Uuid::new_v4();
+        let mut runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
+        // A short TTL keeps the test quick and is the case where an unbounded tick
+        // is most damaging: it can outlast the TTL while the scheduler is healthy.
+        runner.entry.ttl_ms = 300;
+        runner.register_self().await.expect("register");
+        // Only the tick's own write hangs; registration completed normally.
+        wrapper
+            .armed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let budget = heartbeat_tick_budget(runner.entry.ttl_ms);
+        let started = tokio::time::Instant::now();
+        runner
+            .send_heartbeat()
+            .await
+            .expect("a hanging write must not fail the loop");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < budget * 4,
+            "a tick must stay near its {}ms budget, took {}ms",
+            budget.as_millis(),
+            elapsed.as_millis()
+        );
+    }
+
     /// Store whose heartbeat *reads* fail on demand while writes keep working —
     /// the asymmetric outage that decides between clobbering a successor and
     /// letting a healthy scheduler's TTL lapse.
@@ -1462,8 +1613,8 @@ mod tests {
         let foreign = Uuid::new_v4();
         let runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
         runner.register_self().await.expect("register");
-        // Someone else's beat is present, and this incarnation has never written
-        // through the conditional path, so it holds no version.
+        // Someone else's beat replaces the one registration wrote, so the version
+        // this incarnation retained is now stale.
         heartbeats
             .heartbeat("test:50051", foreign, 40_000, 30_000)
             .await

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -21,9 +21,11 @@ limitations under the License.
 //! `heartbeats/{id}.json`. See
 //! `plans/consolidate-cluster-state-into-cluster-json.md`.
 
+use arc_swap::ArcSwapOption;
+use object_store::UpdateVersion;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use app::spicepod::component::runtime::Scheduler as SchedulerConfig;
@@ -81,13 +83,6 @@ enum Membership {
 /// resolved by re-reading membership rather than by writing harder.
 const MAX_HEARTBEAT_CAS_ATTEMPTS: usize = 3;
 
-/// Consecutive failures to read the current heartbeat before this incarnation
-/// will write without a version predicate. Without the version, a write cannot
-/// prove it is not overwriting a successor, so skipping is preferred while the
-/// TTL still has slack; only when self-eviction becomes the greater risk is a
-/// blind write attempted, and then only against a freshly re-read membership.
-const BLIND_WRITE_AFTER_BEAT_READ_FAILURES: usize = 2;
-
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to initialize scheduler state object store: {source}"))]
@@ -127,8 +122,12 @@ struct SchedulerRegistryRunner {
     /// superseded. Sticky, so a later failed read cannot resume claiming the
     /// heartbeat key.
     superseded: Arc<AtomicBool>,
-    /// Consecutive failures to read the current heartbeat object.
-    beat_read_failures: Arc<AtomicUsize>,
+    /// Version of this incarnation's last successful heartbeat write. A read
+    /// failure therefore does not force a choice between writing blind and
+    /// skipping: the write stays conditional on what this process last wrote, so
+    /// a successor that has written since is protected by the predicate rather
+    /// than by a liveness guess.
+    last_written_version: Arc<ArcSwapOption<UpdateVersion>>,
 }
 
 pub async fn start_scheduler_registry(
@@ -202,7 +201,7 @@ pub async fn start_scheduler_registry(
         peers,
         job_executor,
         superseded: Arc::new(AtomicBool::new(false)),
-        beat_read_failures: Arc::new(AtomicUsize::new(0)),
+        last_written_version: Arc::new(ArcSwapOption::empty()),
     };
 
     runner.run(cancel).await
@@ -485,32 +484,32 @@ impl SchedulerRegistryRunner {
     async fn write_heartbeat(&self, mut membership: Membership) -> Result<()> {
         for _ in 0..MAX_HEARTBEAT_CAS_ATTEMPTS {
             let read_timeout = membership_check_timeout(self.entry.ttl_ms);
-            let observed = match tokio::time::timeout(
+            let (observed, from_cache) = match tokio::time::timeout(
                 read_timeout,
                 self.heartbeats.read_versioned(&self.scheduler_id),
             )
             .await
             {
-                Ok(Ok(result)) => {
-                    self.beat_read_failures.store(0, Ordering::Relaxed);
-                    result
-                }
+                Ok(Ok(result)) => (result, false),
                 // A read error and a read timeout are the same situation: the
                 // current beat is unknown. Aborting the tick here would let
                 // repeated transient errors suppress every beat until the TTL
                 // lapses and this healthy scheduler is reaped.
-                Ok(Err(err)) => {
-                    return self.beat_read_failed(membership, &format!("{err}")).await;
-                }
-                Err(_elapsed) => {
-                    return self.beat_read_failed(membership, "read timed out").await;
-                }
+                Ok(Err(err)) => match self.cached_predicate(&format!("{err}")) {
+                    Some(version) => (Some((None, version)), true),
+                    None => return Ok(()),
+                },
+                Err(_elapsed) => match self.cached_predicate("read timed out") {
+                    Some(version) => (Some((None, version)), true),
+                    None => return Ok(()),
+                },
             };
 
             // An unparsable payload reads back as `None`: the holder is unknown,
             // which is not evidence that it is ours, so it is treated like a
             // foreign beat.
-            if let Some((beat, _)) = observed.as_ref()
+            if !from_cache
+                && let Some((beat, _)) = observed.as_ref()
                 && beat
                     .as_ref()
                     .is_none_or(|beat| beat.instance_id != self.instance_id)
@@ -538,7 +537,10 @@ impl SchedulerRegistryRunner {
                 )
                 .await
             {
-                Ok(()) => return Ok(()),
+                Ok(version) => {
+                    self.last_written_version.store(version.map(Arc::new));
+                    return Ok(());
+                }
                 Err(heartbeat::Error::HeartbeatSupersededDuringWrite { .. }) => {
                     // Someone else wrote between the read and the write. Only a
                     // fresh membership read decides retry versus retire.
@@ -570,41 +572,33 @@ impl SchedulerRegistryRunner {
         Ok(())
     }
 
-    /// The current beat could not be read, so no version predicate is
-    /// available. A write would then be unable to prove it is not overwriting a
-    /// successor, and skipping cannot continue forever without the TTL lapsing.
-    /// Skip while the TTL still has slack; once failures persist, write only
-    /// against a *freshly* re-read membership — the tick's earlier confirmation
-    /// may be a heartbeat interval old, which is long enough for a takeover.
-    async fn beat_read_failed(&self, membership: Membership, reason: &str) -> Result<()> {
-        let failures = self.beat_read_failures.fetch_add(1, Ordering::Relaxed) + 1;
-        if membership == Membership::ConfirmedSelf
-            && failures >= BLIND_WRITE_AFTER_BEAT_READ_FAILURES
-            && self.read_membership().await == Some(true)
-        {
+    /// The current beat could not be read. Rather than choose between writing
+    /// without a predicate (which cannot prove it is not overwriting a
+    /// successor) and skipping until the TTL lapses (which gets a healthy
+    /// scheduler reaped), fall back to the version this incarnation last wrote.
+    ///
+    /// The write therefore stays conditional through a read outage: if a
+    /// successor has written since, the predicate fails and the caller
+    /// reconciles against membership instead of clobbering it. Read-only
+    /// outages, where writes still succeed, no longer force either bad choice.
+    ///
+    /// Returns `None` when there is nothing to condition on — only before this
+    /// incarnation's first successful write — in which case the beat is skipped.
+    fn cached_predicate(&self, reason: &str) -> Option<UpdateVersion> {
+        let Some(version) = self.last_written_version.load_full() else {
             tracing::warn!(
                 scheduler_id = %self.scheduler_id,
-                failures,
                 reason,
-                "Cannot read the heartbeat; writing without a version predicate as the re-confirmed owner"
+                "Cannot read the current heartbeat and no prior write to condition on; skipping this beat"
             );
-            return self.overwrite_heartbeat().await;
-        }
+            return None;
+        };
         tracing::warn!(
             scheduler_id = %self.scheduler_id,
-            failures,
             reason,
-            "Cannot read the current heartbeat; skipping this beat"
+            "Cannot read the current heartbeat; writing conditionally against the last version this process wrote"
         );
-        Ok(())
-    }
-
-    async fn overwrite_heartbeat(&self) -> Result<()> {
-        let now = now_ms()?;
-        self.heartbeats
-            .heartbeat(&self.scheduler_id, self.instance_id, now, self.entry.ttl_ms)
-            .await
-            .context(HeartbeatSnafu)
+        Some(UpdateVersion::clone(&version))
     }
 
     async fn refresh_peers(&self) -> Result<()> {
@@ -765,7 +759,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
-            beat_read_failures: Arc::new(AtomicUsize::new(0)),
+            last_written_version: Arc::new(ArcSwapOption::empty()),
         };
         runner.register_self().await.expect("register");
 
@@ -833,7 +827,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
-            beat_read_failures: Arc::new(AtomicUsize::new(0)),
+            last_written_version: Arc::new(ArcSwapOption::empty()),
         };
         runner.register_self().await.expect("register");
 
@@ -911,6 +905,345 @@ mod tests {
             );
             assert!(timeout <= MEMBERSHIP_CHECK_TIMEOUT_CAP);
         }
+    }
+
+    /// Store whose heartbeat *reads* fail on demand while writes keep working —
+    /// the asymmetric outage that decides between clobbering a successor and
+    /// letting a healthy scheduler's TTL lapse.
+    #[derive(Debug)]
+    struct FailingBeatReads {
+        inner: Arc<dyn ObjectStore>,
+        failing: std::sync::atomic::AtomicBool,
+    }
+
+    impl std::fmt::Display for FailingBeatReads {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FailingBeatReads")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for FailingBeatReads {
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            if location.as_ref().contains("heartbeats/")
+                && self.failing.load(std::sync::atomic::Ordering::Relaxed)
+            {
+                return Err(object_store::Error::Generic {
+                    store: "FailingBeatReads",
+                    source: "injected heartbeat read failure".into(),
+                });
+            }
+            self.inner.get_opts(location, options).await
+        }
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<
+                'static,
+                object_store::Result<object_store::path::Path>,
+            >,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
+        {
+            self.inner.delete_stream(locations)
+        }
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// Builds a runner over the given stores. `inner` is the un-wrapped store, so
+    /// a test can observe and seed state the runner sees through its wrapper.
+    fn runner_over(
+        cluster: &Arc<ClusterStateStore>,
+        heartbeats: &Arc<SchedulerHeartbeatStore>,
+        inner: &Arc<dyn ObjectStore>,
+        instance_id: Uuid,
+    ) -> SchedulerRegistryRunner {
+        let entry = SchedulerEntry {
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            advertise_address: "test:50051".to_string(),
+            grpc_address: "test:50051".to_string(),
+            http_address: "test:8090".to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        };
+        let job_store = crate::jobs::JobStore::new(Arc::clone(inner), "", instance_id.to_string());
+        let df = DataFusionBuilder::new(
+            status::RuntimeStatus::new(),
+            Arc::new(AcceleratorEngineRegistry::default()),
+            Handle::current(),
+        )
+        .build();
+        let job_executor = Arc::new(crate::jobs::JobExecutor::new(
+            Arc::new(job_store),
+            Arc::new(df),
+        ));
+        SchedulerRegistryRunner {
+            cluster: Arc::clone(cluster),
+            heartbeats: Arc::clone(heartbeats),
+            reaper: Reaper::new(Arc::clone(cluster), Arc::clone(heartbeats)),
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            entry,
+            peers: Arc::new(RwLock::new(HashMap::new())),
+            job_executor,
+            superseded: Arc::new(AtomicBool::new(false)),
+            last_written_version: Arc::new(ArcSwapOption::empty()),
+        }
+    }
+
+    /// A read-only outage must not cost this scheduler its liveness. Writes still
+    /// work, so the beat is written conditionally against the version this
+    /// process last wrote rather than skipped until the TTL lapses.
+    #[tokio::test]
+    async fn a_heartbeat_read_outage_still_refreshes_the_heartbeat() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wrapper = Arc::new(FailingBeatReads {
+            inner: Arc::clone(&inner),
+            failing: std::sync::atomic::AtomicBool::new(false),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+        let observer = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&inner), ""));
+
+        let instance_id = Uuid::new_v4();
+        let runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
+        runner.register_self().await.expect("register");
+        // One good tick, so there is a version to condition on.
+        runner.send_heartbeat().await.expect("first beat");
+        let before = observer
+            .read("test:50051")
+            .await
+            .expect("read")
+            .expect("present");
+
+        wrapper
+            .failing
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        runner
+            .send_heartbeat()
+            .await
+            .expect("a read outage must not fail the loop");
+
+        let after = observer
+            .read("test:50051")
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(
+            after.instance_id, instance_id,
+            "the beat must still belong to this incarnation"
+        );
+        assert!(
+            after.last_heartbeat_ms >= before.last_heartbeat_ms,
+            "a read outage must not suppress the beat: {} < {}",
+            after.last_heartbeat_ms,
+            before.last_heartbeat_ms
+        );
+        assert!(
+            !runner.superseded.load(Ordering::Relaxed),
+            "a read outage is not evidence of supersession"
+        );
+    }
+
+    /// When membership has already moved to the successor, a read outage must not
+    /// stop this incarnation from noticing: it retires on the membership read
+    /// alone, without attempting any write.
+    #[tokio::test]
+    async fn a_read_outage_retires_when_membership_has_moved_on() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wrapper = Arc::new(FailingBeatReads {
+            inner: Arc::clone(&inner),
+            failing: std::sync::atomic::AtomicBool::new(false),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+        let observer = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&inner), ""));
+
+        let instance_id = Uuid::new_v4();
+        let successor = Uuid::new_v4();
+        let runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
+        runner.register_self().await.expect("register");
+        runner.send_heartbeat().await.expect("first beat");
+
+        // A real takeover: membership *and* the heartbeat move to the successor.
+        cluster
+            .mutate(|state| {
+                if let Some(entry) = state.schedulers.get_mut("test:50051") {
+                    entry.instance_id = successor;
+                    entry.started_at_ms = 50_000;
+                }
+                MutationOutcome::Apply
+            })
+            .await
+            .expect("successor claims membership");
+        heartbeats
+            .heartbeat("test:50051", successor, 60_000, 30_000)
+            .await
+            .expect("successor beat");
+
+        wrapper
+            .failing
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        runner
+            .send_heartbeat()
+            .await
+            .expect("losing the key must not fail the loop");
+
+        let beat = observer
+            .read("test:50051")
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(
+            beat.instance_id, successor,
+            "a successor must not be clobbered by a write made during a read outage"
+        );
+        assert!(
+            runner.superseded.load(Ordering::Relaxed),
+            "losing the conditional write to the registered incarnation retires this one"
+        );
+    }
+
+    /// The clobber this change exists to prevent, in the form that actually
+    /// reaches the conditional write: the beat has been written by someone else,
+    /// but membership still names this incarnation, so it does not retire. Its
+    /// beat cannot be read, so ownership of the *object* cannot be re-observed —
+    /// only the version it last wrote is available. That predicate no longer
+    /// matches, so the write must fail rather than overwrite the other beat.
+    #[tokio::test]
+    async fn a_read_outage_does_not_clobber_a_beat_written_since_the_last_write() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wrapper = Arc::new(FailingBeatReads {
+            inner: Arc::clone(&inner),
+            failing: std::sync::atomic::AtomicBool::new(false),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+        let observer = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&inner), ""));
+
+        let instance_id = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
+        runner.register_self().await.expect("register");
+        // A good tick, so there is a version to condition on.
+        runner.send_heartbeat().await.expect("first beat");
+
+        // Someone else writes the key. Membership is untouched, so this
+        // incarnation still believes — correctly — that it is registered.
+        heartbeats
+            .heartbeat("test:50051", other, 60_000, 30_000)
+            .await
+            .expect("other beat");
+
+        wrapper
+            .failing
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        runner
+            .send_heartbeat()
+            .await
+            .expect("a contended beat during a read outage must not fail the loop");
+
+        let beat = observer
+            .read("test:50051")
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(
+            beat.instance_id, other,
+            "a write during a read outage must stay conditional and lose to the newer beat"
+        );
+        assert_eq!(
+            beat.last_heartbeat_ms, 60_000,
+            "the other beat must be left exactly as written"
+        );
+    }
+
+    /// Before the first successful write there is nothing to condition on, so an
+    /// unreadable beat is skipped rather than overwritten blind.
+    #[tokio::test]
+    async fn a_read_outage_before_any_write_skips_the_beat() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wrapper = Arc::new(FailingBeatReads {
+            inner: Arc::clone(&inner),
+            failing: std::sync::atomic::AtomicBool::new(false),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+        let observer = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&inner), ""));
+
+        let instance_id = Uuid::new_v4();
+        let foreign = Uuid::new_v4();
+        let runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
+        runner.register_self().await.expect("register");
+        // Someone else's beat is present, and this incarnation has never written
+        // through the conditional path, so it holds no version.
+        heartbeats
+            .heartbeat("test:50051", foreign, 40_000, 30_000)
+            .await
+            .expect("foreign beat");
+
+        wrapper
+            .failing
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        runner.send_heartbeat().await.expect("skip must not fail");
+
+        let beat = observer
+            .read("test:50051")
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(
+            beat.instance_id, foreign,
+            "with no version to condition on the beat must be skipped, not written blind"
+        );
     }
 
     /// Store that lets a successor take over *between* the heartbeat read and
@@ -1075,7 +1408,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
-            beat_read_failures: Arc::new(AtomicUsize::new(0)),
+            last_written_version: Arc::new(ArcSwapOption::empty()),
         };
         // Registered and heartbeating normally, so the membership check passes
         // and the conditional write is actually attempted.
@@ -1223,7 +1556,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
-            beat_read_failures: Arc::new(AtomicUsize::new(0)),
+            last_written_version: Arc::new(ArcSwapOption::empty()),
         };
 
         // Paused time auto-advances once the read is the only pending work, so
@@ -1301,7 +1634,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
-            beat_read_failures: Arc::new(AtomicUsize::new(0)),
+            last_written_version: Arc::new(ArcSwapOption::empty()),
         };
 
         runner
@@ -1371,7 +1704,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
-            beat_read_failures: Arc::new(AtomicUsize::new(0)),
+            last_written_version: Arc::new(ArcSwapOption::empty()),
         };
 
         runner
@@ -1459,7 +1792,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
-            beat_read_failures: Arc::new(AtomicUsize::new(0)),
+            last_written_version: Arc::new(ArcSwapOption::empty()),
         };
 
         runner
@@ -1521,7 +1854,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
-            beat_read_failures: Arc::new(AtomicUsize::new(0)),
+            last_written_version: Arc::new(ArcSwapOption::empty()),
         };
         runner.register_self().await.expect("register");
 
@@ -1603,7 +1936,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
-            beat_read_failures: Arc::new(AtomicUsize::new(0)),
+            last_written_version: Arc::new(ArcSwapOption::empty()),
         };
 
         runner

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -64,20 +64,6 @@ const DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
 const JOB_RECOVERY_INTERVAL: Duration = Duration::from_secs(10);
 const HEARTBEAT_DIVISOR: u64 = 3;
 
-/// What this tick could prove about who owns the scheduler id.
-///
-/// A conditional write can only prove "the object did not change since I read
-/// it" — it cannot prove "I am the registered incarnation". That distinction is
-/// what keeps a superseded incarnation from refreshing over its successor when
-/// membership is merely unreadable, so it is carried explicitly.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Membership {
-    /// A successful read showed this incarnation registered.
-    ConfirmedSelf,
-    /// Membership could not be read. Not evidence either way.
-    Unknown,
-}
-
 /// Compare-and-set attempts for one heartbeat before skipping this beat.
 /// Contention means another incarnation is writing the same key, which is
 /// resolved by re-reading membership rather than by writing harder.
@@ -420,7 +406,6 @@ impl SchedulerRegistryRunner {
         }
 
         match self.read_membership().await {
-            Some(true) => self.write_heartbeat(Membership::ConfirmedSelf).await,
             Some(false) => {
                 // A successful read proved someone else owns the id. Retire.
                 self.superseded.store(true, Ordering::Relaxed);
@@ -431,13 +416,15 @@ impl SchedulerRegistryRunner {
                 );
                 Ok(())
             }
-            // Membership unreadable. Heartbeats deliberately live outside
-            // `cluster.json` so emission does not depend on that document:
-            // suppressing beats here would self-evict a healthy scheduler.
-            // The write path still refuses to overwrite *another*
-            // incarnation's beat without proof, so failing open cannot clobber
-            // a successor.
-            None => self.write_heartbeat(Membership::Unknown).await,
+            // Registered, or membership unreadable. Both proceed, and for the
+            // same reason: heartbeats deliberately live outside `cluster.json`
+            // so emission does not depend on that document, and suppressing
+            // beats when it cannot be read would self-evict a healthy
+            // scheduler. Proceeding is safe because the write path re-confirms
+            // ownership against a fresh read before it will touch a beat
+            // belonging to another incarnation — this observation is not
+            // carried forward as proof of anything.
+            Some(true) | None => self.write_heartbeat().await,
         }
     }
 
@@ -482,11 +469,13 @@ impl SchedulerRegistryRunner {
     ///
     /// - Our own beat, or none yet: refresh it. Safe even when membership is
     ///   unreadable, and refusing would self-evict a healthy scheduler.
-    /// - A foreign beat: overwrite only with a successful membership read
-    ///   proving we are registered. Without that proof, skip the beat — a
-    ///   superseded incarnation must not refresh over its successor merely
-    ///   because `cluster.json` was slow.
-    async fn write_heartbeat(&self, mut membership: Membership) -> Result<()> {
+    /// - A foreign beat: overwrite only against a membership read taken *after*
+    ///   that beat was observed, proving we are still registered. Without that
+    ///   proof, skip the beat — a superseded incarnation must not refresh over
+    ///   its successor merely because `cluster.json` was slow, and an
+    ///   observation from earlier in the tick may predate a successor's
+    ///   registration.
+    async fn write_heartbeat(&self) -> Result<()> {
         for _ in 0..MAX_HEARTBEAT_CAS_ATTEMPTS {
             let read_timeout = membership_check_timeout(self.entry.ttl_ms);
             let (observed, from_cache) = match tokio::time::timeout(
@@ -513,20 +502,43 @@ impl SchedulerRegistryRunner {
             // An unparsable payload reads back as `None`: the holder is unknown,
             // which is not evidence that it is ours, so it is treated like a
             // foreign beat.
+            // A beat belonging to someone else — or one that cannot be parsed, so
+            // the holder is unknown — may only be reclaimed against a membership
+            // read taken *after* it was observed. The read this tick started with
+            // may predate a successor's registration, and a version predicate
+            // does not help: it proves the object has not changed since the beat
+            // was read, not that this incarnation still owns the id.
             if !from_cache
                 && let Some((beat, _)) = observed.as_ref()
                 && beat
                     .as_ref()
                     .is_none_or(|beat| beat.instance_id != self.instance_id)
-                && membership != Membership::ConfirmedSelf
             {
-                tracing::warn!(
-                    scheduler_id = %self.scheduler_id,
-                    instance_id = %self.instance_id,
-                    holder = ?beat.as_ref().map(|b| b.instance_id),
-                    "Another incarnation holds the heartbeat and membership is unconfirmed; skipping this beat"
-                );
-                return Ok(());
+                let holder = beat.as_ref().map(|b| b.instance_id);
+                match self.read_membership().await {
+                    // Freshly proven to still own the id, so reclaiming the key
+                    // is legitimate: fall through to the conditional write.
+                    Some(true) => {}
+                    Some(false) => {
+                        self.superseded.store(true, Ordering::Relaxed);
+                        tracing::warn!(
+                            scheduler_id = %self.scheduler_id,
+                            instance_id = %self.instance_id,
+                            holder = ?holder,
+                            "Another incarnation holds the heartbeat and is the registered owner; retiring"
+                        );
+                        return Ok(());
+                    }
+                    None => {
+                        tracing::warn!(
+                            scheduler_id = %self.scheduler_id,
+                            instance_id = %self.instance_id,
+                            holder = ?holder,
+                            "Another incarnation holds the heartbeat and membership is unreadable; skipping this beat"
+                        );
+                        return Ok(());
+                    }
+                }
             }
 
             let expected = observed.as_ref().map(|(_, version)| version.clone());
@@ -550,11 +562,9 @@ impl SchedulerRegistryRunner {
                     // Someone else wrote between the read and the write. Only a
                     // fresh membership read decides retry versus retire.
                     match self.read_membership().await {
-                        // Still ours. Remember that: this read is proof of
-                        // ownership, and without promoting it a retry would
-                        // still refuse a foreign beat and leave the rightful
-                        // owner unable to reclaim its key.
-                        Some(true) => membership = Membership::ConfirmedSelf,
+                        // Still ours, so retry: the next attempt re-reads the
+                        // beat and re-confirms ownership before writing.
+                        Some(true) => {}
                         Some(false) => {
                             self.superseded.store(true, Ordering::Relaxed);
                             tracing::warn!(
@@ -911,6 +921,156 @@ mod tests {
             );
             assert!(timeout <= MEMBERSHIP_CHECK_TIMEOUT_CAP);
         }
+    }
+
+    /// Store that lets a successor complete its takeover *between* the membership
+    /// read and the heartbeat read. That window is invisible to a version
+    /// predicate: the predicate proves the beat object has not changed since it
+    /// was read, while what went stale is the membership observation that
+    /// authorised overwriting a foreign beat at all.
+    #[derive(Debug)]
+    struct TakeOverBetweenMembershipAndBeatRead {
+        inner: Arc<dyn ObjectStore>,
+        cluster: Arc<ClusterStateStore>,
+        heartbeats: Arc<SchedulerHeartbeatStore>,
+        successor: Uuid,
+        armed: std::sync::atomic::AtomicBool,
+    }
+
+    impl std::fmt::Display for TakeOverBetweenMembershipAndBeatRead {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "TakeOverBetweenMembershipAndBeatRead")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for TakeOverBetweenMembershipAndBeatRead {
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            let result = self.inner.get_opts(location, options).await;
+            // Fire once, after the membership read has been answered: the caller
+            // now holds a `ConfirmedSelf` observation that is already obsolete.
+            if location.as_ref().contains("cluster.json")
+                && self.armed.swap(false, std::sync::atomic::Ordering::Relaxed)
+            {
+                self.cluster
+                    .mutate(|state| {
+                        if let Some(entry) = state.schedulers.get_mut("test:50051") {
+                            entry.instance_id = self.successor;
+                            entry.started_at_ms = 50_000;
+                        }
+                        MutationOutcome::Apply
+                    })
+                    .await
+                    .expect("successor claims membership");
+                self.heartbeats
+                    .heartbeat("test:50051", self.successor, 60_000, 30_000)
+                    .await
+                    .expect("successor beat");
+            }
+            result
+        }
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<
+                'static,
+                object_store::Result<object_store::path::Path>,
+            >,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
+        {
+            self.inner.delete_stream(locations)
+        }
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// A membership observation authorising the overwrite of a foreign beat can be
+    /// obsolete by the time the beat is read. A version predicate does not cover
+    /// that window, so the overwrite must be re-authorised against a fresh read.
+    #[tokio::test]
+    async fn a_successor_registering_before_the_beat_read_is_not_clobbered() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        // The takeover the wrapper performs must not re-enter the wrapper, so it
+        // acts through stores bound directly to the un-wrapped object store.
+        let inner_cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let inner_heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&inner), ""));
+        let successor = Uuid::new_v4();
+        let wrapper = Arc::new(TakeOverBetweenMembershipAndBeatRead {
+            inner: Arc::clone(&inner),
+            cluster: Arc::clone(&inner_cluster),
+            heartbeats: Arc::clone(&inner_heartbeats),
+            successor,
+            armed: std::sync::atomic::AtomicBool::new(false),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
+        // The runner reads membership *through* the wrapper, which is what lets
+        // the successor land between its membership read and its beat read.
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        inner_cluster.bootstrap().await.expect("bootstrap");
+
+        let instance_id = Uuid::new_v4();
+        let runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
+        runner.register_self().await.expect("register");
+
+        wrapper
+            .armed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        runner
+            .send_heartbeat()
+            .await
+            .expect("losing the id mid-tick must not fail the loop");
+
+        let beat = inner_heartbeats
+            .read("test:50051")
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(
+            beat.instance_id, successor,
+            "a successor that registered before the beat was read must not be clobbered"
+        );
+        assert!(
+            runner.superseded.load(Ordering::Relaxed),
+            "the fresh membership read proves supersession, which must be sticky"
+        );
     }
 
     /// Store whose heartbeat *reads* fail on demand while writes keep working —

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -23,6 +23,7 @@ limitations under the License.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use app::spicepod::component::runtime::Scheduler as SchedulerConfig;
@@ -36,13 +37,19 @@ use uuid::Uuid;
 
 use crate::Runtime;
 use crate::cluster::cluster_state::{
-    self, ClusterStateStore, MutateError, MutationOutcome, SchedulerEntry,
+    self, ClusterStateStore, MutateError, MutateOk, MutationOutcome, SchedulerEntry,
 };
 use crate::cluster::heartbeat::{self, CLOCK_SKEW_TOLERANCE_MS, SchedulerHeartbeatStore};
 use crate::cluster::reaper::Reaper;
 use runtime_metrics::cluster as cluster_metrics;
 
 const DEFAULT_TTL_MS: u64 = 30_000;
+
+/// Deadline for the membership read that gates a heartbeat. Must stay well
+/// below the heartbeat interval (`ttl / HEARTBEAT_DIVISOR`) so a slow store
+/// cannot delay a beat far enough for peers to consider this scheduler dead.
+/// `membership_check_timeout_is_below_the_heartbeat_interval` pins that.
+const MEMBERSHIP_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
 const DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
 const JOB_RECOVERY_INTERVAL: Duration = Duration::from_secs(10);
 const HEARTBEAT_DIVISOR: u64 = 3;
@@ -82,6 +89,10 @@ struct SchedulerRegistryRunner {
     entry: SchedulerEntry,
     peers: Arc<RwLock<SchedulerPeers>>,
     job_executor: Arc<crate::jobs::JobExecutor>,
+    /// Set once this incarnation has been *definitively* observed as
+    /// superseded. Sticky, so a later failed read cannot resume claiming the
+    /// heartbeat key.
+    superseded: Arc<AtomicBool>,
 }
 
 pub async fn start_scheduler_registry(
@@ -154,6 +165,7 @@ pub async fn start_scheduler_registry(
         entry,
         peers,
         job_executor,
+        superseded: Arc::new(AtomicBool::new(false)),
     };
 
     runner.run(cancel).await
@@ -340,6 +352,74 @@ impl SchedulerRegistryRunner {
     }
 
     async fn send_heartbeat(&self) -> Result<()> {
+        // `scheduler_id` is `{advertise_host}:{port}` and so is stable across
+        // restarts, while `instance_id` is per-process. Two incarnations can
+        // therefore share the heartbeat key, and registration deliberately
+        // lets a new one take over once the old looks stale. An incarnation
+        // that has been superseded must stop claiming the id: otherwise it
+        // keeps overwriting the key with its own `instance_id`, `list_alive`
+        // filters the *registered* incarnation out as an orphan, and peers
+        // re-drive jobs it is still running.
+
+        if self.superseded.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
+        // Only a *successful* read is evidence of supersession. Heartbeats
+        // deliberately live outside `cluster.json` so the high-frequency write
+        // path does not depend on that document; making emission conditional
+        // on reading it would mean a slow or failing GET silently suppresses
+        // beats and self-evicts a healthy scheduler — producing exactly the
+        // false-dead job re-drive this change exists to prevent. So fail open
+        // on a read error and only decline on a definitive observation.
+        // Bound the read. Failing open covers an *erroring* store, but a hung
+        // or very slow GET would block this loop before the heartbeat write,
+        // and once that exceeds the TTL peers reap this healthy scheduler and
+        // re-drive its jobs — the exact failure the fail-open behaviour exists
+        // to prevent. A timeout is treated exactly like an error: heartbeat
+        // anyway.
+        let membership =
+            match tokio::time::timeout(MEMBERSHIP_CHECK_TIMEOUT, self.cluster.read()).await {
+                Ok(result) => result,
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        scheduler_id = %self.scheduler_id,
+                        timeout_ms = MEMBERSHIP_CHECK_TIMEOUT.as_millis(),
+                        "Timed out confirming cluster membership; heartbeating anyway"
+                    );
+                    return self.write_heartbeat().await;
+                }
+            };
+        match membership {
+            Ok(state) => {
+                let registered = state
+                    .schedulers
+                    .get(&self.scheduler_id)
+                    .map(|entry| entry.instance_id);
+                if registered != Some(self.instance_id) {
+                    self.superseded.store(true, Ordering::Relaxed);
+                    tracing::warn!(
+                        scheduler_id = %self.scheduler_id,
+                        instance_id = %self.instance_id,
+                        registered = ?registered,
+                        "This scheduler incarnation is no longer registered; it will stop heartbeating"
+                    );
+                    return Ok(());
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    scheduler_id = %self.scheduler_id,
+                    error = %err,
+                    "Could not confirm cluster membership; heartbeating anyway"
+                );
+            }
+        }
+
+        self.write_heartbeat().await
+    }
+
+    async fn write_heartbeat(&self) -> Result<()> {
         let now = now_ms()?;
         self.heartbeats
             .heartbeat(&self.scheduler_id, self.instance_id, now, self.entry.ttl_ms)
@@ -383,7 +463,7 @@ impl SchedulerRegistryRunner {
     async fn shutdown(&self) {
         let scheduler_id = self.scheduler_id.clone();
         let instance_id = self.instance_id;
-        if let Err(err) = self
+        let owned_the_entry = match self
             .cluster
             .mutate(|state| match state.schedulers.get(&scheduler_id) {
                 Some(entry) if entry.instance_id == instance_id => {
@@ -394,10 +474,34 @@ impl SchedulerRegistryRunner {
             })
             .await
         {
-            tracing::warn!("Failed to remove scheduler entry on shutdown: {err}");
-        }
-        if let Err(err) = self.heartbeats.delete(&self.scheduler_id).await {
-            tracing::warn!("Failed to delete heartbeat on shutdown: {err}");
+            Ok(MutateOk::Committed) => true,
+            // We were not the registered incarnation, so the id — and the
+            // heartbeat object under it — belongs to someone else now.
+            Ok(MutateOk::AlreadySatisfied) => false,
+            Err(err) => {
+                tracing::warn!("Failed to remove scheduler entry on shutdown: {err}");
+                false
+            }
+        };
+
+        // The heartbeat object is keyed by scheduler id alone, so a superseded
+        // incarnation deleting it would remove the *successor's* liveness and
+        // make it look orphaned until its next tick — the same false-orphan
+        // window this change exists to close. The object store has no
+        // conditional delete, so only delete when we just removed our own
+        // membership entry, which proves we still owned the id. Otherwise
+        // leave it: with our entry gone the stale object is inert, and it is
+        // overwritten by whoever owns the id next.
+        if owned_the_entry {
+            if let Err(err) = self.heartbeats.delete(&self.scheduler_id).await {
+                tracing::warn!("Failed to delete heartbeat on shutdown: {err}");
+            }
+        } else {
+            tracing::debug!(
+                scheduler_id = %self.scheduler_id,
+                instance_id = %self.instance_id,
+                "Not deleting the heartbeat: this incarnation no longer owns the scheduler id"
+            );
         }
     }
 }
@@ -445,6 +549,7 @@ mod tests {
     use crate::dataaccelerator::AcceleratorEngineRegistry;
     use crate::datafusion::builder::DataFusionBuilder;
     use crate::status;
+    use object_store::ObjectStoreExt;
     use object_store::memory::InMemory;
 
     #[tokio::test]
@@ -486,6 +591,7 @@ mod tests {
             entry,
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
+            superseded: Arc::new(AtomicBool::new(false)),
         };
         runner.register_self().await.expect("register");
 
@@ -499,5 +605,268 @@ mod tests {
         assert!(!snap.schedulers.contains_key("test:50051"));
         let beat = heartbeats.read("test:50051").await.expect("read hb");
         assert!(beat.is_none());
+    }
+
+    /// A superseded incarnation must stop claiming the shared heartbeat key.
+    /// `scheduler_id` is stable across restarts, so without this an old
+    /// process keeps overwriting the key with its own `instance_id`,
+    /// `list_alive` filters the registered incarnation out as an orphan, and
+    /// peers re-drive jobs it is still running.
+    #[tokio::test]
+    async fn a_superseded_incarnation_stops_heartbeating() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+
+        let instance_id = Uuid::new_v4();
+        let successor = Uuid::new_v4();
+        let entry = SchedulerEntry {
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            advertise_address: "test:50051".to_string(),
+            grpc_address: "test:50051".to_string(),
+            http_address: "test:8090".to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        };
+        let job_store = crate::jobs::JobStore::new(Arc::clone(&store), "", instance_id.to_string());
+        let df = DataFusionBuilder::new(
+            status::RuntimeStatus::new(),
+            Arc::new(AcceleratorEngineRegistry::default()),
+            Handle::current(),
+        )
+        .build();
+        let job_executor = Arc::new(crate::jobs::JobExecutor::new(
+            Arc::new(job_store),
+            Arc::new(df),
+        ));
+        let runner = SchedulerRegistryRunner {
+            cluster: Arc::clone(&cluster),
+            heartbeats: Arc::clone(&heartbeats),
+            reaper: Reaper::new(Arc::clone(&cluster), Arc::clone(&heartbeats)),
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            entry: entry.clone(),
+            peers: Arc::new(RwLock::new(HashMap::new())),
+            job_executor,
+            superseded: Arc::new(AtomicBool::new(false)),
+        };
+        runner.register_self().await.expect("register");
+
+        // A successor takes the id over, as registration allows once the old
+        // incarnation looks stale.
+        let mut successor_entry = entry;
+        successor_entry.instance_id = successor;
+        cluster
+            .mutate(|state| {
+                state
+                    .schedulers
+                    .insert("test:50051".to_string(), successor_entry.clone());
+                MutationOutcome::Apply
+            })
+            .await
+            .expect("successor takes over");
+        heartbeats
+            .heartbeat("test:50051", successor, 10_000, 30_000)
+            .await
+            .expect("successor heartbeat");
+
+        // The superseded runner must now decline to write.
+        runner.send_heartbeat().await.expect("send_heartbeat");
+
+        let beat = heartbeats
+            .read("test:50051")
+            .await
+            .expect("read hb")
+            .expect("heartbeat present");
+        assert_eq!(
+            beat.instance_id, successor,
+            "a superseded incarnation must not overwrite the registered one's heartbeat"
+        );
+        assert_eq!(beat.last_heartbeat_ms, 10_000);
+
+        // The decision is sticky. Make the next cluster read fail outright and
+        // heartbeat again: fail-open would otherwise write, so this is what
+        // actually proves the guard — asserting the flag alone would pass even
+        // with the guard removed.
+        store
+            .delete(&object_store::path::Path::from("cluster.json"))
+            .await
+            .expect("remove cluster state so the next read fails");
+        runner
+            .send_heartbeat()
+            .await
+            .expect("send_heartbeat after supersession");
+
+        let beat = heartbeats
+            .read("test:50051")
+            .await
+            .expect("read hb")
+            .expect("heartbeat present");
+        assert_eq!(
+            beat.instance_id, successor,
+            "a later failed read must not let a superseded incarnation resume claiming the key"
+        );
+        assert_eq!(beat.last_heartbeat_ms, 10_000);
+        assert!(runner.superseded.load(Ordering::Relaxed));
+    }
+
+    /// The membership read is on the heartbeat path, so its deadline must be
+    /// comfortably inside one heartbeat interval — otherwise a slow store
+    /// delays beats far enough for peers to reap a healthy scheduler.
+    #[test]
+    fn membership_check_timeout_is_below_the_heartbeat_interval() {
+        let interval = Duration::from_millis(DEFAULT_TTL_MS.saturating_div(HEARTBEAT_DIVISOR));
+        assert!(
+            MEMBERSHIP_CHECK_TIMEOUT * 2 <= interval,
+            "membership read deadline {MEMBERSHIP_CHECK_TIMEOUT:?} leaves too little room in a {interval:?} heartbeat interval"
+        );
+    }
+
+    /// A superseded incarnation must not delete the heartbeat key on the way
+    /// out: the key is shared, so deleting it removes the *successor's*
+    /// liveness and makes it look orphaned until its next tick.
+    #[tokio::test]
+    async fn a_superseded_incarnation_does_not_delete_the_successors_heartbeat() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+
+        let instance_id = Uuid::new_v4();
+        let successor = Uuid::new_v4();
+        let entry = SchedulerEntry {
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            advertise_address: "test:50051".to_string(),
+            grpc_address: "test:50051".to_string(),
+            http_address: "test:8090".to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        };
+        let job_store = crate::jobs::JobStore::new(Arc::clone(&store), "", instance_id.to_string());
+        let df = DataFusionBuilder::new(
+            status::RuntimeStatus::new(),
+            Arc::new(AcceleratorEngineRegistry::default()),
+            Handle::current(),
+        )
+        .build();
+        let job_executor = Arc::new(crate::jobs::JobExecutor::new(
+            Arc::new(job_store),
+            Arc::new(df),
+        ));
+        let runner = SchedulerRegistryRunner {
+            cluster: Arc::clone(&cluster),
+            heartbeats: Arc::clone(&heartbeats),
+            reaper: Reaper::new(Arc::clone(&cluster), Arc::clone(&heartbeats)),
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            entry: entry.clone(),
+            peers: Arc::new(RwLock::new(HashMap::new())),
+            job_executor,
+            superseded: Arc::new(AtomicBool::new(false)),
+        };
+        runner.register_self().await.expect("register");
+
+        // A successor takes the id over and publishes its own liveness.
+        let mut successor_entry = entry;
+        successor_entry.instance_id = successor;
+        cluster
+            .mutate(|state| {
+                state
+                    .schedulers
+                    .insert("test:50051".to_string(), successor_entry.clone());
+                MutationOutcome::Apply
+            })
+            .await
+            .expect("successor takes over");
+        heartbeats
+            .heartbeat("test:50051", successor, 10_000, 30_000)
+            .await
+            .expect("successor heartbeat");
+
+        runner.shutdown().await;
+
+        let beat = heartbeats
+            .read("test:50051")
+            .await
+            .expect("read hb")
+            .expect("the successor's heartbeat must survive the old incarnation's shutdown");
+        assert_eq!(beat.instance_id, successor);
+        let snap = cluster.read().await.expect("read");
+        assert_eq!(
+            snap.schedulers.get("test:50051").map(|e| e.instance_id),
+            Some(successor),
+            "shutdown must not remove the successor's membership entry"
+        );
+    }
+
+    /// Heartbeats deliberately live outside `cluster.json`. Gating them on a
+    /// read of that document must fail OPEN: a slow or failing GET is not
+    /// evidence of supersession, and suppressing the beat would let peers reap
+    /// a healthy scheduler and re-drive its jobs.
+    #[tokio::test]
+    async fn a_failed_cluster_read_does_not_suppress_the_heartbeat() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        // Deliberately NOT bootstrapped: `cluster.read()` fails, standing in
+        // for a timed-out or erroring GET of the cluster document.
+
+        let instance_id = Uuid::new_v4();
+        let entry = SchedulerEntry {
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            advertise_address: "test:50051".to_string(),
+            grpc_address: "test:50051".to_string(),
+            http_address: "test:8090".to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        };
+        let job_store = crate::jobs::JobStore::new(Arc::clone(&store), "", instance_id.to_string());
+        let df = DataFusionBuilder::new(
+            status::RuntimeStatus::new(),
+            Arc::new(AcceleratorEngineRegistry::default()),
+            Handle::current(),
+        )
+        .build();
+        let job_executor = Arc::new(crate::jobs::JobExecutor::new(
+            Arc::new(job_store),
+            Arc::new(df),
+        ));
+        let runner = SchedulerRegistryRunner {
+            cluster: Arc::clone(&cluster),
+            heartbeats: Arc::clone(&heartbeats),
+            reaper: Reaper::new(Arc::clone(&cluster), Arc::clone(&heartbeats)),
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            entry,
+            peers: Arc::new(RwLock::new(HashMap::new())),
+            job_executor,
+            superseded: Arc::new(AtomicBool::new(false)),
+        };
+
+        runner
+            .send_heartbeat()
+            .await
+            .expect("a failed cluster read must not fail the heartbeat");
+
+        let beat = heartbeats
+            .read("test:50051")
+            .await
+            .expect("read hb")
+            .expect("heartbeat must still have been written");
+        assert_eq!(beat.instance_id, instance_id);
+        assert!(
+            !runner.superseded.load(Ordering::Relaxed),
+            "a read failure is not evidence of supersession"
+        );
     }
 }

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -61,19 +61,6 @@ fn membership_check_timeout(ttl_ms: u64) -> Duration {
     (interval / 2).min(MEMBERSHIP_CHECK_TIMEOUT_CAP)
 }
 
-/// Deadline for one whole heartbeat tick.
-///
-/// Individual reads have their own deadlines, but a tick can perform several of
-/// them — a membership read, then per retry a beat read, an ownership
-/// re-confirmation, and a post-conflict re-read — and bounding each one says
-/// nothing about their sum. Against a uniformly slow store those deadlines stack
-/// into far more than one interval, which delays every other duty on the same
-/// task and, for a short TTL, can exceed the TTL itself while the scheduler is
-/// healthy. Capping the tick at one interval means a slow tick can postpone the
-/// next beat by at most one slot, and the staleness tolerance absorbs that.
-fn heartbeat_tick_budget(ttl_ms: u64) -> Duration {
-    Duration::from_millis(ttl_ms.saturating_div(HEARTBEAT_DIVISOR).max(1))
-}
 const DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
 const JOB_RECOVERY_INTERVAL: Duration = Duration::from_secs(10);
 const HEARTBEAT_DIVISOR: u64 = 3;
@@ -81,7 +68,7 @@ const HEARTBEAT_DIVISOR: u64 = 3;
 /// Compare-and-set attempts for one heartbeat before skipping this beat.
 /// Contention means another incarnation is writing the same key, which is
 /// resolved by re-reading membership rather than by writing harder.
-const MAX_HEARTBEAT_CAS_ATTEMPTS: usize = 3;
+const MAX_HEARTBEAT_CAS_ATTEMPTS: usize = 2;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -321,9 +308,11 @@ impl SchedulerRegistryRunner {
     async fn register_self(&self) -> Result<()> {
         let observed = self
             .heartbeats
-            .read(&self.scheduler_id)
+            .read_versioned(&self.scheduler_id)
             .await
             .context(HeartbeatSnafu)?;
+        let observed_version = observed.as_ref().map(|(_, version)| version.clone());
+        let observed_beat = observed.and_then(|(beat, _)| beat);
 
         let entry = self.entry.clone();
         let scheduler_id = self.scheduler_id.clone();
@@ -351,7 +340,7 @@ impl SchedulerRegistryRunner {
                     // successor's beat would let a third incarnation evict that
                     // live successor. Recovery is then delayed by at most the
                     // TTL it takes the foreign beat to go stale.
-                    let stale_or_missing = match observed.as_ref() {
+                    let stale_or_missing = match observed_beat.as_ref() {
                         Some(beat) if beat.instance_id == existing.instance_id => {
                             beat.is_stale(now)
                         }
@@ -393,17 +382,47 @@ impl SchedulerRegistryRunner {
             Err(other) => return Err(Error::ClusterState { source: other }),
         }
 
-        // Write our first heartbeat so peers see liveness on next discovery, and
-        // keep its version: without it, an incarnation whose reads fail from
-        // birth would have nothing to condition on and would skip every beat
-        // until it was reaped, which the unconditional write never did.
-        let version = self
+        // Write our first heartbeat so peers see liveness on next discovery. This
+        // write is conditional on the beat observed above, like every other
+        // heartbeat write: registration commits membership first, and if this
+        // task stalls in between, a successor can register and publish its own
+        // beat — an unconditional seed would replace it and recreate exactly the
+        // false-orphan window this guards against.
+        //
+        // Its version is retained, because without one an incarnation whose reads
+        // fail from birth would have nothing to condition on and would skip every
+        // beat until it was reaped.
+        match self
             .heartbeats
-            .heartbeat(&self.scheduler_id, self.instance_id, now, self.entry.ttl_ms)
+            .heartbeat_if_unchanged(
+                &self.scheduler_id,
+                self.instance_id,
+                now,
+                self.entry.ttl_ms,
+                observed_version.as_ref(),
+            )
             .await
-            .context(HeartbeatSnafu)?;
-        self.last_written_version.store(version.map(Arc::new));
-        Ok(())
+        {
+            Ok(version) => {
+                self.last_written_version.store(version.map(Arc::new));
+                Ok(())
+            }
+            // Someone wrote the key between the observation and this seed. Leave
+            // it alone: membership already names this incarnation, so the first
+            // heartbeat tick reclaims the key legitimately once it can read the
+            // beat and re-confirm ownership. Liveness is delayed by at most one
+            // interval, where overwriting could silence a live successor.
+            Err(heartbeat::Error::HeartbeatSupersededDuringWrite { .. }) => {
+                self.last_written_version.store(None);
+                tracing::warn!(
+                    scheduler_id = %self.scheduler_id,
+                    instance_id = %self.instance_id,
+                    "Heartbeat changed while registering; leaving it for the first beat to reconcile"
+                );
+                Ok(())
+            }
+            Err(source) => Err(Error::Heartbeat { source }),
+        }
     }
 
     async fn send_heartbeat(&self) -> Result<()> {
@@ -419,22 +438,6 @@ impl SchedulerRegistryRunner {
             return Ok(());
         }
 
-        let budget = heartbeat_tick_budget(self.entry.ttl_ms);
-        match tokio::time::timeout(budget, self.heartbeat_tick()).await {
-            Ok(result) => result,
-            Err(_elapsed) => {
-                tracing::warn!(
-                    scheduler_id = %self.scheduler_id,
-                    budget_ms = budget.as_millis(),
-                    "Heartbeat tick exceeded its budget; skipping this beat"
-                );
-                Ok(())
-            }
-        }
-    }
-
-    /// One heartbeat tick, run under the deadline imposed by `send_heartbeat`.
-    async fn heartbeat_tick(&self) -> Result<()> {
         match self.read_membership().await {
             Some(false) => {
                 // A successful read proved someone else owns the id. Retire.
@@ -586,6 +589,23 @@ impl SchedulerRegistryRunner {
             {
                 Ok(version) => {
                     self.last_written_version.store(version.map(Arc::new));
+                    return Ok(());
+                }
+                Err(heartbeat::Error::HeartbeatSupersededDuringWrite { .. }) if from_cache => {
+                    // The predicate came from this incarnation's own last write,
+                    // not from a read of the current object. A failed precondition
+                    // therefore does not prove someone else took the key: an
+                    // earlier write of ours may have landed while its
+                    // acknowledgement was lost, moving the version. Treat the
+                    // retained version as unusable and wait for a readable beat
+                    // rather than retrying against a predicate known to be wrong,
+                    // or retiring on evidence that does not exist.
+                    self.last_written_version.store(None);
+                    tracing::warn!(
+                        scheduler_id = %self.scheduler_id,
+                        instance_id = %self.instance_id,
+                        "Heartbeat version is stale and the beat is unreadable; skipping until it can be read"
+                    );
                     return Ok(());
                 }
                 Err(heartbeat::Error::HeartbeatSupersededDuringWrite { .. }) => {
@@ -1100,127 +1120,6 @@ mod tests {
         assert!(
             runner.superseded.load(Ordering::Relaxed),
             "the fresh membership read proves supersession, which must be sticky"
-        );
-    }
-
-    /// Store whose heartbeat writes never complete. Reads carry their own
-    /// deadlines but writes do not, so this is what an unbounded tick stalls on
-    /// indefinitely.
-    #[derive(Debug)]
-    struct HangingBeatWrites {
-        inner: Arc<dyn ObjectStore>,
-        /// Set after registration, so only the tick's own write hangs.
-        armed: std::sync::atomic::AtomicBool,
-    }
-
-    impl std::fmt::Display for HangingBeatWrites {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "HangingBeatWrites")
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl ObjectStore for HangingBeatWrites {
-        async fn get_opts(
-            &self,
-            location: &object_store::path::Path,
-            options: object_store::GetOptions,
-        ) -> object_store::Result<object_store::GetResult> {
-            self.inner.get_opts(location, options).await
-        }
-        async fn put_opts(
-            &self,
-            location: &object_store::path::Path,
-            payload: object_store::PutPayload,
-            opts: object_store::PutOptions,
-        ) -> object_store::Result<object_store::PutResult> {
-            if location.as_ref().contains("heartbeats/")
-                && self.armed.load(std::sync::atomic::Ordering::Relaxed)
-            {
-                return std::future::pending().await;
-            }
-            self.inner.put_opts(location, payload, opts).await
-        }
-        async fn put_multipart_opts(
-            &self,
-            location: &object_store::path::Path,
-            opts: object_store::PutMultipartOptions,
-        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
-            self.inner.put_multipart_opts(location, opts).await
-        }
-        fn list(
-            &self,
-            prefix: Option<&object_store::path::Path>,
-        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
-        {
-            self.inner.list(prefix)
-        }
-        fn delete_stream(
-            &self,
-            locations: futures::stream::BoxStream<
-                'static,
-                object_store::Result<object_store::path::Path>,
-            >,
-        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
-        {
-            self.inner.delete_stream(locations)
-        }
-        async fn list_with_delimiter(
-            &self,
-            prefix: Option<&object_store::path::Path>,
-        ) -> object_store::Result<object_store::ListResult> {
-            self.inner.list_with_delimiter(prefix).await
-        }
-        async fn copy_opts(
-            &self,
-            from: &object_store::path::Path,
-            to: &object_store::path::Path,
-            options: object_store::CopyOptions,
-        ) -> object_store::Result<()> {
-            self.inner.copy_opts(from, to, options).await
-        }
-    }
-
-    /// Individual reads carry deadlines; the write does not. Bounding the parts
-    /// therefore says nothing about the whole, so the tick itself is bounded —
-    /// otherwise a store that accepts a write and never answers stalls the task
-    /// that also drives discovery, recovery and the reaper.
-    #[tokio::test]
-    async fn a_hanging_write_cannot_stall_a_tick_past_its_budget() {
-        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let wrapper = Arc::new(HangingBeatWrites {
-            inner: Arc::clone(&inner),
-            armed: std::sync::atomic::AtomicBool::new(false),
-        });
-        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
-        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
-        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
-        cluster.bootstrap().await.expect("bootstrap");
-
-        let instance_id = Uuid::new_v4();
-        let mut runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
-        // A short TTL keeps the test quick and is the case where an unbounded tick
-        // is most damaging: it can outlast the TTL while the scheduler is healthy.
-        runner.entry.ttl_ms = 300;
-        runner.register_self().await.expect("register");
-        // Only the tick's own write hangs; registration completed normally.
-        wrapper
-            .armed
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-
-        let budget = heartbeat_tick_budget(runner.entry.ttl_ms);
-        let started = tokio::time::Instant::now();
-        runner
-            .send_heartbeat()
-            .await
-            .expect("a hanging write must not fail the loop");
-        let elapsed = started.elapsed();
-
-        assert!(
-            elapsed < budget * 4,
-            "a tick must stay near its {}ms budget, took {}ms",
-            budget.as_millis(),
-            elapsed.as_millis()
         );
     }
 

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -739,6 +739,140 @@ mod tests {
         }
     }
 
+    /// Object store whose `get` never returns, standing in for a hung backend.
+    /// Everything else delegates to an in-memory store so the heartbeat write
+    /// under test still works.
+    #[derive(Debug)]
+    struct HangingReads(Arc<dyn ObjectStore>);
+
+    impl std::fmt::Display for HangingReads {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "HangingReads")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for HangingReads {
+        async fn get_opts(
+            &self,
+            _location: &object_store::path::Path,
+            _options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            std::future::pending().await
+        }
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            self.0.put_opts(location, payload, opts).await
+        }
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.0.put_multipart_opts(location, opts).await
+        }
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.0.list(prefix)
+        }
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<
+                'static,
+                object_store::Result<object_store::path::Path>,
+            >,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
+        {
+            self.0.delete_stream(locations)
+        }
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.0.list_with_delimiter(prefix).await
+        }
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.0.copy_opts(from, to, options).await
+        }
+    }
+
+    /// A hung membership read must not suppress the heartbeat. This is the
+    /// branch that keeps a healthy scheduler from being reaped when the store
+    /// stalls rather than errors, so it is exercised directly.
+    #[tokio::test(start_paused = true)]
+    async fn a_hung_cluster_read_does_not_suppress_the_heartbeat() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store: Arc<dyn ObjectStore> = Arc::new(HangingReads(Arc::clone(&inner)));
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+
+        let instance_id = Uuid::new_v4();
+        let entry = SchedulerEntry {
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            advertise_address: "test:50051".to_string(),
+            grpc_address: "test:50051".to_string(),
+            http_address: "test:8090".to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        };
+        let job_store = crate::jobs::JobStore::new(Arc::clone(&store), "", instance_id.to_string());
+        let df = DataFusionBuilder::new(
+            status::RuntimeStatus::new(),
+            Arc::new(AcceleratorEngineRegistry::default()),
+            Handle::current(),
+        )
+        .build();
+        let job_executor = Arc::new(crate::jobs::JobExecutor::new(
+            Arc::new(job_store),
+            Arc::new(df),
+        ));
+        let runner = SchedulerRegistryRunner {
+            cluster,
+            heartbeats: Arc::clone(&heartbeats),
+            reaper: Reaper::new(
+                Arc::new(ClusterStateStore::new(Arc::clone(&store), "")),
+                Arc::clone(&heartbeats),
+            ),
+            scheduler_id: "test:50051".to_string(),
+            instance_id,
+            entry,
+            peers: Arc::new(RwLock::new(HashMap::new())),
+            job_executor,
+            superseded: Arc::new(AtomicBool::new(false)),
+        };
+
+        // Paused time auto-advances once the read is the only pending work, so
+        // the deadline fires without a real wait.
+        runner
+            .send_heartbeat()
+            .await
+            .expect("a hung membership read must not fail the heartbeat");
+
+        let beat = inner
+            .get(&heartbeats.path_for("test:50051"))
+            .await
+            .expect("the heartbeat must still have been written");
+        let bytes = beat.bytes().await.expect("bytes");
+        let beat: crate::cluster::heartbeat::SchedulerHeartbeat =
+            serde_json::from_slice(&bytes).expect("parse");
+        assert_eq!(beat.instance_id, instance_id);
+    }
+
     /// A superseded incarnation must not delete the heartbeat key on the way
     /// out: the key is shared, so deleting it removes the *successor's*
     /// liveness and makes it look orphaned until its next tick.

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -54,6 +54,20 @@ const DEFAULT_TTL_MS: u64 = 30_000;
 /// TTL and delay a beat far enough for peers to reap a healthy scheduler.
 const MEMBERSHIP_CHECK_TIMEOUT_CAP: Duration = Duration::from_secs(2);
 
+/// Deadline for a single conditional heartbeat write.
+///
+/// Object-store clients default to request timeouts around the same order as a
+/// scheduler's TTL, so one stalled write would otherwise hold the registry task —
+/// which also drives discovery, recovery and the reaper — for a whole TTL while
+/// the last good beat ages out. Cancelling a write is safe here only because an
+/// unknown outcome clears the retained version instead of being mistaken for
+/// supersession: the next tick re-reads the beat rather than trusting a predicate
+/// that may already have been superseded by this very write.
+fn heartbeat_write_timeout(ttl_ms: u64) -> Duration {
+    let interval = Duration::from_millis(ttl_ms.saturating_div(HEARTBEAT_DIVISOR).max(1));
+    interval / 2
+}
+
 /// Deadline for the membership read that gates a heartbeat, as a fraction of
 /// that scheduler's heartbeat interval so it always fits inside one beat.
 fn membership_check_timeout(ttl_ms: u64) -> Duration {
@@ -413,13 +427,45 @@ impl SchedulerRegistryRunner {
             // beat and re-confirm ownership. Liveness is delayed by at most one
             // interval, where overwriting could silence a live successor.
             Err(heartbeat::Error::HeartbeatSupersededDuringWrite { .. }) => {
-                self.last_written_version.store(None);
-                tracing::warn!(
-                    scheduler_id = %self.scheduler_id,
-                    instance_id = %self.instance_id,
-                    "Heartbeat changed while registering; leaving it for the first beat to reconcile"
-                );
-                Ok(())
+                // The key moved between the observation and this write. Membership
+                // was just committed under OCC, so this incarnation is provably the
+                // registered owner *now* and may reclaim the key — but only against
+                // a freshly read version, so a successor that registered after this
+                // commit still wins. Leaving it unwritten instead would publish no
+                // liveness at all, and if `cluster.json` then became unreadable
+                // this incarnation could not reclaim later either.
+                let observed = self
+                    .heartbeats
+                    .read_versioned(&self.scheduler_id)
+                    .await
+                    .context(HeartbeatSnafu)?;
+                let expected = observed.as_ref().map(|(_, version)| version.clone());
+                match self
+                    .heartbeats
+                    .heartbeat_if_unchanged(
+                        &self.scheduler_id,
+                        self.instance_id,
+                        now_ms()?,
+                        self.entry.ttl_ms,
+                        expected.as_ref(),
+                    )
+                    .await
+                {
+                    Ok(version) => {
+                        self.last_written_version.store(version.map(Arc::new));
+                        Ok(())
+                    }
+                    Err(heartbeat::Error::HeartbeatSupersededDuringWrite { .. }) => {
+                        self.last_written_version.store(None);
+                        tracing::warn!(
+                            scheduler_id = %self.scheduler_id,
+                            instance_id = %self.instance_id,
+                            "Heartbeat contended twice while registering; leaving it for the first beat"
+                        );
+                        Ok(())
+                    }
+                    Err(source) => Err(Error::Heartbeat { source }),
+                }
             }
             Err(source) => Err(Error::Heartbeat { source }),
         }
@@ -438,27 +484,7 @@ impl SchedulerRegistryRunner {
             return Ok(());
         }
 
-        match self.read_membership().await {
-            Some(false) => {
-                // A successful read proved someone else owns the id. Retire.
-                self.superseded.store(true, Ordering::Relaxed);
-                tracing::warn!(
-                    scheduler_id = %self.scheduler_id,
-                    instance_id = %self.instance_id,
-                    "This scheduler incarnation is no longer registered; it will stop heartbeating"
-                );
-                Ok(())
-            }
-            // Registered, or membership unreadable. Both proceed, and for the
-            // same reason: heartbeats deliberately live outside `cluster.json`
-            // so emission does not depend on that document, and suppressing
-            // beats when it cannot be read would self-evict a healthy
-            // scheduler. Proceeding is safe because the write path re-confirms
-            // ownership against a fresh read before it will touch a beat
-            // belonging to another incarnation — this observation is not
-            // carried forward as proof of anything.
-            Some(true) | None => self.write_heartbeat().await,
-        }
+        self.write_heartbeat().await
     }
 
     /// `Some(true)` when a successful, bounded read shows this incarnation
@@ -532,61 +558,85 @@ impl SchedulerRegistryRunner {
                 },
             };
 
-            // An unparsable payload reads back as `None`: the holder is unknown,
-            // which is not evidence that it is ours, so it is treated like a
-            // foreign beat.
-            // A beat belonging to someone else — or one that cannot be parsed, so
-            // the holder is unknown — may only be reclaimed against a membership
-            // read taken *after* it was observed. The read this tick started with
-            // may predate a successor's registration, and a version predicate
-            // does not help: it proves the object has not changed since the beat
-            // was read, not that this incarnation still owns the id.
-            if !from_cache
-                && let Some((beat, _)) = observed.as_ref()
-                && beat
-                    .as_ref()
-                    .is_none_or(|beat| beat.instance_id != self.instance_id)
-            {
-                let holder = beat.as_ref().map(|b| b.instance_id);
-                match self.read_membership().await {
-                    // Freshly proven to still own the id, so reclaiming the key
-                    // is legitimate: fall through to the conditional write.
-                    Some(true) => {}
-                    Some(false) => {
-                        self.superseded.store(true, Ordering::Relaxed);
-                        tracing::warn!(
-                            scheduler_id = %self.scheduler_id,
-                            instance_id = %self.instance_id,
-                            holder = ?holder,
-                            "Another incarnation holds the heartbeat and is the registered owner; retiring"
-                        );
-                        return Ok(());
-                    }
-                    None => {
-                        tracing::warn!(
-                            scheduler_id = %self.scheduler_id,
-                            instance_id = %self.instance_id,
-                            holder = ?holder,
-                            "Another incarnation holds the heartbeat and membership is unreadable; skipping this beat"
-                        );
-                        return Ok(());
-                    }
+            // Ownership is confirmed *after* the beat was read, for every write
+            // rather than only for writes over a foreign beat. Refreshing a beat
+            // that is already ours looks safe but is not: once membership has
+            // moved to a successor, that refresh is exactly the zombie write this
+            // guards against — it keeps the key naming a superseded incarnation,
+            // so `list_alive` drops the live successor and its jobs are re-driven.
+            //
+            // A version predicate cannot substitute for this: it proves the beat
+            // object has not changed since it was read, not that this incarnation
+            // still owns the id, and ownership lives in a different object.
+            //
+            // An unparsable payload reads back as `None`, so the holder is
+            // unknown, which is not evidence that it is ours.
+            let holder = observed
+                .as_ref()
+                .and_then(|(beat, _)| beat.as_ref())
+                .map(|beat| beat.instance_id);
+            let ours = holder == Some(self.instance_id);
+            // No object at all is different from an object whose holder cannot be
+            // determined: the write is then a create, which fails outright if a
+            // successor got there first, so it cannot displace anyone.
+            let absent = observed.is_none();
+            match self.read_membership().await {
+                Some(true) => {}
+                Some(false) => {
+                    self.superseded.store(true, Ordering::Relaxed);
+                    tracing::warn!(
+                        scheduler_id = %self.scheduler_id,
+                        instance_id = %self.instance_id,
+                        holder = ?holder,
+                        "The registered incarnation is someone else; retiring instead of writing"
+                    );
+                    return Ok(());
+                }
+                // Membership is unreadable. Refreshing a beat that is already
+                // ours — or creating one where there is none — still fails open,
+                // because suppressing beats on an unreadable `cluster.json` would
+                // self-evict a healthy scheduler, and heartbeats deliberately do
+                // not depend on that document. A beat that exists but is not
+                // provably ours is left alone: claiming it would assert ownership
+                // that cannot be shown.
+                None if ours || from_cache || absent => {}
+                None => {
+                    tracing::warn!(
+                        scheduler_id = %self.scheduler_id,
+                        instance_id = %self.instance_id,
+                        holder = ?holder,
+                        "Another incarnation holds the heartbeat and membership is unreadable; skipping this beat"
+                    );
+                    return Ok(());
                 }
             }
 
             let expected = observed.as_ref().map(|(_, version)| version.clone());
             let now = now_ms()?;
-            match self
-                .heartbeats
-                .heartbeat_if_unchanged(
+            let write_timeout = heartbeat_write_timeout(self.entry.ttl_ms);
+            let written = tokio::time::timeout(
+                write_timeout,
+                self.heartbeats.heartbeat_if_unchanged(
                     &self.scheduler_id,
                     self.instance_id,
                     now,
                     self.entry.ttl_ms,
                     expected.as_ref(),
-                )
-                .await
-            {
+                ),
+            )
+            .await;
+            let Ok(written) = written else {
+                // The write may or may not have landed, so the retained version
+                // can no longer be trusted as a predicate.
+                self.last_written_version.store(None);
+                tracing::warn!(
+                    scheduler_id = %self.scheduler_id,
+                    timeout_ms = write_timeout.as_millis(),
+                    "Heartbeat write did not complete in time; its outcome is unknown"
+                );
+                return Ok(());
+            };
+            match written {
                 Ok(version) => {
                     self.last_written_version.store(version.map(Arc::new));
                     return Ok(());
@@ -1120,6 +1170,255 @@ mod tests {
         assert!(
             runner.superseded.load(Ordering::Relaxed),
             "the fresh membership read proves supersession, which must be sticky"
+        );
+    }
+
+    /// Store whose heartbeat writes hang once armed. Object-store clients default
+    /// to request timeouts on the order of a scheduler TTL, so this is the shape
+    /// that would otherwise hold the registry task for a whole TTL.
+    #[derive(Debug)]
+    struct StallingBeatWrites {
+        inner: Arc<dyn ObjectStore>,
+        armed: std::sync::atomic::AtomicBool,
+    }
+
+    impl std::fmt::Display for StallingBeatWrites {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "StallingBeatWrites")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for StallingBeatWrites {
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            if location.as_ref().contains("heartbeats/")
+                && self.armed.load(std::sync::atomic::Ordering::Relaxed)
+            {
+                return std::future::pending().await;
+            }
+            self.inner.put_opts(location, payload, opts).await
+        }
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<
+                'static,
+                object_store::Result<object_store::path::Path>,
+            >,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
+        {
+            self.inner.delete_stream(locations)
+        }
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// A stalled write must not hold the registry task — which also drives
+    /// discovery, recovery and the reaper — for anything like a TTL, and because
+    /// its outcome is unknown it must not leave a predicate behind that the next
+    /// tick would trust.
+    #[tokio::test]
+    async fn a_stalled_write_is_bounded_and_discards_its_predicate() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wrapper = Arc::new(StallingBeatWrites {
+            inner: Arc::clone(&inner),
+            armed: std::sync::atomic::AtomicBool::new(false),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+
+        let instance_id = Uuid::new_v4();
+        let mut runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
+        // Short TTL: the write deadline scales with it, keeping the test quick.
+        runner.entry.ttl_ms = 600;
+        runner.register_self().await.expect("register");
+        assert!(
+            runner.last_written_version.load_full().is_some(),
+            "registration must retain the version it wrote"
+        );
+
+        wrapper
+            .armed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let deadline = heartbeat_write_timeout(runner.entry.ttl_ms);
+        let started = tokio::time::Instant::now();
+        runner
+            .send_heartbeat()
+            .await
+            .expect("a stalled write must not fail the loop");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < deadline * 4,
+            "a stalled write must be bounded near its {}ms deadline, took {}ms",
+            deadline.as_millis(),
+            elapsed.as_millis()
+        );
+        assert!(
+            runner.last_written_version.load_full().is_none(),
+            "a write whose outcome is unknown must not leave a predicate behind"
+        );
+    }
+
+    /// Store that writes a foreign beat once, just before the caller's own write
+    /// lands, so a conditional write finds the key changed under it.
+    #[derive(Debug)]
+    struct StealKeyBeforeWrite {
+        inner: Arc<dyn ObjectStore>,
+        thief: Uuid,
+        armed: std::sync::atomic::AtomicBool,
+    }
+
+    impl std::fmt::Display for StealKeyBeforeWrite {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "StealKeyBeforeWrite")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for StealKeyBeforeWrite {
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            if location.as_ref().contains("heartbeats/")
+                && self.armed.swap(false, std::sync::atomic::Ordering::Relaxed)
+            {
+                let beat = crate::cluster::heartbeat::SchedulerHeartbeat {
+                    scheduler_id: "test:50051".to_string(),
+                    instance_id: self.thief,
+                    last_heartbeat_ms: 5_000,
+                    ttl_ms: 30_000,
+                };
+                self.inner
+                    .put_opts(
+                        location,
+                        serde_json::to_vec(&beat).expect("serialize").into(),
+                        object_store::PutOptions::from(object_store::PutMode::Overwrite),
+                    )
+                    .await?;
+            }
+            self.inner.put_opts(location, payload, opts).await
+        }
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<
+                'static,
+                object_store::Result<object_store::path::Path>,
+            >,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
+        {
+            self.inner.delete_stream(locations)
+        }
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// A seed write that loses its race must not leave the registered incarnation
+    /// with no liveness at all: membership was just committed under OCC, so it may
+    /// reclaim the key against a freshly read version. Leaving it unwritten would
+    /// also strand it if `cluster.json` became unreadable afterwards.
+    #[tokio::test]
+    async fn a_contended_seed_write_still_publishes_liveness() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let thief = Uuid::new_v4();
+        let wrapper = Arc::new(StealKeyBeforeWrite {
+            inner: Arc::clone(&inner),
+            thief,
+            armed: std::sync::atomic::AtomicBool::new(true),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+        let observer = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&inner), ""));
+
+        let instance_id = Uuid::new_v4();
+        let runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
+        runner.register_self().await.expect("register");
+
+        let beat = observer
+            .read("test:50051")
+            .await
+            .expect("read")
+            .expect("a registered incarnation must publish a heartbeat");
+        assert_eq!(
+            beat.instance_id, instance_id,
+            "the registered incarnation must reclaim the key it just won"
         );
     }
 

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -65,14 +65,27 @@ const MEMBERSHIP_CHECK_TIMEOUT_CAP: Duration = Duration::from_secs(2);
 /// that may already have been superseded by this very write.
 fn heartbeat_write_timeout(ttl_ms: u64) -> Duration {
     let interval = Duration::from_millis(ttl_ms.saturating_div(HEARTBEAT_DIVISOR).max(1));
-    interval / 2
+    interval / 3
 }
 
 /// Deadline for the membership read that gates a heartbeat, as a fraction of
 /// that scheduler's heartbeat interval so it always fits inside one beat.
 fn membership_check_timeout(ttl_ms: u64) -> Duration {
     let interval = Duration::from_millis(ttl_ms.saturating_div(HEARTBEAT_DIVISOR).max(1));
-    (interval / 2).min(MEMBERSHIP_CHECK_TIMEOUT_CAP)
+    (interval / 6).min(MEMBERSHIP_CHECK_TIMEOUT_CAP)
+}
+
+/// Worst case wall time for one heartbeat tick, from the deadlines above:
+/// `MAX_HEARTBEAT_CAS_ATTEMPTS` x (beat read + ownership read + write + the
+/// ownership read after a write conflict). The fractions are chosen so this stays
+/// below the TTL for *any* `ttl_ms`, because a tick that can outlast the TTL
+/// starves the beats it exists to publish — and it also blocks discovery,
+/// recovery and the reaper, which share the task.
+#[cfg(test)]
+fn worst_case_tick(ttl_ms: u64) -> Duration {
+    let reads = membership_check_timeout(ttl_ms) * 3;
+    let write = heartbeat_write_timeout(ttl_ms);
+    (reads + write) * u32::try_from(MAX_HEARTBEAT_CAS_ATTEMPTS).unwrap_or(u32::MAX)
 }
 
 const DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
@@ -406,17 +419,7 @@ impl SchedulerRegistryRunner {
         // Its version is retained, because without one an incarnation whose reads
         // fail from birth would have nothing to condition on and would skip every
         // beat until it was reaped.
-        match self
-            .heartbeats
-            .heartbeat_if_unchanged(
-                &self.scheduler_id,
-                self.instance_id,
-                now,
-                self.entry.ttl_ms,
-                observed_version.as_ref(),
-            )
-            .await
-        {
+        match self.write_seed_beat(observed_version.as_ref()).await {
             Ok(version) => {
                 self.last_written_version.store(version.map(Arc::new));
                 Ok(())
@@ -439,18 +442,36 @@ impl SchedulerRegistryRunner {
                     .read_versioned(&self.scheduler_id)
                     .await
                     .context(HeartbeatSnafu)?;
+                // A fresh *version* is not a fresh ownership proof. Between this
+                // incarnation's membership commit and this point, a successor can
+                // have committed membership and published its own beat; writing
+                // against that beat's version would replace a live successor. So
+                // ownership is re-confirmed here, exactly as the heartbeat path
+                // does before touching a beat it does not hold.
+                match self.read_membership().await {
+                    Some(true) => {}
+                    Some(false) => {
+                        self.superseded.store(true, Ordering::Relaxed);
+                        self.last_written_version.store(None);
+                        tracing::warn!(
+                            scheduler_id = %self.scheduler_id,
+                            instance_id = %self.instance_id,
+                            "Lost the registration to another incarnation while seeding; retiring"
+                        );
+                        return Ok(());
+                    }
+                    None => {
+                        self.last_written_version.store(None);
+                        tracing::warn!(
+                            scheduler_id = %self.scheduler_id,
+                            instance_id = %self.instance_id,
+                            "Cannot re-confirm ownership while seeding; leaving the heartbeat alone"
+                        );
+                        return Ok(());
+                    }
+                }
                 let expected = observed.as_ref().map(|(_, version)| version.clone());
-                match self
-                    .heartbeats
-                    .heartbeat_if_unchanged(
-                        &self.scheduler_id,
-                        self.instance_id,
-                        now_ms()?,
-                        self.entry.ttl_ms,
-                        expected.as_ref(),
-                    )
-                    .await
-                {
+                match self.write_seed_beat(expected.as_ref()).await {
                     Ok(version) => {
                         self.last_written_version.store(version.map(Arc::new));
                         Ok(())
@@ -468,6 +489,38 @@ impl SchedulerRegistryRunner {
                 }
             }
             Err(source) => Err(Error::Heartbeat { source }),
+        }
+    }
+
+    /// A registration heartbeat write, bounded like the loop's writes: an
+    /// unbounded put here can outlast the grace period that lets another
+    /// incarnation take the id over, which is worse than publishing late.
+    async fn write_seed_beat(
+        &self,
+        expected: Option<&UpdateVersion>,
+    ) -> std::result::Result<Option<UpdateVersion>, heartbeat::Error> {
+        let write_timeout = heartbeat_write_timeout(self.entry.ttl_ms);
+        match tokio::time::timeout(
+            write_timeout,
+            self.heartbeats.heartbeat_if_unchanged(
+                &self.scheduler_id,
+                self.instance_id,
+                now_ms().unwrap_or_default(),
+                self.entry.ttl_ms,
+                expected,
+            ),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                tracing::warn!(
+                    scheduler_id = %self.scheduler_id,
+                    timeout_ms = write_timeout.as_millis(),
+                    "Registration heartbeat write did not complete in time"
+                );
+                Ok(None)
+            }
         }
     }
 
@@ -1173,6 +1226,77 @@ mod tests {
         );
     }
 
+    /// Reclaiming a contended seed is authorised by the membership commit that
+    /// preceded it — but only until someone else commits membership. A fresh
+    /// *version* is not an ownership proof, so a successor that took the id in
+    /// that window must survive.
+    #[tokio::test]
+    async fn a_contended_seed_does_not_reclaim_from_a_registered_successor() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let thief = Uuid::new_v4();
+        let wrapper = Arc::new(StealKeyBeforeWrite {
+            inner: Arc::clone(&inner),
+            cluster: Arc::new(ClusterStateStore::new(Arc::clone(&inner), "")),
+            thief,
+            steal_membership: true,
+            armed: std::sync::atomic::AtomicBool::new(true),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        ClusterStateStore::new(Arc::clone(&inner), "")
+            .bootstrap()
+            .await
+            .expect("bootstrap");
+        let observer = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&inner), ""));
+
+        let instance_id = Uuid::new_v4();
+        let runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
+        runner.register_self().await.expect("register");
+
+        let beat = observer
+            .read("test:50051")
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(
+            beat.instance_id, thief,
+            "a successor that registered during the seed must not be reclaimed from"
+        );
+        assert!(
+            runner.superseded.load(Ordering::Relaxed),
+            "losing the registration while seeding must retire this incarnation"
+        );
+    }
+
+    /// A tick that can outlast the TTL starves the beats it exists to publish, and
+    /// blocks discovery, recovery and the reaper on the same task. The deadlines
+    /// are fractions of the interval precisely so their worst-case sum stays under
+    /// the TTL for *any* `ttl_ms`, not just the default.
+    #[test]
+    fn the_worst_case_tick_stays_within_the_ttl() {
+        for ttl_ms in [
+            1,
+            10,
+            100,
+            1_000,
+            6_000,
+            15_000,
+            18_000,
+            DEFAULT_TTL_MS,
+            300_000,
+        ] {
+            let worst = worst_case_tick(ttl_ms);
+            let ttl = Duration::from_millis(ttl_ms);
+            assert!(
+                // A 1ms TTL is the one value the bound cannot hold for: every
+                // deadline floors at 1ms, so their sum necessarily exceeds it.
+                worst < ttl || ttl_ms == 1,
+                "ttl_ms={ttl_ms}: worst-case tick {worst:?} does not fit inside a {ttl:?} TTL"
+            );
+        }
+    }
+
     /// Store whose heartbeat writes hang once armed. Object-store clients default
     /// to request timeouts on the order of a scheduler TTL, so this is the shape
     /// that would otherwise hold the registry task for a whole TTL.
@@ -1304,7 +1428,11 @@ mod tests {
     #[derive(Debug)]
     struct StealKeyBeforeWrite {
         inner: Arc<dyn ObjectStore>,
+        cluster: Arc<ClusterStateStore>,
         thief: Uuid,
+        /// When set, the thief also commits membership, so it is the registered
+        /// owner rather than a writer with no claim.
+        steal_membership: bool,
         armed: std::sync::atomic::AtomicBool,
     }
 
@@ -1345,6 +1473,18 @@ mod tests {
                         object_store::PutOptions::from(object_store::PutMode::Overwrite),
                     )
                     .await?;
+                if self.steal_membership {
+                    self.cluster
+                        .mutate(|state| {
+                            if let Some(entry) = state.schedulers.get_mut("test:50051") {
+                                entry.instance_id = self.thief;
+                                entry.started_at_ms = 50_000;
+                            }
+                            MutationOutcome::Apply
+                        })
+                        .await
+                        .expect("thief claims membership");
+                }
             }
             self.inner.put_opts(location, payload, opts).await
         }
@@ -1398,7 +1538,9 @@ mod tests {
         let thief = Uuid::new_v4();
         let wrapper = Arc::new(StealKeyBeforeWrite {
             inner: Arc::clone(&inner),
+            cluster: Arc::new(ClusterStateStore::new(Arc::clone(&inner), "")),
             thief,
+            steal_membership: false,
             armed: std::sync::atomic::AtomicBool::new(true),
         });
         let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -315,7 +315,6 @@ impl SchedulerRegistryRunner {
             .read(&self.scheduler_id)
             .await
             .context(HeartbeatSnafu)?;
-        let observed_instance = observed.as_ref().map(|b| b.instance_id);
 
         let entry = self.entry.clone();
         let scheduler_id = self.scheduler_id.clone();
@@ -327,22 +326,25 @@ impl SchedulerRegistryRunner {
             .cluster
             .mutate(|state| {
                 if let Some(existing) = state.schedulers.get(&scheduler_id) {
-                    // Allow takeover only if (a) the heartbeat we
-                    // observed matches the existing entry's
-                    // instance_id (so we are taking over the
-                    // incarnation we judged stale), AND (b) that
-                    // observation is in fact stale, OR there is no
-                    // heartbeat at all and the existing entry has
-                    // had time to publish one.
-                    let observed_matches =
-                        observed_instance.is_none_or(|i| i == existing.instance_id);
-                    let stale_or_missing = if let Some(beat) = observed.as_ref() {
+                    // Judge the registered entry only by *its own*
+                    // heartbeat. The key is shared, so a beat left by some
+                    // other incarnation says nothing about this entry: if a
+                    // successor commits its membership and dies before its
+                    // first beat, the predecessor's beat is what remains, and
+                    // treating that as a mismatch would lock the id forever
+                    // (registration refuses, and the reaper skips the same
+                    // mismatch). An unrelated beat is therefore treated as no
+                    // beat, which falls through to the startup grace window.
+                    let own_beat = observed
+                        .as_ref()
+                        .filter(|beat| beat.instance_id == existing.instance_id);
+                    let stale_or_missing = if let Some(beat) = own_beat {
                         beat.is_stale(now)
                     } else {
                         let grace = existing.ttl_ms.saturating_add(CLOCK_SKEW_TOLERANCE_MS);
                         now.saturating_sub(existing.started_at_ms) > grace
                     };
-                    if observed_matches && stale_or_missing {
+                    if stale_or_missing {
                         state.schedulers.insert(scheduler_id.clone(), entry.clone());
                         MutationOutcome::Apply
                     } else if existing.instance_id == instance_id {
@@ -467,7 +469,27 @@ impl SchedulerRegistryRunner {
             )
             .await
             {
-                Ok(result) => result.context(HeartbeatSnafu)?,
+                Ok(Ok(result)) => result,
+                // A read error and a read timeout are the same situation: the
+                // current beat is unknown. Aborting the tick here would let
+                // repeated transient errors suppress every beat until the TTL
+                // lapses and this healthy scheduler is reaped.
+                Ok(Err(err)) => {
+                    if membership == Membership::ConfirmedSelf {
+                        tracing::warn!(
+                            scheduler_id = %self.scheduler_id,
+                            error = %err,
+                            "Could not read the current heartbeat; writing as the confirmed owner"
+                        );
+                        return self.overwrite_heartbeat().await;
+                    }
+                    tracing::warn!(
+                        scheduler_id = %self.scheduler_id,
+                        error = %err,
+                        "Could not read the current heartbeat with membership unconfirmed; skipping this beat"
+                    );
+                    return Ok(());
+                }
                 Err(_elapsed) => {
                     // The current beat is unknown. With membership confirmed we
                     // are entitled to the key, so write unconditionally rather
@@ -486,14 +508,19 @@ impl SchedulerRegistryRunner {
                 }
             };
 
+            // An unparsable payload reads back as `None`: the holder is unknown,
+            // which is not evidence that it is ours, so it is treated like a
+            // foreign beat.
             if let Some((beat, _)) = observed.as_ref()
-                && beat.instance_id != self.instance_id
+                && beat
+                    .as_ref()
+                    .is_none_or(|beat| beat.instance_id != self.instance_id)
                 && membership != Membership::ConfirmedSelf
             {
                 tracing::warn!(
                     scheduler_id = %self.scheduler_id,
                     instance_id = %self.instance_id,
-                    holder = %beat.instance_id,
+                    holder = ?beat.as_ref().map(|b| b.instance_id),
                     "Another incarnation holds the heartbeat and membership is unconfirmed; skipping this beat"
                 );
                 return Ok(());
@@ -1224,6 +1251,89 @@ mod tests {
         assert!(
             beat.last_heartbeat_ms > 1_000,
             "our own heartbeat must be refreshed even when membership is unreadable"
+        );
+    }
+
+    /// A successor that commits its membership entry and dies before its first
+    /// heartbeat leaves the *predecessor's* beat under a shared key. That must
+    /// not lock the id: registration has to judge the entry by its own beat,
+    /// treat an unrelated one as absent, and take over after the grace window.
+    #[tokio::test]
+    async fn a_successor_that_died_before_its_first_heartbeat_does_not_lock_the_id() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+
+        let predecessor = Uuid::new_v4();
+        let dead_successor = Uuid::new_v4();
+        let newcomer = Uuid::new_v4();
+
+        // Membership names a successor that never published a beat, while the
+        // shared key still holds the predecessor's.
+        let mut dead_entry = SchedulerEntry {
+            scheduler_id: "test:50051".to_string(),
+            instance_id: dead_successor,
+            advertise_address: "test:50051".to_string(),
+            grpc_address: "test:50051".to_string(),
+            http_address: "test:8090".to_string(),
+            started_at_ms: 0,
+            ttl_ms: 30_000,
+            build_version: "test".to_string(),
+            labels: HashMap::new(),
+        };
+        cluster
+            .mutate(|state| {
+                state
+                    .schedulers
+                    .insert("test:50051".to_string(), dead_entry.clone());
+                MutationOutcome::Apply
+            })
+            .await
+            .expect("seed the crashed successor");
+        heartbeats
+            .heartbeat("test:50051", predecessor, 1_000, 30_000)
+            .await
+            .expect("predecessor heartbeat");
+
+        // A fresh process starts long after the grace window.
+        dead_entry.instance_id = newcomer;
+        let entry = dead_entry;
+        let job_store = crate::jobs::JobStore::new(Arc::clone(&store), "", newcomer.to_string());
+        let df = DataFusionBuilder::new(
+            status::RuntimeStatus::new(),
+            Arc::new(AcceleratorEngineRegistry::default()),
+            Handle::current(),
+        )
+        .build();
+        let job_executor = Arc::new(crate::jobs::JobExecutor::new(
+            Arc::new(job_store),
+            Arc::new(df),
+        ));
+        let runner = SchedulerRegistryRunner {
+            cluster: Arc::clone(&cluster),
+            heartbeats: Arc::clone(&heartbeats),
+            reaper: Reaper::new(Arc::clone(&cluster), Arc::clone(&heartbeats)),
+            scheduler_id: "test:50051".to_string(),
+            instance_id: newcomer,
+            entry,
+            peers: Arc::new(RwLock::new(HashMap::new())),
+            job_executor,
+            superseded: Arc::new(AtomicBool::new(false)),
+        };
+
+        runner
+            .register_self()
+            .await
+            .expect("an unrelated heartbeat must not block takeover");
+
+        let snap = cluster.read().await.expect("read");
+        assert_eq!(
+            snap.schedulers
+                .get("test:50051")
+                .map(|entry| entry.instance_id),
+            Some(newcomer),
+            "the id must be recoverable, not locked by a stale unrelated heartbeat"
         );
     }
 

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -45,11 +45,19 @@ use runtime_metrics::cluster as cluster_metrics;
 
 const DEFAULT_TTL_MS: u64 = 30_000;
 
-/// Deadline for the membership read that gates a heartbeat. Must stay well
-/// below the heartbeat interval (`ttl / HEARTBEAT_DIVISOR`) so a slow store
-/// cannot delay a beat far enough for peers to consider this scheduler dead.
-/// `membership_check_timeout_is_below_the_heartbeat_interval` pins that.
-const MEMBERSHIP_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
+/// Upper bound on the deadline for the membership read that gates a heartbeat.
+/// The effective deadline is derived from the scheduler's own heartbeat
+/// interval by [`membership_check_timeout`] and capped here, because `ttl_ms`
+/// is carried per entry: a fixed deadline could exceed the interval for a short
+/// TTL and delay a beat far enough for peers to reap a healthy scheduler.
+const MEMBERSHIP_CHECK_TIMEOUT_CAP: Duration = Duration::from_secs(2);
+
+/// Deadline for the membership read that gates a heartbeat, as a fraction of
+/// that scheduler's heartbeat interval so it always fits inside one beat.
+fn membership_check_timeout(ttl_ms: u64) -> Duration {
+    let interval = Duration::from_millis(ttl_ms.saturating_div(HEARTBEAT_DIVISOR).max(1));
+    (interval / 2).min(MEMBERSHIP_CHECK_TIMEOUT_CAP)
+}
 const DISCOVERY_INTERVAL: Duration = Duration::from_secs(5);
 const JOB_RECOVERY_INTERVAL: Duration = Duration::from_secs(10);
 const HEARTBEAT_DIVISOR: u64 = 3;
@@ -378,18 +386,18 @@ impl SchedulerRegistryRunner {
         // re-drive its jobs — the exact failure the fail-open behaviour exists
         // to prevent. A timeout is treated exactly like an error: heartbeat
         // anyway.
-        let membership =
-            match tokio::time::timeout(MEMBERSHIP_CHECK_TIMEOUT, self.cluster.read()).await {
-                Ok(result) => result,
-                Err(_elapsed) => {
-                    tracing::warn!(
-                        scheduler_id = %self.scheduler_id,
-                        timeout_ms = MEMBERSHIP_CHECK_TIMEOUT.as_millis(),
-                        "Timed out confirming cluster membership; heartbeating anyway"
-                    );
-                    return self.write_heartbeat().await;
-                }
-            };
+        let read_timeout = membership_check_timeout(self.entry.ttl_ms);
+        let membership = match tokio::time::timeout(read_timeout, self.cluster.read()).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                tracing::warn!(
+                    scheduler_id = %self.scheduler_id,
+                    timeout_ms = read_timeout.as_millis(),
+                    "Timed out confirming cluster membership; heartbeating anyway"
+                );
+                return self.write_heartbeat().await;
+            }
+        };
         match membership {
             Ok(state) => {
                 let registered = state
@@ -713,16 +721,22 @@ mod tests {
         assert!(runner.superseded.load(Ordering::Relaxed));
     }
 
-    /// The membership read is on the heartbeat path, so its deadline must be
-    /// comfortably inside one heartbeat interval — otherwise a slow store
-    /// delays beats far enough for peers to reap a healthy scheduler.
+    /// The membership read sits on the heartbeat path, so its deadline must
+    /// stay inside one heartbeat interval for *any* `ttl_ms`, not just the
+    /// default: `ttl_ms` is carried per entry, and a short one would otherwise
+    /// leave a slow store able to delay beats until peers reap a healthy
+    /// scheduler.
     #[test]
-    fn membership_check_timeout_is_below_the_heartbeat_interval() {
-        let interval = Duration::from_millis(DEFAULT_TTL_MS.saturating_div(HEARTBEAT_DIVISOR));
-        assert!(
-            MEMBERSHIP_CHECK_TIMEOUT * 2 <= interval,
-            "membership read deadline {MEMBERSHIP_CHECK_TIMEOUT:?} leaves too little room in a {interval:?} heartbeat interval"
-        );
+    fn membership_check_timeout_stays_within_the_heartbeat_interval() {
+        for ttl_ms in [1, 10, 100, 1_000, DEFAULT_TTL_MS, 300_000] {
+            let interval = Duration::from_millis(ttl_ms.saturating_div(HEARTBEAT_DIVISOR).max(1));
+            let timeout = membership_check_timeout(ttl_ms);
+            assert!(
+                timeout < interval,
+                "ttl_ms={ttl_ms}: deadline {timeout:?} does not fit inside a {interval:?} heartbeat interval"
+            );
+            assert!(timeout <= MEMBERSHIP_CHECK_TIMEOUT_CAP);
+        }
     }
 
     /// A superseded incarnation must not delete the heartbeat key on the way

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -23,7 +23,7 @@ limitations under the License.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use app::spicepod::component::runtime::Scheduler as SchedulerConfig;
@@ -81,6 +81,13 @@ enum Membership {
 /// resolved by re-reading membership rather than by writing harder.
 const MAX_HEARTBEAT_CAS_ATTEMPTS: usize = 3;
 
+/// Consecutive failures to read the current heartbeat before this incarnation
+/// will write without a version predicate. Without the version, a write cannot
+/// prove it is not overwriting a successor, so skipping is preferred while the
+/// TTL still has slack; only when self-eviction becomes the greater risk is a
+/// blind write attempted, and then only against a freshly re-read membership.
+const BLIND_WRITE_AFTER_BEAT_READ_FAILURES: usize = 2;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to initialize scheduler state object store: {source}"))]
@@ -120,6 +127,8 @@ struct SchedulerRegistryRunner {
     /// superseded. Sticky, so a later failed read cannot resume claiming the
     /// heartbeat key.
     superseded: Arc<AtomicBool>,
+    /// Consecutive failures to read the current heartbeat object.
+    beat_read_failures: Arc<AtomicUsize>,
 }
 
 pub async fn start_scheduler_registry(
@@ -193,6 +202,7 @@ pub async fn start_scheduler_registry(
         peers,
         job_executor,
         superseded: Arc::new(AtomicBool::new(false)),
+        beat_read_failures: Arc::new(AtomicUsize::new(0)),
     };
 
     runner.run(cancel).await
@@ -326,23 +336,35 @@ impl SchedulerRegistryRunner {
             .cluster
             .mutate(|state| {
                 if let Some(existing) = state.schedulers.get(&scheduler_id) {
-                    // Judge the registered entry only by *its own*
-                    // heartbeat. The key is shared, so a beat left by some
-                    // other incarnation says nothing about this entry: if a
-                    // successor commits its membership and dies before its
-                    // first beat, the predecessor's beat is what remains, and
-                    // treating that as a mismatch would lock the id forever
+                    // Judge the registered entry by *its own* heartbeat. The
+                    // key is shared, so a beat left by another incarnation says
+                    // nothing about this entry: if a successor commits its
+                    // membership and dies before its first beat, the
+                    // predecessor's beat is what remains, and treating that as
+                    // a disqualifying mismatch would lock the id forever
                     // (registration refuses, and the reaper skips the same
-                    // mismatch). An unrelated beat is therefore treated as no
-                    // beat, which falls through to the startup grace window.
-                    let own_beat = observed
-                        .as_ref()
-                        .filter(|beat| beat.instance_id == existing.instance_id);
-                    let stale_or_missing = if let Some(beat) = own_beat {
-                        beat.is_stale(now)
-                    } else {
-                        let grace = existing.ttl_ms.saturating_add(CLOCK_SKEW_TOLERANCE_MS);
-                        now.saturating_sub(existing.started_at_ms) > grace
+                    // mismatch).
+                    //
+                    // A foreign beat is therefore not proof this entry is
+                    // alive — but a *fresh* one is proof that something is
+                    // actively writing the key, so it still blocks takeover.
+                    // Otherwise a legacy writer that briefly overwrites a live
+                    // successor's beat would let a third incarnation evict that
+                    // live successor. Recovery is then delayed by at most the
+                    // TTL it takes the foreign beat to go stale.
+                    let stale_or_missing = match observed.as_ref() {
+                        Some(beat) if beat.instance_id == existing.instance_id => {
+                            beat.is_stale(now)
+                        }
+                        Some(foreign) => {
+                            let grace = existing.ttl_ms.saturating_add(CLOCK_SKEW_TOLERANCE_MS);
+                            foreign.is_stale(now)
+                                && now.saturating_sub(existing.started_at_ms) > grace
+                        }
+                        None => {
+                            let grace = existing.ttl_ms.saturating_add(CLOCK_SKEW_TOLERANCE_MS);
+                            now.saturating_sub(existing.started_at_ms) > grace
+                        }
                     };
                     if stale_or_missing {
                         state.schedulers.insert(scheduler_id.clone(), entry.clone());
@@ -469,42 +491,19 @@ impl SchedulerRegistryRunner {
             )
             .await
             {
-                Ok(Ok(result)) => result,
+                Ok(Ok(result)) => {
+                    self.beat_read_failures.store(0, Ordering::Relaxed);
+                    result
+                }
                 // A read error and a read timeout are the same situation: the
                 // current beat is unknown. Aborting the tick here would let
                 // repeated transient errors suppress every beat until the TTL
                 // lapses and this healthy scheduler is reaped.
                 Ok(Err(err)) => {
-                    if membership == Membership::ConfirmedSelf {
-                        tracing::warn!(
-                            scheduler_id = %self.scheduler_id,
-                            error = %err,
-                            "Could not read the current heartbeat; writing as the confirmed owner"
-                        );
-                        return self.overwrite_heartbeat().await;
-                    }
-                    tracing::warn!(
-                        scheduler_id = %self.scheduler_id,
-                        error = %err,
-                        "Could not read the current heartbeat with membership unconfirmed; skipping this beat"
-                    );
-                    return Ok(());
+                    return self.beat_read_failed(membership, &format!("{err}")).await;
                 }
                 Err(_elapsed) => {
-                    // The current beat is unknown. With membership confirmed we
-                    // are entitled to the key, so write unconditionally rather
-                    // than skip: skipping repeatedly would let the TTL lapse and
-                    // get this healthy scheduler reaped. Without that proof,
-                    // skip — writing blind could clobber a successor.
-                    if membership == Membership::ConfirmedSelf {
-                        return self.overwrite_heartbeat().await;
-                    }
-                    tracing::warn!(
-                        scheduler_id = %self.scheduler_id,
-                        timeout_ms = read_timeout.as_millis(),
-                        "Timed out reading the heartbeat with membership unconfirmed; skipping this beat"
-                    );
-                    return Ok(());
+                    return self.beat_read_failed(membership, "read timed out").await;
                 }
             };
 
@@ -567,6 +566,35 @@ impl SchedulerRegistryRunner {
         tracing::warn!(
             scheduler_id = %self.scheduler_id,
             "Heartbeat contended by another incarnation; skipping this beat"
+        );
+        Ok(())
+    }
+
+    /// The current beat could not be read, so no version predicate is
+    /// available. A write would then be unable to prove it is not overwriting a
+    /// successor, and skipping cannot continue forever without the TTL lapsing.
+    /// Skip while the TTL still has slack; once failures persist, write only
+    /// against a *freshly* re-read membership — the tick's earlier confirmation
+    /// may be a heartbeat interval old, which is long enough for a takeover.
+    async fn beat_read_failed(&self, membership: Membership, reason: &str) -> Result<()> {
+        let failures = self.beat_read_failures.fetch_add(1, Ordering::Relaxed) + 1;
+        if membership == Membership::ConfirmedSelf
+            && failures >= BLIND_WRITE_AFTER_BEAT_READ_FAILURES
+            && self.read_membership().await == Some(true)
+        {
+            tracing::warn!(
+                scheduler_id = %self.scheduler_id,
+                failures,
+                reason,
+                "Cannot read the heartbeat; writing without a version predicate as the re-confirmed owner"
+            );
+            return self.overwrite_heartbeat().await;
+        }
+        tracing::warn!(
+            scheduler_id = %self.scheduler_id,
+            failures,
+            reason,
+            "Cannot read the current heartbeat; skipping this beat"
         );
         Ok(())
     }
@@ -737,6 +765,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
+            beat_read_failures: Arc::new(AtomicUsize::new(0)),
         };
         runner.register_self().await.expect("register");
 
@@ -804,6 +833,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
+            beat_read_failures: Arc::new(AtomicUsize::new(0)),
         };
         runner.register_self().await.expect("register");
 
@@ -883,19 +913,136 @@ mod tests {
         }
     }
 
-    /// The exact interleaving the conditional write exists for: a successor
-    /// takes the id over and publishes *after* this incarnation has confirmed
-    /// membership but *before* its write lands. The write must fail its
-    /// precondition and retire rather than clobber the successor.
+    /// Store that lets a successor take over *between* the heartbeat read and
+    /// the conditional write, which is the only way to reach the CAS-conflict
+    /// branch: installing the successor beforehand makes the initial membership
+    /// check retire first, so the conditional write is never attempted.
+    ///
+    /// The successor claims membership as well as the heartbeat, because that is
+    /// what a real takeover does — `register_self` mutates `cluster.json` before
+    /// it beats. A heartbeat-only writer has no ownership claim, and reclaiming
+    /// the key from one is correct rather than a clobber.
+    #[derive(Debug)]
+    struct PublishBetweenReadAndWrite {
+        inner: Arc<dyn ObjectStore>,
+        cluster: Arc<ClusterStateStore>,
+        successor: Uuid,
+        armed: std::sync::atomic::AtomicBool,
+    }
+
+    impl std::fmt::Display for PublishBetweenReadAndWrite {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "PublishBetweenReadAndWrite")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for PublishBetweenReadAndWrite {
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            let result = self.inner.get_opts(location, options).await;
+            // After the heartbeat has been read once, let the successor take the
+            // key. The pending conditional write then finds a changed object.
+            if location.as_ref().contains("heartbeats/")
+                && self.armed.swap(false, std::sync::atomic::Ordering::Relaxed)
+            {
+                self.cluster
+                    .mutate(|state| {
+                        if let Some(entry) = state.schedulers.get_mut("test:50051") {
+                            entry.instance_id = self.successor;
+                            entry.started_at_ms = 50_000;
+                        }
+                        MutationOutcome::Apply
+                    })
+                    .await
+                    .expect("successor claims membership");
+                let beat = crate::cluster::heartbeat::SchedulerHeartbeat {
+                    scheduler_id: "test:50051".to_string(),
+                    instance_id: self.successor,
+                    last_heartbeat_ms: 50_000,
+                    ttl_ms: 30_000,
+                };
+                self.inner
+                    .put_opts(
+                        location,
+                        serde_json::to_vec(&beat).expect("serialize").into(),
+                        object_store::PutOptions::from(object_store::PutMode::Overwrite),
+                    )
+                    .await?;
+            }
+            result
+        }
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<
+                'static,
+                object_store::Result<object_store::path::Path>,
+            >,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
+        {
+            self.inner.delete_stream(locations)
+        }
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// The interleaving the conditional write exists for: membership still names
+    /// this incarnation when it checks, and the successor publishes after the
+    /// heartbeat read but before the write lands. The write must lose its
+    /// precondition and leave the successor's beat intact.
     #[tokio::test]
     async fn a_successor_publishing_mid_write_is_not_clobbered() {
-        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&store), ""));
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let successor = Uuid::new_v4();
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let wrapper = Arc::new(PublishBetweenReadAndWrite {
+            inner: Arc::clone(&inner),
+            cluster: Arc::clone(&cluster),
+            successor,
+            armed: std::sync::atomic::AtomicBool::new(false),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
         let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
         cluster.bootstrap().await.expect("bootstrap");
 
         let instance_id = Uuid::new_v4();
-        let successor = Uuid::new_v4();
         let entry = SchedulerEntry {
             scheduler_id: "test:50051".to_string(),
             instance_id,
@@ -907,7 +1054,7 @@ mod tests {
             build_version: "test".to_string(),
             labels: HashMap::new(),
         };
-        let job_store = crate::jobs::JobStore::new(Arc::clone(&store), "", instance_id.to_string());
+        let job_store = crate::jobs::JobStore::new(Arc::clone(&inner), "", instance_id.to_string());
         let df = DataFusionBuilder::new(
             status::RuntimeStatus::new(),
             Arc::new(AcceleratorEngineRegistry::default()),
@@ -924,32 +1071,20 @@ mod tests {
             reaper: Reaper::new(Arc::clone(&cluster), Arc::clone(&heartbeats)),
             scheduler_id: "test:50051".to_string(),
             instance_id,
-            entry: entry.clone(),
+            entry,
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
+            beat_read_failures: Arc::new(AtomicUsize::new(0)),
         };
+        // Registered and heartbeating normally, so the membership check passes
+        // and the conditional write is actually attempted.
         runner.register_self().await.expect("register");
 
-        // Simulate the interleaving: membership still names this incarnation
-        // when it checks, and the successor registers *and* publishes before
-        // the write lands. Writing the successor's heartbeat here changes the
-        // object version the old incarnation observed at registration time.
-        let mut successor_entry = entry;
-        successor_entry.instance_id = successor;
-        cluster
-            .mutate(|state| {
-                state
-                    .schedulers
-                    .insert("test:50051".to_string(), successor_entry.clone());
-                MutationOutcome::Apply
-            })
-            .await
-            .expect("successor takes over");
-        heartbeats
-            .heartbeat("test:50051", successor, 20_000, 30_000)
-            .await
-            .expect("successor heartbeat");
+        // Arm the interleaving for the next heartbeat read.
+        wrapper
+            .armed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
 
         runner
             .send_heartbeat()
@@ -963,11 +1098,7 @@ mod tests {
             .expect("heartbeat present");
         assert_eq!(
             beat.instance_id, successor,
-            "the successor's heartbeat must survive a concurrent write by the old incarnation"
-        );
-        assert!(
-            runner.superseded.load(Ordering::Relaxed),
-            "losing the write must make the old incarnation observe it was superseded"
+            "a successor that took over mid-write must not be clobbered"
         );
     }
 
@@ -1092,6 +1223,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
+            beat_read_failures: Arc::new(AtomicUsize::new(0)),
         };
 
         // Paused time auto-advances once the read is the only pending work, so
@@ -1169,6 +1301,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
+            beat_read_failures: Arc::new(AtomicUsize::new(0)),
         };
 
         runner
@@ -1238,6 +1371,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
+            beat_read_failures: Arc::new(AtomicUsize::new(0)),
         };
 
         runner
@@ -1294,8 +1428,10 @@ mod tests {
             })
             .await
             .expect("seed the crashed successor");
+        // Long stale: a *fresh* foreign beat deliberately still blocks
+        // takeover, because something is actively writing the key.
         heartbeats
-            .heartbeat("test:50051", predecessor, 1_000, 30_000)
+            .heartbeat("test:50051", predecessor, 1, 1)
             .await
             .expect("predecessor heartbeat");
 
@@ -1323,6 +1459,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
+            beat_read_failures: Arc::new(AtomicUsize::new(0)),
         };
 
         runner
@@ -1384,6 +1521,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
+            beat_read_failures: Arc::new(AtomicUsize::new(0)),
         };
         runner.register_self().await.expect("register");
 
@@ -1465,6 +1603,7 @@ mod tests {
             peers: Arc::new(RwLock::new(HashMap::new())),
             job_executor,
             superseded: Arc::new(AtomicBool::new(false)),
+            beat_read_failures: Arc::new(AtomicUsize::new(0)),
         };
 
         runner

--- a/crates/runtime/src/cluster/scheduler_registry.rs
+++ b/crates/runtime/src/cluster/scheduler_registry.rs
@@ -393,11 +393,16 @@ impl SchedulerRegistryRunner {
             Err(other) => return Err(Error::ClusterState { source: other }),
         }
 
-        // Write our first heartbeat so peers see liveness on next discovery.
-        self.heartbeats
+        // Write our first heartbeat so peers see liveness on next discovery, and
+        // keep its version: without it, an incarnation whose reads fail from
+        // birth would have nothing to condition on and would skip every beat
+        // until it was reaped, which the unconditional write never did.
+        let version = self
+            .heartbeats
             .heartbeat(&self.scheduler_id, self.instance_id, now, self.entry.ttl_ms)
             .await
             .context(HeartbeatSnafu)?;
+        self.last_written_version.store(version.map(Arc::new));
         Ok(())
     }
 
@@ -582,8 +587,9 @@ impl SchedulerRegistryRunner {
     /// reconciles against membership instead of clobbering it. Read-only
     /// outages, where writes still succeed, no longer force either bad choice.
     ///
-    /// Returns `None` when there is nothing to condition on — only before this
-    /// incarnation's first successful write — in which case the beat is skipped.
+    /// Returns `None` only when no write by this incarnation has ever reported a
+    /// version — registration seeds one, so in practice this means the store does
+    /// not report versions at all — in which case the beat is skipped.
     fn cached_predicate(&self, reason: &str) -> Option<UpdateVersion> {
         let Some(version) = self.last_written_version.load_full() else {
             tracing::warn!(
@@ -914,6 +920,7 @@ mod tests {
     struct FailingBeatReads {
         inner: Arc<dyn ObjectStore>,
         failing: std::sync::atomic::AtomicBool,
+        beat_writes: std::sync::atomic::AtomicUsize,
     }
 
     impl std::fmt::Display for FailingBeatReads {
@@ -945,7 +952,12 @@ mod tests {
             payload: object_store::PutPayload,
             opts: object_store::PutOptions,
         ) -> object_store::Result<object_store::PutResult> {
-            self.inner.put_opts(location, payload, opts).await
+            let result = self.inner.put_opts(location, payload, opts).await;
+            if result.is_ok() && location.as_ref().contains("heartbeats/") {
+                self.beat_writes
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            result
         }
         async fn put_multipart_opts(
             &self,
@@ -1040,6 +1052,7 @@ mod tests {
         let wrapper = Arc::new(FailingBeatReads {
             inner: Arc::clone(&inner),
             failing: std::sync::atomic::AtomicBool::new(false),
+            beat_writes: std::sync::atomic::AtomicUsize::new(0),
         });
         let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
         let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
@@ -1061,10 +1074,20 @@ mod tests {
         wrapper
             .failing
             .store(true, std::sync::atomic::Ordering::Relaxed);
+        let writes_before = wrapper
+            .beat_writes
+            .load(std::sync::atomic::Ordering::Relaxed);
         runner
             .send_heartbeat()
             .await
             .expect("a read outage must not fail the loop");
+        assert_eq!(
+            wrapper
+                .beat_writes
+                .load(std::sync::atomic::Ordering::Relaxed),
+            writes_before + 1,
+            "the beat must actually be written during a read outage, not merely left alone"
+        );
 
         let after = observer
             .read("test:50051")
@@ -1077,7 +1100,7 @@ mod tests {
         );
         assert!(
             after.last_heartbeat_ms >= before.last_heartbeat_ms,
-            "a read outage must not suppress the beat: {} < {}",
+            "the refreshed beat must not move backwards: {} < {}",
             after.last_heartbeat_ms,
             before.last_heartbeat_ms
         );
@@ -1096,6 +1119,7 @@ mod tests {
         let wrapper = Arc::new(FailingBeatReads {
             inner: Arc::clone(&inner),
             failing: std::sync::atomic::AtomicBool::new(false),
+            beat_writes: std::sync::atomic::AtomicUsize::new(0),
         });
         let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
         let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
@@ -1160,6 +1184,7 @@ mod tests {
         let wrapper = Arc::new(FailingBeatReads {
             inner: Arc::clone(&inner),
             failing: std::sync::atomic::AtomicBool::new(false),
+            beat_writes: std::sync::atomic::AtomicUsize::new(0),
         });
         let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
         let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
@@ -1204,14 +1229,68 @@ mod tests {
         );
     }
 
-    /// Before the first successful write there is nothing to condition on, so an
-    /// unreadable beat is skipped rather than overwritten blind.
+    /// Reads failing from the moment the process registers must not cost it its
+    /// liveness. The unconditional first write seeds a predicate, so the beat can
+    /// still be refreshed conditionally without ever having read the object.
     #[tokio::test]
-    async fn a_read_outage_before_any_write_skips_the_beat() {
+    async fn a_read_outage_from_birth_still_refreshes_the_heartbeat() {
         let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let wrapper = Arc::new(FailingBeatReads {
             inner: Arc::clone(&inner),
             failing: std::sync::atomic::AtomicBool::new(false),
+            beat_writes: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
+        let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
+        let heartbeats = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&store), ""));
+        cluster.bootstrap().await.expect("bootstrap");
+        let observer = Arc::new(SchedulerHeartbeatStore::new(Arc::clone(&inner), ""));
+
+        let instance_id = Uuid::new_v4();
+        let runner = runner_over(&cluster, &heartbeats, &inner, instance_id);
+        runner.register_self().await.expect("register");
+
+        // Reads fail from here on, and this incarnation has never completed a
+        // conditional write — only the unconditional registration one.
+        wrapper
+            .failing
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let writes_before = wrapper
+            .beat_writes
+            .load(std::sync::atomic::Ordering::Relaxed);
+        runner
+            .send_heartbeat()
+            .await
+            .expect("a read outage from birth must not fail the loop");
+
+        assert_eq!(
+            wrapper
+                .beat_writes
+                .load(std::sync::atomic::Ordering::Relaxed),
+            writes_before + 1,
+            "the beat must be refreshed from the version the registration write reported"
+        );
+        let beat = observer
+            .read("test:50051")
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(
+            beat.instance_id, instance_id,
+            "the refreshed beat must belong to this incarnation"
+        );
+    }
+
+    /// A retained predicate that no longer matches must not be escalated into an
+    /// unconditional write: the beat has moved on, this incarnation cannot read
+    /// it, and so it skips rather than displacing whatever is there.
+    #[tokio::test]
+    async fn a_stale_predicate_does_not_displace_a_newer_beat() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wrapper = Arc::new(FailingBeatReads {
+            inner: Arc::clone(&inner),
+            failing: std::sync::atomic::AtomicBool::new(false),
+            beat_writes: std::sync::atomic::AtomicUsize::new(0),
         });
         let store: Arc<dyn ObjectStore> = Arc::clone(&wrapper) as Arc<dyn ObjectStore>;
         let cluster = Arc::new(ClusterStateStore::new(Arc::clone(&inner), ""));
@@ -1242,7 +1321,7 @@ mod tests {
             .expect("present");
         assert_eq!(
             beat.instance_id, foreign,
-            "with no version to condition on the beat must be skipped, not written blind"
+            "a predicate that no longer matches must not be escalated to a blind write"
         );
     }
 


### PR DESCRIPTION
## What

Stops a superseded scheduler incarnation from writing the shared heartbeat key, and stops a live incarnation from being clobbered on that key by a peer that cannot prove it owns the scheduler id.

## Why

`scheduler_id` is stable across restarts, so successive incarnations of the same scheduler share one heartbeat object while `instance_id` differs per process. Whoever writes last owns the liveness record. An incarnation that had been superseded could therefore keep refreshing the key with its own `instance_id`, which makes the *live* successor look absent to `list_alive` and the reaper — and the recovery path then re-drives jobs the successor is still running.

## How

Membership (`cluster.json`) is the authority on which `instance_id` owns a scheduler id; the heartbeat object is only liveness. Heartbeats deliberately live outside `cluster.json` so the high-frequency write path does not depend on that document.

- **A conditional write proves the object did not change, not that the writer owns the id.** So the two are combined: the write carries a version predicate, and membership decides whether a *foreign* beat may be overwritten at all. An incarnation that cannot confirm membership refuses to take a key another `instance_id` holds, but still refreshes a beat that is already its own — a failing membership read cannot silently suppress a healthy scheduler and get it reaped.
- **Supersession is sticky.** Once definitively observed, a later failed read cannot resume claiming the key.
- **Every heartbeat write is conditional, including during a read outage.** The version returned by each successful write is retained, so when the current beat cannot be read there is still something to condition on: the write stays conditional on what this process last wrote. If anyone has written since, the predicate fails and this incarnation reconciles against membership instead of overwriting them. That removes the need to choose between writing blind (which cannot prove it is not clobbering a successor) and skipping until the TTL lapses (which gets a healthy scheduler reaped) — a read-only outage, where writes still succeed, now keeps heartbeating safely. A beat is skipped only when no write by this incarnation has ever reported a version, or when the retained version no longer matches and cannot be refreshed because reads are still failing.
- **The first write seeds the predicate.** Registration's write reports the version it wrote and that version is retained, so an incarnation whose reads fail from the moment it starts can still refresh conditionally rather than skipping until its TTL lapses.
- **The conditional write is a single attempt, deliberately.** Retrying it after an ambiguous failure is what makes a lost acknowledgement dangerous: the retry's precondition fails against a write that may have been this incarnation's own, and that is indistinguishable from a successor's. The store's own retry policy still covers transport errors.
- **A single write carries a deadline.** Object-store clients default to request timeouts on the order of a scheduler TTL, so one stalled write would hold the registry task — which also drives discovery, recovery and the reaper — for a whole TTL while the last good beat aged out. Cancelling a write is only safe because an unknown outcome discards the retained version rather than being mistaken for supersession, so the next tick re-reads the beat instead of trusting a predicate this write may already have superseded.
- **A failed precondition against a retained version is not evidence of supersession.** The retained version comes from this incarnation's own last write, not from a read of the current object, so an acknowledgement lost after the write landed would move the version and fail the next predicate. That case now clears the retained version and waits for a readable beat, instead of retiring on evidence that does not exist or retrying against a predicate already known to be wrong.
- **Registration's first write is conditional too.** Registration commits membership before writing its first beat; if it stalls in between, a successor can register and publish, and an unconditional seed would replace that beat and recreate the false-orphan window. If the key changed under it, registration re-reads the beat and reclaims the key against that fresh version: membership was committed under OCC just before, so this incarnation is provably the registered owner at that moment, while a successor that registered *after* that commit still wins the conditional write. Leaving the key unwritten instead would publish no liveness at all, and if `cluster.json` then became unreadable this incarnation could not reclaim later either — it would look absent for as long as the outage lasted.
- **Ownership is re-confirmed where it is used, not carried forward.** A membership read taken at the start of a tick can be obsolete by the time the current beat is read, and a successor that completed its registration in that window would otherwise be overwritten on the strength of the stale observation. A beat belonging to another incarnation — or one whose holder cannot be determined — is only overwritten against a membership read taken *after* that beat was observed.
- **Reclaiming a registered id requires the incumbent to look dead**, not merely foreign: a foreign beat must itself be stale, and an entry with no beat at all must be past a grace period derived from its TTL plus clock-skew tolerance, so a successor that has registered but not yet published its first beat does not get displaced.

The heartbeat object layout is unchanged, so there is no new on-disk shape for a mixed-version fleet to disagree about.

Rollout still matters. This guard only governs processes that have it: during a mixed-version rollout a pre-change scheduler that is superseded and then recovers keeps writing the shared key unconditionally and can suppress its upgraded successor. That is existing behaviour rather than a regression, but it is not fixed here either — old scheduler processes should be terminated during a rollout, not merely superseded. Fencing a legacy writer cannot defeat would need a layout change, and instance-keyed objects are not viable: un-upgraded peers parse the nested key as a different scheduler id and reap the live node.

**Shutdown no longer deletes the heartbeat object.** The key is shared with any successor and there is no conditional delete, so deleting it races registration — a successor can register between the membership removal committing and the delete landing, and this process would erase the new incarnation's liveness. Removing the membership entry is sufficient, because `list_alive` only reports a heartbeat matching a registered entry.

## Tests

```
cargo test -p runtime --lib -- cluster:: jobs::
cargo fmt --all -- --check
make lint-rust
```

- `a_contended_seed_write_still_publishes_liveness` — a seed write that loses its race still ends with the registered incarnation owning the key. Verified non-vacuous: leaving the key unwritten fails this test.
- `a_stalled_write_is_bounded_and_discards_its_predicate` — a write that never completes is bounded, and the retained version is dropped because its outcome is unknown. Verified non-vacuous: widening the deadline makes the same test take 20s and fail.
- `a_read_outage_does_not_clobber_a_beat_written_since_the_last_write` — the beat has been written by someone else while membership still names this incarnation, so it does not retire; its own beat is unreadable, so only the retained version is available. The write must lose. Verified non-vacuous: making the write ignore its predicate fails this test.
- `a_heartbeat_read_outage_still_refreshes_the_heartbeat` — a read-only outage does not cost a healthy scheduler its liveness.
- `a_read_outage_from_birth_still_refreshes_the_heartbeat` — reads failing from the moment the process registers still refresh the beat, from the version the registration write reported. Verified non-vacuous: without the seeding it writes once instead of twice and fails.
- `a_stale_predicate_does_not_displace_a_newer_beat` — a retained predicate that no longer matches is not escalated into an unconditional write.
- `a_read_outage_retires_when_membership_has_moved_on` — retirement is decided on the membership read alone, with no write attempted.
- `a_successor_registering_before_the_beat_read_is_not_clobbered` — the successor completes its takeover between the membership read and the beat read, a window no version predicate covers. Verified non-vacuous: allowing the stale observation to authorise the write fails this test.
- `a_successor_publishing_mid_write_is_not_clobbered` — a successor completes a real takeover (membership *and* heartbeat) between the read and the conditional write; the write loses the race, re-reads membership, and retires. Also verified non-vacuous by removing the ownership re-check.
- `a_superseded_incarnation_stops_heartbeating`, `a_failed_cluster_read_does_not_suppress_the_heartbeat`, `a_hung_cluster_read_does_not_suppress_the_heartbeat`, `an_unconfirmed_incarnation_does_not_overwrite_a_successors_heartbeat`, `an_unconfirmed_incarnation_still_refreshes_its_own_heartbeat`, `a_successor_that_died_before_its_first_heartbeat_does_not_lock_the_id`, `membership_check_timeout_stays_within_the_heartbeat_interval`.

## Risks

- A superseded incarnation goes quiet rather than shutting down or re-registering. That restores the successor's liveness; re-registering would be wrong while a successor owns the id.
- A slow cluster read defers that tick's beat by the read latency, bounded by a deadline derived from the scheduler's own heartbeat interval. The staleness tolerance absorbs a deferred tick.
- **Accepted limitation.** If this incarnation's retained version goes stale *while* its own beat reads are failing — because a writer with no ownership claim overwrote the key, or because a write landed but its acknowledgement was lost — it cannot refresh until a read succeeds, and after a full TTL peers may treat it as dead and re-drive its jobs while it is still running. It requires two simultaneous faults, and it fails safe on correctness: it skips rather than overwriting a key it cannot prove it owns, and it recovers on the first readable beat. Closing it would mean permitting one unconditional write, which reinstates the clobber this change exists to prevent; with a single object shared by every incarnation there is no third option, since an old incarnation's overwrite destroys the payload a reader would need to compare against.
- A tick performs more reads than before — a membership read, and on a foreign beat a re-confirmation — each bounded by a deadline derived from the scheduler's own heartbeat interval. Against a store that is slow rather than failing, beats are therefore later than on a fast store, and the staleness tolerance (roughly three intervals) absorbs that. Bounding the tick as a whole was tried and removed: cancelling an in-flight write discards the acknowledgement for a write that may have landed, which is precisely what poisons the retained version, and at short TTLs the read deadlines could consume the budget before any write was attempted — evicting a healthy scheduler faster than not bounding it at all.
- `file://` conditional puts are implemented as check-then-act, so the version predicate is not atomic for file-backed state locations. The conditional path is exact on stores with real preconditions; a local file-backed run has no competing writer in practice.
- **Known limitation, not fixed here.** An incarnation that still holds the key keeps refreshing its own beat while `cluster.json` is unreadable — deliberate, since suppressing beats on an unreadable membership document would self-evict a healthy scheduler. If a successor has committed membership and then died before its first beat, that combination pins the id: `list_alive` reports nobody (membership and beat name different instances), the reaper does not evict on an `instance_id` mismatch, and registration will not take over while a foreign beat is fresh. Recovery waits for membership to become readable again plus a TTL. This state is reachable on `trunk` today — a test asserting that such an entry is neither reported by `list_alive` nor reaped passes unmodified — so it is pre-existing rather than introduced here: this change removes the *cause* (a superseded incarnation overwriting the key) while leaving how `list_alive` and the reaper judge a mismatch untouched. Fixing that means letting the reaper evict an entry whose own instance has not beaten well past its grace period even though another instance's beat is fresh — a reaper policy change, in a rule that exists to protect a mid-takeover successor, so it belongs in its own change.
- Orphan heartbeat keys accumulate where advertise addresses change over time, and discovery/reaper passes read every object under the prefix. Non-graceful exits already left keys behind, so this widens existing behaviour; a race-safe GC of keys with no registered entry is worth doing separately.
