### PR TITLE
feat(cli): typed login sessions and explicit connect organization selection

### DIFF
--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -826,7 +826,7 @@ fn resolve_project_id(
 }
 
 /// Render org names as `'a'`, `'a' and 'b'`, or `'a', 'b', and 'c'`.
-fn format_org_list(orgs: &[String]) -> String {
+pub(crate) fn format_org_list(orgs: &[String]) -> String {
     let quoted: Vec<String> = orgs.iter().map(|org| format!("'{org}'")).collect();
     match quoted.split_last() {
         None => "no organizations".to_string(),

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -29,6 +29,7 @@ use dialoguer::{Input, Password, Select, theme::ColorfulTheme};
 use snafu::ResultExt;
 use std::{fmt, io::IsTerminal};
 
+pub(crate) use client::format_org_list;
 pub use client::{
     CloudClient, ProjectTarget, is_device_authorization_denied_error, parse_org_project,
 };

--- a/bin/spice/src/commands/login/connect_org.rs
+++ b/bin/spice/src/commands/login/connect_org.rs
@@ -1,0 +1,1344 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Explicit organization selection for connecting an instance.
+//!
+//! Connecting an instance enrolls it into exactly one organization, and that
+//! choice is part of the connection — not a side effect of whichever org the
+//! login happens to treat as default. This module resolves the organization
+//! for **one invocation**: it enumerates the organizations the login belongs
+//! to, keeps only those whose membership role may enroll (owner or admin),
+//! validates an explicit `--org`, and asks the user to choose when more than
+//! one qualifies. The stored active org and the login's own org are only ever
+//! *highlighted* as the chooser's starting position; neither is selected on
+//! its own when alternatives exist.
+//!
+//! Nothing here reads the choice into, or writes it out of, the machine-wide
+//! `spice cloud org use` state — the resolution lives and dies with the
+//! invocation that asked for it.
+
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::{Confirm, Select};
+use spice_cloud_client::types::Org;
+
+use crate::commands::cloud::{CloudClient, format_org_list, org as cloud_org};
+use crate::error::{CloudErrorCode, Error, Result};
+
+use super::session::AuthenticatedSession;
+
+/// The membership roles allowed to connect an instance into an organization.
+///
+/// Compared case-insensitively against the role the API reports: this filter
+/// is a permission boundary, and formatting drift on the wire must not widen
+/// or narrow it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectRole {
+    Owner,
+    Admin,
+}
+
+impl ConnectRole {
+    /// Parse a reported membership role, `None` for any role that may not
+    /// connect an instance (member, viewer, deleted, or anything unknown).
+    fn parse(role: &str) -> Option<Self> {
+        let role = role.trim();
+        if role.eq_ignore_ascii_case("owner") {
+            Some(Self::Owner)
+        } else if role.eq_ignore_ascii_case("admin") {
+            Some(Self::Admin)
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Owner => "owner",
+            Self::Admin => "admin",
+        }
+    }
+}
+
+/// An organization resolved for one connect invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectOrg {
+    /// The organization name, as `--org` and the API address it.
+    pub name: String,
+    /// Human-readable display name, when the API reports one.
+    pub display_name: Option<String>,
+    /// The membership role that made the org eligible. `None` when discovery
+    /// could not report roles — the server still enforces the role on every
+    /// mutation.
+    pub role: Option<ConnectRole>,
+}
+
+impl std::fmt::Display for ConnectOrg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)?;
+        if let Some(display_name) = self
+            .display_name
+            .as_ref()
+            .filter(|display| !display.is_empty() && !display.eq_ignore_ascii_case(&self.name))
+        {
+            write!(f, " — {display_name}")?;
+        }
+        if let Some(role) = self.role {
+            write!(f, " ({})", role.as_str())?;
+        }
+        Ok(())
+    }
+}
+
+/// How the organization resolution ended.
+#[derive(Debug)]
+pub enum OrgResolution {
+    /// The organization this invocation connects into.
+    Selected(ConnectOrg),
+    /// The user cancelled the chooser (Esc, `q`, Ctrl-C, or EOF). A normal
+    /// exit for the caller to unwind cleanly, not an error.
+    Cancelled,
+}
+
+/// Resolve the organization one connect invocation acts on, using the
+/// credential a live login session carries.
+///
+/// - An explicit `org` is validated against the login's memberships and must
+///   carry the owner or admin role; it skips the chooser.
+/// - With exactly one eligible organization, it is printed and used.
+/// - With several, an interactive chooser is required: the stored active org
+///   (or the login's own org) is highlighted but never chosen silently. When
+///   `interactive` is false the resolution fails and names `--org`.
+/// - When organization discovery is unavailable, an explicit `org` is
+///   membership-checked server-side and the unverifiable role is reported;
+///   otherwise only the organization the credential itself proves can be
+///   offered, and only interactively.
+///
+/// The choice is scoped to this invocation. Nothing here mutates the
+/// machine-wide active org.
+///
+/// # Errors
+///
+/// Returns an error if the organizations cannot be listed, if `org` is not an
+/// eligible membership, if no membership is eligible, or if a choice is
+/// required and the invocation is not interactive.
+pub async fn resolve_connect_organization(
+    session: &AuthenticatedSession,
+    org: Option<&str>,
+    interactive: bool,
+) -> Result<OrgResolution> {
+    let client = session.management_client()?;
+    resolve_connect_organization_with_client(&client, org, Some(session.org_name()), interactive)
+        .await
+}
+
+/// [`resolve_connect_organization`] for a caller that already holds an
+/// authenticated management client — the already-logged-in path, where no
+/// browser flow ran and no [`AuthenticatedSession`] exists.
+///
+/// `credential_org` is the organization the credential is known to belong to,
+/// when the caller knows it. It is only a chooser highlight and the
+/// discovery-unavailable confirmation candidate — never a silent choice.
+///
+/// # Errors
+///
+/// As [`resolve_connect_organization`].
+pub async fn resolve_connect_organization_with_client(
+    client: &CloudClient,
+    org: Option<&str>,
+    credential_org: Option<&str>,
+    interactive: bool,
+) -> Result<OrgResolution> {
+    // `interactive` is the caller's intent; the terminal is a fact. Clamp on
+    // the real stdin so a caller passing `true` under a pipe still gets the
+    // non-interactive error shapes instead of a prompt nothing can answer.
+    use std::io::IsTerminal as _;
+    let interactive = interactive && std::io::stdin().is_terminal();
+
+    resolve_with_stored_default(
+        client,
+        org,
+        credential_org.filter(|org| !org.is_empty()),
+        interactive,
+        &mut TerminalPrompter,
+    )
+    .await
+}
+
+/// The layer that folds in the machine-wide highlight hint. Everything below
+/// the terminal clamp and the client construction runs through here, so tests
+/// can exercise it — including that it only ever *reads* the stored state.
+async fn resolve_with_stored_default<D: OrgDiscovery, P: Prompter>(
+    discovery: &D,
+    explicit_org: Option<&str>,
+    credential_org: Option<&str>,
+    interactive: bool,
+    prompter: &mut P,
+) -> Result<OrgResolution> {
+    // Highlight hint only. A context file that cannot be read must not block
+    // the resolution — the hint moves the chooser's cursor, nothing else.
+    let stored_default = cloud_org::active_org().unwrap_or(None);
+
+    resolve_with(
+        discovery,
+        explicit_org,
+        stored_default.as_deref(),
+        credential_org,
+        interactive,
+        prompter,
+    )
+    .await
+}
+
+/// Where the resolver asks about the login's organizations. Implemented by the
+/// Spice Cloud client; tests substitute a scripted source.
+trait OrgDiscovery {
+    /// The organizations the login belongs to, or `None` when the API cannot
+    /// enumerate them.
+    async fn list_orgs(&self) -> Result<Option<Vec<Org>>>;
+
+    /// Server-side membership check for one explicitly named organization.
+    async fn confirm_membership(&self, org: &str) -> Result<()>;
+}
+
+impl OrgDiscovery for CloudClient {
+    async fn list_orgs(&self) -> Result<Option<Vec<Org>>> {
+        CloudClient::list_orgs(self).await
+    }
+
+    async fn confirm_membership(&self, org: &str) -> Result<()> {
+        self.get_auth_context_for_org(org).await.map(drop)
+    }
+}
+
+/// Where the chooser's cursor starts, and why. The *why* controls the label:
+/// marking the login's own org "(default)" would claim `spice cloud org use`
+/// state that does not exist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Highlight {
+    index: usize,
+    source: HighlightSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HighlightSource {
+    /// The machine-wide active org selected by `spice cloud org use`.
+    StoredDefault,
+    /// The organization the login credential itself belongs to.
+    LoginOrg,
+}
+
+/// How the resolver asks — and tells — the user. Implemented on the terminal;
+/// tests substitute a scripted prompter (or one that panics, to prove no
+/// prompt was reached).
+trait Prompter {
+    /// Choose among `options`, with the cursor starting on `highlight` when
+    /// one of them deserves it. `None` means the user cancelled.
+    async fn choose(
+        &mut self,
+        options: &[ConnectOrg],
+        highlight: Option<Highlight>,
+    ) -> Result<Option<usize>>;
+
+    /// Confirm connecting into `org`, the only organization the credential
+    /// proves. `None` means the user cancelled.
+    async fn confirm(&mut self, org: &str) -> Result<Option<bool>>;
+
+    /// Show the user one line of resolver output. Not a prompt — routed
+    /// through this trait so tests can assert what a path reported.
+    fn notify(&mut self, line: String);
+}
+
+struct TerminalPrompter;
+
+impl Prompter for TerminalPrompter {
+    async fn choose(
+        &mut self,
+        options: &[ConnectOrg],
+        highlight: Option<Highlight>,
+    ) -> Result<Option<usize>> {
+        let items = chooser_items(options, highlight);
+        let cursor = highlight.map_or(0, |highlight| highlight.index);
+
+        // dialoguer blocks on terminal input for as long as the user thinks;
+        // that wait must not occupy an async runtime thread.
+        let selection = tokio::task::spawn_blocking(move || {
+            Select::with_theme(&ColorfulTheme::default())
+                .with_prompt("Organization")
+                .items(&items)
+                .default(cursor)
+                .interact_opt()
+        })
+        .await
+        .map_err(|err| Error::InvalidArgument {
+            message: format!("Failed to read the organization selection: {err}"),
+        })?;
+
+        map_prompt_cancellation(selection, "organization selection")
+    }
+
+    async fn confirm(&mut self, org: &str) -> Result<Option<bool>> {
+        let prompt =
+            format!("Connect using organization '{org}' (the organization this login belongs to)?");
+        let confirmation = tokio::task::spawn_blocking(move || {
+            Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt(prompt)
+                .default(false)
+                .interact_opt()
+        })
+        .await
+        .map_err(|err| Error::InvalidArgument {
+            message: format!("Failed to read the organization confirmation: {err}"),
+        })?;
+
+        map_prompt_cancellation(confirmation, "organization confirmation")
+    }
+
+    fn notify(&mut self, line: String) {
+        println!("{line}");
+    }
+}
+
+/// The chooser rows: "(default)" marks only a highlight that really is the
+/// stored `spice cloud org use` state — the login's own org gets the cursor
+/// without a label it has not earned.
+fn chooser_items(options: &[ConnectOrg], highlight: Option<Highlight>) -> Vec<String> {
+    options
+        .iter()
+        .enumerate()
+        .map(|(index, org)| match highlight {
+            Some(highlight)
+                if highlight.index == index
+                    && highlight.source == HighlightSource::StoredDefault =>
+            {
+                format!("{org} (default)")
+            }
+            _ => org.to_string(),
+        })
+        .collect()
+}
+
+/// Fold the two shapes of "the user backed out" — `Esc`/`q` (`Ok(None)`) and
+/// Ctrl-C/EOF (an interrupted read) — into `None`, so every way of declining a
+/// prompt is the same clean cancellation.
+fn map_prompt_cancellation<T>(
+    outcome: dialoguer::Result<Option<T>>,
+    what: &str,
+) -> Result<Option<T>> {
+    match outcome {
+        Ok(selection) => Ok(selection),
+        Err(dialoguer::Error::IO(err))
+            if matches!(
+                err.kind(),
+                std::io::ErrorKind::Interrupted | std::io::ErrorKind::UnexpectedEof
+            ) =>
+        {
+            Ok(None)
+        }
+        Err(err) => Err(Error::InvalidArgument {
+            message: format!("Failed to read the {what}: {err}"),
+        }),
+    }
+}
+
+/// The resolver behind [`resolve_connect_organization`], with its two effect
+/// channels — discovery and prompting — injectable.
+async fn resolve_with<D: OrgDiscovery, P: Prompter>(
+    discovery: &D,
+    explicit_org: Option<&str>,
+    stored_default: Option<&str>,
+    credential_org: Option<&str>,
+    interactive: bool,
+    prompter: &mut P,
+) -> Result<OrgResolution> {
+    if let Some(requested) = explicit_org {
+        cloud_org::validate_org_name(requested)?;
+    }
+
+    let Some(listing) = discovery.list_orgs().await? else {
+        return resolve_without_discovery(
+            discovery,
+            explicit_org,
+            credential_org,
+            interactive,
+            prompter,
+        )
+        .await;
+    };
+
+    let eligible = eligible_orgs(&listing);
+
+    if let Some(requested) = explicit_org {
+        return Ok(OrgResolution::Selected(validate_explicit(
+            &listing, &eligible, requested,
+        )?));
+    }
+
+    match eligible.as_slice() {
+        [] => Err(no_eligible_org_error(&listing)),
+        [only] => {
+            // Show the org before anything acts on it: with no chooser and no
+            // flag, this line is the only place the user sees the target.
+            prompter.notify(format!("Organization: {only}"));
+            Ok(OrgResolution::Selected(only.clone()))
+        }
+        _ => {
+            if !interactive {
+                return Err(ambiguous_without_terminal_error(&eligible));
+            }
+            let highlight = highlight(&eligible, stored_default, credential_org);
+            match prompter.choose(&eligible, highlight).await? {
+                Some(index) => {
+                    let chosen =
+                        eligible
+                            .get(index)
+                            .cloned()
+                            .ok_or_else(|| Error::InvalidArgument {
+                                message: format!(
+                                    "Failed to read the organization selection: choice {index} \
+                                     is out of range for {} organizations.",
+                                    eligible.len()
+                                ),
+                            })?;
+                    Ok(OrgResolution::Selected(chosen))
+                }
+                None => Ok(OrgResolution::Cancelled),
+            }
+        }
+    }
+}
+
+/// Resolution when the API serves no organization listing.
+///
+/// Without a listing there are no roles to check, so the CLI can offer only
+/// what it can prove: an explicit `--org` is membership-checked server-side
+/// with the unverifiable role reported out loud, and the only organization
+/// offerable interactively is the one the credential itself belongs to —
+/// confirmed, never assumed.
+async fn resolve_without_discovery<D: OrgDiscovery, P: Prompter>(
+    discovery: &D,
+    explicit_org: Option<&str>,
+    credential_org: Option<&str>,
+    interactive: bool,
+    prompter: &mut P,
+) -> Result<OrgResolution> {
+    if let Some(requested) = explicit_org {
+        discovery.confirm_membership(requested).await?;
+        // Membership is proven; the role is not — there is no listing to read
+        // it from. Say so rather than silently weakening the owner/admin
+        // gate. Spice Cloud re-validates the role before any enrollment
+        // mutation commits, so an ineligible role still fails before side
+        // effects.
+        prompter.notify(format!(
+            "Organization '{requested}': membership confirmed, but your role could not be \
+             verified because organization discovery is unavailable. Spice Cloud enforces the \
+             owner or admin requirement at enrollment."
+        ));
+        return Ok(OrgResolution::Selected(ConnectOrg {
+            name: requested.to_string(),
+            display_name: None,
+            role: None,
+        }));
+    }
+
+    let Some(own_org) = credential_org.filter(|org| !org.is_empty()) else {
+        return Err(discovery_unavailable_error(None));
+    };
+
+    if !interactive {
+        return Err(discovery_unavailable_error(Some(own_org)));
+    }
+
+    // The same weakened guarantee the explicit-`--org` branch reports: with no
+    // listing, no role can be verified locally.
+    prompter.notify(
+        "Organization roles could not be verified because organization discovery is \
+         unavailable. Spice Cloud enforces the owner or admin requirement at enrollment."
+            .to_string(),
+    );
+    match prompter.confirm(own_org).await? {
+        Some(true) => Ok(OrgResolution::Selected(ConnectOrg {
+            name: own_org.to_string(),
+            display_name: None,
+            role: None,
+        })),
+        Some(false) | None => Ok(OrgResolution::Cancelled),
+    }
+}
+
+/// The organizations whose membership role may connect an instance.
+fn eligible_orgs(listing: &[Org]) -> Vec<ConnectOrg> {
+    listing
+        .iter()
+        .filter_map(|org| {
+            let role = org.role.as_deref().and_then(ConnectRole::parse)?;
+            Some(ConnectOrg {
+                name: org.name.clone(),
+                display_name: org.display_name.clone(),
+                role: Some(role),
+            })
+        })
+        .collect()
+}
+
+/// Validate an explicitly named organization against the listing.
+///
+/// Distinguishes "member, but the role may not connect" from "not a member at
+/// all" — the fix for the first is a role grant, for the second an invitation
+/// or a corrected name — and fails before anything is minted or mutated.
+fn validate_explicit(
+    listing: &[Org],
+    eligible: &[ConnectOrg],
+    requested: &str,
+) -> Result<ConnectOrg> {
+    if let Some(org) = eligible
+        .iter()
+        .find(|org| org.name.eq_ignore_ascii_case(requested))
+    {
+        return Ok(org.clone());
+    }
+
+    if let Some(org) = listing
+        .iter()
+        .find(|org| org.name.eq_ignore_ascii_case(requested))
+    {
+        let role = org
+            .role
+            .as_deref()
+            .map_or_else(|| "not reported".to_string(), str::to_string);
+        return Err(Error::cloud_with_hint(
+            CloudErrorCode::Forbidden,
+            format!(
+                "Failed to select organization {requested}: your membership role is '{role}', \
+                 and connecting an instance requires owner or admin."
+            ),
+            format!(
+                "Ask an owner of '{requested}' to grant you the admin role, or pass --org <name> \
+                 for an organization where you already have it."
+            ),
+        ));
+    }
+
+    let hint = if eligible.is_empty() {
+        "Run 'spice cloud orgs' to list the organizations you can access.".to_string()
+    } else {
+        format!(
+            "Eligible organizations for this login: {}.",
+            format_org_list(&org_names(eligible))
+        )
+    };
+    // `OrgNotFound` matches what the membership probe answers for an org that
+    // does not exist or is invisible to this login. (The probe can also answer
+    // `OrgForbidden` for a real org the login is not a member of — a
+    // distinction the listing cannot make, so callers must handle both.)
+    Err(Error::cloud_with_hint(
+        CloudErrorCode::OrgNotFound,
+        format!("Failed to select organization {requested}: this login is not a member of it."),
+        hint,
+    ))
+}
+
+/// The chooser position to start on: the stored active org when it is
+/// eligible, else the login's own org when it is. Position only — the user
+/// still makes the choice.
+fn highlight(
+    eligible: &[ConnectOrg],
+    stored_default: Option<&str>,
+    credential_org: Option<&str>,
+) -> Option<Highlight> {
+    let position = |hint: Option<&str>| {
+        hint.and_then(|hint| {
+            eligible
+                .iter()
+                .position(|org| org.name.eq_ignore_ascii_case(hint))
+        })
+    };
+
+    if let Some(index) = position(stored_default) {
+        return Some(Highlight {
+            index,
+            source: HighlightSource::StoredDefault,
+        });
+    }
+    position(credential_org).map(|index| Highlight {
+        index,
+        source: HighlightSource::LoginOrg,
+    })
+}
+
+fn org_names(orgs: &[ConnectOrg]) -> Vec<String> {
+    orgs.iter().map(|org| org.name.clone()).collect()
+}
+
+fn no_eligible_org_error(listing: &[Org]) -> Error {
+    let memberships = if listing.is_empty() {
+        "this login belongs to no organizations".to_string()
+    } else {
+        format!(
+            "your memberships ({}) all carry roles that may not enroll",
+            format_org_list(
+                &listing
+                    .iter()
+                    .map(|org| org.name.clone())
+                    .collect::<Vec<_>>()
+            )
+        )
+    };
+    Error::cloud_with_hint(
+        CloudErrorCode::Forbidden,
+        format!(
+            "Failed to resolve an organization for this login: connecting an instance requires \
+             the owner or admin role, and {memberships}."
+        ),
+        "Ask an organization owner to grant you the admin role, then re-run the command.",
+    )
+}
+
+// The two errors below say "non-interactive" rather than blaming the
+// terminal: the resolution is non-interactive when stdin is not a terminal
+// *or* when the caller asked for a non-interactive run, and the fix — `--org`
+// — is the same either way.
+
+fn ambiguous_without_terminal_error(eligible: &[ConnectOrg]) -> Error {
+    Error::cloud_with_hint(
+        CloudErrorCode::InvalidRequest,
+        format!(
+            "Failed to resolve an organization for this login: {} are eligible, and this run is \
+             non-interactive, so the choice cannot be prompted for.",
+            format_org_list(&org_names(eligible))
+        ),
+        "Pass --org <name> to choose the organization non-interactively.",
+    )
+}
+
+fn discovery_unavailable_error(credential_org: Option<&str>) -> Error {
+    let hint = match credential_org {
+        Some(org) => format!(
+            "Pass --org <name> to name the organization explicitly (this login belongs to \
+             '{org}')."
+        ),
+        None => "Pass --org <name> to name the organization explicitly.".to_string(),
+    };
+    Error::cloud_with_hint(
+        CloudErrorCode::InvalidRequest,
+        "Failed to resolve an organization for this login: Spice Cloud did not serve the \
+         organization listing, and this run is non-interactive, so the organization cannot be \
+         confirmed interactively.",
+        hint,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A scripted discovery source: a fixed listing (or `None` for
+    /// "unavailable") and a set of orgs the membership probe accepts.
+    struct FakeDiscovery {
+        listing: Option<Vec<Org>>,
+        members: Vec<&'static str>,
+    }
+
+    impl FakeDiscovery {
+        fn serving(listing: Vec<Org>) -> Self {
+            Self {
+                listing: Some(listing),
+                members: Vec::new(),
+            }
+        }
+
+        fn unavailable(members: Vec<&'static str>) -> Self {
+            Self {
+                listing: None,
+                members,
+            }
+        }
+    }
+
+    impl OrgDiscovery for FakeDiscovery {
+        async fn list_orgs(&self) -> Result<Option<Vec<Org>>> {
+            Ok(self.listing.clone())
+        }
+
+        async fn confirm_membership(&self, org: &str) -> Result<()> {
+            if self.members.iter().any(|m| m.eq_ignore_ascii_case(org)) {
+                Ok(())
+            } else {
+                Err(Error::cloud(
+                    CloudErrorCode::OrgForbidden,
+                    format!("You are not a member of organization '{org}'."),
+                ))
+            }
+        }
+    }
+
+    /// A prompter that must never be asked anything. Proves a path resolved
+    /// (or failed) without prompting. Notifications are output, not prompts,
+    /// and are ignored here.
+    struct NoPrompt;
+
+    impl Prompter for NoPrompt {
+        async fn choose(
+            &mut self,
+            _options: &[ConnectOrg],
+            _highlight: Option<Highlight>,
+        ) -> Result<Option<usize>> {
+            panic!("this path must not prompt");
+        }
+
+        async fn confirm(&mut self, _org: &str) -> Result<Option<bool>> {
+            panic!("this path must not prompt");
+        }
+
+        fn notify(&mut self, _line: String) {}
+    }
+
+    /// A prompter that records what it was asked and told, and answers from a
+    /// script.
+    struct ScriptedPrompt {
+        answer: Option<usize>,
+        confirm_answer: Option<bool>,
+        asked: Vec<(Vec<ConnectOrg>, Option<Highlight>)>,
+        confirmed: Vec<String>,
+        notices: Vec<String>,
+    }
+
+    impl ScriptedPrompt {
+        fn choosing(answer: Option<usize>) -> Self {
+            Self {
+                answer,
+                confirm_answer: None,
+                asked: Vec::new(),
+                confirmed: Vec::new(),
+                notices: Vec::new(),
+            }
+        }
+
+        fn confirming(answer: Option<bool>) -> Self {
+            Self {
+                answer: None,
+                confirm_answer: answer,
+                asked: Vec::new(),
+                confirmed: Vec::new(),
+                notices: Vec::new(),
+            }
+        }
+    }
+
+    impl Prompter for ScriptedPrompt {
+        async fn choose(
+            &mut self,
+            options: &[ConnectOrg],
+            highlight: Option<Highlight>,
+        ) -> Result<Option<usize>> {
+            self.asked.push((options.to_vec(), highlight));
+            Ok(self.answer)
+        }
+
+        async fn confirm(&mut self, org: &str) -> Result<Option<bool>> {
+            self.confirmed.push(org.to_string());
+            Ok(self.confirm_answer)
+        }
+
+        fn notify(&mut self, line: String) {
+            self.notices.push(line);
+        }
+    }
+
+    fn org(name: &str, role: Option<&str>) -> Org {
+        Org {
+            id: None,
+            name: name.to_string(),
+            display_name: None,
+            role: role.map(str::to_string),
+        }
+    }
+
+    async fn resolve<P: Prompter>(
+        discovery: &FakeDiscovery,
+        explicit: Option<&str>,
+        stored_default: Option<&str>,
+        credential_org: Option<&str>,
+        interactive: bool,
+        prompter: &mut P,
+    ) -> Result<OrgResolution> {
+        resolve_with(
+            discovery,
+            explicit,
+            stored_default,
+            credential_org,
+            interactive,
+            prompter,
+        )
+        .await
+    }
+
+    fn selected(resolution: Result<OrgResolution>) -> ConnectOrg {
+        match resolution.expect("resolution should succeed") {
+            OrgResolution::Selected(org) => org,
+            OrgResolution::Cancelled => panic!("expected a selection, got a cancellation"),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Role filtering
+    // ------------------------------------------------------------------
+
+    /// Only owner and admin may enroll, compared case-insensitively; member,
+    /// viewer, deleted, unknown, and role-less memberships are excluded.
+    #[test]
+    fn eligibility_keeps_owner_and_admin_case_insensitively() {
+        let listing = vec![
+            org("a-owner", Some("owner")),
+            org("b-admin", Some("Admin")),
+            org("c-owner-caps", Some("OWNER")),
+            org("d-member", Some("member")),
+            org("e-viewer", Some("viewer")),
+            org("f-deleted", Some("deleted")),
+            org("g-unknown", Some("superuser")),
+            org("h-none", None),
+        ];
+
+        let eligible = eligible_orgs(&listing);
+
+        let names = org_names(&eligible);
+        assert_eq!(names, vec!["a-owner", "b-admin", "c-owner-caps"]);
+        assert_eq!(eligible[0].role, Some(ConnectRole::Owner));
+        assert_eq!(eligible[1].role, Some(ConnectRole::Admin));
+    }
+
+    /// Padded role strings still parse — the filter must not narrow on
+    /// formatting drift.
+    #[test]
+    fn padded_roles_still_parse() {
+        assert_eq!(ConnectRole::parse(" owner "), Some(ConnectRole::Owner));
+        assert_eq!(ConnectRole::parse("ADMIN"), Some(ConnectRole::Admin));
+        assert_eq!(ConnectRole::parse("member"), None);
+        assert_eq!(ConnectRole::parse(""), None);
+    }
+
+    // ------------------------------------------------------------------
+    // Explicit --org
+    // ------------------------------------------------------------------
+
+    /// An explicit eligible org resolves without prompting, whatever the
+    /// terminal is.
+    #[tokio::test]
+    async fn an_explicit_eligible_org_skips_the_chooser() {
+        let discovery = FakeDiscovery::serving(vec![
+            org("acme", Some("owner")),
+            org("globex", Some("admin")),
+        ]);
+
+        for interactive in [true, false] {
+            let resolved = selected(
+                resolve(
+                    &discovery,
+                    Some("globex"),
+                    None,
+                    Some("acme"),
+                    interactive,
+                    &mut NoPrompt,
+                )
+                .await,
+            );
+            assert_eq!(resolved.name, "globex");
+            assert_eq!(resolved.role, Some(ConnectRole::Admin));
+        }
+    }
+
+    /// `--org` is matched case-insensitively, but the resolved name is the
+    /// API's spelling — the one every later request must carry.
+    #[tokio::test]
+    async fn an_explicit_org_matches_case_insensitively() {
+        let discovery = FakeDiscovery::serving(vec![org("Acme", Some("owner"))]);
+
+        let resolved =
+            selected(resolve(&discovery, Some("ACME"), None, None, false, &mut NoPrompt).await);
+        assert_eq!(resolved.name, "Acme");
+    }
+
+    /// A membership whose role may not enroll is rejected before anything is
+    /// minted or mutated, and the error names the actual role.
+    #[tokio::test]
+    async fn an_explicit_ineligible_org_fails_before_any_mutation() {
+        let discovery = FakeDiscovery::serving(vec![
+            org("acme", Some("owner")),
+            org("globex", Some("member")),
+        ]);
+
+        let err = resolve(
+            &discovery,
+            Some("globex"),
+            None,
+            Some("acme"),
+            true,
+            &mut NoPrompt,
+        )
+        .await
+        .expect_err("a member role must not connect an instance");
+
+        assert_eq!(err.cloud_code(), Some(CloudErrorCode::Forbidden));
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("'member'") && rendered.contains("owner or admin"),
+            "the error should name the actual and the required roles: {rendered}"
+        );
+    }
+
+    /// Naming an org the login does not belong to at all is its own failure,
+    /// pointing at the eligible alternatives.
+    #[tokio::test]
+    async fn an_explicit_unknown_org_is_rejected_by_name() {
+        let discovery = FakeDiscovery::serving(vec![org("acme", Some("owner"))]);
+
+        let err = resolve(
+            &discovery,
+            Some("initech"),
+            None,
+            Some("acme"),
+            true,
+            &mut NoPrompt,
+        )
+        .await
+        .expect_err("an unknown org must not resolve");
+
+        assert_eq!(err.cloud_code(), Some(CloudErrorCode::OrgNotFound));
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("initech") && rendered.contains("'acme'"),
+            "the error should name the request and the eligible alternative: {rendered}"
+        );
+    }
+
+    /// An org name unsafe for URLs and headers is rejected before any request
+    /// carries it.
+    #[tokio::test]
+    async fn an_invalid_org_name_is_rejected_before_discovery() {
+        let discovery = FakeDiscovery::serving(vec![org("acme", Some("owner"))]);
+
+        let err = resolve(
+            &discovery,
+            Some("bad org name"),
+            None,
+            None,
+            true,
+            &mut NoPrompt,
+        )
+        .await
+        .expect_err("an invalid org name must not resolve");
+        assert_eq!(err.cloud_code(), Some(CloudErrorCode::InvalidRequest));
+    }
+
+    // ------------------------------------------------------------------
+    // No explicit org
+    // ------------------------------------------------------------------
+
+    /// Exactly one eligible org resolves without prompting, on and off a
+    /// terminal — and it is printed, because with no chooser and no flag that
+    /// line is the only place the user sees the target.
+    #[tokio::test]
+    async fn a_single_eligible_org_resolves_without_prompting_and_is_printed() {
+        let discovery = FakeDiscovery::serving(vec![
+            org("acme", Some("owner")),
+            org("globex", Some("member")),
+        ]);
+
+        for interactive in [true, false] {
+            let mut prompt = ScriptedPrompt::choosing(None);
+            let resolved = selected(
+                resolve(
+                    &discovery,
+                    None,
+                    None,
+                    Some("acme"),
+                    interactive,
+                    &mut prompt,
+                )
+                .await,
+            );
+            assert_eq!(resolved.name, "acme");
+            assert!(
+                prompt.asked.is_empty(),
+                "a single eligible org must not open a chooser"
+            );
+            assert_eq!(
+                prompt.notices,
+                vec!["Organization: acme (owner)".to_string()],
+                "the single eligible org must be shown before anything acts on it"
+            );
+        }
+    }
+
+    /// No eligible org is an actionable failure, not an empty chooser.
+    #[tokio::test]
+    async fn no_eligible_org_is_an_actionable_error() {
+        let discovery = FakeDiscovery::serving(vec![
+            org("acme", Some("member")),
+            org("globex", Some("viewer")),
+        ]);
+
+        let err = resolve(&discovery, None, None, Some("acme"), true, &mut NoPrompt)
+            .await
+            .expect_err("no eligible org must not resolve");
+
+        assert_eq!(err.cloud_code(), Some(CloudErrorCode::Forbidden));
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("owner or admin"),
+            "the error should say which roles qualify: {rendered}"
+        );
+    }
+
+    /// Multiple eligible orgs on a terminal require a real choice; the answer
+    /// is the org the user picked.
+    #[tokio::test]
+    async fn multiple_eligible_orgs_require_a_choice_on_a_terminal() {
+        let discovery = FakeDiscovery::serving(vec![
+            org("acme", Some("owner")),
+            org("globex", Some("admin")),
+        ]);
+
+        let mut prompt = ScriptedPrompt::choosing(Some(1));
+        let resolved =
+            selected(resolve(&discovery, None, None, Some("acme"), true, &mut prompt).await);
+
+        assert_eq!(resolved.name, "globex");
+        assert_eq!(prompt.asked.len(), 1, "exactly one chooser must be shown");
+        let (options, _) = &prompt.asked[0];
+        assert_eq!(org_names(options), vec!["acme", "globex"]);
+    }
+
+    /// The stored default org moves the chooser's cursor and nothing else: it
+    /// is never selected on the user's behalf.
+    #[tokio::test]
+    async fn the_stored_default_is_highlighted_but_never_chosen() {
+        let discovery = FakeDiscovery::serving(vec![
+            org("acme", Some("owner")),
+            org("globex", Some("admin")),
+        ]);
+
+        // The user cancels: the stored default must NOT be selected for them.
+        let mut prompt = ScriptedPrompt::choosing(None);
+        let resolution = resolve(
+            &discovery,
+            None,
+            Some("globex"),
+            Some("acme"),
+            true,
+            &mut prompt,
+        )
+        .await
+        .expect("a cancelled chooser is not an error");
+
+        assert!(
+            matches!(resolution, OrgResolution::Cancelled),
+            "cancelling must not fall back to the stored default: {resolution:?}"
+        );
+        let (_, highlight) = &prompt.asked[0];
+        assert_eq!(
+            *highlight,
+            Some(Highlight {
+                index: 1,
+                source: HighlightSource::StoredDefault
+            }),
+            "the stored default should be where the cursor starts"
+        );
+    }
+
+    /// Without a stored default the login's own org is the highlight — marked
+    /// as such, so the chooser does not call it a default it is not; with
+    /// neither eligible there is no highlight at all.
+    #[test]
+    fn the_highlight_falls_back_from_stored_default_to_credential_org() {
+        let eligible = eligible_orgs(&[org("acme", Some("owner")), org("globex", Some("admin"))]);
+
+        assert_eq!(
+            highlight(&eligible, Some("globex"), Some("acme")),
+            Some(Highlight {
+                index: 1,
+                source: HighlightSource::StoredDefault
+            })
+        );
+        assert_eq!(
+            highlight(&eligible, None, Some("acme")),
+            Some(Highlight {
+                index: 0,
+                source: HighlightSource::LoginOrg
+            })
+        );
+        assert_eq!(highlight(&eligible, Some("initech"), None), None);
+        assert_eq!(highlight(&eligible, None, None), None);
+    }
+
+    /// The "(default)" chooser label appears only when the highlight really is
+    /// the stored `spice cloud org use` state — never for the login's own org.
+    #[test]
+    fn the_default_label_marks_only_the_stored_default() {
+        let eligible = eligible_orgs(&[org("acme", Some("owner")), org("globex", Some("admin"))]);
+
+        let stored = chooser_items(
+            &eligible,
+            Some(Highlight {
+                index: 1,
+                source: HighlightSource::StoredDefault,
+            }),
+        );
+        assert_eq!(stored, vec!["acme (owner)", "globex (admin) (default)"]);
+
+        let login_org = chooser_items(
+            &eligible,
+            Some(Highlight {
+                index: 1,
+                source: HighlightSource::LoginOrg,
+            }),
+        );
+        assert_eq!(
+            login_org,
+            vec!["acme (owner)", "globex (admin)"],
+            "the login's own org must not be labelled a default it is not"
+        );
+
+        assert_eq!(
+            chooser_items(&eligible, None),
+            vec!["acme (owner)", "globex (admin)"]
+        );
+    }
+
+    /// A chooser answer outside the option list is an error, never a panic —
+    /// the prompter is an injectable boundary and cannot be trusted blindly.
+    #[tokio::test]
+    async fn an_out_of_range_chooser_answer_is_an_error() {
+        let discovery = FakeDiscovery::serving(vec![
+            org("acme", Some("owner")),
+            org("globex", Some("admin")),
+        ]);
+
+        let mut prompt = ScriptedPrompt::choosing(Some(99));
+        let err = resolve(&discovery, None, None, None, true, &mut prompt)
+            .await
+            .expect_err("an out-of-range choice must not resolve");
+        assert!(
+            err.to_string().contains("out of range"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Off a terminal, ambiguity must fail fast and name `--org` — never hang
+    /// on a prompt no one can answer.
+    #[tokio::test]
+    async fn multiple_eligible_orgs_without_a_terminal_name_the_flag() {
+        let discovery = FakeDiscovery::serving(vec![
+            org("acme", Some("owner")),
+            org("globex", Some("admin")),
+        ]);
+
+        let err = resolve(&discovery, None, None, Some("acme"), false, &mut NoPrompt)
+            .await
+            .expect_err("ambiguity off a terminal must not resolve");
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("--org"),
+            "the error must name the flag that fixes it: {rendered}"
+        );
+        assert!(
+            rendered.contains("'acme'") && rendered.contains("'globex'"),
+            "the error should name the candidates: {rendered}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Discovery unavailable
+    // ------------------------------------------------------------------
+
+    /// With no listing to check roles against, an explicit org is
+    /// membership-checked server-side and carries no locally proven role.
+    #[tokio::test]
+    async fn discovery_unavailable_with_explicit_org_probes_membership() {
+        let discovery = FakeDiscovery::unavailable(vec!["acme"]);
+
+        let mut prompt = ScriptedPrompt::choosing(None);
+        let resolved = selected(
+            resolve(
+                &discovery,
+                Some("acme"),
+                None,
+                Some("acme"),
+                false,
+                &mut prompt,
+            )
+            .await,
+        );
+        assert_eq!(resolved.name, "acme");
+        assert_eq!(
+            resolved.role, None,
+            "no role can be proven without the listing"
+        );
+        // The weakened guarantee must be said out loud, not silently deferred
+        // to the server.
+        assert!(
+            prompt
+                .notices
+                .iter()
+                .any(|line| line.contains("could not be verified")),
+            "the unverifiable role must be reported: {:?}",
+            prompt.notices
+        );
+    }
+
+    /// The membership probe's rejection propagates: a non-member org does not
+    /// resolve just because discovery is down.
+    #[tokio::test]
+    async fn discovery_unavailable_rejects_a_non_member_org() {
+        let discovery = FakeDiscovery::unavailable(vec!["acme"]);
+
+        let err = resolve(
+            &discovery,
+            Some("initech"),
+            None,
+            Some("acme"),
+            false,
+            &mut NoPrompt,
+        )
+        .await
+        .expect_err("a non-member org must not resolve");
+        assert_eq!(err.cloud_code(), Some(CloudErrorCode::OrgForbidden));
+    }
+
+    /// Interactively, the only offerable org is the one the credential
+    /// proves — and it is confirmed, never assumed, with the unverifiable
+    /// role reported the same way the explicit-`--org` branch reports it.
+    #[tokio::test]
+    async fn discovery_unavailable_confirms_the_credential_org_interactively() {
+        let discovery = FakeDiscovery::unavailable(vec![]);
+
+        let mut prompt = ScriptedPrompt::confirming(Some(true));
+        let resolved =
+            selected(resolve(&discovery, None, None, Some("acme"), true, &mut prompt).await);
+
+        assert_eq!(resolved.name, "acme");
+        assert_eq!(prompt.confirmed, vec!["acme"]);
+        assert!(
+            prompt
+                .notices
+                .iter()
+                .any(|line| line.contains("could not be verified")),
+            "the unverifiable role must be reported: {:?}",
+            prompt.notices
+        );
+    }
+
+    /// Declining (or cancelling) the confirmation is a clean cancellation.
+    #[tokio::test]
+    async fn discovery_unavailable_confirmation_declined_is_cancelled() {
+        let discovery = FakeDiscovery::unavailable(vec![]);
+
+        for answer in [Some(false), None] {
+            let mut prompt = ScriptedPrompt::confirming(answer);
+            let resolution = resolve(&discovery, None, None, Some("acme"), true, &mut prompt)
+                .await
+                .expect("declining a confirmation is not an error");
+            assert!(matches!(resolution, OrgResolution::Cancelled));
+        }
+    }
+
+    /// Off a terminal with no listing and no flag, the resolution fails and
+    /// names `--org` — it must not guess the credential's org.
+    #[tokio::test]
+    async fn discovery_unavailable_without_a_terminal_names_the_flag() {
+        let discovery = FakeDiscovery::unavailable(vec![]);
+
+        let err = resolve(&discovery, None, None, Some("acme"), false, &mut NoPrompt)
+            .await
+            .expect_err("no listing off a terminal must not resolve");
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("--org") && rendered.contains("'acme'"),
+            "the error must name the flag and the login's own org: {rendered}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Global org state
+    // ------------------------------------------------------------------
+
+    /// Resolving an organization must not touch the machine-wide active-org
+    /// state: the choice is scoped to the invocation. Guards every path that
+    /// completes a selection.
+    #[tokio::test]
+    async fn resolving_never_mutates_the_global_active_org() {
+        let context_path = dirs::home_dir()
+            .expect("home dir should resolve in tests")
+            .join(".spice")
+            .join("cloud-context.json");
+        let before = std::fs::read(&context_path).ok();
+
+        let discovery = FakeDiscovery::serving(vec![
+            org("acme", Some("owner")),
+            org("globex", Some("admin")),
+        ]);
+
+        // Explicit selection, single-org auto-selection, and a prompted
+        // choice — all through the layer that also reads the stored default,
+        // so a mutation slipped in beside that read is caught too.
+        let _ = selected(
+            resolve_with_stored_default(&discovery, Some("acme"), None, false, &mut NoPrompt).await,
+        );
+        let single = FakeDiscovery::serving(vec![org("acme", Some("owner"))]);
+        let _ =
+            selected(resolve_with_stored_default(&single, None, None, false, &mut NoPrompt).await);
+        let mut prompt = ScriptedPrompt::choosing(Some(0));
+        let _ =
+            selected(resolve_with_stored_default(&discovery, None, None, true, &mut prompt).await);
+
+        let after = std::fs::read(&context_path).ok();
+        assert_eq!(
+            before, after,
+            "resolution must never write the machine-wide cloud context"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Rendering
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn a_connect_org_renders_name_display_name_and_role() {
+        let full = ConnectOrg {
+            name: "acme".to_string(),
+            display_name: Some("Acme Corp".to_string()),
+            role: Some(ConnectRole::Owner),
+        };
+        assert_eq!(full.to_string(), "acme — Acme Corp (owner)");
+
+        let bare = ConnectOrg {
+            name: "acme".to_string(),
+            display_name: None,
+            role: None,
+        };
+        assert_eq!(bare.to_string(), "acme");
+
+        // A display name that only repeats the name is noise, not signal.
+        let echoed = ConnectOrg {
+            name: "acme".to_string(),
+            display_name: Some("Acme".to_string()),
+            role: Some(ConnectRole::Admin),
+        };
+        assert_eq!(echoed.to_string(), "acme (admin)");
+    }
+}

--- a/bin/spice/src/commands/login/connect_org.rs
+++ b/bin/spice/src/commands/login/connect_org.rs
@@ -190,7 +190,13 @@ async fn resolve_with_stored_default<D: OrgDiscovery, P: Prompter>(
 ) -> Result<OrgResolution> {
     // Highlight hint only. A context file that cannot be read must not block
     // the resolution — the hint moves the chooser's cursor, nothing else.
-    let stored_default = cloud_org::active_org().unwrap_or(None);
+    // Read under spawn_blocking: it is filesystem I/O against the home
+    // directory, which must not occupy an async runtime thread.
+    let stored_default = tokio::task::spawn_blocking(cloud_org::active_org)
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .flatten();
 
     resolve_with(
         discovery,

--- a/bin/spice/src/commands/login/mod.rs
+++ b/bin/spice/src/commands/login/mod.rs
@@ -17,7 +17,9 @@ limitations under the License.
 //! Login command and subcommands for authenticating with various data sources.
 
 mod auth_config;
+pub mod connect_org;
 mod providers;
+pub mod session;
 
 use crate::context::RuntimeContext;
 use crate::error::Result;
@@ -193,86 +195,53 @@ async fn login_spiceai(
     }
 
     // Spice.ai OAuth flow
-    let base_url = get_spice_base_url();
-    let auth_code = generate_auth_code();
-
-    let auth_url = format!("{base_url}/auth/token?code={auth_code}");
+    let flow = session::BrowserLogin::new();
 
     if !is_json {
-        println!("Attempting to open Spice.ai authorization page in your default browser");
-        println!("\nYour auth code:\n");
-        println!("{}-{}", &auth_code[..4], &auth_code[4..]);
-        println!("\nIf the browser does not open, visit the following URL manually:");
-        println!("\n{auth_url}\n");
+        flow.announce();
     }
-
-    // Fire-and-forget: open in spawn_blocking so Command::status does not
-    // block a Tokio worker or delay the OAuth poll loop.
-    let auth_url_for_open = auth_url.clone();
-    tokio::task::spawn_blocking(move || {
-        let _ = system_open::that(auth_url_for_open);
-    });
+    flow.open_browser();
 
     tracing::info!("Waiting for authentication...");
 
-    // Poll for auth status. The exchange below posts the auth code in the request body, so
-    // this client must not follow a redirect off the origin.
-    let client = credentialed_client()?;
-    let exchange_url = format!("{base_url}/auth/token/exchange");
+    let (access_token, auth_context) = match flow.authenticate().await? {
+        session::BrowserLoginOutcome::Declined => return Err(access_denied_error()),
+        session::BrowserLoginOutcome::Granted {
+            access_token,
+            context,
+        } => (access_token, context),
+    };
 
-    let access_token = poll_for_access_token(
-        &client,
-        &exchange_url,
-        &auth_code,
-        LOGIN_POLL_TIMEOUT,
-        LOGIN_POLL_INTERVAL,
-    )
-    .await?;
-
-    // Try to read the Spicepod manifest for preferred org/app.
-    let (org_name, app_name) = read_spicepod_metadata();
-
-    // Get auth context
-    let auth_context = get_spice_auth_context(
-        &base_url,
-        &access_token,
-        org_name.as_deref(),
-        app_name.as_deref(),
-    )
-    .await?;
-
-    let api_key_value = auth_context.app_api_key.unwrap_or_default();
-
-    // Save credentials
     if is_json {
         // In JSON mode, include auth context fields alongside credentials
         let json = serde_json::json!({
             "SPICE_SPICEAI_TOKEN": &access_token,
-            "SPICE_SPICEAI_API_KEY": &api_key_value,
+            "SPICE_SPICEAI_API_KEY": auth_context.app_api_key.as_deref().unwrap_or_default(),
             "username": &auth_context.username,
             "org": &auth_context.org_name,
             "app": auth_context.app_name.as_deref().unwrap_or_default(),
         });
         println!("{}", serde_json::to_string(&json).unwrap_or_default());
-    } else {
-        save_credentials(
-            &output,
-            "SPICEAI",
-            &[("TOKEN", &access_token), ("API_KEY", &api_key_value)],
-        )?;
-
-        println!(
-            "\x1b[32mSuccessfully logged in to Spice.ai as {} ({})\x1b[0m",
-            auth_context.username, auth_context.email
-        );
-        println!(
-            "\x1b[32mUsing app {}/{}\x1b[0m",
-            auth_context.org_name,
-            auth_context.app_name.unwrap_or_default()
-        );
+        return Ok(());
     }
 
+    let session = session::establish_session(
+        access_token,
+        auth_context,
+        session::CredentialStore::from_output(&output),
+    )?;
+    session::print_login_success(&session);
+
     Ok(())
+}
+
+/// The user refused the browser authorization. The standalone command reports
+/// it as a failure; an inline login maps the same outcome to a clean
+/// cancellation instead.
+fn access_denied_error() -> crate::error::Error {
+    crate::error::Error::InvalidArgument {
+        message: "Access denied".to_string(),
+    }
 }
 
 /// How long the Spice.ai browser flow waits for the user before giving up.
@@ -376,20 +345,39 @@ fn classify_exchange_body(body: &serde_json::Value) -> ExchangeOutcome {
     }
 }
 
+/// What the exchange poll decided: the browser flow granted a token, or the
+/// user refused the authorization. Refusal is a decision, not a transport
+/// failure — the standalone command and the inline continuation report it
+/// differently, so the poll does not turn it into an error itself.
+enum AccessTokenPoll {
+    Granted(String),
+    Denied,
+}
+
+/// Redacts the token; this type carries a live credential.
+impl std::fmt::Debug for AccessTokenPoll {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Granted(_) => f.write_str("Granted(<redacted>)"),
+            Self::Denied => f.write_str("Denied"),
+        }
+    }
+}
+
 /// Poll the Spice.ai token exchange until it yields a token, refuses, or
 /// `timeout` elapses.
 ///
 /// # Errors
 ///
-/// Returns an error if the authorization is refused, if the endpoint reports a
-/// failure that repeating cannot clear, or if `timeout` elapses first.
+/// Returns an error if the endpoint reports a failure that repeating cannot
+/// clear, or if `timeout` elapses first.
 async fn poll_for_access_token(
     client: &reqwest::Client,
     exchange_url: &str,
     auth_code: &str,
     timeout: std::time::Duration,
     interval: std::time::Duration,
-) -> Result<String> {
+) -> Result<AccessTokenPoll> {
     let start = std::time::Instant::now();
     // Kept so an endpoint that only ever fails reports *why* it timed out,
     // rather than logging the same line once a second for the whole deadline.
@@ -438,12 +426,8 @@ async fn poll_for_access_token(
         };
 
         match outcome {
-            ExchangeOutcome::Token(token) => return Ok(token),
-            ExchangeOutcome::Denied => {
-                return Err(crate::error::Error::InvalidArgument {
-                    message: "Access denied".to_string(),
-                });
-            }
+            ExchangeOutcome::Token(token) => return Ok(AccessTokenPoll::Granted(token)),
+            ExchangeOutcome::Denied => return Ok(AccessTokenPoll::Denied),
             ExchangeOutcome::Permanent(message) => {
                 return Err(crate::error::Error::InvalidArgument {
                     message: format!("Authentication failed: {message}."),
@@ -544,13 +528,29 @@ fn read_spicepod_metadata() -> (Option<String>, Option<String>) {
 }
 
 /// Auth context from Spice.ai API.
-#[derive(Debug, serde::Deserialize)]
 struct SpiceAuthContext {
     username: String,
     email: String,
     org_name: String,
     app_name: Option<String>,
     app_api_key: Option<String>,
+}
+
+/// Redacts the app API key: the context rides inside login outcomes and
+/// sessions whose `Debug` output can reach logs and assertion messages.
+impl std::fmt::Debug for SpiceAuthContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpiceAuthContext")
+            .field("username", &self.username)
+            .field("email", &self.email)
+            .field("org_name", &self.org_name)
+            .field("app_name", &self.app_name)
+            .field(
+                "app_api_key",
+                &self.app_api_key.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 /// Get auth context from Spice.ai API.
@@ -611,8 +611,8 @@ async fn get_spice_auth_context(
 #[cfg(test)]
 mod tests {
     use super::{
-        ExchangeOutcome, classify_exchange_body, classify_exchange_status, credentialed_client,
-        poll_for_access_token,
+        AccessTokenPoll, ExchangeOutcome, classify_exchange_body, classify_exchange_status,
+        credentialed_client, poll_for_access_token,
     };
     use std::io::{BufRead, BufReader, Read, Write};
     use std::net::{TcpListener, TcpStream};
@@ -628,7 +628,9 @@ mod tests {
         reqwest::StatusCode::from_u16(code).expect("code should be a valid HTTP status")
     }
 
-    async fn poll_against(server: &wiremock::MockServer) -> (crate::error::Result<String>, u64) {
+    async fn poll_against(
+        server: &wiremock::MockServer,
+    ) -> (crate::error::Result<AccessTokenPoll>, u64) {
         let url = format!("{}/auth/token/exchange", server.uri());
         let client = reqwest::Client::new();
         let started = std::time::Instant::now();
@@ -641,7 +643,7 @@ mod tests {
 
     async fn exchange_against(
         template: wiremock::ResponseTemplate,
-    ) -> (crate::error::Result<String>, u64) {
+    ) -> (crate::error::Result<AccessTokenPoll>, u64) {
         let server = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::method("POST"))
             .respond_with(template)
@@ -801,9 +803,10 @@ mod tests {
 
         let (result, _) = poll_against(&server).await;
 
-        assert_eq!(
-            result.expect("a token after the leading 404s should succeed"),
-            "tok_after_404".to_string()
+        let outcome = result.expect("a token after the leading 404s should succeed");
+        assert!(
+            matches!(outcome, AccessTokenPoll::Granted(ref token) if token == "tok_after_404"),
+            "expected the token, got: {outcome:?}"
         );
     }
 
@@ -858,28 +861,35 @@ mod tests {
             .set_body_json(serde_json::json!({ "access_token": "tok_abc" }));
         let (result, _) = exchange_against(template).await;
 
-        assert_eq!(
-            result.expect("a token response should succeed"),
-            "tok_abc".to_string()
+        let outcome = result.expect("a token response should succeed");
+        assert!(
+            matches!(outcome, AccessTokenPoll::Granted(ref token) if token == "tok_abc"),
+            "expected the token, got: {outcome:?}"
         );
     }
 
+    /// A refusal ends the poll as a decided outcome — the standalone command
+    /// turns it into "Access denied", an inline login into a cancellation.
     #[tokio::test]
     async fn an_access_denied_response_stops_immediately() {
         let template = wiremock::ResponseTemplate::new(200)
             .set_body_json(serde_json::json!({ "access_denied": true }));
         let (result, elapsed) = exchange_against(template).await;
 
-        let Err(err) = result else {
-            panic!("an access_denied response should not succeed");
-        };
+        let outcome = result.expect("a denial is a decided outcome, not an error");
         assert!(
-            err.to_string().contains("Access denied"),
-            "expected an access-denied error, got: {err}"
+            matches!(outcome, AccessTokenPoll::Denied),
+            "expected a denial, got: {outcome:?}"
         );
         assert!(
             elapsed < TEST_TIMEOUT_MS,
             "a denial should not wait out the deadline, took {elapsed}ms"
+        );
+        assert!(
+            super::access_denied_error()
+                .to_string()
+                .contains("Access denied"),
+            "the standalone login must still report the denial as 'Access denied'"
         );
     }
 
@@ -935,6 +945,54 @@ mod tests {
             .local_addr()
             .expect("listener should have a local address")
             .port()
+    }
+
+    /// Provider regression guard: the SharePoint/ABFS OAuth device-code flows
+    /// are dispatched to the provider module untouched by the session refactor.
+    /// A grammar change that rerouted them through the Spice.ai browser flow
+    /// would change their vocabulary and credential handling.
+    #[test]
+    fn provider_subcommands_still_route_to_the_device_code_flows() {
+        use clap::Parser;
+
+        #[derive(clap::Parser)]
+        struct TestCli {
+            #[command(subcommand)]
+            command: TestCommand,
+        }
+
+        #[derive(clap::Subcommand)]
+        enum TestCommand {
+            Login(super::LoginArgs),
+        }
+
+        for provider in ["sharepoint", "abfs"] {
+            let cli = TestCli::try_parse_from([
+                "spice",
+                "login",
+                provider,
+                "-t",
+                "tenant123",
+                "-c",
+                "client456",
+            ])
+            .unwrap_or_else(|e| panic!("`spice login {provider}` should still parse: {e}"));
+
+            let TestCommand::Login(args) = cli.command;
+            match (provider, args.command) {
+                ("sharepoint", Some(super::LoginCommands::Sharepoint(provider_args))) => {
+                    assert_eq!(provider_args.tenant_id, "tenant123");
+                    assert_eq!(provider_args.client_id, "client456");
+                }
+                ("abfs", Some(super::LoginCommands::Abfs(provider_args))) => {
+                    assert_eq!(provider_args.tenant_id, "tenant123");
+                    assert_eq!(provider_args.client_id, "client456");
+                }
+                (provider, other) => panic!(
+                    "`spice login {provider}` no longer routes to its provider flow: {other:?}"
+                ),
+            }
+        }
     }
 
     /// A cross-origin redirect must not be followed, because the request body carries the

--- a/bin/spice/src/commands/login/session.rs
+++ b/bin/spice/src/commands/login/session.rs
@@ -297,9 +297,11 @@ impl BrowserLogin {
 /// Persist the credential the browser flow produced and build the session.
 ///
 /// This is the persistence `spice login` has always performed —
-/// `SPICE_SPICEAI_TOKEN` and `SPICE_SPICEAI_API_KEY` written to the chosen
-/// store — so an inline login leaves the machine in the same state a
-/// standalone `spice login` would. Taking a [`CredentialStore`] (not a
+/// `SPICE_SPICEAI_TOKEN` and, when the auth context supplies one,
+/// `SPICE_SPICEAI_API_KEY` written to the chosen store — so an inline login
+/// leaves the machine in the same state a standalone `spice login` would.
+/// Omitting a missing API key preserves any valid key already in the store.
+/// Taking a [`CredentialStore`] (not a
 /// [`LoginOutput`]) makes the persistence policy explicit at every call site
 /// and leaves no path that could print the secrets instead of storing them.
 ///
@@ -313,11 +315,14 @@ pub(super) fn establish_session(
     context: SpiceAuthContext,
     store: CredentialStore,
 ) -> Result<AuthenticatedSession> {
-    let api_key = context.app_api_key.clone().unwrap_or_default();
-    store.save(
-        "SPICEAI",
-        &[("TOKEN", &access_token), ("API_KEY", &api_key)],
-    )?;
+    match context.app_api_key.as_deref() {
+        Some(api_key) => {
+            store.save("SPICEAI", &[("TOKEN", &access_token), ("API_KEY", api_key)])?;
+        }
+        None => {
+            store.save("SPICEAI", &[("TOKEN", &access_token)])?;
+        }
+    }
 
     Ok(AuthenticatedSession {
         access_token,
@@ -523,6 +528,20 @@ mod tests {
             assert_eq!(session.username(), "jane");
             assert_eq!(session.org_name(), "acme");
             assert_eq!(session.access_token(), "tok_live_123");
+
+            let context_without_api_key = SpiceAuthContext {
+                username: "jane".to_string(),
+                email: "jane@example.com".to_string(),
+                org_name: "acme".to_string(),
+                app_name: Some("retail-analytics".to_string()),
+                app_api_key: None,
+            };
+            establish_session(
+                "tok_refreshed_789".to_string(),
+                context_without_api_key,
+                CredentialStore::EnvFile,
+            )
+            .expect("a missing API key should not prevent token persistence");
             return;
         }
 
@@ -548,9 +567,9 @@ mod tests {
         let env = std::fs::read_to_string(scratch.path().join(".env"))
             .expect(".env should be written in the child's working directory");
         assert!(
-            env.contains("SPICE_SPICEAI_TOKEN=tok_live_123")
+            env.contains("SPICE_SPICEAI_TOKEN=tok_refreshed_789")
                 && env.contains("SPICE_SPICEAI_API_KEY=key_live_456"),
-            "the credential pair must be persisted: {env}"
+            "a token refresh without an API key must preserve the stored key: {env}"
         );
     }
 

--- a/bin/spice/src/commands/login/session.rs
+++ b/bin/spice/src/commands/login/session.rs
@@ -1,0 +1,692 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Authenticated Spice.ai login sessions.
+//!
+//! `spice login` completes a browser authorization and persists the credential
+//! for later commands. Commands that need the credential *in the same process*
+//! — `spice connect` running an inline login and then enrolling with it —
+//! consume the result as an [`AuthenticatedSession`] instead of shelling out to
+//! `spice login` and re-reading the credential store afterwards: the session
+//! carries the live access token, the identity it belongs to, and a
+//! [`CredentialStore`] handle naming where the credential was persisted.
+//!
+//! The access token and app API key are unreachable through `Debug`: a session
+//! travels through command code whose errors and traces format their context,
+//! and no formatting path may put a live credential in a log line.
+
+use crate::commands::cloud::CloudClient;
+use crate::error::{Error, Result};
+
+use super::{LoginOutput, SpiceAuthContext, save_credentials};
+
+/// Where a login credential was persisted, without holding the credential.
+///
+/// Carried by [`AuthenticatedSession`] so a caller that obtains more
+/// credentials mid-command can file them where the user's login already lives,
+/// rather than guessing a backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialStore {
+    /// Credentials are merged into the local `.env`/`.env.local` file.
+    EnvFile,
+    /// Credentials are stored in the platform keychain.
+    Keychain,
+    /// Nothing was persisted — the credential was printed (JSON mode) or
+    /// supplied externally. Saving through this handle fails rather than
+    /// silently dropping a credential.
+    Unpersisted,
+}
+
+impl CredentialStore {
+    /// The store the given login output backend persists to.
+    pub(super) fn from_output(output: &LoginOutput) -> Self {
+        match output {
+            LoginOutput::Env => Self::EnvFile,
+            LoginOutput::Keychain => Self::Keychain,
+            LoginOutput::Json => Self::Unpersisted,
+        }
+    }
+
+    /// Save credentials to this store, using the same writers as `spice login`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the store cannot be written, or if this handle is
+    /// [`CredentialStore::Unpersisted`] — a caller holding no persistent store
+    /// must decide what to do with the credential itself.
+    pub fn save(&self, auth_type: &str, params: &[(&str, &str)]) -> Result<()> {
+        match self {
+            Self::EnvFile => save_credentials(&LoginOutput::Env, auth_type, params),
+            Self::Keychain => save_credentials(&LoginOutput::Keychain, auth_type, params),
+            Self::Unpersisted => Err(Error::InvalidArgument {
+                message: "Failed to save credentials: this login was not persisted (JSON output \
+                          mode), so there is no credential store to write to."
+                    .to_string(),
+            }),
+        }
+    }
+}
+
+/// A live Spice.ai login: the access token, the identity it authenticates, and
+/// where the credential was persisted.
+///
+/// Internal to the CLI. The token is reachable only through
+/// [`Self::access_token`] and [`Self::management_client`], never through
+/// `Debug`.
+pub struct AuthenticatedSession {
+    access_token: String,
+    username: String,
+    email: String,
+    org_name: String,
+    app_name: Option<String>,
+    credential_store: CredentialStore,
+}
+
+/// Redacts the token. Sessions travel through command code whose errors and
+/// traces format their context, and this type must never be the reason a live
+/// credential reaches a log line. The app API key is deliberately not retained
+/// on the session at all — it is persisted by [`establish_session`] and read
+/// back from the credential store by whatever needs it.
+impl std::fmt::Debug for AuthenticatedSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthenticatedSession")
+            .field("access_token", &"<redacted>")
+            .field("username", &self.username)
+            .field("email", &self.email)
+            .field("org_name", &self.org_name)
+            .field("app_name", &self.app_name)
+            .field("credential_store", &self.credential_store)
+            .finish()
+    }
+}
+
+impl AuthenticatedSession {
+    /// The login's username.
+    #[must_use]
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+
+    /// The login's email address.
+    #[must_use]
+    pub fn email(&self) -> &str {
+        &self.email
+    }
+
+    /// The organization the login itself belongs to.
+    ///
+    /// This is the login's *default* org — evidence of identity, not a choice
+    /// of enrollment target. Callers that act on an organization resolve one
+    /// explicitly with
+    /// [`super::connect_org::resolve_connect_organization`].
+    #[must_use]
+    pub fn org_name(&self) -> &str {
+        &self.org_name
+    }
+
+    /// The app the login resolved, when the auth context reported one.
+    #[must_use]
+    pub fn app_name(&self) -> Option<&str> {
+        self.app_name.as_deref()
+    }
+
+    /// Where the login credential was persisted.
+    #[must_use]
+    pub fn credential_store(&self) -> CredentialStore {
+        self.credential_store
+    }
+
+    /// The live access token. Deliberately a method, not a field: reaching for
+    /// the credential is explicit at the call site, and `Debug` never sees it.
+    #[must_use]
+    pub(crate) fn access_token(&self) -> &str {
+        &self.access_token
+    }
+
+    /// A Spice Cloud management client authenticated as this session, bound to
+    /// no organization.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be built.
+    pub fn management_client(&self) -> Result<CloudClient> {
+        CloudClient::with_token_for_org(self.access_token().to_string(), None)
+    }
+}
+
+/// How the browser authorization ended: with a token, or with the user
+/// refusing it. Refusal is a decision, not a failure — inline callers treat it
+/// as a clean cancellation.
+pub(super) enum BrowserLoginOutcome {
+    /// The user authorized the login.
+    Granted {
+        access_token: String,
+        context: SpiceAuthContext,
+    },
+    /// The user refused the authorization in the browser.
+    Declined,
+}
+
+/// Redacts the token; see [`AuthenticatedSession`]'s `Debug` for why.
+impl std::fmt::Debug for BrowserLoginOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Granted { context, .. } => f
+                .debug_struct("Granted")
+                .field("access_token", &"<redacted>")
+                .field("context", context)
+                .finish(),
+            Self::Declined => f.write_str("Declined"),
+        }
+    }
+}
+
+/// One Spice.ai browser login flow: a locally minted auth code, the URL that
+/// authorizes it, and the poll that waits for the authorization.
+pub(super) struct BrowserLogin {
+    base_url: String,
+    auth_code: String,
+}
+
+impl BrowserLogin {
+    pub(super) fn new() -> Self {
+        Self::at(super::get_spice_base_url())
+    }
+
+    /// A flow against an explicit base URL. Tests point this at a mock server;
+    /// production goes through [`Self::new`].
+    pub(super) fn at(base_url: String) -> Self {
+        Self {
+            base_url,
+            auth_code: super::generate_auth_code(),
+        }
+    }
+
+    /// The authorization page for this flow's auth code.
+    fn auth_url(&self) -> String {
+        format!("{}/auth/token?code={}", self.base_url, self.auth_code)
+    }
+
+    /// Print the preamble `spice login` has always shown: the auth code to
+    /// compare in the browser, and the URL to visit if the browser does not
+    /// open.
+    pub(super) fn announce(&self) {
+        println!("Attempting to open Spice.ai authorization page in your default browser");
+        println!("\nYour auth code:\n");
+        println!("{}-{}", &self.auth_code[..4], &self.auth_code[4..]);
+        println!("\nIf the browser does not open, visit the following URL manually:");
+        println!("\n{}\n", self.auth_url());
+    }
+
+    /// Open the authorization page in the default browser, fire-and-forget.
+    pub(super) fn open_browser(&self) {
+        // `Command::status` in spawn_blocking so the opener does not block a
+        // Tokio worker or delay the poll loop.
+        let auth_url = self.auth_url();
+        tokio::task::spawn_blocking(move || {
+            let _ = system_open::that(auth_url);
+        });
+    }
+
+    /// Wait for the browser authorization, then fetch who it authenticated.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the exchange fails in a way waiting cannot clear,
+    /// if the wait times out, or if the auth context cannot be fetched.
+    pub(super) async fn authenticate(&self) -> Result<BrowserLoginOutcome> {
+        self.authenticate_within(super::LOGIN_POLL_TIMEOUT, super::LOGIN_POLL_INTERVAL)
+            .await
+    }
+
+    /// [`Self::authenticate`] with explicit bounds, so tests do not wait out
+    /// the production timeout.
+    async fn authenticate_within(
+        &self,
+        timeout: std::time::Duration,
+        interval: std::time::Duration,
+    ) -> Result<BrowserLoginOutcome> {
+        let client = super::credentialed_client()?;
+        let exchange_url = format!("{}/auth/token/exchange", self.base_url);
+
+        let access_token = match super::poll_for_access_token(
+            &client,
+            &exchange_url,
+            &self.auth_code,
+            timeout,
+            interval,
+        )
+        .await?
+        {
+            super::AccessTokenPoll::Granted(token) => token,
+            super::AccessTokenPoll::Denied => return Ok(BrowserLoginOutcome::Declined),
+        };
+
+        // The spicepod manifest in the working directory may name a preferred
+        // org/app for the auth context to resolve against.
+        let (org_name, app_name) = super::read_spicepod_metadata();
+
+        let context = super::get_spice_auth_context(
+            &self.base_url,
+            &access_token,
+            org_name.as_deref(),
+            app_name.as_deref(),
+        )
+        .await?;
+
+        Ok(BrowserLoginOutcome::Granted {
+            access_token,
+            context,
+        })
+    }
+}
+
+/// Persist the credential the browser flow produced and build the session.
+///
+/// This is the persistence `spice login` has always performed —
+/// `SPICE_SPICEAI_TOKEN` and `SPICE_SPICEAI_API_KEY` written to the chosen
+/// store — so an inline login leaves the machine in the same state a
+/// standalone `spice login` would. Taking a [`CredentialStore`] (not a
+/// [`LoginOutput`]) makes the persistence policy explicit at every call site
+/// and leaves no path that could print the secrets instead of storing them.
+///
+/// # Errors
+///
+/// Returns an error if the credential store cannot be written, or if `store`
+/// is [`CredentialStore::Unpersisted`] — a session must not claim a login
+/// completed while its credential went nowhere.
+pub(super) fn establish_session(
+    access_token: String,
+    context: SpiceAuthContext,
+    store: CredentialStore,
+) -> Result<AuthenticatedSession> {
+    let api_key = context.app_api_key.clone().unwrap_or_default();
+    store.save(
+        "SPICEAI",
+        &[("TOKEN", &access_token), ("API_KEY", &api_key)],
+    )?;
+
+    Ok(AuthenticatedSession {
+        access_token,
+        username: context.username,
+        email: context.email,
+        org_name: context.org_name,
+        app_name: context.app_name,
+        credential_store: store,
+    })
+}
+
+/// Print the success lines `spice login` has always printed.
+pub(super) fn print_login_success(session: &AuthenticatedSession) {
+    println!(
+        "\x1b[32mSuccessfully logged in to Spice.ai as {} ({})\x1b[0m",
+        session.username(),
+        session.email()
+    );
+    println!(
+        "\x1b[32mUsing app {}/{}\x1b[0m",
+        session.org_name(),
+        session.app_name().unwrap_or_default()
+    );
+}
+
+/// How an inline login ended, for a command that continues afterwards.
+#[derive(Debug)]
+pub enum LoginContinuation {
+    /// The login completed; the session is live and the credential persisted.
+    Authenticated(Box<AuthenticatedSession>),
+    /// The user declined the authorization. A normal exit for the caller to
+    /// return to its own flow, not an error.
+    Cancelled,
+}
+
+/// Run the Spice.ai browser login inside another command and return the live
+/// session, so the command continues without the user re-running anything.
+///
+/// Behaves like a bare `spice login`: same preamble, same browser flow, same
+/// success output — the machine ends up logged in either way. The caller
+/// chooses `store` explicitly (a bare `spice login` defaults to
+/// [`CredentialStore::EnvFile`]); passing [`CredentialStore::Unpersisted`]
+/// fails rather than completing a login whose credential went nowhere. The
+/// user declining the authorization is a clean
+/// [`LoginContinuation::Cancelled`], not an error.
+///
+/// # Errors
+///
+/// Returns an error if the flow fails or times out, or if the credential
+/// cannot be persisted.
+pub async fn login_inline(store: CredentialStore) -> Result<LoginContinuation> {
+    let flow = BrowserLogin::new();
+    flow.announce();
+    flow.open_browser();
+    tracing::info!("Waiting for authentication...");
+
+    let outcome = flow.authenticate().await?;
+    continue_login(outcome, store)
+}
+
+/// Map a finished browser flow to its continuation: persist-and-hand-back for
+/// a grant, a clean cancellation for a decline.
+fn continue_login(
+    outcome: BrowserLoginOutcome,
+    store: CredentialStore,
+) -> Result<LoginContinuation> {
+    match outcome {
+        BrowserLoginOutcome::Declined => Ok(LoginContinuation::Cancelled),
+        BrowserLoginOutcome::Granted {
+            access_token,
+            context,
+        } => {
+            let session = establish_session(access_token, context, store)?;
+            print_login_success(&session);
+            Ok(LoginContinuation::Authenticated(Box::new(session)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    const TEST_TIMEOUT: Duration = Duration::from_millis(600);
+    const TEST_INTERVAL: Duration = Duration::from_millis(20);
+
+    fn test_session(store: CredentialStore) -> AuthenticatedSession {
+        AuthenticatedSession {
+            access_token: "tok_super_secret".to_string(),
+            username: "jane".to_string(),
+            email: "jane@example.com".to_string(),
+            org_name: "acme".to_string(),
+            app_name: Some("retail-analytics".to_string()),
+            credential_store: store,
+        }
+    }
+
+    /// The session is the type command code passes around, so its `Debug` is
+    /// the boundary that keeps the token out of logs and assertion messages.
+    #[test]
+    fn session_debug_redacts_the_token_and_api_key() {
+        let rendered = format!("{:?}", test_session(CredentialStore::EnvFile));
+
+        assert!(
+            !rendered.contains("tok_super_secret"),
+            "a live credential leaked into Debug output: {rendered}"
+        );
+        assert!(
+            rendered.contains("<redacted>"),
+            "the redaction should be visible so a reader knows a value exists: {rendered}"
+        );
+        assert!(
+            rendered.contains("jane") && rendered.contains("acme"),
+            "the identity fields are not secrets and should stay diagnosable: {rendered}"
+        );
+    }
+
+    #[test]
+    fn browser_outcome_debug_redacts_the_token() {
+        let outcome = BrowserLoginOutcome::Granted {
+            access_token: "tok_super_secret".to_string(),
+            context: SpiceAuthContext {
+                username: "jane".to_string(),
+                email: "jane@example.com".to_string(),
+                org_name: "acme".to_string(),
+                app_name: None,
+                app_api_key: Some("key_super_secret".to_string()),
+            },
+        };
+
+        let rendered = format!("{outcome:?}");
+        assert!(
+            !rendered.contains("tok_super_secret") && !rendered.contains("key_super_secret"),
+            "a live credential leaked into Debug output: {rendered}"
+        );
+    }
+
+    #[test]
+    fn the_session_reports_where_the_credential_lives() {
+        assert_eq!(
+            test_session(CredentialStore::EnvFile).credential_store(),
+            CredentialStore::EnvFile
+        );
+        assert_eq!(
+            CredentialStore::from_output(&LoginOutput::Env),
+            CredentialStore::EnvFile
+        );
+        assert_eq!(
+            CredentialStore::from_output(&LoginOutput::Keychain),
+            CredentialStore::Keychain
+        );
+        assert_eq!(
+            CredentialStore::from_output(&LoginOutput::Json),
+            CredentialStore::Unpersisted
+        );
+    }
+
+    /// An unpersisted store must refuse writes rather than silently dropping a
+    /// credential the caller believes is saved.
+    #[test]
+    fn an_unpersisted_store_refuses_to_save() {
+        let err = CredentialStore::Unpersisted
+            .save("SPICEAI", &[("TOKEN", "tok")])
+            .expect_err("an unpersisted store has nowhere to write");
+        assert!(
+            err.to_string().contains("not persisted"),
+            "the error should say why: {err}"
+        );
+    }
+
+    /// Serializes tests that change the working directory (the env-file
+    /// backend writes to the cwd-relative `.env`), and restores it afterwards.
+    /// `cargo nextest` isolates each test in its own process anyway; this
+    /// keeps a plain `cargo test` correct too.
+    static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct DirGuard {
+        original: std::path::PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl DirGuard {
+        fn enter(dir: &std::path::Path) -> Self {
+            let lock = CWD_LOCK.lock().expect("cwd lock should not be poisoned");
+            let original = std::env::current_dir().expect("current dir should resolve");
+            std::env::set_current_dir(dir).expect("test dir should be enterable");
+            Self {
+                original,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for DirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
+    }
+
+    /// The session must leave the machine in the same state `spice login`
+    /// always has: token and API key merged into the env file, and the handle
+    /// reporting where they went.
+    #[test]
+    fn establishing_a_session_persists_the_credential_pair() {
+        let dir = std::env::temp_dir().join(format!("spice-login-session-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir should be creatable");
+        let guard = DirGuard::enter(&dir);
+
+        let context = SpiceAuthContext {
+            username: "jane".to_string(),
+            email: "jane@example.com".to_string(),
+            org_name: "acme".to_string(),
+            app_name: Some("retail-analytics".to_string()),
+            app_api_key: Some("key_live_456".to_string()),
+        };
+
+        let session = establish_session(
+            "tok_live_123".to_string(),
+            context,
+            CredentialStore::EnvFile,
+        )
+        .expect("the env backend should persist");
+
+        assert_eq!(session.credential_store(), CredentialStore::EnvFile);
+        assert_eq!(session.username(), "jane");
+        assert_eq!(session.org_name(), "acme");
+        assert_eq!(session.access_token(), "tok_live_123");
+
+        let env = std::fs::read_to_string(dir.join(".env")).expect(".env should be written");
+        assert!(
+            env.contains("SPICE_SPICEAI_TOKEN=tok_live_123")
+                && env.contains("SPICE_SPICEAI_API_KEY=key_live_456"),
+            "the credential pair must be persisted: {env}"
+        );
+
+        drop(guard);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The user declining in the browser ends an inline login cleanly: the
+    /// caller gets `Cancelled` back and returns to its own flow.
+    #[test]
+    fn a_declined_authorization_continues_as_cancelled() {
+        let continuation = continue_login(BrowserLoginOutcome::Declined, CredentialStore::EnvFile)
+            .expect("a decline is not an error");
+        assert!(
+            matches!(continuation, LoginContinuation::Cancelled),
+            "a decline must map to Cancelled, got: {continuation:?}"
+        );
+    }
+
+    /// A session must not come into existence with its credential unpersisted:
+    /// establishing against the unpersisted store is an error, not a print.
+    #[test]
+    fn establishing_a_session_refuses_an_unpersisted_store() {
+        let context = SpiceAuthContext {
+            username: "jane".to_string(),
+            email: "jane@example.com".to_string(),
+            org_name: "acme".to_string(),
+            app_name: None,
+            app_api_key: None,
+        };
+
+        let err = establish_session(
+            "tok_live_123".to_string(),
+            context,
+            CredentialStore::Unpersisted,
+        )
+        .expect_err("an unpersisted store cannot back a session");
+        assert!(
+            err.to_string().contains("not persisted"),
+            "the error should say why: {err}"
+        );
+    }
+
+    async fn flow_against(
+        server: &wiremock::MockServer,
+    ) -> crate::error::Result<BrowserLoginOutcome> {
+        BrowserLogin::at(server.uri())
+            .authenticate_within(TEST_TIMEOUT, TEST_INTERVAL)
+            .await
+    }
+
+    async fn mount_exchange(server: &wiremock::MockServer, body: serde_json::Value) {
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/auth/token/exchange"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(body))
+            .mount(server)
+            .await;
+    }
+
+    /// The full mock-server flow: the exchange grants a token, the auth
+    /// context answers who it belongs to, and the outcome carries both.
+    #[tokio::test]
+    async fn a_granted_authorization_yields_the_token_and_identity() {
+        let server = wiremock::MockServer::start().await;
+        mount_exchange(
+            &server,
+            serde_json::json!({ "access_token": "tok_live_123" }),
+        )
+        .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/spice-cli/auth"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer tok_live_123",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "username": "jane",
+                    "email": "jane@example.com",
+                    "org": { "name": "acme" },
+                    "app": { "name": "retail-analytics", "api_key": "key_123" },
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let outcome = flow_against(&server)
+            .await
+            .expect("a granted flow should succeed");
+
+        let BrowserLoginOutcome::Granted {
+            access_token,
+            context,
+        } = outcome
+        else {
+            panic!("expected a granted outcome");
+        };
+        assert_eq!(access_token, "tok_live_123");
+        assert_eq!(context.username, "jane");
+        assert_eq!(context.org_name, "acme");
+        assert_eq!(context.app_name.as_deref(), Some("retail-analytics"));
+        assert_eq!(context.app_api_key.as_deref(), Some("key_123"));
+    }
+
+    /// A refusal in the browser is an outcome, not an error — the standalone
+    /// command turns it into "Access denied", the inline one into `Cancelled`.
+    #[tokio::test]
+    async fn a_denied_authorization_is_a_declined_outcome() {
+        let server = wiremock::MockServer::start().await;
+        mount_exchange(&server, serde_json::json!({ "access_denied": true })).await;
+
+        let outcome = flow_against(&server)
+            .await
+            .expect("a denial is a decided outcome, not an error");
+        assert!(matches!(outcome, BrowserLoginOutcome::Declined));
+    }
+
+    /// The token is only as good as the identity behind it: a granted exchange
+    /// whose auth context cannot be fetched is a failed login.
+    #[tokio::test]
+    async fn a_failed_auth_context_fails_the_flow() {
+        let server = wiremock::MockServer::start().await;
+        mount_exchange(&server, serde_json::json!({ "access_token": "tok_live" })).await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/spice-cli/auth"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let err = flow_against(&server)
+            .await
+            .expect_err("an unfetchable auth context should fail the login");
+        assert!(
+            err.to_string().contains("Auth context request failed"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/bin/spice/src/commands/login/session.rs
+++ b/bin/spice/src/commands/login/session.rs
@@ -297,11 +297,11 @@ impl BrowserLogin {
 /// Persist the credential the browser flow produced and build the session.
 ///
 /// This is the persistence `spice login` has always performed —
-/// `SPICE_SPICEAI_TOKEN` and, when the auth context supplies one,
-/// `SPICE_SPICEAI_API_KEY` written to the chosen store — so an inline login
-/// leaves the machine in the same state a standalone `spice login` would.
-/// Omitting a missing API key preserves any valid key already in the store.
-/// Taking a [`CredentialStore`] (not a
+/// `SPICE_SPICEAI_TOKEN` and `SPICE_SPICEAI_API_KEY` written to the chosen
+/// store — so an inline login leaves the machine in the same state a
+/// standalone `spice login` would. A missing API key is persisted as an empty
+/// value so an older key cannot remain active for the new login. Taking a
+/// [`CredentialStore`] (not a
 /// [`LoginOutput`]) makes the persistence policy explicit at every call site
 /// and leaves no path that could print the secrets instead of storing them.
 ///
@@ -315,14 +315,11 @@ pub(super) fn establish_session(
     context: SpiceAuthContext,
     store: CredentialStore,
 ) -> Result<AuthenticatedSession> {
-    match context.app_api_key.as_deref() {
-        Some(api_key) => {
-            store.save("SPICEAI", &[("TOKEN", &access_token), ("API_KEY", api_key)])?;
-        }
-        None => {
-            store.save("SPICEAI", &[("TOKEN", &access_token)])?;
-        }
-    }
+    let api_key = context.app_api_key.clone().unwrap_or_default();
+    store.save(
+        "SPICEAI",
+        &[("TOKEN", &access_token), ("API_KEY", &api_key)],
+    )?;
 
     Ok(AuthenticatedSession {
         access_token,
@@ -568,8 +565,12 @@ mod tests {
             .expect(".env should be written in the child's working directory");
         assert!(
             env.contains("SPICE_SPICEAI_TOKEN=tok_refreshed_789")
-                && env.contains("SPICE_SPICEAI_API_KEY=key_live_456"),
-            "a token refresh without an API key must preserve the stored key: {env}"
+                && env.contains("SPICE_SPICEAI_API_KEY="),
+            "a login without an API key must clear the stored key: {env}"
+        );
+        assert!(
+            !env.contains("SPICE_SPICEAI_API_KEY=key_live_456"),
+            "an API key from the previous login must not remain active: {env}"
         );
     }
 

--- a/bin/spice/src/commands/login/session.rs
+++ b/bin/spice/src/commands/login/session.rs
@@ -489,74 +489,69 @@ mod tests {
         );
     }
 
-    /// Serializes tests that change the working directory (the env-file
-    /// backend writes to the cwd-relative `.env`), and restores it afterwards.
-    /// `cargo nextest` isolates each test in its own process anyway; this
-    /// keeps a plain `cargo test` correct too.
-    static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    struct DirGuard {
-        original: std::path::PathBuf,
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl DirGuard {
-        fn enter(dir: &std::path::Path) -> Self {
-            let lock = CWD_LOCK.lock().expect("cwd lock should not be poisoned");
-            let original = std::env::current_dir().expect("current dir should resolve");
-            std::env::set_current_dir(dir).expect("test dir should be enterable");
-            Self {
-                original,
-                _lock: lock,
-            }
-        }
-    }
-
-    impl Drop for DirGuard {
-        fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.original);
-        }
-    }
+    /// Marks the child half of [`establishing_a_session_persists_the_credential_pair`].
+    const ESTABLISH_SESSION_CHILD_FLAG: &str = "SPICE_TEST_ESTABLISH_SESSION_IN_CHILD_CWD";
 
     /// The session must leave the machine in the same state `spice login`
     /// always has: token and API key merged into the env file, and the handle
     /// reporting where they went.
+    ///
+    /// The env-file backend writes to the cwd-relative `.env`, and the process
+    /// working directory is shared by every test in this binary — so instead
+    /// of mutating it, the test re-runs itself as a child process whose cwd
+    /// *is* a scratch directory, and the parent asserts what landed on disk.
     #[test]
     fn establishing_a_session_persists_the_credential_pair() {
-        let dir = std::env::temp_dir().join(format!("spice-login-session-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir should be creatable");
-        let guard = DirGuard::enter(&dir);
+        if std::env::var_os(ESTABLISH_SESSION_CHILD_FLAG).is_some() {
+            // Child: the parent spawned us with a scratch working directory.
+            let context = SpiceAuthContext {
+                username: "jane".to_string(),
+                email: "jane@example.com".to_string(),
+                org_name: "acme".to_string(),
+                app_name: Some("retail-analytics".to_string()),
+                app_api_key: Some("key_live_456".to_string()),
+            };
 
-        let context = SpiceAuthContext {
-            username: "jane".to_string(),
-            email: "jane@example.com".to_string(),
-            org_name: "acme".to_string(),
-            app_name: Some("retail-analytics".to_string()),
-            app_api_key: Some("key_live_456".to_string()),
-        };
+            let session = establish_session(
+                "tok_live_123".to_string(),
+                context,
+                CredentialStore::EnvFile,
+            )
+            .expect("the env backend should persist");
 
-        let session = establish_session(
-            "tok_live_123".to_string(),
-            context,
-            CredentialStore::EnvFile,
-        )
-        .expect("the env backend should persist");
+            assert_eq!(session.credential_store(), CredentialStore::EnvFile);
+            assert_eq!(session.username(), "jane");
+            assert_eq!(session.org_name(), "acme");
+            assert_eq!(session.access_token(), "tok_live_123");
+            return;
+        }
 
-        assert_eq!(session.credential_store(), CredentialStore::EnvFile);
-        assert_eq!(session.username(), "jane");
-        assert_eq!(session.org_name(), "acme");
-        assert_eq!(session.access_token(), "tok_live_123");
+        let scratch = tempfile::TempDir::new().expect("scratch dir should be creatable");
+        let exe = std::env::current_exe().expect("test binary path should resolve");
+        let output = std::process::Command::new(exe)
+            .args([
+                "commands::login::session::tests::establishing_a_session_persists_the_credential_pair",
+                "--exact",
+                "--test-threads=1",
+            ])
+            .env(ESTABLISH_SESSION_CHILD_FLAG, "1")
+            .current_dir(scratch.path())
+            .output()
+            .expect("child test process should run");
+        assert!(
+            output.status.success(),
+            "the child assertions failed:\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
 
-        let env = std::fs::read_to_string(dir.join(".env")).expect(".env should be written");
+        let env = std::fs::read_to_string(scratch.path().join(".env"))
+            .expect(".env should be written in the child's working directory");
         assert!(
             env.contains("SPICE_SPICEAI_TOKEN=tok_live_123")
                 && env.contains("SPICE_SPICEAI_API_KEY=key_live_456"),
             "the credential pair must be persisted: {env}"
         );
-
-        drop(guard);
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The user declining in the browser ends an inline login cleanly: the

--- a/bin/spice/tests/cli_integration.rs
+++ b/bin/spice/tests/cli_integration.rs
@@ -275,6 +275,59 @@ mod login {
             .assert()
             .failure();
     }
+
+    /// Standalone `spice login --key` keeps its credential-store behavior: the
+    /// key lands in the working directory's `.env`, owner-readable only, with
+    /// the same success line as always.
+    #[test]
+    fn test_login_with_key_writes_env_credentials() {
+        let temp_dir = TempDir::new().expect("temp dir should be creatable");
+
+        let mut cmd = spice_cmd();
+        cmd.current_dir(temp_dir.path())
+            .args(["login", "--key", "sk_test_abc123"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Successfully logged in to Spice.ai with API key",
+            ));
+
+        let env_path = temp_dir.path().join(".env");
+        let contents = fs::read_to_string(&env_path).expect(".env should be written");
+        assert!(
+            contents.contains("SPICE_SPICEAI_API_KEY=sk_test_abc123"),
+            "the key must be stored under its credential variable: {contents}"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&env_path)
+                .expect(".env metadata should be readable")
+                .permissions()
+                .mode();
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "the credential file must stay owner-only"
+            );
+        }
+    }
+
+    /// Provider regression guard: the `SharePoint` and ABFS logins keep their
+    /// OAuth device-code flows and vocabulary — their help still asks for the
+    /// Azure AD tenant/client pair rather than anything session-based.
+    #[test]
+    fn test_provider_device_flow_help_unchanged() {
+        for provider in ["sharepoint", "abfs"] {
+            let mut cmd = spice_cmd();
+            cmd.args(["login", provider, "--help"])
+                .assert()
+                .success()
+                .stdout(predicate::str::contains("--tenant-id"))
+                .stdout(predicate::str::contains("--client-id"));
+        }
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes spiceai/spiceai#12900
Part of spicehq/spiceai#1396

## What

Extracts a reusable, typed login session from `spice login` and adds explicit eligible-organization selection for connecting an instance.

`spice login` completed the browser flow but returned only `Result<()>`, so a command that needs the credential in the same process (`spice connect`) had to re-read the credential store afterwards and could not continue after an inline login. There was also no invocation-local, permission-aware organization chooser: connect could only test a default/org-scoped credential and fail when none existed.

### `AuthenticatedSession` (`commands/login/session.rs`)

- The browser login now produces an internal `AuthenticatedSession` carrying the live access token, the auth context (username, email, the login's own org, app), and a `CredentialStore` handle naming where the credential was persisted (`.env` file, keychain, or unpersisted for JSON mode).
- The access token and app API key are unreachable through `Debug` on every type that carries them (`AuthenticatedSession`, `BrowserLoginOutcome`, `AccessTokenPoll`, `SpiceAuthContext`), so no formatting path can put a live credential in a log line or assertion message.
- `login_inline(store)` is an in-process login continuation for commands that need a session mid-flow: it behaves like a bare `spice login` (same preamble, same success output), persists to the store the caller names explicitly, and maps the user declining the browser authorization to a clean `LoginContinuation::Cancelled` instead of an error. A session can never be established against an unpersisted store, and the session does not retain the app API key at all — it is persisted and read back from the store by whatever needs it.
- Standalone `spice login` behavior is preserved: output lines, JSON mode, `--key` path, credential persistence (`SPICE_SPICEAI_TOKEN` + `SPICE_SPICEAI_API_KEY`), and the "Access denied" failure on refusal are unchanged. The SharePoint/ABFS OAuth device-code provider flows are untouched.

### Organization resolution (`commands/login/connect_org.rs`)

`resolve_connect_organization(session, org, interactive)` resolves the organization one connect invocation acts on; `resolve_connect_organization_with_client(client, org, credential_org, interactive)` is the same resolution for the already-logged-in path, where no browser flow ran and no session exists.

- Enumerates the login's organizations and keeps only memberships whose role is `owner` or `admin`, compared case-insensitively; member/viewer/deleted/unknown/role-less memberships are excluded.
- An explicit `--org` is validated and skips the chooser; an org the login belongs to with an ineligible role fails before any mutation, naming the actual and required roles.
- Exactly one eligible org is printed and used. Multiple eligible orgs require an interactive choice: the stored active org (or the login's own org) is only the chooser's highlighted starting position — the "(default)" label appears only when the highlight really is the stored `spice cloud org use` state — and is never selected silently; cancelling the chooser cancels the resolution.
- `interactive` is clamped against the real stdin at the public boundary, so a caller passing `true` under a pipe still gets the non-interactive error shapes: ambiguity fails immediately, naming `--org`.
- When org discovery is unavailable, an explicit `--org` is membership-checked server-side and the CLI says out loud that the role could not be verified locally (Spice Cloud enforces the owner/admin requirement at enrollment); the only org offerable interactively is the one the credential itself proves — confirmed, never assumed.
- Prompts run under `spawn_blocking` so the interactive wait never occupies an async runtime thread, and the chooser's answer is bounds-checked into a typed error.
- No path calls or emulates `spice cloud org use` or mutates the machine-wide active-org state; the resolution is scoped to the invocation.

## Testing

- Mock-server tests for the browser flow (granted, denied, unfetchable auth context) and for the exchange poll's new typed outcome.
- Credential-store tests: session persistence writes the token/API-key pair; `spice login --key` integration test asserts `.env` contents and 0600 permissions; an unpersisted store refuses writes.
- Debug-redaction tests for the session and login outcomes.
- Org resolution: multiple-role filtering (case-insensitive, padded), explicit eligible/ineligible/unknown/invalid org, single-org auto-resolution, TTY chooser (choice required, highlight index, cancel), non-TTY ambiguity naming `--org`, discovery-unavailable paths (probe, confirm, decline, non-TTY failure), and a global-org-unchanged guard.
- Provider regression: clap routing test plus CLI help assertions for the SharePoint/ABFS device-code flows.

Each load-bearing behavior was mutation-checked: role filtering, ineligible-org rejection, silent default selection, missing non-TTY guard, cancel-falls-back-to-default, decline-as-error, global org mutation, skipped persistence, and Debug token leakage were each broken deliberately and observed to fail the corresponding test before being restored.
