### PR TITLE
fix(dev-tools): show merge-queue and conflict state as labels in scripts/signoff mine

### DIFF
--- a/scripts/signoff
+++ b/scripts/signoff
@@ -2113,19 +2113,53 @@ cmd_mine() {
     return 0
   fi
 
-  # Fetch in-flight Remote Sign-off runs once for all PRs, not once per PR.
+  # Everything below is independent of everything else, so it all runs
+  # concurrently instead of one round trip after another: `mine`'s wall-clock
+  # time is network-bound, and this turns N+2 sequential round trips into
+  # roughly the slowest one. Each PR's combined commit status is the one
+  # remaining per-PR REST call (statuses aren't a GraphQL field for an
+  # arbitrary sha, so they can't join the batched query below); capped at
+  # $max_parallel concurrent `gh api` processes to stay polite to the rate
+  # limit, by draining the batch every $max_parallel jobs rather than
+  # `wait -n`, since that needs bash 4.3+ and this script runs under macOS's
+  # bash 3.2 (see has_content() above).
+  local status_dir
+  status_dir=$(mktemp -d "${TMPDIR:-/tmp}/spice-signoff-mine.XXXXXX") \
+    || fail "failed to create a temp directory for concurrent status lookups"
+  # A RETURN trap isn't function-scoped — left set, it fires again when this
+  # function's *caller* (main's case statement) returns too, by which point
+  # $status_dir (a local of this function) no longer exists, aborting under
+  # `set -u`. Clear it as part of firing so it only ever runs once.
+  trap 'rm -rf "$status_dir"; trap - RETURN' RETURN
+
   # Match on displayTitle, not headBranch: a workflow_dispatch run's headBranch
   # is the ref it was dispatched *against* (always trunk here — cmd_remote
   # doesn't pass --ref), not the `branch` input. signoff.yml's `run-name:
   # Remote Sign-off (${{ inputs.branch }})` puts the actual branch in the
   # title instead, so we match on that exact string.
-  local remote_runs
-  remote_runs=$(gh run list --repo "$repo" --workflow signoff.yml \
-    --json displayTitle,status,conclusion,databaseId --limit 50) || remote_runs="[]"
+  ( gh run list --repo "$repo" --workflow signoff.yml \
+      --json displayTitle,status,conclusion,databaseId --limit 50 \
+      > "${status_dir}/remote_runs" 2>/dev/null ) &
 
-  # Fetch merge-queue membership once for all PRs, not once per PR.
-  local mq_status
-  mq_status=$(fetch_merge_queue_status "$repo" "$(jq '[.[].number]' <<<"$prs")")
+  ( fetch_merge_queue_status "$repo" "$(jq '[.[].number]' <<<"$prs")" \
+      > "${status_dir}/mq_status" ) &
+
+  local max_parallel=8 launched=2 i number sha
+  for ((i = 0; i < count; i++)); do
+    number=$(jq -r ".[$i].number" <<<"$prs")
+    sha=$(jq -r ".[$i].headRefOid" <<<"$prs")
+    ( gh api "repos/${repo}/commits/${sha}/status" 2>/dev/null \
+        > "${status_dir}/status_${number}" ) &
+    launched=$((launched + 1))
+    (( launched % max_parallel == 0 )) && wait
+  done
+  wait
+
+  local remote_runs mq_status
+  remote_runs=$(cat "${status_dir}/remote_runs" 2>/dev/null)
+  [[ -n "$remote_runs" ]] || remote_runs="[]"
+  mq_status=$(cat "${status_dir}/mq_status" 2>/dev/null)
+  [[ -n "$mq_status" ]] || mq_status="{}"
 
   local width
   width=$(tput cols 2>/dev/null) || width=100
@@ -2133,7 +2167,7 @@ cmd_mine() {
   echo "${C_BOLD}${repo}${C_RESET} — ${count} open PR(s)"
   echo
 
-  local i pr number title branch sha combined state run_id running in_queue review_decision is_draft has_conflicts
+  local pr title branch combined state run_id running in_queue review_decision is_draft has_conflicts
   for ((i = 0; i < count; i++)); do
     pr=$(jq -c ".[$i]" <<<"$prs")
     number=$(jq -r '.number' <<<"$pr")
@@ -2141,7 +2175,8 @@ cmd_mine() {
     branch=$(jq -r '.headRefName' <<<"$pr")
     sha=$(jq -r '.headRefOid' <<<"$pr")
 
-    combined=$(gh api "repos/${repo}/commits/${sha}/status" 2>/dev/null) || combined='{}'
+    combined=$(cat "${status_dir}/status_${number}" 2>/dev/null)
+    [[ -n "$combined" ]] || combined='{}'
     state=$(combined_status_state "$combined")
     state="${state:-none}"
 

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -2015,15 +2015,21 @@ truncate_str() {
 # `run_id`, if set, is the most recent *failed* run for a `failure`/`error`
 # state, so you can jump straight to its logs instead of re-triggering blind.
 # `in_queue`=1 means GitHub's merge queue already holds an entry for this PR —
-# distinguished from a plain attested-and-waiting PR by color, since both show
-# the same checkmark glyph. `review_decision`/`is_draft` drive a review-status
-# column: "draft" (not reviewable yet), "changes" (CHANGES_REQUESTED),
-# "needs review" (no approval yet), or "ready to merge" (approved, attested,
-# and not already queued — queued PRs leave the column blank, since the
-# checkmark color already says "already merging").
+# surfaced as a "in merge queue" label rather than a distinct checkmark color,
+# so it lives alongside "needs review"/"ready to merge" in the same column.
+# `has_conflicts`=1 means GitHub's `mergeable` field is `CONFLICTING` (not
+# `MERGEABLE`/`UNKNOWN` — the latter is a transient "still computing" state,
+# so it's treated as no conflict rather than guessed at).
+# `review_decision`/`is_draft` drive that review-status column: "draft" (not
+# reviewable yet), "changes" (CHANGES_REQUESTED), "conflicts" (base has
+# diverged — takes priority over queue/review state, since a conflicted PR
+# can't merge regardless of approval), "in merge queue" (PR is queued — takes
+# priority over the remaining states, since queued implies approved and
+# attested), "needs review" (no approval yet), or "ready to merge" (approved,
+# attested, and not already queued).
 print_pr_row() {
   local number="$1" title="$2" state="$3" run_id="$4" running="$5" width="$6" \
-    in_queue="$7" review_decision="$8" is_draft="$9"
+    in_queue="$7" review_decision="$8" is_draft="$9" has_conflicts="${10}"
   local icon room run_col run_color review_col
 
   if [[ "$running" == "1" ]]; then
@@ -2031,13 +2037,7 @@ print_pr_row() {
     run_color="$C_YELLOW"
   else
     case "$state" in
-      success)
-        if [[ "$in_queue" == "1" ]]; then
-          icon="${C_CYAN}${OK}${C_RESET}"  # attested and already in the merge queue
-        else
-          icon="${C_GREEN}${OK}${C_RESET}"
-        fi
-        ;;
+      success)       icon="${C_GREEN}${OK}${C_RESET}" ;;
       pending)       icon="${C_YELLOW}…${C_RESET}" ;;
       failure|error) icon="${C_RED}${NO}${C_RESET}" ;;   # a sign-off attempt ran and failed
       *)             icon="${C_DIM}○${C_RESET}" ;;       # none: never attempted
@@ -2055,9 +2055,13 @@ print_pr_row() {
     review_col="${C_DIM}$(printf '%-14s' 'draft')${C_RESET}"
   elif [[ "$review_decision" == "CHANGES_REQUESTED" ]]; then
     review_col="${C_RED}$(printf '%-14s' 'changes')${C_RESET}"
+  elif [[ "$has_conflicts" == "1" ]]; then
+    review_col="${C_RED}$(printf '%-14s' 'conflicts')${C_RESET}"
+  elif [[ "$in_queue" == "1" ]]; then
+    review_col="${C_CYAN}$(printf '%-14s' 'in merge queue')${C_RESET}"
   elif [[ "$review_decision" != "APPROVED" ]]; then
     review_col="${C_YELLOW}$(printf '%-14s' 'needs review')${C_RESET}"
-  elif [[ "$state" == "success" && "$in_queue" != "1" ]]; then
+  elif [[ "$state" == "success" ]]; then
     review_col="${C_GREEN}${C_BOLD}$(printf '%-14s' 'ready to merge')${C_RESET}"
   else
     review_col="$(printf '%-14s' '')"
@@ -2068,18 +2072,23 @@ print_pr_row() {
   printf '%s %-6s %s %s %s\n' "$icon" "#${number}" "$run_col" "$review_col" "$(truncate_str "$title" "$room")"
 }
 
-# Batched GraphQL lookup of merge-queue membership and review status for a set
-# of PR numbers, one round trip for all of them via aliases (a REST call per
-# PR would be N+1). `reviewDecision` reflects the trunk ruleset's required
-# approving review (currently 1, see docs/dev/ci_signoff.md) — null/empty when
-# GitHub hasn't computed a decision yet, which we treat like REVIEW_REQUIRED.
+# Batched GraphQL lookup of merge-queue membership, review status, and
+# mergeability for a set of PR numbers, one round trip for all of them via
+# aliases (a REST call per PR would be N+1). `reviewDecision` reflects the
+# trunk ruleset's required approving review (currently 1, see
+# docs/dev/ci_signoff.md) — null/empty when GitHub hasn't computed a decision
+# yet, which we treat like REVIEW_REQUIRED. `mergeable` is `MERGEABLE`,
+# `CONFLICTING`, or `UNKNOWN` (GitHub computes it asynchronously; UNKNOWN just
+# means "not yet", not "no conflict", but there's no cheap way to force or
+# await the computation from here, so a fresh PR may show one blank cycle
+# before conflicts appear).
 # Returns `{}` on any failure so callers degrade to "not queued, needs review".
 fetch_merge_queue_status() {
   local repo="$1" numbers="$2"
   local owner name fields query
   owner="${repo%%/*}"
   name="${repo#*/}"
-  fields=$(jq -r '[.[] | "pr\(.): pullRequest(number: \(.)) { isInMergeQueue reviewDecision isDraft }"] | join("\n")' <<<"$numbers")
+  fields=$(jq -r '[.[] | "pr\(.): pullRequest(number: \(.)) { isInMergeQueue reviewDecision isDraft mergeable }"] | join("\n")' <<<"$numbers")
   [[ -n "$fields" ]] || { echo '{}'; return; }
   query="query(\$owner:String!,\$name:String!){repository(owner:\$owner,name:\$name){${fields}}}"
   gh api graphql -f query="$query" -f owner="$owner" -f name="$name" 2>/dev/null || echo '{}'
@@ -2124,7 +2133,7 @@ cmd_mine() {
   echo "${C_BOLD}${repo}${C_RESET} — ${count} open PR(s)"
   echo
 
-  local i pr number title branch sha combined state run_id running in_queue review_decision is_draft
+  local i pr number title branch sha combined state run_id running in_queue review_decision is_draft has_conflicts
   for ((i = 0; i < count; i++)); do
     pr=$(jq -c ".[$i]" <<<"$prs")
     number=$(jq -r '.number' <<<"$pr")
@@ -2155,14 +2164,16 @@ cmd_mine() {
     review_decision=$(jq -r ".data.repository.pr${number}.reviewDecision // \"\"" <<<"$mq_status")
     is_draft=0
     [[ "$(jq -r ".data.repository.pr${number}.isDraft // false" <<<"$mq_status")" == "true" ]] && is_draft=1
+    has_conflicts=0
+    [[ "$(jq -r ".data.repository.pr${number}.mergeable // \"\"" <<<"$mq_status")" == "CONFLICTING" ]] && has_conflicts=1
 
     print_pr_row "$number" "$title" "$state" "$run_id" "$running" "$width" \
-      "$in_queue" "$review_decision" "$is_draft"
+      "$in_queue" "$review_decision" "$is_draft" "$has_conflicts"
   done
 
   echo
-  echo "${C_DIM}○ not attested   ${NO} attestation failed   … pending   ⟳ remote sign-off running   ${OK} attested, awaiting queue   ${C_CYAN}${OK}${C_DIM} in merge queue${C_RESET}"
-  echo "${C_DIM}draft   ${C_RED}changes${C_DIM} requested   ${C_YELLOW}needs review${C_DIM}   ${C_GREEN}${C_BOLD}ready to merge${C_RESET}"
+  echo "${C_DIM}○ not attested   ${NO} attestation failed   … pending   ⟳ remote sign-off running   ${OK} attested${C_RESET}"
+  echo "${C_DIM}draft   ${C_RED}changes${C_DIM} requested   ${C_RED}conflicts${C_DIM}   ${C_CYAN}in merge queue${C_DIM}   ${C_YELLOW}needs review${C_DIM}   ${C_GREEN}${C_BOLD}ready to merge${C_RESET}"
   echo "${C_DIM}Sign off with: make signoff  (or: scripts/signoff remote)${C_RESET}"
 }
 


### PR DESCRIPTION
## Summary
Two changes
1. Add `conflicts` and `in merge queue` statuses.
2. Run PR enrichment (statuses, etc) in parallel, up to 8. 

Now
```
scripts/signoff mine
spiceai/spiceai — 17 open PR(s)

○ #12924              draft          fix(dev-tools): show merge-queue and confl…
○ #12920              needs review   bug: SQL-tier function body does not suppo…
○ #12919              needs review   bug: SQL-tier function arguments cannot be…
✓ #12853              in merge queue fix(cayenne): use valid snapshot IDs for d…
○ #12816              needs review   Support SQL filters pushdown for Elasticse…
○ #12812              needs review   feat(search): push SQL filters down into t…
○ #12807              needs review   feat(tools): add pdf-parse tool to compare…
✓ #12796              needs review   fix(cayenne): fractional proptest scaling …
✓ #12784              in merge queue fix(cayenne): reserve append sequence for …
✓ #12783              in merge queue fix(search): make chunked embedding and of…
✓ #12684              in merge queue fix(ci): New branch for each `push-snap-ch…
○ #12635                             test: cover warm-index delete paths across…
✓ #12603              needs review   Helpful tool to track what users/bots have…
○ #12392              needs review   Make `signoff.yml` more searchable.
○ #12189              needs review   feat(views): support `.time_column`/`.time…
✗ #12085              conflicts      chore: narrow unnecessary pub visibility w…
○ #11588              draft          fix(ci): bump Go version for ADBC BigQuery…

○ not attested   ✗ attestation failed   … pending   ⟳ remote sign-off running   ✓ attested
draft   changes requested   conflicts   in merge queue   needs review   ready to merge
Sign off with: make signoff  (or: scripts/signoff remote)
```