### PR TITLE
fix(flight): resolve per-request settings from the live app

### DIFF
--- a/crates/runtime/src/cluster/servers.rs
+++ b/crates/runtime/src/cluster/servers.rs
@@ -248,9 +248,6 @@ pub async fn start_executor_flight_server(
     let session_store = spice_service.session_store();
     let composite_service = CompositeFlightService::new(spice_service);
 
-    // Get app for request context
-    let app = rt.app.read().await.as_ref().map(Arc::clone);
-
     // Wrap the auth in session-awareness to accept session IDs as bearer tokens
     let session_aware_auth = session_auth::with_session_awareness(
         endpoint_auth.flight_basic_auth,
@@ -268,7 +265,7 @@ pub async fn start_executor_flight_server(
     let rate_limits = &rt.rate_limits;
     let mut server = server
         .layer(
-            RequestContextLayer::new(app, rt.datafusion(), session_store, rt.secrets())
+            RequestContextLayer::new(rt.app(), rt.datafusion(), session_store, rt.secrets())
                 .with_job_executor(job_executor),
         )
         .layer(auth_layer)

--- a/crates/runtime/src/flight/middleware/request_context.rs
+++ b/crates/runtime/src/flight/middleware/request_context.rs
@@ -43,7 +43,7 @@ use tower::{Layer, Service};
 /// Extracts the request context from the HTTP headers and adds it to the task-local context.
 #[derive(Clone)]
 pub struct RequestContextLayer {
-    app: Option<Arc<App>>,
+    app: Arc<RwLock<Option<Arc<App>>>>,
     df: Arc<DataFusion>,
     session_store: SessionStore,
     secrets: Arc<RwLock<secrets::Secrets>>,
@@ -53,7 +53,7 @@ pub struct RequestContextLayer {
 impl RequestContextLayer {
     #[must_use]
     pub fn new(
-        app: Option<Arc<App>>,
+        app: Arc<RwLock<Option<Arc<App>>>>,
         df: Arc<DataFusion>,
         session_store: SessionStore,
         secrets: Arc<RwLock<secrets::Secrets>>,
@@ -81,7 +81,7 @@ impl<S> Layer<S> for RequestContextLayer {
     fn layer(&self, inner: S) -> Self::Service {
         RequestContextMiddleware {
             inner,
-            app: self.app.clone(),
+            app: Arc::clone(&self.app),
             df: Arc::clone(&self.df),
             session_store: self.session_store.clone(),
             secrets: Arc::clone(&self.secrets),
@@ -93,7 +93,7 @@ impl<S> Layer<S> for RequestContextLayer {
 #[derive(Clone)]
 pub struct RequestContextMiddleware<S> {
     inner: S,
-    app: Option<Arc<App>>,
+    app: Arc<RwLock<Option<Arc<App>>>>,
     df: Arc<DataFusion>,
     session_store: SessionStore,
     secrets: Arc<RwLock<secrets::Secrets>>,
@@ -119,8 +119,6 @@ where
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
 
-        let headers = req.headers();
-
         // Try to get or create a session for this request. Capture the owning
         // principal's stable id (if the request names an existing, owned session)
         // so the session can be bound to its owner at execution time. This layer
@@ -132,44 +130,243 @@ where
             .get_or_create_session_from_http(req.headers(), &self.df.ctx)
             .map(|ctx| FlightSessionExtension::new(ctx, owner_stable_id));
 
-        let mut builder = RequestContext::builder(Protocol::Flight)
-            .with_app_opt(self.app.clone())
-            .with_extension(DataFusionContextExtension::new(Arc::clone(&self.df)))
-            .with_extension(ModelContextExtension::new())
-            .with_extension(AppContextExtension::new(self.app.clone()))
-            .with_extension(SecretsContextExtension::new(Arc::clone(&self.secrets)));
+        let app_lock = Arc::clone(&self.app);
+        let df = Arc::clone(&self.df);
+        let secrets = Arc::clone(&self.secrets);
+        let job_executor = self.job_executor.clone();
 
-        // Add job executor extension if available (cluster mode)
-        if let Some(ref executor) = self.job_executor {
-            builder =
-                builder.with_extension(JobExecutorContextExtension::new(Arc::clone(executor)));
+        Box::pin(async move {
+            // Read the app the runtime is currently serving, so a spicepod
+            // reload is visible to the next request. The guard is released
+            // before any `.await` in the request path.
+            let app = app_lock.read().await.as_ref().map(Arc::clone);
+
+            let mut builder = RequestContext::builder(Protocol::Flight)
+                .with_app_opt(app.clone())
+                .with_extension(DataFusionContextExtension::new(df))
+                .with_extension(ModelContextExtension::new())
+                .with_extension(AppContextExtension::new(app))
+                .with_extension(SecretsContextExtension::new(secrets));
+
+            // Add job executor extension if available (cluster mode)
+            if let Some(executor) = job_executor {
+                builder = builder.with_extension(JobExecutorContextExtension::new(executor));
+            }
+
+            // Add session extension if we have one
+            if let Some(session_ext) = session_ext {
+                builder = builder.with_extension(session_ext);
+            }
+
+            let request_context = Arc::new(builder.from_headers(req.headers()).build());
+
+            req.extensions_mut()
+                .insert::<Arc<dyn AuthRequestContext + Send + Sync>>(
+                    Arc::clone(&request_context) as Arc<dyn AuthRequestContext + Send + Sync>
+                );
+
+            Arc::clone(&request_context)
+                .scope(async move {
+                    request_context.load_extensions().await;
+                    // Drop guard cancels the request's cancellation token if the
+                    // response body is dropped mid-flight (e.g. client disconnects
+                    // during a long-running Flight DoGet stream). The guard is
+                    // attached to the response body via `CancelGuardBody`, which
+                    // disarms it once the body signals end-of-stream so normal
+                    // completion does not cancel the token.
+                    let cancel_guard = request_context.cancellation_token().clone().drop_guard();
+                    let response = inner.call(req).await?;
+                    let (parts, body) = response.into_parts();
+                    let body = util::cancel_guard_body::CancelGuardBody::new(body, cancel_guard);
+                    Ok(http::Response::from_parts(parts, body))
+                })
+                .await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        dataaccelerator::AcceleratorEngineRegistry, datafusion::builder::DataFusionBuilder,
+        status::RuntimeStatus,
+    };
+    use axum::body::Body;
+    use runtime_request_context::{AsyncMarker, CacheControl, CacheKeyType};
+    use spicepod::component::caching::{
+        CacheKeyType as ConfiguredCacheKeyType, SQLResultsCacheConfig,
+    };
+    use spicepod::component::runtime::{Flight, FlightBatchSize, Query, UserAgentCollection};
+    use std::sync::Mutex;
+    use std::time::Duration;
+    use tokio::runtime::Handle;
+
+    /// The app-derived settings a request resolves, covering each channel the
+    /// app reaches the request context through: `cache_control` and
+    /// `query_timeout` are baked by `RequestContextBuilder::build`,
+    /// `user_agent_collected` by `RequestContextBuilder::from_headers`, and
+    /// `flight_batch_size` is read back off [`AppContextExtension`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct Observed {
+        query_timeout: Option<Duration>,
+        cache_control: CacheControl,
+        user_agent_collected: bool,
+        flight_batch_size: Option<FlightBatchSize>,
+    }
+
+    /// Terminal service that records what the surrounding request context
+    /// resolves, so the assertions run against the context the middleware
+    /// actually installed rather than against the app itself.
+    #[derive(Clone)]
+    struct ObserveContext {
+        observed: Arc<Mutex<Vec<Observed>>>,
+    }
+
+    impl Service<http::Request<Body>> for ObserveContext {
+        type Response = http::Response<Body>;
+        type Error = std::convert::Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
         }
 
-        // Add session extension if we have one
-        if let Some(session_ext) = session_ext {
-            builder = builder.with_extension(session_ext);
+        fn call(&mut self, _req: http::Request<Body>) -> Self::Future {
+            let observed = Arc::clone(&self.observed);
+            Box::pin(async move {
+                let context = RequestContext::current(AsyncMarker::new().await);
+                let flight_batch_size = context
+                    .extension::<AppContextExtension>()
+                    .and_then(|app_ext| app_ext.app())
+                    .and_then(|app| app.runtime.flight.as_ref().map(|flight| flight.batch_size));
+                let user_agent_collected = context
+                    .to_dimensions()
+                    .iter()
+                    .any(|dimension| dimension.key.as_str() == "user_agent");
+
+                observed
+                    .lock()
+                    .expect("observations mutex is not poisoned")
+                    .push(Observed {
+                        query_timeout: context.query_timeout(),
+                        cache_control: context.cache_control(),
+                        user_agent_collected,
+                        flight_batch_size,
+                    });
+
+                Ok(http::Response::new(Body::empty()))
+            })
         }
+    }
 
-        let request_context = Arc::new(builder.from_headers(headers).build());
+    fn app_with(
+        timeout: &str,
+        cache_key_type: ConfiguredCacheKeyType,
+        user_agent_collection: UserAgentCollection,
+        max_batch_size: usize,
+    ) -> Arc<App> {
+        let mut app = app::AppBuilder::new("test").build();
+        app.runtime.query = Some(Query {
+            timeout: Some(timeout.to_string()),
+            ..Default::default()
+        });
+        app.runtime.caching.sql_results = Some(SQLResultsCacheConfig {
+            cache_key_type,
+            ..SQLResultsCacheConfig::default()
+        });
+        app.runtime.telemetry.user_agent_collection = user_agent_collection;
+        app.runtime.flight = Some(Flight {
+            batch_size: FlightBatchSize::Adaptive {
+                max: max_batch_size,
+            },
+            ..Flight::default()
+        });
+        Arc::new(app)
+    }
 
-        req.extensions_mut()
-            .insert::<Arc<dyn AuthRequestContext + Send + Sync>>(
-                Arc::clone(&request_context) as Arc<dyn AuthRequestContext + Send + Sync>
-            );
+    async fn observe(service: &mut RequestContextMiddleware<ObserveContext>) {
+        let request = http::Request::builder()
+            .uri("/arrow.flight.protocol.FlightService/DoGet")
+            .header(http::header::USER_AGENT, "spice-test/1.0")
+            .body(Body::empty())
+            .expect("request builds");
 
-        Box::pin(Arc::clone(&request_context).scope(async move {
-            request_context.load_extensions().await;
-            // Drop guard cancels the request's cancellation token if the
-            // response body is dropped mid-flight (e.g. client disconnects
-            // during a long-running Flight DoGet stream). The guard is
-            // attached to the response body via `CancelGuardBody`, which
-            // disarms it once the body signals end-of-stream so normal
-            // completion does not cancel the token.
-            let cancel_guard = request_context.cancellation_token().clone().drop_guard();
-            let response = inner.call(req).await?;
-            let (parts, body) = response.into_parts();
-            let body = util::cancel_guard_body::CancelGuardBody::new(body, cancel_guard);
-            Ok(http::Response::from_parts(parts, body))
-        }))
+        service
+            .call(request)
+            .await
+            .expect("the middleware forwards to the observing service");
+    }
+
+    /// A Flight request resolves its app-derived settings from the app the
+    /// runtime is currently serving, so a spicepod reload is visible to the
+    /// next request and both protocols report the same value.
+    #[tokio::test]
+    async fn flight_request_context_follows_app_reload() {
+        let app = Arc::new(RwLock::new(Some(app_with(
+            "30s",
+            ConfiguredCacheKeyType::Plan,
+            UserAgentCollection::Full,
+            1024,
+        ))));
+        let df = Arc::new(
+            DataFusionBuilder::new(
+                RuntimeStatus::new(),
+                Arc::new(AcceleratorEngineRegistry::new()),
+                Handle::current(),
+            )
+            .build(),
+        );
+
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let mut service = RequestContextLayer::new(
+            Arc::clone(&app),
+            df,
+            SessionStore::new(),
+            Arc::new(RwLock::new(secrets::Secrets::new())),
+        )
+        .layer(ObserveContext {
+            observed: Arc::clone(&observed),
+        });
+
+        observe(&mut service).await;
+
+        *app.write().await = Some(app_with(
+            "5s",
+            ConfiguredCacheKeyType::Sql,
+            UserAgentCollection::Disabled,
+            4096,
+        ));
+
+        observe(&mut service).await;
+
+        let http_context = RequestContext::builder(Protocol::Http)
+            .with_app_opt(app.read().await.as_ref().map(Arc::clone))
+            .build();
+
+        let observed = observed
+            .lock()
+            .expect("observations mutex is not poisoned")
+            .clone();
+
+        assert_eq!(
+            observed,
+            vec![
+                Observed {
+                    query_timeout: Some(Duration::from_secs(30)),
+                    cache_control: CacheControl::Cache(CacheKeyType::Default),
+                    user_agent_collected: true,
+                    flight_batch_size: Some(FlightBatchSize::Adaptive { max: 1024 }),
+                },
+                Observed {
+                    query_timeout: Some(Duration::from_secs(5)),
+                    cache_control: CacheControl::Cache(CacheKeyType::Raw),
+                    user_agent_collected: false,
+                    flight_batch_size: Some(FlightBatchSize::Adaptive { max: 4096 }),
+                },
+            ]
+        );
+        assert_eq!(observed[1].query_timeout, http_context.query_timeout());
+        assert_eq!(observed[1].cache_control, http_context.cache_control());
     }
 }

--- a/crates/runtime/src/flight/mod.rs
+++ b/crates/runtime/src/flight/mod.rs
@@ -909,7 +909,7 @@ pub async fn start(
 
     let mut server = server
         .layer(
-            RequestContextLayer::new(app, rt.datafusion(), session_store, rt.secrets())
+            RequestContextLayer::new(rt.app(), rt.datafusion(), session_store, rt.secrets())
                 .with_job_executor(job_executor),
         )
         // mTLS principal injection runs *after* RequestContextLayer

--- a/crates/runtime/src/http/routes.rs
+++ b/crates/runtime/src/http/routes.rs
@@ -539,10 +539,9 @@ async fn track_metrics(
     mut req: Request<Body>,
     next: Next,
 ) -> impl IntoResponse {
-    let app_lock = app.read().await;
-    let app = app_lock.as_ref().map(Arc::clone);
+    let app = app.read().await.as_ref().map(Arc::clone);
     let mut request_context_builder = RequestContext::builder(Protocol::Http)
-        .with_app_opt(app_lock.as_ref().map(Arc::clone))
+        .with_app_opt(app.clone())
         .from_headers(&headers);
 
     if let Some(ext) = DatabricksAuthExtension::from_headers(&app, &Some(Arc::clone(&df)), &headers)


### PR DESCRIPTION
Flight's `RequestContextLayer` captured an `Option<Arc<App>>` when the Flight server was built and cloned that snapshot into every request context. HTTP reads the live app behind its lock on each request, so after a spicepod reload the two protocols disagreed: on Flight, every app-derived setting resolved per request stayed frozen at process start.

Editing `runtime.query.timeout` under `spice run` took effect on `/v1/sql` and silently never on Flight SQL. The settings this affected, grouped by the channel the app reaches the request context through:

| Setting | Resolved by |
| --- | --- |
| `runtime.query.timeout` | `RequestContextBuilder::build` |
| `runtime.caching.sql_results.cache_key_type` | `RequestContextBuilder::build` |
| `runtime.telemetry.user_agent_collection` | `RequestContextBuilder::from_headers` |
| `runtime.flight.batch_size` | `AppContextExtension` |
| `runtime.flight.ipc_compression` | `AppContextExtension` |

`RequestContextLayer` now holds the same `Arc<RwLock<Option<Arc<App>>>>` the runtime serves and snapshots it per request, releasing the guard before the request path awaits. Taking one `Arc<App>` snapshot per request keeps a single consistent view for the whole request, so a reload cannot change batch size or IPC compression part-way through a `DoGet` stream.

`track_metrics` on the HTTP side bound its read guard for the entire request, including `next.run(req).await`. A reload writer therefore queued behind a long-running query, and because tokio's `RwLock` is write-preferring, that pending writer would then block the per-request Flight reads this change introduces. The HTTP read is scoped the same way so the two protocols share one lock discipline.

`runtime.flight.max_message_size` stays resolved when the server starts: it configures the tonic transport's encode and decode limits at bind time, not per request.

The test drives the real middleware twice with a reload in between and reads the values back through a Flight request context, covering all three channels.

Closes spiceai/spiceai#12861
Part of spiceai/spiceai#12860
