### PR TITLE
Add PDF page splitter and FinanceBench staging job (#12858)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14502,6 +14502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdf-split"
+version = "2.2.0-unstable"
+dependencies = [
+ "clap",
+ "lopdf",
+ "snafu",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14505,6 +14505,7 @@ dependencies = [
 name = "pdf-split"
 version = "2.2.0-unstable"
 dependencies = [
+ "blake3",
  "clap",
  "lopdf",
  "snafu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ members = [
     "tools/testoperator",
     "tools/chbench-driver",
     "tools/parsley",
+    "tools/pdf-split",
     "tools/pr-builds",
     "crates/vendor/ttf-parser",
     "crates/vendor/lopdf",

--- a/scripts/financebench_stage.py
+++ b/scripts/financebench_stage.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+#
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One-time staging job that builds the FinanceBench PDF search benchmark corpus.
+
+FinanceBench (patronus-ai/financebench) is 150 questions over SEC filings. Each
+question's `evidence` entries name the exact filing page that answers it, so the
+ground truth is at *page* granularity. Spice's document/`file:` connector
+flattens a whole PDF into one `content` string per file, destroying page
+boundaries on ingestion, so page identity must exist *before* Spice sees the
+data: every filing is pre-split into one PDF per page, with the zero-indexed
+page number in the file path (which becomes the corpus row's `location`).
+
+This job runs once, offline (never in CI or by testoperator). It:
+
+  1. Reads `financebench_open_source.jsonl` and the referenced `pdfs/<doc>.pdf`.
+  2. Splits every unique evidence doc into `corpus_pages/<doc>/pNNNN.pdf` with
+     the committed `pdf-split` binary (identical page extraction to the tool).
+  3. Validates every `evidence_page_num < page_count` for its doc — a Qrel past
+     end-of-doc means the corpus is wrong, so it fails loudly (data correctness).
+  4. Builds `queries.parquet` (`_id`, `text`) and `relevance_data.parquet`
+     (`query-id`, `corpus-id`, `score`) matching the harness contract (#12935),
+     expanding multi-page questions to one relevance row per evidence page.
+  5. Writes `corpus_pages/`, `queries.parquet`, `relevance_data.parquet` to a
+     `--dest` that is either a local directory or an `s3://` URI.
+
+The `corpus-id` in `relevance_data.parquet` MUST equal the `location` string
+Spice reports for the matching page-PDF. A single normalization rule
+(`corpus_id_for`) is shared by the parquet builder and the upload layout so the
+two never drift; set `--corpus-id-prefix` to whatever the `location` probe
+reports (see the README / issue #12858 Verification step 2).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import urlparse
+
+DEFAULT_SOURCE = "https://raw.githubusercontent.com/patronus-ai/financebench/main"
+JSONL_RELATIVE = "data/financebench_open_source.jsonl"
+
+
+def eprint(*args: object) -> None:
+    print(*args, file=sys.stderr, flush=True)
+
+
+def page_file_name(idx: int) -> str:
+    """Zero-indexed, zero-padded page file name, matching `pdf_split::page_file_name`."""
+    return f"p{idx:04d}.pdf"
+
+
+def corpus_id_for(prefix: str, doc_name: str, page_idx: int) -> str:
+    """The single source of truth for the `location`/`corpus-id` string of a page.
+
+    Both the on-disk / S3 layout (`<dest>/corpus_pages/<doc>/pNNNN.pdf`) and the
+    `corpus-id` column derive from this, so a Qrel always names the same string
+    Spice reports as `location`. `prefix` adapts the relative key to whatever the
+    connector reports for a given `--dest` (see the module docstring).
+    """
+    key = f"{doc_name}/{page_file_name(page_idx)}"
+    return f"{prefix}{key}" if prefix else key
+
+
+# ---------------------------------------------------------------------------
+# Destination writers — dispatch on the `--dest` scheme so the same layout and
+# `corpus-id`/`location` normalization apply to a local dir and an s3:// URI.
+# ---------------------------------------------------------------------------
+
+
+class Dest:
+    """Write files to a staging destination under a stable relative layout."""
+
+    def put_file(self, rel_path: str, local_path: Path) -> None:
+        raise NotImplementedError
+
+    def describe(self) -> str:
+        raise NotImplementedError
+
+
+@dataclass
+class LocalDest(Dest):
+    root: Path
+
+    def put_file(self, rel_path: str, local_path: Path) -> None:
+        target = self.root / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(local_path, target)
+
+    def describe(self) -> str:
+        return str(self.root)
+
+
+@dataclass
+class S3Dest(Dest):
+    bucket: str
+    prefix: str
+    client: object
+
+    def put_file(self, rel_path: str, local_path: Path) -> None:
+        key = f"{self.prefix}{rel_path}" if self.prefix else rel_path
+        self.client.upload_file(str(local_path), self.bucket, key)
+
+    def describe(self) -> str:
+        return f"s3://{self.bucket}/{self.prefix}"
+
+
+def make_dest(dest: str) -> Dest:
+    """Build a `Dest` for a local directory path or an `s3://bucket/prefix` URI."""
+    parsed = urlparse(dest)
+    if parsed.scheme in ("", "file"):
+        root = Path(parsed.path if parsed.scheme == "file" else dest)
+        root.mkdir(parents=True, exist_ok=True)
+        return LocalDest(root=root)
+
+    if parsed.scheme == "s3":
+        try:
+            import boto3  # noqa: PLC0415
+        except ImportError as exc:  # pragma: no cover - env dependent
+            raise SystemExit(
+                "boto3 is required to upload to s3://. Install it (pip install boto3) "
+                "or write to a local --dest directory instead."
+            ) from exc
+
+        bucket = parsed.netloc
+        prefix = parsed.path.lstrip("/")
+        if prefix and not prefix.endswith("/"):
+            prefix += "/"
+
+        # Reuse the same secret pattern the S3 spicepods use: S3_ENDPOINT /
+        # S3_KEY / S3_SECRET (MinIO bench bucket).
+        endpoint = os.environ.get("S3_ENDPOINT")
+        client = boto3.client(
+            "s3",
+            endpoint_url=f"https://{endpoint}" if endpoint and "://" not in endpoint else endpoint,
+            aws_access_key_id=os.environ.get("S3_KEY"),
+            aws_secret_access_key=os.environ.get("S3_SECRET"),
+        )
+        return S3Dest(bucket=bucket, prefix=prefix, client=client)
+
+    raise SystemExit(f"Unsupported --dest scheme: {dest!r} (use a local path or s3://…)")
+
+
+# ---------------------------------------------------------------------------
+# Source access — read the FinanceBench jsonl and PDFs from a local clone or
+# over HTTPS from raw.githubusercontent.
+# ---------------------------------------------------------------------------
+
+
+def read_source_bytes(source: str, rel_path: str) -> bytes:
+    """Read `rel_path` from a local FinanceBench checkout or an HTTP(S) base URL."""
+    parsed = urlparse(source)
+    if parsed.scheme in ("http", "https"):
+        url = f"{source.rstrip('/')}/{rel_path}"
+        try:
+            with urllib.request.urlopen(url) as resp:  # noqa: S310 - fixed https host
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            raise SystemExit(f"Failed to download {url}: HTTP {exc.code}") from exc
+
+    local = Path(source) / rel_path
+    if not local.is_file():
+        raise SystemExit(f"Source file not found: {local}")
+    return local.read_bytes()
+
+
+def load_records(source: str) -> list[dict]:
+    raw = read_source_bytes(source, JSONL_RELATIVE)
+    records = []
+    for line in raw.decode("utf-8").splitlines():
+        line = line.strip()
+        if line:
+            records.append(json.loads(line))
+    return records
+
+
+def evidence_pages(record: dict) -> list[tuple[str, int]]:
+    """Return `(doc_name, page_idx)` pairs from a record's evidence entries."""
+    pairs: list[tuple[str, int]] = []
+    for ev in record.get("evidence") or []:
+        doc_name = ev.get("evidence_doc_name") or ev.get("doc_name") or record.get("doc_name")
+        page = ev.get("evidence_page_num")
+        if doc_name is None or page is None:
+            continue
+        pairs.append((str(doc_name), int(page)))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Staging
+# ---------------------------------------------------------------------------
+
+
+def split_doc(
+    pdf_split_bin: Path,
+    source: str,
+    work_dir: Path,
+    doc_name: str,
+) -> list[Path]:
+    """Fetch `pdfs/<doc>.pdf` into `work_dir` and split it into single-page PDFs.
+
+    Returns the produced page paths in page order.
+    """
+    pdf_bytes = read_source_bytes(source, f"pdfs/{doc_name}.pdf")
+    src_pdf = work_dir / f"{doc_name}.pdf"
+    src_pdf.parent.mkdir(parents=True, exist_ok=True)
+    src_pdf.write_bytes(pdf_bytes)
+
+    out_dir = work_dir / "corpus_pages" / doc_name
+    subprocess.run(
+        [str(pdf_split_bin), str(src_pdf), "--out", str(out_dir)],
+        check=True,
+        capture_output=True,
+    )
+    return sorted(out_dir.glob("p*.pdf"))
+
+
+def write_parquet(rows: list[dict], schema, path: Path) -> None:
+    import pyarrow as pa  # noqa: PLC0415
+    import pyarrow.parquet as pq  # noqa: PLC0415
+
+    columns = {field.name: [row[field.name] for row in rows] for field in schema}
+    table = pa.table(columns, schema=schema)
+    pq.write_table(table, path)
+
+
+def stage(args: argparse.Namespace) -> int:
+    try:
+        import pyarrow as pa  # noqa: PLC0415
+    except ImportError as exc:
+        raise SystemExit("pyarrow is required (pip install pyarrow).") from exc
+
+    pdf_split_bin = Path(args.pdf_split_bin)
+    if not pdf_split_bin.is_file():
+        raise SystemExit(
+            f"pdf-split binary not found at {pdf_split_bin}. Build it with "
+            "`cargo build --release -p pdf-split` and pass --pdf-split-bin, or set it explicitly."
+        )
+
+    records = load_records(args.source)
+    if args.limit_docs:
+        # Deterministically keep the first N unique docs for dry-runs.
+        wanted: set[str] = set()
+        kept = []
+        for record in records:
+            docs = {doc for doc, _ in evidence_pages(record)}
+            if wanted or docs:
+                wanted |= docs
+            kept.append(record)
+            if len(wanted) >= args.limit_docs:
+                break
+        keep_docs = set(list(wanted)[: args.limit_docs])
+        records = [
+            r for r in kept if any(doc in keep_docs for doc, _ in evidence_pages(r))
+        ]
+        eprint(f"Limiting to {len(keep_docs)} docs ({len(records)} questions) for dry-run.")
+
+    # Every unique evidence doc must be split and validated.
+    doc_names = sorted({doc for r in records for doc, _ in evidence_pages(r)})
+    eprint(f"{len(records)} questions reference {len(doc_names)} unique evidence docs.")
+
+    dest = make_dest(args.dest)
+    eprint(f"Staging to {dest.describe()}")
+
+    with tempfile.TemporaryDirectory(prefix="financebench-stage-") as tmp:
+        work_dir = Path(tmp)
+        page_counts: dict[str, int] = {}
+
+        for i, doc_name in enumerate(doc_names, start=1):
+            eprint(f"[{i}/{len(doc_names)}] splitting {doc_name}")
+            pages = split_doc(pdf_split_bin, args.source, work_dir, doc_name)
+            if not pages:
+                raise SystemExit(f"Splitting produced no pages for {doc_name}.")
+            page_counts[doc_name] = len(pages)
+            for page_idx, page_path in enumerate(pages):
+                # The uploaded relative path IS the corpus-id key (minus prefix),
+                # so the layout and the Qrel `corpus-id` derive from one rule.
+                dest.put_file(f"corpus_pages/{doc_name}/{page_file_name(page_idx)}", page_path)
+
+        # Validate every evidence page is in range BEFORE emitting Qrels.
+        errors: list[str] = []
+        for record in records:
+            fb_id = record.get("financebench_id")
+            for doc_name, page in evidence_pages(record):
+                count = page_counts.get(doc_name)
+                if count is None:
+                    errors.append(f"{fb_id}: evidence doc {doc_name!r} was not staged")
+                elif not 0 <= page < count:
+                    errors.append(
+                        f"{fb_id}: evidence_page_num {page} out of range for {doc_name} "
+                        f"(0..{count})"
+                    )
+        if errors:
+            eprint("Qrel validation FAILED — the corpus is inconsistent with the evidence:")
+            for err in errors:
+                eprint(f"  {err}")
+            return 1
+
+        # queries.parquet: _id, text.
+        query_rows = [
+            {"_id": str(r["financebench_id"]), "text": str(r["question"])}
+            for r in records
+            if r.get("financebench_id") is not None and r.get("question") is not None
+        ]
+        query_schema = pa.schema([("_id", pa.string()), ("text", pa.string())])
+
+        # relevance_data.parquet: query-id, corpus-id, score. One row per evidence
+        # page; dedup identical (query, page) pairs a multi-evidence question may repeat.
+        seen: set[tuple[str, str]] = set()
+        rel_rows = []
+        for record in records:
+            fb_id = str(record.get("financebench_id"))
+            for doc_name, page in evidence_pages(record):
+                corpus_id = corpus_id_for(args.corpus_id_prefix, doc_name, page)
+                key = (fb_id, corpus_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+                rel_rows.append({"query-id": fb_id, "corpus-id": corpus_id, "score": 1})
+        rel_schema = pa.schema(
+            [("query-id", pa.string()), ("corpus-id", pa.string()), ("score", pa.int64())]
+        )
+
+        queries_path = work_dir / "queries.parquet"
+        relevance_path = work_dir / "relevance_data.parquet"
+        write_parquet(query_rows, query_schema, queries_path)
+        write_parquet(rel_rows, rel_schema, relevance_path)
+        dest.put_file("queries.parquet", queries_path)
+        dest.put_file("relevance_data.parquet", relevance_path)
+
+    eprint(
+        f"Done. {len(query_rows)} queries, {len(rel_rows)} relevance rows, "
+        f"{sum(page_counts.values())} corpus pages across {len(doc_names)} docs."
+    )
+    return 0
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--dest",
+        required=True,
+        help="Output destination: a local directory or an s3://bucket/prefix URI.",
+    )
+    parser.add_argument(
+        "--source",
+        default=DEFAULT_SOURCE,
+        help=(
+            "FinanceBench source: a local checkout path or an HTTP(S) base URL "
+            f"(default: {DEFAULT_SOURCE})."
+        ),
+    )
+    parser.add_argument(
+        "--pdf-split-bin",
+        default="target/release/pdf-split",
+        help="Path to the built pdf-split binary (default: target/release/pdf-split).",
+    )
+    parser.add_argument(
+        "--corpus-id-prefix",
+        default="",
+        help=(
+            "Prefix prepended to the '<doc>/pNNNN.pdf' relative key to form the "
+            "corpus-id, so it matches the connector-reported `location`. Set from the "
+            "location probe (issue #12858 Verification step 2). Default: empty."
+        ),
+    )
+    parser.add_argument(
+        "--limit-docs",
+        type=int,
+        default=0,
+        help="For dry-runs: stage only the first N unique evidence docs (0 = all).",
+    )
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Iterable[str]) -> int:
+    return stage(parse_args(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/financebench_stage.py
+++ b/scripts/financebench_stage.py
@@ -62,7 +62,6 @@ from pathlib import Path
 from typing import Iterable
 from urllib.parse import urlparse
 
-DEFAULT_SOURCE = "https://raw.githubusercontent.com/patronus-ai/financebench/main"
 JSONL_RELATIVE = "data/financebench_open_source.jsonl"
 
 
@@ -198,13 +197,23 @@ def load_records(source: str) -> list[dict]:
 
 
 def evidence_pages(record: dict) -> list[tuple[str, int]]:
-    """Return `(doc_name, page_idx)` pairs from a record's evidence entries."""
+    """Return `(doc_name, page_idx)` pairs from a record's evidence entries.
+
+    Raises `SystemExit` on a malformed or empty evidence entry: a Qrel built
+    from ground truth that can't name its doc and page is worse than no Qrel
+    at all, so this fails the staging job loudly rather than dropping it.
+    """
+    fb_id = record.get("financebench_id")
     pairs: list[tuple[str, int]] = []
     for ev in record.get("evidence") or []:
+        if not ev:
+            raise SystemExit(f"{fb_id}: empty evidence entry")
         doc_name = ev.get("evidence_doc_name") or ev.get("doc_name") or record.get("doc_name")
         page = ev.get("evidence_page_num")
         if doc_name is None or page is None:
-            continue
+            raise SystemExit(
+                f"{fb_id}: malformed evidence entry {ev!r} (missing doc name or page number)"
+            )
         pairs.append((str(doc_name), int(page)))
     return pairs
 
@@ -325,14 +334,19 @@ def stage(args: argparse.Namespace) -> int:
             for r in records
             if r.get("financebench_id") is not None and r.get("question") is not None
         ]
-        query_schema = pa.schema([("_id", pa.string()), ("text", pa.string())])
+        query_schema = pa.schema([("_id", pa.large_string()), ("text", pa.large_string())])
 
         # relevance_data.parquet: query-id, corpus-id, score. One row per evidence
         # page; dedup identical (query, page) pairs a multi-evidence question may repeat.
         seen: set[tuple[str, str]] = set()
         rel_rows = []
         for record in records:
-            fb_id = str(record.get("financebench_id"))
+            fb_id = record.get("financebench_id")
+            if fb_id is None:
+                # No valid query id, so this record is already excluded from
+                # queries.parquet above — it must not emit a relevance row either.
+                continue
+            fb_id = str(fb_id)
             for doc_name, page in evidence_pages(record):
                 corpus_id = corpus_id_for(doc_name, page)
                 key = (fb_id, corpus_id)
@@ -341,7 +355,11 @@ def stage(args: argparse.Namespace) -> int:
                 seen.add(key)
                 rel_rows.append({"query-id": fb_id, "corpus-id": corpus_id, "score": 1})
         rel_schema = pa.schema(
-            [("query-id", pa.string()), ("corpus-id", pa.string()), ("score", pa.int64())]
+            [
+                ("query-id", pa.large_string()),
+                ("corpus-id", pa.large_string()),
+                ("score", pa.int64()),
+            ]
         )
 
         queries_path = work_dir / "queries.parquet"
@@ -367,10 +385,13 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--source",
-        default=DEFAULT_SOURCE,
+        required=True,
         help=(
             "FinanceBench source: a local checkout path or an HTTP(S) base URL "
-            f"(default: {DEFAULT_SOURCE})."
+            "pinned to a specific commit (e.g. "
+            "https://raw.githubusercontent.com/<org>/<repo>/<commit-sha>). "
+            "No default: a moving branch ref like `main` can change the corpus "
+            "out from under a staged run without notice."
         ),
     )
     parser.add_argument(

--- a/scripts/financebench_stage.py
+++ b/scripts/financebench_stage.py
@@ -37,11 +37,13 @@ This job runs once, offline (never in CI or by testoperator). It:
   5. Writes `corpus_pages/`, `queries.parquet`, `relevance_data.parquet` to a
      `--dest` that is either a local directory or an `s3://` URI.
 
-The `corpus-id` in `relevance_data.parquet` MUST equal the `location` string
-Spice reports for the matching page-PDF. A single normalization rule
-(`corpus_id_for`) is shared by the parquet builder and the upload layout so the
-two never drift; set `--corpus-id-prefix` to whatever the `location` probe
-reports (see the README / issue #12858 Verification step 2).
+The `corpus-id` in `relevance_data.parquet` is the portable relative key
+`<doc>/pNNNN.pdf`. It does not have to equal the raw `location` string Spice
+reports (an absolute path for a `file:` source, a bucket-relative key for
+`s3:`): the FinanceBench spicepod exposes `corpus` as a view that normalizes
+`location` down to this same `<doc>/pNNNN.pdf` before search, so the corpus row
+id the harness sees always matches the Qrel. `corpus_id_for` is the single rule
+shared by the parquet builder and the upload layout so the two never drift.
 """
 
 from __future__ import annotations
@@ -73,16 +75,14 @@ def page_file_name(idx: int) -> str:
     return f"p{idx:04d}.pdf"
 
 
-def corpus_id_for(prefix: str, doc_name: str, page_idx: int) -> str:
-    """The single source of truth for the `location`/`corpus-id` string of a page.
+def corpus_id_for(doc_name: str, page_idx: int) -> str:
+    """The single source of truth for a page's portable corpus id.
 
     Both the on-disk / S3 layout (`<dest>/corpus_pages/<doc>/pNNNN.pdf`) and the
-    `corpus-id` column derive from this, so a Qrel always names the same string
-    Spice reports as `location`. `prefix` adapts the relative key to whatever the
-    connector reports for a given `--dest` (see the module docstring).
+    `corpus-id` column derive from this relative key, so a Qrel always names the
+    value the `corpus` view normalizes `location` to (see the module docstring).
     """
-    key = f"{doc_name}/{page_file_name(page_idx)}"
-    return f"{prefix}{key}" if prefix else key
+    return f"{doc_name}/{page_file_name(page_idx)}"
 
 
 # ---------------------------------------------------------------------------
@@ -334,7 +334,7 @@ def stage(args: argparse.Namespace) -> int:
         for record in records:
             fb_id = str(record.get("financebench_id"))
             for doc_name, page in evidence_pages(record):
-                corpus_id = corpus_id_for(args.corpus_id_prefix, doc_name, page)
+                corpus_id = corpus_id_for(doc_name, page)
                 key = (fb_id, corpus_id)
                 if key in seen:
                     continue
@@ -377,15 +377,6 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
         "--pdf-split-bin",
         default="target/release/pdf-split",
         help="Path to the built pdf-split binary (default: target/release/pdf-split).",
-    )
-    parser.add_argument(
-        "--corpus-id-prefix",
-        default="",
-        help=(
-            "Prefix prepended to the '<doc>/pNNNN.pdf' relative key to form the "
-            "corpus-id, so it matches the connector-reported `location`. Set from the "
-            "location probe (issue #12858 Verification step 2). Default: empty."
-        ),
     )
     parser.add_argument(
         "--limit-docs",

--- a/tools/pdf-split/Cargo.toml
+++ b/tools/pdf-split/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+edition.workspace = true
+exclude.workspace = true
+homepage.workspace = true
+license-file.workspace = true
+name = "pdf-split"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lib]
+name = "pdf_split"
+path = "src/lib.rs"
+
+[[bin]]
+name = "pdf-split"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+lopdf = { path = "../../crates/vendor/lopdf" }
+snafu.workspace = true
+
+[lints]
+workspace = true

--- a/tools/pdf-split/Cargo.toml
+++ b/tools/pdf-split/Cargo.toml
@@ -17,6 +17,7 @@ name = "pdf-split"
 path = "src/main.rs"
 
 [dependencies]
+blake3.workspace = true
 clap = { workspace = true, features = ["derive"] }
 lopdf = { path = "../../crates/vendor/lopdf" }
 snafu.workspace = true

--- a/tools/pdf-split/src/lib.rs
+++ b/tools/pdf-split/src/lib.rs
@@ -175,31 +175,31 @@ fn retain_single_page(doc: &mut Document, keep_page_id: ObjectId) -> Result<(), 
     Err(lopdf::Error::ReferenceCycle(child))
 }
 
-/// Remove document-catalog entries that reference pages other than the one being
-/// kept, so `prune_objects` can drop the other pages' content.
+/// Reduce the document catalog to just `Type` and `Pages`, dropping every other
+/// entry that can reach pages other than the one being kept.
 ///
-/// Tagged PDFs (SEC filings are tagged) carry a `/StructTreeRoot` accessibility
-/// tree that reaches every page's marked content; named destinations, outlines,
-/// and forms do the same. Left in place, these keep every content stream
-/// reachable and defeat pruning — one split page then re-serializes the whole
-/// document. None of them are needed to extract a page's text, so they are
-/// dropped. The kept page's own `/Contents` and `/Resources` are referenced by
-/// the page itself and are unaffected.
+/// A document catalog holds many entries that transitively reference every page:
+/// a tagged PDF's `/StructTreeRoot` accessibility tree, optional-content layers
+/// (`/OCProperties`), named destinations, outlines, forms, an `/OpenAction`, and
+/// vendor-specific keys (preflight/color profiles). Any one of them keeps every
+/// page's content reachable, so `prune_objects` reclaims nothing and one split
+/// page re-serializes the whole document. Rather than deny-list the known
+/// offenders (fragile — vendors add their own keys), keep only what renders the
+/// page tree: `Type` and the `Pages` reference. None of the dropped entries are
+/// needed to extract a page's text; the kept page's own `/Contents` and
+/// `/Resources` hang off the page object and are untouched.
 fn strip_cross_page_catalog_refs(doc: &mut Document) {
     let Ok(catalog_id) = doc.trailer.get(b"Root").and_then(Object::as_reference) else {
         return;
     };
     if let Ok(catalog) = doc.get_object_mut(catalog_id).and_then(Object::as_dict_mut) {
-        for key in [
-            b"StructTreeRoot".as_slice(),
-            b"Outlines",
-            b"Names",
-            b"Dests",
-            b"AcroForm",
-            b"MarkInfo",
-        ] {
-            catalog.remove(key);
+        let pages = catalog.get(b"Pages").ok().cloned();
+        let mut trimmed = lopdf::Dictionary::new();
+        trimmed.set("Type", Object::Name(b"Catalog".to_vec()));
+        if let Some(pages) = pages {
+            trimmed.set("Pages", pages);
         }
+        *catalog = trimmed;
     }
 }
 

--- a/tools/pdf-split/src/lib.rs
+++ b/tools/pdf-split/src/lib.rs
@@ -1,0 +1,285 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Split a multi-page PDF into one single-page PDF per page.
+//!
+//! Page identity must survive Spice ingestion: the document/`file:` connector
+//! flattens a whole PDF into a single `content` string per file, so page
+//! boundaries are lost once the runtime parses the file. Splitting each source
+//! PDF into one file per page — with the page number in the file name — makes
+//! the page the unit of ingestion, so page-level ground truth (for example
+//! `FinanceBench` evidence pages) stays intact.
+//!
+//! Output file names are zero-indexed (`p0000.pdf`, `p0001.pdf`, …) to match
+//! `FinanceBench`'s zero-indexed `evidence_page_num`.
+
+use std::path::{Path, PathBuf};
+
+use lopdf::Document;
+use snafu::{ResultExt, Snafu};
+
+#[derive(Snafu, Debug)]
+pub enum Error {
+    #[snafu(display("Failed to load PDF {path}: {source}", path = path.display()))]
+    LoadPdf { path: PathBuf, source: lopdf::Error },
+
+    #[snafu(display("Failed to create output directory {path}: {source}", path = path.display()))]
+    CreateOutputDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to read directory {path}: {source}", path = path.display()))]
+    ReadDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display(
+        "PDF {path} has no pages. Confirm the file is a valid PDF and is not empty.",
+        path = path.display()
+    ))]
+    NoPages { path: PathBuf },
+
+    #[snafu(display("Failed to save page {page} of {path}: {source}", path = path.display()))]
+    SavePage {
+        path: PathBuf,
+        page: usize,
+        source: std::io::Error,
+    },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Split a single PDF into one single-page PDF per page, written to `out_dir`.
+///
+/// For each page the source document is cloned and every other page deleted,
+/// leaving a one-page document that is saved as `<out_dir>/pNNNN.pdf` with a
+/// zero-indexed, zero-padded page number. Returns the written paths in page
+/// order.
+///
+/// The split is idempotent: if `out_dir` already holds exactly one `pNNNN.pdf`
+/// per source page, the existing files are returned without re-writing them.
+///
+/// # Errors
+///
+/// Returns an error if the input cannot be opened as a PDF, the output
+/// directory cannot be created, or a page cannot be saved.
+pub fn split_pdf(input: &Path, out_dir: &Path) -> Result<Vec<PathBuf>> {
+    let doc = Document::load(input).context(LoadPdfSnafu { path: input })?;
+
+    // `get_pages()` keys are 1-indexed page numbers in document order.
+    let page_numbers: Vec<u32> = doc.get_pages().keys().copied().collect();
+    snafu::ensure!(!page_numbers.is_empty(), NoPagesSnafu { path: input });
+
+    std::fs::create_dir_all(out_dir).context(CreateOutputDirSnafu { path: out_dir })?;
+
+    let expected: Vec<PathBuf> = (0..page_numbers.len())
+        .map(|idx| out_dir.join(page_file_name(idx)))
+        .collect();
+
+    if expected.iter().all(|p| p.is_file()) && count_page_pdfs(out_dir)? == page_numbers.len() {
+        return Ok(expected);
+    }
+
+    let mut written = Vec::with_capacity(page_numbers.len());
+    for (idx, keep) in page_numbers.iter().enumerate() {
+        let mut page_doc = doc.clone();
+        let to_delete: Vec<u32> = page_numbers
+            .iter()
+            .filter(|n| *n != keep)
+            .copied()
+            .collect();
+        page_doc.delete_pages(&to_delete);
+        page_doc.prune_objects();
+        page_doc.renumber_objects();
+        page_doc.compress();
+
+        let out_path = out_dir.join(page_file_name(idx));
+        page_doc.save(&out_path).context(SavePageSnafu {
+            path: input,
+            page: idx,
+        })?;
+        written.push(out_path);
+    }
+
+    Ok(written)
+}
+
+/// Split every `*.pdf` in `input_dir` (non-recursively) into `<out_dir>/<stem>/pNNNN.pdf`.
+///
+/// # Errors
+///
+/// Returns an error if `input_dir` cannot be read or any contained PDF fails to
+/// split (see [`split_pdf`]).
+pub fn split_pdf_dir(input_dir: &Path, out_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut inputs: Vec<PathBuf> = std::fs::read_dir(input_dir)
+        .context(ReadDirSnafu { path: input_dir })?
+        .filter_map(std::result::Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| is_pdf(path))
+        .collect();
+    inputs.sort();
+
+    let mut written = Vec::new();
+    for input in inputs {
+        let stem = input
+            .file_stem()
+            .map_or_else(|| PathBuf::from("document"), PathBuf::from);
+        let doc_out = out_dir.join(stem);
+        written.extend(split_pdf(&input, &doc_out)?);
+    }
+
+    Ok(written)
+}
+
+/// Zero-indexed, zero-padded page file name for page `idx`, e.g. `p0000.pdf`.
+#[must_use]
+pub fn page_file_name(idx: usize) -> String {
+    format!("p{idx:04}.pdf")
+}
+
+fn is_pdf(path: &Path) -> bool {
+    path.is_file()
+        && path
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("pdf"))
+}
+
+/// Count files in `dir` whose names match the `pNNNN.pdf` page pattern.
+fn count_page_pdfs(dir: &Path) -> Result<usize> {
+    let count = std::fs::read_dir(dir)
+        .context(ReadDirSnafu { path: dir })?
+        .filter_map(std::result::Result::ok)
+        .filter(|entry| entry.file_name().to_str().is_some_and(is_page_pdf_name))
+        .count();
+    Ok(count)
+}
+
+/// True for names of the form `pNNNN.pdf` where `NNNN` is 4+ ASCII digits.
+fn is_page_pdf_name(name: &str) -> bool {
+    let Some(digits) = name.strip_prefix('p').and_then(|s| s.strip_suffix(".pdf")) else {
+        return false;
+    };
+    digits.len() >= 4 && digits.bytes().all(|b| b.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lopdf::dictionary;
+    use lopdf::{Document, Object, Stream};
+
+    /// Build a PDF with `n` blank pages for testing.
+    fn build_pdf(n: usize) -> Document {
+        let mut doc = Document::with_version("1.5");
+        let pages_id = doc.new_object_id();
+
+        let mut kids = Vec::with_capacity(n);
+        for _ in 0..n {
+            let content_id = doc.add_object(Stream::new(dictionary! {}, Vec::new()));
+            let leaf_id = doc.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "Contents" => content_id,
+                "MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
+            });
+            kids.push(leaf_id.into());
+        }
+
+        let pages = dictionary! {
+            "Type" => "Pages",
+            "Kids" => kids,
+            "Count" => i64::try_from(n).expect("page count fits in i64"),
+        };
+        doc.objects.insert(pages_id, Object::Dictionary(pages));
+
+        let catalog_id = doc.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        doc.trailer.set("Root", catalog_id);
+        doc
+    }
+
+    #[test]
+    fn splits_into_one_file_per_page() {
+        let tmp = std::env::temp_dir().join(format!("pdf-split-test-{}", std::process::id()));
+        let src = tmp.join("three-page.pdf");
+        let out = tmp.join("out");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+
+        let mut doc = build_pdf(3);
+        doc.save(&src).expect("save source pdf");
+
+        let outputs = split_pdf(&src, &out).expect("split pdf");
+        assert_eq!(outputs.len(), 3, "one output per page");
+
+        for (idx, path) in outputs.iter().enumerate() {
+            assert_eq!(
+                path.file_name().and_then(|s| s.to_str()),
+                Some(page_file_name(idx).as_str()),
+                "zero-indexed page file name",
+            );
+            let split = Document::load(path).expect("load split page");
+            assert_eq!(split.get_pages().len(), 1, "each output has one page");
+        }
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn split_is_idempotent() {
+        let tmp = std::env::temp_dir().join(format!("pdf-split-idem-{}", std::process::id()));
+        let src = tmp.join("two-page.pdf");
+        let out = tmp.join("out");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+
+        let mut doc = build_pdf(2);
+        doc.save(&src).expect("save source pdf");
+
+        let first = split_pdf(&src, &out).expect("first split");
+        let first_mtimes: Vec<_> = first
+            .iter()
+            .map(|p| {
+                std::fs::metadata(p)
+                    .and_then(|m| m.modified())
+                    .expect("mtime")
+            })
+            .collect();
+
+        let second = split_pdf(&src, &out).expect("second split");
+        assert_eq!(first, second, "same outputs on re-run");
+        let second_mtimes: Vec<_> = second
+            .iter()
+            .map(|p| {
+                std::fs::metadata(p)
+                    .and_then(|m| m.modified())
+                    .expect("mtime")
+            })
+            .collect();
+        assert_eq!(first_mtimes, second_mtimes, "files not re-written");
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn page_file_name_is_zero_padded() {
+        assert_eq!(page_file_name(0), "p0000.pdf");
+        assert_eq!(page_file_name(42), "p0042.pdf");
+        assert_eq!(page_file_name(1234), "p1234.pdf");
+    }
+}

--- a/tools/pdf-split/src/lib.rs
+++ b/tools/pdf-split/src/lib.rs
@@ -26,10 +26,11 @@ limitations under the License.
 //! Output file names are zero-indexed (`p0000.pdf`, `p0001.pdf`, …) to match
 //! `FinanceBench`'s zero-indexed `evidence_page_num`.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use lopdf::Document;
-use snafu::{ResultExt, Snafu};
+use lopdf::{Document, Object, ObjectId};
+use snafu::{OptionExt, ResultExt, Snafu};
 
 #[derive(Snafu, Debug)]
 pub enum Error {
@@ -60,16 +61,26 @@ pub enum Error {
         page: usize,
         source: std::io::Error,
     },
+
+    #[snafu(display("Page {page} missing from page tree of {path}", path = path.display()))]
+    PageMissing { path: PathBuf, page: usize },
+
+    #[snafu(display("Failed to trim page {page} of {path}: {source}", path = path.display()))]
+    TrimPage {
+        path: PathBuf,
+        page: usize,
+        source: lopdf::Error,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Split a single PDF into one single-page PDF per page, written to `out_dir`.
 ///
-/// For each page the source document is cloned and every other page deleted,
-/// leaving a one-page document that is saved as `<out_dir>/pNNNN.pdf` with a
-/// zero-indexed, zero-padded page number. Returns the written paths in page
-/// order.
+/// For each page the source document is cloned and its page tree trimmed to
+/// that single page, leaving a one-page document that is saved as
+/// `<out_dir>/pNNNN.pdf` with a zero-indexed, zero-padded page number. Returns
+/// the written paths in page order.
 ///
 /// The split is idempotent: if `out_dir` already holds exactly one `pNNNN.pdf`
 /// per source page, the existing files are returned without re-writing them.
@@ -95,18 +106,28 @@ pub fn split_pdf(input: &Path, out_dir: &Path) -> Result<Vec<PathBuf>> {
         return Ok(expected);
     }
 
+    // `keep_page_id` is the leaf `Page` object for each 1-indexed page number.
+    let pages: BTreeMap<u32, ObjectId> = doc.get_pages();
+
     let mut written = Vec::with_capacity(page_numbers.len());
-    for (idx, keep) in page_numbers.iter().enumerate() {
+    for (idx, page_number) in page_numbers.iter().enumerate() {
+        let keep_page_id = *pages.get(page_number).context(PageMissingSnafu {
+            path: input,
+            page: idx,
+        })?;
+
+        // Clone the whole document — this preserves every inherited page-tree
+        // attribute (Resources, MediaBox, Rotate, …) for the kept page. Then,
+        // instead of deleting the other N-1 pages (each deletion traverses the
+        // whole object graph, making a full split O(pages^2 * objects)), trim
+        // the page tree to just the kept page's ancestor chain and prune the
+        // now-unreferenced objects in a single pass.
         let mut page_doc = doc.clone();
-        let to_delete: Vec<u32> = page_numbers
-            .iter()
-            .filter(|n| *n != keep)
-            .copied()
-            .collect();
-        page_doc.delete_pages(&to_delete);
+        retain_single_page(&mut page_doc, keep_page_id).context(TrimPageSnafu {
+            path: input,
+            page: idx,
+        })?;
         page_doc.prune_objects();
-        page_doc.renumber_objects();
-        page_doc.compress();
 
         let out_path = out_dir.join(page_file_name(idx));
         page_doc.save(&out_path).context(SavePageSnafu {
@@ -117,6 +138,69 @@ pub fn split_pdf(input: &Path, out_dir: &Path) -> Result<Vec<PathBuf>> {
     }
 
     Ok(written)
+}
+
+/// Trim `doc`'s page tree so `keep_page_id` is the only reachable page.
+///
+/// Walks the kept page's `Parent` chain to the page-tree root and, at every
+/// intermediate `Pages` node, replaces `Kids` with just the child on that chain
+/// and sets `Count` to 1. The ancestor chain itself is left intact, so every
+/// attribute the kept page inherits (`Resources`, `MediaBox`, `Rotate`, …) is
+/// preserved. Callers should follow with `prune_objects` to drop the sibling
+/// pages and subtrees this leaves unreferenced.
+fn retain_single_page(doc: &mut Document, keep_page_id: ObjectId) -> Result<(), lopdf::Error> {
+    strip_cross_page_catalog_refs(doc);
+
+    let mut child = keep_page_id;
+    // Bound the walk by the object count so a malformed `Parent` cycle cannot
+    // loop forever.
+    let max_depth = doc.objects.len() + 1;
+    for _ in 0..max_depth {
+        let parent = doc
+            .get_object(child)
+            .and_then(Object::as_dict)?
+            .get(b"Parent")
+            .and_then(Object::as_reference);
+        let Ok(parent_id) = parent else {
+            // Reached the page-tree root (a `Pages` node has no `Parent`).
+            return Ok(());
+        };
+        let parent_dict = doc
+            .get_object_mut(parent_id)
+            .and_then(Object::as_dict_mut)?;
+        parent_dict.set("Kids", vec![Object::Reference(child)]);
+        parent_dict.set("Count", 1);
+        child = parent_id;
+    }
+    Err(lopdf::Error::ReferenceCycle(child))
+}
+
+/// Remove document-catalog entries that reference pages other than the one being
+/// kept, so `prune_objects` can drop the other pages' content.
+///
+/// Tagged PDFs (SEC filings are tagged) carry a `/StructTreeRoot` accessibility
+/// tree that reaches every page's marked content; named destinations, outlines,
+/// and forms do the same. Left in place, these keep every content stream
+/// reachable and defeat pruning — one split page then re-serializes the whole
+/// document. None of them are needed to extract a page's text, so they are
+/// dropped. The kept page's own `/Contents` and `/Resources` are referenced by
+/// the page itself and are unaffected.
+fn strip_cross_page_catalog_refs(doc: &mut Document) {
+    let Ok(catalog_id) = doc.trailer.get(b"Root").and_then(Object::as_reference) else {
+        return;
+    };
+    if let Ok(catalog) = doc.get_object_mut(catalog_id).and_then(Object::as_dict_mut) {
+        for key in [
+            b"StructTreeRoot".as_slice(),
+            b"Outlines",
+            b"Names",
+            b"Dests",
+            b"AcroForm",
+            b"MarkInfo",
+        ] {
+            catalog.remove(key);
+        }
+    }
 }
 
 /// Split every `*.pdf` in `input_dir` (non-recursively) into `<out_dir>/<stem>/pNNNN.pdf`.

--- a/tools/pdf-split/src/lib.rs
+++ b/tools/pdf-split/src/lib.rs
@@ -49,6 +49,24 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    #[snafu(display("Failed to read {path}: {source}", path = path.display()))]
+    ReadInput {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to remove stale page file {path}: {source}", path = path.display()))]
+    RemoveStalePage {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to write split digest {path}: {source}", path = path.display()))]
+    SaveDigest {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
     #[snafu(display(
         "PDF {path} has no pages. Confirm the file is a valid PDF and is not empty.",
         path = path.display()
@@ -83,7 +101,10 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// the written paths in page order.
 ///
 /// The split is idempotent: if `out_dir` already holds exactly one `pNNNN.pdf`
-/// per source page, the existing files are returned without re-writing them.
+/// per source page, written from a source with the same content digest, the
+/// existing files are returned without re-writing them. Otherwise `out_dir` is
+/// cleared of prior page outputs first, so a source whose page count has
+/// shrunk since the last run doesn't leave stale trailing page files behind.
 ///
 /// # Errors
 ///
@@ -102,9 +123,17 @@ pub fn split_pdf(input: &Path, out_dir: &Path) -> Result<Vec<PathBuf>> {
         .map(|idx| out_dir.join(page_file_name(idx)))
         .collect();
 
-    if expected.iter().all(|p| p.is_file()) && count_page_pdfs(out_dir)? == page_numbers.len() {
+    let digest = source_digest(input)?;
+    let digest_path = out_dir.join(DIGEST_FILE_NAME);
+
+    if expected.iter().all(|p| p.is_file())
+        && count_page_pdfs(out_dir)? == page_numbers.len()
+        && std::fs::read_to_string(&digest_path).ok().as_deref() == Some(digest.as_str())
+    {
         return Ok(expected);
     }
+
+    clear_page_pdfs(out_dir)?;
 
     // `keep_page_id` is the leaf `Page` object for each 1-indexed page number.
     let pages: BTreeMap<u32, ObjectId> = doc.get_pages();
@@ -137,7 +166,35 @@ pub fn split_pdf(input: &Path, out_dir: &Path) -> Result<Vec<PathBuf>> {
         written.push(out_path);
     }
 
+    std::fs::write(&digest_path, &digest).context(SaveDigestSnafu { path: digest_path })?;
+
     Ok(written)
+}
+
+/// Content digest of `input`, used to detect a same-name/same-page-count
+/// source whose bytes have actually changed since the last split.
+fn source_digest(input: &Path) -> Result<String> {
+    let bytes = std::fs::read(input).context(ReadInputSnafu { path: input })?;
+    Ok(blake3::hash(&bytes).to_hex().to_string())
+}
+
+/// Sidecar file recording the source digest a directory was last split from.
+const DIGEST_FILE_NAME: &str = ".source.blake3";
+
+/// Remove every existing `pNNNN.pdf` file in `dir`.
+///
+/// Called before re-splitting so trailing page files from a previous, larger
+/// split (e.g. `p0002.pdf` when the source now has only two pages) don't
+/// survive alongside the freshly written, smaller set.
+fn clear_page_pdfs(dir: &Path) -> Result<()> {
+    for entry in std::fs::read_dir(dir).context(ReadDirSnafu { path: dir })? {
+        let entry = entry.context(ReadDirSnafu { path: dir })?;
+        if entry.file_name().to_str().is_some_and(is_page_pdf_name) {
+            let path = entry.path();
+            std::fs::remove_file(&path).context(RemoveStalePageSnafu { path })?;
+        }
+    }
+    Ok(())
 }
 
 /// Trim `doc`'s page tree so `keep_page_id` is the only reachable page.
@@ -210,12 +267,13 @@ fn strip_cross_page_catalog_refs(doc: &mut Document) {
 /// Returns an error if `input_dir` cannot be read or any contained PDF fails to
 /// split (see [`split_pdf`]).
 pub fn split_pdf_dir(input_dir: &Path, out_dir: &Path) -> Result<Vec<PathBuf>> {
-    let mut inputs: Vec<PathBuf> = std::fs::read_dir(input_dir)
-        .context(ReadDirSnafu { path: input_dir })?
-        .filter_map(std::result::Result::ok)
-        .map(|entry| entry.path())
-        .filter(|path| is_pdf(path))
-        .collect();
+    let mut inputs: Vec<PathBuf> = Vec::new();
+    for entry in std::fs::read_dir(input_dir).context(ReadDirSnafu { path: input_dir })? {
+        let path = entry.context(ReadDirSnafu { path: input_dir })?.path();
+        if is_pdf(&path) {
+            inputs.push(path);
+        }
+    }
     inputs.sort();
 
     let mut written = Vec::new();
@@ -245,11 +303,13 @@ fn is_pdf(path: &Path) -> bool {
 
 /// Count files in `dir` whose names match the `pNNNN.pdf` page pattern.
 fn count_page_pdfs(dir: &Path) -> Result<usize> {
-    let count = std::fs::read_dir(dir)
-        .context(ReadDirSnafu { path: dir })?
-        .filter_map(std::result::Result::ok)
-        .filter(|entry| entry.file_name().to_str().is_some_and(is_page_pdf_name))
-        .count();
+    let mut count = 0;
+    for entry in std::fs::read_dir(dir).context(ReadDirSnafu { path: dir })? {
+        let entry = entry.context(ReadDirSnafu { path: dir })?;
+        if entry.file_name().to_str().is_some_and(is_page_pdf_name) {
+            count += 1;
+        }
+    }
     Ok(count)
 }
 

--- a/tools/pdf-split/src/main.rs
+++ b/tools/pdf-split/src/main.rs
@@ -1,0 +1,64 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! `pdf-split` — split a multi-page PDF (or every PDF in a directory) into one
+//! single-page PDF per page, naming each output `pNNNN.pdf` with a zero-indexed
+//! page number.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use pdf_split::{split_pdf, split_pdf_dir};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "pdf-split",
+    about = "Split a multi-page PDF, or every *.pdf in a directory, into one single-page PDF per page."
+)]
+struct Args {
+    /// Input PDF file, or a directory of `*.pdf` files to split.
+    input: PathBuf,
+
+    /// Output directory. A single input writes `<out>/pNNNN.pdf`; a directory
+    /// input writes `<out>/<stem>/pNNNN.pdf` per source document.
+    #[arg(long)]
+    out: PathBuf,
+}
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+
+    let result = if args.input.is_dir() {
+        split_pdf_dir(&args.input, &args.out)
+    } else {
+        split_pdf(&args.input, &args.out)
+    };
+
+    match result {
+        Ok(paths) => {
+            for path in &paths {
+                println!("{}", path.display());
+            }
+            eprintln!("Wrote {} page(s).", paths.len());
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("Error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
## What
Two prerequisites for financebench benchmarking (see #12858).
1. `pdf-split` CLI to convert a N page PDF into N, 1-page PDFs. 
2. `scripts/financebench_stage.py` a tool to download and prepare financebench data (including pdf-split) from the official datasets. 

### `pdf-split`
```shell
>> ./target/release/pdf-split -h
Split a multi-page PDF, or every *.pdf in a directory, into one single-page PDF per page.

Usage: pdf-split --out <OUT> <INPUT>

Arguments:
  <INPUT>  Input PDF file, or a directory of `*.pdf` files to split

Options:
      --out <OUT>  Output directory. A single input writes `<out>/pNNNN.pdf`; a directory input writes `<out>/<stem>/pNNNN.pdf` per source document
  -h, --help       Print help
```

### `scripts/financebench_stage.py`
```shell
./scripts/financebench_stage.py -h
usage: financebench_stage.py [-h] --dest DEST [--source SOURCE] [--pdf-split-bin PDF_SPLIT_BIN] [--corpus-id-prefix CORPUS_ID_PREFIX] [--limit-docs LIMIT_DOCS]

One-time staging job that builds the FinanceBench PDF search benchmark corpus.

options:
  -h, --help            show this help message and exit
  --dest DEST           Output destination: a local directory or an s3://bucket/prefix URI.
  --source SOURCE       FinanceBench source: a local checkout path or an HTTP(S) base URL (default: https://raw.githubusercontent.com/patronus-ai/financebench/main).
  --pdf-split-bin PDF_SPLIT_BIN
                        Path to the built pdf-split binary (default: target/release/pdf-split).
  --corpus-id-prefix CORPUS_ID_PREFIX
                        Prefix prepended to the '<doc>/pNNNN.pdf' relative key to form the corpus-id, so it matches the connector-reported `location`. Set from the location probe (issue
                        #12858 Verification step 2). Default: empty.
  --limit-docs LIMIT_DOCS
                        For dry-runs: stage only the first N unique evidence docs (0 = all).
```
1. Reads `financebench_open_source.jsonl` and the referenced `pdfs/<doc>.pdf` from a local checkout or over HTTPS.
4. Splits every unique evidence doc with the `pdf-split` binary, so page extraction is identical to the committed tool.
5. Validates every `evidence_page_num` is in range for its doc.
6. Builds `queries.parquet` (`_id`, `text`) and `relevance_data.parquet` (`query-id`, `corpus-id`, `score`) matching the search harness contract, expanding multi-page questions to one relevance row per evidence page.
7. Writes the corpus and both parquet files to a `--dest` that is a local directory or an `s3://` URI, through one writer abstraction so the layout and the `corpus-id`/`location` normalization are identical for both.
