### PR TITLE
feat(localpod): Trigger full refresh on parent dataset on query cache  post-TTL 

### DIFF
--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -163,6 +163,19 @@ macro_rules! generate_cache_metrics {
                         .build()
                 });
 
+            pub static STALE_WHILE_REVALIDATE_ACCELERATION_REFRESHES: LazyLock<Counter<u64>> =
+                LazyLock::new(|| {
+                    METER
+                        .u64_counter(concat!(
+                            $prefix,
+                            "_cache_swr_acceleration_refresh_count"
+                        ))
+                        .with_description(
+                            "Number of acceleration refreshes triggered by stale-while-revalidate cache hits.",
+                        )
+                        .build()
+                });
+
             /// Publishes every counter in this module at zero.
             ///
             /// A `LazyLock` counter is only built — and so only registered with
@@ -181,6 +194,7 @@ macro_rules! generate_cache_metrics {
                 STALE_REJECTIONS.add(0, &[]);
                 STALE_WHILE_REVALIDATE_SKIPPED.add(0, &[]);
                 STALE_WHILE_REVALIDATE_BACKGROUND_QUERIES.add(0, &[]);
+                STALE_WHILE_REVALIDATE_ACCELERATION_REFRESHES.add(0, &[]);
                 for reason in EvictionReason::ALL {
                     EVICTIONS.add(0, &[reason.key_value()]);
                 }

--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -1259,6 +1259,23 @@ impl AcceleratedTable {
         }
     }
 
+    /// The parent dataset this table's refreshes are synchronized with, if any.
+    ///
+    /// Set for `localpod` children: they have no refresh loop of their own
+    /// ([`Self::trigger_refresh`] returns `RefreshNotSupportedForChildTable`),
+    /// so a refresh must be triggered on the (transitive) parent instead.
+    #[must_use]
+    pub fn synchronized_parent(&self) -> Option<TableReference> {
+        self.synchronized_with
+            .as_ref()
+            .map(SynchronizedTable::parent_dataset_name)
+    }
+
+    #[must_use]
+    pub fn refresh_mode(&self) -> RefreshMode {
+        self.refresh_mode
+    }
+
     /// # Errors
     ///
     /// Returns an error if the table has no refresh trigger (it is not configured

--- a/crates/runtime/src/datafusion/query/cache.rs
+++ b/crates/runtime/src/datafusion/query/cache.rs
@@ -17,7 +17,10 @@ limitations under the License.
 use super::{
     BindingParametersSnafu, Query, QueryResult, QueryTracker, attach_query_tracker_to_stream,
 };
+use crate::accelerated::AcceleratedTable;
+use crate::component::dataset::acceleration::RefreshMode;
 use crate::datafusion::{DataFusion, error::find_datafusion_root, query::error_code::ErrorCode};
+use crate::status::ComponentStatus;
 use cache::{
     key::{CacheKey, RawCacheKey},
     result::CacheStatus,
@@ -36,6 +39,7 @@ use runtime_request_context::{
 };
 use snafu::ResultExt;
 use std::sync::OnceLock;
+use std::time::Duration;
 use std::{collections::HashSet, hash::Hasher, sync::Arc};
 use tracing::Span;
 
@@ -629,6 +633,196 @@ impl Query {
         }
     }
 
+    /// Resolve the dataset whose refresh actually loads new data for
+    /// `table_ref`, when `table_ref` is a `localpod`-synchronized accelerated
+    /// dataset.
+    ///
+    /// A `localpod` child has no refresh loop of its own and its federated
+    /// "source" is another dataset's accelerator, so refreshing anything but
+    /// the *root* of the synchronization chain would only re-copy stale
+    /// accelerated data. The root's refresh writes through to every
+    /// synchronized child before signaling completion.
+    ///
+    /// Returns `None` when `table_ref` is not a localpod-synchronized
+    /// accelerated dataset, or when the chain root is not refreshed in `full`
+    /// mode (a `caching`-mode root revalidates per cache entry through its own
+    /// stale-while-revalidate path and must not receive full-refresh triggers).
+    async fn swr_acceleration_refresh_target(
+        df: &Arc<DataFusion>,
+        table_ref: &TableReference,
+    ) -> Option<TableReference> {
+        // Bounds the parent walk so a malformed chain cannot loop forever.
+        const MAX_SYNCHRONIZATION_CHAIN_DEPTH: usize = 16;
+
+        let provider = df
+            .get_accelerated_table_provider(table_ref.to_string().as_str())
+            .await
+            .ok()?;
+        let mut parent = provider
+            .downcast_ref::<AcceleratedTable>()?
+            .synchronized_parent()?;
+
+        for _ in 0..MAX_SYNCHRONIZATION_CHAIN_DEPTH {
+            let provider = df
+                .get_accelerated_table_provider(parent.to_string().as_str())
+                .await
+                .ok()?;
+            let accelerated = provider.downcast_ref::<AcceleratedTable>()?;
+            match accelerated.synchronized_parent() {
+                Some(grandparent) => parent = grandparent,
+                None => {
+                    return (accelerated.refresh_mode() == RefreshMode::Full).then_some(parent);
+                }
+            }
+        }
+
+        tracing::warn!(
+            "Skipping stale-while-revalidate acceleration refresh for dataset {table_ref}: its localpod synchronization chain exceeds {MAX_SYNCHRONIZATION_CHAIN_DEPTH} levels"
+        );
+        None
+    }
+
+    /// Trigger an acceleration refresh for `dataset` and wait (bounded by
+    /// `max_wait`) for it to complete, so the revalidation query that follows
+    /// observes refreshed data.
+    ///
+    /// At most one stale-while-revalidate triggered refresh is in flight per
+    /// dataset at any moment: the refresh task runner *cancels* an in-flight
+    /// refresh when a new trigger arrives, so triggering on every stale hit
+    /// would keep restarting the refresh and it could never complete. The
+    /// first revalidation to arrive triggers; concurrent revalidations (other
+    /// cache keys over the same dataset) wait on the same completion signal.
+    async fn refresh_acceleration_and_wait(
+        df: &Arc<DataFusion>,
+        dataset: &TableReference,
+        max_wait: Duration,
+    ) {
+        // Datasets with a stale-while-revalidate triggered refresh currently in
+        // flight. Completion is only signaled on success, so entries expire on
+        // a TTL as the backstop for failed or abandoned refreshes.
+        static IN_FLIGHT_REFRESHES: OnceLock<
+            moka::future::Cache<String, (), std::hash::RandomState>,
+        > = OnceLock::new();
+        let in_flight = IN_FLIGHT_REFRESHES.get_or_init(|| {
+            moka::future::Cache::builder()
+                .max_capacity(10_000)
+                .time_to_live(Duration::from_mins(5))
+                .build()
+        });
+
+        let Ok(provider) = df
+            .get_accelerated_table_provider(dataset.to_string().as_str())
+            .await
+        else {
+            return;
+        };
+        let Some(accelerated) = provider.downcast_ref::<AcceleratedTable>() else {
+            return;
+        };
+        let Some(notifier) = accelerated.refresher().on_complete_notification() else {
+            // Without a completion signal we cannot know when the refreshed
+            // data is visible, and firing blind triggers risks cancelling an
+            // in-flight refresh.
+            return;
+        };
+
+        // Register for the completion signal BEFORE deciding whether to
+        // trigger: `Notify::notify_waiters` only wakes waiters that are
+        // already registered, so a fast refresh could otherwise complete
+        // unobserved and stall this task until the timeout.
+        let notified = notifier.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        let guard_key = dataset.to_string();
+        let is_first_revalidation = in_flight
+            .entry(guard_key.clone())
+            .or_insert(())
+            .await
+            .is_fresh();
+        // Also stand down while any refresh is already running (scheduled or
+        // manual, not just SWR-triggered) — a new trigger would cancel it.
+        let already_refreshing = matches!(
+            df.runtime_status().get_dataset_status(dataset),
+            Some(ComponentStatus::Refreshing)
+        );
+
+        if is_first_revalidation && !already_refreshing {
+            tracing::debug!(
+                "Stale-while-revalidate triggering acceleration refresh for dataset {dataset}"
+            );
+            if let Err(e) = accelerated.trigger_refresh(None).await {
+                tracing::warn!(
+                    "Failed to refresh dataset {dataset} for stale-while-revalidate: {e}"
+                );
+                in_flight.invalidate(&guard_key).await;
+                return;
+            }
+            cache::metrics::sql_results::STALE_WHILE_REVALIDATE_ACCELERATION_REFRESHES.add(1, &[]);
+        }
+
+        match tokio::time::timeout(max_wait, notified).await {
+            Ok(()) => {
+                tracing::debug!(
+                    "Acceleration refresh for dataset {dataset} completed, revalidating cached results"
+                );
+                // Let the next stale hit trigger a fresh refresh.
+                in_flight.invalidate(&guard_key).await;
+            }
+            Err(_) => {
+                // Re-execute against the current accelerated data rather than
+                // leaving the entry stale; this matches the behavior for
+                // non-accelerated sources. The in-flight entry is deliberately
+                // kept: the refresh may still be running and a new trigger
+                // would cancel it — the TTL expires the entry if the refresh
+                // failed.
+                tracing::debug!(
+                    "Acceleration refresh for dataset {dataset} did not complete within {max_wait:?}; revalidating against current accelerated data"
+                );
+            }
+        }
+    }
+
+    /// Refresh the accelerations a stale-while-revalidate revalidation depends
+    /// on before re-executing the query.
+    ///
+    /// Queries over `localpod`-accelerated datasets are served entirely from
+    /// the acceleration, so re-executing the query alone would re-cache the
+    /// same stale data the acceleration already holds. For every input table
+    /// that is a localpod-synchronized dataset, trigger a refresh of its
+    /// synchronization-chain root (which writes through to the children) and
+    /// wait — bounded — for it to complete.
+    async fn refresh_accelerations_for_revalidation(
+        df: &Arc<DataFusion>,
+        input_tables: &HashSet<TableReference>,
+    ) {
+        let mut targets: Vec<TableReference> = Vec::new();
+        for table_ref in input_tables {
+            if let Some(target) = Self::swr_acceleration_refresh_target(df, table_ref).await
+                && !targets.contains(&target)
+            {
+                targets.push(target);
+            }
+        }
+        if targets.is_empty() {
+            return;
+        }
+
+        // Waiting longer than the stale-while-revalidate window is pointless —
+        // the entry being revalidated expires with it. Capped below the
+        // 5-minute per-key revalidation lock TTL so a second revalidation for
+        // the same cache key cannot start while this one is still waiting.
+        let max_wait = df
+            .results_cache_provider()
+            .and_then(|provider| provider.stale_while_revalidate_ttl())
+            .unwrap_or(Duration::from_secs(60))
+            .min(Duration::from_secs(240));
+
+        for target in targets {
+            Self::refresh_acceleration_and_wait(df, &target, max_wait).await;
+        }
+    }
+
     fn trigger_background_query_revalidation(
         df: Arc<DataFusion>,
         sql: &str,
@@ -682,6 +876,11 @@ impl Query {
                         plan_owned,
                         cached_input_tables,
                     );
+
+                    // Refresh any localpod accelerations the query reads from
+                    // before re-executing it — the query alone would only
+                    // re-cache the acceleration's current (stale) contents.
+                    Self::refresh_accelerations_for_revalidation(&df, &input_tables).await;
 
                     // Captured before the query reads anything, so any
                     // invalidation of its tables that lands while it executes

--- a/crates/runtime/tests/acceleration/localpod_sync.rs
+++ b/crates/runtime/tests/acceleration/localpod_sync.rs
@@ -39,10 +39,12 @@ use std::time::Duration;
 
 use app::AppBuilder;
 use arrow::array::Int64Array;
-use runtime::Runtime;
+use cache::result::CacheStatus;
+use futures::TryStreamExt;
+use runtime::{Runtime, datafusion::query::QueryBuilder};
 use spicepod::{
     acceleration::{Acceleration, RefreshMode},
-    component::dataset::Dataset,
+    component::{caching::SQLResultsCacheConfig, dataset::Dataset},
     param::Params,
 };
 use tempfile::TempDir;
@@ -215,6 +217,150 @@ async fn test_localpod_full_refresh_synchronization_with_arrow_parent() -> Resul
                 child_count, 5,
                 "localpod child should synchronize with the parent's refresh (was frozen at \
                  startup count before #11137 fix)"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// Run `sql` through the cached query pipeline, returning the observed cache status and the
+/// single `Int64` value of the first column (the tests query `COUNT(*)`).
+async fn run_cached_count(rt: &Runtime, sql: &str) -> (CacheStatus, i64) {
+    let result = QueryBuilder::new(sql, rt.datafusion())
+        .build()
+        .run()
+        .await
+        .expect("query should succeed");
+    let cache_status = result.cache_status;
+    let batches = result
+        .data
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("query results should collect");
+    let value = batches
+        .first()
+        .expect("query should return a batch")
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("COUNT(*) should be an Int64Array")
+        .value(0);
+    (cache_status, value)
+}
+
+/// A SQL results cache hit inside the stale-while-revalidate window must trigger a refresh of
+/// the localpod acceleration chain, so the background revalidation observes (and re-caches)
+/// fresh data instead of re-reading the same stale accelerated rows forever.
+///
+/// Regression test for <https://github.com/spiceai/spiceai/issues/12918>.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_localpod_swr_cache_hit_triggers_acceleration_refresh() -> Result<(), anyhow::Error> {
+    const SQL: &str = "SELECT COUNT(*) AS c FROM local_time_series";
+
+    let _tracing = init_tracing(Some(
+        "integration=debug,runtime=debug,runtime_table::accelerated=debug",
+    ));
+
+    test_request_context()
+        .scope(async {
+            let temp_dir = TempDir::new().expect("create temp dir");
+            let csv_path = temp_dir.path().join("data.csv");
+            fs::write(&csv_path, format!("{CSV_HEADER}{}", rows(0, 2)))
+                .await
+                .expect("write initial csv");
+
+            // Parent: file connector, full refresh, no refresh interval — the only way its
+            // acceleration refreshes after startup is the stale-while-revalidate trigger under
+            // test.
+            let mut parent = Dataset::new(format!("file://{}", csv_path.display()), "time_series");
+            parent.params = Some(Params::from_string_map(
+                vec![
+                    ("file_format".to_string(), "csv".to_string()),
+                    ("csv_has_header".to_string(), "true".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ));
+            parent.acceleration = Some(Acceleration {
+                enabled: true,
+                refresh_mode: Some(RefreshMode::Full),
+                ..Acceleration::default()
+            });
+
+            // Child: localpod over the parent, synchronized with the parent's refreshes.
+            let mut child = Dataset::new("localpod:time_series", "local_time_series");
+            child.acceleration = Some(Acceleration {
+                enabled: true,
+                refresh_mode: Some(RefreshMode::Full),
+                ..Acceleration::default()
+            });
+
+            let app = AppBuilder::new("test_localpod_swr_refresh")
+                .with_sql_cache(SQLResultsCacheConfig {
+                    item_ttl: Some("1s".to_string()),
+                    stale_while_revalidate_ttl: Some("5m".to_string()),
+                    ..Default::default()
+                })
+                .with_dataset(parent)
+                .with_dataset(child)
+                .build();
+
+            configure_test_datafusion();
+            let runtime = Arc::new(Runtime::builder().with_app(app).build().await);
+
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(30)) => {
+                    return Err(anyhow::Error::msg("Timed out waiting for datasets to load"));
+                }
+                () = Arc::clone(&runtime).load_components() => {}
+            }
+            runtime_ready_check(&runtime).await;
+
+            // Populate the cache from the child's initial accelerated load.
+            let (status, count) = run_cached_count(&runtime, SQL).await;
+            assert_eq!(status, CacheStatus::CacheMiss, "first request must miss");
+            assert_eq!(count, 2, "initial load should see the two startup rows");
+
+            // The source grows to five rows; nothing refreshes the accelerations on its own.
+            fs::write(&csv_path, format!("{CSV_HEADER}{}", rows(0, 5)))
+                .await
+                .expect("append rows to csv");
+
+            // Age the cached entry past its TTL into the stale-while-revalidate window. The
+            // sleep is the behavior under test (TTL expiry), not a readiness wait.
+            tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+            // A stale hit serves the cached (old) result and must kick off the acceleration
+            // refresh in the background.
+            let (status, count) = run_cached_count(&runtime, SQL).await;
+            assert_eq!(
+                status,
+                CacheStatus::CacheStaleWhileRevalidate,
+                "aged entry must be served stale-while-revalidate"
+            );
+            assert_eq!(count, 2, "stale hit still serves the cached rows");
+
+            // Poll until the refreshed data lands: the parent re-reads the CSV, writes through
+            // to the localpod child, and the background revalidation re-caches the query with
+            // the new count. Without the refresh trigger, the revalidation re-caches the stale
+            // accelerated count of 2 and this loop never observes 5.
+            let mut last = (status, count);
+            for _ in 0..120 {
+                if let Some(provider) = runtime.datafusion().results_cache_provider() {
+                    provider.run_pending_tasks().await;
+                }
+                last = run_cached_count(&runtime, SQL).await;
+                if last == (CacheStatus::CacheHit, 5) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            assert_eq!(
+                last,
+                (CacheStatus::CacheHit, 5),
+                "stale-while-revalidate hit should refresh the localpod acceleration and \
+                 re-cache the query with the refreshed rows"
             );
 
             Ok(())


### PR DESCRIPTION
Fixes #12918

## Problem

With `runtime.caching.sql_results.stale_while_revalidate_ttl` configured, a cache hit inside the SWR window triggers a background revalidation that re-executes the query. For a `localpod` dataset the query is served entirely from its acceleration, so the revalidation just re-read the same stale accelerated rows and re-cached them with a fresh timestamp — the data never actually refreshed, no matter how many SWR cycles ran.

## Change

A stale-while-revalidate hit now triggers a refresh of the acceleration chain before the revalidation query re-executes:

- For every input table of the stale entry that is a `localpod`-synchronized accelerated dataset, the background revalidation resolves the **root** of the synchronization chain (a `localpod` child has no refresh loop of its own — its refreshes are synchronized with the parent, and the parent's refresh writes through to every synchronized child before signaling completion). Only roots with `refresh_mode: full` are triggered; `caching`-mode roots keep revalidating through their own per-entry SWR path.
- The revalidation waits (bounded by the configured `stale_while_revalidate_ttl`, capped at 4 minutes) for the refresh to complete, then re-executes the query and re-caches the result — so the revalidated entry holds genuinely fresh data.

### Only one refresh in flight per dataset

`RefreshTaskRunner` cancels an in-flight refresh when a new trigger arrives, so triggering on every stale hit would keep restarting the refresh and it could never complete. Two guards prevent that:

- a per-dataset single-flight registry: the first revalidation to arrive triggers the refresh; concurrent revalidations (other cache keys over the same dataset) wait on the same completion notification. The registry entry is dropped on completion and expires on a TTL as the backstop for failed refreshes (completion is only signaled on success).
- the trigger also stands down when the dataset's runtime status is already `Refreshing` (scheduled or manual refresh in progress), waiting on its completion instead.

On timeout the revalidation proceeds against the current accelerated data (matching the previous behavior for slow/failed refreshes) and deliberately leaves the single-flight entry in place so a still-running refresh is not cancelled by a subsequent trigger.

Also adds a `results_cache_swr_acceleration_refresh_count` counter alongside the existing SWR metrics.

## Testing

- New integration test `test_localpod_swr_cache_hit_triggers_acceleration_refresh`: file-connector parent (full refresh, no interval) + `localpod` child + SQL results cache (`item_ttl: 1s`, `stale_while_revalidate_ttl: 5m`). After the source grows, a stale hit serves the old count and the test polls until the entry is re-cached with the refreshed count — which only happens when the SWR hit refreshes the parent and the write-through reaches the child.
