### PR TITLE
bug: Support search UDTFs in SQL function components

### DIFF
--- a/crates/runtime-datafusion-udfs/src/user_functions/mod.rs
+++ b/crates/runtime-datafusion-udfs/src/user_functions/mod.rs
@@ -46,6 +46,7 @@ mod args_inliner;
 mod arrow_type;
 #[cfg(feature = "http-functions")]
 pub mod remote;
+mod search_query_rewrite;
 pub mod sql;
 #[cfg(feature = "wasm-functions")]
 pub mod wasm;

--- a/crates/runtime-datafusion-udfs/src/user_functions/search_query_rewrite.rs
+++ b/crates/runtime-datafusion-udfs/src/user_functions/search_query_rewrite.rs
@@ -1,0 +1,310 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Inline SQL table-function arguments used as the query text of search
+//! UDTFs (`vector_search`, `text_search`) before `DataFusion` plans the
+//! function body.
+//!
+//! Search UDTFs inspect their query argument while the table function
+//! itself is being constructed during planning
+//! (`runtime-search::rrf::parse_search_args`,
+//! `runtime-search::full_text_udtf`, `runtime::embeddings::udtf`), and all
+//! three require that argument in the *second positional* slot — none of
+//! them consult a named `query` argument. A SQL-tier function's own
+//! arguments, by contrast, are only replaced with literal values in
+//! [`super::args_inliner::inline_args_into_plan`], which runs on the
+//! logical plan *after* planning. That's too late for these UDTFs.
+//!
+//! This module closes the gap by rewriting the parsed SQL text: any
+//! argument in the search UDTF's query position — whether already
+//! positional or passed as `query => ...` — that resolves to a known
+//! string-valued function argument is normalized into the second
+//! positional slot as a literal, before the body is planned.
+
+use std::collections::HashMap;
+use std::ops::ControlFlow;
+
+use arrow::datatypes::Schema;
+use datafusion::common::Result as DataFusionResult;
+use datafusion::scalar::ScalarValue;
+use datafusion::sql::{
+    parser::DFParser,
+    sqlparser::{
+        ast,
+        ast::{VisitMut, VisitorMut},
+        dialect::Dialect,
+    },
+};
+
+pub(crate) fn inline_search_query_args(
+    body: &str,
+    dialect: &dyn Dialect,
+    schema: &Schema,
+    values: &[ScalarValue],
+) -> DataFusionResult<String> {
+    let mut statements = DFParser::parse_sql_with_dialect(body, dialect)?;
+    let arg_values: HashMap<String, ScalarValue> = schema
+        .fields()
+        .iter()
+        .zip(values)
+        .map(|(field, value)| (field.name().to_ascii_lowercase(), value.clone()))
+        .collect();
+
+    let mut rewriter = SearchQueryArgRewriter {
+        values: &arg_values,
+    };
+    for statement in &mut statements {
+        if let datafusion::sql::parser::Statement::Statement(statement) = statement {
+            let _: ControlFlow<()> = statement.visit(&mut rewriter);
+        }
+    }
+    Ok(statements
+        .into_iter()
+        .map(|statement| statement.to_string())
+        .collect::<Vec<_>>()
+        .join("; "))
+}
+
+struct SearchQueryArgRewriter<'a> {
+    values: &'a HashMap<String, ScalarValue>,
+}
+
+impl VisitorMut for SearchQueryArgRewriter<'_> {
+    type Break = ();
+
+    // A search UDTF nested inside another call — e.g. `vector_search(...)`
+    // as an argument to `rrf(...)` — parses as an `Expr::Function`.
+    fn pre_visit_expr(&mut self, expr: &mut ast::Expr) -> ControlFlow<Self::Break> {
+        let ast::Expr::Function(function) = expr else {
+            return ControlFlow::Continue(());
+        };
+        if !is_search_udtf(&function.name.to_string()) {
+            return ControlFlow::Continue(());
+        }
+        let ast::FunctionArguments::List(arguments) = &mut function.args else {
+            return ControlFlow::Continue(());
+        };
+        normalize_query_argument(&mut arguments.args, self.values);
+        ControlFlow::Continue(())
+    }
+
+    // A search UDTF used directly as a `FROM` source — e.g.
+    // `FROM vector_search(docs, q)` — parses as a `TableFactor::Table`
+    // rather than an `Expr::Function`, so it needs its own hook.
+    fn pre_visit_table_factor(
+        &mut self,
+        table_factor: &mut ast::TableFactor,
+    ) -> ControlFlow<Self::Break> {
+        let ast::TableFactor::Table {
+            name,
+            args: Some(table_args),
+            ..
+        } = table_factor
+        else {
+            return ControlFlow::Continue(());
+        };
+        if !is_search_udtf(&name.to_string()) {
+            return ControlFlow::Continue(());
+        }
+        normalize_query_argument(&mut table_args.args, self.values);
+        ControlFlow::Continue(())
+    }
+}
+
+fn is_search_udtf(function_name: &str) -> bool {
+    function_name.rsplit('.').next().is_some_and(|name| {
+        name.eq_ignore_ascii_case("vector_search") || name.eq_ignore_ascii_case("text_search")
+    })
+}
+
+fn is_named(arg: &ast::FunctionArg) -> bool {
+    matches!(
+        arg,
+        ast::FunctionArg::Named { .. } | ast::FunctionArg::ExprNamed { .. }
+    )
+}
+
+/// The `name => value` key of a named argument, if that key is a plain
+/// identifier (rather than a computed expression).
+fn named_key(arg: &ast::FunctionArg) -> Option<&str> {
+    match arg {
+        ast::FunctionArg::Named { name, .. } => Some(name.value.as_str()),
+        ast::FunctionArg::ExprNamed {
+            name: ast::Expr::Identifier(identifier),
+            ..
+        } => Some(identifier.value.as_str()),
+        _ => None,
+    }
+}
+
+fn arg_expr_mut(arg: &mut ast::FunctionArg) -> &mut ast::FunctionArgExpr {
+    match arg {
+        ast::FunctionArg::Named { arg, .. }
+        | ast::FunctionArg::ExprNamed { arg, .. }
+        | ast::FunctionArg::Unnamed(arg) => arg,
+    }
+}
+
+/// If `expr` is an identifier bound to a known `Utf8` argument value,
+/// returns the literal `FunctionArgExpr` it should be replaced with.
+fn resolve_identifier_literal(
+    expr: &ast::FunctionArgExpr,
+    values: &HashMap<String, ScalarValue>,
+) -> Option<ast::FunctionArgExpr> {
+    let ast::FunctionArgExpr::Expr(ast::Expr::Identifier(identifier)) = expr else {
+        return None;
+    };
+    let ScalarValue::Utf8(Some(query)) = values.get(&identifier.value.to_ascii_lowercase())? else {
+        return None;
+    };
+    Some(ast::FunctionArgExpr::Expr(ast::Expr::Value(
+        ast::ValueWithSpan::from(ast::Value::SingleQuotedString(query.clone())),
+    )))
+}
+
+/// Ensure the search UDTF's query argument ends up as a literal in the
+/// second *positional* slot, since that's the only place every search UDTF
+/// parser looks for it. A `query => q` named argument is moved into that
+/// slot rather than merely having its value inlined in place, since it
+/// would otherwise still be rejected as an unrecognized named argument.
+fn normalize_query_argument(
+    args: &mut Vec<ast::FunctionArg>,
+    values: &HashMap<String, ScalarValue>,
+) {
+    let Some(table_idx) = args.iter().position(|arg| !is_named(arg)) else {
+        // No positional table argument — the query position can't be
+        // resolved by convention, so leave the call as written.
+        return;
+    };
+
+    let mut positional_count = 0;
+    let second_positional_idx = args.iter().position(|arg| {
+        if is_named(arg) {
+            return false;
+        }
+        let is_second = positional_count == 1;
+        positional_count += 1;
+        is_second
+    });
+
+    if let Some(idx) = second_positional_idx {
+        let expr = arg_expr_mut(&mut args[idx]);
+        if let Some(literal) = resolve_identifier_literal(expr, values) {
+            *expr = literal;
+        }
+        return;
+    }
+
+    let Some(query_idx) = args
+        .iter()
+        .position(|arg| named_key(arg).is_some_and(|name| name.eq_ignore_ascii_case("query")))
+    else {
+        return;
+    };
+    let Some(literal) = resolve_identifier_literal(arg_expr_mut(&mut args[query_idx]), values)
+    else {
+        return;
+    };
+
+    args.remove(query_idx);
+    let insert_at = if query_idx < table_idx {
+        table_idx
+    } else {
+        table_idx + 1
+    };
+    args.insert(insert_at, ast::FunctionArg::Unnamed(literal));
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::datatypes::{DataType, Field};
+    use datafusion::sql::sqlparser::dialect::GenericDialect;
+
+    use super::*;
+
+    fn schema() -> Schema {
+        Schema::new(vec![Field::new("q", DataType::Utf8, true)])
+    }
+
+    fn values() -> Vec<ScalarValue> {
+        vec![ScalarValue::Utf8(Some("hybrid search".to_string()))]
+    }
+
+    /// Table-driven over the call shapes search UDTFs must accept: plain
+    /// positional, named `query => q` before/after other named args, and
+    /// both `vector_search`/`text_search` inside `rrf`. Every case must end
+    /// up with the query argument as a literal in positional slot two,
+    /// since that's the only place any search UDTF parser looks for it.
+    #[test]
+    fn normalizes_every_search_udtf_query_argument_shape() {
+        let cases = [
+            (
+                "SELECT * FROM vector_search(docs, q)",
+                "vector_search(docs, 'hybrid search')",
+            ),
+            (
+                "SELECT * FROM vector_search(docs, query => q)",
+                "vector_search(docs, 'hybrid search')",
+            ),
+            (
+                "SELECT * FROM vector_search(docs, limit => 10, query => q)",
+                "vector_search(docs, 'hybrid search', limit => 10)",
+            ),
+            (
+                "SELECT * FROM rrf(vector_search(docs, q), text_search(docs, query => q))",
+                "rrf(vector_search(docs, 'hybrid search'), text_search(docs, 'hybrid search'))",
+            ),
+            (
+                "SELECT * FROM search.vector_search(docs, query => q)",
+                "search.vector_search(docs, 'hybrid search')",
+            ),
+        ];
+
+        for (body, expected_fragment) in cases {
+            let rewritten =
+                inline_search_query_args(body, &GenericDialect {}, &schema(), &values())
+                    .unwrap_or_else(|e| panic!("rewrite of {body:?} failed: {e}"));
+            assert!(
+                rewritten.contains(expected_fragment),
+                "expected {rewritten:?} to contain {expected_fragment:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn leaves_non_identifier_query_arguments_untouched() {
+        let rewritten = inline_search_query_args(
+            "SELECT * FROM vector_search(docs, 'literal already')",
+            &GenericDialect {},
+            &schema(),
+            &values(),
+        )
+        .expect("rewrites without error");
+        assert!(rewritten.contains("vector_search(docs, 'literal already')"));
+    }
+
+    #[test]
+    fn leaves_unrelated_functions_untouched() {
+        let rewritten = inline_search_query_args(
+            "SELECT * FROM some_other_udtf(docs, q)",
+            &GenericDialect {},
+            &schema(),
+            &values(),
+        )
+        .expect("rewrites without error");
+        assert!(rewritten.contains("some_other_udtf(docs, q)"));
+    }
+}

--- a/crates/runtime-datafusion-udfs/src/user_functions/sql.rs
+++ b/crates/runtime-datafusion-udfs/src/user_functions/sql.rs
@@ -28,7 +28,7 @@ limitations under the License.
 //! The beta surface supports scalar and complex Arrow types, including lists,
 //! structs, decimals, and timestamps with timezones.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 use std::sync::{
@@ -57,7 +57,7 @@ use datafusion::scalar::ScalarValue;
 use datafusion::sql::{
     TableReference,
     parser::DFParser,
-    sqlparser::{ast, dialect::PostgreSqlDialect},
+    sqlparser::{ast, ast::VisitMut, dialect::PostgreSqlDialect},
 };
 use snafu::{ResultExt, Snafu};
 use spicepod::component::function::{
@@ -515,7 +515,14 @@ impl TableProvider for SqlTableProvider {
         )
         .await?;
 
-        let (session_state, plan) = ctx.sql(&self.body).await?.into_parts();
+        // Search UDTFs require their query argument to be a literal while the
+        // SQL planner is constructing the logical plan. The regular args
+        // table cannot satisfy that requirement: its values are only made
+        // literal by `inline_args_into_plan`, after this planning step.
+        // Rewrite search-query argument positions before planning, preserving
+        // the args table for all other references in the body.
+        let body = inline_search_query_args(&self.body, self.arg_schema.as_ref(), &self.args)?;
+        let (session_state, plan) = ctx.sql(&body).await?.into_parts();
         let inlined_plan = inline_args_into_plan(plan, self.arg_schema.as_ref(), &self.args)?;
         let mut df = DataFrame::new(session_state, inlined_plan);
         validate_output_schema(&self.name, df.schema().as_arrow(), self.schema.as_ref())
@@ -645,6 +652,100 @@ fn validate_table_body_syntax(body: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Substitute SQL table-function arguments used as the query text of search
+/// UDTFs before DataFusion plans the body. Search UDTFs inspect their argument
+/// expressions during table-function construction, so the later logical-plan
+/// argument inliner is too late for these positions.
+fn inline_search_query_args(
+    body: &str,
+    schema: &Schema,
+    values: &[ScalarValue],
+) -> DataFusionResult<String> {
+    let mut statements = DFParser::parse_sql_with_dialect(body, &PostgreSqlDialect {})?;
+    let arg_values: HashMap<String, ScalarValue> = schema
+        .fields()
+        .iter()
+        .zip(values)
+        .map(|(field, value)| (field.name().to_ascii_lowercase(), value.clone()))
+        .collect();
+
+    struct SearchQueryArgRewriter<'a> {
+        values: &'a HashMap<String, ScalarValue>,
+    }
+
+    impl VisitMut for SearchQueryArgRewriter<'_> {
+        type Break = ();
+
+        fn pre_visit_expr(&mut self, expr: &mut ast::Expr) -> std::ops::ControlFlow<Self::Break> {
+            let ast::Expr::Function(function) = expr else {
+                return std::ops::ControlFlow::Continue(());
+            };
+            let function_name = function.name.to_string();
+            if !function_name.rsplit('.').next().is_some_and(|name| {
+                name.eq_ignore_ascii_case("vector_search")
+                    || name.eq_ignore_ascii_case("text_search")
+            }) {
+                return std::ops::ControlFlow::Continue(());
+            }
+
+            let ast::FunctionArguments::List(arguments) = &mut function.args else {
+                return std::ops::ControlFlow::Continue(());
+            };
+            let mut positional_index = 0;
+            for argument in &mut arguments.args {
+                let (name, value) = match argument {
+                    ast::FunctionArg::Named { name, arg, .. } => (Some(name.value.as_str()), arg),
+                    ast::FunctionArg::ExprNamed { name, arg, .. } => {
+                        let name = match name {
+                            ast::Expr::Identifier(identifier) => Some(identifier.value.as_str()),
+                            _ => None,
+                        };
+                        (name, arg)
+                    }
+                    ast::FunctionArg::Unnamed(arg) => {
+                        let index = positional_index;
+                        positional_index += 1;
+                        if index != 1 {
+                            continue;
+                        }
+                        (Some("query"), arg)
+                    }
+                };
+                if name.is_none_or(|name| !name.eq_ignore_ascii_case("query")) {
+                    continue;
+                }
+                let ast::FunctionArgExpr::Expr(ast::Expr::Identifier(identifier)) = value else {
+                    continue;
+                };
+                let Some(scalar) = self.values.get(&identifier.value.to_ascii_lowercase()) else {
+                    continue;
+                };
+                let ScalarValue::Utf8(Some(query)) = scalar else {
+                    continue;
+                };
+                *value = ast::FunctionArgExpr::Expr(ast::Expr::Value(ast::ValueWithSpan::from(
+                    ast::Value::SingleQuotedString(query.clone()),
+                )));
+            }
+            std::ops::ControlFlow::Continue(())
+        }
+    }
+
+    let mut rewriter = SearchQueryArgRewriter {
+        values: &arg_values,
+    };
+    for statement in &mut statements {
+        if let datafusion::sql::parser::Statement::Statement(statement) = statement {
+            statement.visit(&mut rewriter);
+        }
+    }
+    Ok(statements
+        .into_iter()
+        .map(|statement| statement.to_string())
+        .collect::<Vec<_>>()
+        .join("; "))
 }
 
 fn table_arg_values(
@@ -1560,6 +1661,21 @@ mod tests {
             .await
             .expect("projected query runs");
         assert_eq!(projected[0].num_columns(), 1);
+    }
+
+    #[test]
+    fn search_query_arguments_are_inlined_before_sql_planning() {
+        let schema = Schema::new(vec![Field::new("q", DataType::Utf8, true)]);
+        let body = "SELECT * FROM rrf(vector_search(docs, q), text_search(docs, q))";
+        let rewritten = inline_search_query_args(
+            body,
+            &schema,
+            &[ScalarValue::Utf8(Some("hybrid search".to_string()))],
+        )
+        .expect("rewrites search query arguments");
+
+        assert!(rewritten.contains("vector_search(docs, 'hybrid search')"));
+        assert!(rewritten.contains("text_search(docs, 'hybrid search')"));
     }
 
     #[tokio::test]

--- a/crates/runtime-datafusion-udfs/src/user_functions/sql.rs
+++ b/crates/runtime-datafusion-udfs/src/user_functions/sql.rs
@@ -28,7 +28,7 @@ limitations under the License.
 //! The beta surface supports scalar and complex Arrow types, including lists,
 //! structs, decimals, and timestamps with timezones.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 use std::sync::{
@@ -57,7 +57,10 @@ use datafusion::scalar::ScalarValue;
 use datafusion::sql::{
     TableReference,
     parser::DFParser,
-    sqlparser::{ast, ast::VisitMut, dialect::PostgreSqlDialect},
+    sqlparser::{
+        ast,
+        dialect::{Dialect, GenericDialect, PostgreSqlDialect, dialect_from_str},
+    },
 };
 use snafu::{ResultExt, Snafu};
 use spicepod::component::function::{
@@ -66,6 +69,7 @@ use spicepod::component::function::{
 use util::session_state::builder_from_existing;
 
 use crate::user_functions::args_inliner::inline_args_into_plan;
+use crate::user_functions::search_query_rewrite::inline_search_query_args;
 
 pub(crate) const SQL_TABLE_ARGS_TABLE_NAME: &str = "args";
 
@@ -520,8 +524,20 @@ impl TableProvider for SqlTableProvider {
         // table cannot satisfy that requirement: its values are only made
         // literal by `inline_args_into_plan`, after this planning step.
         // Rewrite search-query argument positions before planning, preserving
-        // the args table for all other references in the body.
-        let body = inline_search_query_args(&self.body, self.arg_schema.as_ref(), &self.args)?;
+        // the args table for all other references in the body. Parse with
+        // the session's configured SQL dialect so this pre-parse agrees with
+        // the `ctx.sql` planning parse just below.
+        let body = {
+            let dialect: Box<dyn Dialect> =
+                dialect_from_str(state.config_options().sql_parser.dialect.as_ref())
+                    .unwrap_or_else(|| Box::new(GenericDialect {}));
+            inline_search_query_args(
+                &self.body,
+                dialect.as_ref(),
+                self.arg_schema.as_ref(),
+                &self.args,
+            )?
+        };
         let (session_state, plan) = ctx.sql(&body).await?.into_parts();
         let inlined_plan = inline_args_into_plan(plan, self.arg_schema.as_ref(), &self.args)?;
         let mut df = DataFrame::new(session_state, inlined_plan);
@@ -652,100 +668,6 @@ fn validate_table_body_syntax(body: &str) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Substitute SQL table-function arguments used as the query text of search
-/// UDTFs before DataFusion plans the body. Search UDTFs inspect their argument
-/// expressions during table-function construction, so the later logical-plan
-/// argument inliner is too late for these positions.
-fn inline_search_query_args(
-    body: &str,
-    schema: &Schema,
-    values: &[ScalarValue],
-) -> DataFusionResult<String> {
-    let mut statements = DFParser::parse_sql_with_dialect(body, &PostgreSqlDialect {})?;
-    let arg_values: HashMap<String, ScalarValue> = schema
-        .fields()
-        .iter()
-        .zip(values)
-        .map(|(field, value)| (field.name().to_ascii_lowercase(), value.clone()))
-        .collect();
-
-    struct SearchQueryArgRewriter<'a> {
-        values: &'a HashMap<String, ScalarValue>,
-    }
-
-    impl VisitMut for SearchQueryArgRewriter<'_> {
-        type Break = ();
-
-        fn pre_visit_expr(&mut self, expr: &mut ast::Expr) -> std::ops::ControlFlow<Self::Break> {
-            let ast::Expr::Function(function) = expr else {
-                return std::ops::ControlFlow::Continue(());
-            };
-            let function_name = function.name.to_string();
-            if !function_name.rsplit('.').next().is_some_and(|name| {
-                name.eq_ignore_ascii_case("vector_search")
-                    || name.eq_ignore_ascii_case("text_search")
-            }) {
-                return std::ops::ControlFlow::Continue(());
-            }
-
-            let ast::FunctionArguments::List(arguments) = &mut function.args else {
-                return std::ops::ControlFlow::Continue(());
-            };
-            let mut positional_index = 0;
-            for argument in &mut arguments.args {
-                let (name, value) = match argument {
-                    ast::FunctionArg::Named { name, arg, .. } => (Some(name.value.as_str()), arg),
-                    ast::FunctionArg::ExprNamed { name, arg, .. } => {
-                        let name = match name {
-                            ast::Expr::Identifier(identifier) => Some(identifier.value.as_str()),
-                            _ => None,
-                        };
-                        (name, arg)
-                    }
-                    ast::FunctionArg::Unnamed(arg) => {
-                        let index = positional_index;
-                        positional_index += 1;
-                        if index != 1 {
-                            continue;
-                        }
-                        (Some("query"), arg)
-                    }
-                };
-                if name.is_none_or(|name| !name.eq_ignore_ascii_case("query")) {
-                    continue;
-                }
-                let ast::FunctionArgExpr::Expr(ast::Expr::Identifier(identifier)) = value else {
-                    continue;
-                };
-                let Some(scalar) = self.values.get(&identifier.value.to_ascii_lowercase()) else {
-                    continue;
-                };
-                let ScalarValue::Utf8(Some(query)) = scalar else {
-                    continue;
-                };
-                *value = ast::FunctionArgExpr::Expr(ast::Expr::Value(ast::ValueWithSpan::from(
-                    ast::Value::SingleQuotedString(query.clone()),
-                )));
-            }
-            std::ops::ControlFlow::Continue(())
-        }
-    }
-
-    let mut rewriter = SearchQueryArgRewriter {
-        values: &arg_values,
-    };
-    for statement in &mut statements {
-        if let datafusion::sql::parser::Statement::Statement(statement) = statement {
-            statement.visit(&mut rewriter);
-        }
-    }
-    Ok(statements
-        .into_iter()
-        .map(|statement| statement.to_string())
-        .collect::<Vec<_>>()
-        .join("; "))
 }
 
 fn table_arg_values(
@@ -1661,21 +1583,6 @@ mod tests {
             .await
             .expect("projected query runs");
         assert_eq!(projected[0].num_columns(), 1);
-    }
-
-    #[test]
-    fn search_query_arguments_are_inlined_before_sql_planning() {
-        let schema = Schema::new(vec![Field::new("q", DataType::Utf8, true)]);
-        let body = "SELECT * FROM rrf(vector_search(docs, q), text_search(docs, q))";
-        let rewritten = inline_search_query_args(
-            body,
-            &schema,
-            &[ScalarValue::Utf8(Some("hybrid search".to_string()))],
-        )
-        .expect("rewrites search query arguments");
-
-        assert!(rewritten.contains("vector_search(docs, 'hybrid search')"));
-        assert!(rewritten.contains("text_search(docs, 'hybrid search')"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Describe the bug
Users can provide SQL UDTFs defined in the spicepod.yaml. The inputs to these UDTFs are represented as single row temporary tables (CTE). Because they are represented as columns of this single-row table, they cannot be used as inputs to search UDTFS. For example

```sql
-- If the UDTF `search_cookbook` is defined as so (with input q).
select * from rrf(
    vector_search(cookbook_files, q),
    text_search(cookbook_files, q)
)

-- This SQL UDTF call
SELECT * FROM search_cookbook('how does hybrid search work') LIMIT 10;

--- Should become 
select * from rrf(
    vector_search(cookbook_files, 'how does hybrid search work'),
    text_search(cookbook_files, 'how does hybrid search work')
) limit 10
```

The issue is that before we resolve `q` as `'how does hybrid search work'`, the database planner type checks `vector_search(cookbook_files, q)`, and `vector_search` requires its second parameter to be a string literal. This is reasonable since most table columns are not from single-row tables. 

**Fix**
In the user-defined SQL UDTF, for all search UDTFs, attempt to populate them with the string literal, before planning. This avoids the: _"database planner type checks `vector_search(cookbook_files, q)`"_ described above.

## To Reproduce
See issue details

Resolves #12899.
