### PR TITLE
fix(postgres): rebuild the acceleration when a replication slot's history is gone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4757,6 +4757,8 @@ dependencies = [
  "runtime-api-types",
  "runtime-metrics",
  "secrecy",
+ "serde",
+ "serde_json",
  "snafu",
  "tokio",
  "tokio-postgres",

--- a/crates/data-connectors/connector-dynamodb/src/connector.rs
+++ b/crates/data-connectors/connector-dynamodb/src/connector.rs
@@ -694,6 +694,7 @@ async fn emit_overwrite_then_live(
         )),
         checkpoint_batch,
         false, // readiness comes from the live stream, preserving prior behavior
+        false, // not a history-unavailable signal: this is the bootstrap checkpoint barrier
     );
 
     let live = match changes_stream_from_checkpoint(

--- a/crates/data-connectors/connector-mongodb/src/changes.rs
+++ b/crates/data-connectors/connector-mongodb/src/changes.rs
@@ -215,7 +215,7 @@ pub fn build_changes_stream(
                 )))?;
             let ready = build_ready_signal_envelope(&schema)
                 .map_err(|error| StreamError::Arrow(error.to_string()))?;
-            let (_, batch, is_ready) = ready.into_parts()
+            let (_, batch, is_ready, _) = ready.into_parts()
                 .map_err(|error| StreamError::Arrow(error.to_string()))?;
             let committer: Box<dyn CommitChange + Send + Sync> = match mongo_sys.as_ref() {
                 Some(sys) => Box::new(MongoResumeTokenCommitter::new(
@@ -226,7 +226,9 @@ pub fn build_changes_stream(
                 )),
                 None => Box::new(NoOpCommitter),
             };
-            yield ChangeEnvelope::from_parts(committer, batch, is_ready);
+            // Not a history-unavailable signal: this is the readiness envelope
+            // re-wrapped with the resume-token committer.
+            yield ChangeEnvelope::from_parts(committer, batch, is_ready, false);
 
             tracing::info!(
                 dataset = %dataset.name,

--- a/crates/data-connectors/connector-postgres/Cargo.toml
+++ b/crates/data-connectors/connector-postgres/Cargo.toml
@@ -26,6 +26,8 @@ description = "PostgreSQL data connector for Spice.ai runtime"
 linkme.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 data_components = { path = "../../data_components", features = ["postgres"] }
 datafusion.workspace = true
 datafusion-table-providers = { workspace = true, features = ["postgres", "postgres-federation"] }

--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -28,9 +28,9 @@ use std::time::Duration;
 use async_stream::try_stream;
 use data_components::cdc::{ChangesStream, InitialSnapshotMode, StreamError};
 use data_components::postgres_replication::{
-    AppliedLsn, AppliedLsnStore, NoopAppliedLsnStore, PgOutputFormat, ReplicationMetrics,
-    ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput, SchemaEvolutionPolicy,
-    config, start_replication_stream,
+    AppliedLsn, AppliedLsnStore, NoopAppliedLsnStore, PgOutputFormat, RecordedPosition,
+    ReplicationMetrics, ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput,
+    SchemaEvolutionPolicy, config, start_replication_stream,
 };
 use datafusion::sql::TableReference;
 use futures::StreamExt;
@@ -63,35 +63,75 @@ const MAX_MEMBER_CHANNEL_CAPACITY: usize = 1_048_576;
 /// without a migration.
 struct SidecarAppliedLsnStore {
     blobs: Arc<dyn runtime::dataaccelerator::spice_sys::postgres_replication::WatermarkBlobStore>,
+    /// Which source the recorded position belongs to (see [`source_identity`]).
+    ///
+    /// LSNs are only comparable within one source's history. Without this, a
+    /// dataset repointed to another server, database, or table while keeping its
+    /// acceleration files would compare the new source's LSNs against a
+    /// watermark describing the old one's contents — and a low new LSN reads as
+    /// "already covered", leaving the old rows in place and never loading the
+    /// new source's.
+    identity: String,
+}
+
+/// Identity of the source a watermark was recorded against: endpoint, database,
+/// and table.
+///
+/// Deliberately not the slot name — a different slot on the same server shares
+/// its LSN space, so slot changes stay comparable. Note this does not detect a
+/// same-endpoint cluster restored from a backup or rewound by PITR, whose LSNs
+/// can move backwards; the resume-position clamp in `postgres_replication` is
+/// what keeps that from silently skipping changes.
+fn source_identity(params: &ReplicationParams, schema: &str, table: &str) -> String {
+    format!(
+        "{}:{}/{}/{}.{}",
+        params.host, params.port, params.database, schema, table
+    )
 }
 
 /// Serialized form of [`AppliedLsn`] in the sidecar.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct StoredAppliedLsn {
     lsn: u64,
+    /// The source this position was recorded against. Absent in records written
+    /// before the field existed, which are treated as belonging to a different
+    /// source — the conservative reading, since they cannot be verified.
+    #[serde(default)]
+    source: Option<String>,
 }
 
 #[async_trait::async_trait]
 impl AppliedLsnStore for SidecarAppliedLsnStore {
     async fn load(
         &self,
-    ) -> std::result::Result<Option<AppliedLsn>, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> std::result::Result<RecordedPosition, Box<dyn std::error::Error + Send + Sync>> {
         let Some(checkpoint) = self.blobs.get().await? else {
-            return Ok(None);
+            return Ok(RecordedPosition::Absent);
         };
         // A row that exists but cannot be parsed is surfaced, not swallowed:
         // treating corruption as "no watermark" would silently resume as if this
         // were a first load, and the caller's fallback for an unreadable
         // watermark is a rebuild — the safe direction.
         let stored: StoredAppliedLsn = serde_json::from_str(&checkpoint.data)?;
-        Ok(Some(AppliedLsn { lsn: stored.lsn }))
+        if stored.source.as_deref() != Some(self.identity.as_str()) {
+            tracing::warn!(
+                recorded_for = stored.source.as_deref().unwrap_or("an unrecorded source"),
+                streaming_from = %self.identity,
+                "this acceleration's recorded position belongs to a different source, so its contents cannot be resumed against this one; it will be rebuilt from the source"
+            );
+            return Ok(RecordedPosition::ForeignSource);
+        }
+        Ok(RecordedPosition::At(AppliedLsn { lsn: stored.lsn }))
     }
 
     async fn save(
         &self,
         applied: AppliedLsn,
     ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let payload = serde_json::to_string(&StoredAppliedLsn { lsn: applied.lsn })?;
+        let payload = serde_json::to_string(&StoredAppliedLsn {
+            lsn: applied.lsn,
+            source: Some(self.identity.clone()),
+        })?;
         self.blobs.upsert(&payload).await?;
         Ok(())
     }
@@ -300,7 +340,10 @@ pub fn build_changes_stream(
             )
             .await
             {
-                Some(blobs) => Arc::new(SidecarAppliedLsnStore { blobs }),
+                Some(blobs) => Arc::new(SidecarAppliedLsnStore {
+                    blobs,
+                    identity: source_identity(&params_for_stream, &schema_name, &table_name),
+                }),
                 None => Arc::new(NoopAppliedLsnStore),
             }
         };

--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -28,8 +28,9 @@ use std::time::Duration;
 use async_stream::try_stream;
 use data_components::cdc::{ChangesStream, InitialSnapshotMode, StreamError};
 use data_components::postgres_replication::{
-    PgOutputFormat, ReplicationMetrics, ReplicationMetricsCollector, ReplicationParams,
-    ReplicationStreamInput, SchemaEvolutionPolicy, config, start_replication_stream,
+    AppliedLsn, AppliedLsnStore, NoopAppliedLsnStore, PgOutputFormat, ReplicationMetrics,
+    ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput, SchemaEvolutionPolicy,
+    config, start_replication_stream,
 };
 use datafusion::sql::TableReference;
 use futures::StreamExt;
@@ -53,6 +54,56 @@ const MAX_BOOTSTRAP_BATCH_SIZE: usize = 1_048_576;
 // the bootstrap-batch ceiling — a bounded, backpressure-preserving queue in
 // front of the accelerator prefetch, not an unbounded buffer.
 const MAX_MEMBER_CHANNEL_CAPACITY: usize = 1_048_576;
+
+/// [`AppliedLsnStore`] over the accelerator's `spice_sys_postgres_replication`
+/// sidecar.
+///
+/// The payload is a single `{"lsn": <u64>}` object rather than the bare number,
+/// so the record can gain fields (a slot identity, a snapshot as-of marker)
+/// without a migration.
+struct SidecarAppliedLsnStore {
+    blobs: Arc<dyn runtime::dataaccelerator::spice_sys::postgres_replication::WatermarkBlobStore>,
+}
+
+/// Serialized form of [`AppliedLsn`] in the sidecar.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct StoredAppliedLsn {
+    lsn: u64,
+}
+
+#[async_trait::async_trait]
+impl AppliedLsnStore for SidecarAppliedLsnStore {
+    async fn load(
+        &self,
+    ) -> std::result::Result<Option<AppliedLsn>, Box<dyn std::error::Error + Send + Sync>> {
+        let Some(checkpoint) = self.blobs.get().await? else {
+            return Ok(None);
+        };
+        // A row that exists but cannot be parsed is surfaced, not swallowed:
+        // treating corruption as "no watermark" would silently resume as if this
+        // were a first load, and the caller's fallback for an unreadable
+        // watermark is a rebuild — the safe direction.
+        let stored: StoredAppliedLsn = serde_json::from_str(&checkpoint.data)?;
+        Ok(Some(AppliedLsn { lsn: stored.lsn }))
+    }
+
+    async fn save(
+        &self,
+        applied: AppliedLsn,
+    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let payload = serde_json::to_string(&StoredAppliedLsn { lsn: applied.lsn })?;
+        self.blobs.upsert(&payload).await?;
+        Ok(())
+    }
+
+    async fn clear(&self) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // The sidecar exposes upsert-only semantics, so "forget" is recorded as a
+        // zero watermark: it precedes every real LSN, so the comparison against
+        // what the slot can supply resolves to a rebuild, which is what clearing
+        // is for.
+        self.save(AppliedLsn { lsn: 0 }).await
+    }
+}
 
 pub fn build_changes_stream(
     params: &Parameters,
@@ -97,6 +148,11 @@ pub fn build_changes_stream(
              will run on every start, including replication-slot resume"
         );
     }
+
+    // Resolving the watermark store needs to await, so it happens inside the
+    // stream below; clone the dataset handle it needs (cheap — `Dataset` is an
+    // `Arc`-bound wrapper over its spec).
+    let dataset_for_watermark = dataset.clone();
 
     // Prefer the dataset's explicitly-declared acceleration `primary_key` —
     // that's what the accelerator write path uses for upsert/delete, and it's
@@ -227,6 +283,28 @@ pub fn build_changes_stream(
             Err(StreamError::External(msg))?;
         }
 
+        // Where this dataset's applied-LSN watermark lives. An ephemeral
+        // acceleration gets the no-op store: it boots empty and re-snapshots
+        // every start, so a recorded position would describe rows the restart
+        // already threw away, and resuming on it would skip everything before it.
+        //
+        // A durable acceleration with no reachable store also records nothing,
+        // which reads as "never loaded" — correct, since an acceleration that
+        // cannot persist a watermark cannot have persisted the rows one would
+        // describe.
+        let applied_lsn_store: Arc<dyn AppliedLsnStore> = if ephemeral {
+            Arc::new(NoopAppliedLsnStore)
+        } else {
+            match runtime::dataaccelerator::spice_sys::postgres_replication::init_watermark_store(
+                &dataset_for_watermark,
+            )
+            .await
+            {
+                Some(blobs) => Arc::new(SidecarAppliedLsnStore { blobs }),
+                None => Arc::new(NoopAppliedLsnStore),
+            }
+        };
+
         let input = ReplicationStreamInput {
             dataset_name: dataset_name.clone(),
             params: params_for_stream,
@@ -236,6 +314,7 @@ pub fn build_changes_stream(
             table_name,
             metrics,
             policy: schema_evolution_policy,
+            applied_lsn_store,
         };
 
         let mut inner = start_replication_stream(input);

--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -444,6 +444,7 @@ pub struct ChangeEnvelope {
     change_committer: Box<dyn CommitChange + Send + Sync>,
     change_batch: LazyChangeBatch,
     is_dataset_ready: bool,
+    history_unavailable: bool,
 }
 
 impl ChangeEnvelope {
@@ -457,6 +458,7 @@ impl ChangeEnvelope {
             change_committer,
             change_batch: LazyChangeBatch::ready(change_batch),
             is_dataset_ready,
+            history_unavailable: false,
         }
     }
 
@@ -478,6 +480,7 @@ impl ChangeEnvelope {
             change_committer,
             change_batch: LazyChangeBatch::from_rows(rows),
             is_dataset_ready,
+            history_unavailable: false,
         }
     }
 
@@ -554,7 +557,12 @@ impl ChangeEnvelope {
     /// this for synchronous contexts or already-materialized envelopes.
     pub fn into_parts(self) -> Result<ChangeEnvelopeParts, ChangeBatchError> {
         let batch = self.change_batch.into_built()?;
-        Ok((self.change_committer, batch, self.is_dataset_ready))
+        Ok((
+            self.change_committer,
+            batch,
+            self.is_dataset_ready,
+            self.history_unavailable,
+        ))
     }
 
     /// [`Self::into_parts`] for async callers: a *deferred* envelope's
@@ -580,12 +588,38 @@ impl ChangeEnvelope {
         change_committer: Box<dyn CommitChange + Send + Sync>,
         change_batch: ChangeBatch,
         is_dataset_ready: bool,
+        history_unavailable: bool,
     ) -> Self {
         Self {
             change_committer,
             change_batch: LazyChangeBatch::ready(change_batch),
             is_dataset_ready,
+            history_unavailable,
         }
+    }
+
+    /// Whether the accelerator must be rebuilt from the source before this
+    /// envelope's changes — and everything after it — can be applied.
+    ///
+    /// Set by a source that has lost the incremental history it was resuming
+    /// from, and therefore cannot describe what changed while it was away: a
+    /// `PostgreSQL` replication slot that was dropped or invalidated, and by
+    /// extension any equivalent (a purged binlog, an expired stream shard). The
+    /// changes that were missed are gone from the source's log, so no sequence
+    /// of change rows can reconstruct them — only re-reading the table can.
+    ///
+    /// The consumer answers this by re-reading the source into the accelerator
+    /// as a single atomic replacement (the `refresh_mode: full` write path)
+    /// before resuming the stream. It must not be answered by clearing the
+    /// table and letting the stream refill it: that is observable to queries as
+    /// an empty, then partially-filled, table.
+    ///
+    /// Carried as its own zero-row envelope (see
+    /// [`build_history_unavailable_envelope`]) so it is ordered in the stream
+    /// rather than racing it.
+    #[must_use]
+    pub fn history_unavailable(&self) -> bool {
+        self.history_unavailable
     }
 
     /// Returns `true` if processing this envelope means the dataset can be
@@ -600,8 +634,14 @@ impl ChangeEnvelope {
 }
 
 /// The parts of a consumed [`ChangeEnvelope`]: committer, built change batch,
-/// and dataset-ready flag.
-pub type ChangeEnvelopeParts = (Box<dyn CommitChange + Send + Sync>, ChangeBatch, bool);
+/// dataset-ready flag, and rebuild-required flag.
+///
+/// Every field is carried explicitly rather than defaulted on reconstruction:
+/// a consumer that decomposes an envelope and rebuilds it (indexing, embedding,
+/// full-text wrapping) must forward the flags, and dropping one is a silent
+/// correctness bug rather than a compile error if the tuple hides it. See
+/// [`ChangeEnvelope::history_unavailable`].
+pub type ChangeEnvelopeParts = (Box<dyn CommitChange + Send + Sync>, ChangeBatch, bool, bool);
 
 /// Run a CDC batch build off the async worker, but only when it would actually
 /// block: an already-materialized build is a no-op, and `spawn_blocking`
@@ -796,6 +836,28 @@ pub fn build_heartbeat_envelope(
 /// the readiness contract.
 pub fn build_ready_signal_envelope(schema: &SchemaRef) -> Result<ChangeEnvelope, ChangeBatchError> {
     build_heartbeat_envelope(schema, None, true)
+}
+
+/// Construct a zero-row [`ChangeEnvelope`] that asks the consumer to rebuild the
+/// accelerator from the source before applying anything further — see
+/// [`ChangeEnvelope::history_unavailable`] for when a source must emit one.
+///
+/// Zero rows and a no-op committer, like the readiness and heartbeat signals:
+/// it carries no data and acknowledges no source position. It is emitted
+/// *before* the changes it precedes, so the rebuild is ordered ahead of them
+/// rather than racing them, and `is_dataset_ready` is false because a dataset
+/// whose accelerator is about to be replaced is not ready to serve.
+pub fn build_history_unavailable_envelope(
+    schema: &SchemaRef,
+) -> Result<ChangeEnvelope, ChangeBatchError> {
+    let (committer, batch, is_dataset_ready, _) =
+        build_heartbeat_envelope(schema, None, false)?.into_parts()?;
+    Ok(ChangeEnvelope::from_parts(
+        committer,
+        batch,
+        is_dataset_ready,
+        true,
+    ))
 }
 
 /// Lag-based readiness predicate shared by CDC connectors: returns `true` when
@@ -1813,7 +1875,7 @@ mod deferred_tests {
             },
             true,
         );
-        let (_committer, batch, ready) = env.into_parts().expect("into_parts builds ok");
+        let (_committer, batch, ready, _) = env.into_parts().expect("into_parts builds ok");
         assert_eq!(batch.record.num_rows(), 1);
         assert!(ready);
         assert_eq!(builds.load(Ordering::SeqCst), 1);
@@ -1886,7 +1948,7 @@ mod deferred_tests {
         assert_eq!(
             parts
                 .iter()
-                .map(|(_, batch, _)| batch.record.num_rows())
+                .map(|(_, batch, _, _)| batch.record.num_rows())
                 .collect::<Vec<_>>(),
             vec![1, 2, 3],
             "burst order must be preserved — committers pair with their batches"
@@ -1911,7 +1973,7 @@ mod deferred_tests {
         assert_eq!(
             parts
                 .iter()
-                .map(|(_, batch, ready)| (batch.record.num_rows(), *ready))
+                .map(|(_, batch, ready, _)| (batch.record.num_rows(), *ready))
                 .collect::<Vec<_>>(),
             vec![(2, false), (4, true)]
         );
@@ -2063,11 +2125,33 @@ mod deferred_tests {
         let ready = build_ready_signal_envelope(&schema).expect("ready envelope builds");
         assert!(ready.is_no_op_heartbeat());
 
+        // The history-unavailable signal is ALSO a droppable heartbeat by this
+        // predicate — zero rows, no-op committer — which is why a consumer must
+        // read `history_unavailable` BEFORE stripping heartbeats from the write
+        // path. Asserted here so the overlap stays visible: silently stripping it
+        // would skip the rebuild and resume streaming onto stale rows.
+        let reload = build_history_unavailable_envelope(&schema)
+            .expect("history-unavailable envelope builds");
+        assert!(
+            reload.is_no_op_heartbeat(),
+            "the signal carries no rows and no committer, so heartbeat stripping would drop it"
+        );
+        assert!(reload.history_unavailable());
+        assert!(
+            !reload.is_dataset_ready(),
+            "a dataset whose accelerator is about to be replaced is not ready to serve"
+        );
+
+        // Every other envelope must leave the flag clear, so only a source that
+        // actually lost its history can trigger a full re-read.
+        assert!(!heartbeat.history_unavailable());
+        assert!(!ready.history_unavailable());
+
         // A zero-row envelope re-wrapped with a REAL committer (the MySQL
         // snapshot-boundary pattern) must NOT be treated as a heartbeat: its
         // commit persists source progress and needs durability-then-commit
         // ordering.
-        let (_, boundary_batch, _) = build_heartbeat_envelope(&schema, None, false)
+        let (_, boundary_batch, _, _) = build_heartbeat_envelope(&schema, None, false)
             .expect("boundary batch builds")
             .into_parts()
             .expect("already built");

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -917,7 +917,7 @@ async fn attach_member(
         let schema_mismatch = |e: crate::cdc::ChangeBatchError| Error::SchemaMismatch {
             message: e.to_string(),
         };
-        let (_, boundary_batch, _) = crate::cdc::build_heartbeat_envelope(&schema, None, false)
+        let (_, boundary_batch, _, _) = crate::cdc::build_heartbeat_envelope(&schema, None, false)
             .map_err(schema_mismatch)?
             .into_parts()
             .map_err(schema_mismatch)?;
@@ -928,6 +928,10 @@ async fn attach_member(
                 dataset: dataset_for_boundary,
             }),
             boundary_batch,
+            false,
+            // Not a history-unavailable signal: this boundary envelope exists to
+            // persist the snapshot head, and MySQL's own purged-binlog case is
+            // not wired to this mechanism.
             false,
         );
         Box::pin(
@@ -2237,10 +2241,11 @@ async fn rebootstrap_member(
     let schema_mismatch = |e: crate::cdc::ChangeBatchError| Error::SchemaMismatch {
         message: e.to_string(),
     };
-    let (_, boundary_batch, _) = crate::cdc::build_heartbeat_envelope(&member.schema, None, false)
-        .map_err(schema_mismatch)?
-        .into_parts()
-        .map_err(schema_mismatch)?;
+    let (_, boundary_batch, _, _) =
+        crate::cdc::build_heartbeat_envelope(&member.schema, None, false)
+            .map_err(schema_mismatch)?
+            .into_parts()
+            .map_err(schema_mismatch)?;
     let boundary = ChangeEnvelope::from_parts(
         Box::new(SnapshotBoundaryCommitter {
             source: Arc::clone(source),
@@ -2248,6 +2253,8 @@ async fn rebootstrap_member(
             dataset: member.dataset_name.clone(),
         }),
         boundary_batch,
+        false,
+        // See the sibling boundary envelope: not a history-unavailable signal.
         false,
     );
     if member.sender.send(Ok(boundary)).await.is_err() {

--- a/crates/data_components/src/postgres_replication/mod.rs
+++ b/crates/data_components/src/postgres_replication/mod.rs
@@ -203,20 +203,35 @@ pub struct AppliedLsn {
 /// The whole gap decision, as arithmetic rather than inference:
 ///
 /// * `watermark` — the LSN the acceleration's contents are complete as of, or
-///   `None` when it has never been loaded.
+///   `None` when none has been recorded.
 /// * `slot_restart_lsn` — the earliest LSN the slot can still stream from, or
 ///   `None` when the slot does not exist.
+/// * `absence_implies_gap` — whether a *missing* watermark is evidence of one.
+///   True when the acceleration survives restarts (so it can hold rows this
+///   process did not load) and a position could have been recorded (so absence
+///   is informative rather than permanent).
 ///
 /// A watermark the slot cannot reach is a gap nothing can fill: the changes in
 /// between are gone from the source's log, so a row deleted there would never be
 /// deleted here. Rebuilding re-reads the table; resuming would keep it forever.
+///
+/// A *missing* watermark is not proof of an empty acceleration. It is also what
+/// an acceleration written by a version that never recorded one looks like, and
+/// what one whose watermark write failed looks like. Both can hold rows, and both
+/// can be missing deletions for exactly the same reason. So a durable
+/// acceleration with no recorded position is rebuilt rather than assumed fresh:
+/// on a genuinely first load the rebuild reads the same rows the bootstrap would
+/// have, and on an upgraded one it repairs divergence that is already there.
 #[must_use]
-pub fn needs_rebuild(watermark: Option<AppliedLsn>, slot_restart_lsn: Option<u64>) -> bool {
+pub fn needs_rebuild(
+    watermark: Option<AppliedLsn>,
+    slot_restart_lsn: Option<u64>,
+    absence_implies_gap: bool,
+) -> bool {
     match watermark {
-        // Never loaded, so there is nothing to be inconsistent with — a first
-        // bootstrap, not a gap. Also every ephemeral acceleration, whose store
-        // records nothing because it boots empty and re-snapshots each start.
-        None => false,
+        // Nothing recorded: a gap only when absence is informative — see
+        // `absence_implies_gap`.
+        None => absence_implies_gap,
         // A gap when there is no slot at all, or when the slot's earliest
         // retained position is already past the watermark.
         Some(watermark) => slot_restart_lsn.is_none_or(|earliest| earliest > watermark.lsn),
@@ -232,6 +247,17 @@ pub fn needs_rebuild(watermark: Option<AppliedLsn>, slot_restart_lsn: Option<u64
 /// [`ReplicationStreamInput`].
 #[async_trait::async_trait]
 pub trait AppliedLsnStore: Send + Sync {
+    /// Whether this store can actually record a position.
+    ///
+    /// A store that cannot (see [`NoopAppliedLsnStore`]) makes the *absence* of a
+    /// watermark meaningless: it proves nothing about what the acceleration
+    /// holds, and no start will ever record one. Rebuilding on absence would then
+    /// re-read the whole table on every restart, forever, so absence is treated
+    /// as it was before watermarks existed.
+    fn records_positions(&self) -> bool {
+        true
+    }
+
     /// The recorded position, or `None` when this acceleration has never been
     /// loaded — a first bootstrap, not a gap.
     async fn load(
@@ -256,6 +282,10 @@ pub struct NoopAppliedLsnStore;
 
 #[async_trait::async_trait]
 impl AppliedLsnStore for NoopAppliedLsnStore {
+    fn records_positions(&self) -> bool {
+        false
+    }
+
     async fn load(
         &self,
     ) -> std::result::Result<Option<AppliedLsn>, Box<dyn std::error::Error + Send + Sync>> {
@@ -399,39 +429,52 @@ mod tests {
     #[test]
     fn a_watermark_the_slot_cannot_reach_is_the_only_thing_that_forces_a_rebuild() {
         let at = |lsn| Some(AppliedLsn { lsn });
+        // A recorded watermark makes durability irrelevant: the comparison alone
+        // decides, so these cases are asserted against a persisting acceleration.
+        let needs_rebuild_persist = |watermark, restart| needs_rebuild(watermark, restart, true);
 
-        // Never loaded: a first bootstrap, not a gap. Snapshot-and-append is
-        // exactly right, and this is also every ephemeral acceleration (whose
-        // store records nothing because it boots empty).
-        assert!(!needs_rebuild(None, Some(100)));
+        // Nothing recorded, and the acceleration boots empty: a first bootstrap,
+        // not a gap. Snapshot-and-append is exactly right.
+        assert!(!needs_rebuild(None, Some(100), false));
         assert!(
-            !needs_rebuild(None, None),
-            "a first load with no slot yet is still a first load"
+            !needs_rebuild(None, None, false),
+            "an ephemeral acceleration with no slot yet is still a first load"
         );
+
+        // Nothing recorded, but the acceleration persists: it may be holding rows
+        // from a version that never recorded a watermark, or from a start whose
+        // watermark write failed — either can already be missing deletions.
+        // Rebuilding costs a re-read on a genuinely first load and repairs the
+        // rest, so absence must not be read as emptiness.
+        assert!(needs_rebuild(None, Some(100), true));
+        assert!(needs_rebuild(None, None, true));
 
         // The slot still holds WAL from at or before the watermark, so the gap is
         // replayable: resume.
-        assert!(!needs_rebuild(at(100), Some(100)), "exactly reachable");
         assert!(
-            !needs_rebuild(at(100), Some(40)),
+            !needs_rebuild_persist(at(100), Some(100)),
+            "exactly reachable"
+        );
+        assert!(
+            !needs_rebuild_persist(at(100), Some(40)),
             "slot reaches further back"
         );
 
         // The slot's earliest position is past the watermark: the changes in
         // between are gone from the source's log and cannot be replayed.
         assert!(
-            needs_rebuild(at(100), Some(101)),
+            needs_rebuild_persist(at(100), Some(101)),
             "one byte past is still a gap"
         );
-        assert!(needs_rebuild(at(100), Some(u64::MAX)));
+        assert!(needs_rebuild_persist(at(100), Some(u64::MAX)));
 
         // No slot at all reaches nothing.
-        assert!(needs_rebuild(at(100), None));
+        assert!(needs_rebuild_persist(at(100), None));
 
         // An unreadable watermark is reported by the caller as position 0, which
         // must resolve to a rebuild against any real slot position rather than
         // being mistaken for "never loaded".
-        assert!(needs_rebuild(at(0), Some(1)));
-        assert!(needs_rebuild(at(0), None));
+        assert!(needs_rebuild_persist(at(0), Some(1)));
+        assert!(needs_rebuild_persist(at(0), None));
     }
 }

--- a/crates/data_components/src/postgres_replication/mod.rs
+++ b/crates/data_components/src/postgres_replication/mod.rs
@@ -183,6 +183,95 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// The LSN an acceleration's contents are complete as of, as recorded locally.
+///
+/// `PostgreSQL` CDC has historically kept no client-side position at all — it
+/// relied on the slot's server-tracked `confirmed_flush_lsn`, which is precisely
+/// what disappears when a slot is dropped or invalidated. Recording the position
+/// locally (the same thing `MySQL` does with `spice_sys_mysql_binlog`) is what
+/// lets startup *compute* whether the source can still supply the missing
+/// changes instead of inferring it from slot and publication state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AppliedLsn {
+    /// Every change committed at or before this LSN is durably reflected in the
+    /// acceleration.
+    pub lsn: u64,
+}
+
+/// Whether the acceleration must be rebuilt from the source rather than resumed.
+///
+/// The whole gap decision, as arithmetic rather than inference:
+///
+/// * `watermark` — the LSN the acceleration's contents are complete as of, or
+///   `None` when it has never been loaded.
+/// * `slot_restart_lsn` — the earliest LSN the slot can still stream from, or
+///   `None` when the slot does not exist.
+///
+/// A watermark the slot cannot reach is a gap nothing can fill: the changes in
+/// between are gone from the source's log, so a row deleted there would never be
+/// deleted here. Rebuilding re-reads the table; resuming would keep it forever.
+#[must_use]
+pub fn needs_rebuild(watermark: Option<AppliedLsn>, slot_restart_lsn: Option<u64>) -> bool {
+    match watermark {
+        // Never loaded, so there is nothing to be inconsistent with — a first
+        // bootstrap, not a gap. Also every ephemeral acceleration, whose store
+        // records nothing because it boots empty and re-snapshots each start.
+        None => false,
+        // A gap when there is no slot at all, or when the slot's earliest
+        // retained position is already past the watermark.
+        Some(watermark) => slot_restart_lsn.is_none_or(|earliest| earliest > watermark.lsn),
+    }
+}
+
+/// Durable, client-side record of how far a dataset's acceleration has been
+/// advanced, so a restart can tell a resumable gap from an unfillable one.
+///
+/// Mirrors `mysql_replication::PositionStore`: implemented on the runtime side
+/// over a `spice_sys` sidecar table (the replication layer cannot reach the
+/// accelerator's own store), and supplied per dataset on
+/// [`ReplicationStreamInput`].
+#[async_trait::async_trait]
+pub trait AppliedLsnStore: Send + Sync {
+    /// The recorded position, or `None` when this acceleration has never been
+    /// loaded — a first bootstrap, not a gap.
+    async fn load(
+        &self,
+    ) -> std::result::Result<Option<AppliedLsn>, Box<dyn std::error::Error + Send + Sync>>;
+    /// Record `applied` as durably reflected in the acceleration. Called only
+    /// after the corresponding changes are durable, never before.
+    async fn save(
+        &self,
+        applied: AppliedLsn,
+    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
+    /// Forget the recorded position, so the next start treats the acceleration
+    /// as never loaded.
+    async fn clear(&self) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
+}
+
+/// An [`AppliedLsnStore`] that persists nothing, for an acceleration that does
+/// not survive a restart. There is no state a resumed position could be
+/// consistent with — such an accelerator boots empty and re-snapshots every
+/// start — so recording one would only invite a resume that skipped its rows.
+pub struct NoopAppliedLsnStore;
+
+#[async_trait::async_trait]
+impl AppliedLsnStore for NoopAppliedLsnStore {
+    async fn load(
+        &self,
+    ) -> std::result::Result<Option<AppliedLsn>, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(None)
+    }
+    async fn save(
+        &self,
+        _applied: AppliedLsn,
+    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
+    async fn clear(&self) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
+}
+
 /// Input required to start a replication stream for a single dataset.
 pub struct ReplicationStreamInput {
     /// Dataset name as it will appear in `ChangeBatch` commits.
@@ -210,6 +299,13 @@ pub struct ReplicationStreamInput {
     /// connector maps the dataset's `on_schema_change`); [`start_replication_stream`]
     /// consumes it as-is, and [`start_replication_stream_with_policy`] overrides it.
     pub policy: SchemaEvolutionPolicy,
+    /// Where this dataset's applied-LSN watermark is read and written.
+    ///
+    /// Supplied by the connector: a `spice_sys`-backed store for an acceleration
+    /// that survives restarts, [`NoopAppliedLsnStore`] for one that does not.
+    /// Startup compares the loaded watermark against what the slot can still
+    /// supply to decide between resuming and rebuilding.
+    pub applied_lsn_store: Arc<dyn AppliedLsnStore>,
 }
 
 /// Starts the bootstrap+WAL replication stream.
@@ -289,4 +385,53 @@ fn stream_error(err: &Error) -> StreamError {
 )]
 pub(crate) fn err_to_stream(err: Error) -> StreamError {
     stream_error(&err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AppliedLsn, needs_rebuild};
+
+    /// The gap decision is the correctness hinge of the rebuild path: a wrong
+    /// `false` resumes over rows the source has deleted (silent divergence, the
+    /// bug this exists to fix), while a wrong `true` costs a needless re-read of
+    /// the table. Each case is asserted individually rather than trusting the
+    /// comparison to read correctly.
+    #[test]
+    fn a_watermark_the_slot_cannot_reach_is_the_only_thing_that_forces_a_rebuild() {
+        let at = |lsn| Some(AppliedLsn { lsn });
+
+        // Never loaded: a first bootstrap, not a gap. Snapshot-and-append is
+        // exactly right, and this is also every ephemeral acceleration (whose
+        // store records nothing because it boots empty).
+        assert!(!needs_rebuild(None, Some(100)));
+        assert!(
+            !needs_rebuild(None, None),
+            "a first load with no slot yet is still a first load"
+        );
+
+        // The slot still holds WAL from at or before the watermark, so the gap is
+        // replayable: resume.
+        assert!(!needs_rebuild(at(100), Some(100)), "exactly reachable");
+        assert!(
+            !needs_rebuild(at(100), Some(40)),
+            "slot reaches further back"
+        );
+
+        // The slot's earliest position is past the watermark: the changes in
+        // between are gone from the source's log and cannot be replayed.
+        assert!(
+            needs_rebuild(at(100), Some(101)),
+            "one byte past is still a gap"
+        );
+        assert!(needs_rebuild(at(100), Some(u64::MAX)));
+
+        // No slot at all reaches nothing.
+        assert!(needs_rebuild(at(100), None));
+
+        // An unreadable watermark is reported by the caller as position 0, which
+        // must resolve to a rebuild against any real slot position rather than
+        // being mistaken for "never loaded".
+        assert!(needs_rebuild(at(0), Some(1)));
+        assert!(needs_rebuild(at(0), None));
+    }
 }

--- a/crates/data_components/src/postgres_replication/mod.rs
+++ b/crates/data_components/src/postgres_replication/mod.rs
@@ -224,18 +224,44 @@ pub struct AppliedLsn {
 /// have, and on an upgraded one it repairs divergence that is already there.
 #[must_use]
 pub fn needs_rebuild(
-    watermark: Option<AppliedLsn>,
+    position: &RecordedPosition,
     slot_restart_lsn: Option<u64>,
     absence_implies_gap: bool,
 ) -> bool {
-    match watermark {
+    match position {
         // Nothing recorded: a gap only when absence is informative — see
         // `absence_implies_gap`.
-        None => absence_implies_gap,
+        RecordedPosition::Absent => absence_implies_gap,
+        // Recorded against a different source. Whatever the acceleration holds
+        // came from somewhere else, and the LSN is not even comparable — a small
+        // LSN from the new source would otherwise read as "already covered" and
+        // leave the old source's rows in place while never loading the new
+        // source's.
+        RecordedPosition::ForeignSource => true,
         // A gap when there is no slot at all, or when the slot's earliest
         // retained position is already past the watermark.
-        Some(watermark) => slot_restart_lsn.is_none_or(|earliest| earliest > watermark.lsn),
+        RecordedPosition::At(watermark) => {
+            slot_restart_lsn.is_none_or(|earliest| earliest > watermark.lsn)
+        }
     }
+}
+
+/// What the local record says about an acceleration's position.
+///
+/// Three outcomes rather than `Option`, because "recorded against a different
+/// source" is neither "no record" nor a usable position: LSNs are only
+/// comparable within one source's history, so a watermark carried over to a
+/// different server, database, or table describes contents that have nothing to
+/// do with what this dataset now streams.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RecordedPosition {
+    /// Nothing recorded.
+    Absent,
+    /// A position exists, but for a different source than this dataset streams
+    /// from now. Its LSN cannot be compared and its contents cannot be trusted.
+    ForeignSource,
+    /// A position recorded against this same source.
+    At(AppliedLsn),
 }
 
 /// Durable, client-side record of how far a dataset's acceleration has been
@@ -258,11 +284,11 @@ pub trait AppliedLsnStore: Send + Sync {
         true
     }
 
-    /// The recorded position, or `None` when this acceleration has never been
-    /// loaded — a first bootstrap, not a gap.
+    /// The recorded position — see [`RecordedPosition`] for why a record made
+    /// against a different source is reported distinctly from no record at all.
     async fn load(
         &self,
-    ) -> std::result::Result<Option<AppliedLsn>, Box<dyn std::error::Error + Send + Sync>>;
+    ) -> std::result::Result<RecordedPosition, Box<dyn std::error::Error + Send + Sync>>;
     /// Record `applied` as durably reflected in the acceleration. Called only
     /// after the corresponding changes are durable, never before.
     async fn save(
@@ -288,8 +314,8 @@ impl AppliedLsnStore for NoopAppliedLsnStore {
 
     async fn load(
         &self,
-    ) -> std::result::Result<Option<AppliedLsn>, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(None)
+    ) -> std::result::Result<RecordedPosition, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(RecordedPosition::Absent)
     }
     async fn save(
         &self,
@@ -419,7 +445,7 @@ pub(crate) fn err_to_stream(err: Error) -> StreamError {
 
 #[cfg(test)]
 mod tests {
-    use super::{AppliedLsn, needs_rebuild};
+    use super::{AppliedLsn, RecordedPosition, needs_rebuild};
 
     /// The gap decision is the correctness hinge of the rebuild path: a wrong
     /// `false` resumes over rows the source has deleted (silent divergence, the
@@ -428,16 +454,17 @@ mod tests {
     /// comparison to read correctly.
     #[test]
     fn a_watermark_the_slot_cannot_reach_is_the_only_thing_that_forces_a_rebuild() {
-        let at = |lsn| Some(AppliedLsn { lsn });
+        let at = |lsn| RecordedPosition::At(AppliedLsn { lsn });
         // A recorded watermark makes durability irrelevant: the comparison alone
         // decides, so these cases are asserted against a persisting acceleration.
-        let needs_rebuild_persist = |watermark, restart| needs_rebuild(watermark, restart, true);
+        let needs_rebuild_persist =
+            |position: RecordedPosition, restart| needs_rebuild(&position, restart, true);
 
         // Nothing recorded, and the acceleration boots empty: a first bootstrap,
         // not a gap. Snapshot-and-append is exactly right.
-        assert!(!needs_rebuild(None, Some(100), false));
+        assert!(!needs_rebuild(&RecordedPosition::Absent, Some(100), false));
         assert!(
-            !needs_rebuild(None, None, false),
+            !needs_rebuild(&RecordedPosition::Absent, None, false),
             "an ephemeral acceleration with no slot yet is still a first load"
         );
 
@@ -446,8 +473,23 @@ mod tests {
         // watermark write failed — either can already be missing deletions.
         // Rebuilding costs a re-read on a genuinely first load and repairs the
         // rest, so absence must not be read as emptiness.
-        assert!(needs_rebuild(None, Some(100), true));
-        assert!(needs_rebuild(None, None, true));
+        assert!(needs_rebuild(&RecordedPosition::Absent, Some(100), true));
+        assert!(needs_rebuild(&RecordedPosition::Absent, None, true));
+
+        // A position recorded against another source is never usable, whatever
+        // the slot says and whatever the acceleration's durability: its LSN is
+        // not comparable and its contents describe a different table.
+        assert!(needs_rebuild(
+            &RecordedPosition::ForeignSource,
+            Some(0),
+            true
+        ));
+        assert!(needs_rebuild(
+            &RecordedPosition::ForeignSource,
+            Some(0),
+            false
+        ));
+        assert!(needs_rebuild(&RecordedPosition::ForeignSource, None, false));
 
         // The slot still holds WAL from at or before the watermark, so the gap is
         // replayable: resume.

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -888,6 +888,7 @@ fn snapshot_watermark_envelope(
     applied_lsn_store: Arc<dyn AppliedLsnStore>,
     lsn: u64,
     dataset: String,
+    history_unavailable: bool,
 ) -> std::result::Result<ChangeEnvelope, StreamError> {
     let (_, batch, _, _) = crate::cdc::build_heartbeat_envelope(schema, None, false)
         .map_err(|e| StreamError::External(e.to_string()))?
@@ -900,10 +901,9 @@ fn snapshot_watermark_envelope(
             dataset,
         }),
         batch,
-        // Readiness stays lag-based, and this envelope is not a rebuild request:
-        // it only records where the snapshot left off.
+        // Readiness stays lag-based: an acceleration being loaded is not ready.
         false,
-        false,
+        history_unavailable,
     ))
 }
 
@@ -1998,7 +1998,24 @@ async fn attach_member(
             Some(AppliedLsn { lsn: 0 })
         }
     };
-    let rebuild_via_consumer = super::needs_rebuild(watermark, setup.slot_restart_lsn);
+    // Absence of a watermark is evidence of a gap only when the acceleration
+    // could be holding rows this process did not load AND a position could have
+    // been recorded. An ephemeral acceleration boots empty, so absence means
+    // nothing is there; a store that cannot record (no durable sidecar) makes
+    // absence permanent, and rebuilding on it would re-read the whole table on
+    // every restart rather than once.
+    let tracks_positions = applied_lsn_store.records_positions();
+    if !params.ephemeral_accelerator && !tracks_positions {
+        tracing::warn!(
+            dataset = %dataset_name,
+            "this acceleration persists across restarts but has nowhere to record how far it has been advanced, so a replication slot that is dropped or invalidated cannot be detected and rows deleted at the source while it was gone would survive here"
+        );
+    }
+    let rebuild_via_consumer = super::needs_rebuild(
+        watermark,
+        setup.slot_restart_lsn,
+        !params.ephemeral_accelerator && tracks_positions,
+    );
 
     let (sender, receiver) = member_mailbox(params.member_channel_capacity);
     // Grouping signal for the analysis: record which shared slot this dataset joined.
@@ -2098,11 +2115,24 @@ async fn attach_member(
         // snapshot. The consumer applies nothing further until the reload
         // completes, so the WAL that follows lands on top of it — back-pressure
         // in the member mailbox is what orders the two.
-        let signal_schema = Arc::clone(&schema);
-        let signal = stream::once(async move {
-            crate::cdc::build_history_unavailable_envelope(&signal_schema)
-                .map_err(|e| StreamError::External(e.to_string()))
-        });
+        // The signal carries the watermark committer, not a no-op one, so the
+        // position is recorded when the consumer finishes the rebuild and commits
+        // it. Without that, a rebuild would leave no watermark behind and the
+        // very next start would rebuild again — re-reading the whole table on
+        // every restart of a dataset whose source happens to be quiet.
+        //
+        // A real committer also keeps this envelope out of the consumer's
+        // heartbeat stripping (which requires a no-op committer), so it reaches
+        // the write path and is committed with the usual durability-then-commit
+        // ordering.
+        let signal_item = snapshot_watermark_envelope(
+            &schema,
+            Arc::clone(&applied_lsn_store),
+            setup.slot.consistent_lsn,
+            dataset_name.clone(),
+            true,
+        );
+        let signal = stream::once(async move { signal_item });
         tracing::warn!(
             dataset = %dataset_name,
             table = %format_member(&member_key),
@@ -2121,6 +2151,7 @@ async fn attach_member(
             Arc::clone(&applied_lsn_store),
             setup.slot.consistent_lsn,
             dataset_name.clone(),
+            false,
         );
         let snapshot = bootstrap::snapshot_stream(bootstrap::SnapshotInput {
             params: params.clone(),
@@ -2146,20 +2177,38 @@ async fn attach_member(
         let hook_source = Arc::clone(source);
         let hook_key = member_key.clone();
         let mut hook_fired = false;
+        let flip_error_flag = Arc::clone(&saw_error);
         let bootstrap_finished = stream::poll_fn(move |_| {
             if !hook_fired {
                 hook_fired = true;
-                if !saw_error.load(Ordering::Acquire) {
+                if !flip_error_flag.load(Ordering::Acquire) {
                     hook_source.ack.snapshot_finished(&hook_key);
                     hook_source.restart_requested.store(true, Ordering::Release);
                 }
             }
             std::task::Poll::Ready(None)
         });
-        // Record the snapshot's position as soon as its rows are durable, then
-        // flip the member live. The boundary envelope's committer cannot be
-        // deferred, so it runs only after the snapshot is durably applied.
-        let boundary = stream::once(async move { watermark_boundary });
+        // Record the snapshot's position, but ONLY for a snapshot that completed
+        // cleanly — gated on the same flag as the live flip above.
+        //
+        // A failed snapshot ends its stream after yielding the error, so without
+        // this gate the boundary would still be reached and could record a
+        // watermark for an acceleration that is missing base rows. The next start
+        // would then find that watermark reachable, resume, and never load the
+        // rows the snapshot never delivered.
+        //
+        // The committer itself cannot be deferred, so when it does run, the
+        // snapshot's rows are already durable.
+        let mut boundary_item = Some(watermark_boundary);
+        let boundary = stream::poll_fn(move |_| {
+            let Some(item) = boundary_item.take() else {
+                return std::task::Poll::Ready(None);
+            };
+            if saw_error.load(Ordering::Acquire) {
+                return std::task::Poll::Ready(None);
+            }
+            std::task::Poll::Ready(Some(item))
+        });
         Box::pin(snapshot.chain(boundary).chain(bootstrap_finished))
     } else {
         metrics.mark_bootstrap_complete();

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -1934,7 +1934,7 @@ async fn attach_member(
     }
 
     // Slot + publication DDL (idempotent, retried on transient errors).
-    let setup = slot::setup_shared_member(&source.params, &schema_name, &table_name).await?;
+    let mut setup = slot::setup_shared_member(&source.params, &schema_name, &table_name).await?;
     if setup.slot.created_fresh {
         source.slot_created_fresh.store(true, Ordering::Release);
     }
@@ -1989,13 +1989,14 @@ async fn attach_member(
         Ok(watermark) => watermark,
         Err(e) => {
             // Reading it failed, so we cannot prove the gap is fillable. Treat it
-            // as unfillable: a needless rebuild costs a re-read, while a wrong
-            // resume silently keeps rows the source has deleted.
+            // the same as a position belonging to another source — unusable — so
+            // the acceleration is rebuilt: a needless rebuild costs a re-read,
+            // while a wrong resume silently keeps rows the source has deleted.
             tracing::warn!(
                 dataset = %dataset_name,
                 "could not read how far this acceleration has been advanced, so it will be rebuilt from the source rather than resumed on an unproven position: {e}"
             );
-            Some(AppliedLsn { lsn: 0 })
+            super::RecordedPosition::ForeignSource
         }
     };
     // Absence of a watermark is evidence of a gap only when the acceleration
@@ -2012,10 +2013,36 @@ async fn attach_member(
         );
     }
     let rebuild_via_consumer = super::needs_rebuild(
-        watermark,
+        &watermark,
         setup.slot_restart_lsn,
         !params.ephemeral_accelerator && tracks_positions,
     );
+
+    // Resume from the watermark, not from the server's acknowledged position,
+    // whenever the watermark is behind it.
+    //
+    // The two can disagree: the slot ack is advanced by the same commit that
+    // records the watermark, but the ack reaches the server through the pump's
+    // status updates while the watermark is a local write that can fail or be
+    // interrupted. The server's `confirmed_flush_lsn` is what streaming would
+    // otherwise resume from, so a watermark behind it means the interval between
+    // them was acknowledged but never recorded as applied — and resuming at the
+    // server's position would skip it silently. The WAL for that interval is
+    // still retained (`restart_lsn` is at or before the watermark, or this would
+    // have been a rebuild), so replaying it is both possible and idempotent
+    // through the primary-key upsert.
+    if let super::RecordedPosition::At(watermark) = &watermark
+        && !rebuild_via_consumer
+        && setup.slot.consistent_lsn > watermark.lsn
+    {
+        tracing::warn!(
+            dataset = %dataset_name,
+            server_position = %slot::format_lsn(setup.slot.consistent_lsn),
+            recorded_position = %slot::format_lsn(watermark.lsn),
+            "this slot was acknowledged past what the acceleration recorded as applied, so streaming resumes from the recorded position and replays the difference rather than skipping it"
+        );
+        setup.slot.consistent_lsn = watermark.lsn;
+    }
 
     let (sender, receiver) = member_mailbox(params.member_channel_capacity);
     // Grouping signal for the analysis: record which shared slot this dataset joined.

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -145,9 +145,9 @@ use tokio::sync::Notify;
 use bytes::Bytes;
 
 use super::{
-    Error, ReplicationMetricsCollector, ReplicationStreamInput, Result, SchemaEvolutionPolicy,
-    bootstrap, changes::PgChangeRows, client, config::ReplicationParams, pgoutput, resilience,
-    schema_evolution::RelationSchemaTracker, slot,
+    AppliedLsn, AppliedLsnStore, Error, ReplicationMetricsCollector, ReplicationStreamInput,
+    Result, SchemaEvolutionPolicy, bootstrap, changes::PgChangeRows, client,
+    config::ReplicationParams, pgoutput, resilience, schema_evolution::RelationSchemaTracker, slot,
 };
 use rustc_hash::FxHashMap;
 
@@ -477,6 +477,9 @@ struct MemberHandle {
     /// source-commit time is within this of now, so the dataset becomes Ready
     /// only once it has caught up to the source head.
     ready_lag: std::time::Duration,
+    /// Where this member's applied-LSN watermark is recorded; cloned into each
+    /// envelope's committer. See `SharedLsnCommitter::applied_lsn_store`.
+    applied_lsn_store: Arc<dyn AppliedLsnStore>,
 }
 
 /// `LIVE`: the member is attached and routing to it is allowed. Cleared on
@@ -800,12 +803,40 @@ struct SharedLsnCommitter {
     /// Source-commit timestamp (ms since the Unix epoch) of the batch this
     /// commit acks; `None` when the transaction carried no commit time.
     source_commit_ts_ms: Option<i64>,
+    /// Where this member's applied-LSN watermark is recorded.
+    ///
+    /// Written from [`CommitChange::commit`] specifically, which is the only
+    /// point at which the acked changes are known durable: this committer
+    /// supports deferral, so under an in-memory CDC durability tier the runtime
+    /// holds it until the covering checkpoint is durable
+    /// (`SlotAdvancer::on_checkpoint_durable`). Recording the watermark anywhere
+    /// earlier — when a batch reaches the memory tier — would claim rows a
+    /// restart loses, and the next start would then resume *past* changes the
+    /// acceleration never durably received.
+    applied_lsn_store: Arc<dyn AppliedLsnStore>,
 }
 
 #[async_trait]
 impl CommitChange for SharedLsnCommitter {
     async fn commit(&self) -> std::result::Result<(), CommitError> {
         self.slot.commit(self.flush_to);
+        // Record the watermark alongside the slot ack, never ahead of it. A
+        // failure here is logged rather than surfaced: the ack already happened,
+        // so failing the commit would stall CDC over bookkeeping, and a stale
+        // watermark only ever costs a redundant rebuild on the next start —
+        // whereas a watermark ahead of durable data would resume past changes
+        // the acceleration does not hold.
+        if let Err(e) = self
+            .applied_lsn_store
+            .save(AppliedLsn { lsn: self.flush_to })
+            .await
+        {
+            tracing::warn!(
+                dataset = %self.dataset,
+                "could not record how far this acceleration has been advanced (lsn={}); if the process restarts before this succeeds, the acceleration is rebuilt from the source rather than resumed: {e}",
+                self.flush_to,
+            );
+        }
         crate::cdc::log_committer_progress(
             "postgres",
             &self.dataset,
@@ -849,11 +880,88 @@ impl CommitChange for SharedLsnCommitter {
 /// A shared-slot `PostgreSQL` envelope before it crosses the member stream
 /// boundary. It keeps pgoutput messages raw so adjacent source transactions can
 /// be folded without tuple decoding or Arrow construction on the pump.
+/// The zero-row boundary envelope that carries a
+/// [`SnapshotWatermarkCommitter`], or the stream error if its (empty) batch
+/// cannot be built.
+fn snapshot_watermark_envelope(
+    schema: &SchemaRef,
+    applied_lsn_store: Arc<dyn AppliedLsnStore>,
+    lsn: u64,
+    dataset: String,
+) -> std::result::Result<ChangeEnvelope, StreamError> {
+    let (_, batch, _, _) = crate::cdc::build_heartbeat_envelope(schema, None, false)
+        .map_err(|e| StreamError::External(e.to_string()))?
+        .into_parts()
+        .map_err(|e| StreamError::External(e.to_string()))?;
+    Ok(ChangeEnvelope::from_parts(
+        Box::new(SnapshotWatermarkCommitter {
+            applied_lsn_store,
+            lsn,
+            dataset,
+        }),
+        batch,
+        // Readiness stays lag-based, and this envelope is not a rebuild request:
+        // it only records where the snapshot left off.
+        false,
+        false,
+    ))
+}
+
+/// Records the watermark for a just-completed snapshot, as its own zero-row
+/// boundary envelope.
+///
+/// Without this the watermark is first written by the acknowledgement of a *WAL*
+/// change, so a restart in the window between "snapshot applied" and "first
+/// change acked" reads no watermark at all and treats a fully populated
+/// acceleration as a first load — appending a fresh snapshot over surviving rows,
+/// which is the silent divergence the watermark exists to prevent.
+///
+/// Deliberately does **not** override `supports_deferral`, so it inherits the
+/// conservative `false`: the consumer cannot hold this commit behind a later
+/// in-memory durability fence, which is what guarantees the snapshot's rows are
+/// durable before their watermark claims them. Same contract as
+/// `mysql_replication`'s snapshot-boundary committer.
+struct SnapshotWatermarkCommitter {
+    applied_lsn_store: Arc<dyn AppliedLsnStore>,
+    /// The LSN the snapshot's contents are complete as of: the slot's consistent
+    /// point, which is at or before the snapshot's visibility. Undershooting is
+    /// safe — replay from it re-delivers changes the snapshot already reflects —
+    /// whereas a later LSN could skip a change the snapshot did not see.
+    lsn: u64,
+    dataset: String,
+}
+
+#[async_trait]
+impl CommitChange for SnapshotWatermarkCommitter {
+    async fn commit(&self) -> std::result::Result<(), CommitError> {
+        if let Err(e) = self
+            .applied_lsn_store
+            .save(AppliedLsn { lsn: self.lsn })
+            .await
+        {
+            tracing::warn!(
+                dataset = %self.dataset,
+                "could not record the snapshot's applied position (lsn={}); the acceleration is correct, but a restart before the next acknowledgement will rebuild it from the source rather than resume: {e}",
+                self.lsn,
+            );
+        }
+        crate::cdc::log_committer_progress(
+            "postgres",
+            &self.dataset,
+            &format!("snapshot-complete lsn={}", self.lsn),
+            None,
+        );
+        Ok(())
+    }
+}
+
 struct PendingPgEnvelope {
     rows: PgChangeRows,
     slot: Arc<AckSlot>,
     flush_to: u64,
     dataset: String,
+    /// Cloned from the member; see `SharedLsnCommitter::applied_lsn_store`.
+    applied_lsn_store: Arc<dyn AppliedLsnStore>,
     is_dataset_ready: bool,
     first_received_at: std::time::Instant,
 }
@@ -886,6 +994,9 @@ impl PendingPgEnvelope {
             slot,
             flush_to,
             dataset,
+            // Same member (the `slot` pointer check above proves it), so both
+            // sides carry the same store; either may be kept.
+            applied_lsn_store,
             is_dataset_ready,
             first_received_at,
         } = other;
@@ -897,6 +1008,7 @@ impl PendingPgEnvelope {
                 slot,
                 flush_to,
                 dataset,
+                applied_lsn_store,
                 is_dataset_ready,
                 first_received_at,
             });
@@ -920,6 +1032,7 @@ impl PendingPgEnvelope {
                 flush_to: self.flush_to,
                 dataset: self.dataset,
                 source_commit_ts_ms,
+                applied_lsn_store: self.applied_lsn_store,
             }),
             Box::new(self.rows),
             self.is_dataset_ready,
@@ -1754,6 +1867,7 @@ async fn attach_member(
         table_name,
         metrics,
         policy,
+        applied_lsn_store,
     } = input;
     let member_key: MemberKey = (schema_name.clone(), table_name.clone());
 
@@ -1850,6 +1964,42 @@ async fn attach_member(
         || (!rejoining && source.slot_created_fresh.load(Ordering::Acquire));
 
     let snapshotting = need_snapshot && params.initial_snapshot;
+
+    // Is there a gap this slot cannot supply?
+    //
+    // Computed, not inferred. The watermark records the LSN the acceleration's
+    // contents are complete as of; `restart_lsn` is the earliest LSN the slot can
+    // still stream from. A watermark older than that is a gap no stream can fill:
+    // a row deleted at the source in that window has no change event left to
+    // replay, so appending snapshot rows over the survivors would leave the
+    // deletion applied at the source and never here, in every later query.
+    //
+    // The three outcomes:
+    //
+    //   * no watermark -> this acceleration has never been loaded. A first
+    //     bootstrap, not a gap: snapshot-and-append is exactly right, and this is
+    //     also every ephemeral accelerator (their store records nothing, since
+    //     they boot empty and re-snapshot every start).
+    //   * watermark, and the slot still reaches it -> resume; the WAL between the
+    //     two is still there to replay.
+    //   * watermark the slot cannot reach (or no slot at all) -> hand the reload
+    //     to the consumer, which owns the accelerator and can replace its
+    //     contents atomically (see `cdc::ChangeEnvelope::history_unavailable`).
+    let watermark = match applied_lsn_store.load().await {
+        Ok(watermark) => watermark,
+        Err(e) => {
+            // Reading it failed, so we cannot prove the gap is fillable. Treat it
+            // as unfillable: a needless rebuild costs a re-read, while a wrong
+            // resume silently keeps rows the source has deleted.
+            tracing::warn!(
+                dataset = %dataset_name,
+                "could not read how far this acceleration has been advanced, so it will be rebuilt from the source rather than resumed on an unproven position: {e}"
+            );
+            Some(AppliedLsn { lsn: 0 })
+        }
+    };
+    let rebuild_via_consumer = super::needs_rebuild(watermark, setup.slot_restart_lsn);
+
     let (sender, receiver) = member_mailbox(params.member_channel_capacity);
     // Grouping signal for the analysis: record which shared slot this dataset joined.
     // (Membership liveness is marked by `mark_member_attached` just below.)
@@ -1870,6 +2020,7 @@ async fn attach_member(
             sender,
             metrics: Arc::clone(&metrics),
             ready_lag: params.ready_lag,
+            applied_lsn_store: Arc::clone(&applied_lsn_store),
         }),
     );
     // Membership liveness is now observable (`dataset_postgres_replication_member_attached`):
@@ -1924,7 +2075,53 @@ async fn attach_member(
     // `bootstrap_finished` hook flips the member live and asks the pump to
     // reconnect — Postgres resumes from the held floor and replays the
     // member's gap (idempotent for everyone).
-    let head: ChangesStream = if snapshotting {
+    // Flips the member live and asks the pump to reconnect, so Postgres replays
+    // from the held floor. Shared by the two held-at-join arms below: after a
+    // clean snapshot, and after the consumer has been told to reload.
+    let live_flip_hook = |source: &Arc<SharedSource>, key: &MemberKey| {
+        let hook_source = Arc::clone(source);
+        let hook_key = key.clone();
+        let mut hook_fired = false;
+        stream::poll_fn(move |_| {
+            if !hook_fired {
+                hook_fired = true;
+                hook_source.ack.snapshot_finished(&hook_key);
+                hook_source.restart_requested.store(true, Ordering::Release);
+            }
+            std::task::Poll::Ready(None)
+        })
+    };
+
+    let head: ChangesStream = if rebuild_via_consumer {
+        // One zero-row envelope asking the consumer to replace the accelerator's
+        // contents from the source, then the same live-flip as a finished
+        // snapshot. The consumer applies nothing further until the reload
+        // completes, so the WAL that follows lands on top of it — back-pressure
+        // in the member mailbox is what orders the two.
+        let signal_schema = Arc::clone(&schema);
+        let signal = stream::once(async move {
+            crate::cdc::build_history_unavailable_envelope(&signal_schema)
+                .map_err(|e| StreamError::External(e.to_string()))
+        });
+        tracing::warn!(
+            dataset = %dataset_name,
+            table = %format_member(&member_key),
+            slot = %source.key.slot_name,
+            "this replication slot has no history for the table, and the acceleration persists across restarts, so it will be rebuilt from the source before changes are applied"
+        );
+        // No snapshot runs on this path — the consumer's reload replaces it — so
+        // the gauge's documented "finished, or skipped" state is reached here.
+        // Leaving it at 0 would strand every readiness probe reading it.
+        metrics.mark_bootstrap_complete();
+        Box::pin(signal.chain(live_flip_hook(source, &member_key)))
+    } else if snapshotting {
+        // Built before `dataset_name` is moved into the snapshot input below.
+        let watermark_boundary = snapshot_watermark_envelope(
+            &schema,
+            Arc::clone(&applied_lsn_store),
+            setup.slot.consistent_lsn,
+            dataset_name.clone(),
+        );
         let snapshot = bootstrap::snapshot_stream(bootstrap::SnapshotInput {
             params: params.clone(),
             schema_name,
@@ -1959,7 +2156,11 @@ async fn attach_member(
             }
             std::task::Poll::Ready(None)
         });
-        Box::pin(snapshot.chain(bootstrap_finished))
+        // Record the snapshot's position as soon as its rows are durable, then
+        // flip the member live. The boundary envelope's committer cannot be
+        // deferred, so it runs only after the snapshot is durably applied.
+        let boundary = stream::once(async move { watermark_boundary });
+        Box::pin(snapshot.chain(boundary).chain(bootstrap_finished))
     } else {
         metrics.mark_bootstrap_complete();
         // Readiness is lag-based: a resuming member becomes Ready via lag-gated
@@ -3257,6 +3458,7 @@ async fn deliver_commit(
             slot: Arc::clone(slot),
             flush_to: boundary.end_lsn,
             dataset: member.dataset_name.clone(),
+            applied_lsn_store: Arc::clone(&member.applied_lsn_store),
             is_dataset_ready: is_ready,
             first_received_at: std::time::Instant::now(),
         };
@@ -3354,6 +3556,7 @@ mod tests {
                 Some(source_commit_ts_ms),
             ),
             slot: Arc::clone(slot),
+            applied_lsn_store: Arc::new(crate::postgres_replication::NoopAppliedLsnStore),
             flush_to,
             dataset: "ds".to_string(),
             is_dataset_ready: ready,
@@ -3394,6 +3597,7 @@ mod tests {
         tables: &[&str],
     ) -> slot::SharedMemberSetup {
         slot::SharedMemberSetup {
+            slot_restart_lsn: Some(0),
             slot: slot::SlotInfo {
                 slot_name: "slot".to_string(),
                 publication_name: "pub".to_string(),
@@ -3521,6 +3725,7 @@ mod tests {
             lock(&source.members).insert(
                 member_key.clone(),
                 Arc::new(MemberHandle {
+                    applied_lsn_store: Arc::new(crate::postgres_replication::NoopAppliedLsnStore),
                     dataset_name: format!("ds{i}"),
                     schema: Arc::clone(&schema),
                     primary_keys: vec![],
@@ -3558,6 +3763,7 @@ mod tests {
         lock(&source.members).insert(
             member_key.clone(),
             Arc::new(MemberHandle {
+                applied_lsn_store: Arc::new(crate::postgres_replication::NoopAppliedLsnStore),
                 dataset_name: "users".into(),
                 schema,
                 primary_keys: vec!["id".into()],
@@ -3676,6 +3882,7 @@ mod tests {
             lock(&source.members).insert(
                 member_key.clone(),
                 Arc::new(MemberHandle {
+                    applied_lsn_store: Arc::new(crate::postgres_replication::NoopAppliedLsnStore),
                     dataset_name: "users".into(),
                     schema,
                     primary_keys: vec!["id".into()],
@@ -4882,6 +5089,7 @@ mod tests {
         ack.seed(10);
         ack.register(&key("a"), false);
         let committer = SharedLsnCommitter {
+            applied_lsn_store: Arc::new(crate::postgres_replication::NoopAppliedLsnStore),
             slot: ack.slot(&key("a")).expect("slot registered"),
             flush_to: 42,
             dataset: "test".to_string(),

--- a/crates/data_components/src/postgres_replication/slot.rs
+++ b/crates/data_components/src/postgres_replication/slot.rs
@@ -95,6 +95,15 @@ pub struct SharedMemberSetup {
     /// has subscribed yet — the caller holds the ack floor for the ones that
     /// have not, so their changes are not acked away before they join.
     pub publication_tables: Vec<(String, String)>,
+    /// The earliest LSN this slot can still stream from — see
+    /// [`read_slot_restart_lsn`] — read *after* the slot is ensured, so a slot
+    /// just created reports its own creation point rather than `None`.
+    ///
+    /// `None` only when the slot does not exist, which cannot normally follow
+    /// `ensure_slot`; it is carried as an `Option` so a slot dropped underneath
+    /// us between the two reads is reported as the unfillable gap it is rather
+    /// than silently compared against a fabricated position.
+    pub slot_restart_lsn: Option<u64>,
 }
 
 /// Idempotent setup for one member of a shared slot: validates the table's
@@ -131,11 +140,13 @@ pub async fn setup_shared_member(
                 let publication_tables =
                     list_publication_tables(&client, &params.publication_name).await?;
                 let slot = ensure_slot(&client, params).await?;
+                let slot_restart_lsn = read_slot_restart_lsn(&client, &params.slot_name).await?;
                 Ok(SharedMemberSetup {
                     slot,
                     table_added,
                     generated_columns,
                     publication_tables,
+                    slot_restart_lsn,
                 })
             }
             .await;
@@ -763,6 +774,48 @@ fn ignore_duplicate_object<T>(
                 Err(e).context(SetupExecSnafu)
             }
         }
+    }
+}
+
+/// The earliest LSN a slot can still stream from: its `restart_lsn`.
+///
+/// This is the authority on whether a gap is fillable. `confirmed_flush_lsn`
+/// says how far a consumer acknowledged; `restart_lsn` says how far back the
+/// server still holds WAL *for this slot*, and it is what `START_REPLICATION`
+/// can be asked to resume from. A recorded watermark older than this is a gap no
+/// stream can supply.
+///
+/// `Ok(None)` means the slot cannot be shown to reach *any* previously recorded
+/// position, so a caller comparing against a watermark must treat it as an
+/// unfillable gap. Two catalog states produce it:
+///
+///   * the slot does not exist — the widest possible gap; and
+///   * the slot exists with a NULL `restart_lsn`, i.e. it was just created and
+///     has never streamed. Its WAL reservation begins at its *creation point*,
+///     which is later than anything a previous run could have recorded — so it
+///     supplies nothing a watermark refers to.
+///
+/// That second case is easy to get backwards. Reporting it as `Some(0)` reads as
+/// "reserved from the beginning of time, so it can supply anything", which
+/// inverts the decision precisely when the slot was recreated after being
+/// dropped — the case gap detection exists for.
+pub async fn read_slot_restart_lsn(
+    client: &tokio_postgres::Client,
+    slot_name: &str,
+) -> Result<Option<u64>> {
+    let row = client
+        .query_opt(
+            "SELECT restart_lsn::text FROM pg_catalog.pg_replication_slots WHERE slot_name = $1",
+            &[&slot_name],
+        )
+        .await
+        .context(SetupExecSnafu)?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    match row.get::<_, Option<String>>(0) {
+        Some(lsn) => Ok(Some(parse_lsn(&lsn)?)),
+        None => Ok(None),
     }
 }
 

--- a/crates/data_components/src/postgres_replication/slot.rs
+++ b/crates/data_components/src/postgres_replication/slot.rs
@@ -254,10 +254,81 @@ async fn fetch_generated_columns(
 
 /// Look up the named slot, creating it if absent. See [`setup_slot_and_publication`]
 /// for the semantics of the returned `consistent_lsn` / `created_fresh`.
+/// SQLSTATE `42703` (`undefined_column`) — `pg_replication_slots.wal_status` is
+/// `PostgreSQL` 13+.
+const SQLSTATE_UNDEFINED_COLUMN: &str = "42703";
+
+/// Drop a slot the server has invalidated, so the caller's `ensure_slot`
+/// recreates it.
+///
+/// An invalidated slot (`wal_status = 'lost'`, from exhausted
+/// `max_slot_wal_keep_size` or `PostgreSQL` 18 idle-timeout invalidation) still
+/// exists in the catalog and can still report a non-null `confirmed_flush_lsn`,
+/// so every "does the slot exist" check passes while `START_REPLICATION` against
+/// it fails permanently with SQLSTATE 55000 ("can no longer get changes from
+/// replication slot"), which is classified non-transient and stops the stream. Left in place it produces the worst outcome available:
+/// the acceleration is rebuilt from the source, and then streaming never
+/// resumes.
+///
+/// Returns whether a slot was dropped. Best-effort — a failure here leaves the
+/// slot in place and surfaces through the streaming error it was going to cause
+/// anyway.
+async fn drop_slot_if_invalidated(
+    client: &tokio_postgres::Client,
+    slot_name: &str,
+) -> Result<bool> {
+    let row = client
+        .query_opt(
+            "SELECT wal_status FROM pg_catalog.pg_replication_slots WHERE slot_name = $1",
+            &[&slot_name],
+        )
+        .await;
+    let wal_status = match row {
+        Ok(row) => row.and_then(|row| row.get::<_, Option<String>>(0)),
+        // `wal_status` is PostgreSQL 13+. On an older server there is nothing to
+        // read and nothing to detect.
+        Err(e)
+            if e.as_db_error()
+                .is_some_and(|db| db.code().code() == SQLSTATE_UNDEFINED_COLUMN) =>
+        {
+            return Ok(false);
+        }
+        Err(e) => return Err(e).context(SetupExecSnafu),
+    };
+
+    if wal_status.as_deref() != Some("lost") {
+        return Ok(false);
+    }
+
+    tracing::warn!(
+        slot = %slot_name,
+        "PostgreSQL invalidated this replication slot (wal_status=lost): the WAL it needed is gone, so it can never stream again. Dropping it and creating a replacement; the acceleration is rebuilt from the source. Raise max_slot_wal_keep_size, or reduce replication lag, to avoid this."
+    );
+    match client
+        .execute("SELECT pg_drop_replication_slot($1)", &[&slot_name])
+        .await
+    {
+        Ok(_) => Ok(true),
+        // Already gone: a concurrent drop raced us, which is the desired state.
+        Err(e)
+            if e.as_db_error()
+                .is_some_and(|db| db.code().code() == SQLSTATE_UNDEFINED_OBJECT) =>
+        {
+            Ok(true)
+        }
+        Err(e) => Err(e).context(SetupExecSnafu),
+    }
+}
+
 async fn ensure_slot(
     client: &tokio_postgres::Client,
     params: &ReplicationParams,
 ) -> Result<SlotInfo> {
+    // A slot the server has invalidated still looks present to every check
+    // below, so retire it first and let the rest of this function create its
+    // replacement.
+    drop_slot_if_invalidated(client, &params.slot_name).await?;
+
     // Distinguish three catalog states for the named slot:
     //   * None            — no slot exists; we create one and need a bootstrap.
     //   * Some(0)         — slot exists but confirmed_flush_lsn is NULL. This

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -51,6 +51,7 @@ use datafusion::{execution::context::SessionContext, physical_plan::collect};
 use futures::{StreamExt, stream};
 use runtime_acceleration::dataupdate::StreamingDataUpdateExecutionPlan;
 use runtime_component::dataset::OnSchemaChange;
+use runtime_component::dataset::acceleration::RefreshMode;
 use runtime_component::schema_evolution::{
     SCHEMA_EVOLUTION_APPLIED, SCHEMA_EVOLUTION_DETECTED, SCHEMA_EVOLUTION_FAILED,
     emit_schema_evolution_event, evolution_allowed, schema_evolution_labels, widening_plan_kind,
@@ -389,6 +390,10 @@ impl CdcInsertPlanCache {
 struct ApplyContext<'a> {
     refresh_sql: Option<&'a str>,
     dataset_name: &'a TableReference,
+    /// The dataset's refresh configuration, needed to rebuild the accelerator
+    /// through the full-refresh path when the source reports its change history
+    /// is gone (see [`RefreshTask::rebuild_from_source`]).
+    refresh: &'a Arc<RwLock<Refresh>>,
     /// Prebuilt per-dataset metric labels reused by hot record sites in the apply loop
     /// (see [`DatasetMetricLabels`]).
     metric_labels: &'a DatasetMetricLabels,
@@ -1278,6 +1283,7 @@ impl RefreshTask {
                             let mut context = ApplyContext {
                                 refresh_sql: sql.as_deref(),
                                 dataset_name: &dataset_name,
+                                refresh: &refresh,
                                 metric_labels: &metric_labels,
                                 caching: caching.as_ref(),
                                 ready_sender: ready_sender.as_ref(),
@@ -1530,6 +1536,7 @@ impl RefreshTask {
             let mut apply_context = ApplyContext {
                 refresh_sql: sql.as_deref(),
                 dataset_name: &dataset_name,
+                refresh: &refresh,
                 metric_labels: &metric_labels,
                 caching: caching.as_ref(),
                 ready_sender: ready_sender.as_ref(),
@@ -1588,6 +1595,7 @@ impl RefreshTask {
                 let mut context = ApplyContext {
                     refresh_sql: sql.as_deref(),
                     dataset_name: &dataset_name,
+                    refresh: &refresh,
                     metric_labels: &metric_labels,
                     caching: caching.as_ref(),
                     ready_sender: ready_sender.as_ref(),
@@ -1811,6 +1819,55 @@ impl RefreshTask {
             .await;
     }
 
+    /// Re-read the source into the accelerator as one atomic replacement, in
+    /// answer to [`cdc::ChangeEnvelope::history_unavailable`]. Returns `false`
+    /// when the rebuild failed and the stream must stop.
+    ///
+    /// This is deliberately the ordinary `refresh_mode: full` path — one
+    /// `RefreshTask::run` with the mode overridden to
+    /// [`RefreshMode::Full`] — so the replacement is the same atomic
+    /// overwrite (`InsertOp::Overwrite`) a full refresh performs, and readers
+    /// keep seeing the pre-rebuild table until it swaps. Clearing the table and
+    /// letting the change stream refill it would be visible to queries as an
+    /// empty, then partially-filled, table.
+    ///
+    /// The changes that follow this rebuild may predate the re-read, since the
+    /// source resumes from wherever its log still starts. That is safe: the log
+    /// is ordered and complete from that point, so replaying it converges on the
+    /// source's current state — transiently stale, exactly like ordinary CDC
+    /// catch-up lag. What could *not* converge, and is what this exists to fix,
+    /// is a row deleted at the source while the history was gone: no change row
+    /// for it will ever arrive, so only re-reading the table removes it.
+    async fn rebuild_from_source(&self, context: &ApplyContext<'_>) -> bool {
+        let mut refresh = context.refresh.read().await.clone();
+        refresh.mode = RefreshMode::Full;
+
+        tracing::warn!(
+            "Dataset {}: the source can no longer supply the changes needed to continue, so the acceleration is being rebuilt from the source. This re-reads the table.",
+            context.dataset_name,
+        );
+
+        if let Err(e) = self.run(refresh).await {
+            let error_message = format!(
+                "Failed to rebuild the acceleration for {} from the source after its change history became unavailable: {e}",
+                context.dataset_name,
+            );
+            tracing::error!("{error_message}");
+            self.set_refresh_status(
+                context.refresh_sql,
+                status::ComponentStatus::error_with_message(error_message),
+            )
+            .await;
+            return false;
+        }
+
+        tracing::info!(
+            "Dataset {}: rebuilt the acceleration from the source; resuming change streaming.",
+            context.dataset_name,
+        );
+        true
+    }
+
     async fn run_finalize_side_effects(
         &self,
         context: &mut ApplyContext<'_>,
@@ -1900,6 +1957,14 @@ impl RefreshTask {
         // offsets) require this ordering.
         let any_ready = envelopes.iter().any(cdc::ChangeEnvelope::is_dataset_ready);
 
+        // Read before the heartbeat retain below, for the same reason `any_ready`
+        // is: the signal rides a zero-row, no-op-committer envelope (see
+        // `cdc::build_history_unavailable_envelope`), so the retain would
+        // otherwise strip it and the rebuild would never happen.
+        let history_unavailable = envelopes
+            .iter()
+            .any(cdc::ChangeEnvelope::history_unavailable);
+
         // Strip zero-row readiness heartbeats from the write/durability path
         // (#12007). Lag-based readiness (#11777) makes CDC connectors emit a
         // heartbeat roughly every second on a caught-up source; the heartbeat's
@@ -1917,6 +1982,15 @@ impl RefreshTask {
         // envelope persisting the initial resume token) are not heartbeats
         // under that predicate and keep durability-then-commit ordering.
         envelopes.retain(|env| !env.is_no_op_heartbeat());
+
+        // The source has lost the history that explains what changed while it was
+        // away, so nothing in this burst — or after it — can be applied on top of
+        // the accelerator's current contents. Re-read the source into the
+        // accelerator as one atomic replacement first; the changes that follow
+        // then converge on top of it (see `rebuild_from_source`).
+        if history_unavailable && !self.rebuild_from_source(context).await {
+            return false;
+        }
 
         // Readiness-only run: every envelope was a heartbeat. Honor the ready
         // flag and stop — there is nothing to write and nothing to commit, so
@@ -1963,14 +2037,14 @@ impl RefreshTask {
         };
         record_cdc_fixed_cost(context.metric_labels, "decode", decode_start);
 
-        // Readiness was already folded into `any_ready` before the heartbeat
-        // retain, so the per-envelope flag is spent here.
+        // Readiness and the history-unavailable signal were both folded in before
+        // the heartbeat retain, so their per-envelope flags are spent here.
         let (committers, batches): (
             Vec<Box<dyn cdc::CommitChange + Send + Sync>>,
             Vec<ChangeBatch>,
         ) = parts
             .into_iter()
-            .map(|(committer, batch, _is_ready)| (committer, batch))
+            .map(|(committer, batch, _is_ready, _history_unavailable)| (committer, batch))
             .unzip();
 
         // Mixed-schema runs (mid-stream schema evolution): `concat_change_batches`
@@ -6274,8 +6348,13 @@ mod tests {
         let mut pending_commit = None;
         let write_ctx = SessionContext::new();
         let write_session_state = write_ctx.state();
+        // Only consulted when a source reports its history is unavailable, which
+        // these cases never do; the default carries `RefreshMode::Full`, which is
+        // what a rebuild would override it to anyway.
+        let refresh = Arc::new(RwLock::new(Refresh::default()));
         let mut context = ApplyContext {
             refresh_sql: None,
+            refresh: &refresh,
             dataset_name: &dataset_name,
             metric_labels: &metric_labels,
             caching: None,
@@ -6522,8 +6601,13 @@ mod tests {
         let mut pending_commit = None;
         let write_ctx = SessionContext::new();
         let write_session_state = write_ctx.state();
+        // Only consulted when a source reports its history is unavailable, which
+        // these cases never do; the default carries `RefreshMode::Full`, which is
+        // what a rebuild would override it to anyway.
+        let refresh = Arc::new(RwLock::new(Refresh::default()));
         let mut context = ApplyContext {
             refresh_sql: None,
+            refresh: &refresh,
             dataset_name: &dataset_name,
             metric_labels: &metric_labels,
             caching: None,
@@ -6581,8 +6665,13 @@ mod tests {
         let mut pending_commit = None;
         let write_ctx = SessionContext::new();
         let write_session_state = write_ctx.state();
+        // Only consulted when a source reports its history is unavailable, which
+        // these cases never do; the default carries `RefreshMode::Full`, which is
+        // what a rebuild would override it to anyway.
+        let refresh = Arc::new(RwLock::new(Refresh::default()));
         let mut context = ApplyContext {
             refresh_sql: None,
+            refresh: &refresh,
             dataset_name: &dataset_name,
             metric_labels: &metric_labels,
             caching: None,

--- a/crates/runtime/src/changes/mod.rs
+++ b/crates/runtime/src/changes/mod.rs
@@ -46,7 +46,8 @@ pub async fn index_change_envelope(
     // Materialize a deferred batch here (this index wrapper transforms the
     // stream before the accelerator consumes it). Offload the synchronous build
     // so a large deferred burst can't stall this async worker.
-    let (change_committer, batch, is_dataset_ready) = envelope.into_parts_offloaded().await?;
+    let (change_committer, batch, is_dataset_ready, history_unavailable) =
+        envelope.into_parts_offloaded().await?;
     let mut batches = vec![batch.data_batch()];
 
     for index in &indexes.0 {
@@ -59,10 +60,15 @@ pub async fn index_change_envelope(
     let new_change_batch = replace_change_batch_data(&batches[0], &batch)
         .map_err(|e| StreamError::Arrow(e.to_string()))?;
 
-    Ok(ChangeEnvelope::new(
+    // `from_parts` rather than `new`: this wrapper transforms the batch and must
+    // carry every envelope flag through untouched. A rebuild request dropped here
+    // would let the accelerator keep applying changes after the source lost the
+    // history that explains them.
+    Ok(ChangeEnvelope::from_parts(
         change_committer,
         new_change_batch,
         is_dataset_ready,
+        history_unavailable,
     ))
 }
 

--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -76,6 +76,10 @@ pub mod kafka;
 // `dynamodb::init_checkpoint_store` regardless of which accelerator backend is enabled.
 pub mod dynamodb;
 
+// Same driver-free shape, for the same reason: `connector-postgres` resolves the
+// replication watermark store without depending on the accelerator backends.
+pub mod postgres_replication;
+
 #[cfg(feature = "mongodb")]
 pub mod mongodb;
 

--- a/crates/runtime/src/dataaccelerator/spice_sys/postgres_replication/mod.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys/postgres_replication/mod.rs
@@ -1,0 +1,59 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Runtime-side seam for the `PostgreSQL` replication watermark sidecar.
+//!
+//! Records the LSN a dataset's acceleration is complete as of, so a restart can
+//! tell a resumable gap from an unfillable one. `PostgreSQL` CDC historically
+//! kept no client-side position at all, relying on the slot's server-tracked
+//! `confirmed_flush_lsn` — which is exactly what disappears when the slot is
+//! dropped or invalidated, leaving the runtime to *infer* whether the source can
+//! still supply the missing changes. `MySQL` has kept a client-side position all
+//! along (`spice_sys_mysql_binlog`); this is the same idea for Postgres.
+//!
+//! The store lives in the dataset's own accelerator, reached through the
+//! runtime-internal engine registry, so — like the `DynamoDB` Streams sidecar —
+//! this module keeps that resolution inside `runtime` and hands the connector
+//! back only the opaque [`BlobCheckpointStore`] trait object.
+//!
+//! `None` means no usable accelerator connection, i.e. nothing durable to record
+//! a position in. The connector treats that as "never loaded", which is correct:
+//! an acceleration that cannot persist a watermark cannot have persisted rows for
+//! one to describe.
+
+use std::sync::Arc;
+
+use runtime_checkpoint_api::BlobCheckpointStore;
+
+use super::checkpoint_store;
+use crate::component::dataset::Dataset;
+
+/// Re-exported so a connector can name the returned trait object without taking
+/// its own dependency on the checkpoint-api crate — the point of this seam is
+/// that the connector depends on `runtime` alone.
+pub use runtime_checkpoint_api::BlobCheckpointStore as WatermarkBlobStore;
+
+/// Sidecar table (in the dataset's own accelerator) holding the serialized
+/// applied-LSN watermark.
+const POSTGRES_REPLICATION_WATERMARK_TABLE: &str = "spice_sys_postgres_replication";
+
+/// Resolves the dataset's accelerator into a blob checkpoint store for the
+/// `PostgreSQL` replication watermark sidecar.
+pub async fn init_watermark_store(dataset: &Dataset) -> Option<Arc<dyn BlobCheckpointStore>> {
+    // `None` (no usable accelerator connection) is a graceful degradation, and
+    // `checkpoint_store` already logs the underlying reason, so don't double-log.
+    checkpoint_store(dataset, POSTGRES_REPLICATION_WATERMARK_TABLE).await
+}

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -198,7 +198,8 @@ impl EmbeddingConnector {
         // this wrapper sits between a (possibly multiplexed) source and the
         // accelerator, so it must build the deferred rows before augmenting them.
         // Offload the synchronous build so a large burst can't stall this worker.
-        let (change_committer, batch, is_dataset_ready) = envelope.into_parts_offloaded().await?;
+        let (change_committer, batch, is_dataset_ready, history_unavailable) =
+            envelope.into_parts_offloaded().await?;
         let data_batch = batch.data_batch();
 
         let embeddings = compute_additional_embedding_columns(
@@ -226,10 +227,13 @@ impl EmbeddingConnector {
         let new_change_batch = replace_change_batch_data(&embedded_batch, &batch)
             .map_err(|e| StreamError::Arrow(e.to_string()))?;
 
-        Ok(ChangeEnvelope::new(
+        // `from_parts` rather than `new`, so every envelope flag survives this
+        // wrapper — see the same forwarding in `crate::changes`.
+        Ok(ChangeEnvelope::from_parts(
             change_committer,
             new_change_batch,
             is_dataset_ready,
+            history_unavailable,
         ))
     }
 }

--- a/crates/runtime/tests/postgres/catalog_changes.rs
+++ b/crates/runtime/tests/postgres/catalog_changes.rs
@@ -207,9 +207,11 @@ async fn slot_active(port: usize, slot_name: &str) -> Result<Option<bool>, anyho
 /// The slot's `confirmed_flush_lsn`, as the source sees it.
 ///
 /// This advances only when Spice acknowledges a change, which is the same call
-/// that records the local applied-LSN watermark — so it is the source-side proof
-/// that the watermark has been written, without reaching into the accelerator's
-/// sidecar from a test.
+/// that attempts the local applied-LSN watermark write. It is therefore evidence
+/// that the write was *reached*, not that it succeeded — the acknowledgement
+/// proceeds even if the sidecar write fails, which is only logged. Convergence
+/// after the restart is what actually proves the watermark behaved; this exists
+/// so the test stops racing durability before shutting down.
 async fn slot_confirmed_flush(
     port: usize,
     slot_name: &str,
@@ -1361,13 +1363,13 @@ async fn test_durable_acceleration_is_rebuilt_when_its_slot_is_gone() -> Result<
 
             // Drive one change through the live stream before shutting down.
             //
-            // This is what records the applied-LSN watermark: it is written by the
-            // commit that acknowledges a WAL change, which is the only point at
-            // which the acked data is known durable. A bootstrap alone leaves no
-            // watermark yet, so the restart below would read "never loaded" and
-            // take the first-load path. (Persisting the watermark at the snapshot
-            // boundary too would remove that window; it is deliberately deferred
-            // to the atomic replacement work.)
+            // Exercises the ordinary watermark path: the position is recorded by
+            // the commit that acknowledges a WAL change, which is the only point
+            // at which the acked data is known durable. The snapshot boundary
+            // records one too, so this is not the only thing standing between the
+            // restart and a usable watermark — it is the steady-state path, and
+            // it also gives the restart a position strictly newer than the
+            // bootstrap's.
             conn.conn
                 .simple_query("INSERT INTO orders (id, customer) VALUES (3, 'carol-live');")
                 .await?;

--- a/crates/runtime/tests/postgres/catalog_changes.rs
+++ b/crates/runtime/tests/postgres/catalog_changes.rs
@@ -204,6 +204,32 @@ async fn slot_active(port: usize, slot_name: &str) -> Result<Option<bool>, anyho
     Ok(status.map(|s| s.active))
 }
 
+/// The slot's `confirmed_flush_lsn`, as the source sees it.
+///
+/// This advances only when Spice acknowledges a change, which is the same call
+/// that records the local applied-LSN watermark — so it is the source-side proof
+/// that the watermark has been written, without reaching into the accelerator's
+/// sidecar from a test.
+async fn slot_confirmed_flush(
+    port: usize,
+    slot_name: &str,
+) -> Result<Option<String>, anyhow::Error> {
+    let pool = common::get_postgres_connection_pool(port, None).await?;
+    let conn = pool
+        .connect_direct()
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let row = conn
+        .conn
+        .query_opt(
+            "SELECT confirmed_flush_lsn::text FROM pg_catalog.pg_replication_slots \
+             WHERE slot_name = $1",
+            &[&slot_name],
+        )
+        .await?;
+    Ok(row.and_then(|row| row.get::<_, Option<String>>(0)))
+}
+
 /// Lower the source's `wal_sender_timeout` so the catalog's bounded
 /// slot-in-use wait (sized from it) stays short in the fail-loud test. Applied
 /// via `ALTER SYSTEM` + reload, so it takes effect for walsenders started after.
@@ -1287,6 +1313,189 @@ async fn test_catalog_acceleration_reuses_slot_across_restart() -> Result<(), an
                 delivered,
                 "change made during downtime (orders id=3) was not delivered after restart via the reused slot: got {:?}",
                 query_string(&rt, &offline_row_sql).await
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// A durable acceleration whose replication slot is gone must be **rebuilt from
+/// the source**, not topped up from a snapshot appended over what it still
+/// holds.
+///
+/// This is the correctness case behind #12018 §1, and it fails without the
+/// rebuild: the accelerated table keeps rows the source deleted, forever, in
+/// every query. A snapshot bootstrap emits only `Create` rows, so appending it
+/// over the survivors reinstates the ones that are still there and never
+/// revisits the ones that are not — and with the slot gone, no `DELETE` change
+/// event for them exists to replay.
+///
+/// The sequence is the one an operator actually hits: a slot dropped while Spice
+/// is down (by hand, by `idle_replication_slot_timeout`, or by exhausted WAL
+/// retention), with the source mutated in the meantime.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_durable_acceleration_is_rebuilt_when_its_slot_is_gone() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some(
+        "integration=debug,info,runtime::catalogconnector=debug,runtime_table=debug",
+    ));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+
+            seed_tables(port).await?;
+
+            let expected_slot = catalog_slot_name(CATALOG_NAME);
+            let data_dir = tempfile::tempdir()?;
+
+            let rt = start_runtime(durable_accelerated_pg_catalog(port, data_dir.path())).await?;
+            wait_for_table_ready(&rt, "orders", "bootstrap before shutdown").await?;
+
+            let pool = common::get_postgres_connection_pool(port, None).await?;
+            let conn = pool
+                .connect_direct()
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            // Drive one change through the live stream before shutting down.
+            //
+            // This is what records the applied-LSN watermark: it is written by the
+            // commit that acknowledges a WAL change, which is the only point at
+            // which the acked data is known durable. A bootstrap alone leaves no
+            // watermark yet, so the restart below would read "never loaded" and
+            // take the first-load path. (Persisting the watermark at the snapshot
+            // boundary too would remove that window; it is deliberately deferred
+            // to the atomic replacement work.)
+            conn.conn
+                .simple_query("INSERT INTO orders (id, customer) VALUES (3, 'carol-live');")
+                .await?;
+            let live_sql =
+                format!("SELECT customer FROM {CATALOG_NAME}.public.orders WHERE id = 3");
+            let streamed = wait_until_true(Duration::from_mins(2), || {
+                let rt = Arc::clone(&rt);
+                let sql = live_sql.clone();
+                async move { query_string(&rt, &sql).await.as_deref() == Some("carol-live") }
+            })
+            .await;
+            anyhow::ensure!(
+                streamed,
+                "the live change (orders id=3) never arrived, so no watermark was recorded: got {:?}",
+                query_string(&rt, &live_sql).await
+            );
+
+            // The change being *queryable* is not the same as it being
+            // acknowledged: under an in-memory CDC tier the acknowledgement is
+            // deferred behind a durability checkpoint, and the watermark is
+            // written by that same acknowledgement. Wait for the source to see
+            // the ack, so the restart below is genuinely testing a recorded
+            // watermark rather than an unwritten one.
+            let acked = wait_until_true(Duration::from_mins(2), || {
+                let slot = expected_slot.clone();
+                async move {
+                    matches!(slot_confirmed_flush(port, &slot).await, Ok(Some(lsn)) if lsn != "0/0")
+                }
+            })
+            .await;
+            anyhow::ensure!(
+                acked,
+                "the source never saw an acknowledgement for slot '{expected_slot}', so no \
+                 applied-LSN watermark was recorded: confirmed_flush_lsn={:?}",
+                slot_confirmed_flush(port, &expected_slot).await?
+            );
+
+            rt.shutdown().await;
+            drop(rt);
+
+            // Wait for the walsender to exit so the slot can actually be dropped,
+            // then remove it: the source can no longer supply what happens next.
+            let freed = wait_until_true(Duration::from_secs(90), || {
+                let slot = expected_slot.clone();
+                async move { matches!(slot_active(port, &slot).await, Ok(Some(false))) }
+            })
+            .await;
+            anyhow::ensure!(
+                freed,
+                "slot '{expected_slot}' never became inactive after shutdown"
+            );
+            conn.conn
+                .simple_query(&format!("SELECT pg_drop_replication_slot('{expected_slot}')"))
+                .await?;
+
+            // Mutate the source with no slot to record it: one row deleted, one
+            // added. The deletion is the whole point — it is unrecoverable from
+            // WAL and only a re-read of the table can remove it.
+            conn.conn
+                .simple_query(
+                    "DELETE FROM orders WHERE id = 1; \
+                     INSERT INTO orders (id, customer) VALUES (4, 'dave-offline');",
+                )
+                .await?;
+
+            // Restart against the SAME acceleration files: the rows from before
+            // are still on disk, which is what makes an appended snapshot wrong.
+            let rt = start_runtime(durable_accelerated_pg_catalog(port, data_dir.path())).await?;
+            wait_for_table_ready(&rt, "orders", "after the slot was dropped").await?;
+
+            // The acceleration must converge on the source exactly: the deleted
+            // row gone, the offline insert present, and the earlier rows intact.
+            let deleted_sql =
+                format!("SELECT customer FROM {CATALOG_NAME}.public.orders WHERE id = 1");
+            let converged = wait_until_true(Duration::from_mins(3), || {
+                let rt = Arc::clone(&rt);
+                let deleted = deleted_sql.clone();
+                let added = format!(
+                    "SELECT customer FROM {CATALOG_NAME}.public.orders WHERE id = 4"
+                );
+                async move {
+                    query_string(&rt, &deleted).await.is_none()
+                        && query_string(&rt, &added).await.as_deref() == Some("dave-offline")
+                }
+            })
+            .await;
+            if !converged {
+                // Report only what actually diverged. Printing both reads
+                // unconditionally makes a passing check look like a second
+                // failure and hides which half is broken.
+                let mut problems = Vec::new();
+                if let Some(surviving) = query_string(&rt, &deleted_sql).await {
+                    problems.push(format!(
+                        "row id=1 was deleted at the source but still reads {surviving:?} — the \
+                         rebuild did not replace the acceleration's contents"
+                    ));
+                }
+                let added_sql =
+                    format!("SELECT customer FROM {CATALOG_NAME}.public.orders WHERE id = 4");
+                let added = query_string(&rt, &added_sql).await;
+                if added.as_deref() != Some("dave-offline") {
+                    problems.push(format!(
+                        "row id=4 was inserted at the source while no slot recorded it, but reads \
+                         {added:?} instead of \"dave-offline\""
+                    ));
+                }
+                anyhow::bail!(
+                    "the acceleration did not converge on the source after its slot was dropped: {}",
+                    problems.join("; ")
+                );
+            }
+
+            // Streaming resumes on the rebuilt table rather than stopping at it.
+            conn.conn
+                .simple_query("INSERT INTO orders (id, customer) VALUES (5, 'erin-after');")
+                .await?;
+            let after_sql =
+                format!("SELECT customer FROM {CATALOG_NAME}.public.orders WHERE id = 5");
+            let resumed = wait_until_true(Duration::from_mins(2), || {
+                let rt = Arc::clone(&rt);
+                let sql = after_sql.clone();
+                async move { query_string(&rt, &sql).await.as_deref() == Some("erin-after") }
+            })
+            .await;
+            anyhow::ensure!(
+                resumed,
+                "changes after the rebuild were not streamed: got {:?}",
+                query_string(&rt, &after_sql).await
             );
 
             Ok(())

--- a/crates/runtime/tests/postgres/replication.rs
+++ b/crates/runtime/tests/postgres/replication.rs
@@ -34,8 +34,8 @@ use arrow::array::AsArray;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use data_components::cdc::{ChangeEnvelope, ChangesStream};
 use data_components::postgres_replication::{
-    PgOutputFormat, ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput,
-    SchemaEvolutionPolicy, config, start_replication_stream,
+    NoopAppliedLsnStore, PgOutputFormat, ReplicationMetricsCollector, ReplicationParams,
+    ReplicationStreamInput, SchemaEvolutionPolicy, config, start_replication_stream,
 };
 use futures::StreamExt;
 use secrecy::SecretString;
@@ -216,13 +216,14 @@ async fn bootstrap_then_stream_changes() -> Result<(), anyhow::Error> {
         table_name: "repl_users".into(),
         metrics: ReplicationMetricsCollector::new(),
         policy: SchemaEvolutionPolicy::Block,
+        applied_lsn_store: Arc::new(NoopAppliedLsnStore),
     };
 
     let mut stream = start_replication_stream(input);
 
     // --- 1. Bootstrap envelope: two rows, op="c" ---
     let envelope = next_envelope(&mut stream, "bootstrap envelope").await?;
-    let (committer, change_batch, is_ready) = envelope.into_parts().expect("build change batch");
+    let (committer, change_batch, is_ready, _) = envelope.into_parts().expect("build change batch");
     let ops = change_batch
         .record
         .column_by_name("op")
@@ -327,10 +328,11 @@ async fn bootstrap_then_stream_changes() -> Result<(), anyhow::Error> {
         table_name: "repl_users".into(),
         metrics: ReplicationMetricsCollector::new(),
         policy: SchemaEvolutionPolicy::Block,
+        applied_lsn_store: Arc::new(NoopAppliedLsnStore),
     };
     let mut stream = start_replication_stream(input);
     let envelope = next_envelope(&mut stream, "forced resume snapshot").await?;
-    let (committer, change_batch, is_ready) = envelope.into_parts().expect("build change batch");
+    let (committer, change_batch, is_ready, _) = envelope.into_parts().expect("build change batch");
     assert_eq!(
         change_batch.record.num_rows(),
         2,
@@ -389,13 +391,14 @@ async fn large_value_and_burst_replicate_intact() -> Result<(), anyhow::Error> {
         table_name: "repl_big".into(),
         metrics: ReplicationMetricsCollector::new(),
         policy: SchemaEvolutionPolicy::Block,
+        applied_lsn_store: Arc::new(NoopAppliedLsnStore),
     };
     let mut stream = start_replication_stream(input);
 
     // Bootstrap: the seed row arrives as a not-ready boundary; readiness is
     // lag-based and follows from the live/heartbeat path once caught up.
     let envelope = next_envelope(&mut stream, "bootstrap envelope").await?;
-    let (committer, change_batch, is_ready) = envelope.into_parts().expect("build change batch");
+    let (committer, change_batch, is_ready, _) = envelope.into_parts().expect("build change batch");
     assert_eq!(change_batch.record.num_rows(), 1);
     assert!(
         !is_ready,
@@ -468,7 +471,7 @@ async fn large_value_and_burst_replicate_intact() -> Result<(), anyhow::Error> {
                     seen.len()
                 )
             })??;
-        let (committer, change_batch, _) = envelope.into_parts().expect("build change batch");
+        let (committer, change_batch, _, _) = envelope.into_parts().expect("build change batch");
         let data_struct = change_batch
             .record
             .column_by_name("data")
@@ -519,6 +522,7 @@ async fn two_replicas_have_independent_slots() -> Result<(), anyhow::Error> {
         table_name: "repl_users".into(),
         metrics: ReplicationMetricsCollector::new(),
         policy: SchemaEvolutionPolicy::Block,
+        applied_lsn_store: Arc::new(NoopAppliedLsnStore),
     };
 
     let mut stream_a = start_replication_stream(build_input(params_a));
@@ -694,6 +698,7 @@ async fn run_wide_types_scenario(
         table_name: table.clone(),
         metrics: ReplicationMetricsCollector::new(),
         policy: SchemaEvolutionPolicy::Block,
+        applied_lsn_store: Arc::new(NoopAppliedLsnStore),
     };
     let mut stream = start_replication_stream(input);
 
@@ -716,7 +721,7 @@ async fn run_wide_types_scenario(
         ))
         .await?;
     let env = next_change_envelope(&mut stream, &format!("insert envelope ({tag})")).await?;
-    let (committer, batch, _) = env.into_parts().expect("build change batch");
+    let (committer, batch, _, _) = env.into_parts().expect("build change batch");
     assert_eq!(
         batch
             .record
@@ -827,7 +832,7 @@ async fn run_wide_types_scenario(
         ))
         .await?;
     let env = next_change_envelope(&mut stream, &format!("update envelope ({tag})")).await?;
-    let (committer, batch, _) = env.into_parts().expect("build change batch");
+    let (committer, batch, _, _) = env.into_parts().expect("build change batch");
     assert_eq!(
         batch
             .record
@@ -879,7 +884,7 @@ async fn run_wide_types_scenario(
         .simple_query(&format!("DELETE FROM public.{table} WHERE id = 1"))
         .await?;
     let env = next_change_envelope(&mut stream, &format!("delete envelope ({tag})")).await?;
-    let (committer, batch, _) = env.into_parts().expect("build change batch");
+    let (committer, batch, _, _) = env.into_parts().expect("build change batch");
     assert_eq!(
         batch
             .record
@@ -922,6 +927,7 @@ async fn resume_with_stale_backlog_is_not_ready_until_caught_up() -> Result<(), 
         table_name: "repl_users".into(),
         metrics: ReplicationMetricsCollector::new(),
         policy: SchemaEvolutionPolicy::Block,
+        applied_lsn_store: Arc::new(NoopAppliedLsnStore),
     };
 
     // Cold bootstrap, then let the caught-up source reach Ready. Committing the

--- a/crates/runtime/tests/postgres/replication_shared.rs
+++ b/crates/runtime/tests/postgres/replication_shared.rs
@@ -38,8 +38,8 @@ use arrow::array::{Array, AsArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use data_components::cdc::{ChangeEnvelope, ChangesStream};
 use data_components::postgres_replication::{
-    PgOutputFormat, ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput,
-    SchemaEvolutionPolicy, config, start_replication_stream,
+    NoopAppliedLsnStore, PgOutputFormat, ReplicationMetricsCollector, ReplicationParams,
+    ReplicationStreamInput, SchemaEvolutionPolicy, config, start_replication_stream,
 };
 use futures::StreamExt;
 use secrecy::SecretString;
@@ -109,6 +109,7 @@ fn independent_input(port: u16, table: &str) -> ReplicationStreamInput {
         table_name: table.to_string(),
         metrics: ReplicationMetricsCollector::new(),
         policy: SchemaEvolutionPolicy::Block,
+        applied_lsn_store: Arc::new(NoopAppliedLsnStore),
     }
 }
 
@@ -122,6 +123,7 @@ fn input_with_schema(port: u16, table: &str, schema: SchemaRef) -> ReplicationSt
         table_name: table.to_string(),
         metrics: ReplicationMetricsCollector::new(),
         policy: SchemaEvolutionPolicy::Block,
+        applied_lsn_store: Arc::new(NoopAppliedLsnStore),
     }
 }
 


### PR DESCRIPTION
Part of #12018.

## The bug

A `refresh_mode: changes` dataset whose PostgreSQL replication slot was dropped or invalidated silently diverged from its source, permanently.

On the next start the slot was recreated and a snapshot ran — but a snapshot bootstrap emits only `ChangeOp::Create` rows, and nothing clears the accelerated table first. For a **durable** acceleration that is an upsert-merge over the rows already on disk. Any row deleted at the source while the slot was gone has no change event left to replay, so it stayed in the acceleration forever and was returned by every later query.

Detection was also an inference — `slot_created_fresh || table_added` — because PostgreSQL CDC kept **no client-side position at all**. It relied on the slot's server-tracked `confirmed_flush_lsn`, which is precisely the record that disappears in this failure. (MySQL has always kept one, in `spice_sys_mysql_binlog`; that sidecar's own doc comment describes itself as "the client-side replacement for a Postgres replication slot's server-tracked `confirmed_flush_lsn`".)

## What this changes

**Record the position locally**, in a `spice_sys_postgres_replication` sidecar inside the dataset's own accelerator, so the restart decision becomes arithmetic instead of a guess:

| State | Meaning | Action |
| ----- | ------- | ------ |
| no watermark | never loaded | first bootstrap (unchanged behavior) |
| slot's `restart_lsn` ≤ watermark | the WAL between is still there | resume |
| `restart_lsn` > watermark, or no slot | a gap nothing can supply | **rebuild** |

> **Correction (post-merge, fixed in #12990):** the two `restart_lsn` rows above are wrong. `restart_lsn` is the slot's *physical retention* bound, but the earliest position it can actually **stream** from is `confirmed_flush_lsn` — Postgres forwards a `START_REPLICATION` position below that up to it (`CreateDecodingContext`: `"has been already streamed, forwarding to ..."`). A watermark behind `confirmed_flush_lsn` is therefore an unfillable gap even while its WAL is retained, and this table classified it as resumable, skipping the difference silently (#11289). The comparison must be against the later of `restart_lsn` and `confirmed_flush_lsn`.

**Rebuild atomically.** A gap is reported to the consumer, which owns the accelerator, and it replaces the contents through the ordinary full-refresh write path (`InsertOp::Overwrite`). In Cayenne that is a fresh snapshot directory plus a pointer flip, so readers keep seeing the pre-rebuild table until it swaps — clearing the table and letting the change stream refill it would have been observable as an empty, then partially-filled, table.

**Never claim rows that aren't durable.** The watermark is written by the same call that acknowledges the slot, so it inherits that call's durability gate: the committer supports deferral, and the runtime holds it until the covering checkpoint is durable. It therefore cannot record a position covering rows that live only in the memory tier and would be lost on restart. A snapshot additionally records its position at its own boundary, through a committer that refuses deferral — so a restart between "snapshot applied" and "first change acknowledged" no longer reads a fully populated acceleration as a first load.

## Notes for review

- `ChangeEnvelopeParts` gains the new flag rather than defaulting it. That was deliberate: it made the compiler surface both wrapper sites that decompose and rebuild envelopes (indexing in `runtime::changes`, embeddings in `runtime::embeddings::connector`), each of which would otherwise have dropped the signal silently — the same class of bug as #10460. Every other call site now passes it explicitly with a comment saying why `false` is right there.
- The signal rides a zero-row envelope with a no-op committer, which makes it indistinguishable from a droppable heartbeat by `is_no_op_heartbeat()`. It is therefore read *before* the burst handler strips heartbeats, and a unit test pins that overlap so the ordering cannot be quietly reversed.
- An unreadable watermark is reported as position 0, which resolves to a rebuild. A needless rebuild costs a re-read; a wrong resume silently keeps rows the source deleted.
- `clear()` writes `lsn: 0` rather than deleting the row, because the blob sidecar is upsert-only. Zero precedes every real LSN, so the comparison resolves to a rebuild — which is what clearing means.

## Testing

- **End-to-end against a real PostgreSQL** (`test_durable_acceleration_is_rebuilt_when_its_slot_is_gone`): durable Cayenne acceleration, one change streamed and acknowledged, shutdown, slot dropped, then one row deleted and one inserted with nothing recording them, then restart against the same acceleration files. Asserts the deleted row is gone, the offline insert is present, and streaming resumes afterwards. **This test fails without the change** — the deleted row survives.
- The decision matrix as a unit test, asserting each case individually, including the two easy ones to get wrong: `restart_lsn` exactly equal to the watermark is reachable (resume), one byte past is a gap (rebuild).
- Existing suites unchanged and green: 654 `data_components` lib tests, 109 `runtime` lib tests. A first load still takes the bootstrap path, so no existing CDC test changes behavior.
- Both clippy passes clean under the gate's flags (lib+bins and `--tests`), `cargo fmt` clean.

## Release Notes

> **Correction (post-merge):** the release note below is accurate but incomplete — it covers a slot that is *dropped or invalidated*. A slot that is merely **acknowledged past** what the acceleration recorded as applied is the same unfillable gap and was not handled here; #12990 adds it.

**PostgreSQL CDC accelerations recover from a lost replication slot**: a durable acceleration whose replication slot is dropped or invalidated is now rebuilt from the source when it restarts, rather than resuming and silently keeping rows the source deleted while the slot was gone. The rebuild replaces the acceleration atomically, so queries continue to see the previous contents until the new ones are complete.

Two one-time rebuilds to expect:

- **On upgrade.** An existing durable PostgreSQL CDC acceleration has no recorded position yet, and that is indistinguishable from one that has already diverged, so it is rebuilt once on the first start after upgrading. Later restarts resume normally.
- **On repointing a dataset.** An acceleration reused after its dataset is pointed at a different server, database, or table is rebuilt, because positions recorded against different sources are not comparable.

Accelerations that do not survive a restart (`mode: memory`, `mode: file_create`) are unaffected — they already re-snapshot on every start.

## Follow-ups (not in this PR)

- A `pg_replication_initial_snapshot: once` value, for operators who want the first load but never an automatic re-read.
- The capability read (`idle_replication_slot_timeout`, `max_slot_wal_keep_size`) and the slot-creation/shutdown messaging described in #12018.
- MySQL has the same silent-divergence shape on a purged binlog, and already has the watermark this PR adds for Postgres — it needs only the comparison and the signal. To be filed separately.


