### PR TITLE
fix(runtime): invalidate localpod children's cached results on parent refresh

### DIFF
--- a/crates/runtime-table/src/accelerated/refresh.rs
+++ b/crates/runtime-table/src/accelerated/refresh.rs
@@ -916,6 +916,10 @@ impl Refresher {
         let mut refresh_task_runner = refresh_task_runner.build();
 
         let (start_refresh, mut on_refresh_complete) = refresh_task_runner.start()?;
+        // Handle for the refresh-completion handler below: cache invalidation
+        // must cover the live set of dataset names (self + synchronized
+        // children), which grows as children finish their initial loads.
+        let refresh_task = Arc::clone(refresh_task_runner.refresh_task());
         self.refresh_task_runner = Some(refresh_task_runner);
 
         let notifier = self.on_complete_notification.clone();
@@ -1081,10 +1085,18 @@ impl Refresher {
 
                         if refresh_changed_accelerator && let Some(cache_provider_ref) = caching.as_ref() {
                             // No cache provider means runtime is shutting down and cache is already cleaned up
-                            if let Some(cache_provider) = cache_provider_ref.upgrade()
-                                && let Err(e) = cache_provider.invalidate_for_table(dataset_name.clone()) {
-                                    tracing::warn!("Failed to invalidate cached results for dataset {dataset_name}: {e}");
+                            if let Some(cache_provider) = cache_provider_ref.upgrade() {
+                                // The refresh rewrote every synchronized (e.g. localpod) child's
+                                // accelerator along with this dataset's, so cached results for the
+                                // children are exactly as stale as the parent's (#12887). Children
+                                // attach after their own initial load completes, so the set is
+                                // resolved live rather than captured when this loop started.
+                                for table_name in refresh_task.get_dataset_names().await {
+                                    if let Err(e) = cache_provider.invalidate_for_table(table_name.clone()) {
+                                        tracing::warn!("Failed to invalidate cached results for dataset {table_name}: {e}");
+                                    }
                                 }
+                            }
                         }
 
                         if refresh_succeeded && checkpoint_counting_enabled.load(Ordering::Acquire) && create_checkpoint_snapshot_after_refresh && let Some(checkpointer) = &checkpointer {

--- a/crates/runtime-table/src/accelerated/refresh_task.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task.rs
@@ -2249,7 +2249,11 @@ impl RefreshTask {
         }
     }
 
-    async fn get_dataset_names(&self) -> Vec<TableReference> {
+    /// Returns this dataset's name plus the name of every synchronized
+    /// (e.g. `localpod:`) child dataset currently attached to the sink.
+    /// A refresh rewrites all of these tables, so anything derived from one of
+    /// them (metrics labels, cached query results) must cover the whole set.
+    pub(crate) async fn get_dataset_names(&self) -> Vec<TableReference> {
         let mut dataset_names = vec![self.dataset_name.clone()];
         for synchronized_table in self.sink.read().await.synchronized_tables() {
             dataset_names.push(synchronized_table.child_dataset_name());

--- a/crates/runtime-table/src/accelerated/refresh_task_runner.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task_runner.rs
@@ -338,6 +338,14 @@ impl RefreshTaskRunner {
             .await;
     }
 
+    /// The [`RefreshTask`] this runner drives. Used by the refresher loop to
+    /// resolve the live set of dataset names (self + synchronized children) at
+    /// refresh completion — children attach after their own initial load, so
+    /// the set cannot be captured up front.
+    pub(crate) fn refresh_task(&self) -> &Arc<RefreshTask> {
+        &self.refresh_task
+    }
+
     /// Create a new [`Refresh`] based on defaults and overrides.
     async fn create_refresh_from_overrides(
         defaults: Arc<RwLock<Refresh>>,

--- a/crates/runtime/tests/acceleration/localpod_sync.rs
+++ b/crates/runtime/tests/acceleration/localpod_sync.rs
@@ -38,11 +38,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use app::AppBuilder;
-use arrow::array::Int64Array;
-use runtime::Runtime;
+use arrow::array::{Int64Array, RecordBatch};
+use cache::result::CacheStatus;
+use futures::TryStreamExt;
+use runtime::{Runtime, datafusion::query::QueryBuilder};
 use spicepod::{
     acceleration::{Acceleration, RefreshMode},
-    component::dataset::Dataset,
+    component::{caching::SQLResultsCacheConfig, dataset::Dataset},
     param::Params,
 };
 use tempfile::TempDir;
@@ -96,6 +98,178 @@ async fn wait_for_count(rt: &Runtime, table: &str, expected: usize, timeout: Dur
         last = count_rows(rt, table).await;
     }
     last
+}
+
+/// Runs `SELECT COUNT(*)` on `table` through the results-cache-aware query path
+/// (unlike [`count_rows`], which queries the `SessionContext` directly and
+/// bypasses the results cache), returning the observed cache status and count.
+async fn cached_count(rt: &Runtime, table: &str) -> (CacheStatus, usize) {
+    let sql = format!("SELECT COUNT(*) AS c FROM {table}");
+    let query = QueryBuilder::new(&sql, rt.datafusion()).build();
+    let result = query.run().await.expect("cached count query should run");
+    let status = result.cache_status;
+    let batches = result
+        .data
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .expect("cached count query should collect");
+    let count = batches
+        .first()
+        .expect("count query should return a batch")
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("COUNT(*) should be an Int64Array")
+        .value(0);
+    (
+        status,
+        usize::try_from(count).expect("count should be non-negative"),
+    )
+}
+
+/// A parent refresh must invalidate cached query results for its localpod
+/// children, not only for itself.
+///
+/// Regression test for <https://github.com/spiceai/spiceai/issues/12887>: after
+/// a localpod child's initial load its refresher hands off to the parent's
+/// refresh task, and refresh-completion cache invalidation only covered the
+/// refreshing dataset's own name — queries against the child kept being served
+/// pre-refresh results from the cache until `item_ttl` expired. The long TTL
+/// here ensures TTL expiry cannot mask a missing invalidation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_localpod_refresh_invalidates_child_cached_results() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,runtime_table::accelerated=trace",
+    ));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = TempDir::new().expect("create temp dir");
+            let csv_path = temp_dir.path().join("data.csv");
+            fs::write(&csv_path, format!("{CSV_HEADER}{}", rows(0, 2)))
+                .await
+                .expect("write initial csv");
+
+            let mut parent = Dataset::new(format!("file://{}", csv_path.display()), "time_series");
+            parent.params = Some(Params::from_string_map(
+                vec![
+                    ("file_format".to_string(), "csv".to_string()),
+                    ("csv_has_header".to_string(), "true".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+            parent.acceleration = Some(Acceleration {
+                enabled: true,
+                refresh_mode: Some(RefreshMode::Full),
+                ..Acceleration::default()
+            });
+
+            let mut child = Dataset::new("localpod:time_series", "local_time_series");
+            child.acceleration = Some(Acceleration {
+                enabled: true,
+                refresh_mode: Some(RefreshMode::Full),
+                ..Acceleration::default()
+            });
+
+            let app = AppBuilder::new("test_localpod_refresh_invalidates_child_cache")
+                .with_sql_cache(SQLResultsCacheConfig {
+                    item_ttl: Some("10m".to_string()),
+                    ..Default::default()
+                })
+                .with_dataset(parent)
+                .with_dataset(child)
+                .build();
+
+            configure_test_datafusion();
+            let runtime = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = Arc::clone(&runtime).load_components() => {}
+            }
+            runtime_ready_check(&runtime).await;
+
+            // Populate cache entries for both layers, then confirm they are served
+            // from cache on repeat.
+            for table in ["time_series", "local_time_series"] {
+                let (status, count) = cached_count(&runtime, table).await;
+                assert_eq!(status, CacheStatus::CacheMiss, "{table}: first query");
+                assert_eq!(count, 2, "{table}: initial row count");
+                let (status, count) = cached_count(&runtime, table).await;
+                assert_eq!(status, CacheStatus::CacheHit, "{table}: repeat query");
+                assert_eq!(count, 2, "{table}: cached row count");
+            }
+
+            // Change the source, then drive parent refreshes until both accelerators
+            // hold the new data. The child subscribes to the parent's refreshes only
+            // once its own startup load completes, so retry rather than assuming the
+            // first refresh already fans out to the child.
+            fs::write(&csv_path, format!("{CSV_HEADER}{}", rows(0, 5)))
+                .await
+                .expect("append rows to csv");
+
+            let mut child_raw_count = count_rows(&runtime, "local_time_series").await;
+            for _ in 0..15 {
+                let notify = runtime
+                    .datafusion()
+                    .refresh_table(&"time_series".into(), None)
+                    .await
+                    .expect("trigger parent refresh");
+                if let Some(notify) = notify {
+                    tokio::select! {
+                        () = notify.notified() => {}
+                        () = tokio::time::sleep(Duration::from_secs(5)) => {}
+                    }
+                }
+                child_raw_count =
+                    wait_for_count(&runtime, "local_time_series", 5, Duration::from_secs(3)).await;
+                if child_raw_count == 5 {
+                    break;
+                }
+            }
+            assert_eq!(
+                child_raw_count, 5,
+                "localpod child accelerator should hold the refreshed rows"
+            );
+
+            // The parent's entry was always invalidated; sanity-check it first.
+            let (_, parent_count) = cached_count(&runtime, "time_series").await;
+            assert_eq!(
+                parent_count, 5,
+                "parent query should observe the refreshed rows"
+            );
+
+            // The child's cache entry must be invalidated by the same refresh.
+            // Invalidation runs in the refresher's completion handler, which can lag
+            // the data landing by a scheduling beat — poll the actual condition with
+            // a bounded timeout instead of asserting the first read. Before the
+            // #12887 fix the child keeps serving the stale cached count of 2 until
+            // `item_ttl` (10m) and this poll exhausts its deadline.
+            let mut child_count = 0;
+            for _ in 0..50 {
+                (_, child_count) = cached_count(&runtime, "local_time_series").await;
+                if child_count == 5 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            assert_eq!(
+                child_count, 5,
+                "localpod child query should observe the refreshed rows within its \
+                 cache TTL — stale cached results were served before the #12887 fix"
+            );
+
+            // The fresh result is itself cached again.
+            let (status, count) = cached_count(&runtime, "local_time_series").await;
+            assert_eq!(status, CacheStatus::CacheHit, "child repeat after refresh");
+            assert_eq!(count, 5, "child cached row count after refresh");
+
+            Ok(())
+        })
+        .await
 }
 
 /// A localpod child whose parent uses the default in-memory (Arrow) accelerator must keep tracking


### PR DESCRIPTION
Fixes #12887.

## Problem

When an accelerated dataset completed a refresh, its results-cache entries were invalidated — but entries for `localpod` child datasets built on top of it were not. After a child's initial load its refresher hands off to the parent's refresh task (synchronized refresh), and the refresh-completion handler called `invalidate_for_table` only with the refreshing dataset's own name. Queries against the child kept being served pre-refresh results from the cache until `item_ttl` expired, silently making the TTL the only freshness bound for localpod datasets — a long TTL served stale data across refreshes indefinitely.

## Fix

At refresh completion, invalidate the live set of dataset names — the refreshing dataset plus every synchronized child attached to the sink (`RefreshTask::get_dataset_names`, the same set already used for metrics labels and status updates). The set is resolved from the `RefreshTask` at invalidation time rather than captured when the refresher loop starts, because children attach only after their own initial loads complete.

- `refresh_task.rs`: expose `get_dataset_names` as `pub(crate)` with a doc comment on the contract.
- `refresh_task_runner.rs`: accessor handing the refresher loop its `Arc<RefreshTask>`.
- `refresh.rs`: iterate the full name set at the existing invalidation site.

The CDC-changes and retention invalidation paths are deliberately unchanged: synchronized children can only attach to full-refresh-mode datasets, and retention deletes mutate only the parent's accelerator (child accelerator contents are untouched, so child cache entries still match the child's data).

## Test

New integration test `test_localpod_refresh_invalidates_child_cached_results` in `acceleration/localpod_sync.rs`: caches a `COUNT(*)` for both parent and child (verifying `CacheHit` on repeat), changes the source CSV, drives a parent refresh, and asserts the child query observes the new count within a bounded poll — with a 10-minute `item_ttl` so TTL expiry cannot mask a missing invalidation. Before the fix the child serves the stale cached count and the poll exhausts; the pre-existing sync test still passes.