### PR TITLE
feat(telemetry): add spiced_process_cpu_time_seconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19425,6 +19425,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "util",
+ "uuid 1.23.2",
  "yaml",
 ]
 
@@ -20375,9 +20376,11 @@ dependencies = [
  "flight_client",
  "futures",
  "hostname 0.4.2",
+ "libc",
  "opentelemetry",
  "opentelemetry_sdk",
  "otel-arrow",
+ "parking_lot",
  "pin-project",
  "sha2 0.10.9",
  "snafu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,6 +296,7 @@ indexmap = "2"
 insta = { version = "1.46.3", features = ["filters"] }
 itertools = "0.14"
 linkme = "0.3.35"
+libc = "0.2"
 log = "0.4.22"
 logos = "0.16.1"
 # Model-checked concurrency primitives for cayenne's `StructuralVersion` seqlock

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -54,7 +54,7 @@ crash-handler.workspace = true
 event_stream = { path = "../../crates/event_stream" }
 repl = { path = "../../crates/repl" }
 futures.workspace = true
-libc = "0.2"
+libc.workspace = true
 mimalloc = { version = "0.1.48", optional = true }
 opentelemetry.workspace = true
 opentelemetry-http.workspace = true

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -88,6 +88,7 @@ telemetry = { path = "../../crates/telemetry" }
 tikv-jemallocator = { version = "0.6.0", optional = true, features = ["profiling"] }
 tokio.workspace = true
 tpc-extension = { path = "../../crates/tpc_extension", optional = true }
+uuid = { workspace = true, features = ["v4"] }
 tracing.workspace = true
 tracing-log = "0.2.0"
 tracing-opentelemetry.workspace = true

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -541,6 +541,9 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
     register_external_connectors().await;
 
     let prometheus_registry = args.metrics.map(|_| prometheus::Registry::new());
+    // This must exist before constructing the meter provider so every configured
+    // metrics reader receives the same lifecycle identity.
+    let service_instance_id = uuid::Uuid::new_v4().to_string();
 
     let spicepod_path = args
         .spicepod
@@ -879,7 +882,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
         // on-demand reader and inherit attribution from the scheduler-side
         // pipeline, so the empty-resource case here is consistent with the
         // surrounding executor config flow.
-        let resource_attributes: Vec<KeyValue> = telemetry_config
+        let mut resource_attributes: Vec<KeyValue> = telemetry_config
             .get()
             .map(|c| {
                 c.properties
@@ -888,6 +891,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
                     .collect()
             })
             .unwrap_or_default();
+        resource_attributes.push(KeyValue::new("service.instance.id", service_instance_id));
         let metric_prefix = telemetry_config.get().and_then(|c| c.metric_prefix.clone());
 
         init_metrics(
@@ -903,6 +907,8 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
             },
         )
         .context(UnableToInitializeMetricsSnafu)?;
+
+        telemetry::register_process_cpu_time_seconds();
 
         // Metrics are now initialized (the Prometheus meter provider is installed).
         // Register the Cayenne compaction instruments so the carved pool-size gauge

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 #![allow(clippy::missing_errors_doc)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -97,7 +97,7 @@ use connector_snowflake as _;
 #[cfg(feature = "spark")]
 use connector_spark as _;
 use connector_spiceai as _;
-use opentelemetry::{KeyValue, global};
+use opentelemetry::{Key, KeyValue, global};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader;
@@ -1458,7 +1458,7 @@ fn init_metrics(
     if let Some(registry) = registry {
         let prometheus_exporter = opentelemetry_prometheus::exporter()
             .with_registry(registry)
-            .without_scope_info()
+            .with_resource_selector(HashSet::from([Key::new("service.instance.id")]))
             .without_units()
             .without_counter_suffixes()
             .without_target_info()

--- a/crates/cayenne/Cargo.toml
+++ b/crates/cayenne/Cargo.toml
@@ -90,14 +90,14 @@ aegis = { version = "0.9.3", default-features = false, features = [
 # per call, measured), so the plain-fsync ordering tier needs a direct
 # libc::fsync. See the module docs for the durability rationale.
 [target.'cfg(target_os = "macos")'.dependencies]
-libc = "0.2"
+libc.workspace = true
 
 # Linux compaction page-cache hygiene (`provider/fadvise_tier.rs`):
 # `sync_file_range` + `posix_fadvise(POSIX_FADV_DONTNEED)` are Linux-only and
 # not exposed by std. Keeps a background compaction from evicting the hot query
 # working set. See the module docs.
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = "0.2"
+libc.workspace = true
 
 [features]
 default = []
@@ -141,7 +141,7 @@ tokio-stream = { workspace = true }
 # already depends on libc for `target_os = "linux"`, but a bench is a separate
 # crate and must name the dep itself.
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-libc = "0.2"
+libc.workspace = true
 
 # `loom` model-checks the `StructuralVersion` seqlock's memory orderings
 # (`provider/structural_version.rs`). Gated on `cfg(cayenne_loom)` so it is

--- a/crates/runtime-async/Cargo.toml
+++ b/crates/runtime-async/Cargo.toml
@@ -17,7 +17,7 @@ snafu.workspace = true
 cpu-budget = { path = "../cpu-budget" }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/crates/runtime/tests/metrics.rs
+++ b/crates/runtime/tests/metrics.rs
@@ -37,7 +37,7 @@ use std::{
 use app::AppBuilder;
 use cache::{metrics::CacheMetrics, result::query::CachedQueryResult};
 use futures::StreamExt;
-use opentelemetry::global;
+use opentelemetry::{Key, KeyValue, global};
 use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
 use runtime::{Runtime, datafusion::query::QueryBuilder};
 use spicepod::component::runtime::{Query, Runtime as SpicepodRuntime, TaskHistory};
@@ -110,7 +110,9 @@ fn install_prometheus_meter_provider() -> prometheus::Registry {
 
     let exporter = opentelemetry_prometheus::exporter()
         .with_registry(registry.clone())
-        .without_scope_info()
+        .with_resource_selector(std::collections::HashSet::from([Key::new(
+            "service.instance.id",
+        )]))
         .without_units()
         .without_counter_suffixes()
         .without_target_info()
@@ -118,7 +120,14 @@ fn install_prometheus_meter_provider() -> prometheus::Registry {
         .expect("to build the prometheus exporter");
 
     let provider = SdkMeterProvider::builder()
-        .with_resource(Resource::builder().build())
+        .with_resource(
+            Resource::builder()
+                .with_attributes([KeyValue::new(
+                    "service.instance.id",
+                    "metrics-test-instance",
+                )])
+                .build(),
+        )
         .with_reader(exporter)
         .build();
     global::set_meter_provider(provider);
@@ -238,6 +247,56 @@ fn memory_gauges_are_exported_to_the_operator_metrics_pipeline() {
         "memory gauges {missing:?} were recorded but not exported to the Prometheus registry \
          (a gauge on the anonymous-telemetry meter never reaches /metrics); reported: {:?}",
         sorted(&reported)
+    );
+}
+
+#[test]
+fn process_cpu_time_is_exported_with_paired_modes_and_lifecycle_identity() {
+    let registry = &*PROMETHEUS;
+    telemetry::register_process_cpu_time_seconds();
+
+    let metric = registry
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == "spiced_process_cpu_time_seconds")
+        .expect("process CPU time metric is exported");
+
+    assert_eq!(
+        metric.help(),
+        "CPU seconds used by spiced and its threads; excludes child processes, sidecars, cgroup peers, requests, and limits."
+    );
+    assert_eq!(
+        metric.get_field_type(),
+        prometheus::proto::MetricType::COUNTER
+    );
+    assert_eq!(metric.get_metric().len(), 2);
+
+    let modes: HashSet<(&str, &str)> = metric
+        .get_metric()
+        .iter()
+        .map(|sample| {
+            let cpu_mode = sample
+                .get_label()
+                .iter()
+                .find(|label| label.name() == "cpu_mode")
+                .expect("process CPU time sample has cpu_mode label")
+                .value();
+            let service_instance_id = sample
+                .get_label()
+                .iter()
+                .find(|label| label.name() == "service_instance_id")
+                .expect("process CPU time sample has lifecycle identity label")
+                .value();
+            (cpu_mode, service_instance_id)
+        })
+        .collect();
+
+    assert_eq!(
+        modes,
+        HashSet::from([
+            ("user", "metrics-test-instance"),
+            ("system", "metrics-test-instance"),
+        ])
     );
 }
 

--- a/crates/runtime/tests/metrics.rs
+++ b/crates/runtime/tests/metrics.rs
@@ -250,6 +250,7 @@ fn memory_gauges_are_exported_to_the_operator_metrics_pipeline() {
     );
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn process_cpu_time_is_exported_with_paired_modes_and_lifecycle_identity() {
     let registry = &*PROMETHEUS;

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -13,7 +13,7 @@ arrow.workspace = true
 async-trait.workspace = true
 flight_client = { path = "../flight_client" }
 hostname = "0.4.2"
-libc = "0.2"
+libc.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 otel-arrow = { path = "../otel-arrow" }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -13,9 +13,11 @@ arrow.workspace = true
 async-trait.workspace = true
 flight_client = { path = "../flight_client" }
 hostname = "0.4.2"
+libc = "0.2"
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 otel-arrow = { path = "../otel-arrow" }
+parking_lot.workspace = true
 pin-project.workspace = true
 sha2.workspace = true
 snafu.workspace = true

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -428,7 +428,7 @@ fn timeval_to_seconds(time: libc::timeval) -> Result<f64, String> {
             time.tv_sec, time.tv_usec
         ));
     }
-    Ok(time.tv_sec as f64 + time.tv_usec as f64 / 1_000_000.0)
+    Ok(time.tv_sec as f64 + f64::from(time.tv_usec) / 1_000_000.0)
 }
 
 #[cfg(test)]

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -16,10 +16,14 @@ limitations under the License.
 
 pub use opentelemetry::KeyValue;
 use opentelemetry::global;
-use opentelemetry::metrics::{Counter, Histogram};
+use opentelemetry::metrics::{Counter, Histogram, ObservableCounter};
 use opentelemetry::metrics::{Gauge, UpDownCounter};
+use parking_lot::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::{sync::OnceLock, time::Duration};
+use std::{
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
 
 #[cfg(feature = "anonymous_telemetry")]
 pub mod anonymous;
@@ -342,6 +346,82 @@ pub fn track_spilled_bytes(value: u64, dimensions: &[KeyValue]) {
 }
 
 static PROCESS_RESIDENT_MEMORY_BYTES: OnceLock<Gauge<u64>> = OnceLock::new();
+
+static PROCESS_CPU_TIME_SECONDS: OnceLock<ObservableCounter<f64>> = OnceLock::new();
+static PROCESS_CPU_TIME_LAST_WARNING: Mutex<Option<Instant>> = Mutex::new(None);
+
+/// Registers cumulative user and system CPU time for the process and all its threads.
+///
+/// The callback observes both modes from one `getrusage(RUSAGE_SELF)` snapshot. A
+/// failed snapshot omits both series so consumers never calculate a partial total.
+pub fn register_process_cpu_time_seconds() {
+    PROCESS_CPU_TIME_SECONDS.get_or_init(|| {
+        let user_attributes = [KeyValue::new("cpu.mode", "user")];
+        let system_attributes = [KeyValue::new("cpu.mode", "system")];
+
+        global::meter("process")
+            .f64_observable_counter("spiced_process_cpu_time_seconds")
+            .with_description(
+                "CPU seconds used by spiced and its threads; excludes child processes, sidecars, cgroup peers, requests, and limits.",
+            )
+            .with_unit("s")
+            .with_callback(move |observer| match process_cpu_time_seconds() {
+                Ok((user, system)) => {
+                    observer.observe(user, &user_attributes);
+                    observer.observe(system, &system_attributes);
+                }
+                Err(error) => warn_process_cpu_time_collection_failure(&error),
+            })
+            .build()
+    });
+}
+
+fn warn_process_cpu_time_collection_failure(error: &str) {
+    let mut last_warning = PROCESS_CPU_TIME_LAST_WARNING.lock();
+    if last_warning.is_none_or(|last| last.elapsed() >= Duration::from_mins(1)) {
+        tracing::warn!(
+            metric = "spiced_process_cpu_time_seconds",
+            error,
+            "Process CPU metric collection failed; omitted paired observations"
+        );
+        *last_warning = Some(Instant::now());
+    }
+}
+
+fn process_cpu_time_seconds() -> Result<(f64, f64), String> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
+        // `getrusage` initializes every field of the supplied `rusage` on success.
+        if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+            return Err(std::io::Error::last_os_error().to_string());
+        }
+        let usage = unsafe { usage.assume_init() };
+        Ok((
+            timeval_to_seconds(usage.ru_utime)?,
+            timeval_to_seconds(usage.ru_stime)?,
+        ))
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Err("getrusage(RUSAGE_SELF) is not supported on this platform".to_string())
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "OpenTelemetry CPU-time counters are f64 seconds; precision beyond f64 is not exportable"
+)]
+fn timeval_to_seconds(time: libc::timeval) -> Result<f64, String> {
+    if time.tv_sec < 0 || !(0..1_000_000).contains(&time.tv_usec) {
+        return Err(format!(
+            "getrusage returned invalid timeval {} seconds {} microseconds",
+            time.tv_sec, time.tv_usec
+        ));
+    }
+    Ok(time.tv_sec as f64 + time.tv_usec as f64 / 1_000_000.0)
+}
 
 /// Records the process's resident set size — the number the kernel's OOM
 /// decision is made on. Budgets and pool gauges describe intent; this describes

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -378,14 +378,22 @@ pub fn register_process_cpu_time_seconds() {
 
 fn warn_process_cpu_time_collection_failure(error: &str) {
     let mut last_warning = PROCESS_CPU_TIME_LAST_WARNING.lock();
-    if last_warning.is_none_or(|last| last.elapsed() >= Duration::from_mins(1)) {
+    let now = Instant::now();
+    if should_warn_process_cpu_time_collection_failure(last_warning.as_ref(), now) {
         tracing::warn!(
             metric = "spiced_process_cpu_time_seconds",
             error,
             "Process CPU metric collection failed; omitted paired observations"
         );
-        *last_warning = Some(Instant::now());
+        *last_warning = Some(now);
     }
+}
+
+fn should_warn_process_cpu_time_collection_failure(
+    last_warning: Option<&Instant>,
+    now: Instant,
+) -> bool {
+    last_warning.is_none_or(|last| now.duration_since(*last) >= Duration::from_mins(1))
 }
 
 fn process_cpu_time_seconds() -> Result<(f64, f64), String> {
@@ -421,6 +429,55 @@ fn timeval_to_seconds(time: libc::timeval) -> Result<f64, String> {
         ));
     }
     Ok(time.tv_sec as f64 + time.tv_usec as f64 / 1_000_000.0)
+}
+
+#[cfg(test)]
+mod process_cpu_time_tests {
+    use super::*;
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn timeval_conversion_preserves_seconds_and_microseconds() {
+        let seconds = timeval_to_seconds(libc::timeval {
+            tv_sec: 42,
+            tv_usec: 700_000,
+        })
+        .expect("valid timeval converts to seconds");
+
+        assert!((seconds - 42.7).abs() < f64::EPSILON);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn timeval_conversion_rejects_invalid_values() {
+        let negative_seconds = timeval_to_seconds(libc::timeval {
+            tv_sec: -1,
+            tv_usec: 0,
+        });
+        let invalid_microseconds = timeval_to_seconds(libc::timeval {
+            tv_sec: 0,
+            tv_usec: 1_000_000,
+        });
+
+        negative_seconds.expect_err("negative seconds are invalid");
+        invalid_microseconds.expect_err("microseconds outside one second are invalid");
+    }
+
+    #[test]
+    fn process_cpu_time_failure_warning_is_limited_to_one_per_minute() {
+        let now = Instant::now();
+        let later = now + Duration::from_mins(1);
+
+        assert!(should_warn_process_cpu_time_collection_failure(None, now));
+        assert!(!should_warn_process_cpu_time_collection_failure(
+            Some(&now),
+            now
+        ));
+        assert!(should_warn_process_cpu_time_collection_failure(
+            Some(&now),
+            later
+        ));
+    }
 }
 
 /// Records the process's resident set size — the number the kernel's OOM

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -428,7 +428,12 @@ fn timeval_to_seconds(time: libc::timeval) -> Result<f64, String> {
             time.tv_sec, time.tv_usec
         ));
     }
-    Ok(time.tv_sec as f64 + f64::from(time.tv_usec) / 1_000_000.0)
+    #[cfg(target_os = "linux")]
+    let microseconds = time.tv_usec as f64;
+    #[cfg(target_os = "macos")]
+    let microseconds = f64::from(time.tv_usec);
+
+    Ok(time.tv_sec as f64 + microseconds / 1_000_000.0)
 }
 
 #[cfg(test)]

--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -87,7 +87,22 @@ The following guidelines apply the above principles, focusing on Developer Exper
    - **Family**: **Unit**
    - Timestamps and Duration: `ms`
     - Data size: `bytes`
-   - **Why**: Establishing default units ensures predictability, reduces potential scaling errors, and simplifies interpretation, aligning with Developer Experience by maintaining consistency.
+    - **Why**: Establishing default units ensures predictability, reduces potential scaling errors, and simplifies interpretation, aligning with Developer Experience by maintaining consistency.
+
+## Process CPU Time
+
+`spiced_process_cpu_time_seconds` is a monotonic OpenTelemetry counter of CPU seconds used by the `spiced` process and its threads. It has unit `s` and only the `cpu.mode` attribute, whose values are `user` and `system`. Prometheus renders that attribute as the `cpu_mode` label. Sum both modes to calculate total process CPU time; the metric excludes child processes, sidecars, cgroup peers, CPU requests, and CPU limits.
+
+`service.instance.id` is a per-start UUIDv4 resource attribute. Prometheus exposes it as the `service_instance_id` label. Use `rate` or `increase` before aggregating, so counter resets at process restart are handled correctly.
+
+```promql
+# Average process CPU cores used over five minutes
+sum without (cpu_mode) (
+  rate(spiced_process_cpu_time_seconds[5m])
+)
+```
+
+If CPU-time collection fails, neither mode is emitted for that collection. A missing paired sample is preferable to a partial or zero total.
 
 ## References and Standards Alignment
 


### PR DESCRIPTION
## What
Add spiced_process_cpu_time_seconds, a cumulative process CPU-time metric for spiced. It gives operators a reset-safe way to calculate CPU consumed by each running instance rather than inferring it from host capacity, cgroup limits, or wall-clock time.

## Metric Contract
- Emits exactly two monotonic counter series in seconds: cpu.mode=user and cpu.mode=system.
- Reads one getrusage(RUSAGE_SELF) snapshot, covering the spiced process and all of its threads while excluding child processes.
- Uses a UUIDv4 service.instance.id resource attribute for OTLP and the service_instance_id Prometheus label.
- Omits both series if collection fails, preventing a partial process-CPU total; warnings are rate-limited to once per minute.
- Preserves the Spice metric name through existing OTLP, Prometheus, runtime-table, and cluster metric readers. The configured metric prefix remains an SDK-level export transform.

<img width="1190" height="1125" alt="image" src="https://github.com/user-attachments/assets/8934f9b0-2ea2-4eca-821c-2ebc8122c2cb" />

<img width="1197" height="1231" alt="image" src="https://github.com/user-attachments/assets/43884b7c-e520-4c4e-bfd3-935181c69246" />


Closes #12888