### PR TITLE
feat(cloud-connect): add standalone status schema

### DIFF
--- a/crates/runtime-cloud-connect/proto/cloud_connect.proto
+++ b/crates/runtime-cloud-connect/proto/cloud_connect.proto
@@ -47,9 +47,7 @@
 // A oneof is its own group and numbers its arms contiguously from 1; the
 // enclosing message's remaining fields follow it. Every other message numbers
 // contiguously from 1 in declaration order. New fields take the next free
-// number. Nothing is skipped or reserved: the two sides of this contract ship
-// together, so a removed field's number is free to be reused rather than frozen
-// for a peer that does not exist.
+// number. Removed field and enum numbers are reserved and never reused.
 //
 // Protobuf shares one number space across a message and the oneofs inside it,
 // so a message whose oneof starts at 1 declares that oneof first and its own
@@ -240,6 +238,13 @@ message Heartbeat {
   uint32 active_models = 6;
   uint32 active_spicepods = 7;
   map<string, string> runtime_versions = 8;
+  // Presence distinguishes an unreported status from a reported empty status.
+  StandaloneRuntimeStatus standalone_runtime = 9;
+}
+
+message StandaloneRuntimeStatus {
+  // Configuration paths whose desired values require a restart to take effect.
+  repeated string restart_required = 1;
 }
 
 // Terminal reply to a command, correlated by `command_id`.
@@ -427,10 +432,12 @@ message ExecuteQuery {
   uint32 max_rows = 2;
 }
 
-// The app this instance is attached to, as the control plane currently sees it.
-// Absent means detached. If present it must be non-empty.
+// `app_id` absent means detached. Every present field must be non-empty.
 message AttachApp {
   optional string app_id = 1;
+  optional string org_name = 2;
+  optional string app_name = 3;
+  optional string monitor_url = 4;
 }
 
 // Sealed secrets delivery. A secret value is sealed TWICE with HPKE

--- a/crates/runtime-cloud-connect/src/heartbeat.rs
+++ b/crates/runtime-cloud-connect/src/heartbeat.rs
@@ -49,6 +49,7 @@ pub(crate) async fn build_heartbeat(
         active_models,
         active_spicepods: 0,
         runtime_versions: std::collections::HashMap::new(),
+        standalone_runtime: None,
     }
 }
 

--- a/crates/runtime-cloud-connect/tests/adoption_flow.rs
+++ b/crates/runtime-cloud-connect/tests/adoption_flow.rs
@@ -628,6 +628,9 @@ async fn attach_app_applies_complete_state_and_rejects_empty_ids() {
             target: None,
             body: Some(proto::control_message::Body::AttachApp(proto::AttachApp {
                 app_id: app_id.map(str::to_string),
+                org_name: None,
+                app_name: None,
+                monitor_url: None,
             })),
         })
         .collect();


### PR DESCRIPTION
## Summary

- add the frozen standalone runtime status and attachment metadata fields to the authoritative Cloud Connect protobuf
- preserve `spice.cloud.v1`, protocol version 1, and every existing wire declaration
- keep existing Rust consumers compiling with absent/default values for the new generated fields
- reserve removed field and enum numbers against reuse in the numbering policy

Runtime production and persistence of these fields, along with the shared contract fixture, remain outside this PR.

Part of spicehq/spiceai#1398

## Verification

- `cargo check --locked -p runtime-cloud-connect`
- `cargo test --locked -p runtime-cloud-connect` (131 unit, 5 adoption-flow, 28 end-to-end tests)
- `cargo clippy --locked -p runtime-cloud-connect --no-deps --tests -- -D warnings`
- `cargo fmt --check -p runtime-cloud-connect`
- `protoc` syntax and descriptor generation
- descriptor comparison against `byoc@origin`: five exact additions; 105 existing fields, 30 messages, 23 enum values, seven oneofs, and the service method preserved
- non-vacuity probe: an intentionally wrong field-number assertion failed before the correct assertions passed
- adversarial review: PASS (CRITICAL 0, HIGH 0)
