### PR TITLE
bench(cache): add Pingora engine coverage

### DIFF
--- a/crates/cache/benches/README.md
+++ b/crates/cache/benches/README.md
@@ -37,34 +37,34 @@ LRU instead, so that arm would duplicate `pingora_lru`.
 
 ### hot_read_write
 
-The other `LruCache` benchmarks read a 100,000 key space holding at most 5,000
-entries, so roughly 95% of their reads miss. That matters for the engine
-comparison: a Pingora miss is one metadata lookup, while a hit removes the entry
-and re-admits it, because `pingora-lru` has no `peek_value`. Reads that miss
-never reach the path where the engines differ.
+Reads and writes are not independent knobs, because they are not independent in
+the runtime: a miss executes the query and caches the result, so the write rate
+is the miss rate. This benchmark reads, and refills on a miss, so hit rate is
+the only knob and the write rate follows from it.
 
-Reads and writes are not independent knobs here, because they are not
-independent in the runtime: a miss executes the query and caches the result, so
-the write rate *is* the miss rate. Setting a read/write mix separately from a
-hit rate describes states a results cache cannot be in. This benchmark reads,
-and refills on a miss, so hit rate is the only knob and the write rate follows
-from it.
+Hit rate is set by sizing: capacity is fixed at 16,000 entries and the working
+set is `capacity / hit_rate`, since an LRU holding `C` of a `W`-key working set
+hits about `C/W` under uniform access. The cache starts full. Threads are 16 and
+32, straddling the 16 metadata shards Pingora uses.
 
-Parameters:
+## Engine Comparison Results
 
-- **Hit rate**: 50%, 95% and 99%. Under uniform access an LRU holding `C` of a
-  `W`-key working set hits about `C/W`, so capacity is fixed at 16,000 entries
-  and the working set is sized against it. 50% is the thrashing regime the older
-  benchmarks sit in; 99% is where a results cache worth enabling runs.
-- **Threads**: 16 and 32, straddling the 16 metadata shards Pingora uses. At 16
-  shard collisions are incidental; at 32 they are structural.
+Apple M-series, `--sample-size 10`. Lower is faster.
 
-The cache starts full: the whole working set is inserted, then evicted down to
-capacity. One hash algorithm, since raw-key operations bypass the hasher.
+### Pure reads (`concurrent_get`)
 
-Hit rate decides the winner, and it flips between 50% and 95%. Apple M-series,
-`--sample-size 10`, total time for threads x 10,000 operations (lower is
-faster):
+| threads | moka_lru | moka_tinylfu | pingora_lru | pingora vs moka_lru |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 | 2.70 ms | 2.82 ms | 1.27 ms | 0.47x |
+| 4 | 7.62 ms | 7.30 ms | 3.80 ms | 0.50x |
+| 8 | 13.12 ms | 13.05 ms | 6.44 ms | 0.49x |
+| 16 | 29.91 ms | 29.43 ms | 13.78 ms | 0.46x |
+
+`concurrent_get` reads a 100,000 key space holding ~3,125 entries, so ~97% of
+its reads miss. A Pingora miss is one metadata lookup, while a hit removes the
+entry and re-admits it, so this measures the path where Pingora is cheapest.
+
+### Read-through across hit rates (`hot_read_write`)
 
 | hit rate | threads | moka_lru | moka_tinylfu | pingora_lru | pingora vs moka_lru |
 | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -75,42 +75,35 @@ faster):
 | 99% | 16 | 38.3 ms | 38.1 ms | 43.7 ms | 1.14x |
 | 99% | 32 | 73.3 ms | 73.2 ms | 99.6 ms | 1.36x |
 
-At 50% every other operation is a refill, so the run is dominated by insert and
-eviction, and Pingora is 3-3.7x faster. At 95% and 99% the work is nearly all
-reads, and Moka leads by 1.14-2.32x because Pingora expresses a read as a remove
-plus re-admit.
+Hit rate decides the winner. At 50% every other operation is a refill, the run
+is dominated by insert and eviction, and Pingora is 3-3.7x faster. At 95% and
+99% the work is nearly all reads and Moka leads.
 
-Pingora scales worse with threads at every hit rate. Doubling threads doubles
-the work, so 2.0x is break-even:
+Pingora also scales worse with threads. Doubling threads doubles the work, so
+2.0x is break-even: Moka runs 1.81-2.28x, Pingora 2.28-2.76x.
 
-| hit rate | moka_lru | pingora_lru |
-| ---: | ---: | ---: |
-| 50% | 2.28x | 2.76x |
-| 95% | 1.81x | 2.64x |
-| 99% | 1.91x | 2.28x |
+### Does cache size matter?
 
-TinyLFU earns its keep where admission control matters: 13% ahead of LRU at 50%,
-7% at 95%, and level at 99%, where almost nothing is evicted.
+Largely no. A separate pure-read sweep over 1,000 / 5,000 / 30,000 entries put
+the crossover between 80% and 95% at every capacity, and Pingora's timings were
+within 3% of each other across the whole 30x range.
 
-Numbers are from a laptop at reduced sample size, where 32 threads oversubscribes
-the cores.
+One exception, outside the range these benchmarks use: at 3% hits with 30,000
+entries — a 1,000,000-key working set — Moka's pure-read time jumps 2.4x while
+Pingora is unchanged. That corner scales capacity and key space together, so it
+does not separate the two causes.
 
-Moka is far noisier than Pingora. A separate run measuring run-to-run spread
-over five repetitions found Moka varying up to 30% between repetitions while
-Pingora stayed within 1-3%, most likely Moka's background maintenance landing
-differently. Treat differences under roughly 15% against Moka as unresolved at
-this sample size: the 50% gaps are real, the 99% ones are directional. Pingora's
-reproducibility is itself a result, and arguably matters more for tail latency
-than the median either way.
+### Precision
 
-The `C/W` sizing was checked separately against measured hit rates. Achieved
-rates land within half a point of target (3.0 / 50.3 / 80.0 / 95.0 / 99.0) and
-the resident set matches capacity exactly, for both engines. The crossover also
-holds across a 30x capacity range - 1,000, 5,000 and 30,000 entries all put it
-between 80% and 95% - so the single capacity used here does not bias it.
+Moka is far noisier than Pingora. Over five repetitions Moka varied up to 30%
+between runs while Pingora stayed within 1-3%, most likely Moka's background
+maintenance landing differently. Treat differences under roughly 15% against
+Moka as unresolved at this sample size. Pingora's reproducibility is itself a
+result, and arguably matters more for tail latency than the median either way.
 
-This benchmark asserts its hit rates through sizing rather than measuring them.
-That was verified once by hand, as above, but it is an assumption in the code.
+The `C/W` sizing is an assumption in the code, checked once by hand: achieved
+hit rates land within half a point of target (3.0 / 50.3 / 80.0 / 95.0 / 99.0)
+and the resident set matches capacity exactly, for both engines.
 
 ## Thread Counts
 

--- a/crates/cache/benches/README.md
+++ b/crates/cache/benches/README.md
@@ -20,10 +20,6 @@ Benchmarked as named pairs rather than a cartesian product:
 There is no `pingora_tinylfu`: Pingora has no TinyLFU admission and builds an
 LRU instead, so that arm would duplicate `pingora_lru`.
 
-Without `--features pingora` the Pingora arm is not generated. With the feature
-off, requesting the engine falls back to Moka, so including it anyway would
-publish Moka numbers labelled `pingora`.
-
 ### Hash Algorithms (4 variants)
 
 - **siphash**: Rust's default hasher (cryptographically secure, slower)

--- a/crates/cache/benches/README.md
+++ b/crates/cache/benches/README.md
@@ -93,10 +93,24 @@ TinyLFU earns its keep where admission control matters: 13% ahead of LRU at 50%,
 7% at 95%, and level at 99%, where almost nothing is evicted.
 
 Numbers are from a laptop at reduced sample size, where 32 threads oversubscribes
-the cores. Intervals run to roughly +/-8%, so the 50% and 95% gaps are solid and
-the 14% figure at 99% and 16 threads is near the noise floor. Moka reading
-slower at 99% than at 95% is within that margin and should not be read as a
-trend.
+the cores.
+
+Moka is far noisier than Pingora. A separate run measuring run-to-run spread
+over five repetitions found Moka varying up to 30% between repetitions while
+Pingora stayed within 1-3%, most likely Moka's background maintenance landing
+differently. Treat differences under roughly 15% against Moka as unresolved at
+this sample size: the 50% gaps are real, the 99% ones are directional. Pingora's
+reproducibility is itself a result, and arguably matters more for tail latency
+than the median either way.
+
+The `C/W` sizing was checked separately against measured hit rates. Achieved
+rates land within half a point of target (3.0 / 50.3 / 80.0 / 95.0 / 99.0) and
+the resident set matches capacity exactly, for both engines. The crossover also
+holds across a 30x capacity range - 1,000, 5,000 and 30,000 entries all put it
+between 80% and 95% - so the single capacity used here does not bias it.
+
+This benchmark asserts its hit rates through sizing rather than measuring them.
+That was verified once by hand, as above, but it is an assumption in the code.
 
 ## Thread Counts
 

--- a/crates/cache/benches/README.md
+++ b/crates/cache/benches/README.md
@@ -36,42 +36,57 @@ publish Moka numbers labelled `pingora`.
 - **concurrent_get**: Read-heavy workload (100% reads, pre-populated cache)
 - **concurrent_put**: Write-heavy workload (100% writes)
 - **concurrent_mixed_80_20**: Realistic workload (80% reads, 20% writes)
-- **invalidate_for_table**: Invalidating one table's entries — what an accelerated
-  refresh triggers every cycle, once per dataset
+- **hot_read_write**: Full cache whose reads mostly hit, 95/5 and 80/20 read/write
+  at 16 and 32 threads
 
-### invalidate_for_table
+### hot_read_write
 
-Entries are spread over 8 tables and one is invalidated, so the share removed
-stays fixed while the cache is sized at 50 / 1k / 10k / 50k entries. Cache size
-is the axis because that is where the engines differ: Moka matches through its
-own index, while Pingora has no closure-based API and walks every key.
+The other `LruCache` benchmarks read a 100,000 key space holding at most 5,000
+entries, so roughly 95% of their reads miss. That matters for the engine
+comparison: a Pingora miss is one metadata lookup, while a hit removes the entry
+and re-admits it, because `pingora-lru` has no `peek_value`. Reads that miss
+never reach the path where the engines differ.
 
-Timing covers `invalidate_for_table` and `checkpoint()`. Moka's
-`invalidate_entries_if` registers a predicate and applies it during later
-maintenance, so timing the call alone would compare registering a predicate
-against completing a scan. For Pingora it only settles the weight.
+This benchmark reads a key space equal to the working set, so reads hit, and
+sizes capacity at 80% of it, so writes evict and the cache runs full.
 
-This benchmark is single-threaded and uses one hash algorithm: raw-key
-operations bypass the hasher, so it cannot affect the measurement.
+Parameters:
 
-The engines cross over, so a single cache size does not tell you which is
-faster. Apple M-series, `--sample-size 10`:
+- **Threads**: 16 and 32, straddling the 16 metadata shards Pingora uses. At 16
+  shard collisions are incidental; at 32 they are structural.
+- **Mix**: 95/5 and 80/20 read/write. Writes rewrite a key already in the
+  working set, as a refreshed result does, and still evict because the cache is
+  full.
 
-| entries | moka_lru | pingora_lru | ratio |
-| ------: | -------: | ----------: | ----: |
-|      50 |  30.4 µs |     17.7 µs | 0.58x |
-|   1,000 |   178 µs |      237 µs | 1.33x |
-|  10,000 |  1.13 ms |     2.38 ms | 2.10x |
-|  50,000 |  5.39 ms |    18.44 ms | 3.42x |
+Uses one hash algorithm: raw-key operations bypass the hasher, so it cannot
+affect the measurement.
 
-Below roughly a thousand entries Pingora's scan is cheaper than Moka's predicate
-registration and maintenance pass. Above it the walk dominates: 5x the entries
-costs Moka 4.8x and Pingora 7.8x. Treat a shift in the crossover as the signal,
-not any single row.
+Neither engine wins outright. Apple M-series, `--sample-size 10`, total time for
+threads x 10,000 operations (lower is faster):
+
+| case | moka_lru | moka_tinylfu | pingora_lru |
+| ---: | ---: | ---: | ---: |
+| 95/5, 16 threads | 34.6 ms | 32.8 ms | 41.9 ms |
+| 95/5, 32 threads | 64.8 ms | 62.1 ms | 107.2 ms |
+| 80/20, 16 threads | 80.6 ms | 82.2 ms | 50.2 ms |
+| 80/20, 32 threads | 231.2 ms | 186.5 ms | 133.9 ms |
+
+Read-heavy favours Moka, and the gap widens with threads. Doubling threads
+doubles the work, so 2.0x is the break-even: Moka scales at 1.87x and Pingora at
+2.56x. Pingora expresses a read as a remove plus re-admit, so reads contend on
+the 16 shards in a way Moka's do not.
+
+Write-heavy reverses it, with Pingora 38-42% faster at both thread counts.
+TinyLFU also earns its keep here — it costs a little on read-heavy load and
+saves 19% over LRU at 80/20 and 32 threads.
+
+So the write fraction, not the engine, decides which is faster. Numbers are from
+a laptop at reduced sample size, where 32 threads oversubscribes the cores:
+adequate for the direction and the crossover, not for precise ratios.
 
 ## Thread Counts
 
-Tests scalability with: 1, 4, 8, 16 threads
+Tests scalability with: 1, 4, 8, 16 threads. `hot_read_write` uses 16 and 32.
 
 ## Running Benchmarks
 
@@ -90,8 +105,8 @@ cargo bench -p cache --bench cache_throughput -- lru_cache
 # Just get operations
 cargo bench -p cache --bench cache_throughput -- concurrent_get
 
-# Just the invalidation benchmark (needs the feature to include Pingora)
-cargo bench -p cache --features pingora --bench cache_throughput -- invalidate_for_table
+# Just the contention benchmark (needs the feature to include Pingora)
+cargo bench -p cache --features pingora --bench cache_throughput -- hot_read_write
 
 # Specific engine / policy pair
 cargo bench -p cache --bench cache_throughput -- moka_lru
@@ -155,6 +170,12 @@ lru_cache_concurrent_get/moka_lru_xxh3_8threads
 - Cache pre-population: 5,000 entries (for get/mixed benchmarks)
 - TTL: 60 seconds
 - Value size: 32 random alphanumeric characters per BenchValue
+
+`hot_read_write` sizes itself separately, in entries rather than weight:
+
+- `HOT_WORKING_SET`: 20,000 keys, all pre-populated and all read from
+- `HOT_CACHE_WEIGHT`: capacity for 80% of them, so the cache runs full
+- TTL: 10 minutes, so nothing expires mid-run
 
 ## Output
 

--- a/crates/cache/benches/README.md
+++ b/crates/cache/benches/README.md
@@ -60,9 +60,10 @@ Apple M-series, `--sample-size 10`. Lower is faster.
 | 8 | 13.12 ms | 13.05 ms | 6.44 ms | 0.49x |
 | 16 | 29.91 ms | 29.43 ms | 13.78 ms | 0.46x |
 
-`concurrent_get` reads a 100,000 key space holding ~3,125 entries, so ~97% of
-its reads miss. A Pingora miss is one metadata lookup, while a hit removes the
-entry and re-admits it, so this measures the path where Pingora is cheapest.
+`concurrent_get` reads a 100,000 key space while the cache holds ~3,125 entries,
+so ~97% of its reads miss. A Pingora miss returns after one metadata lookup,
+which is why it wins here — the ~2x is a property of the miss path, not of reads
+in general.
 
 ### Pure reads across hit rates
 

--- a/crates/cache/benches/README.md
+++ b/crates/cache/benches/README.md
@@ -64,6 +64,30 @@ Apple M-series, `--sample-size 10`. Lower is faster.
 its reads miss. A Pingora miss is one metadata lookup, while a hit removes the
 entry and re-admits it, so this measures the path where Pingora is cheapest.
 
+### Pure reads across hit rates
+
+`concurrent_get` is fixed at ~3% and `hot_read_write` refills on a miss, so
+neither isolates the read path across hit rates. `tests/hit_rate_experiment.rs`
+does: no writes, no eviction, resident set pinned. 16 threads, capacity 5,000,
+median of five:
+
+| hit rate | moka_lru | moka_tinylfu | pingora_lru | pingora vs moka_lru |
+| ---: | ---: | ---: | ---: | ---: |
+| 3% | 34.9 ms | 36.9 ms | 13.8 ms | 0.40x |
+| 50% | 33.9 ms | 34.9 ms | 22.5 ms | 0.66x |
+| 80% | 32.9 ms | 33.7 ms | 32.5 ms | 0.99x |
+| 95% | 34.7 ms | 34.7 ms | 39.0 ms | 1.12x |
+| 99% | 35.2 ms | 36.6 ms | 40.2 ms | 1.14x |
+
+Moka is flat: 33-35 ms across a 33x swing in hit rate. Pingora rises
+monotonically, 2.9x from end to end, because only a hit pays the remove and
+re-admit. They cross around 80%.
+
+Above the crossover the two are close — Pingora 12-14% behind, against Moka's
+own run-to-run spread — so on reads alone this is a parity result, not a Moka
+win. The larger gaps in `hot_read_write` at 95% and 99% therefore come from the
+refills, not from the read path.
+
 ### Read-through across hit rates (`hot_read_write`)
 
 | hit rate | threads | moka_lru | moka_tinylfu | pingora_lru | pingora vs moka_lru |
@@ -84,9 +108,9 @@ Pingora also scales worse with threads. Doubling threads doubles the work, so
 
 ### Does cache size matter?
 
-Largely no. A separate pure-read sweep over 1,000 / 5,000 / 30,000 entries put
-the crossover between 80% and 95% at every capacity, and Pingora's timings were
-within 3% of each other across the whole 30x range.
+Largely no. The same harness swept 1,000 / 5,000 / 30,000 entries and put the
+crossover between 80% and 95% at every capacity, with Pingora's timings within
+3% of each other across the whole 30x range.
 
 One exception, outside the range these benchmarks use: at 3% hits with 30,000
 entries — a 1,000,000-key working set — Moka's pure-read time jumps 2.4x while

--- a/crates/cache/benches/README.md
+++ b/crates/cache/benches/README.md
@@ -7,12 +7,25 @@ This benchmark suite tests the performance of different cache implementations wi
 ### Cache Implementations
 
 - **SimpleCache**: Pingora-based simple cache (legacy, baseline)
-- **LruCache**: Moka-based LRU cache with configurable caching policies
+- **LruCache**: the results cache, run against both of its engines
 
-### Caching Policies (LruCache only)
+### Engine / policy combinations (LruCache only)
 
-- **LRU**: Standard Least Recently Used eviction policy
-- **TinyLFU**: Frequency-based admission policy with better hit rates for some workloads
+Benchmarked as named pairs rather than a cartesian product, because not every
+combination is real:
+
+- **moka_lru**: Moka with standard Least Recently Used eviction
+- **moka_tinylfu**: Moka with frequency-based admission — better hit rates on some workloads
+- **pingora_lru**: Pingora-LRU, sharded. Requires `--features pingora`
+
+There is deliberately no `pingora_tinylfu`: Pingora has no TinyLFU admission, so
+requesting it logs a warning and builds an LRU. That arm would re-measure
+`pingora_lru` under a misleading name.
+
+Without `--features pingora`, the Pingora arm is not generated at all. This is
+intentional — with the feature off, requesting the Pingora engine silently falls
+back to Moka, so a bench that included it anyway would publish Moka numbers
+labelled `pingora`.
 
 ### Hash Algorithms (4 variants)
 
@@ -26,6 +39,43 @@ This benchmark suite tests the performance of different cache implementations wi
 - **concurrent_get**: Read-heavy workload (100% reads, pre-populated cache)
 - **concurrent_put**: Write-heavy workload (100% writes)
 - **concurrent_mixed_80_20**: Realistic workload (80% reads, 20% writes)
+- **invalidate_for_table**: Invalidating one table's entries — what an accelerated
+  refresh triggers every cycle, once per dataset
+
+### invalidate_for_table
+
+Entries are spread over 8 tables and one table is invalidated, so the number
+removed stays a fixed share while the cache is sized at 50 / 1k / 10k / 50k
+entries.
+Cost that grows with the *total* rather than with the number of matches is the
+regression this is here to catch: Moka matches through its own index, while the
+Pingora path has no closure-based API and walks every key, reading each value to
+test it.
+
+Timing covers `invalidate_for_table` **and** `checkpoint()`. Moka's
+`invalidate_entries_if` only registers a predicate and applies it during later
+maintenance, so timing the call alone would compare registering a predicate
+against completing a scan. `checkpoint()` forces that deferred work; for Pingora
+the removals are already done and it only settles the weight.
+
+Unlike the throughput benchmarks this one is single-threaded and does not vary
+the hash algorithm — raw-key operations hand the `u64` straight to the backend
+without consulting the hasher, so it cannot move the measurement.
+
+The engines cross over, so a single cache size will not tell you which is
+faster. Measured on an M-series laptop, one table of eight invalidated:
+
+| entries | moka_lru | pingora_lru | ratio |
+| ------: | -------: | ----------: | ----: |
+|      50 |  30.4 µs |     17.7 µs | 0.58x |
+|   1,000 |   178 µs |      237 µs | 1.33x |
+|  10,000 |  1.13 ms |     2.38 ms | 2.10x |
+|  50,000 |  5.39 ms |    18.44 ms | 3.42x |
+
+Below roughly a thousand entries Pingora's scan is cheaper than Moka's predicate
+registration and maintenance pass. Above it the walk dominates and the gap keeps
+widening — 5x the entries costs Moka 4.8x but Pingora 7.8x. Treat a change in
+where that crossover sits as the signal, not any single row.
 
 ## Thread Counts
 
@@ -48,9 +98,13 @@ cargo bench -p cache --bench cache_throughput -- lru_cache
 # Just get operations
 cargo bench -p cache --bench cache_throughput -- concurrent_get
 
-# Specific caching policy
-cargo bench -p cache --bench cache_throughput -- lru
-cargo bench -p cache --bench cache_throughput -- tinylfu
+# Just the invalidation benchmark (needs the feature to include Pingora)
+cargo bench -p cache --features pingora --bench cache_throughput -- invalidate_for_table
+
+# Specific engine / policy pair
+cargo bench -p cache --bench cache_throughput -- moka_lru
+cargo bench -p cache --bench cache_throughput -- moka_tinylfu
+cargo bench -p cache --features pingora --bench cache_throughput -- pingora_lru
 
 # Specific hash algorithm
 cargo bench -p cache --bench cache_throughput -- xxh3
@@ -78,7 +132,7 @@ cargo bench -p cache --bench cache_throughput --features xxhash
 Criterion outputs results like:
 
 ```text
-lru_cache_concurrent_get/lru_xxh3_8threads
+lru_cache_concurrent_get/moka_lru_xxh3_8threads
                         time:   [125.43 ms 126.89 ms 128.52 ms]
                         thrpt:  [623.18 Kelem/s 631.31 Kelem/s 638.52 Kelem/s]
 ```

--- a/crates/cache/benches/README.md
+++ b/crates/cache/benches/README.md
@@ -112,11 +112,6 @@ Largely no. The same harness swept 1,000 / 5,000 / 30,000 entries and put the
 crossover between 80% and 95% at every capacity, with Pingora's timings within
 3% of each other across the whole 30x range.
 
-One exception, outside the range these benchmarks use: at 3% hits with 30,000
-entries — a 1,000,000-key working set — Moka's pure-read time jumps 2.4x while
-Pingora is unchanged. That corner scales capacity and key space together, so it
-does not separate the two causes.
-
 ### Precision
 
 Moka is far noisier than Pingora. Over five repetitions Moka varied up to 30%

--- a/crates/cache/benches/README.md
+++ b/crates/cache/benches/README.md
@@ -11,21 +11,18 @@ This benchmark suite tests the performance of different cache implementations wi
 
 ### Engine / policy combinations (LruCache only)
 
-Benchmarked as named pairs rather than a cartesian product, because not every
-combination is real:
+Benchmarked as named pairs rather than a cartesian product:
 
-- **moka_lru**: Moka with standard Least Recently Used eviction
-- **moka_tinylfu**: Moka with frequency-based admission — better hit rates on some workloads
+- **moka_lru**: Moka with Least Recently Used eviction
+- **moka_tinylfu**: Moka with frequency-based admission
 - **pingora_lru**: Pingora-LRU, sharded. Requires `--features pingora`
 
-There is deliberately no `pingora_tinylfu`: Pingora has no TinyLFU admission, so
-requesting it logs a warning and builds an LRU. That arm would re-measure
-`pingora_lru` under a misleading name.
+There is no `pingora_tinylfu`: Pingora has no TinyLFU admission and builds an
+LRU instead, so that arm would duplicate `pingora_lru`.
 
-Without `--features pingora`, the Pingora arm is not generated at all. This is
-intentional — with the feature off, requesting the Pingora engine silently falls
-back to Moka, so a bench that included it anyway would publish Moka numbers
-labelled `pingora`.
+Without `--features pingora` the Pingora arm is not generated. With the feature
+off, requesting the engine falls back to Moka, so including it anyway would
+publish Moka numbers labelled `pingora`.
 
 ### Hash Algorithms (4 variants)
 
@@ -44,26 +41,21 @@ labelled `pingora`.
 
 ### invalidate_for_table
 
-Entries are spread over 8 tables and one table is invalidated, so the number
-removed stays a fixed share while the cache is sized at 50 / 1k / 10k / 50k
-entries.
-Cost that grows with the *total* rather than with the number of matches is the
-regression this is here to catch: Moka matches through its own index, while the
-Pingora path has no closure-based API and walks every key, reading each value to
-test it.
+Entries are spread over 8 tables and one is invalidated, so the share removed
+stays fixed while the cache is sized at 50 / 1k / 10k / 50k entries. Cache size
+is the axis because that is where the engines differ: Moka matches through its
+own index, while Pingora has no closure-based API and walks every key.
 
-Timing covers `invalidate_for_table` **and** `checkpoint()`. Moka's
-`invalidate_entries_if` only registers a predicate and applies it during later
+Timing covers `invalidate_for_table` and `checkpoint()`. Moka's
+`invalidate_entries_if` registers a predicate and applies it during later
 maintenance, so timing the call alone would compare registering a predicate
-against completing a scan. `checkpoint()` forces that deferred work; for Pingora
-the removals are already done and it only settles the weight.
+against completing a scan. For Pingora it only settles the weight.
 
-Unlike the throughput benchmarks this one is single-threaded and does not vary
-the hash algorithm — raw-key operations hand the `u64` straight to the backend
-without consulting the hasher, so it cannot move the measurement.
+This benchmark is single-threaded and uses one hash algorithm: raw-key
+operations bypass the hasher, so it cannot affect the measurement.
 
-The engines cross over, so a single cache size will not tell you which is
-faster. Measured on an M-series laptop, one table of eight invalidated:
+The engines cross over, so a single cache size does not tell you which is
+faster. Apple M-series, `--sample-size 10`:
 
 | entries | moka_lru | pingora_lru | ratio |
 | ------: | -------: | ----------: | ----: |
@@ -73,9 +65,9 @@ faster. Measured on an M-series laptop, one table of eight invalidated:
 |  50,000 |  5.39 ms |    18.44 ms | 3.42x |
 
 Below roughly a thousand entries Pingora's scan is cheaper than Moka's predicate
-registration and maintenance pass. Above it the walk dominates and the gap keeps
-widening — 5x the entries costs Moka 4.8x but Pingora 7.8x. Treat a change in
-where that crossover sits as the signal, not any single row.
+registration and maintenance pass. Above it the walk dominates: 5x the entries
+costs Moka 4.8x and Pingora 7.8x. Treat a shift in the crossover as the signal,
+not any single row.
 
 ## Thread Counts
 

--- a/crates/cache/benches/README.md
+++ b/crates/cache/benches/README.md
@@ -36,8 +36,8 @@ publish Moka numbers labelled `pingora`.
 - **concurrent_get**: Read-heavy workload (100% reads, pre-populated cache)
 - **concurrent_put**: Write-heavy workload (100% writes)
 - **concurrent_mixed_80_20**: Realistic workload (80% reads, 20% writes)
-- **hot_read_write**: Full cache whose reads mostly hit, 95/5 and 80/20 read/write
-  at 16 and 32 threads
+- **hot_read_write**: Read-through on a full cache, swept across 50/95/99% hit
+  rates at 16 and 32 threads
 
 ### hot_read_write
 
@@ -47,42 +47,60 @@ comparison: a Pingora miss is one metadata lookup, while a hit removes the entry
 and re-admits it, because `pingora-lru` has no `peek_value`. Reads that miss
 never reach the path where the engines differ.
 
-This benchmark reads a key space equal to the working set, so reads hit, and
-sizes capacity at 80% of it, so writes evict and the cache runs full.
+Reads and writes are not independent knobs here, because they are not
+independent in the runtime: a miss executes the query and caches the result, so
+the write rate *is* the miss rate. Setting a read/write mix separately from a
+hit rate describes states a results cache cannot be in. This benchmark reads,
+and refills on a miss, so hit rate is the only knob and the write rate follows
+from it.
 
 Parameters:
 
+- **Hit rate**: 50%, 95% and 99%. Under uniform access an LRU holding `C` of a
+  `W`-key working set hits about `C/W`, so capacity is fixed at 16,000 entries
+  and the working set is sized against it. 50% is the thrashing regime the older
+  benchmarks sit in; 99% is where a results cache worth enabling runs.
 - **Threads**: 16 and 32, straddling the 16 metadata shards Pingora uses. At 16
   shard collisions are incidental; at 32 they are structural.
-- **Mix**: 95/5 and 80/20 read/write. Writes rewrite a key already in the
-  working set, as a refreshed result does, and still evict because the cache is
-  full.
 
-Uses one hash algorithm: raw-key operations bypass the hasher, so it cannot
-affect the measurement.
+The cache starts full: the whole working set is inserted, then evicted down to
+capacity. One hash algorithm, since raw-key operations bypass the hasher.
 
-Neither engine wins outright. Apple M-series, `--sample-size 10`, total time for
-threads x 10,000 operations (lower is faster):
+Hit rate decides the winner, and it flips between 50% and 95%. Apple M-series,
+`--sample-size 10`, total time for threads x 10,000 operations (lower is
+faster):
 
-| case | moka_lru | moka_tinylfu | pingora_lru |
-| ---: | ---: | ---: | ---: |
-| 95/5, 16 threads | 34.6 ms | 32.8 ms | 41.9 ms |
-| 95/5, 32 threads | 64.8 ms | 62.1 ms | 107.2 ms |
-| 80/20, 16 threads | 80.6 ms | 82.2 ms | 50.2 ms |
-| 80/20, 32 threads | 231.2 ms | 186.5 ms | 133.9 ms |
+| hit rate | threads | moka_lru | moka_tinylfu | pingora_lru | pingora vs moka_lru |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 50% | 16 | 275.9 ms | 239.6 ms | 74.9 ms | 0.27x |
+| 50% | 32 | 628.0 ms | 529.3 ms | 206.7 ms | 0.33x |
+| 95% | 16 | 33.6 ms | 31.3 ms | 53.5 ms | 1.59x |
+| 95% | 32 | 60.8 ms | 61.1 ms | 141.1 ms | 2.32x |
+| 99% | 16 | 38.3 ms | 38.1 ms | 43.7 ms | 1.14x |
+| 99% | 32 | 73.3 ms | 73.2 ms | 99.6 ms | 1.36x |
 
-Read-heavy favours Moka, and the gap widens with threads. Doubling threads
-doubles the work, so 2.0x is the break-even: Moka scales at 1.87x and Pingora at
-2.56x. Pingora expresses a read as a remove plus re-admit, so reads contend on
-the 16 shards in a way Moka's do not.
+At 50% every other operation is a refill, so the run is dominated by insert and
+eviction, and Pingora is 3-3.7x faster. At 95% and 99% the work is nearly all
+reads, and Moka leads by 1.14-2.32x because Pingora expresses a read as a remove
+plus re-admit.
 
-Write-heavy reverses it, with Pingora 38-42% faster at both thread counts.
-TinyLFU also earns its keep here — it costs a little on read-heavy load and
-saves 19% over LRU at 80/20 and 32 threads.
+Pingora scales worse with threads at every hit rate. Doubling threads doubles
+the work, so 2.0x is break-even:
 
-So the write fraction, not the engine, decides which is faster. Numbers are from
-a laptop at reduced sample size, where 32 threads oversubscribes the cores:
-adequate for the direction and the crossover, not for precise ratios.
+| hit rate | moka_lru | pingora_lru |
+| ---: | ---: | ---: |
+| 50% | 2.28x | 2.76x |
+| 95% | 1.81x | 2.64x |
+| 99% | 1.91x | 2.28x |
+
+TinyLFU earns its keep where admission control matters: 13% ahead of LRU at 50%,
+7% at 95%, and level at 99%, where almost nothing is evicted.
+
+Numbers are from a laptop at reduced sample size, where 32 threads oversubscribes
+the cores. Intervals run to roughly +/-8%, so the 50% and 95% gaps are solid and
+the 14% figure at 99% and 16 threads is near the noise floor. Moka reading
+slower at 99% than at 95% is within that margin and should not be read as a
+trend.
 
 ## Thread Counts
 
@@ -173,8 +191,9 @@ lru_cache_concurrent_get/moka_lru_xxh3_8threads
 
 `hot_read_write` sizes itself separately, in entries rather than weight:
 
-- `HOT_WORKING_SET`: 20,000 keys, all pre-populated and all read from
-- `HOT_CACHE_WEIGHT`: capacity for 80% of them, so the cache runs full
+- `HOT_RESIDENT_ENTRIES`: 16,000, the capacity the cache is built with
+- `HOT_HIT_RATES`: 50 / 95 / 99%, each setting the working set to
+  `HOT_RESIDENT_ENTRIES` divided by that rate
 - TTL: 10 minutes, so nothing expires mid-run
 
 ## Output

--- a/crates/cache/benches/SUMMARY.md
+++ b/crates/cache/benches/SUMMARY.md
@@ -4,10 +4,15 @@
 
 Enhanced the cache throughput benchmarks to comprehensively test all combinations of:
 
-### 1. **Caching Policies** (2 variants)
+### 1. **Engine / policy pairs** (3, or 2 without `--features pingora`)
 
-- LRU: Standard Least Recently Used eviction policy
-- TinyLFU: Frequency-based admission policy with better hit rates for some workloads
+- `moka_lru`: Moka with Least Recently Used eviction
+- `moka_tinylfu`: Moka with frequency-based admission
+- `pingora_lru`: Pingora-LRU, sharded. Requires `--features pingora`
+
+Named pairs rather than a cartesian product: Pingora has no TinyLFU admission
+and builds an LRU instead, so a `pingora_tinylfu` arm would duplicate
+`pingora_lru`.
 
 ### 2. **Hash Algorithms** (4 variants)
 
@@ -16,11 +21,13 @@ Enhanced the cache throughput benchmarks to comprehensively test all combination
 - `xxh3`: xxHash3 64-bit ⚡ **FASTEST**
 - `xxh64`: xxHash 64-bit
 
-### 3. **Workload Patterns** (3 types)
+### 3. **Workload Patterns** (4 types)
 
-- `concurrent_get`: 100% reads (pre-populated cache)
+- `concurrent_get`: 100% reads (pre-populated cache, ~3% hit rate)
 - `concurrent_put`: 100% writes
 - `concurrent_mixed_80_20`: 80% reads, 20% writes
+- `hot_read_write`: read-through on a full cache, swept across 50/95/99% hit
+  rates at 16 and 32 threads
 
 ### 4. **Thread Counts** (4 levels)
 
@@ -28,15 +35,22 @@ Enhanced the cache throughput benchmarks to comprehensively test all combination
 
 ## Total Benchmark Combinations
 
-**LruCache benchmarks:**
+Counts below are with `--features pingora`; without it the Pingora arm is not
+generated and each LruCache figure drops by a third.
 
-- 2 caching policies × 4 hash algos × 4 thread counts × 3 workloads = **96 benchmark configurations**
+**LruCache throughput benchmarks:**
+
+- 3 engine/policy pairs × 4 hash algos × 4 thread counts × 3 workloads = **144 configurations**
+
+**`hot_read_write`:**
+
+- 3 engine/policy pairs × 3 hit rates × 2 thread counts = **18 configurations**
 
 **SimpleCache benchmarks:**
 
-- 1 hash algo × 4 thread counts × 3 workloads = **12 benchmark configurations**
+- 1 hash algo × 4 thread counts × 3 workloads = **12 configurations**
 
-**Total: 108 benchmark configurations**
+**Total: 174 configurations** (120 without `--features pingora`)
 
 ## Code Changes
 
@@ -47,11 +61,13 @@ Enhanced the cache throughput benchmarks to comprehensively test all combination
    - Added `get_hash_builder` import from cache crate
    - Added `HashingAlgorithm` and `CachingPolicy` imports from spicepod
    - Created `all_hash_algorithms()` helper returning 4 hash algorithm variants
-   - Created `all_caching_policies()` helper returning LRU and TinyLFU policies
+   - Created `all_engine_policy_pairs()` helper returning the engine/policy pairs
    - Updated `bench_lru_cache_concurrent_get()` to iterate over all combinations
    - Updated `bench_lru_cache_concurrent_put()` to iterate over all combinations
    - Updated `bench_lru_cache_concurrent_mixed()` to iterate over all combinations
-   - Benchmark naming: `{policy}_{hash}_{threads}threads` (e.g., `lru_xxh3_8threads`)
+   - Added `bench_lru_cache_hot_read_write()`, swept across hit rates
+   - Benchmark naming: `{pair}_{hash}_{threads}threads` (e.g. `moka_lru_xxh3_8threads`),
+     and `{pair}_{hit_rate}_{threads}threads` for `hot_read_write`
 
 2. **`crates/cache/benches/README.md`** (NEW)
 
@@ -65,19 +81,10 @@ Enhanced the cache throughput benchmarks to comprehensively test all combination
    - Overview of implementation
    - Summary of all combinations tested
 
-## Sample Results (Preliminary - 8 threads)
+## Results
 
-From initial benchmark runs:
-
-| Configuration         | Throughput  | Notes          |
-| --------------------- | ----------- | -------------- |
-| lru_xxh3_8threads     | ~10 Melem/s | Fastest hash   |
-| lru_xxh64_8threads    | ~10 Melem/s |                |
-| lru_ahash_8threads    | ~9 Melem/s  |                |
-| tinylfu_xxh3_8threads | ~10 Melem/s | TinyLFU policy |
-| lru_siphash_8threads  | ~7 Melem/s  | Slowest hash   |
-
-**Key Finding:** Hash algorithm choice significantly impacts throughput, with xxh3/xxh64 being fastest.
+Measured engine comparisons, including the Moka/Pingora crossover, live in
+[README.md](README.md) under "Engine Comparison Results".
 
 ## Running the Benchmarks
 
@@ -100,9 +107,10 @@ cargo bench -p cache --bench cache_throughput -- --sample-size 10
 ### Filtering by Component
 
 ```bash
-# Specific caching policy
-cargo bench -p cache -- lru
-cargo bench -p cache -- tinylfu
+# Specific engine / policy pair
+cargo bench -p cache -- moka_lru
+cargo bench -p cache -- moka_tinylfu
+cargo bench -p cache --features pingora -- pingora_lru
 
 # Specific hash algorithm
 cargo bench -p cache -- xxh3

--- a/crates/cache/benches/cache_throughput.rs
+++ b/crates/cache/benches/cache_throughput.rs
@@ -20,7 +20,7 @@ limitations under the License.
 
 use cache::{
     AsTableRefs, CacheMetrics, CacheProvider, EvictionReason, HashBuilder, LruCache, SimpleCache,
-    Sizeable, TabledCacheProvider, get_hash_builder,
+    Sizeable, get_hash_builder,
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion::sql::TableReference;
@@ -37,6 +37,17 @@ use std::time::Duration;
 const CACHE_WEIGHT: u64 = 100_000;
 const KEY_SPACE: u64 = 100_000;
 const OPERATIONS_PER_THREAD: usize = 10_000;
+
+/// Bytes per cached value, from [`random_value`]. Used to size a cache in
+/// entries rather than in weight.
+const VALUE_BYTES: u64 = 32;
+
+/// Distinct keys the contention benchmark touches.
+const HOT_WORKING_SET: u64 = 20_000;
+
+/// Capacity for 80% of the working set, so the cache runs full and evicting
+/// while most reads still hit.
+const HOT_CACHE_WEIGHT: u64 = HOT_WORKING_SET * VALUE_BYTES * 8 / 10;
 
 /// Creates a runtime that can be shared across benchmark worker threads.
 fn create_bench_runtime() -> tokio::runtime::Runtime {
@@ -72,56 +83,6 @@ impl CacheMetrics for BenchValue {
 impl AsTableRefs for BenchValue {
     fn as_table_refs(&self) -> Arc<HashSet<TableReference>> {
         Arc::new(HashSet::new())
-    }
-}
-
-/// Tables the invalidation benchmark spreads entries over. Invalidating one
-/// removes an eighth of the cache.
-const INVALIDATION_TABLE_COUNT: u64 = 8;
-
-/// A value that reports the table it read, so `invalidate_for_table` matches it.
-///
-/// [`BenchValue`] reports an empty set, which nothing matches, so invalidating
-/// against it would time the scan without any removals.
-#[derive(Clone)]
-struct TabledBenchValue {
-    payload: String,
-    tables: Arc<HashSet<TableReference>>,
-}
-
-impl TabledBenchValue {
-    fn new(payload: String, table_idx: u64) -> Self {
-        let mut tables = HashSet::new();
-        tables.insert(TableReference::bare(format!("table_{table_idx}")));
-        Self {
-            payload,
-            tables: Arc::new(tables),
-        }
-    }
-}
-
-impl Sizeable for TabledBenchValue {
-    fn get_memory_size(&self) -> usize {
-        self.payload.len()
-    }
-}
-
-impl CacheMetrics for TabledBenchValue {
-    fn record_hit() {}
-    fn record_miss() {}
-    fn record_request() {}
-    fn record_item_count(_count: u64) {}
-    fn record_size(_size: u64) {}
-    fn record_max_size(_size: u64) {}
-    fn record_eviction(_reason: EvictionReason) {}
-    fn record_stale_rejection() {}
-    fn update_hit_ratio(_hits: u64, _total: u64) {}
-    fn publish_counters_at_zero() {}
-}
-
-impl AsTableRefs for TabledBenchValue {
-    fn as_table_refs(&self) -> Arc<HashSet<TableReference>> {
-        Arc::clone(&self.tables)
     }
 }
 
@@ -584,18 +545,19 @@ fn bench_lru_cache_concurrent_mixed(c: &mut Criterion) {
     group.finish();
 }
 
-/// Invalidating one table's entries, as an accelerated refresh does each cycle.
+/// Read/write contention on a full cache whose reads mostly hit.
 ///
-/// Cache size is the axis because that is where the engines differ: Moka
-/// matches through its own index, while Pingora has no closure-based API and
-/// walks every key. The share removed stays fixed as the total grows.
+/// The other `LruCache` benchmarks read a 100k key space holding at most 5,000
+/// entries, so ~95% of their reads miss. That matters for the engine comparison
+/// because a Pingora miss is one metadata lookup, while a hit removes the entry
+/// and re-admits it — `pingora-lru` has no `peek_value`. Reads that miss never
+/// reach the path where the engines differ.
 ///
-/// `checkpoint()` is measured alongside the call. Moka's
-/// `invalidate_entries_if` registers a predicate and applies it during later
-/// maintenance, so timing the call alone would compare registering a predicate
-/// against completing a scan. For Pingora it only settles the weight.
-fn bench_lru_cache_invalidate_for_table(c: &mut Criterion) {
-    let mut group = c.benchmark_group("lru_cache_invalidate_for_table");
+/// Here the read key space is the working set, so reads hit, and capacity holds
+/// 80% of it, so writes evict. Thread counts straddle the 16 metadata shards:
+/// at 16 threads shard collisions are incidental, at 32 they are structural.
+fn bench_lru_cache_hot_read_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lru_cache_hot_read_write");
     let rt = create_bench_runtime();
     let handle = rt.handle().clone();
 
@@ -605,67 +567,84 @@ fn bench_lru_cache_invalidate_for_table(c: &mut Criterion) {
         get_hash_builder(HashingAlgorithm::XXH3).expect("Failed to get hash builder");
 
     for (pair_name, engine, policy) in all_engine_policy_pairs() {
-        // Spans three orders of magnitude because the engines cross over: 50
-        // covers a cache holding a small set of distinct queries, where the
-        // per-entry cost is still negligible.
-        for entry_count in [50u64, 1_000, 10_000, 50_000] {
-            // Throughput is per entry considered, not per entry removed.
-            group.throughput(Throughput::Elements(entry_count));
+        for (mix_name, read_percent) in [("95_5", 95u32), ("80_20", 80)] {
+            for thread_count in [16usize, 32] {
+                group.throughput(Throughput::Elements(
+                    (thread_count * OPERATIONS_PER_THREAD) as u64,
+                ));
 
-            let bench_name = format!("{pair_name}_{entry_count}entries");
+                let bench_name = format!("{pair_name}_{mix_name}_{thread_count}threads");
 
-            group.bench_with_input(
-                BenchmarkId::from_parameter(&bench_name),
-                &entry_count,
-                |b, &entries| {
-                    let hash_builder = hash_builder.clone();
-                    b.iter_batched(
-                        || {
-                            // Capacity above the population so nothing is
-                            // evicted before the measured call.
-                            let cache: Arc<
-                                LruCache<
-                                    TabledBenchValue,
-                                    HashBuilder,
-                                    Box<dyn Hasher + Send + Sync>,
-                                >,
-                            > = Arc::new(LruCache::new(
-                                entries * 128,
-                                Duration::from_mins(10),
-                                hash_builder.clone(),
-                                policy,
-                                engine,
-                            ));
-                            let mut rng = StdRng::seed_from_u64(42);
-                            handle.block_on(async {
-                                for i in 0..entries {
-                                    let value = TabledBenchValue::new(
-                                        random_value(&mut rng),
-                                        i % INVALIDATION_TABLE_COUNT,
-                                    );
-                                    cache.put_raw_key(&i, value).await;
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(&bench_name),
+                    &thread_count,
+                    |b, &threads| {
+                        let hash_builder = hash_builder.clone();
+                        b.iter_batched(
+                            || {
+                                let cache: Arc<
+                                    LruCache<
+                                        BenchValue,
+                                        HashBuilder,
+                                        Box<dyn Hasher + Send + Sync>,
+                                    >,
+                                > = Arc::new(LruCache::new(
+                                    HOT_CACHE_WEIGHT,
+                                    Duration::from_mins(10),
+                                    hash_builder.clone(),
+                                    policy,
+                                    engine,
+                                ));
+                                let mut rng = StdRng::seed_from_u64(42);
+                                handle.block_on(async {
+                                    // Insert the whole working set; the cache
+                                    // evicts down to capacity and starts full.
+                                    for key in 0..HOT_WORKING_SET {
+                                        let value = BenchValue(random_value(&mut rng));
+                                        cache.put_raw_key(&key, value).await;
+                                    }
+                                    cache.checkpoint().await;
+                                });
+                                cache
+                            },
+                            |cache| {
+                                let handles: Vec<_> = (0..threads)
+                                    .map(|thread_id| {
+                                        let cache = Arc::clone(&cache);
+                                        let handle = handle.clone();
+                                        std::thread::spawn(move || {
+                                            let mut rng = StdRng::seed_from_u64(thread_id as u64);
+                                            handle.block_on(async {
+                                                for _ in 0..OPERATIONS_PER_THREAD {
+                                                    let key =
+                                                        rng.random_range(0..HOT_WORKING_SET);
+                                                    if rng.random_range(0..100) < read_percent {
+                                                        black_box(cache.get_raw_key(&key).await);
+                                                    } else {
+                                                        // Rewriting a key already in the
+                                                        // working set is what a refreshed
+                                                        // result does; it still evicts,
+                                                        // because the cache is full.
+                                                        let value =
+                                                            BenchValue(random_value(&mut rng));
+                                                        black_box(
+                                                            cache.put_raw_key(&key, value).await,
+                                                        );
+                                                    }
+                                                }
+                                            });
+                                        })
+                                    })
+                                    .collect();
+                                for handle in handles {
+                                    handle.join().expect("thread panicked");
                                 }
-                                // Settle the population so setup work is not
-                                // charged to the measured call.
-                                cache.checkpoint().await;
-                            });
-                            cache
-                        },
-                        |cache| {
-                            handle.block_on(async {
-                                black_box(
-                                    cache
-                                        .invalidate_for_table(TableReference::bare("table_3"))
-                                        .await,
-                                )
-                                .expect("invalidation failed");
-                                cache.checkpoint().await;
-                            });
-                        },
-                        criterion::BatchSize::LargeInput,
-                    );
-                },
-            );
+                            },
+                            criterion::BatchSize::LargeInput,
+                        );
+                    },
+                );
+            }
         }
     }
     group.finish();
@@ -679,6 +658,6 @@ criterion_group!(
     bench_lru_cache_concurrent_get,
     bench_lru_cache_concurrent_put,
     bench_lru_cache_concurrent_mixed,
-    bench_lru_cache_invalidate_for_table
+    bench_lru_cache_hot_read_write
 );
 criterion_main!(benches);

--- a/crates/cache/benches/cache_throughput.rs
+++ b/crates/cache/benches/cache_throughput.rs
@@ -75,17 +75,14 @@ impl AsTableRefs for BenchValue {
     }
 }
 
-/// Number of distinct tables entries are spread over in the invalidation
-/// benchmark. Mirrors a pod serving a handful of accelerated datasets, where a
-/// refresh of one table invalidates only the entries that read it.
+/// Tables the invalidation benchmark spreads entries over. Invalidating one
+/// removes an eighth of the cache.
 const INVALIDATION_TABLE_COUNT: u64 = 8;
 
-/// A value that reports the table it read, so `invalidate_for_table` can match
-/// it.
+/// A value that reports the table it read, so `invalidate_for_table` matches it.
 ///
-/// [`BenchValue`] reports an empty set, which no table reference matches, so
-/// invalidating against it would walk the cache and remove nothing — timing the
-/// scan but never the removals.
+/// [`BenchValue`] reports an empty set, which nothing matches, so invalidating
+/// against it would time the scan without any removals.
 #[derive(Clone)]
 struct TabledBenchValue {
     payload: String,
@@ -138,16 +135,13 @@ fn all_hash_algorithms() -> Vec<(&'static str, HashingAlgorithm)> {
     ]
 }
 
-/// The engine/policy combinations worth measuring.
+/// Engine and policy combinations to benchmark.
 ///
-/// Not a cartesian product of the two: Pingora has no `TinyLFU` admission, so
-/// `LruCache::new` warns and builds an LRU. A `pingora_tinylfu` arm would
-/// re-measure `pingora_lru` under a name claiming otherwise.
+/// Not a cartesian product: Pingora has no `TinyLFU` admission and builds an
+/// LRU instead, so a `pingora_tinylfu` arm would duplicate `pingora_lru`.
 ///
-/// Pingora is behind a feature flag, and when it is off `LruCache::new` falls
-/// back to Moka *silently* as far as a benchmark can tell. Gating the arm here
-/// rather than filtering later is what keeps a `cargo bench` without
-/// `--features pingora` from publishing Moka numbers labelled `pingora`.
+/// The Pingora arm is gated because with the feature off `LruCache::new` falls
+/// back to Moka, which would publish Moka results labelled `pingora`.
 fn all_engine_policy_pairs() -> Vec<(&'static str, CacheEngine, CachingPolicy)> {
     #[cfg_attr(
         not(feature = "pingora"),
@@ -590,39 +584,32 @@ fn bench_lru_cache_concurrent_mixed(c: &mut Criterion) {
     group.finish();
 }
 
-/// Invalidating one table's entries — what an accelerated refresh triggers on
-/// every cycle, once per dataset.
+/// Invalidating one table's entries, as an accelerated refresh does each cycle.
 ///
-/// Scaled by *total* entries while the number removed stays a fixed share:
-/// Moka matches through its own index, while the Pingora path has no
-/// closure-based API and walks every key, reading each value to test it
-/// (`LruCache::invalidate_for_table`). Cost that tracks cache size rather than
-/// match count is the difference this is here to catch, so cache size is the
-/// axis.
+/// Cache size is the axis because that is where the engines differ: Moka
+/// matches through its own index, while Pingora has no closure-based API and
+/// walks every key. The share removed stays fixed as the total grows.
 ///
-/// `checkpoint()` is inside the measured region deliberately. Moka's
-/// `invalidate_entries_if` only registers a predicate and applies it during
-/// later maintenance, so timing the call alone would compare registering a
-/// predicate against completing a scan. `checkpoint()` forces the deferred work
-/// for Moka; for Pingora the removals are already done and it only settles the
-/// weight.
+/// `checkpoint()` is measured alongside the call. Moka's
+/// `invalidate_entries_if` registers a predicate and applies it during later
+/// maintenance, so timing the call alone would compare registering a predicate
+/// against completing a scan. For Pingora it only settles the weight.
 fn bench_lru_cache_invalidate_for_table(c: &mut Criterion) {
     let mut group = c.benchmark_group("lru_cache_invalidate_for_table");
     let rt = create_bench_runtime();
     let handle = rt.handle().clone();
 
-    // Raw-key operations hand the u64 straight to the backend without consulting
-    // the hasher, so the hash algorithm cannot move this measurement.
+    // Raw-key operations bypass the hasher, so the hash algorithm cannot affect
+    // this measurement.
     let hash_builder =
         get_hash_builder(HashingAlgorithm::XXH3).expect("Failed to get hash builder");
 
     for (pair_name, engine, policy) in all_engine_policy_pairs() {
-        // 50 is not a rounding-down of the others: a pod whose workload has a
-        // small set of distinct queries holds a cache this size, and it is the
-        // point where a per-entry cost is still cheap enough to be invisible.
+        // Spans three orders of magnitude because the engines cross over: 50
+        // covers a cache holding a small set of distinct queries, where the
+        // per-entry cost is still negligible.
         for entry_count in [50u64, 1_000, 10_000, 50_000] {
-            // Elements are the entries the implementation may have to consider,
-            // which is what makes the per-entry cost readable off the throughput.
+            // Throughput is per entry considered, not per entry removed.
             group.throughput(Throughput::Elements(entry_count));
 
             let bench_name = format!("{pair_name}_{entry_count}entries");
@@ -634,9 +621,8 @@ fn bench_lru_cache_invalidate_for_table(c: &mut Criterion) {
                     let hash_builder = hash_builder.clone();
                     b.iter_batched(
                         || {
-                            // Capacity well above the population: an eviction
-                            // during setup would leave each iteration
-                            // invalidating a different-sized cache.
+                            // Capacity above the population so nothing is
+                            // evicted before the measured call.
                             let cache: Arc<
                                 LruCache<
                                     TabledBenchValue,
@@ -659,8 +645,8 @@ fn bench_lru_cache_invalidate_for_table(c: &mut Criterion) {
                                     );
                                     cache.put_raw_key(&i, value).await;
                                 }
-                                // Settle the population so the first
-                                // invalidation is not charged for setup work.
+                                // Settle the population so setup work is not
+                                // charged to the measured call.
                                 cache.checkpoint().await;
                             });
                             cache

--- a/crates/cache/benches/cache_throughput.rs
+++ b/crates/cache/benches/cache_throughput.rs
@@ -20,7 +20,7 @@ limitations under the License.
 
 use cache::{
     AsTableRefs, CacheMetrics, CacheProvider, EvictionReason, HashBuilder, LruCache, SimpleCache,
-    Sizeable, get_hash_builder,
+    Sizeable, TabledCacheProvider, get_hash_builder,
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use datafusion::sql::TableReference;
@@ -75,6 +75,59 @@ impl AsTableRefs for BenchValue {
     }
 }
 
+/// Number of distinct tables entries are spread over in the invalidation
+/// benchmark. Mirrors a pod serving a handful of accelerated datasets, where a
+/// refresh of one table invalidates only the entries that read it.
+const INVALIDATION_TABLE_COUNT: u64 = 8;
+
+/// A value that reports the table it read, so `invalidate_for_table` can match
+/// it.
+///
+/// [`BenchValue`] reports an empty set, which no table reference matches, so
+/// invalidating against it would walk the cache and remove nothing — timing the
+/// scan but never the removals.
+#[derive(Clone)]
+struct TabledBenchValue {
+    payload: String,
+    tables: Arc<HashSet<TableReference>>,
+}
+
+impl TabledBenchValue {
+    fn new(payload: String, table_idx: u64) -> Self {
+        let mut tables = HashSet::new();
+        tables.insert(TableReference::bare(format!("table_{table_idx}")));
+        Self {
+            payload,
+            tables: Arc::new(tables),
+        }
+    }
+}
+
+impl Sizeable for TabledBenchValue {
+    fn get_memory_size(&self) -> usize {
+        self.payload.len()
+    }
+}
+
+impl CacheMetrics for TabledBenchValue {
+    fn record_hit() {}
+    fn record_miss() {}
+    fn record_request() {}
+    fn record_item_count(_count: u64) {}
+    fn record_size(_size: u64) {}
+    fn record_max_size(_size: u64) {}
+    fn record_eviction(_reason: EvictionReason) {}
+    fn record_stale_rejection() {}
+    fn update_hit_ratio(_hits: u64, _total: u64) {}
+    fn publish_counters_at_zero() {}
+}
+
+impl AsTableRefs for TabledBenchValue {
+    fn as_table_refs(&self) -> Arc<HashSet<TableReference>> {
+        Arc::clone(&self.tables)
+    }
+}
+
 // Get all hash algorithms to benchmark
 fn all_hash_algorithms() -> Vec<(&'static str, HashingAlgorithm)> {
     vec![
@@ -85,12 +138,28 @@ fn all_hash_algorithms() -> Vec<(&'static str, HashingAlgorithm)> {
     ]
 }
 
-// Get all caching policies to benchmark
-fn all_caching_policies() -> Vec<(&'static str, CachingPolicy)> {
-    vec![
-        ("lru", CachingPolicy::Lru),
-        ("tinylfu", CachingPolicy::TinyLfu),
-    ]
+/// The engine/policy combinations worth measuring.
+///
+/// Not a cartesian product of the two: Pingora has no `TinyLFU` admission, so
+/// `LruCache::new` warns and builds an LRU. A `pingora_tinylfu` arm would
+/// re-measure `pingora_lru` under a name claiming otherwise.
+///
+/// Pingora is behind a feature flag, and when it is off `LruCache::new` falls
+/// back to Moka *silently* as far as a benchmark can tell. Gating the arm here
+/// rather than filtering later is what keeps a `cargo bench` without
+/// `--features pingora` from publishing Moka numbers labelled `pingora`.
+fn all_engine_policy_pairs() -> Vec<(&'static str, CacheEngine, CachingPolicy)> {
+    #[cfg_attr(
+        not(feature = "pingora"),
+        expect(unused_mut, reason = "only the pingora arm below pushes")
+    )]
+    let mut pairs = vec![
+        ("moka_lru", CacheEngine::Moka, CachingPolicy::Lru),
+        ("moka_tinylfu", CacheEngine::Moka, CachingPolicy::TinyLfu),
+    ];
+    #[cfg(feature = "pingora")]
+    pairs.push(("pingora_lru", CacheEngine::Pingora, CachingPolicy::Lru));
+    pairs
 }
 
 fn random_value(rng: &mut StdRng) -> String {
@@ -298,7 +367,7 @@ fn bench_lru_cache_concurrent_get(c: &mut Criterion) {
     let handle = rt.handle().clone();
 
     // Benchmark all combinations of caching policy and hash algorithm
-    for (policy_name, policy) in all_caching_policies() {
+    for (pair_name, engine, policy) in all_engine_policy_pairs() {
         for (hash_name, hash_algo) in all_hash_algorithms() {
             let hash_builder = get_hash_builder(hash_algo).expect("Failed to get hash builder");
 
@@ -307,7 +376,7 @@ fn bench_lru_cache_concurrent_get(c: &mut Criterion) {
                     (thread_count * OPERATIONS_PER_THREAD) as u64,
                 ));
 
-                let bench_name = format!("{policy_name}_{hash_name}_{thread_count}threads");
+                let bench_name = format!("{pair_name}_{hash_name}_{thread_count}threads");
 
                 group.bench_with_input(
                     BenchmarkId::from_parameter(&bench_name),
@@ -327,7 +396,7 @@ fn bench_lru_cache_concurrent_get(c: &mut Criterion) {
                                     Duration::from_mins(1),
                                     hash_builder.clone(),
                                     policy,
-                                    CacheEngine::Moka,
+                                    engine,
                                 ));
                                 let mut rng = StdRng::seed_from_u64(42);
                                 handle.block_on(async {
@@ -375,7 +444,7 @@ fn bench_lru_cache_concurrent_put(c: &mut Criterion) {
     let handle = rt.handle().clone();
 
     // Benchmark all combinations of caching policy and hash algorithm
-    for (policy_name, policy) in all_caching_policies() {
+    for (pair_name, engine, policy) in all_engine_policy_pairs() {
         for (hash_name, hash_algo) in all_hash_algorithms() {
             let hash_builder = get_hash_builder(hash_algo).expect("Failed to get hash builder");
 
@@ -384,7 +453,7 @@ fn bench_lru_cache_concurrent_put(c: &mut Criterion) {
                     (thread_count * OPERATIONS_PER_THREAD) as u64,
                 ));
 
-                let bench_name = format!("{policy_name}_{hash_name}_{thread_count}threads");
+                let bench_name = format!("{pair_name}_{hash_name}_{thread_count}threads");
 
                 group.bench_with_input(
                     BenchmarkId::from_parameter(&bench_name),
@@ -402,7 +471,7 @@ fn bench_lru_cache_concurrent_put(c: &mut Criterion) {
                                     Duration::from_mins(1),
                                     hash_builder.clone(),
                                     policy,
-                                    CacheEngine::Moka,
+                                    engine,
                                 ))
                             },
                             |cache| {
@@ -442,7 +511,7 @@ fn bench_lru_cache_concurrent_mixed(c: &mut Criterion) {
     let handle = rt.handle().clone();
 
     // Benchmark all combinations of caching policy and hash algorithm
-    for (policy_name, policy) in all_caching_policies() {
+    for (pair_name, engine, policy) in all_engine_policy_pairs() {
         for (hash_name, hash_algo) in all_hash_algorithms() {
             let hash_builder = get_hash_builder(hash_algo).expect("Failed to get hash builder");
 
@@ -451,7 +520,7 @@ fn bench_lru_cache_concurrent_mixed(c: &mut Criterion) {
                     (thread_count * OPERATIONS_PER_THREAD) as u64,
                 ));
 
-                let bench_name = format!("{policy_name}_{hash_name}_{thread_count}threads");
+                let bench_name = format!("{pair_name}_{hash_name}_{thread_count}threads");
 
                 group.bench_with_input(
                     BenchmarkId::from_parameter(&bench_name),
@@ -471,7 +540,7 @@ fn bench_lru_cache_concurrent_mixed(c: &mut Criterion) {
                                     Duration::from_mins(1),
                                     hash_builder.clone(),
                                     policy,
-                                    CacheEngine::Moka,
+                                    engine,
                                 ));
                                 let mut rng = StdRng::seed_from_u64(42);
                                 handle.block_on(async {
@@ -521,6 +590,101 @@ fn bench_lru_cache_concurrent_mixed(c: &mut Criterion) {
     group.finish();
 }
 
+/// Invalidating one table's entries — what an accelerated refresh triggers on
+/// every cycle, once per dataset.
+///
+/// Scaled by *total* entries while the number removed stays a fixed share:
+/// Moka matches through its own index, while the Pingora path has no
+/// closure-based API and walks every key, reading each value to test it
+/// (`LruCache::invalidate_for_table`). Cost that tracks cache size rather than
+/// match count is the difference this is here to catch, so cache size is the
+/// axis.
+///
+/// `checkpoint()` is inside the measured region deliberately. Moka's
+/// `invalidate_entries_if` only registers a predicate and applies it during
+/// later maintenance, so timing the call alone would compare registering a
+/// predicate against completing a scan. `checkpoint()` forces the deferred work
+/// for Moka; for Pingora the removals are already done and it only settles the
+/// weight.
+fn bench_lru_cache_invalidate_for_table(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lru_cache_invalidate_for_table");
+    let rt = create_bench_runtime();
+    let handle = rt.handle().clone();
+
+    // Raw-key operations hand the u64 straight to the backend without consulting
+    // the hasher, so the hash algorithm cannot move this measurement.
+    let hash_builder =
+        get_hash_builder(HashingAlgorithm::XXH3).expect("Failed to get hash builder");
+
+    for (pair_name, engine, policy) in all_engine_policy_pairs() {
+        // 50 is not a rounding-down of the others: a pod whose workload has a
+        // small set of distinct queries holds a cache this size, and it is the
+        // point where a per-entry cost is still cheap enough to be invisible.
+        for entry_count in [50u64, 1_000, 10_000, 50_000] {
+            // Elements are the entries the implementation may have to consider,
+            // which is what makes the per-entry cost readable off the throughput.
+            group.throughput(Throughput::Elements(entry_count));
+
+            let bench_name = format!("{pair_name}_{entry_count}entries");
+
+            group.bench_with_input(
+                BenchmarkId::from_parameter(&bench_name),
+                &entry_count,
+                |b, &entries| {
+                    let hash_builder = hash_builder.clone();
+                    b.iter_batched(
+                        || {
+                            // Capacity well above the population: an eviction
+                            // during setup would leave each iteration
+                            // invalidating a different-sized cache.
+                            let cache: Arc<
+                                LruCache<
+                                    TabledBenchValue,
+                                    HashBuilder,
+                                    Box<dyn Hasher + Send + Sync>,
+                                >,
+                            > = Arc::new(LruCache::new(
+                                entries * 128,
+                                Duration::from_mins(10),
+                                hash_builder.clone(),
+                                policy,
+                                engine,
+                            ));
+                            let mut rng = StdRng::seed_from_u64(42);
+                            handle.block_on(async {
+                                for i in 0..entries {
+                                    let value = TabledBenchValue::new(
+                                        random_value(&mut rng),
+                                        i % INVALIDATION_TABLE_COUNT,
+                                    );
+                                    cache.put_raw_key(&i, value).await;
+                                }
+                                // Settle the population so the first
+                                // invalidation is not charged for setup work.
+                                cache.checkpoint().await;
+                            });
+                            cache
+                        },
+                        |cache| {
+                            handle.block_on(async {
+                                black_box(
+                                    cache
+                                        .invalidate_for_table(TableReference::bare("table_3"))
+                                        .await,
+                                )
+                                .expect("invalidation failed");
+                                cache.checkpoint().await;
+                            });
+                        },
+                        criterion::BatchSize::LargeInput,
+                    );
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_simple_cache_concurrent_get,
@@ -528,6 +692,7 @@ criterion_group!(
     bench_simple_cache_concurrent_mixed,
     bench_lru_cache_concurrent_get,
     bench_lru_cache_concurrent_put,
-    bench_lru_cache_concurrent_mixed
+    bench_lru_cache_concurrent_mixed,
+    bench_lru_cache_invalidate_for_table
 );
 criterion_main!(benches);

--- a/crates/cache/benches/cache_throughput.rs
+++ b/crates/cache/benches/cache_throughput.rs
@@ -552,11 +552,14 @@ fn bench_lru_cache_concurrent_mixed(c: &mut Criterion) {
 
 /// Read-through contention on a full cache, swept across hit rates.
 ///
-/// The other `LruCache` benchmarks read a 100,000 key space holding at most
-/// 5,000 entries, so roughly 95% of their reads miss. That matters for the
-/// engine comparison because a Pingora miss is one metadata lookup, while a hit
-/// removes the entry and re-admits it — `pingora-lru` has no `peek_value`.
-/// Reads that miss never reach the path where the engines differ.
+/// The other `LruCache` benchmarks read a 100,000 key space while the cache
+/// holds about 3,125 entries — 5,000 are inserted and capacity evicts to that —
+/// so roughly 97% of their reads miss.
+///
+/// The engines diverge on both paths, in opposite directions. A Pingora miss
+/// returns after one metadata lookup; a hit removes the entry and re-admits it,
+/// because `pingora-lru` has no `peek_value`. Measuring only the miss path
+/// therefore favours Pingora by construction.
 ///
 /// Reads and writes are not independent here, because they are not independent
 /// in the runtime: a miss executes the query and caches the result, so the

--- a/crates/cache/benches/cache_throughput.rs
+++ b/crates/cache/benches/cache_throughput.rs
@@ -42,12 +42,17 @@ const OPERATIONS_PER_THREAD: usize = 10_000;
 /// entries rather than in weight.
 const VALUE_BYTES: u64 = 32;
 
-/// Distinct keys the contention benchmark touches.
-const HOT_WORKING_SET: u64 = 20_000;
+/// Entries the contention benchmark keeps resident. Capacity is set from this,
+/// and the working set is sized against it to reach a target hit rate.
+const HOT_RESIDENT_ENTRIES: u64 = 16_000;
 
-/// Capacity for 80% of the working set, so the cache runs full and evicting
-/// while most reads still hit.
-const HOT_CACHE_WEIGHT: u64 = HOT_WORKING_SET * VALUE_BYTES * 8 / 10;
+/// Hit rates to sweep, as percentages.
+///
+/// Under uniform access an LRU holding `C` entries of a `W`-key working set hits
+/// about `C/W` of the time, so the working set is `C` scaled by the inverse.
+/// 50% is the thrashing regime the older benchmarks sit in; 99% is where a
+/// results cache worth enabling actually runs.
+const HOT_HIT_RATES: [(&str, u64); 3] = [("50pct", 50), ("95pct", 95), ("99pct", 99)];
 
 /// Creates a runtime that can be shared across benchmark worker threads.
 fn create_bench_runtime() -> tokio::runtime::Runtime {
@@ -545,17 +550,22 @@ fn bench_lru_cache_concurrent_mixed(c: &mut Criterion) {
     group.finish();
 }
 
-/// Read/write contention on a full cache whose reads mostly hit.
+/// Read-through contention on a full cache, swept across hit rates.
 ///
-/// The other `LruCache` benchmarks read a 100k key space holding at most 5,000
-/// entries, so ~95% of their reads miss. That matters for the engine comparison
-/// because a Pingora miss is one metadata lookup, while a hit removes the entry
-/// and re-admits it — `pingora-lru` has no `peek_value`. Reads that miss never
-/// reach the path where the engines differ.
+/// The other `LruCache` benchmarks read a 100,000 key space holding at most
+/// 5,000 entries, so roughly 95% of their reads miss. That matters for the
+/// engine comparison because a Pingora miss is one metadata lookup, while a hit
+/// removes the entry and re-admits it — `pingora-lru` has no `peek_value`.
+/// Reads that miss never reach the path where the engines differ.
 ///
-/// Here the read key space is the working set, so reads hit, and capacity holds
-/// 80% of it, so writes evict. Thread counts straddle the 16 metadata shards:
-/// at 16 threads shard collisions are incidental, at 32 they are structural.
+/// Reads and writes are not independent here, because they are not independent
+/// in the runtime: a miss executes the query and caches the result, so the
+/// write rate is the miss rate. Dialling a read/write mix separately from a hit
+/// rate describes states a results cache cannot be in. This loop reads, and
+/// refills on a miss, so hit rate is the only knob and the write rate follows.
+///
+/// Thread counts straddle the 16 metadata shards Pingora uses: at 16 shard
+/// collisions are incidental, at 32 they are structural.
 fn bench_lru_cache_hot_read_write(c: &mut Criterion) {
     let mut group = c.benchmark_group("lru_cache_hot_read_write");
     let rt = create_bench_runtime();
@@ -567,13 +577,15 @@ fn bench_lru_cache_hot_read_write(c: &mut Criterion) {
         get_hash_builder(HashingAlgorithm::XXH3).expect("Failed to get hash builder");
 
     for (pair_name, engine, policy) in all_engine_policy_pairs() {
-        for (mix_name, read_percent) in [("95_5", 95u32), ("80_20", 80)] {
+        for (hit_name, hit_percent) in HOT_HIT_RATES {
+            let working_set = HOT_RESIDENT_ENTRIES * 100 / hit_percent;
+
             for thread_count in [16usize, 32] {
                 group.throughput(Throughput::Elements(
                     (thread_count * OPERATIONS_PER_THREAD) as u64,
                 ));
 
-                let bench_name = format!("{pair_name}_{mix_name}_{thread_count}threads");
+                let bench_name = format!("{pair_name}_{hit_name}_{thread_count}threads");
 
                 group.bench_with_input(
                     BenchmarkId::from_parameter(&bench_name),
@@ -589,7 +601,7 @@ fn bench_lru_cache_hot_read_write(c: &mut Criterion) {
                                         Box<dyn Hasher + Send + Sync>,
                                     >,
                                 > = Arc::new(LruCache::new(
-                                    HOT_CACHE_WEIGHT,
+                                    HOT_RESIDENT_ENTRIES * VALUE_BYTES,
                                     Duration::from_mins(10),
                                     hash_builder.clone(),
                                     policy,
@@ -599,7 +611,7 @@ fn bench_lru_cache_hot_read_write(c: &mut Criterion) {
                                 handle.block_on(async {
                                     // Insert the whole working set; the cache
                                     // evicts down to capacity and starts full.
-                                    for key in 0..HOT_WORKING_SET {
+                                    for key in 0..working_set {
                                         let value = BenchValue(random_value(&mut rng));
                                         cache.put_raw_key(&key, value).await;
                                     }
@@ -616,15 +628,11 @@ fn bench_lru_cache_hot_read_write(c: &mut Criterion) {
                                             let mut rng = StdRng::seed_from_u64(thread_id as u64);
                                             handle.block_on(async {
                                                 for _ in 0..OPERATIONS_PER_THREAD {
-                                                    let key =
-                                                        rng.random_range(0..HOT_WORKING_SET);
-                                                    if rng.random_range(0..100) < read_percent {
-                                                        black_box(cache.get_raw_key(&key).await);
-                                                    } else {
-                                                        // Rewriting a key already in the
-                                                        // working set is what a refreshed
-                                                        // result does; it still evicts,
-                                                        // because the cache is full.
+                                                    let key = rng.random_range(0..working_set);
+                                                    if cache.get_raw_key(&key).await.is_none() {
+                                                        // Refill on miss, as the
+                                                        // runtime does after
+                                                        // executing the query.
                                                         let value =
                                                             BenchValue(random_value(&mut rng));
                                                         black_box(

--- a/crates/cache/tests/hit_rate_experiment.rs
+++ b/crates/cache/tests/hit_rate_experiment.rs
@@ -1,0 +1,194 @@
+//! Pure-read performance against hit rate and cache size, for both engines.
+//!
+//! Complements `benches/cache_throughput.rs`. The benchmarks there either sit at
+//! a fixed hit rate (`concurrent_get`, ~3%) or refill on a miss
+//! (`hot_read_write`), so neither isolates the read path across hit rates. This
+//! does: no writes, no eviction, the resident set pinned for the whole run.
+//!
+//! It also measures the achieved hit rate rather than assuming it, which is what
+//! validates the `C/W` sizing the benchmarks rely on.
+//!
+//! Ignored by default: it takes a few minutes, and it prints a table rather than
+//! asserting.
+//!
+//! cargo test -p cache --features pingora --release --test hit_rate_experiment \
+//!   -- --ignored --nocapture
+
+#![allow(clippy::expect_used)]
+
+use cache::{
+    AsTableRefs, CacheMetrics, CacheProvider, EvictionReason, HashBuilder, LruCache, Sizeable,
+    get_hash_builder,
+};
+use datafusion::sql::TableReference;
+use rand::distr::Alphanumeric;
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+use spicepod::component::caching::{CacheEngine, CachingPolicy, HashingAlgorithm};
+use std::collections::HashSet;
+use std::hash::Hasher;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+const VALUE_BYTES: u64 = 32;
+const OPS: usize = 10_000;
+const THREADS: usize = 16;
+/// Measured repetitions per point, plus one discarded warm-up.
+const REPS: usize = 5;
+const CAPACITIES: [u64; 3] = [1_000, 5_000, 30_000];
+const HIT_RATES: [u64; 5] = [3, 50, 80, 95, 99];
+
+#[derive(Clone)]
+struct V(String);
+
+impl Sizeable for V {
+    fn get_memory_size(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl CacheMetrics for V {
+    fn record_hit() {}
+    fn record_miss() {}
+    fn record_request() {}
+    fn record_item_count(_: u64) {}
+    fn record_size(_: u64) {}
+    fn record_max_size(_: u64) {}
+    fn record_eviction(_: EvictionReason) {}
+    fn record_stale_rejection() {}
+    fn update_hit_ratio(_: u64, _: u64) {}
+    fn publish_counters_at_zero() {}
+}
+
+impl AsTableRefs for V {
+    fn as_table_refs(&self) -> Arc<HashSet<TableReference>> {
+        Arc::new(HashSet::new())
+    }
+}
+
+fn random_value(rng: &mut StdRng) -> String {
+    rng.sample_iter(&Alphanumeric).take(32).map(char::from).collect()
+}
+
+type Cache = LruCache<V, HashBuilder, Box<dyn Hasher + Send + Sync>>;
+
+/// Returns (elapsed, achieved hit rate, resident entries).
+fn run(
+    engine: CacheEngine,
+    policy: CachingPolicy,
+    capacity: u64,
+    working: u64,
+    handle: &tokio::runtime::Handle,
+) -> (Duration, f64, u64) {
+    let hash_builder =
+        get_hash_builder(HashingAlgorithm::XXH3).expect("Failed to get hash builder");
+    let cache: Arc<Cache> = Arc::new(LruCache::new(
+        capacity * VALUE_BYTES,
+        Duration::from_secs(600),
+        hash_builder,
+        policy,
+        engine,
+    ));
+
+    let mut rng = StdRng::seed_from_u64(42);
+    handle.block_on(async {
+        for key in 0..working {
+            cache.put_raw_key(&key, V(random_value(&mut rng))).await;
+        }
+        cache.checkpoint().await;
+    });
+    let resident = handle.block_on(async { cache.item_count().await });
+
+    let misses = Arc::new(AtomicU64::new(0));
+    let start = Instant::now();
+    let threads: Vec<_> = (0..THREADS)
+        .map(|tid| {
+            let cache = Arc::clone(&cache);
+            let handle = handle.clone();
+            let misses = Arc::clone(&misses);
+            std::thread::spawn(move || {
+                let mut rng = StdRng::seed_from_u64(tid as u64);
+                let mut local = 0u64;
+                handle.block_on(async {
+                    for _ in 0..OPS {
+                        let key = rng.random_range(0..working);
+                        // Pure reads: no refill, so the resident set cannot drift
+                        // and the hit rate stays what the sizing set it to.
+                        if cache.get_raw_key(&key).await.is_none() {
+                            local += 1;
+                        }
+                    }
+                });
+                misses.fetch_add(local, Ordering::Relaxed);
+            })
+        })
+        .collect();
+    for t in threads {
+        t.join().expect("thread panicked");
+    }
+    let elapsed = start.elapsed();
+
+    let total = (THREADS * OPS) as f64;
+    let hit_rate = 1.0 - misses.load(Ordering::Relaxed) as f64 / total;
+    (elapsed, hit_rate, resident)
+}
+
+#[test]
+#[ignore = "reports timings; run explicitly with --ignored"]
+fn pure_read_vs_hit_rate() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let handle = rt.handle().clone();
+
+    let mut engines: Vec<(&str, CacheEngine, CachingPolicy)> = vec![
+        ("moka_lru", CacheEngine::Moka, CachingPolicy::Lru),
+        ("moka_tinylfu", CacheEngine::Moka, CachingPolicy::TinyLfu),
+    ];
+    #[cfg(feature = "pingora")]
+    engines.push(("pingora_lru", CacheEngine::Pingora, CachingPolicy::Lru));
+
+    println!(
+        "\npure reads, {THREADS} threads, {OPS} ops/thread, median of {REPS} (+1 warm-up discarded)\n"
+    );
+
+    for capacity in CAPACITIES {
+        println!("=== capacity {capacity} entries ===");
+        println!(
+            "{:<14} {:>7} {:>8} {:>10} {:>9} {:>8}",
+            "engine", "target", "actual", "resident", "median ms", "spread"
+        );
+        for target in HIT_RATES {
+            let working = capacity * 100 / target;
+            for (name, engine, policy) in &engines {
+                // Discarded: the first run pays allocator and page-fault costs
+                // the later ones do not.
+                let _ = run(*engine, *policy, capacity, working, &handle);
+
+                let mut times = Vec::new();
+                let (mut actual, mut resident) = (0.0, 0u64);
+                for _ in 0..REPS {
+                    let (d, h, r) = run(*engine, *policy, capacity, working, &handle);
+                    times.push(d.as_secs_f64() * 1000.0);
+                    actual = h;
+                    resident = r;
+                }
+                times.sort_by(f64::total_cmp);
+                let median = times[REPS / 2];
+                let spread = (times[REPS - 1] - times[0]) / median * 100.0;
+                println!(
+                    "{:<14} {:>6}% {:>7.1}% {:>10} {:>9.1} {:>7.1}%",
+                    name,
+                    target,
+                    actual * 100.0,
+                    resident,
+                    median,
+                    spread
+                );
+            }
+            println!();
+        }
+    }
+}

--- a/crates/cache/tests/hit_rate_experiment.rs
+++ b/crates/cache/tests/hit_rate_experiment.rs
@@ -11,10 +11,10 @@
 //! Ignored by default: it takes a few minutes, and it prints a table rather than
 //! asserting.
 //!
+//! ```text
 //! cargo test -p cache --features pingora --release --test hit_rate_experiment \
 //!   -- --ignored --nocapture
-
-#![allow(clippy::expect_used)]
+//! ```
 
 use cache::{
     AsTableRefs, CacheMetrics, CacheProvider, EvictionReason, HashBuilder, LruCache, Sizeable,
@@ -85,7 +85,7 @@ fn run(
         get_hash_builder(HashingAlgorithm::XXH3).expect("Failed to get hash builder");
     let cache: Arc<Cache> = Arc::new(LruCache::new(
         capacity * VALUE_BYTES,
-        Duration::from_secs(600),
+        Duration::from_mins(10),
         hash_builder,
         policy,
         engine,
@@ -129,8 +129,13 @@ fn run(
     }
     let elapsed = start.elapsed();
 
-    let total = (THREADS * OPS) as f64;
-    let hit_rate = 1.0 - misses.load(Ordering::Relaxed) as f64 / total;
+    // Bounded by THREADS * OPS, so u32 holds them and the widening to f64 is
+    // lossless.
+    let total = f64::from(u32::try_from(THREADS * OPS).expect("operation count fits in u32"));
+    let miss_count = f64::from(
+        u32::try_from(misses.load(Ordering::Relaxed)).expect("miss count fits in u32"),
+    );
+    let hit_rate = 1.0 - miss_count / total;
     (elapsed, hit_rate, resident)
 }
 
@@ -143,6 +148,10 @@ fn pure_read_vs_hit_rate() {
         .expect("runtime");
     let handle = rt.handle().clone();
 
+    #[cfg_attr(
+        not(feature = "pingora"),
+        expect(unused_mut, reason = "only the pingora arm below pushes")
+    )]
     let mut engines: Vec<(&str, CacheEngine, CachingPolicy)> = vec![
         ("moka_lru", CacheEngine::Moka, CachingPolicy::Lru),
         ("moka_tinylfu", CacheEngine::Moka, CachingPolicy::TinyLfu),

--- a/crates/cache/tests/hit_rate_experiment.rs
+++ b/crates/cache/tests/hit_rate_experiment.rs
@@ -1,3 +1,20 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#![expect(clippy::expect_used, reason = "integration-test helpers")]
+
 //! Pure-read performance against hit rate and cache size, for both engines.
 //!
 //! Complements `benches/cache_throughput.rs`. The benchmarks there either sit at
@@ -68,7 +85,10 @@ impl AsTableRefs for V {
 }
 
 fn random_value(rng: &mut StdRng) -> String {
-    rng.sample_iter(&Alphanumeric).take(32).map(char::from).collect()
+    rng.sample_iter(&Alphanumeric)
+        .take(32)
+        .map(char::from)
+        .collect()
 }
 
 type Cache = LruCache<V, HashBuilder, Box<dyn Hasher + Send + Sync>>;
@@ -132,9 +152,8 @@ fn run(
     // Bounded by THREADS * OPS, so u32 holds them and the widening to f64 is
     // lossless.
     let total = f64::from(u32::try_from(THREADS * OPS).expect("operation count fits in u32"));
-    let miss_count = f64::from(
-        u32::try_from(misses.load(Ordering::Relaxed)).expect("miss count fits in u32"),
-    );
+    let miss_count =
+        f64::from(u32::try_from(misses.load(Ordering::Relaxed)).expect("miss count fits in u32"));
     let hit_rate = 1.0 - miss_count / total;
     (elapsed, hit_rate, resident)
 }


### PR DESCRIPTION
## 1. Pingora support in the benchmarks

Currently `LruCache` benchmark includes Moka only, this PR extends benchmark with Pingora

## 2. Additional coverage

The existing `LruCache` benchmarks read a 100,000 key space while the cache holds ~3,125 entries — 5,000 are inserted and capacity evicts to that — so ~97% of their reads miss.

That matters because the engines diverge on **both** paths, in opposite directions. A Pingora miss returns after one metadata lookup and is ~2x faster than Moka's; a Pingora hit removes the entry and re-admits it, since `pingora-lru` has no `peek_value`, and is slower. Measuring only the miss path favours Pingora by construction.


**`tests/hit_rate_experiment.rs`**  measures cache item get time  based on hit rate and cached items size.

**`bench_lru_cache_hot_read_write`** simulate cache behavior that includes both reads and writes on cache miss.

```rust
if cache.get_raw_key(&key).await.is_none() {
    cache.put_raw_key(&key, value).await;   // refill, as the runtime does
}
```

Hit rate is the only knob, set by sizing: capacity fixed at 16,000 entries, working set `capacity / hit_rate`. Threads are 16 and 32, straddling the 16 metadata shards Pingora uses.

No production code changed.

## 3. Results

Apple M-series, `--sample-size 10` / median of five. Lower is faster.

### Pure reads, fixed ~3% hit rate — `concurrent_get`

| threads | moka_lru | moka_tinylfu | pingora_lru | pingora vs moka_lru |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 2.70 ms | 2.82 ms | 1.27 ms | 0.47x |
| 4 | 7.62 ms | 7.30 ms | 3.80 ms | 0.50x |
| 8 | 13.12 ms | 13.05 ms | 6.44 ms | 0.49x |
| 16 | 29.91 ms | 29.43 ms | 13.78 ms | 0.46x |

Pingora ~2x faster, and the ratio is flat across thread counts. This is the miss path, where Pingora is cheapest.

### Pure reads across hit rates — 16 threads, capacity 5,000

| hit rate | moka_lru | moka_tinylfu | pingora_lru | pingora vs moka_lru |
| ---: | ---: | ---: | ---: | ---: |
| 3% | 34.9 ms | 36.9 ms | 13.8 ms | 0.40x |
| 50% | 33.9 ms | 34.9 ms | 22.5 ms | 0.66x |
| 80% | 32.9 ms | 33.7 ms | 32.5 ms | 0.99x |
| 95% | 34.7 ms | 34.7 ms | 39.0 ms | 1.12x |
| 99% | 35.2 ms | 36.6 ms | 40.2 ms | 1.14x |

Moka is flat — 33-35 ms across a 33x swing in hit rate. Pingora rises monotonically, 2.9x end to end, because only a hit pays the remove and re-admit. They cross around **80%**.

Above the crossover they are close: Pingora 12-14% behind, against Moka's own run-to-run spread. On reads alone this is a parity result, not a Moka win.

### Read-through across hit rates — `hot_read_write`

| hit rate | threads | moka_lru | moka_tinylfu | pingora_lru | pingora vs moka_lru |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 50% | 16 | 275.9 ms | 239.6 ms | 74.9 ms | 0.27x |
| 50% | 32 | 628.0 ms | 529.3 ms | 206.7 ms | 0.33x |
| 95% | 16 | 33.6 ms | 31.3 ms | 53.5 ms | 1.59x |
| 95% | 32 | 60.8 ms | 61.1 ms | 141.1 ms | 2.32x |
| 99% | 16 | 38.3 ms | 38.1 ms | 43.7 ms | 1.14x |
| 99% | 32 | 73.3 ms | 73.2 ms | 99.6 ms | 1.36x |

### Does cache size matter?

Largely no. The same harness swept 1,000 / 5,000 / 30,000 entries and put the crossover between 80% and 95% at every capacity, with Pingora's timings within 3% of each other across the whole 30x range.



