### PR TITLE
chore(deps): bump model2vec-rs for fast WordPiece tokenizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12473,7 +12473,7 @@ dependencies = [
 [[package]]
 name = "model2vec-rs"
 version = "0.1.3"
-source = "git+https://github.com/spiceai/model2vec-rs.git?rev=f1190f1f140105f0c5ac8335fbbac402051ab072#f1190f1f140105f0c5ac8335fbbac402051ab072"
+source = "git+https://github.com/spiceai/model2vec-rs.git?rev=724ba911dbf7b73f345e1f2ad0821bf4fa4d5073#724ba911dbf7b73f345e1f2ad0821bf4fa4d5073"
 dependencies = [
  "anyhow",
  "clap",
@@ -12484,6 +12484,8 @@ dependencies = [
  "safetensors 0.5.3",
  "serde_json",
  "tokenizers 0.21.4",
+ "unicode-normalization",
+ "unicode_categories",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12473,7 +12473,7 @@ dependencies = [
 [[package]]
 name = "model2vec-rs"
 version = "0.1.3"
-source = "git+https://github.com/spiceai/model2vec-rs.git?rev=724ba911dbf7b73f345e1f2ad0821bf4fa4d5073#724ba911dbf7b73f345e1f2ad0821bf4fa4d5073"
+source = "git+https://github.com/spiceai/model2vec-rs.git?rev=55fef28a3556895b20204634b788f7c836b610bc#55fef28a3556895b20204634b788f7c836b610bc"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -63,7 +63,7 @@ indexmap.workspace = true
 tempfile.workspace = true
 token_provider = { path = "../token_provider" }
 
-model2vec-rs = { git = "https://github.com/spiceai/model2vec-rs.git", rev = "f1190f1f140105f0c5ac8335fbbac402051ab072", optional = true }
+model2vec-rs = { git = "https://github.com/spiceai/model2vec-rs.git", rev = "724ba911dbf7b73f345e1f2ad0821bf4fa4d5073", optional = true } # branch: fast-wordpiece
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/llms/Cargo.toml
+++ b/crates/llms/Cargo.toml
@@ -63,7 +63,7 @@ indexmap.workspace = true
 tempfile.workspace = true
 token_provider = { path = "../token_provider" }
 
-model2vec-rs = { git = "https://github.com/spiceai/model2vec-rs.git", rev = "724ba911dbf7b73f345e1f2ad0821bf4fa4d5073", optional = true } # branch: fast-wordpiece
+model2vec-rs = { git = "https://github.com/spiceai/model2vec-rs.git", rev = "55fef28a3556895b20204634b788f7c836b610bc", optional = true } # branch: spiceai
 
 [dev-dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
> https://github.com/spiceai/model2vec-rs/pull/5 must be merged, `rev`s in `Cargo.toml` to be updated. 

## Summary
- Bumps `model2vec-rs` to `724ba911dbf7b73f345e1f2ad0821bf4fa4d5073`, which adds an IDs-only fast WordPiece tokenizer for the BertNormalizer + BertPreTokenizer + WordPiece pipeline used by `minishlab/potion-*` embedding models. It parses `tokenizer.json` directly, skipping the `tokenizers` crate's full-Encoding machinery, since model2vec forward passes are dominated by tokenization time.
- The fast path is opt-in per model and falls back to the existing `tokenizers`-crate path for any other tokenizer (for example a Unigram/multilingual model), so output is unchanged for non-WordPiece models.
- Note: this pins to the head commit of an open, unmerged PR on the fork (spiceai/model2vec-rs#5) rather than a merged commit on its tracked `spiceai` branch.

## Test plan
- [ ] Sign-off (`make signoff` / remote sign-off) passes for `llms` with the `model2vec` feature enabled
- [ ] Verify a `potion-*` embedding model still produces identical embeddings to before this bump