### PR TITLE
fix(search): Improve search benchmarking DX and fix some vector index names

### DIFF
--- a/.github/workflows/testoperator_run_search.yml
+++ b/.github/workflows/testoperator_run_search.yml
@@ -1,4 +1,5 @@
 name: testoperator search tests
+run-name: bench - ${{ github.event.inputs.benchmark_dataset }} - ${{ github.event.inputs.spicepod_path }}
 
 on:
   workflow_dispatch:

--- a/test/spicepods/search/mteb/miracl_en/model2vec[potion-multilingual-128M]-s3_vectors.yaml
+++ b/test/spicepods/search/mteb/miracl_en/model2vec[potion-multilingual-128M]-s3_vectors.yaml
@@ -15,7 +15,7 @@ datasets:
       engine: s3_vectors
       params:
         s3_vectors_bucket: spice-ci-search-benchmarks-variant-001
-        s3_vectors_index: miracl_en
+        s3_vectors_index: miracl-en
         s3_vectors_aws_region: us-east-2
         s3_vectors_aws_access_key_id: ${env:AWS_S3_VECTORS_KEY}
         s3_vectors_aws_secret_access_key: ${env:AWS_S3_VECTORS_SECRET}

--- a/test/spicepods/search/mteb/trec_covid/model2vec[potion-multilingual-128M]-s3_vectors.yaml
+++ b/test/spicepods/search/mteb/trec_covid/model2vec[potion-multilingual-128M]-s3_vectors.yaml
@@ -15,7 +15,7 @@ datasets:
       engine: s3_vectors
       params:
         s3_vectors_bucket: spice-ci-search-benchmarks-variant-001
-        s3_vectors_index: trec_covid
+        s3_vectors_index: trec-covid
         s3_vectors_aws_region: us-east-2
         s3_vectors_aws_access_key_id: ${env:AWS_S3_VECTORS_KEY}
         s3_vectors_aws_secret_access_key: ${env:AWS_S3_VECTORS_SECRET}


### PR DESCRIPTION
## Changes

- Rename the `miracl_en` S3 Vectors index to `miracl-en`.
- Rename the `trec_covid` S3 Vectors index to `trec-covid`.
- Add benchmark and Spicepod details to search workflow run names.

AWS S3 Vectors index names do not permit underscores, so these configurations could fail with `ValidationException: Invalid index name`.

## Validation

- `target/debug/spicepod-validator test/spicepods/search/mteb/miracl_en/model2vec[potion-multilingual-128M]-s3_vectors.yaml`
- `target/debug/spicepod-validator test/spicepods/search/mteb/trec_covid/model2vec[potion-multilingual-128M]-s3_vectors.yaml`
- `git diff --check`
