### PR TITLE
feat(cloud-connect): apply a component-only Spicepod deployment in place

### DIFF
--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -39,24 +39,28 @@ limitations under the License.
 //!
 //! ## How a deployment applies
 //!
-//! By restarting, and only by restarting. `apply_spicepod` validates the
-//! incoming spicepod, persists it as `spicepod-cloud-managed.yml`, records the
-//! deployment version beside it, and exits 0 — the supervisor relaunches
-//! `spiced`, [`cloud_managed_spicepod`] hands the persisted file to the app
-//! builder, and the instance comes up serving it and reporting its version.
+//! `apply_spicepod` validates the incoming spicepod and persists it as
+//! `spicepod-cloud-managed.yml`, and how it becomes live depends on what it
+//! changes. That is decided — see [`classify_deployment`] — before the spicepod
+//! is written, its secrets are installed, or any component is reconciled, so an
+//! apply cannot start down one path and discover it needed the other.
 //!
-//! Two consequences the caller has to hold:
+//! A change confined to the sections `Runtime::apply_app` reconciles
+//! ([`HOT_SECTIONS`]) is applied to this process: the instance keeps serving and
+//! the result says the deployment is live. Anything else is made live by
+//! exiting 0 — the supervisor relaunches `spiced`, [`cloud_managed_spicepod`]
+//! hands the persisted file to the app builder, and the instance comes up
+//! serving it.
+//!
+//! Two consequences of the restart path the caller has to hold:
 //!
 //! - **The command result may never arrive.** The process exits mid-command, so
 //!   the stream drops before the result is guaranteed to land — a caller cannot
 //!   treat its absence as a failed deployment.
 //! - **Downtime is proportional to the app's size, not the change's.** A
 //!   one-line edit reloads every dataset and rebuilds every acceleration.
-//!
-//! What this buys is one behaviour instead of two: no section that reconciles
-//! in-process while another waits for an operator, and no partially-applied
-//! state that is neither the old configuration nor the new one.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -151,9 +155,9 @@ fn build_config(runtime_version: &str) -> CloudConnectConfig {
 
 /// The spicepod a deployment persisted, and the deployment it belongs to.
 ///
-/// A deployment applies by persisting this file and restarting, so on every
-/// start it — not the instance directory's `spicepod.yaml` — is the
-/// configuration a cloud-managed instance serves.
+/// Every deployment persists this file, so on every start it — not the instance
+/// directory's `spicepod.yaml` — is the configuration a cloud-managed instance
+/// serves.
 #[derive(Debug)]
 pub struct CloudManagedSpicepod {
     pub path: PathBuf,
@@ -255,6 +259,10 @@ pub async fn restore_delivered_secrets(
 /// deployed one that failed to build). It is what a redelivered `ApplySpicepod`
 /// is compared against, so passing a configuration that is not live would let a
 /// redelivery be answered as already applied when it is not.
+///
+/// `runtime_overrides` are the process's `--set-runtime` values, which a
+/// deployment applied in place has to carry the same way a restart onto it
+/// would.
 pub async fn maybe_start(
     runtime_version: &str,
     runtime: Arc<Runtime>,
@@ -262,6 +270,7 @@ pub async fn maybe_start(
     delivered_secrets: Option<DeliveredSecretsState>,
     running_deployment: Option<CloudManagedSpicepod>,
     metrics: Option<MetricsReader>,
+    runtime_overrides: Vec<(String, String)>,
 ) -> Option<CloudConnect> {
     let config = build_config(runtime_version);
 
@@ -355,7 +364,7 @@ pub async fn maybe_start(
         tracing::warn!("Spice Cloud Connect: {caveat}");
     } else {
         tracing::info!(
-            "Spice Cloud Connect: process supervisor detected ({}); a deployment applies by restarting spiced",
+            "Spice Cloud Connect: process supervisor detected ({}); a deployment that cannot be applied in place relaunches spiced",
             supervisor.as_str()
         );
     }
@@ -373,6 +382,7 @@ pub async fn maybe_start(
             supervisor,
             metrics,
             app_id: persisted_app_id,
+            runtime_overrides,
         }));
 
     match CloudConnect::start(config, handle).await {
@@ -452,8 +462,17 @@ enum Disposition {
 ///
 /// The spicepod itself is the identity of a deployment here: with nothing else to
 /// compare, byte-identical YAML is the same configuration and anything else is a
-/// new one.
-fn disposition(live: &str, persisted: Option<&str>, incoming: &str) -> Disposition {
+/// new one — unless it delivers secret values this instance does not hold, which
+/// is a change the YAML does not show and which nothing else would apply.
+fn disposition(
+    live: &str,
+    persisted: Option<&str>,
+    incoming: &str,
+    secrets_changed: bool,
+) -> Disposition {
+    if secrets_changed {
+        return Disposition::Apply;
+    }
     if persisted.is_some_and(|persisted| persisted == incoming) {
         return Disposition::AlreadyPersisted;
     }
@@ -463,6 +482,228 @@ fn disposition(live: &str, persisted: Option<&str>, incoming: &str) -> Dispositi
         return Disposition::AlreadyLive;
     }
     Disposition::Apply
+}
+
+/// The spicepod sections [`Runtime::apply_app`] reconciles in a running
+/// process.
+///
+/// Every other section — `runtime`, `secrets`, `extensions`, `embeddings`,
+/// `tools`, and the rest — is read while the process starts, so a change to one
+/// takes effect by starting again. `workers` reconciles only in a build without
+/// the `models` feature, so it is left out: the cost of omitting a section is a
+/// restart that was not needed, while listing one the runtime does not
+/// reconcile in every build drops the change silently.
+const HOT_SECTIONS: [&str; 5] = ["catalogs", "datasets", "functions", "models", "views"];
+
+/// How an incoming spicepod takes effect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ApplyMode {
+    /// Reconcile it into this process.
+    Hot,
+    /// Persist it and restart onto it.
+    Cold(ColdReason),
+}
+
+/// What makes a deployment reach the instance by restarting it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ColdReason {
+    /// Sections the deployment changes that are read at start. Never empty.
+    Sections(Vec<String>),
+    /// The deployment carries secret values this instance does not hold.
+    /// A component resolves `${ secrets:… }` as it loads, so a new value
+    /// reaches the components already loaded by loading them again.
+    DeliveredSecrets,
+    /// This process serves no deployment, so there is nothing to diff an
+    /// incoming one against.
+    NoLiveDeployment,
+    /// This process has already persisted another deployment and is on its way
+    /// out for it. It cannot be the process that makes this one live: applying
+    /// it in place would reconcile components into a runtime that is draining,
+    /// and report as live a configuration this process will not serve. The
+    /// newest deployment is still the one persisted, so the restart comes up on
+    /// it rather than on the one it superseded.
+    RestartPending,
+    /// The initial component load has not finished. It is still registering the
+    /// components of the app being replaced, and reconciling only what the diff
+    /// shows as changed would leave the two writing the same tables — the load
+    /// installing what this deployment replaced, after it replaced it.
+    InitialLoadUnfinished,
+}
+
+impl ColdReason {
+    /// The spicepod sections that forced the restart, for the command result.
+    ///
+    /// Empty when what forced it is the state of this process rather than
+    /// something the deployment changed.
+    fn sections(&self) -> Vec<String> {
+        match self {
+            Self::Sections(sections) => sections.clone(),
+            Self::DeliveredSecrets => vec!["secrets".to_string()],
+            Self::NoLiveDeployment | Self::RestartPending | Self::InitialLoadUnfinished => {
+                Vec::new()
+            }
+        }
+    }
+
+    /// The clause naming what forced the restart, phrased to follow "because".
+    fn summary(&self) -> String {
+        match self {
+            Self::Sections(sections) => format!(
+                "it changes configuration this instance reads when it starts: {}",
+                sections.join(", ")
+            ),
+            Self::DeliveredSecrets => {
+                "it delivers secret values this instance does not hold, and a component resolves its secrets as it loads".to_string()
+            }
+            Self::NoLiveDeployment => {
+                "this instance is not serving a deployment to apply the change onto".to_string()
+            }
+            Self::RestartPending => {
+                "this instance is already restarting onto a deployment it persisted".to_string()
+            }
+            Self::InitialLoadUnfinished => {
+                "this instance has not finished loading its components".to_string()
+            }
+        }
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "The spicepod was validated and persisted. This instance is restarting to serve it because {}. The restart reloads every dataset, so the app is unavailable until it finishes.",
+            self.summary()
+        )
+    }
+}
+
+/// What this process knows about an incoming deployment when it decides how to
+/// apply it.
+struct ApplyFacts<'a> {
+    /// The spicepod this process is serving, empty when it serves none.
+    live: &'a str,
+    /// The spicepod being deployed.
+    incoming: &'a str,
+    /// Whether the deployment carries secret values other than the ones
+    /// installed.
+    secrets_changed: bool,
+    /// Whether this process has already persisted a deployment and is
+    /// restarting onto it.
+    restart_pending: bool,
+    /// Whether the initial component load is still running.
+    initial_load_unfinished: bool,
+}
+
+/// Decide whether a deployment can be applied to this process.
+///
+/// Called before the spicepod is persisted, before its secrets are installed,
+/// and before any component is reconciled, so the decision holds for the whole
+/// apply: a hot apply can never discover halfway through that it needed the
+/// restart.
+/// Any one of these answers is enough on its own, so what the deployment
+/// carries is reported ahead of what the process happens to be doing: it is the
+/// half the caller can change.
+fn classify_deployment(facts: &ApplyFacts) -> ApplyMode {
+    if facts.live.is_empty() {
+        return ApplyMode::Cold(ColdReason::NoLiveDeployment);
+    }
+    let mut changed = start_time_changes(facts.live, facts.incoming);
+    if !changed.is_empty() {
+        if facts.secrets_changed {
+            // Delivered values are not in the document, but they are the app's
+            // secrets: an operator who reverted only the sections named here
+            // would be restarted again by the rotation.
+            changed.push("secrets".to_string());
+            changed.sort();
+            changed.dedup();
+        }
+        return ApplyMode::Cold(ColdReason::Sections(changed));
+    }
+    if facts.secrets_changed {
+        return ApplyMode::Cold(ColdReason::DeliveredSecrets);
+    }
+    if facts.restart_pending {
+        return ApplyMode::Cold(ColdReason::RestartPending);
+    }
+    if facts.initial_load_unfinished {
+        return ApplyMode::Cold(ColdReason::InitialLoadUnfinished);
+    }
+    ApplyMode::Hot
+}
+
+/// The sections in which `incoming` differs from `live`, excluding the ones a
+/// running process reconciles.
+///
+/// A document that is not a mapping — malformed YAML, or a scalar — reads as
+/// having no sections at all, so the `name`, `version` and `kind` every valid
+/// spicepod carries count as changed and the deployment takes the restart path.
+/// Validation rejects it before any of that is applied.
+fn start_time_changes(live: &str, incoming: &str) -> Vec<String> {
+    let live = sections(live);
+    let incoming = sections(incoming);
+    let mut changed: Vec<String> = live
+        .keys()
+        .chain(incoming.keys())
+        .filter(|section| !HOT_SECTIONS.contains(&section.as_str()))
+        .filter(|section| live.get(*section) != incoming.get(*section))
+        .cloned()
+        .collect();
+    changed.sort();
+    changed.dedup();
+    changed
+}
+
+/// The top-level sections of a spicepod document.
+///
+/// A section that is null or empty is dropped, so a `secrets: []` and no
+/// `secrets:` at all — which build the same app — do not read as a change.
+fn sections(spicepod_yaml: &str) -> BTreeMap<String, yaml::Value> {
+    let Ok(yaml::Value::Mapping(document)) = yaml::from_str::<yaml::Value>(spicepod_yaml) else {
+        return BTreeMap::new();
+    };
+    document
+        .into_iter()
+        .filter_map(|(name, section)| match name {
+            yaml::Value::String(name) if !is_empty_section(&section) => Some((name, section)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn is_empty_section(section: &yaml::Value) -> bool {
+    match section {
+        yaml::Value::Null => true,
+        yaml::Value::Sequence(items) => items.is_empty(),
+        yaml::Value::Mapping(entries) => entries.is_empty(),
+        _ => false,
+    }
+}
+
+/// The components an applied deployment reports.
+struct ComponentCounts {
+    datasets: usize,
+    models: usize,
+    catalogs: usize,
+    views: usize,
+}
+
+impl ComponentCounts {
+    fn of(app: &App) -> Self {
+        Self {
+            datasets: app.datasets.len(),
+            models: app.models.len(),
+            catalogs: app.catalogs.len(),
+            views: app.views.len(),
+        }
+    }
+}
+
+impl std::fmt::Display for ComponentCounts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} datasets, {} models, {} catalogs, {} views",
+            self.datasets, self.models, self.catalogs, self.views
+        )
+    }
 }
 
 /// Thin adapter so the cloud-connect client can call into the runtime
@@ -484,18 +725,29 @@ struct SpicedRuntimeHandle {
     /// unwritable on a first boot, which is precisely the case the cache exists
     /// for.
     identity_path: std::path::PathBuf,
-    /// The deployment this process is serving. Fixed for the life of the
-    /// process: a deployment takes effect by restarting, so nothing can change
-    /// what is live without starting a new one.
+    /// The deployment this process is serving, replaced by a hot apply so the
+    /// next one is diffed against what the process serves now rather than what
+    /// it booted on.
     ///
     /// A runtime serving a local spicepod holds an empty string, which matches
     /// no incoming deployment.
-    live: String,
+    ///
+    /// Guarded by a `parking_lot` lock held for the read/write only, never
+    /// across an `.await`.
+    live: RwLock<String>,
     /// A deployment this process validated and persisted, waiting on the exit
-    /// that makes it live. Read on every `Hello`, written once per apply — a
-    /// `parking_lot` lock held for the read/write only, never across an
-    /// `.await`.
+    /// that makes it live. Read on every status report, written by an apply
+    /// that needs a restart — a `parking_lot` lock held for the read/write
+    /// only, never across an `.await`.
     persisted: RwLock<Option<String>>,
+    /// The `--set-runtime` overrides this process was started with, applied to a
+    /// deployment the same way the start path applies them so what a hot apply
+    /// installs is the app a restart onto the same file would have produced.
+    runtime_overrides: Vec<(String, String)>,
+    /// Serializes an apply end to end — the decision, the persistence it commits
+    /// to, and the live-deployment update that follows — so two dispatches
+    /// cannot interleave one's decision with the other's state change.
+    applying: tokio::sync::Mutex<()>,
     /// What will relaunch this process after a deployment exits it.
     supervisor: Supervisor,
     /// Reader for the metrics pushed to the control plane. `None` when no
@@ -525,6 +777,7 @@ struct SpicedRuntimeHandleParts {
     supervisor: Supervisor,
     metrics: Option<MetricsReader>,
     app_id: Option<String>,
+    runtime_overrides: Vec<(String, String)>,
 }
 
 impl SpicedRuntimeHandle {
@@ -538,6 +791,7 @@ impl SpicedRuntimeHandle {
             supervisor,
             metrics,
             app_id,
+            runtime_overrides,
         } = parts;
         let live = running_deployment.map_or_else(String::new, |running| running.spicepod_yaml);
         Self {
@@ -545,8 +799,10 @@ impl SpicedRuntimeHandle {
             logs,
             delivered_secrets,
             identity_path,
-            live,
+            live: RwLock::new(live),
             persisted: RwLock::new(None),
+            runtime_overrides,
+            applying: tokio::sync::Mutex::new(()),
             supervisor,
             metrics,
             app_id: RwLock::new(app_id),
@@ -613,8 +869,8 @@ impl SpicedRuntimeHandle {
             .and_then(|identity| identity.cache_key())
     }
 
-    /// Persist the delivered secrets so the restart every deployment performs
-    /// comes back up with them, without a control-plane round trip.
+    /// Persist the delivered secrets so the restart a deployment takes comes
+    /// back up with them, without a control-plane round trip.
     ///
     /// Best-effort by design: the secrets are already applied to this running
     /// instance, so a cache failure costs a redeploy after the next restart
@@ -635,6 +891,157 @@ impl SpicedRuntimeHandle {
                 Some(err.to_string())
             }
         }
+    }
+
+    /// Write the delivered secrets to the cache for a deployment that has
+    /// nothing else left to do.
+    ///
+    /// The values are the ones this instance already holds — that is what makes
+    /// the deployment a redelivery — but the cache is what the next start
+    /// reads, and a write that failed on an earlier deployment would otherwise
+    /// never be retried: a redelivery is the last chance to repair it before a
+    /// restart needs it.
+    fn refresh_secret_cache(
+        &self,
+        config_dir: &Path,
+        delivered_secrets: Option<&runtime_cloud_connect::sealed_secrets::DeliveredSecrets>,
+    ) -> Option<String> {
+        self.cache_delivered_secrets(config_dir, delivered_secrets?)
+    }
+
+    /// Persist the deployment and reconcile it into this running process.
+    ///
+    /// Components converge one at a time: one that fails to build lands in an
+    /// error state, stays visible through `GetStatus`, and is retried by the
+    /// next deployment — the same place a component that fails at boot lands.
+    /// Nothing is rolled back, and the result does not claim otherwise.
+    ///
+    /// The deployment is recorded as live only once the app is installed, so a
+    /// redelivery arriving before that is answered as the deployment still
+    /// being applied rather than as one already serving. Live names the
+    /// deployment this process serves, not a component-by-component state:
+    /// which components are ready is what `GetStatus` answers.
+    async fn hot_apply(
+        &self,
+        config_dir: &Path,
+        spicepod_yaml: &str,
+        delivered_secrets: Option<runtime_cloud_connect::sealed_secrets::DeliveredSecrets>,
+    ) -> Result<ApplyOutcome, CommandError> {
+        let staged =
+            stage_cloud_managed_spicepod(config_dir, spicepod_yaml, &self.runtime_overrides)
+                .await?;
+
+        // The instance already holds these values — that is what makes this a
+        // hot apply — but a cache write that failed on an earlier deployment
+        // would otherwise never be retried, and the restart that eventually
+        // comes would have no secrets to resolve.
+        let mut cache_error = None;
+        let delivered_names = delivered_secrets.map(|secrets| {
+            cache_error = self.cache_delivered_secrets(config_dir, &secrets);
+            secrets.keys().cloned().collect::<Vec<String>>()
+        });
+
+        let (new_app, path) = staged.promote().await?;
+        let counts = ComponentCounts::of(&new_app);
+
+        Arc::clone(&self.runtime).apply_app(Arc::new(new_app)).await;
+        *self.live.write() = spicepod_yaml.to_string();
+
+        tracing::info!(
+            "Spice Cloud Connect: the deployed spicepod was validated, persisted to {} ({counts}), and applied without restarting",
+            path.display(),
+        );
+
+        Ok(ApplyOutcome::settled(serde_json::json!({
+            "path": path.display().to_string(),
+            "applied": true,
+            "live": true,
+            "restart": "not_required",
+            "message": "The spicepod was validated, persisted, and applied to this running instance, which is serving it. Its components reconcile one at a time, so some may still be loading: GetStatus reports which are ready, and one that fails to load stays there and is retried by the next deployment.",
+            "datasets": counts.datasets,
+            "models": counts.models,
+            "catalogs": counts.catalogs,
+            "views": counts.views,
+            // Names only — a delivered value never leaves this process.
+            "delivered_secrets": delivered_names,
+            "secrets_cache_error": cache_error,
+        })))
+    }
+
+    /// Persist the deployment for the restart that makes it live.
+    ///
+    /// Ordered so that a deployment that does not land leaves the running
+    /// instance as it was, and one interrupted part-way leaves it able to
+    /// start.
+    ///
+    /// The spicepod is validated before the delivered secrets are touched at
+    /// all: building the [`App`] parses the document rather than resolving
+    /// `${ secrets:… }` — a component does that as it loads — so a deployment
+    /// that does not build changes nothing.
+    ///
+    /// They are cached before the spicepod is promoted, because the restart is
+    /// what makes it live and the components that resolve `${ secrets:… }` run
+    /// during that start: an instance interrupted in between comes back on the
+    /// previous spicepod with the current credentials cached for it, rather
+    /// than on a spicepod whose secrets it cannot resolve.
+    ///
+    /// What this process resolves changes last, so a promotion that fails
+    /// leaves the instance serving the configuration and resolving the
+    /// credentials it already had.
+    async fn cold_apply(
+        &self,
+        config_dir: &Path,
+        spicepod_yaml: &str,
+        delivered_secrets: Option<runtime_cloud_connect::sealed_secrets::DeliveredSecrets>,
+        reason: &ColdReason,
+    ) -> Result<ApplyOutcome, CommandError> {
+        let staged =
+            stage_cloud_managed_spicepod(config_dir, spicepod_yaml, &self.runtime_overrides)
+                .await?;
+
+        let mut cache_error = None;
+        if let Some(secrets) = &delivered_secrets {
+            cache_error = self.cache_delivered_secrets(config_dir, secrets);
+        }
+
+        let (new_app, path) = staged.promote().await?;
+
+        let delivered_names = delivered_secrets.map(|secrets| {
+            let names: Vec<String> = secrets.keys().cloned().collect();
+            // Replaces the whole set: an app whose secrets were removed must
+            // stop resolving them.
+            self.delivered_secrets.replace(secrets);
+            names
+        });
+        let counts = ComponentCounts::of(&new_app);
+
+        *self.persisted.write() = Some(spicepod_yaml.to_string());
+
+        tracing::info!(
+            "Spice Cloud Connect: the deployed spicepod was validated and persisted to {} ({counts}); restarting to apply it because {}",
+            path.display(),
+            reason.summary(),
+        );
+
+        Ok(ApplyOutcome::exit_to_apply(serde_json::json!({
+            "path": path.display().to_string(),
+            "applied": true,
+            "live": false,
+            "restart": "required",
+            // The sections that forced the restart, so a caller can tell an
+            // operator what to change to keep the next deployment in place.
+            "restart_sections": reason.sections(),
+            "supervised": self.supervisor.is_supervised(),
+            "supervisor": self.supervisor.as_str(),
+            "message": reason.message(),
+            "datasets": counts.datasets,
+            "models": counts.models,
+            "catalogs": counts.catalogs,
+            "views": counts.views,
+            // Names only — a delivered value never leaves this process.
+            "delivered_secrets": delivered_names,
+            "secrets_cache_error": cache_error,
+        })))
     }
 }
 
@@ -663,7 +1070,7 @@ impl RuntimeHandle for SpicedRuntimeHandle {
 
     fn unsupported_reason(&self, capability: Capability) -> String {
         match capability {
-            Capability::Restart => "Restart is unsupported on standalone spiced: it is not a control the runtime offers on demand. A deployment already applies by restarting this instance onto the spicepod it validated; to restart it without deploying, use your process manager (systemd/Docker/Kubernetes). See: https://spiceai.org/docs".to_string(),
+            Capability::Restart => "Restart is unsupported on standalone spiced: it is not a control the runtime offers on demand. A deployment that needs one already restarts this instance onto the spicepod it validated; to restart it without deploying, use your process manager (systemd/Docker/Kubernetes). See: https://spiceai.org/docs".to_string(),
             Capability::UpgradeRuntime => "UpgradeRuntime is unsupported on standalone spiced: it cannot replace its own binary. Upgrade it the way you installed it (`spice upgrade`, your container image, or your package manager). See: https://spiceai.org/docs".to_string(),
             Capability::GetLogs => "Log capture is not enabled for this runtime: Spice Cloud Connect must be configured before startup for spiced to install the log-capture layer. See: https://spiceai.org/docs".to_string(),
             Capability::ApplySpicepod
@@ -711,35 +1118,30 @@ impl RuntimeHandle for SpicedRuntimeHandle {
         })
     }
 
-    /// Apply a cloud-managed spicepod by persisting it and restarting onto it.
+    /// Apply a cloud-managed spicepod, in this process where it can be and by
+    /// restarting where it cannot.
     ///
     /// 1. A redelivery of the spicepod this process is already serving — the
-    ///    same YAML, byte for byte — is answered as applied and changes nothing,
-    ///    not even the delivered secrets. Restarting for it would make a
-    ///    redelivery a restart loop, so a change to an app's secrets has to
-    ///    arrive with a changed spicepod rather than as a re-send of the current
-    ///    one.
-    /// 2. Delivered secrets are installed and cached first. The restart is what
-    ///    makes the spicepod live, and the components that resolve
-    ///    `${ secrets:… }` run during that start, so the cache — not this
-    ///    process's in-memory store — is what has to hold them by then.
-    /// 3. The YAML is validated by building an [`App`] from it on a sibling
-    ///    temp file, so a malformed push is rejected with a clear error and the
-    ///    previous good `spicepod-cloud-managed.yml` is left untouched and
-    ///    still running.
-    /// 4. The validated file is promoted to the canonical path and the
-    ///    deployment version recorded beside it, so the next start comes up on
-    ///    this configuration and reports this version.
-    /// 5. The client sends this result and then calls
-    ///    [`RuntimeHandle::exit_to_apply`], which drains and exits 0 for the
-    ///    supervisor to relaunch.
-    ///
-    /// There is deliberately no hot-reload path. Reconciling part of a spicepod
-    /// in-process and leaving the rest (`runtime:`, `secrets:`, embeddings,
-    /// tools) for an operator to restart for meant two behaviours to reason
-    /// about and a partially-applied state that was neither. The cost is that
-    /// downtime is proportional to the app's size rather than the change's —
-    /// every deployment is a full start, including acceleration rebuilds.
+    ///    same YAML, byte for byte, delivering the secret values it already
+    ///    holds — is answered as applied without reconciling or restarting
+    ///    anything; restarting for it would make a redelivery a restart loop.
+    ///    It does write the delivered secrets to the cache the next start reads
+    ///    ([`SpicedRuntimeHandle::refresh_secret_cache`]), which is the one
+    ///    thing a redelivery can still repair.
+    /// 2. [`classify_deployment`] decides how the deployment applies, before the
+    ///    spicepod is written, its secrets are installed, or any component is
+    ///    reconciled.
+    /// 3. Either way the YAML is validated by building an [`App`] from it on a
+    ///    sibling temp file, so a malformed push is rejected with a clear error
+    ///    and the previous good `spicepod-cloud-managed.yml` is left untouched
+    ///    and still running, and the validated file is then promoted to the
+    ///    canonical path so the next start comes up on this configuration.
+    /// 4. A hot apply reconciles the new app into this process
+    ///    ([`SpicedRuntimeHandle::hot_apply`]) and records it as what is live. A
+    ///    cold one installs the delivered secrets, records the spicepod as
+    ///    persisted, and returns [`ApplyOutcome::exit_to_apply`] — the client
+    ///    sends the result and then calls [`RuntimeHandle::exit_to_apply`],
+    ///    which drains and exits 0 for the supervisor to relaunch.
     async fn apply_spicepod(
         &self,
         deployment: SpicepodDeployment<'_>,
@@ -750,6 +1152,14 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             delivered_secrets,
             app_id,
         } = deployment;
+
+        // One apply at a time. The decision below is only immutable if nothing
+        // else can persist a spicepod, install secrets, or change what is live
+        // between taking it and completing the apply it commits to. It does not
+        // extend to the exit a cold apply asks the client for, which happens
+        // after this returns — `persisted` is what keeps a deployment arriving
+        // in that window off the hot path.
+        let _applying = self.applying.lock().await;
 
         // Recorded before staging, and independently of whether staging succeeds:
         // which app this instance belongs to is a fact about the deploy's target,
@@ -793,13 +1203,20 @@ impl RuntimeHandle for SpicedRuntimeHandle {
             }
         }
 
-        // Cloned out of the lock rather than compared under it: the guard must
-        // not be held across the awaits below.
+        // A delivered set this instance does not hold is a change the spicepod
+        // text does not show, so it is decided before anything reads the text.
+        let secrets_changed = delivered_secrets
+            .as_ref()
+            .is_some_and(|secrets| !self.delivered_secrets.holds(secrets));
+
+        // Cloned out of the locks rather than compared under them: the guards
+        // must not be held across the awaits below.
+        let live = self.live.read().clone();
         let persisted = self.persisted.read().clone();
-        match disposition(&self.live, persisted.as_deref(), spicepod_yaml) {
+        match disposition(&live, persisted.as_deref(), spicepod_yaml, secrets_changed) {
             Disposition::AlreadyLive => {
                 tracing::info!(
-                    "Spice Cloud Connect: the deployed spicepod is already applied; nothing to do"
+                    "Spice Cloud Connect: the deployed spicepod is already applied; nothing to reconcile"
                 );
                 return Ok(ApplyOutcome::settled(serde_json::json!({
                     "path": config_dir.join(CLOUD_MANAGED_SPICEPOD_FILE).display().to_string(),
@@ -807,6 +1224,7 @@ impl RuntimeHandle for SpicedRuntimeHandle {
                     "live": true,
                     "restart": "not_required",
                     "message": "This spicepod is already applied and live; this instance is serving it.",
+                    "secrets_cache_error": self.refresh_secret_cache(config_dir, delivered_secrets.as_ref()),
                 })));
             }
             Disposition::AlreadyPersisted => {
@@ -819,57 +1237,30 @@ impl RuntimeHandle for SpicedRuntimeHandle {
                     "live": false,
                     "restart": "in_progress",
                     "message": "This spicepod is persisted; this instance is restarting onto it.",
+                    "secrets_cache_error": self.refresh_secret_cache(config_dir, delivered_secrets.as_ref()),
                 })));
             }
             Disposition::Apply => {}
         }
 
-        // Install and cache the delivered secrets BEFORE the spicepod is
-        // validated: `AppBuilder::build_from_path` resolves `${ secrets:… }`
-        // references, so secrets installed afterwards would arrive after
-        // validation had already failed on them.
-        let mut cache_error = None;
-        let delivered_names = match delivered_secrets {
-            None => None,
-            Some(secrets) => {
-                let names: Vec<String> = secrets.keys().cloned().collect();
-                cache_error = self.cache_delivered_secrets(config_dir, &secrets);
-                // Replaces the whole set: an app whose secrets were removed
-                // must stop resolving them.
-                self.delivered_secrets.replace(secrets);
-                Some(names)
+        let mode = classify_deployment(&ApplyFacts {
+            live: &live,
+            incoming: spicepod_yaml,
+            secrets_changed,
+            restart_pending: persisted.is_some(),
+            initial_load_unfinished: self.runtime.initial_load_in_flight(),
+        });
+
+        match mode {
+            ApplyMode::Hot => {
+                self.hot_apply(config_dir, spicepod_yaml, delivered_secrets)
+                    .await
             }
-        };
-
-        let (new_app, path) = stage_cloud_managed_spicepod(config_dir, spicepod_yaml).await?;
-
-        *self.persisted.write() = Some(spicepod_yaml.to_string());
-
-        tracing::info!(
-            "Spice Cloud Connect: the deployed spicepod was validated and persisted to {} ({} datasets, {} models, {} catalogs, {} views); restarting to apply it",
-            path.display(),
-            new_app.datasets.len(),
-            new_app.models.len(),
-            new_app.catalogs.len(),
-            new_app.views.len(),
-        );
-
-        Ok(ApplyOutcome::exit_to_apply(serde_json::json!({
-            "path": path.display().to_string(),
-            "applied": true,
-            "live": false,
-            "restart": "required",
-            "supervised": self.supervisor.is_supervised(),
-            "supervisor": self.supervisor.as_str(),
-            "message": "The spicepod was validated and persisted. This instance is restarting to serve it; the restart reloads every dataset, so the app is unavailable until it finishes.",
-            "datasets": new_app.datasets.len(),
-            "models": new_app.models.len(),
-            "catalogs": new_app.catalogs.len(),
-            "views": new_app.views.len(),
-            // Names only — a delivered value never leaves this process.
-            "delivered_secrets": delivered_names,
-            "secrets_cache_error": cache_error,
-        })))
+            ApplyMode::Cold(reason) => {
+                self.cold_apply(config_dir, spicepod_yaml, delivered_secrets, &reason)
+                    .await
+            }
+        }
     }
 
     /// Drain and exit 0 so the supervisor relaunches spiced on the spicepod
@@ -1298,15 +1689,48 @@ fn encode_error(overflowed: &AtomicBool, source: &ArrowError) -> CommandError {
     ))
 }
 
-/// Validate a cloud-managed spicepod and persist it to disk.
+/// A validated cloud-managed spicepod, written beside the canonical file and
+/// waiting to be promoted onto it.
 ///
-/// Writes `spicepod_yaml` to a sibling `*.incoming.yml` temp file, builds an
-/// [`App`] from it to validate (parse + resolve), and only on success
-/// atomically promotes the temp file to the canonical
-/// [`CLOUD_MANAGED_SPICEPOD_FILE`] path. On any failure the canonical file is
-/// left untouched — the instance keeps serving it — and the temp file is
-/// cleaned up. Returns the built `App`, which the caller reads counts off for
-/// the command result, and the canonical path it was written to.
+/// Validating and promoting are separate steps so a caller with state that has
+/// to survive the deployment — the delivered-secrets cache, which the restart
+/// reads — can write it while the instance still starts on the previous
+/// spicepod. A crash in that window comes back on the previous configuration
+/// with the new secrets, rather than on the new configuration with secrets it
+/// cannot resolve.
+#[derive(Debug)]
+struct StagedSpicepod {
+    /// The app the deployment builds. The caller reads the component counts it
+    /// reports off it.
+    app: App,
+    incoming: std::path::PathBuf,
+    canonical: std::path::PathBuf,
+}
+
+impl StagedSpicepod {
+    /// Promote the validated file onto the canonical path, so the next start
+    /// comes up on this configuration.
+    async fn promote(self) -> Result<(App, std::path::PathBuf), CommandError> {
+        match replace_canonical_spicepod(&self.incoming, &self.canonical).await {
+            Ok(()) => Ok((self.app, self.canonical)),
+            Err(err) => {
+                // Best-effort cleanup; ignore failure (temp file is inert).
+                let _ = tokio::fs::remove_file(&self.incoming).await;
+                Err(err)
+            }
+        }
+    }
+}
+
+/// Validate a cloud-managed spicepod against a sibling `*.incoming.yml` temp
+/// file, so a bad push never clobbers the last known-good spicepod on disk.
+///
+/// On any failure the canonical file is left untouched — the instance keeps
+/// serving it — and the temp file is cleaned up.
+///
+/// `runtime_overrides` are applied to the built app exactly as the start path
+/// applies them, so a deployment applied to this process lands the app a restart
+/// onto the same file would have produced.
 ///
 /// Factored out of [`SpicedRuntimeHandle::apply_spicepod`] so the
 /// file-staging + validation can be unit-tested without a running runtime.
@@ -1316,23 +1740,37 @@ fn encode_error(overflowed: &AtomicBool, source: &ArrowError) -> CommandError {
 async fn stage_cloud_managed_spicepod(
     config_dir: &Path,
     spicepod_yaml: &str,
-) -> Result<(App, std::path::PathBuf), CommandError> {
-    let path = config_dir.join(CLOUD_MANAGED_SPICEPOD_FILE);
+    runtime_overrides: &[(String, String)],
+) -> Result<StagedSpicepod, CommandError> {
+    let canonical = config_dir.join(CLOUD_MANAGED_SPICEPOD_FILE);
     tokio::fs::create_dir_all(config_dir)
         .await
         .map_err(|e| CommandError::failed(format!("create config dir: {e}")))?;
 
-    // Validate on a temp file first so a bad push never clobbers the last
-    // known-good spicepod on disk.
     let incoming = config_dir.join("spicepod-cloud-managed.incoming.yml");
     tokio::fs::write(&incoming, spicepod_yaml)
         .await
         .map_err(|e| CommandError::failed(format!("write spicepod: {e}")))?;
 
     match AppBuilder::build_from_path(incoming.clone()).await {
-        Ok(app) => {
-            replace_canonical_spicepod(&incoming, &path).await?;
-            Ok((app, path))
+        Ok(mut app) => {
+            // Rendered before the cleanup below: the error is not `Send`, so
+            // holding it across an `.await` would make this future unspawnable.
+            match crate::apply_overrides(app.runtime, runtime_overrides).map_err(|e| e.to_string())
+            {
+                Ok(runtime) => app.runtime = runtime,
+                Err(e) => {
+                    let _ = tokio::fs::remove_file(&incoming).await;
+                    return Err(CommandError::invalid_argument(format!(
+                        "invalid spicepod: the runtime overrides this instance was started with (--set-runtime) do not apply to it: {e}"
+                    )));
+                }
+            }
+            Ok(StagedSpicepod {
+                app,
+                incoming,
+                canonical,
+            })
         }
         Err(e) => {
             // Best-effort cleanup; ignore failure (temp file is inert).
@@ -1397,7 +1835,9 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
     use arrow::ipc::reader::StreamReader;
     use datafusion::physical_plan::memory::MemoryStream;
-    use runtime_cloud_connect::handlers::MAX_QUERY_ROWS;
+    use futures::TryStreamExt as _;
+    use runtime_cloud_connect::handlers::{MAX_QUERY_ROWS, PostApply};
+    use runtime_cloud_connect::sealed_secrets::{DeliveredSecrets, Zeroizing};
 
     /// Minimal valid spicepod (no components — an empty app is valid).
     const VALID_SPICEPOD: &str = "version: v2\nkind: Spicepod\nname: cloud-managed-test\n";
@@ -1447,9 +1887,12 @@ mod tests {
     #[tokio::test]
     async fn stage_valid_spicepod_writes_canonical_and_returns_app() {
         let dir = scratch_dir("valid");
-        let (app, path) = stage_cloud_managed_spicepod(&dir, VALID_SPICEPOD)
+        let (app, path) = stage_cloud_managed_spicepod(&dir, VALID_SPICEPOD, &[])
             .await
-            .expect("valid spicepod stages");
+            .expect("valid spicepod stages")
+            .promote()
+            .await
+            .expect("a validated spicepod is promoted");
 
         assert_eq!(app.name, "cloud-managed-test");
         assert_eq!(path, dir.join(CLOUD_MANAGED_SPICEPOD_FILE));
@@ -1466,13 +1909,16 @@ mod tests {
     async fn stage_invalid_spicepod_preserves_previous_good_file() {
         let dir = scratch_dir("invalid-preserves");
         // Land a known-good canonical file first.
-        stage_cloud_managed_spicepod(&dir, VALID_SPICEPOD)
+        stage_cloud_managed_spicepod(&dir, VALID_SPICEPOD, &[])
             .await
-            .expect("first valid stage");
+            .expect("first valid stage")
+            .promote()
+            .await
+            .expect("a validated spicepod is promoted");
         let canonical = dir.join(CLOUD_MANAGED_SPICEPOD_FILE);
 
         // A subsequent invalid push must be rejected and must NOT clobber it.
-        let err = stage_cloud_managed_spicepod(&dir, INVALID_SPICEPOD)
+        let err = stage_cloud_managed_spicepod(&dir, INVALID_SPICEPOD, &[])
             .await
             .expect_err("invalid spicepod rejected");
         assert!(
@@ -1494,7 +1940,7 @@ mod tests {
     #[tokio::test]
     async fn stage_invalid_spicepod_when_none_exists_leaves_no_canonical() {
         let dir = scratch_dir("invalid-fresh");
-        let err = stage_cloud_managed_spicepod(&dir, INVALID_SPICEPOD)
+        let err = stage_cloud_managed_spicepod(&dir, INVALID_SPICEPOD, &[])
             .await
             .expect_err("invalid spicepod rejected");
         assert!(
@@ -1517,7 +1963,7 @@ mod tests {
     #[test]
     fn redelivering_the_running_spicepod_is_a_no_op() {
         assert_eq!(
-            disposition(VALID_SPICEPOD, None, VALID_SPICEPOD),
+            disposition(VALID_SPICEPOD, None, VALID_SPICEPOD, false),
             Disposition::AlreadyLive
         );
     }
@@ -1528,7 +1974,7 @@ mod tests {
     fn a_changed_spicepod_is_applied() {
         let changed = "version: v2\nkind: Spicepod\nname: changed\n";
         assert_eq!(
-            disposition(VALID_SPICEPOD, None, changed),
+            disposition(VALID_SPICEPOD, None, changed, false),
             Disposition::Apply
         );
     }
@@ -1541,13 +1987,13 @@ mod tests {
     fn redelivery_while_a_restart_is_pending_re_issues_the_exit() {
         let pending = "version: v2\nkind: Spicepod\nname: next\n";
         assert_eq!(
-            disposition(VALID_SPICEPOD, Some(pending), pending),
+            disposition(VALID_SPICEPOD, Some(pending), pending, false),
             Disposition::AlreadyPersisted
         );
         // And the spicepod it replaced is no longer "already live": it is on its
         // way out, so re-sending it is a new configuration to apply.
         assert_eq!(
-            disposition(VALID_SPICEPOD, Some(pending), VALID_SPICEPOD),
+            disposition(VALID_SPICEPOD, Some(pending), VALID_SPICEPOD, false),
             Disposition::Apply
         );
     }
@@ -1556,7 +2002,27 @@ mod tests {
     /// first one always applies.
     #[test]
     fn a_runtime_with_no_deployment_applies_the_first_one() {
-        assert_eq!(disposition("", None, VALID_SPICEPOD), Disposition::Apply);
+        assert_eq!(
+            disposition("", None, VALID_SPICEPOD, false),
+            Disposition::Apply
+        );
+    }
+
+    /// A rotation can arrive with the spicepod the instance already serves, and
+    /// the values are not in the text. Answering it as already applied would
+    /// report success for a rotation that never reached the app.
+    #[test]
+    fn a_redelivery_carrying_new_secret_values_is_not_already_applied() {
+        assert_eq!(
+            disposition(VALID_SPICEPOD, None, VALID_SPICEPOD, true),
+            Disposition::Apply
+        );
+        let pending = "version: v2\nkind: Spicepod\nname: next\n";
+        assert_eq!(
+            disposition(VALID_SPICEPOD, Some(pending), pending, true),
+            Disposition::Apply,
+            "a rotation arriving before the restart still has to be installed and cached for it"
+        );
     }
 
     // ----------------------------------------------------------------------
@@ -1803,6 +2269,964 @@ mod tests {
             matches!(query_error(&execution), CommandError::Failed { .. }),
             "an execution failure is retryable, not the caller's mistake"
         );
+    }
+
+    // ----------------------------------------------------------------------
+    // The gate: what a deployment changes decides how it applies.
+    // ----------------------------------------------------------------------
+
+    /// The deployment the gate tests are changes against.
+    const LIVE: &str = "\
+version: v2
+kind: Spicepod
+name: gate
+datasets:
+  - from: memory:a
+    name: a
+";
+
+    /// `LIVE` with `extra` appended as further top-level sections.
+    fn with_sections(extra: &str) -> String {
+        format!("{LIVE}{extra}")
+    }
+
+    /// Facts for a deployment arriving at an instance that is serving `live`
+    /// with everything else in the settled state: no secrets delivered, load
+    /// finished.
+    fn arriving<'a>(live: &'a str, incoming: &'a str) -> ApplyFacts<'a> {
+        ApplyFacts {
+            live,
+            incoming,
+            secrets_changed: false,
+            restart_pending: false,
+            initial_load_unfinished: false,
+        }
+    }
+
+    /// The case the gate exists for: a change confined to the components the
+    /// runtime reconciles applies without restarting.
+    #[test]
+    fn a_component_only_change_applies_in_place() {
+        let changes = [
+            "datasets:\n  - from: memory:b\n    name: b\n",
+            "views:\n  - name: v\n    sql: SELECT 1\n",
+            "catalogs:\n  - from: spice.ai\n    name: c\n",
+            "models:\n  - from: openai\n    name: m\n",
+            "functions:\n  - name: f\n    from: https://example.com\n",
+        ];
+        for change in changes {
+            // Appending to `LIVE` would leave two `datasets:` keys, so the
+            // component sections are compared against a document holding none.
+            let live = "version: v2\nkind: Spicepod\nname: gate\n";
+            let incoming = format!("{live}{change}");
+            assert_eq!(
+                classify_deployment(&arriving(live, &incoming)),
+                ApplyMode::Hot,
+                "a change to `{change}` alone must not restart the instance"
+            );
+        }
+    }
+
+    /// Every section outside the component set is read while the process
+    /// starts, so a change to one has to restart it — and the result has to
+    /// name which one, because that is all the operator has to go on.
+    #[test]
+    fn every_start_time_section_restarts_and_is_named() {
+        let changes = [
+            ("dependencies", "dependencies:\n  - spiceai/quickstart\n"),
+            ("embeddings", "embeddings:\n  - name: e\n    from: openai\n"),
+            (
+                "extensions",
+                "extensions:\n  spice_cloud:\n    enabled: true\n",
+            ),
+            ("management", "management:\n  enabled: true\n"),
+            ("metadata", "metadata:\n  team: data\n"),
+            ("rerankers", "rerankers:\n  - name: r\n    from: openai\n"),
+            ("runtime", "runtime:\n  dataset_load_parallelism: 2\n"),
+            ("secrets", "secrets:\n  - from: env\n    name: env\n"),
+            ("snapshots", "snapshots:\n  enabled: true\n"),
+            ("tools", "tools:\n  - name: t\n    from: builtin\n"),
+            ("workers", "workers:\n  - name: w\n    from: builtin\n"),
+        ];
+        for (section, change) in changes {
+            let incoming = with_sections(change);
+            assert_eq!(
+                classify_deployment(&arriving(LIVE, &incoming)),
+                ApplyMode::Cold(ColdReason::Sections(vec![section.to_string()])),
+                "changing `{section}` must restart the instance and name the section"
+            );
+        }
+    }
+
+    /// The spicepod's own identity is start-time configuration too.
+    #[test]
+    fn a_renamed_or_reversioned_spicepod_restarts() {
+        for (section, from, to) in [
+            ("name", "name: gate", "name: renamed"),
+            ("version", "version: v2", "version: v1"),
+        ] {
+            let incoming = LIVE.replace(from, to);
+            assert_eq!(
+                classify_deployment(&arriving(LIVE, &incoming)),
+                ApplyMode::Cold(ColdReason::Sections(vec![section.to_string()])),
+                "changing `{section}` must restart the instance"
+            );
+        }
+    }
+
+    /// A rotation riding along with a start-time change is named too: an
+    /// operator who reverted only the sections in the document would deploy
+    /// again and be restarted again by the secrets.
+    #[test]
+    fn a_rotation_alongside_a_start_time_change_is_named_with_it() {
+        let incoming = with_sections("runtime:\n  dataset_load_parallelism: 2\n");
+        let mut facts = arriving(LIVE, &incoming);
+        facts.secrets_changed = true;
+
+        let ApplyMode::Cold(reason) = classify_deployment(&facts) else {
+            panic!("a start-time change must restart the instance");
+        };
+        assert_eq!(
+            reason.sections(),
+            vec!["runtime".to_string(), "secrets".to_string()]
+        );
+    }
+
+    /// Reporting one of the sections that forced the restart is not enough: an
+    /// operator who reverts only what was named would deploy again and be
+    /// restarted again by the section that was left out.
+    #[test]
+    fn every_section_that_forced_the_restart_is_named() {
+        let incoming = with_sections(
+            "runtime:\n  dataset_load_parallelism: 2\nmetadata:\n  team: data\nviews:\n  - name: v\n    sql: SELECT 1\n",
+        );
+
+        let ApplyMode::Cold(reason) = classify_deployment(&arriving(LIVE, &incoming)) else {
+            panic!("a start-time change must restart the instance");
+        };
+        assert_eq!(
+            reason.sections(),
+            vec!["metadata".to_string(), "runtime".to_string()],
+            "both start-time sections must be named, and the component one must not be"
+        );
+        let message = reason.message();
+        assert!(message.contains("metadata"), "{message}");
+        assert!(message.contains("runtime"), "{message}");
+    }
+
+    /// A section written out empty configures what an absent one does, so it
+    /// must not cost a restart.
+    #[test]
+    fn an_empty_section_is_not_a_change() {
+        let incoming = with_sections("secrets: []\nruntime:\nmetadata: {}\n");
+        assert_eq!(
+            classify_deployment(&arriving(LIVE, &incoming)),
+            ApplyMode::Hot
+        );
+    }
+
+    /// Sections are compared as documents, not as text: rewriting one without
+    /// changing what it configures is not a change.
+    #[test]
+    fn a_reordered_start_time_section_is_not_a_change() {
+        let live =
+            with_sections("runtime:\n  dataset_load_parallelism: 2\n  ready_state: on_load\n");
+        let incoming =
+            with_sections("runtime:\n  ready_state: on_load\n  dataset_load_parallelism: 2\n");
+        assert_eq!(
+            classify_deployment(&arriving(&live, &incoming)),
+            ApplyMode::Hot
+        );
+    }
+
+    /// Secret propagation is restart-only: a component resolves
+    /// `${ secrets:… }` as it loads, so a rotated value reaches the components
+    /// already loaded by loading them again.
+    #[test]
+    fn a_delivered_secret_change_restarts_an_otherwise_hot_deployment() {
+        let incoming = with_sections("views:\n  - name: v\n    sql: SELECT 1\n");
+        let mut facts = arriving(LIVE, &incoming);
+        facts.secrets_changed = true;
+
+        let ApplyMode::Cold(reason) = classify_deployment(&facts) else {
+            panic!("a delivered-secret change must restart the instance");
+        };
+        assert_eq!(reason, ColdReason::DeliveredSecrets);
+        assert_eq!(
+            reason.sections(),
+            vec!["secrets".to_string()],
+            "the caller has to be able to tell what forced the restart"
+        );
+    }
+
+    /// A diff against an app whose components are not all registered yet would
+    /// treat the ones the load has not reached as already applied and never
+    /// register them.
+    #[test]
+    fn an_unfinished_component_load_restarts() {
+        let incoming = with_sections("views:\n  - name: v\n    sql: SELECT 1\n");
+        let mut facts = arriving(LIVE, &incoming);
+        facts.initial_load_unfinished = true;
+
+        assert_eq!(
+            classify_deployment(&facts),
+            ApplyMode::Cold(ColdReason::InitialLoadUnfinished)
+        );
+    }
+
+    /// Once this process has committed to restarting onto a deployment, a later
+    /// one has to restart too: applied in place it would be persisted over the
+    /// deployment the restart is for, which the restart would then not serve.
+    #[test]
+    fn a_deployment_arriving_after_a_restart_was_committed_restarts_too() {
+        let incoming = with_sections("views:\n  - name: v\n    sql: SELECT 1\n");
+        let mut facts = arriving(LIVE, &incoming);
+        facts.restart_pending = true;
+
+        assert_eq!(
+            classify_deployment(&facts),
+            ApplyMode::Cold(ColdReason::RestartPending)
+        );
+    }
+
+    /// An instance serving a local spicepod, or one whose deployment failed to
+    /// build, has nothing to diff the incoming deployment against.
+    #[test]
+    fn an_instance_serving_no_deployment_restarts() {
+        assert_eq!(
+            classify_deployment(&arriving("", LIVE)),
+            ApplyMode::Cold(ColdReason::NoLiveDeployment)
+        );
+    }
+
+    /// Input the gate cannot read must never be applied in place. Validation
+    /// rejects it, but the gate runs first — and a gate that answered "nothing
+    /// start-time changed" for a document it failed to parse would answer it
+    /// for every document it failed to parse.
+    #[test]
+    fn an_unreadable_deployment_is_never_applied_in_place() {
+        for incoming in [INVALID_SPICEPOD, "", "a scalar", "- a\n- b\n", "\u{fffd}"] {
+            assert!(
+                matches!(
+                    classify_deployment(&arriving(LIVE, incoming)),
+                    ApplyMode::Cold(_)
+                ),
+                "a document the gate cannot read must restart the instance: {incoming:?}"
+            );
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Applying a deployment: what the process serves afterwards.
+    // ----------------------------------------------------------------------
+
+    /// The deployment a handle under test starts out serving.
+    const SERVING: &str = "\
+version: v2
+kind: Spicepod
+name: applied
+views:
+  - name: served_view
+    sql: SELECT 1 AS n
+";
+
+    /// `SERVING` plus a second view — a change the runtime reconciles.
+    const SERVING_PLUS_VIEW: &str = "\
+version: v2
+kind: Spicepod
+name: applied
+views:
+  - name: served_view
+    sql: SELECT 1 AS n
+  - name: deployed_view
+    sql: SELECT 2 AS n
+";
+
+    /// A handle over a runtime that has finished loading `live`, which is the
+    /// state an instance is in between deployments.
+    async fn handle_serving(dir: &Path, live: &str) -> Arc<SpicedRuntimeHandle> {
+        let handle = handle_loading(dir, live).await;
+        tokio::time::timeout(
+            Duration::from_mins(2),
+            Arc::clone(&handle.runtime).load_components(),
+        )
+        .await
+        .expect("the runtime finishes loading its components");
+        handle
+    }
+
+    /// A handle over a runtime that has not run its component load, which is
+    /// the state an instance is in from the moment Cloud Connect connects until
+    /// the load finishes.
+    async fn handle_loading(dir: &Path, live: &str) -> Arc<SpicedRuntimeHandle> {
+        let path = dir.join(CLOUD_MANAGED_SPICEPOD_FILE);
+        std::fs::write(&path, live).expect("write the live deployment");
+        let app = AppBuilder::build_from_path(path.clone())
+            .await
+            .expect("the live deployment builds");
+
+        let runtime = Arc::new(Runtime::builder().with_app(app).build().await);
+
+        Arc::new(SpicedRuntimeHandle::new(SpicedRuntimeHandleParts {
+            runtime,
+            logs: None,
+            delivered_secrets: Arc::new(CloudDeliveredSecretStore::new()),
+            identity_path: dir.join(IDENTITY_FILE),
+            running_deployment: Some(CloudManagedSpicepod {
+                path,
+                spicepod_yaml: live.to_string(),
+            }),
+            supervisor: Supervisor::detect(),
+            metrics: None,
+            app_id: None,
+            runtime_overrides: Vec::new(),
+        }))
+    }
+
+    fn deployment<'a>(config_dir: &'a Path, spicepod_yaml: &'a str) -> SpicepodDeployment<'a> {
+        SpicepodDeployment {
+            config_dir,
+            spicepod_yaml,
+            delivered_secrets: None,
+            app_id: None,
+        }
+    }
+
+    /// One delivered secret, for the tests that rotate one.
+    fn delivered(name: &str, value: &[u8]) -> DeliveredSecrets {
+        [(name.to_string(), Zeroizing::new(value.to_vec()))]
+            .into_iter()
+            .collect()
+    }
+
+    /// Give the instance an identity carrying a cache key, which is what makes
+    /// the delivered-secrets cache writable — without one the cache is skipped
+    /// and a test asserting on it would pass for the wrong reason.
+    fn enrol_with_a_cache_key(identity_path: &Path) {
+        let mock_pem = "-----BEGIN PRIVATE KEY-----\nMOCK\n-----END PRIVATE KEY-----\n".to_string();
+        let mut identity = runtime_cloud_connect::identity::Identity {
+            identifier: "inst_test".to_string(),
+            identity_cert_pem: "-----BEGIN CERTIFICATE-----\nMOCK\n-----END CERTIFICATE-----\n"
+                .to_string(),
+            private_key_pem: mock_pem.clone(),
+            public_key_pem: "-----BEGIN PUBLIC KEY-----\nMOCK\n-----END PUBLIC KEY-----\n"
+                .to_string(),
+            ca_bundle_pem: String::new(),
+            gateway_addr: "gateway.test.spice.ai:443".to_string(),
+            not_after_unix: None,
+            app_id: None,
+            enc_private_key_pem: mock_pem,
+            enc_public_key_pem: "-----BEGIN PUBLIC KEY-----\nMOCKENC\n-----END PUBLIC KEY-----\n"
+                .to_string(),
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+        };
+        assert!(
+            identity.ensure_cache_key(),
+            "the identity mints a cache key"
+        );
+        IdentityStore::store(identity_path, &identity).expect("write the identity");
+    }
+
+    /// What the delivered-secrets cache holds, read back the way a restart
+    /// reads it. `None` when nothing has been cached.
+    fn cached_secrets(dir: &Path) -> Option<CloudDeliveredSecretStore> {
+        let key = IdentityStore::load_optional(&dir.join(IDENTITY_FILE))
+            .expect("read the identity")?
+            .cache_key()?;
+        let cached = runtime_cloud_connect::secret_cache::read(
+            &dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE),
+            &key,
+        )
+        .expect("the cache is readable")?;
+        let store = CloudDeliveredSecretStore::new();
+        store.replace(cached.into_values());
+        Some(store)
+    }
+
+    /// How long a test waits for a component to finish converging.
+    const CONVERGE_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Count the rows `sql` answers with, waiting for the component it reads to
+    /// converge.
+    ///
+    /// The runtime registers a view in a task of its own, so a component the
+    /// apply reconciled is not necessarily registered by the time the apply
+    /// returns. Polling is what a caller does; asserting on the first attempt
+    /// would make this a race rather than a test.
+    async fn query_rows(runtime: &Runtime, sql: &str) -> usize {
+        let start = tokio::time::Instant::now();
+        loop {
+            let last = match runtime.datafusion().query_builder(sql).build().run().await {
+                Ok(result) => {
+                    let batches: Vec<RecordBatch> =
+                        result.data.try_collect().await.expect("the query streams");
+                    return total_rows(&batches);
+                }
+                Err(err) => err.to_string(),
+            };
+            assert!(
+                start.elapsed() < CONVERGE_TIMEOUT,
+                "`{sql}` did not answer within {CONVERGE_TIMEOUT:?}: {last}"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    fn view_names(app: &App) -> Vec<String> {
+        app.views.iter().map(|view| view.name.clone()).collect()
+    }
+
+    async fn live_view_names(handle: &SpicedRuntimeHandle) -> Vec<String> {
+        view_names(&handle.runtime.read_app().await.expect("an app is loaded"))
+    }
+
+    fn persisted_spicepod(dir: &Path) -> String {
+        std::fs::read_to_string(dir.join(CLOUD_MANAGED_SPICEPOD_FILE))
+            .expect("the canonical spicepod exists")
+    }
+
+    /// The whole point: a component-only deployment is served by this process,
+    /// not by the next one. The query is what proves it — an assertion that the
+    /// runtime is still up would pass for a deployment that was ignored.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_component_only_deployment_is_applied_in_place_and_queryable() {
+        let dir = scratch_dir("hot-apply");
+        let handle = handle_serving(&dir, SERVING).await;
+
+        let outcome = handle
+            .apply_spicepod(deployment(&dir, SERVING_PLUS_VIEW))
+            .await
+            .expect("a component-only deployment applies");
+
+        assert_eq!(
+            outcome.post_apply,
+            PostApply::Nothing,
+            "a component-only deployment must not exit the process"
+        );
+        assert_eq!(outcome.document["live"], serde_json::json!(true));
+        assert_eq!(
+            outcome.document["restart"],
+            serde_json::json!("not_required")
+        );
+        assert_eq!(outcome.document["views"], serde_json::json!(2));
+
+        assert_eq!(
+            query_rows(&handle.runtime, "SELECT n FROM deployed_view").await,
+            1,
+            "the deployed view must answer in this process"
+        );
+        assert_eq!(
+            live_view_names(&handle).await,
+            vec!["served_view", "deployed_view"]
+        );
+        assert_eq!(persisted_spicepod(&dir), SERVING_PLUS_VIEW);
+        assert_eq!(*handle.live.read(), SERVING_PLUS_VIEW);
+        assert!(
+            handle.persisted.read().is_none(),
+            "nothing is waiting on a restart"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A start-time change persists and restarts, and says which section made
+    /// it restart — the instance keeps serving what it was serving until it
+    /// does.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_start_time_deployment_persists_and_restarts_naming_the_section() {
+        let dir = scratch_dir("cold-apply");
+        let handle = handle_serving(&dir, SERVING).await;
+        let incoming = format!("{SERVING_PLUS_VIEW}runtime:\n  dataset_load_parallelism: 2\n");
+
+        let outcome = handle
+            .apply_spicepod(deployment(&dir, &incoming))
+            .await
+            .expect("a start-time deployment persists");
+
+        assert_eq!(
+            outcome.post_apply,
+            PostApply::ExitToApply,
+            "a start-time change takes effect by restarting"
+        );
+        assert_eq!(outcome.document["live"], serde_json::json!(false));
+        assert_eq!(outcome.document["restart"], serde_json::json!("required"));
+        assert_eq!(
+            outcome.document["restart_sections"],
+            serde_json::json!(["runtime"])
+        );
+
+        assert_eq!(persisted_spicepod(&dir), incoming, "it is persisted");
+        assert_eq!(
+            *handle.live.read(),
+            SERVING,
+            "and not live: this process still serves what it was serving"
+        );
+        assert_eq!(
+            live_view_names(&handle).await,
+            vec!["served_view"],
+            "the deployment must not have been half-applied on the way to the restart"
+        );
+
+        // A component-only deployment arriving in the window before the process
+        // exits cannot be applied in place either: this process is on its way
+        // out and would not be the one serving it. It is persisted, so the
+        // restart comes up on the newest deployment rather than the one it
+        // superseded.
+        let follow_on = handle
+            .apply_spicepod(deployment(&dir, SERVING_PLUS_VIEW))
+            .await
+            .expect("a deployment arriving before the restart is answered");
+        assert_eq!(follow_on.post_apply, PostApply::ExitToApply);
+        assert_eq!(live_view_names(&handle).await, vec!["served_view"]);
+        assert_eq!(persisted_spicepod(&dir), SERVING_PLUS_VIEW);
+        assert_eq!(
+            handle.persisted.read().as_deref(),
+            Some(SERVING_PLUS_VIEW),
+            "the restart is for the deployment that will be on disk when it happens"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The next deployment is diffed against what this process serves now. A
+    /// gate still reading the boot-time spicepod would answer a redelivery of
+    /// the deployment it just applied as a new one, and the one it replaced as
+    /// already live.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_next_deployment_is_diffed_against_the_one_now_serving() {
+        let dir = scratch_dir("hot-apply-twice");
+        let handle = handle_serving(&dir, SERVING).await;
+
+        handle
+            .apply_spicepod(deployment(&dir, SERVING_PLUS_VIEW))
+            .await
+            .expect("the first deployment applies");
+        // Reverting is only a test of the revert once the view it removes has
+        // finished converging.
+        assert_eq!(
+            query_rows(&handle.runtime, "SELECT n FROM deployed_view").await,
+            1
+        );
+
+        let redelivered = handle
+            .apply_spicepod(deployment(&dir, SERVING_PLUS_VIEW))
+            .await
+            .expect("a redelivery is answered");
+        assert_eq!(redelivered.post_apply, PostApply::Nothing);
+        assert_eq!(
+            redelivered.document["message"],
+            serde_json::json!(
+                "This spicepod is already applied and live; this instance is serving it."
+            ),
+            "the deployment this process now serves is a no-op, not another apply"
+        );
+
+        // And the spicepod it replaced is a new deployment, not the live one.
+        let reverted = handle
+            .apply_spicepod(deployment(&dir, SERVING))
+            .await
+            .expect("the previous deployment applies again");
+        assert_eq!(reverted.post_apply, PostApply::Nothing);
+        assert_eq!(reverted.document["live"], serde_json::json!(true));
+        assert_eq!(
+            live_view_names(&handle).await,
+            vec!["served_view"],
+            "reverting must actually remove the view the first deployment added"
+        );
+        assert!(
+            handle
+                .runtime
+                .datafusion()
+                .query_builder("SELECT n FROM deployed_view")
+                .build()
+                .run()
+                .await
+                .is_err(),
+            "the removed view must stop answering"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A deployment arriving before the instance has finished loading restarts
+    /// it. The load is still registering the components of the app being
+    /// replaced, so reconciling only what changed would leave the two of them
+    /// writing the same tables.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_deployment_arriving_before_the_load_finishes_restarts() {
+        let dir = scratch_dir("loading-apply");
+        let handle = handle_loading(&dir, SERVING).await;
+        assert!(
+            handle.runtime.initial_load_in_flight(),
+            "the runtime under test has not loaded its components"
+        );
+
+        let outcome = handle
+            .apply_spicepod(deployment(&dir, SERVING_PLUS_VIEW))
+            .await
+            .expect("a deployment arriving during the load is answered");
+
+        assert_eq!(
+            outcome.post_apply,
+            PostApply::ExitToApply,
+            "a component-only deployment still restarts an instance that is still loading"
+        );
+        assert_eq!(persisted_spicepod(&dir), SERVING_PLUS_VIEW);
+        assert_eq!(*handle.live.read(), SERVING);
+        assert_eq!(
+            live_view_names(&handle).await,
+            vec!["served_view"],
+            "nothing was reconciled into the app the load is still installing"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A deployment that does not build changes nothing: not the file this
+    /// instance starts on, not what it is serving, not what it reports as live.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_malformed_deployment_changes_neither_the_persisted_nor_the_live_spicepod() {
+        let dir = scratch_dir("malformed-apply");
+        let handle = handle_serving(&dir, SERVING).await;
+
+        let err = handle
+            .apply_spicepod(deployment(&dir, INVALID_SPICEPOD))
+            .await
+            .expect_err("a malformed deployment is refused");
+        assert!(
+            matches!(err, CommandError::InvalidArgument { .. }),
+            "a malformed push is the caller's mistake: {err}"
+        );
+
+        assert_eq!(persisted_spicepod(&dir), SERVING);
+        assert_eq!(*handle.live.read(), SERVING);
+        assert!(handle.persisted.read().is_none());
+        assert_eq!(live_view_names(&handle).await, vec!["served_view"]);
+        assert_eq!(
+            query_rows(&handle.runtime, "SELECT n FROM served_view").await,
+            1,
+            "the instance keeps serving what it was serving"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A deployment's secrets are installed only once its spicepod validates,
+    /// so a malformed push leaves the instance resolving what it was resolving
+    /// and leaves nothing behind for the restart it is not taking.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_malformed_deployment_leaves_the_delivered_secrets_alone() {
+        let dir = scratch_dir("malformed-secrets");
+        let handle = handle_serving(&dir, SERVING).await;
+        handle
+            .delivered_secrets
+            .replace(delivered("api_key", b"value-one"));
+
+        handle
+            .apply_spicepod(SpicepodDeployment {
+                config_dir: &dir,
+                spicepod_yaml: INVALID_SPICEPOD,
+                delivered_secrets: Some(delivered("api_key", b"value-two")),
+                app_id: None,
+            })
+            .await
+            .expect_err("a malformed deployment is refused");
+
+        assert!(
+            handle
+                .delivered_secrets
+                .holds(&delivered("api_key", b"value-one")),
+            "the rejected deployment's secrets must not have stayed installed"
+        );
+        assert!(
+            !dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE)
+                .exists(),
+            "nothing is cached for a restart that is not happening"
+        );
+        assert_eq!(persisted_spicepod(&dir), SERVING);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The cache is what a restart resolves its secrets from, so a deployment
+    /// that does not build must leave it holding the values the instance is
+    /// still serving on.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_malformed_deployment_leaves_the_cached_secrets_alone() {
+        let dir = scratch_dir("malformed-cache");
+        let handle = handle_serving(&dir, SERVING).await;
+        enrol_with_a_cache_key(&dir.join(IDENTITY_FILE));
+
+        handle
+            .apply_spicepod(SpicepodDeployment {
+                config_dir: &dir,
+                spicepod_yaml: SERVING_PLUS_VIEW,
+                delivered_secrets: Some(delivered("api_key", b"value-one")),
+                app_id: None,
+            })
+            .await
+            .expect("the first deployment applies");
+        assert!(
+            cached_secrets(&dir)
+                .expect("the applied deployment cached its secrets")
+                .holds(&delivered("api_key", b"value-one"))
+        );
+
+        handle
+            .apply_spicepod(SpicepodDeployment {
+                config_dir: &dir,
+                spicepod_yaml: INVALID_SPICEPOD,
+                delivered_secrets: Some(delivered("api_key", b"value-two")),
+                app_id: None,
+            })
+            .await
+            .expect_err("a malformed deployment is refused");
+
+        assert!(
+            cached_secrets(&dir)
+                .expect("the cache is still there")
+                .holds(&delivered("api_key", b"value-one")),
+            "a rejected deployment must not leave its secrets for the next start"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A cache write fails for its own reasons — a full disk, a permission —
+    /// and the instance keeps running on secrets it holds in memory. The
+    /// redelivery that follows is the last chance to repair it before a restart
+    /// needs it, so it must not be answered as a pure no-op.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_redelivery_repairs_a_cache_an_earlier_deployment_did_not_write() {
+        let dir = scratch_dir("cache-repair");
+        let handle = handle_serving(&dir, SERVING).await;
+        // The state a failed cache write leaves: installed in memory, absent
+        // from the cache the next start reads.
+        handle
+            .delivered_secrets
+            .replace(delivered("api_key", b"value-one"));
+        enrol_with_a_cache_key(&dir.join(IDENTITY_FILE));
+        assert!(cached_secrets(&dir).is_none(), "nothing is cached yet");
+
+        let outcome = handle
+            .apply_spicepod(SpicepodDeployment {
+                config_dir: &dir,
+                spicepod_yaml: SERVING,
+                delivered_secrets: Some(delivered("api_key", b"value-one")),
+                app_id: None,
+            })
+            .await
+            .expect("a redelivery of the live deployment is answered");
+
+        assert_eq!(outcome.post_apply, PostApply::Nothing);
+        assert_eq!(
+            outcome.document["secrets_cache_error"],
+            serde_json::Value::Null,
+            "the repair is reported as having succeeded"
+        );
+        assert!(
+            cached_secrets(&dir)
+                .expect("the redelivery wrote the cache")
+                .holds(&delivered("api_key", b"value-one")),
+            "the restart this instance may take must find its secrets"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Delivered secrets reach a component as it loads, so a rotation restarts
+    /// the instance however small the spicepod change is — and a redelivery of
+    /// the values it already holds does not.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_rotated_delivered_secret_restarts_and_a_redelivered_one_does_not() {
+        let dir = scratch_dir("secret-rotation");
+        let handle = handle_serving(&dir, SERVING).await;
+        handle
+            .delivered_secrets
+            .replace(delivered("api_key", b"value-one"));
+
+        let redelivered = handle
+            .apply_spicepod(SpicepodDeployment {
+                config_dir: &dir,
+                spicepod_yaml: SERVING_PLUS_VIEW,
+                delivered_secrets: Some(delivered("api_key", b"value-one")),
+                app_id: None,
+            })
+            .await
+            .expect("a deployment redelivering the installed secrets applies");
+        assert_eq!(
+            redelivered.post_apply,
+            PostApply::Nothing,
+            "secrets this instance already holds are not a change"
+        );
+        assert_eq!(
+            redelivered.document["delivered_secrets"],
+            serde_json::json!(["api_key"]),
+            "names only, and the names the deployment carried"
+        );
+
+        let rotated = handle
+            .apply_spicepod(SpicepodDeployment {
+                config_dir: &dir,
+                spicepod_yaml: SERVING,
+                delivered_secrets: Some(delivered("api_key", b"value-two")),
+                app_id: None,
+            })
+            .await
+            .expect("a rotation applies");
+        assert_eq!(
+            rotated.post_apply,
+            PostApply::ExitToApply,
+            "a rotated value reaches loaded components by loading them again"
+        );
+        assert_eq!(
+            rotated.document["restart_sections"],
+            serde_json::json!(["secrets"])
+        );
+        for document in [&redelivered.document, &rotated.document] {
+            let rendered = document.to_string();
+            assert!(
+                !rendered.contains("value-one") && !rendered.contains("value-two"),
+                "a delivered value must never reach the command result: {rendered}"
+            );
+        }
+
+        // A rotation carrying the spicepod this instance already serves is
+        // still a rotation: answering it as already applied would report
+        // success for values that never reached the app.
+        let unchanged_spicepod = handle
+            .apply_spicepod(SpicepodDeployment {
+                config_dir: &dir,
+                spicepod_yaml: SERVING,
+                delivered_secrets: Some(delivered("api_key", b"value-three")),
+                app_id: None,
+            })
+            .await
+            .expect("a rotation with an unchanged spicepod applies");
+        assert_eq!(unchanged_spicepod.post_apply, PostApply::ExitToApply);
+        assert_eq!(
+            unchanged_spicepod.document["restart_sections"],
+            serde_json::json!(["secrets"])
+        );
+        assert!(
+            handle
+                .delivered_secrets
+                .holds(&delivered("api_key", b"value-three")),
+            "the rotated values are installed for the restart to come up on"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The decision and the state it commits to are taken together. Two
+    /// dispatches of one deployment must apply it once: a second that read the
+    /// live spicepod before the first replaced it would apply it again, on top
+    /// of itself.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_deliveries_of_one_deployment_apply_it_once() {
+        let dir = scratch_dir("concurrent-same");
+        let handle = handle_serving(&dir, SERVING).await;
+
+        let dispatches = 4;
+        let start = Arc::new(tokio::sync::Barrier::new(dispatches));
+        let mut tasks = Vec::with_capacity(dispatches);
+        for _ in 0..dispatches {
+            let handle = Arc::clone(&handle);
+            let start = Arc::clone(&start);
+            let dir = dir.clone();
+            tasks.push(tokio::spawn(async move {
+                start.wait().await;
+                handle
+                    .apply_spicepod(deployment(&dir, SERVING_PLUS_VIEW))
+                    .await
+                    .expect("every dispatch is answered")
+            }));
+        }
+
+        let mut applied = 0;
+        for task in tasks {
+            let outcome = task.await.expect("the dispatch finishes");
+            assert_eq!(
+                outcome.post_apply,
+                PostApply::Nothing,
+                "a component-only deployment never exits the process"
+            );
+            // Only an apply reports what it applied; the answer for a
+            // deployment already being served carries no component counts.
+            if outcome.document.get("views").is_some() {
+                applied += 1;
+            }
+        }
+        assert_eq!(applied, 1, "the deployment must be applied exactly once");
+
+        assert_eq!(*handle.live.read(), SERVING_PLUS_VIEW);
+        assert_eq!(persisted_spicepod(&dir), SERVING_PLUS_VIEW);
+        assert_eq!(
+            live_view_names(&handle).await,
+            vec!["served_view", "deployed_view"]
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Deployments arriving together leave one state: the file this instance
+    /// starts on, the spicepod it reports as live, and the app it is serving
+    /// all describe the same deployment. Interleaving them could persist one,
+    /// serve another, and diff the next against a third.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_deployments_leave_one_consistent_state() {
+        let dir = scratch_dir("concurrent-distinct");
+        let handle = handle_serving(&dir, SERVING).await;
+
+        let deployments: Vec<String> = ["alpha", "beta", "gamma", "delta"]
+            .into_iter()
+            .map(|name| format!("{SERVING}  - name: view_{name}\n    sql: SELECT 3 AS n\n"))
+            .collect();
+        let start = Arc::new(tokio::sync::Barrier::new(deployments.len()));
+        let mut tasks = Vec::with_capacity(deployments.len());
+        for spicepod in deployments {
+            let handle = Arc::clone(&handle);
+            let start = Arc::clone(&start);
+            let dir = dir.clone();
+            tasks.push(tokio::spawn(async move {
+                start.wait().await;
+                handle
+                    .apply_spicepod(deployment(&dir, &spicepod))
+                    .await
+                    .expect("every dispatch is answered");
+            }));
+        }
+        for task in tasks {
+            task.await.expect("the dispatch finishes");
+        }
+
+        let live = handle.live.read().clone();
+        assert_eq!(
+            persisted_spicepod(&dir),
+            live,
+            "the file this instance starts on is the deployment it reports as live"
+        );
+        let views = live_view_names(&handle).await;
+        assert_eq!(
+            views.len(),
+            2,
+            "one deployment's views, not several: {views:?}"
+        );
+        // Exactly the deployment that is live, and none of the three it raced.
+        for name in ["view_alpha", "view_beta", "view_gamma", "view_delta"] {
+            assert_eq!(
+                live.contains(name),
+                views[1] == name,
+                "the app being served is the deployment reported as live: {views:?}"
+            );
+        }
+        assert!(
+            handle.persisted.read().is_none(),
+            "no restart was committed for a component-only deployment"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A result that fits must never be misreported as oversized.

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -1051,6 +1051,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
 
     // Captured before `args` is moved into the server task below.
     let cloud_connect_flag = args.cloud_connect;
+    let runtime_overrides = args.set_runtime.clone();
 
     let server_thread = tokio::spawn(async move {
         Box::pin(cloned_rt.start_servers(args.runtime, tls_config, endpoint_auth)).await
@@ -1059,10 +1060,10 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
     // Restore control-plane-delivered secrets from the local cache and register
     // their store BEFORE loading components. Component initialization is what
     // resolves `${ secrets:… }`, so a store installed after this point would
-    // arrive too late for every component that referenced one — and since a
-    // deployment applies by restarting, that is the normal path, not an edge
-    // case. Local files only, no control-plane round trip, so this neither
-    // blocks nor fails when the gateway is unreachable.
+    // arrive too late for every component that referenced one — and a
+    // deployment that delivers secrets applies by restarting, so that is the
+    // path they arrive by. Local files only, no control-plane round trip, so
+    // this neither blocks nor fails when the gateway is unreachable.
     let delivered_secrets = cloud_connect::restore_delivered_secrets(
         env!("CARGO_PKG_VERSION"),
         &rt,
@@ -1090,6 +1091,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
         delivered_secrets,
         running_deployment,
         cloud_connect_metrics,
+        runtime_overrides,
     )
     .await;
 
@@ -1245,9 +1247,9 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
     }
 
     // A cloud-managed instance serves what its last deployment persisted, not
-    // the instance directory's `spicepod.yaml`: a deployment applies by writing
-    // that file and restarting, so reading anything else here would drop every
-    // deployment on the floor at the moment it was meant to take effect.
+    // the instance directory's `spicepod.yaml`: every deployment writes that
+    // file, so reading anything else here would drop every deployment on the
+    // floor at the moment it was meant to take effect.
     let mut deployment_note = None;
     let cloud_managed_spicepod = cloud_connect::cloud_managed_spicepod(args.cloud_connect)
         .await
@@ -1586,7 +1588,7 @@ fn parse_set_string(s: &str) -> Result<(String, String), String> {
 
 fn apply_overrides(
     runtime_config: SpicepodRuntime,
-    overrides: &Vec<(String, String)>,
+    overrides: &[(String, String)],
 ) -> Result<SpicepodRuntime> {
     if overrides.is_empty() {
         return Ok(runtime_config);

--- a/crates/runtime-cloud-connect/src/handlers.rs
+++ b/crates/runtime-cloud-connect/src/handlers.rs
@@ -417,12 +417,13 @@ pub trait RuntimeHandle: Send + Sync + 'static {
     /// Persist a cloud-managed spicepod as the configuration this instance
     /// starts on.
     ///
-    /// Applying is **not** a hot reload: the spicepod is validated, persisted,
-    /// and made live by a restart ([`PostApply::ExitToApply`]), so a change to
-    /// any section takes effect by one path instead of some sections reloading
-    /// and the rest waiting for an operator. Redelivering a deployment the
-    /// instance is already serving must return [`PostApply::Nothing`] —
-    /// restarting for it would make a redelivery a restart loop.
+    /// The spicepod is validated and persisted, and how it becomes live is the
+    /// handle's to decide: one that reconciled the change into the running
+    /// process returns [`PostApply::Nothing`] and reports the deployment as
+    /// live, one that cannot returns [`PostApply::ExitToApply`] and is restarted
+    /// onto the file it persisted. Redelivering a deployment the instance is
+    /// already serving must return [`PostApply::Nothing`] — restarting for it
+    /// would make a redelivery a restart loop.
     ///
     /// The default implementation writes the YAML to
     /// `config_dir/spicepod-cloud-managed.yml` via `tokio::fs` so the

--- a/crates/runtime-cloud-connect/src/sealed_secrets.rs
+++ b/crates/runtime-cloud-connect/src/sealed_secrets.rs
@@ -41,7 +41,6 @@ use std::collections::BTreeMap;
 use cloud_connect_crypto::{EncryptionKeypair, EncryptionKeyring, SecretAddress};
 use prost::Message as _;
 use snafu::{OptionExt as _, ResultExt, Snafu};
-use zeroize::Zeroizing;
 
 use crate::proto;
 
@@ -103,6 +102,10 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// Secret names and values as delivered. Values are [`Zeroizing`] so the
 /// plaintext is scrubbed when dropped rather than left in freed heap.
 pub type DeliveredSecrets = BTreeMap<String, Zeroizing<Vec<u8>>>;
+
+/// Re-exported so a caller holding a [`DeliveredSecrets`] can name what is in
+/// it without depending on `zeroize` itself.
+pub use zeroize::Zeroizing;
 
 /// A successfully opened payload.
 pub struct Opened {

--- a/crates/runtime-cloud-connect/src/secret_cache.rs
+++ b/crates/runtime-cloud-connect/src/secret_cache.rs
@@ -16,9 +16,9 @@ limitations under the License.
 
 //! Encrypted at-rest cache for control-plane-delivered secrets.
 //!
-//! Every deployment applies by restart, so delivered secrets that lived only in
-//! process memory would be gone by the time the components that need them come
-//! back up — the normal deploy would take two deploys. This cache closes that:
+//! A deployment that delivers secrets applies by restart, so secrets that lived
+//! only in process memory would be gone by the time the components that need
+//! them come back up — that deploy would take two deploys. This cache closes it:
 //! it is written when a deployment delivers secrets and opened locally at
 //! startup, with **no control-plane round trip**, so a restart succeeds even
 //! with the gateway unreachable.

--- a/crates/runtime-cloud-connect/src/supervisor.rs
+++ b/crates/runtime-cloud-connect/src/supervisor.rs
@@ -16,9 +16,10 @@ limitations under the License.
 
 //! What will relaunch this process after a deployment exits it.
 //!
-//! A deployment applies by persisting the spicepod and exiting, so whatever
-//! supervises the process is the mechanism, not a convenience: with nothing
-//! watching, a deployment *stops* the instance instead of updating it. The
+//! A deployment the runtime cannot apply in place applies by persisting the
+//! spicepod and exiting, so whatever supervises the process is the mechanism,
+//! not a convenience: with nothing watching, such a deployment *stops* the
+//! instance instead of updating it. The
 //! runtime cannot install a supervisor, so it detects one and says what it
 //! found — at startup, in `get_status`, and therefore in the portal — before
 //! the first deployment is the way the operator finds out.

--- a/crates/runtime-secrets/src/stores/cloud_delivered.rs
+++ b/crates/runtime-secrets/src/stores/cloud_delivered.rs
@@ -72,6 +72,17 @@ impl CloudDeliveredSecretStore {
         *self.values.write() = Arc::new(values);
     }
 
+    /// Whether `values` is exactly the set already held — same names, same
+    /// bytes.
+    ///
+    /// Answers whether a delivery changes anything without handing the caller a
+    /// value to compare itself, which is what lets a redelivery of the current
+    /// secrets be told apart from a rotation.
+    #[must_use]
+    pub fn holds(&self, values: &BTreeMap<String, Zeroizing<Vec<u8>>>) -> bool {
+        **self.values.read() == *values
+    }
+
     /// The delivered secret names, sorted. Safe to log and to report in status;
     /// the values are never exposed this way.
     #[must_use]
@@ -184,6 +195,34 @@ mod tests {
         assert!(
             !message.contains('\u{fffd}'),
             "no lossy replacement: {message}"
+        );
+    }
+
+    /// A caller deciding whether a delivery changes anything has to see a
+    /// rotated value, not just a changed name — the names are identical across
+    /// a rotation, which is the case that matters.
+    #[test]
+    fn holds_distinguishes_a_redelivery_from_a_rotation() {
+        let store = CloudDeliveredSecretStore::new();
+        store.replace(values(&[("a", b"1"), ("b", b"2")]));
+
+        assert!(store.holds(&values(&[("a", b"1"), ("b", b"2")])));
+        assert!(
+            !store.holds(&values(&[("a", b"9"), ("b", b"2")])),
+            "a rotated value is not the set already held"
+        );
+        assert!(
+            !store.holds(&values(&[("a", b"1")])),
+            "a removed secret is not the set already held"
+        );
+        assert!(
+            !store.holds(&values(&[("a", b"1"), ("b", b"2"), ("c", b"3")])),
+            "an added secret is not the set already held"
+        );
+        assert!(!store.holds(&BTreeMap::new()));
+        assert!(
+            CloudDeliveredSecretStore::new().holds(&BTreeMap::new()),
+            "an empty delivery to an empty store changes nothing"
         );
     }
 

--- a/crates/runtime/src/init/pods_watcher.rs
+++ b/crates/runtime/src/init/pods_watcher.rs
@@ -50,9 +50,8 @@ impl Runtime {
     /// workers against the currently-loaded app.
     ///
     /// This is the diff-based reconcile the pods watcher performs when a
-    /// spicepod file changes on disk. It is the *local* configuration path: a
-    /// Spice Cloud deployment does not come through here, because it applies by
-    /// persisting the spicepod and restarting onto it (see
+    /// spicepod file changes on disk, and the one a Spice Cloud deployment takes
+    /// when what it changes is confined to the sections reconciled here (see
     /// `spiced`'s `cloud_connect` module).
     ///
     /// Returns `true` if `new_app` differed from the current app and was

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1699,6 +1699,17 @@ impl Runtime {
         }
     }
 
+    /// Whether the initial component load is still running.
+    ///
+    /// While it is, what is registered is not yet what the loaded app describes,
+    /// so a caller that reconciles a new app against the loaded one — the diff
+    /// [`Runtime::apply_app`] performs — would treat components the load has not
+    /// reached yet as already registered.
+    #[must_use]
+    pub fn initial_load_in_flight(&self) -> bool {
+        self.initial_load.in_flight.load(Ordering::SeqCst)
+    }
+
     /// Will load all of the components of the Runtime, including `secret_stores`, `catalogs`, `datasets`, `models`, and `embeddings`.
     ///
     /// The future returned by this function will not resolve until all components have been loaded and marked as ready.


### PR DESCRIPTION
Every applied Spicepod deployment restarted `spiced`, so downtime was proportional to the size of the app rather than the size of the change: editing one dataset reloaded every dataset and rebuilt every acceleration.

`apply_spicepod` now classifies the incoming Spicepod against the one this process is serving, before it writes, installs, or reconciles anything:

- A change confined to the sections `Runtime::apply_app` reconciles — `catalogs`, `datasets`, `functions`, `models`, `views` — is persisted and applied to the running process. The instance keeps serving, and the result reports the deployment as applied and live.
- Anything else is persisted and made live by the restart the runtime already performed, and the result names the sections that forced it.

Sections are compared as documents rather than as text, so a section written out empty or in a different key order is not a change. Everything else errs towards the restart: a section whose fields are spelled out at their defaults, an unknown or future top-level key, and a document the gate cannot read all take the restart, which costs a restart that was not needed rather than risking one that was.

Secret propagation stays restart-only: a component resolves `${ secrets:… }` as it loads, so a deployment carrying secret values this instance does not already hold restarts it.

The gate also restarts, rather than applying in place, whenever this process has nothing sound to diff against: it is not serving a deployment, it has already persisted one and is restarting onto it, or its initial component load has not finished — a diff against a partly-registered app would treat the components the load has not reached as already applied, and the load would then register the configuration being replaced on top of the one just applied.

The decision is taken once, before any state changes, and the whole apply — decision, persistence, in-process reconcile, and the live-deployment update — is serialized, so two dispatches cannot leave the persisted file, the app being served, and the Spicepod reported as live describing different deployments. The live deployment the next diff is computed against is now what the process serves, not what it booted on.

A deployment applied in place takes the `--set-runtime` overrides the process was started with, the same way a restart onto the persisted file would, so both paths land the same app.

Convergence, not transactions: components reconcile one at a time, and one that fails to load lands in an error state, stays visible through `GetStatus`, and is retried by the next deployment. The result says so rather than claiming a rollback the runtime does not perform.

The reconcile this routes deployments onto is `Runtime::apply_app`, which awaits a component load that retries a transient failure without bound, so a deployment naming an unreachable source does not return until it succeeds. This depends on spiceai/spiceai#12862 bounding that apply and must not land before it.

Closes spiceai/spiceai#12866
Part of spiceai/spiceai#12860
