### PR TITLE
chore(byoc): use American enrollment spelling

### DIFF
--- a/bin/spice/tests/cli_integration.rs
+++ b/bin/spice/tests/cli_integration.rs
@@ -1479,7 +1479,7 @@ mod connect {
 
     /// Omitting `--region` must send no `region` field at all. `null` would be
     /// read cloud-side as "clear it", silently erasing a region set in the
-    /// portal on every re-enrol.
+    /// portal on every re-enroll.
     #[cfg(unix)]
     #[test]
     fn test_connect_without_region_omits_the_field() {

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -2602,7 +2602,7 @@ views:
     /// Give the instance an identity carrying a cache key, which is what makes
     /// the delivered-secrets cache writable — without one the cache is skipped
     /// and a test asserting on it would pass for the wrong reason.
-    fn enrol_with_a_cache_key(identity_path: &Path) {
+    fn enroll_with_a_cache_key(identity_path: &Path) {
         let mock_pem = "-----BEGIN PRIVATE KEY-----\nMOCK\n-----END PRIVATE KEY-----\n".to_string();
         let mut identity = runtime_cloud_connect::identity::Identity {
             identifier: "inst_test".to_string(),
@@ -2956,7 +2956,7 @@ views:
     async fn a_malformed_deployment_leaves_the_cached_secrets_alone() {
         let dir = scratch_dir("malformed-cache");
         let handle = handle_serving(&dir, SERVING).await;
-        enrol_with_a_cache_key(&dir.join(IDENTITY_FILE));
+        enroll_with_a_cache_key(&dir.join(IDENTITY_FILE));
 
         handle
             .apply_spicepod(SpicepodDeployment {
@@ -3006,7 +3006,7 @@ views:
         handle
             .delivered_secrets
             .replace(delivered("api_key", b"value-one"));
-        enrol_with_a_cache_key(&dir.join(IDENTITY_FILE));
+        enroll_with_a_cache_key(&dir.join(IDENTITY_FILE));
         assert!(cached_secrets(&dir).is_none(), "nothing is cached yet");
 
         let outcome = handle

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -159,7 +159,7 @@ pub struct CloudConnectConfig {
     /// than as one of them. The cloud records it on the registry row and
     /// resolves the instance's gateway stamp from it.
     ///
-    /// `None` means "leave the stored value alone": a re-enrol (the recovery
+    /// `None` means "leave the stored value alone": a re-enroll (the recovery
     /// path once the renewal grace window has passed) must not erase a region
     /// set in the portal.
     pub instance_region: Option<String>,

--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -188,7 +188,7 @@ struct EnrollRequest<'a> {
     /// `spice connect --region`.
     ///
     /// Omitted (never `null`) when unset — the cloud reads absence as "leave
-    /// the stored region alone", so a re-enrol cannot erase a region set in
+    /// the stored region alone", so a re-enroll cannot erase a region set in
     /// the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
     region: Option<&'a str>,
@@ -1010,7 +1010,7 @@ mod tests {
         .expect("serialize request without a region");
 
         // Absence means "leave the stored region alone". Sending `null` would
-        // make every re-enrol — the recovery path past the renewal grace
+        // make every re-enroll — the recovery path past the renewal grace
         // window — silently erase a region set in the portal.
         assert!(
             omitted.get("region").is_none(),

--- a/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_adoption_e2e.rs
@@ -271,7 +271,7 @@ async fn mock_enroll(
     }
     // The real cloud reports the region now stored on the row: the declared
     // one when the request carried it, otherwise whatever the row already
-    // held (a re-enrol with no `region` leaves it alone). The mock stands in
+    // held (a re-enroll with no `region` leaves it alone). The mock stands in
     // for that stored value.
     let stored_region = match body["region"].as_str() {
         Some(region) => {
@@ -1718,8 +1718,8 @@ async fn one_shot_enroll_records_the_declared_region() {
     );
 }
 
-/// Omitting `--region` on a re-enrol must leave the stored region alone.
-/// Re-enrolment is how a standalone instance recovers past its renewal grace
+/// Omitting `--region` on a re-enroll must leave the stored region alone.
+/// Re-enrollment is how a standalone instance recovers past its renewal grace
 /// window, so a request that unconditionally wrote the region would erase one
 /// set in the portal on every recovery.
 #[tokio::test]
@@ -1770,7 +1770,7 @@ async fn re_enroll_without_a_region_leaves_the_stored_region_untouched() {
     assert_eq!(
         second.registration.region.as_deref(),
         Some("us-west-2"),
-        "the region set by the first enroll must survive the re-enrol"
+        "the region set by the first enroll must survive the re-enroll"
     );
 }
 


### PR DESCRIPTION
## Summary
- standardize the BYOC branch on American `enroll*` spelling
- rename the private test helper and update comments and test messages only
- preserve runtime behavior, wire contracts, schemas, and persistence

## Verification
- tracked content and path scans: zero case-insensitive `enrol(?!l)` matches
- `cargo fmt --all -- --check`
- `cargo test --locked -p spiced --no-default-features --lib cloud_connect::tests` (44 passed)
- `cargo clippy --locked -p spiced --no-default-features --lib --no-deps -- -D warnings`
- adversarial review: READY, no findings