### PR TITLE
fix(cayenne): use valid snapshot IDs for deferred appends

### DIFF
--- a/crates/cayenne/src/provider/staging_wal.rs
+++ b/crates/cayenne/src/provider/staging_wal.rs
@@ -1295,7 +1295,7 @@ impl CayenneTableProvider {
         // cross-partition append. Refuse before cloning or consuming input until
         // those states are included in the coordinated transaction.
         let current_snapshot_id = self.get_current_snapshot_id();
-        let target_snapshot_id = Self::new_staging_snapshot_id();
+        let (_, target_snapshot_id) = Self::new_staging_snapshot_id_pair();
         let mut setup_cleanup = DeferredSetupCleanup {
             table: self.clone_for_write_operations(),
             snapshots: vec![target_snapshot_id.clone()],

--- a/crates/cayenne/tests/cross_partition_overwrite_test.rs
+++ b/crates/cayenne/tests/cross_partition_overwrite_test.rs
@@ -169,6 +169,46 @@ async fn snapshot_pointers(setup: &PartitionSetup) -> Vec<String> {
     snapshots
 }
 
+// Regression test for partitioned append refreshes: the deferred target is a
+// durable catalog snapshot identifier, while only the transient writer path is
+// rooted under `_staging/`. Passing the staging path to the catalog makes every
+// partitioned append fail before its atomic pointer update.
+#[tokio::test]
+async fn deferred_append_uses_catalog_valid_target_snapshot_id() {
+    let setup = setup_partitions(1).await;
+    let table = &setup.tables[0];
+    let prepared = table
+        .begin_deferred_snapshot_append(batch_to_stream(make_batch(&[1], &["one"])), 1)
+        .await
+        .expect("prepare deferred append");
+
+    let target_snapshot_id = prepared.target_snapshot_id().to_string();
+    uuid::Uuid::parse_str(&target_snapshot_id)
+        .expect("deferred target snapshot must be a catalog-valid UUID");
+    assert!(
+        !target_snapshot_id.starts_with("_staging/"),
+        "durable target snapshot must not use a staging path"
+    );
+
+    let mut txn = setup
+        .catalog
+        .begin_transaction()
+        .await
+        .expect("begin transaction");
+    setup
+        .catalog
+        .set_current_snapshots_in_txn(
+            &mut *txn,
+            &[(prepared.table_id(), target_snapshot_id.as_str())],
+        )
+        .await
+        .expect("catalog accepts deferred target snapshot");
+    txn.rollback()
+        .await
+        .expect("rollback catalog pointer update");
+    prepared.rollback().await.expect("rollback deferred append");
+}
+
 // ============================================================================
 // Test 1 — happy path: prepare all partitions, apply each in one shared
 // MetastoreTransaction, commit once, finish each. Every partition's


### PR DESCRIPTION
## Summary

- use the durable UUID from the staging snapshot ID pair as the deferred append target
- keep the `_staging/<uuid>` identifier limited to transient writer paths
- add a regression test proving the target snapshot ID is catalog-valid

## Problem

Partitioned append refreshes passed `_staging/<uuid>` to the catalog as a snapshot ID. Cross-partition commit validation accepts UUID snapshot IDs, so the refresh failed before the coordinated pointer update.

## Validation

- full-binary Spicepod reproduction verified manually
- `cargo fmt`
- `git diff --check`
- automated tests not run locally

## Documentation

No documentation update is needed. This corrects an invalid internal identifier without changing public behavior or configuration.
