### PR TITLE
fix(search): handle null embeddings in vector writes and JIT search

### DIFF
--- a/crates/runtime/src/embeddings/udtf.rs
+++ b/crates/runtime/src/embeddings/udtf.rs
@@ -868,6 +868,11 @@ impl TableProvider for VectorSearchUDTFProvider {
             base_expr.push(ident(embedding_col_name.clone()));
         }
 
+        // Rows with NULL embeddings cannot participate in vector search. Exclude
+        // them before scoring and limiting so a caller's outer `ORDER BY _score
+        // DESC` cannot promote NULL scores ahead of real matches.
+        scan = scan.filter(ident(embedding_col_name.clone()).is_not_null())?;
+
         // Pick the scoring expression based on the requested distance metric.
         // In all cases the result is monotonically increasing with similarity
         // (higher == more similar) so the downstream `ORDER BY _score DESC` is correct.

--- a/crates/search/src/index/duckdb/write.rs
+++ b/crates/search/src/index/duckdb/write.rs
@@ -190,7 +190,8 @@ fn create_embedding_array(
                 });
             }
             None => {
-                builder.values().append_nulls(expected);
+                // Nullness belongs to the list slot; the child field is non-nullable.
+                builder.values().append_value_n(0.0, expected);
                 builder.append(false);
             }
         }

--- a/crates/search/src/index/duckdb/write.rs
+++ b/crates/search/src/index/duckdb/write.rs
@@ -190,7 +190,7 @@ fn create_embedding_array(
                 });
             }
             None => {
-                // Nullness belongs to the list slot; the child field is non-nullable.
+                // Store `f32` child values, not `Option<f32>`; the list slot represents a null embedding.
                 builder.values().append_value_n(0.0, expected);
                 builder.append(false);
             }

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -483,7 +483,7 @@ fn create_embedding_array(
                 });
             }
             None => {
-                // Nullness belongs to the list slot; the child field is non-nullable.
+                // Store `f32` child values, not `Option<f32>`; the list slot represents a null embedding.
                 builder.values().append_value_n(0.0, expected);
                 builder.append(false);
             }

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -483,7 +483,8 @@ fn create_embedding_array(
                 });
             }
             None => {
-                builder.values().append_nulls(expected);
+                // Nullness belongs to the list slot; the child field is non-nullable.
+                builder.values().append_value_n(0.0, expected);
                 builder.append(false);
             }
         }

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -328,7 +328,10 @@ pub fn create_embedding_array(
             builder.values().append_slice(embedding);
             builder.append(true);
         } else {
-            builder.values().append_nulls(expected_dim);
+            // A null fixed-size-list slot still occupies `dimension` values in
+            // Arrow's child array. The child field is non-nullable, so use
+            // placeholder values and represent nullness only in the parent.
+            builder.values().append_value_n(0.0, expected_dim);
             builder.append(false);
         }
     }
@@ -382,7 +385,7 @@ mod tests {
                 builder.values().append_slice(&embedding);
                 builder.append(true);
             } else {
-                builder.values().append_nulls(dim as usize);
+                builder.values().append_value_n(0.0, dim as usize);
                 builder.append(false);
             }
         }
@@ -452,6 +455,11 @@ mod tests {
         assert!(!list_array.is_null(0));
         assert!(list_array.is_null(1));
         assert!(!list_array.is_null(2));
+        assert_eq!(
+            list_array.values().null_count(),
+            0,
+            "null vectors must not put nulls in a non-nullable child array"
+        );
 
         // Check first embedding values
         let first_values = list_array.value(0);

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -328,9 +328,8 @@ pub fn create_embedding_array(
             builder.values().append_slice(embedding);
             builder.append(true);
         } else {
-            // A null fixed-size-list slot still occupies `dimension` values in
-            // Arrow's child array. The child field is non-nullable, so use
-            // placeholder values and represent nullness only in the parent.
+            // Store `f32` child values, not `Option<f32>`. Use zero-valued
+            // child slots and represent a null embedding at the list level.
             builder.values().append_value_n(0.0, expected_dim);
             builder.append(false);
         }


### PR DESCRIPTION
## Summary

- Represent null fixed-size-list rows with valid zero-valued child slots (not `NULL`, which makes some users (i.e. cayenne) infer the elements can be null). 
- Apply the same Arrow invariant in shared, Elasticsearch, and DuckDB vector writers
- Also exclude null embeddings before JIT scoring and limiting

## Problem

Null embedding rows retained nulls in the non-nullable fixed-size-list child array, causing Vortex writes to fail. When such rows reached JIT vector search, their null scores could also occupy top results and return empty answers.
