### PR TITLE
test(postgres): converge the catalog on source DDL, and warn when it selects nothing

### DIFF
--- a/crates/data_components/src/catalog_filter.rs
+++ b/crates/data_components/src/catalog_filter.rs
@@ -107,10 +107,13 @@ impl TableSelector {
     /// is absent, so a caller can drop it into a sentence.
     #[must_use]
     pub fn describe(&self) -> String {
+        // Escaped, not interpolated raw: a pattern is user-supplied text that
+        // may legally contain a newline or a control character, and every log
+        // line this lands in has to stay one line.
         let quoted = |patterns: &[String]| {
             patterns
                 .iter()
-                .map(|p| format!("'{p}'"))
+                .map(|p| format!("'{}'", p.escape_debug()))
                 .collect::<Vec<_>>()
                 .join(", ")
         };

--- a/crates/data_components/src/catalog_filter.rs
+++ b/crates/data_components/src/catalog_filter.rs
@@ -43,6 +43,11 @@ pub struct TableSelector {
     /// Literal prefix of each `include` pattern, for [`TableSelector::may_select_within`].
     /// Empty when the patterns were not supplied, which disables that prune.
     include_literal_prefixes: Arc<Vec<String>>,
+    /// The patterns verbatim, for [`TableSelector::describe`]. A [`GlobSet`]
+    /// cannot be printed, and a catalog that selected nothing is diagnosable
+    /// only by the patterns the user actually wrote.
+    include_patterns: Arc<Vec<String>>,
+    exclude_patterns: Arc<Vec<String>>,
 }
 
 impl TableSelector {
@@ -54,6 +59,8 @@ impl TableSelector {
             include: include.map(Arc::new),
             exclude: exclude.map(Arc::new),
             include_literal_prefixes: Arc::default(),
+            include_patterns: Arc::default(),
+            exclude_patterns: Arc::default(),
         }
     }
 
@@ -78,7 +85,44 @@ impl TableSelector {
                 .map(|pattern| glob_literal_prefix(pattern))
                 .collect(),
         );
+        self.include_patterns = Arc::new(patterns.to_vec());
         self
+    }
+
+    /// Records the raw `exclude` patterns for [`TableSelector::describe`].
+    ///
+    /// Diagnostics only -- `exclude` is already applied from the compiled set
+    /// passed to [`TableSelector::new`], so omitting this costs a less specific
+    /// message and nothing else.
+    #[must_use]
+    pub fn with_exclude_patterns(mut self, patterns: &[String]) -> Self {
+        self.exclude_patterns = Arc::new(patterns.to_vec());
+        self
+    }
+
+    /// The configuration as the user wrote it, for a message about what it
+    /// selected. Empty when the catalog filters nothing.
+    ///
+    /// Renders as `include: ['a.*'], exclude: ['a.b']`, omitting whichever half
+    /// is absent, so a caller can drop it into a sentence.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        let quoted = |patterns: &[String]| {
+            patterns
+                .iter()
+                .map(|p| format!("'{p}'"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+
+        let mut parts = Vec::new();
+        if !self.include_patterns.is_empty() {
+            parts.push(format!("include: [{}]", quoted(&self.include_patterns)));
+        }
+        if !self.exclude_patterns.is_empty() {
+            parts.push(format!("exclude: [{}]", quoted(&self.exclude_patterns)));
+        }
+        parts.join(", ")
     }
 
     /// Whether any `include` pattern could match a name beginning with

--- a/crates/data_components/src/postgres/provider.rs
+++ b/crates/data_components/src/postgres/provider.rs
@@ -77,6 +77,8 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+const POSTGRES_CATALOG_DOCS: &str = "https://spiceai.org/docs/components/catalogs/postgres";
+
 pub use connector_postgres_common::{
     ReplicaIdentityOutcome, ReplicationSlotStatus, SkipReason, ViewRelation,
     check_cdc_prerequisites, classify_replica_identity, ensure_replication_slot_capacity,
@@ -115,6 +117,11 @@ pub struct PostgresCatalogProvider {
     table_creator: Arc<dyn Read>,
     schemas: RwLock<HashMap<String, Arc<PostgresSchemaProvider>>>,
     selector: TableSelector,
+    /// Tables registered by the previous refresh, or `None` before the first
+    /// one completes. Only [`empty_catalog_warning`] reads it: this provider is
+    /// polled every refresh interval, so an empty catalog is reported when it
+    /// *becomes* empty rather than once a minute for the life of the process.
+    last_table_count: RwLock<Option<usize>>,
 }
 
 impl std::fmt::Debug for PostgresCatalogProvider {
@@ -138,6 +145,7 @@ impl PostgresCatalogProvider {
             table_creator,
             schemas: RwLock::new(HashMap::new()),
             selector,
+            last_table_count: RwLock::new(None),
         }
     }
 
@@ -247,12 +255,33 @@ impl PostgresCatalogProvider {
             }
         }
 
+        let table_count: usize = schemas.values().map(|schema| schema.table_count()).sum();
+        let schemas_registered = schemas.len();
+
         {
             let mut guard = match self.schemas.write() {
                 Ok(guard) => guard,
                 Err(e) => e.into_inner(),
             };
             *guard = schemas;
+        }
+
+        let previous_count = {
+            let mut guard = match self.last_table_count.write() {
+                Ok(guard) => guard,
+                Err(e) => e.into_inner(),
+            };
+            guard.replace(table_count)
+        };
+
+        if let Some(warning) = empty_catalog_warning(
+            &self.catalog_name,
+            previous_count,
+            table_count,
+            schemas_registered,
+            &self.selector,
+        ) {
+            tracing::warn!("{warning}");
         }
 
         Ok(())
@@ -466,6 +495,16 @@ impl PostgresSchemaProvider {
         }
     }
 
+    /// How many tables this schema registered. Counts without cloning every
+    /// name, which `SchemaProvider::table_names` would.
+    fn table_count(&self) -> usize {
+        let guard = match self.tables.read() {
+            Ok(guard) => guard,
+            Err(e) => e.into_inner(),
+        };
+        guard.len()
+    }
+
     async fn refresh_tables(
         &self,
         foreign_keys: &ForeignKeyMap,
@@ -593,6 +632,46 @@ fn foreign_key_target(catalog: &str, schema: &str, table: &str) -> String {
         quote_identifier(schema),
         quote_identifier(table),
     )
+}
+
+/// The warning for a refresh that registered no tables, or `None` when there is
+/// nothing to report.
+///
+/// A catalog that selects nothing is the one outcome the federated path cannot
+/// distinguish from success on its own: it loads, reports ready, and answers
+/// every query with "table not found". The accelerated path fails loud here
+/// (#11983); the federated path warns instead, because a federated catalog can
+/// legitimately be configured before the tables it names exist -- so this must
+/// say enough for a user to tell "my patterns are wrong" from "my tables are not
+/// there yet".
+///
+/// Reported on the transition to empty rather than on every refresh: a repeated
+/// warning for a steady misconfiguration is how a log stops being read.
+fn empty_catalog_warning(
+    catalog_name: &str,
+    previous_count: Option<usize>,
+    current_count: usize,
+    schemas_registered: usize,
+    selector: &TableSelector,
+) -> Option<String> {
+    if current_count > 0 || previous_count == Some(0) {
+        return None;
+    }
+
+    let patterns = selector.describe();
+    let cause = if patterns.is_empty() {
+        format!(
+            "It selects every table it can see, so either the database has no tables in the {schemas_registered} schema(s) it discovered, or the connected role cannot see them -- check the role's SELECT and USAGE grants"
+        )
+    } else {
+        format!(
+            "None of the tables in the {schemas_registered} schema(s) it discovered matched {patterns}. Patterns match the qualified '<schema>.<table>' name, so an unqualified pattern such as 'orders' never matches -- write 'public.orders' (or 'public.*') instead"
+        )
+    };
+
+    Some(format!(
+        "PostgreSQL catalog {catalog_name} registered no tables, so queries against it will not resolve any table. {cause}. Docs: {POSTGRES_CATALOG_DOCS}"
+    ))
 }
 
 /// What `refresh_schemas` does with a single schema after attempting to refresh
@@ -783,9 +862,9 @@ impl SchemaProvider for PostgresSchemaProvider {
 #[cfg(test)]
 mod tests {
     use super::{
-        CommentMap, ForeignKeyConstraint, ForeignKeyMap, SchemaRefreshOutcome, TableComments,
-        build_table_providers_for_schema, foreign_key_target, schema_refresh_outcome,
-        select_relations,
+        CommentMap, ForeignKeyConstraint, ForeignKeyMap, POSTGRES_CATALOG_DOCS,
+        SchemaRefreshOutcome, TableComments, build_table_providers_for_schema,
+        empty_catalog_warning, foreign_key_target, schema_refresh_outcome, select_relations,
     };
     use crate::{
         DESCRIPTION_METADATA_KEY, FOREIGN_KEYS_METADATA_KEY, Read, SOURCE_TYPE_METADATA_KEY,
@@ -1020,6 +1099,67 @@ mod tests {
                 "table must round-trip (target = `{target}`)"
             );
         }
+    }
+
+    /// The empty-catalog warning has to fire when a catalog *becomes* empty and
+    /// stay quiet while it stays that way, or a steady misconfiguration prints
+    /// once a refresh interval forever and the log stops being worth reading.
+    #[test]
+    fn empty_catalog_warning_reports_the_transition_to_empty() {
+        let selector = TableSelector::select_all();
+        let warn = |previous, current| {
+            empty_catalog_warning("pg", previous, current, 1, &selector).is_some()
+        };
+
+        assert!(warn(None, 0), "the first refresh finding nothing warns");
+        assert!(warn(Some(3), 0), "losing every table warns");
+        assert!(
+            !warn(Some(0), 0),
+            "a catalog that was already empty must not warn again"
+        );
+        assert!(!warn(None, 3), "a catalog with tables never warns");
+        assert!(!warn(Some(0), 3), "recovering from empty does not warn");
+    }
+
+    /// The message exists to tell "my patterns are wrong" from "my tables are
+    /// not there yet", so it must name the patterns when there are any and say
+    /// something useful when there are none.
+    #[test]
+    fn empty_catalog_warning_names_the_configured_patterns() {
+        let filtered = TableSelector::new(Some(make_globset(&["public.orders"])), None)
+            .with_include_patterns(&["public.orders".to_string()])
+            .with_exclude_patterns(&["public.secret".to_string()]);
+
+        let message = empty_catalog_warning("pg", None, 0, 2, &filtered)
+            .expect("an empty filtered catalog should warn");
+        assert!(message.contains("pg"), "names the catalog: {message}");
+        assert!(
+            message.contains("include: ['public.orders']")
+                && message.contains("exclude: ['public.secret']"),
+            "names both halves of the configuration: {message}"
+        );
+        assert!(
+            message.contains("2 schema(s)"),
+            "says how much was searched: {message}"
+        );
+        assert!(
+            message.contains(POSTGRES_CATALOG_DOCS),
+            "links the docs: {message}"
+        );
+        assert!(!message.contains('\n'), "stays on one line: {message:?}");
+
+        // An unfiltered catalog cannot blame patterns, so it must point at the
+        // other two explanations instead of naming an empty pattern list.
+        let unfiltered = empty_catalog_warning("pg", None, 0, 1, &TableSelector::select_all())
+            .expect("an empty unfiltered catalog should warn");
+        assert!(
+            !unfiltered.contains("include:") && !unfiltered.contains("matched"),
+            "does not blame patterns that were never configured: {unfiltered}"
+        );
+        assert!(
+            unfiltered.contains("grants"),
+            "points at the likely cause instead: {unfiltered}"
+        );
     }
 
     /// Regression coverage for #11724: the per-schema failure decision must keep

--- a/crates/data_components/src/postgres/provider.rs
+++ b/crates/data_components/src/postgres/provider.rs
@@ -256,6 +256,7 @@ impl PostgresCatalogProvider {
         }
 
         let table_count: usize = schemas.values().map(|schema| schema.table_count()).sum();
+        let selected_count: usize = schemas.values().map(|schema| schema.selected_count()).sum();
         let schemas_registered = schemas.len();
 
         {
@@ -278,6 +279,7 @@ impl PostgresCatalogProvider {
             &self.catalog_name,
             previous_count,
             table_count,
+            selected_count,
             schemas_registered,
             &self.selector,
         ) {
@@ -468,6 +470,11 @@ pub struct PostgresSchemaProvider {
     table_creator: Arc<dyn Read>,
     tables: RwLock<HashMap<String, Arc<dyn TableProvider>>>,
     selector: TableSelector,
+    /// Relations the last refresh selected, which is not the same as the number
+    /// it registered: a selected table whose provider cannot be built is logged
+    /// and skipped. Keeping both apart is what lets an empty catalog say
+    /// whether the patterns matched nothing or the matches failed to load.
+    selected_count: RwLock<usize>,
 }
 
 impl std::fmt::Debug for PostgresSchemaProvider {
@@ -492,7 +499,17 @@ impl PostgresSchemaProvider {
             table_creator,
             tables: RwLock::new(HashMap::new()),
             selector,
+            selected_count: RwLock::new(0),
         }
+    }
+
+    /// How many relations this schema's last refresh selected.
+    fn selected_count(&self) -> usize {
+        let guard = match self.selected_count.read() {
+            Ok(guard) => guard,
+            Err(e) => e.into_inner(),
+        };
+        *guard
     }
 
     /// How many tables this schema registered. Counts without cloning every
@@ -513,6 +530,13 @@ impl PostgresSchemaProvider {
         let table_names = self.list_tables().await?;
 
         let selected = select_relations(&self.selector, &self.schema_name, &table_names);
+        {
+            let mut guard = match self.selected_count.write() {
+                Ok(guard) => guard,
+                Err(e) => e.into_inner(),
+            };
+            *guard = selected.len();
+        }
 
         // Advisory: an entry lets a table skip its own schema query, and its
         // absence means that table resolves individually. A failure here is
@@ -647,10 +671,17 @@ fn foreign_key_target(catalog: &str, schema: &str, table: &str) -> String {
 ///
 /// Reported on the transition to empty rather than on every refresh: a repeated
 /// warning for a steady misconfiguration is how a log stops being read.
+///
+/// `selected_count` is deliberately separate from `current_count`: a selected
+/// table whose provider cannot be built is logged and skipped, so a catalog can
+/// register nothing while the patterns matched perfectly well. Blaming the
+/// patterns there would contradict the failure logged moments earlier and send
+/// the user to fix configuration that is already correct.
 fn empty_catalog_warning(
     catalog_name: &str,
     previous_count: Option<usize>,
     current_count: usize,
+    selected_count: usize,
     schemas_registered: usize,
     selector: &TableSelector,
 ) -> Option<String> {
@@ -659,7 +690,11 @@ fn empty_catalog_warning(
     }
 
     let patterns = selector.describe();
-    let cause = if patterns.is_empty() {
+    let cause = if selected_count > 0 {
+        format!(
+            "{selected_count} table(s) matched, but none could be registered -- the errors logged above this name the tables that failed and why"
+        )
+    } else if patterns.is_empty() {
         format!(
             "It selects every table it can see, so either the database has no tables in the {schemas_registered} schema(s) it discovered, or the connected role cannot see them -- check the role's SELECT and USAGE grants"
         )
@@ -1108,7 +1143,7 @@ mod tests {
     fn empty_catalog_warning_reports_the_transition_to_empty() {
         let selector = TableSelector::select_all();
         let warn = |previous, current| {
-            empty_catalog_warning("pg", previous, current, 1, &selector).is_some()
+            empty_catalog_warning("pg", previous, current, 0, 1, &selector).is_some()
         };
 
         assert!(warn(None, 0), "the first refresh finding nothing warns");
@@ -1130,7 +1165,7 @@ mod tests {
             .with_include_patterns(&["public.orders".to_string()])
             .with_exclude_patterns(&["public.secret".to_string()]);
 
-        let message = empty_catalog_warning("pg", None, 0, 2, &filtered)
+        let message = empty_catalog_warning("pg", None, 0, 0, 2, &filtered)
             .expect("an empty filtered catalog should warn");
         assert!(message.contains("pg"), "names the catalog: {message}");
         assert!(
@@ -1150,7 +1185,7 @@ mod tests {
 
         // An unfiltered catalog cannot blame patterns, so it must point at the
         // other two explanations instead of naming an empty pattern list.
-        let unfiltered = empty_catalog_warning("pg", None, 0, 1, &TableSelector::select_all())
+        let unfiltered = empty_catalog_warning("pg", None, 0, 0, 1, &TableSelector::select_all())
             .expect("an empty unfiltered catalog should warn");
         assert!(
             !unfiltered.contains("include:") && !unfiltered.contains("matched"),
@@ -1159,6 +1194,53 @@ mod tests {
         assert!(
             unfiltered.contains("grants"),
             "points at the likely cause instead: {unfiltered}"
+        );
+    }
+
+    /// A catalog can register nothing while the patterns matched perfectly well:
+    /// a selected table whose provider cannot be built is logged and skipped.
+    ///
+    /// Blaming the patterns there would contradict the failure logged moments
+    /// earlier and send the user to fix configuration that is already correct.
+    #[test]
+    fn empty_catalog_warning_does_not_blame_patterns_for_tables_that_failed_to_build() {
+        let filtered = TableSelector::new(Some(make_globset(&["public.orders"])), None)
+            .with_include_patterns(&["public.orders".to_string()]);
+
+        let message = empty_catalog_warning("pg", None, 0, 3, 1, &filtered)
+            .expect("a catalog that registered nothing should warn");
+
+        assert!(
+            message.contains("3 table(s) matched, but none could be registered"),
+            "it should report that the matches failed rather than that nothing matched: {message}"
+        );
+        assert!(
+            !message.contains("never matches"),
+            "it must not offer the unqualified-pattern advice when the patterns did match: {message}"
+        );
+        assert!(
+            !message.contains("grants"),
+            "it must not blame grants either: {message}"
+        );
+    }
+
+    /// A pattern is user-supplied text and can legally contain a newline, which
+    /// would split one warning into what reads as two log records.
+    #[test]
+    fn empty_catalog_warning_stays_on_one_line_for_a_pattern_containing_a_newline() {
+        let hostile = TableSelector::new(None, None)
+            .with_include_patterns(&["public.a\nWARN forged line".to_string()]);
+
+        let message = empty_catalog_warning("pg", None, 0, 0, 1, &hostile)
+            .expect("an empty filtered catalog should warn");
+
+        assert!(
+            !message.contains('\n'),
+            "the warning must stay on one line: {message:?}"
+        );
+        assert!(
+            message.contains("\\n"),
+            "the newline should survive as an escape so the pattern is still legible: {message}"
         );
     }
 

--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -118,6 +118,7 @@ impl Catalog {
 pub fn table_selector(catalog: &CatalogSpec) -> TableSelector {
     TableSelector::new(catalog.include.clone(), catalog.exclude.clone())
         .with_include_patterns(&catalog.orig_include)
+        .with_exclude_patterns(&catalog.orig_exclude)
 }
 
 pub struct CatalogBuilder {

--- a/crates/runtime/src/component/catalog.rs
+++ b/crates/runtime/src/component/catalog.rs
@@ -381,6 +381,20 @@ mod tests {
             "an excluded table must not be selected"
         );
         assert!(!selector.selects_table("reporting", "orders"));
+
+        // The raw patterns travel too, and by a separate path: `selects_table`
+        // reads the compiled sets, so dropping either `with_*_patterns` call
+        // leaves every assertion above passing while a diagnostic naming the
+        // configuration silently omits half of it.
+        let described = selector.describe();
+        assert!(
+            described.contains("include: ['public.*']"),
+            "the include patterns should reach the selector verbatim: {described}"
+        );
+        assert!(
+            described.contains("exclude: ['public.audit_log']"),
+            "the exclude patterns should reach the selector verbatim: {described}"
+        );
     }
 
     /// An `exclude` with no `include` still withholds: the connectors that only

--- a/crates/runtime/tests/postgres/catalog.rs
+++ b/crates/runtime/tests/postgres/catalog.rs
@@ -1004,6 +1004,28 @@ async fn test_refresh_registers_a_table_created_at_the_source() -> Result<(), an
                 &rows
             );
 
+            // Values alone do not pin the discovered schema: `1` renders the
+            // same whether it arrived as Int32 or Int64, and `1.50` the same at
+            // any precision with scale 2. The RC criterion is about types, so
+            // assert them.
+            let discovered: Vec<(String, String)> = rows
+                .first()
+                .expect("the query should return a batch")
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| (field.name().clone(), field.data_type().to_string()))
+                .collect();
+            assert_eq!(
+                discovered,
+                vec![
+                    ("id".to_string(), "Int32".to_string()),
+                    ("label".to_string(), "Utf8".to_string()),
+                    ("amount".to_string(), "Decimal128(10, 2)".to_string()),
+                ],
+                "the discovered column types should match the source's INT / TEXT / NUMERIC(10,2)"
+            );
+
             Ok(())
         })
         .await
@@ -1193,13 +1215,13 @@ async fn test_refresh_sees_a_rename_as_a_removal_and_an_addition() -> Result<(),
 ///
 /// The accelerated path fails loud in this situation; the federated path warns,
 /// because a federated catalog can legitimately be configured before the tables
-/// it names exist. The warning's wording is asserted in the provider's unit
-/// tests -- here the observable behavior is pinned: the catalog loads, and it is
-/// empty.
+/// it names exist. The exact wording is asserted in the provider's unit tests;
+/// what this pins is that a real refresh reaches it -- the catalog loads, it is
+/// empty, and it says so once.
 #[tokio::test]
 async fn test_refresh_registers_nothing_when_include_matches_no_table() -> Result<(), anyhow::Error>
 {
-    let _tracing = init_tracing(Some("integration=debug,info"));
+    // No `init_tracing` here: this test installs its own capturing subscriber.
 
     test_request_context()
         .scope(async {
@@ -1226,10 +1248,14 @@ async fn test_refresh_registers_nothing_when_include_matches_no_table() -> Resul
                     .with_include_patterns(&["public.absent".to_string()]),
             );
 
-            provider
-                .refresh()
-                .await
-                .map_err(|e| anyhow::anyhow!("refresh: {e}"))?;
+            // Both refreshes are captured: the first must report the empty
+            // catalog, and the second must not repeat it. Asserting only that
+            // the catalog is empty would leave the report itself untested --
+            // deleting it would keep every assertion here passing.
+            let (first, first_refresh) = capture_logs(provider.refresh()).await;
+            first.map_err(|e| anyhow::anyhow!("refresh: {e}"))?;
+            let (second, second_refresh) = capture_logs(provider.refresh()).await;
+            second.map_err(|e| anyhow::anyhow!("second refresh: {e}"))?;
 
             assert!(
                 catalog_tables(&provider, "public").is_empty(),
@@ -1242,7 +1268,72 @@ async fn test_refresh_registers_nothing_when_include_matches_no_table() -> Resul
                 "the schema should still be registered, empty"
             );
 
+            assert!(
+                first_refresh.contains("registered no tables"),
+                "the first refresh should report the empty catalog: {first_refresh}"
+            );
+            assert!(
+                first_refresh.contains("public.absent"),
+                "the report should name the pattern that matched nothing: {first_refresh}"
+            );
+            assert!(
+                !second_refresh.contains("registered no tables"),
+                "a catalog that is still empty should not report it again: {second_refresh}"
+            );
+
             Ok(())
         })
         .await
+}
+
+/// Captures what is logged while `f` runs.
+///
+/// `set_default` scopes the subscriber to this thread, which is where these
+/// tests' current-thread runtime polls the refresh.
+async fn capture_logs<F, T>(f: F) -> (T, String)
+where
+    F: std::future::Future<Output = T>,
+{
+    let logs = CapturedLogs::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .with_writer(logs.clone())
+        .finish();
+
+    let value = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        f.await
+    };
+
+    let captured = logs
+        .0
+        .lock()
+        .expect("log mutex should not be poisoned")
+        .clone();
+    (value, String::from_utf8_lossy(&captured).into_owned())
+}
+
+#[derive(Clone, Default)]
+struct CapturedLogs(Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for CapturedLogs {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("log mutex should not be poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
 }

--- a/crates/runtime/tests/postgres/catalog.rs
+++ b/crates/runtime/tests/postgres/catalog.rs
@@ -14,17 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Integration test for the `PostgreSQL` catalog connector's handling of
-//! declaratively-partitioned tables (#11726).
+//! Integration tests for the federated `PostgreSQL` catalog connector, against a
+//! live `PostgreSQL`.
 //!
-//! A partitioned parent with two leaf partitions (plus a plain table) is seeded,
-//! then discovered through the catalog connector. The connector must
-//! register the partitioned parent but *not* its leaf partitions: the parent is a
-//! union over its children, so registering both would double-count aggregates and
-//! clutter the catalog. Querying the parent still returns rows from every
-//! partition. This mirrors how the CDC path attributes partitioned-table changes
-//! to the parent (`publish_via_partition_root = true`), so the one-time import and
-//! the streamed import agree on the parent as the unit of a partitioned table.
+//! Three groups:
+//!
+//! - **What gets discovered.** Declaratively-partitioned tables register the
+//!   parent but not its leaf partitions (#11726) -- the parent is a union over
+//!   its children, so registering both would double-count aggregates -- and
+//!   materialized views and foreign tables are discovered alongside plain
+//!   tables (#11725, #12585).
+//! - **How schemas are resolved.** The schema-wide lookup must honour the
+//!   catalog's `unsupported_type_action`, must be used only for the tables the
+//!   catalog selects, and must classify the server from a query no `search_path`
+//!   can shadow.
+//! - **What a refresh does.** Tables and schemas added or dropped at the source
+//!   converge on the next refresh, a rename reads as a removal plus an addition,
+//!   and a catalog selecting nothing registers nothing rather than failing.
+//!
+//! The refresh tests drive [`RefreshableCatalogProvider::refresh`] directly
+//! rather than waiting on the runtime's poller, so they neither sleep nor depend
+//! on a cadence that is not configurable.
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -44,7 +54,9 @@ use data_components::Read;
 use data_components::RefreshableCatalogProvider;
 use data_components::catalog_filter::TableSelector;
 use data_components::postgres::provider::PostgresCatalogProvider;
+use datafusion::prelude::SessionContext;
 use datafusion_table_providers::UnsupportedTypeAction;
+use datafusion_table_providers::postgres::PostgresTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
 use datafusion_table_providers::util::secrets::to_secret_map;
 
@@ -853,4 +865,384 @@ fn globset_of(patterns: &[&str]) -> globset::GlobSet {
         builder.add(globset::Glob::new(pattern).expect("glob pattern should parse"));
     }
     builder.build().expect("glob set should build")
+}
+
+/// Run DDL/DML at the source.
+async fn source_exec(port: usize, sql: &str) -> Result<(), anyhow::Error> {
+    common::get_postgres_connection_pool(port, None)
+        .await?
+        .connect_direct()
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .conn
+        .simple_query(sql)
+        .await?;
+    Ok(())
+}
+
+/// A catalog over `port`, registered in a `DataFusion` session so tables can be
+/// queried, and refreshed only when a test says so.
+///
+/// The refresh cadence is not configurable and the runtime's poller is on a
+/// minute-scale timer, so these tests drive [`RefreshableCatalogProvider::refresh`]
+/// directly. That keeps them fast and free of the fixed sleeps a timer would
+/// otherwise force, and it tests the same entry point the poller calls.
+async fn refreshable_catalog(
+    port: usize,
+) -> Result<(Arc<PostgresCatalogProvider>, SessionContext), anyhow::Error> {
+    let pool = Arc::new(
+        PostgresConnectionPool::new(to_secret_map(
+            get_pg_params(port)
+                .into_iter()
+                .map(|(k, v)| (k, v.expose_secret().to_string()))
+                .collect::<HashMap<String, String>>(),
+        ))
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?,
+    );
+
+    let provider = Arc::new(PostgresCatalogProvider::new(
+        CATALOG_NAME.to_string(),
+        Arc::clone(&pool),
+        Arc::new(PostgresTableFactory::new(pool)) as Arc<dyn Read>,
+        TableSelector::select_all(),
+    ));
+
+    let ctx = SessionContext::new();
+    ctx.register_catalog(
+        CATALOG_NAME,
+        Arc::clone(&provider) as Arc<dyn datafusion::catalog::CatalogProvider>,
+    );
+
+    Ok((provider, ctx))
+}
+
+/// The tables a catalog currently registers in `schema_name`, sorted.
+fn catalog_tables(provider: &PostgresCatalogProvider, schema_name: &str) -> Vec<String> {
+    use datafusion::catalog::CatalogProvider;
+
+    let mut names = provider
+        .schema(schema_name)
+        .map(|schema| schema.table_names())
+        .unwrap_or_default();
+    names.sort();
+    names
+}
+
+/// The schemas a catalog currently registers, sorted.
+fn catalog_schemas(provider: &PostgresCatalogProvider) -> Vec<String> {
+    use datafusion::catalog::CatalogProvider;
+
+    let mut names = provider.schema_names();
+    names.sort();
+    names
+}
+
+/// A table created at the source appears on the next refresh, with the source's
+/// columns and rows.
+///
+/// The RC criteria require a catalog to add datasets that become available. A
+/// table that appears with the wrong schema is worse than one that never
+/// appears, so this pins the discovered columns and the values, not just the
+/// name.
+#[tokio::test]
+async fn test_refresh_registers_a_table_created_at_the_source() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container(port).await?;
+
+            source_exec(port, "CREATE TABLE before_only (id INT PRIMARY KEY)").await?;
+
+            let (provider, ctx) = refreshable_catalog(port).await?;
+            provider
+                .refresh()
+                .await
+                .map_err(|e| anyhow::anyhow!("initial refresh: {e}"))?;
+            assert_eq!(
+                catalog_tables(&provider, "public"),
+                vec!["before_only".to_string()],
+                "only the pre-existing table should be registered before the source changes"
+            );
+
+            source_exec(
+                port,
+                "CREATE TABLE added (id INT PRIMARY KEY, label TEXT NOT NULL, amount NUMERIC(10,2)); \
+                 INSERT INTO added (id, label, amount) VALUES (1, 'first', 1.50), (2, 'second', 2.25);",
+            )
+            .await?;
+
+            provider
+                .refresh()
+                .await
+                .map_err(|e| anyhow::anyhow!("refresh after CREATE TABLE: {e}"))?;
+
+            assert_eq!(
+                catalog_tables(&provider, "public"),
+                vec!["added".to_string(), "before_only".to_string()],
+                "the new table should join the catalog on refresh"
+            );
+
+            let rows = ctx
+                .sql(&format!(
+                    "SELECT id, label, amount FROM {CATALOG_NAME}.public.added ORDER BY id"
+                ))
+                .await?
+                .collect()
+                .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+--------+--------+",
+                    "| id | label  | amount |",
+                    "+----+--------+--------+",
+                    "| 1  | first  | 1.50   |",
+                    "| 2  | second | 2.25   |",
+                    "+----+--------+--------+",
+                ],
+                &rows
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// A table dropped at the source leaves the catalog on the next refresh.
+#[tokio::test]
+async fn test_refresh_removes_a_dropped_table() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container(port).await?;
+
+            source_exec(
+                port,
+                "CREATE TABLE keeper (id INT PRIMARY KEY); \
+                 CREATE TABLE goner (id INT PRIMARY KEY);",
+            )
+            .await?;
+
+            let (provider, ctx) = refreshable_catalog(port).await?;
+            provider
+                .refresh()
+                .await
+                .map_err(|e| anyhow::anyhow!("initial refresh: {e}"))?;
+            assert_eq!(
+                catalog_tables(&provider, "public"),
+                vec!["goner".to_string(), "keeper".to_string()]
+            );
+
+            source_exec(port, "DROP TABLE goner").await?;
+            provider
+                .refresh()
+                .await
+                .map_err(|e| anyhow::anyhow!("refresh after DROP TABLE: {e}"))?;
+
+            assert_eq!(
+                catalog_tables(&provider, "public"),
+                vec!["keeper".to_string()],
+                "the dropped table should leave the catalog namespace"
+            );
+
+            // Absent from the namespace has to mean unresolvable, not merely
+            // hidden from a listing.
+            assert!(
+                ctx.sql(&format!("SELECT id FROM {CATALOG_NAME}.public.goner"))
+                    .await
+                    .is_err(),
+                "a dropped table should no longer resolve"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// A schema created at the source appears with its tables, and a dropped schema
+/// leaves the catalog.
+#[tokio::test]
+async fn test_refresh_tracks_schema_creation_and_removal() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container(port).await?;
+
+            let (provider, _ctx) = refreshable_catalog(port).await?;
+            provider
+                .refresh()
+                .await
+                .map_err(|e| anyhow::anyhow!("initial refresh: {e}"))?;
+            assert!(
+                !catalog_schemas(&provider).contains(&"analytics".to_string()),
+                "the schema should not exist before it is created"
+            );
+
+            source_exec(
+                port,
+                "CREATE SCHEMA analytics; \
+                 CREATE TABLE analytics.reports (id INT PRIMARY KEY);",
+            )
+            .await?;
+            provider
+                .refresh()
+                .await
+                .map_err(|e| anyhow::anyhow!("refresh after CREATE SCHEMA: {e}"))?;
+
+            assert!(
+                catalog_schemas(&provider).contains(&"analytics".to_string()),
+                "a created schema should join the catalog"
+            );
+            assert_eq!(
+                catalog_tables(&provider, "analytics"),
+                vec!["reports".to_string()],
+                "the new schema's tables should be discovered with it"
+            );
+
+            source_exec(port, "DROP SCHEMA analytics CASCADE").await?;
+            provider
+                .refresh()
+                .await
+                .map_err(|e| anyhow::anyhow!("refresh after DROP SCHEMA: {e}"))?;
+
+            assert!(
+                !catalog_schemas(&provider).contains(&"analytics".to_string()),
+                "a dropped schema should leave the catalog"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// A rename is a removal plus an addition, and the renamed table is queryable
+/// under its new name.
+///
+/// Nothing carries over from the old name -- the catalog rebuilds its table map
+/// per refresh -- so this pins the behavior rather than promising a rename is
+/// cheap.
+#[tokio::test]
+async fn test_refresh_sees_a_rename_as_a_removal_and_an_addition() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container(port).await?;
+
+            source_exec(
+                port,
+                "CREATE TABLE old_name (id INT PRIMARY KEY, label TEXT NOT NULL); \
+                 INSERT INTO old_name (id, label) VALUES (7, 'kept through the rename');",
+            )
+            .await?;
+
+            let (provider, ctx) = refreshable_catalog(port).await?;
+            provider
+                .refresh()
+                .await
+                .map_err(|e| anyhow::anyhow!("initial refresh: {e}"))?;
+            assert_eq!(
+                catalog_tables(&provider, "public"),
+                vec!["old_name".to_string()]
+            );
+
+            source_exec(port, "ALTER TABLE old_name RENAME TO new_name").await?;
+            provider
+                .refresh()
+                .await
+                .map_err(|e| anyhow::anyhow!("refresh after RENAME: {e}"))?;
+
+            assert_eq!(
+                catalog_tables(&provider, "public"),
+                vec!["new_name".to_string()],
+                "the old name should be gone and the new one present"
+            );
+
+            let rows = ctx
+                .sql(&format!(
+                    "SELECT id, label FROM {CATALOG_NAME}.public.new_name"
+                ))
+                .await?
+                .collect()
+                .await?;
+            assert_batches_eq!(
+                &[
+                    "+----+-------------------------+",
+                    "| id | label                   |",
+                    "+----+-------------------------+",
+                    "| 7  | kept through the rename |",
+                    "+----+-------------------------+",
+                ],
+                &rows
+            );
+
+            Ok(())
+        })
+        .await
+}
+
+/// A catalog whose `include` matches nothing registers no tables and says so,
+/// rather than loading silently and answering every query with "table not
+/// found".
+///
+/// The accelerated path fails loud in this situation; the federated path warns,
+/// because a federated catalog can legitimately be configured before the tables
+/// it names exist. The warning's wording is asserted in the provider's unit
+/// tests -- here the observable behavior is pinned: the catalog loads, and it is
+/// empty.
+#[tokio::test]
+async fn test_refresh_registers_nothing_when_include_matches_no_table() -> Result<(), anyhow::Error>
+{
+    let _tracing = init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container(port).await?;
+
+            source_exec(port, "CREATE TABLE present (id INT PRIMARY KEY)").await?;
+
+            let pool = Arc::new(
+                PostgresConnectionPool::new(to_secret_map(
+                    get_pg_params(port)
+                        .into_iter()
+                        .map(|(k, v)| (k, v.expose_secret().to_string()))
+                        .collect::<HashMap<String, String>>(),
+                ))
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?,
+            );
+            let provider = PostgresCatalogProvider::new(
+                CATALOG_NAME.to_string(),
+                Arc::clone(&pool),
+                Arc::new(PostgresTableFactory::new(pool)) as Arc<dyn Read>,
+                TableSelector::new(Some(globset_of(&["public.absent"])), None)
+                    .with_include_patterns(&["public.absent".to_string()]),
+            );
+
+            provider
+                .refresh()
+                .await
+                .map_err(|e| anyhow::anyhow!("refresh: {e}"))?;
+
+            assert!(
+                catalog_tables(&provider, "public").is_empty(),
+                "a pattern matching no table should register no table"
+            );
+            // The catalog still loads, and its namespace still reflects the
+            // source's schemas -- an empty catalog is a warning, not a failure.
+            assert!(
+                catalog_schemas(&provider).contains(&"public".to_string()),
+                "the schema should still be registered, empty"
+            );
+
+            Ok(())
+        })
+        .await
 }


### PR DESCRIPTION
Closes #12107.

The RC criteria require that a catalog "can refresh the list of datasets, and add/remove datasets that are available", with an end-to-end test for it. The federated PostgreSQL catalog already behaved that way — `refresh_schemas` rebuilds the schema map and `refresh_tables` replaces each schema's table map wholesale — but nothing tested it, so the criterion was unproven and the boundaries were unspecified.

## What a refresh does, now pinned

Five tests against a live PostgreSQL, covering the criterion's cases:

| at the source | the catalog |
|---|---|
| `CREATE TABLE` | registers it, with the source's columns and rows |
| `DROP TABLE` | drops it from the namespace, and it no longer resolves |
| `CREATE SCHEMA` + table | registers the schema and discovers its tables |
| `DROP SCHEMA` | drops the schema |
| `ALTER TABLE … RENAME` | old name absent, new name queryable with its rows intact |

The create and rename cases assert columns *and* values, not just names: a table that appears with the wrong schema is worse than one that never appears.

They drive `RefreshableCatalogProvider::refresh` directly rather than waiting on the runtime's poller. The cadence is not configurable and the poller runs on a minute-scale timer, so waiting on it would mean fixed sleeps — and `refresh` is the same entry point the poller calls.

**These tests are not decorative.** Each was verified against a deliberately broken build:

| break | caught by |
|---|---|
| schema map merges instead of replacing | schema create/remove |
| schema providers reused across refreshes + table maps merge | dropped-table, rename |

The second is worth a reviewer's attention: *not rebuilding every provider once a minute* looks like an obvious optimization, and it silently stops removals from taking effect — no error, no warning, a dropped table still queryable. That is the same failure shape as #12110 on the accelerated path, and nothing guarded the federated path against it.

## A catalog that selects nothing now says so

This was the one outcome the federated path could not distinguish from success: it loaded, reported ready, and answered every query with "table not found". The accelerated path already fails loud (#11983). The federated path warns instead, because a federated catalog can legitimately be configured before the tables it names exist — so the message has to let a user tell "my patterns are wrong" from "my tables are not there yet":

```
PostgreSQL catalog pg registered no tables, so queries against it will not resolve any
table. None of the tables in the 2 schema(s) it discovered matched include:
['public.orders'], exclude: ['public.secret']. Patterns match the qualified
'<schema>.<table>' name, so an unqualified pattern such as 'orders' never matches --
write 'public.orders' (or 'public.*') instead. Docs: ...
```

Three decisions inside it:

- **It fires on the transition to empty**, not on every refresh. A steady misconfiguration reprinting once a minute for the life of the process is how a log stops being read. The five transitions are unit-tested, and removing the guard fails that test.
- **An unfiltered empty catalog gets different wording.** With no patterns configured, blaming patterns is nonsense, so it points at the connected role's grants or an empty database instead.
- **It does not blame the patterns when the matches failed to load.** A selected table whose provider cannot be built is logged and skipped, so a catalog can register nothing while the patterns matched perfectly well. Reporting "none matched" there would contradict the `Failed to create table provider …` warning logged moments earlier and send the operator to fix configuration that is already correct. What a refresh *selected* is therefore tracked apart from what it *registered*:

  ```
  3 table(s) matched, but none could be registered -- the errors logged above this name
  the tables that failed and why
  ```

The patterns are escaped (`escape_debug`) rather than interpolated raw, because a glob is user-supplied text that can legally contain a newline — which would split one warning into what reads as two log records, against the repo's single-line logging rule.

Naming the patterns required `TableSelector` to keep them. It held only compiled `GlobSet`s and the literal prefixes derived from them — a `GlobSet` cannot be printed, so no diagnostic could quote what the user actually wrote. It now retains both halves verbatim behind `describe()`, and `table_selector()` passes `orig_exclude` through alongside `orig_include`.

## Not included

The RC task also asks for refresh semantics — visibility latency, rename as remove-plus-add, and the transient-failure last-known-good hold — on the catalog docs page. That page lives in `spiceai/docs`; a companion PR covers it rather than leaving the criterion quietly unmet.

## Verification

- 12/12 `postgres::catalog` integration tests pass against a live PostgreSQL (7 pre-existing, 5 new).
- 662 `data_components` unit tests pass, including four covering the empty-catalog warning.
- `cargo fmt --all -- --check` clean; clippy clean with the gate's `--tests` pedantic flags.

Every assertion added here was checked against a deliberately broken build rather than a green run — including the ones that came out of review:

| break | caught by |
|---|---|
| schema map merges instead of replacing | schema create/remove |
| schema providers reused + table maps merge | dropped-table, rename |
| transition guard removed | transition unit test |
| `warn!` emission deleted, call kept | empty-catalog integration test |
| selected-vs-registered distinction removed | failed-to-build unit test |
| pattern escaping removed | newline-pattern unit test |

## Companion

Refresh semantics for the catalog docs page: spiceai/docs#2084.

