### PR TITLE
fix(cayenne): dedup a doubled FilterExec predicate on a join build side

### DIFF
--- a/crates/cayenne/src/optimizer_rules.rs
+++ b/crates/cayenne/src/optimizer_rules.rs
@@ -119,6 +119,7 @@ use datafusion::common::{JoinType, NullEquality, extensions_options};
 use datafusion::config::{ConfigExtension, ConfigOptions};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
+use datafusion::physical_expr_common::physical_expr::is_volatile;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode};
@@ -1646,10 +1647,18 @@ impl PhysicalOptimizerRule for CayenneDedupFilterConjuncts {
     }
 }
 
-/// Splits `predicate` into its top-level `AND` conjuncts and, if any conjunct
-/// repeats (by expression equality, not just pointer identity), rebuilds the
-/// conjunction with only the first occurrence of each kept. Returns `None`
-/// when there is nothing to dedup, so callers can skip rebuilding the node.
+/// Splits `predicate` into its top-level `AND` conjuncts and, if any
+/// *deterministic* conjunct repeats (by expression equality, not just pointer
+/// identity), rebuilds the conjunction with only the first occurrence of each
+/// kept. Returns `None` when there is nothing to dedup, so callers can skip
+/// rebuilding the node.
+///
+/// A volatile conjunct (e.g. a call to a `Volatility::Volatile` UDF) is never
+/// treated as a removable duplicate, even against an structurally-identical
+/// sibling: two calls can return different values or carry side effects, so
+/// collapsing them into one evaluation would change the predicate's meaning,
+/// not just its cost. `DataFusion`'s own optimizer passes guard constant
+/// folding and CSE the same way; `is_volatile` is the same check they use.
 fn dedup_conjunction(predicate: &Arc<dyn PhysicalExpr>) -> Option<Arc<dyn PhysicalExpr>> {
     let conjuncts = split_conjunction(predicate);
     if conjuncts.len() < 2 {
@@ -1658,7 +1667,11 @@ fn dedup_conjunction(predicate: &Arc<dyn PhysicalExpr>) -> Option<Arc<dyn Physic
 
     let mut deduped: Vec<Arc<dyn PhysicalExpr>> = Vec::with_capacity(conjuncts.len());
     for expr in &conjuncts {
-        if !deduped.iter().any(|kept| kept.as_ref() == expr.as_ref()) {
+        let is_removable_duplicate = !is_volatile(expr)
+            && deduped
+                .iter()
+                .any(|kept| !is_volatile(kept) && kept.as_ref() == expr.as_ref());
+        if !is_removable_duplicate {
             deduped.push(Arc::clone(expr));
         }
     }
@@ -1674,10 +1687,10 @@ fn dedup_conjunction(predicate: &Arc<dyn PhysicalExpr>) -> Option<Arc<dyn Physic
 mod tests {
     use super::{
         ANTI_JOIN_SORT_MERGE_MIN_EXACT_ROWS, CayenneAntiJoinSortMergeRewriter,
-        CayenneDynamicFilterSharing, CayenneMaintainedAggregateRewriter, CayenneOptimizerConfig,
-        CayenneStatsAggregateRewriter, FilterAddition, HASH_JOIN_BUILD_SIDE_OVERHEAD_DEN,
-        HASH_JOIN_BUILD_SIDE_OVERHEAD_NUM, apply_filter_additions, build_side_memory_estimate,
-        plan_schema_fields,
+        CayenneDedupFilterConjuncts, CayenneDynamicFilterSharing,
+        CayenneMaintainedAggregateRewriter, CayenneOptimizerConfig, CayenneStatsAggregateRewriter,
+        FilterAddition, HASH_JOIN_BUILD_SIDE_OVERHEAD_DEN, HASH_JOIN_BUILD_SIDE_OVERHEAD_NUM,
+        apply_filter_additions, build_side_memory_estimate, plan_schema_fields,
     };
     use crate::maintained_aggregate::{
         MaintainedAggregateExec, MaintainedAggregateExpr, MaintainedAggregateFunction,
@@ -1696,6 +1709,7 @@ mod tests {
     use datafusion::physical_optimizer::PhysicalOptimizerRule;
     use datafusion::physical_plan::Partitioning;
     use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
+    use datafusion::physical_plan::filter::FilterExec;
     use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode, SortMergeJoinExec};
     use datafusion::physical_plan::repartition::RepartitionExec;
     use datafusion::physical_plan::sorts::sort::SortExec;
@@ -3684,5 +3698,98 @@ mod tests {
                 "each concurrent inner join should be rewritten to sort-merge under fair-share"
             );
         }
+    }
+
+    fn int32_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]))
+    }
+
+    fn empty_memory_exec(schema: &Arc<Schema>) -> Arc<dyn ExecutionPlan> {
+        MemorySourceConfig::try_new_exec(&[vec![]], Arc::clone(schema), None)
+            .expect("empty memory exec should build")
+    }
+
+    #[test]
+    fn dedups_a_repeated_deterministic_conjunct() {
+        let schema = int32_schema();
+        let equals_five = datafusion_physical_expr::expressions::binary(
+            col("a", &schema).expect("column a should exist"),
+            datafusion::logical_expr::Operator::Eq,
+            lit(5),
+            &schema,
+        )
+        .expect("building `a = 5` should succeed");
+        let predicate = conjunction(vec![Arc::clone(&equals_five), equals_five]);
+        let filter = Arc::new(
+            FilterExec::try_new(predicate, empty_memory_exec(&schema))
+                .expect("filter should build"),
+        );
+
+        let optimized = CayenneDedupFilterConjuncts
+            .optimize(filter, &ConfigOptions::new())
+            .expect("optimize should succeed");
+
+        let rewritten = optimized
+            .downcast_ref::<FilterExec>()
+            .expect("plan should remain a FilterExec");
+        assert_eq!(
+            datafusion_physical_expr::utils::split_conjunction(rewritten.predicate()).len(),
+            1,
+            "a repeated deterministic conjunct should collapse to one occurrence"
+        );
+    }
+
+    /// Regression for a review finding on the Cayenne benchmark-snapshot dup-filter
+    /// fix: `dedup_conjunction` must never treat two structurally-identical calls
+    /// to a volatile function as a removable duplicate. Two evaluations of a
+    /// volatile expression can return different values or carry side effects, so
+    /// collapsing them into one changes the predicate's meaning, not just its
+    /// cost — the same hazard `DataFusion`'s own constant-folding/CSE passes guard
+    /// against with the same `is_volatile` check.
+    #[test]
+    fn does_not_dedup_a_repeated_volatile_conjunct() {
+        let schema = int32_schema();
+        let random_udf = datafusion_functions::math::random();
+        let config_options = Arc::new(ConfigOptions::new());
+        let random_call = |fun: Arc<datafusion_expr::ScalarUDF>| -> Arc<dyn PhysicalExpr> {
+            let call: Arc<dyn PhysicalExpr> = Arc::new(
+                datafusion_physical_expr::ScalarFunctionExpr::try_new(
+                    fun,
+                    vec![],
+                    &schema,
+                    Arc::clone(&config_options),
+                )
+                .expect("building a random() call should succeed"),
+            );
+            datafusion_physical_expr::expressions::binary(
+                call,
+                datafusion::logical_expr::Operator::Gt,
+                lit(0.5_f64),
+                &schema,
+            )
+            .expect("building `random() > 0.5` should succeed")
+        };
+        // Two independently-built calls to the same volatile function — same
+        // structure, but each is its own evaluation.
+        let first_call = random_call(Arc::clone(&random_udf));
+        let second_call = random_call(random_udf);
+        let predicate = conjunction(vec![first_call, second_call]);
+        let filter = Arc::new(
+            FilterExec::try_new(predicate, empty_memory_exec(&schema))
+                .expect("filter should build"),
+        );
+
+        let optimized = CayenneDedupFilterConjuncts
+            .optimize(filter, &ConfigOptions::new())
+            .expect("optimize should succeed");
+
+        let rewritten = optimized
+            .downcast_ref::<FilterExec>()
+            .expect("plan should remain a FilterExec");
+        assert_eq!(
+            datafusion_physical_expr::utils::split_conjunction(rewritten.predicate()).len(),
+            2,
+            "two structurally-identical calls to a volatile function must both survive"
+        );
     }
 }

--- a/crates/cayenne/src/optimizer_rules.rs
+++ b/crates/cayenne/src/optimizer_rules.rs
@@ -122,12 +122,14 @@ use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode};
+use datafusion::physical_plan::filter::{FilterExec, FilterExecBuilder};
 use datafusion::physical_plan::joins::{HashJoinExec, SortMergeJoinExec};
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion_common::stats::Precision;
 use datafusion_physical_expr::PhysicalExpr;
 use datafusion_physical_expr::expressions::Column;
+use datafusion_physical_expr::utils::{conjunction, split_conjunction};
 use datafusion_physical_plan::repartition::RepartitionExec;
 use runtime_datafusion::execution_plan::schema_cast::SchemaCastScanExec;
 use runtime_datafusion::extension::bytes_processed::BytesProcessedExec;
@@ -1592,6 +1594,80 @@ impl PhysicalOptimizerRule for CayenneJoinRewriter {
         })
         .data()
     }
+}
+
+/// Collapses a duplicated conjunct in a `FilterExec` predicate (e.g. `p AND
+/// p`) down to a single occurrence.
+///
+/// `CayenneAccelerationExec::handle_child_pushdown_result` relies on
+/// `DataFusion`'s physical `FilterPushdown` `if_all` mechanism to drop a
+/// redundant post-scan `FilterExec` once every union child — in particular the
+/// `FilterExec` that `wrap_memory_branch_with_scan_filters`
+/// (`provider/table.rs`) pre-attaches to an in-memory branch, specifically so
+/// that elimination can fire — already applies the same predicate. When the
+/// scan sits on a join's build side, `ProjectionPushdown` folds the join's
+/// embedded projection onto the outer `FilterExec` before that elimination
+/// runs, so the redundant outer filter survives and merges with the inner one
+/// into a single node carrying the predicate twice instead of being dropped —
+/// every row then pays for evaluating the same condition twice. This rule is a
+/// safety net that removes the duplicate after the fact; it does not address
+/// why the `if_all` elimination didn't fire in that shape.
+#[derive(Default, Debug)]
+pub struct CayenneDedupFilterConjuncts;
+
+impl PhysicalOptimizerRule for CayenneDedupFilterConjuncts {
+    fn name(&self) -> &'static str {
+        "CayenneDedupFilterConjuncts"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        plan.transform_up(|node| {
+            let Some(filter) = node.downcast_ref::<FilterExec>() else {
+                return Ok(Transformed::no(node));
+            };
+            let Some(deduped) = dedup_conjunction(filter.predicate()) else {
+                return Ok(Transformed::no(node));
+            };
+            let rebuilt = FilterExecBuilder::new(deduped, Arc::clone(filter.input()))
+                .apply_projection_by_ref(filter.projection().as_ref())?
+                .with_default_selectivity(filter.default_selectivity())
+                .build()?;
+            Ok(Transformed::yes(Arc::new(rebuilt) as Arc<dyn ExecutionPlan>))
+        })
+        .data()
+    }
+}
+
+/// Splits `predicate` into its top-level `AND` conjuncts and, if any conjunct
+/// repeats (by expression equality, not just pointer identity), rebuilds the
+/// conjunction with only the first occurrence of each kept. Returns `None`
+/// when there is nothing to dedup, so callers can skip rebuilding the node.
+fn dedup_conjunction(predicate: &Arc<dyn PhysicalExpr>) -> Option<Arc<dyn PhysicalExpr>> {
+    let conjuncts = split_conjunction(predicate);
+    if conjuncts.len() < 2 {
+        return None;
+    }
+
+    let mut deduped: Vec<Arc<dyn PhysicalExpr>> = Vec::with_capacity(conjuncts.len());
+    for expr in &conjuncts {
+        if !deduped.iter().any(|kept| kept.as_ref() == expr.as_ref()) {
+            deduped.push(Arc::clone(expr));
+        }
+    }
+
+    if deduped.len() == conjuncts.len() {
+        return None;
+    }
+
+    Some(conjunction(deduped))
 }
 
 #[cfg(test)]

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -46279,6 +46279,96 @@ mod tests {
         );
     }
 
+    /// Regression test for the duplicated `FilterExec` predicate seen in
+    /// benchmark snapshots (e.g. `n_name = GERMANY AND n_name = GERMANY`).
+    ///
+    /// A predicate-filtered scan over an inline-only table on its own collapses
+    /// to a single `FilterExec` (see
+    /// `test_inline_cdc_filtered_scan_returns_only_matching_rows`'s physical
+    /// pipeline), but when that same scan sits on a join's build side,
+    /// `ProjectionPushdown` folds the join's embedded projection onto the
+    /// outer `FilterExec` before the physical `FilterPushdown` `if_all` check
+    /// (`CayenneAccelerationExec::handle_child_pushdown_result`) can drop it as
+    /// redundant against the inner `FilterExec` that
+    /// `wrap_memory_branch_with_scan_filters` pre-attaches to the inline
+    /// branch — so the outer filter survives and merges with the inner one
+    /// into a single node carrying the predicate twice. `CayenneDedupFilterConjuncts`
+    /// (registered by the runtime's session builder alongside `DataFusion`'s own
+    /// physical optimizer rules) cleans up that duplicate; this test registers
+    /// it the same way and asserts the predicate is applied exactly once.
+    #[tokio::test]
+    async fn test_join_build_side_scan_filter_is_not_duplicated() {
+        use datafusion::execution::SessionStateBuilder;
+
+        let plain_ctx = SessionContext::new();
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_runtime_env(plain_ctx.runtime_env())
+            .with_physical_optimizer_rule(Arc::new(
+                crate::optimizer_rules::CayenneDedupFilterConjuncts,
+            ))
+            .build();
+        let ctx = SessionContext::new_with_state(state);
+
+        let (provider, _catalog, _tmp) =
+            create_inline_enabled_upsert_table("join_build_side_filter_dedup", ctx.runtime_env())
+                .await;
+        let schema = Arc::clone(&provider.table_metadata.schema);
+
+        for (id, value) in [(1_i64, 10_i64), (2, 20), (3, 30)] {
+            insert_batch(
+                &provider,
+                id_value_batch(Arc::clone(&schema), &[id], &[value]),
+            )
+            .await;
+        }
+
+        ctx.register_table(
+            "join_build_side_filter_dedup",
+            Arc::new(provider.clone_for_write()),
+        )
+        .expect("table registered");
+
+        // A second, plain in-memory table joined against the filtered Cayenne
+        // table as its build side — mirroring the shape of the benchmark
+        // queries where the duplicate showed up (a small dimension table,
+        // filtered, joined as the build side of a `HashJoinExec`).
+        let other_schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("id", arrow_schema::DataType::Int64, false),
+            arrow_schema::Field::new("other_value", arrow_schema::DataType::Int64, false),
+        ]));
+        let other_batch = RecordBatch::try_new(
+            Arc::clone(&other_schema),
+            vec![
+                Arc::new(arrow::array::Int64Array::from(vec![3_i64, 4, 5])),
+                Arc::new(arrow::array::Int64Array::from(vec![100_i64, 200, 300])),
+            ],
+        )
+        .expect("build other batch");
+        ctx.register_batch("other_table", other_batch)
+            .expect("other table registered");
+
+        let df = ctx
+            .sql(
+                "SELECT o.other_value FROM join_build_side_filter_dedup t \
+                 JOIN other_table o ON t.id = o.id WHERE t.value = 30",
+            )
+            .await
+            .expect("query planned");
+        let physical_plan = df
+            .create_physical_plan()
+            .await
+            .expect("physical plan built");
+        let plan_str = datafusion::physical_plan::displayable(physical_plan.as_ref())
+            .indent(true)
+            .to_string();
+
+        assert!(
+            !plan_str.contains("value@1 = 30 AND value@1 = 30"),
+            "the scan filter must not be applied twice:\n{plan_str}"
+        );
+    }
+
     /// P1-2: `statistics()` must fold the live inline row count into `num_rows`
     /// (as `Inexact`) so the join planner gets a real cardinality, instead of
     /// returning `None`/an undercount, while inline CDC rows are live.

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -1904,6 +1904,9 @@ fn parse_cayenne_optimizer_rules(
             "stats_aggregate" | "metadata_aggregate" | "aggregate_pushdown" => {
                 rules.set_stats_aggregate(true);
             }
+            "dedup_filter_conjuncts" | "dedup_filter" | "filter_dedup" => {
+                rules.set_dedup_filter_conjuncts(true);
+            }
             _ => {
                 // Don't discard the rest of an explicit list because of one bad
                 // token; collect the unknown ones, keep the recognized rules,
@@ -3256,6 +3259,23 @@ mod test {
                 false,
             ),
             stats_aggregate_only
+        );
+
+        // `dedup_filter_conjuncts` is on under both `auto` and `all`, and is also
+        // selectable by token (including its aliases) without enabling anything else.
+        assert!(CayenneOptimizerRules::auto_enabled().dedup_filter_conjuncts());
+        assert!(CayenneOptimizerRules::all_enabled().dedup_filter_conjuncts());
+        let mut dedup_filter_conjuncts_only = CayenneOptimizerRules::none();
+        dedup_filter_conjuncts_only.set_dedup_filter_conjuncts(true);
+        assert_eq!(
+            parse_cayenne_optimizer_rules(
+                &HashMap::from([(
+                    CAYENNE_OPTIMIZER_RULES_PARAM.to_string(),
+                    "filter-dedup".to_string(),
+                )]),
+                false,
+            ),
+            dedup_filter_conjuncts_only
         );
 
         assert_eq!(

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -140,13 +140,15 @@ impl CayennePhysicalOptimizerRules {
     const ANTI_JOIN_SORT_MERGE: u8 = 1 << 2;
     const EXACT_JOIN_FILTER: u8 = 1 << 3;
     const STATS_AGGREGATE: u8 = 1 << 4;
+    const DEDUP_FILTER_CONJUNCTS: u8 = 1 << 5;
 
     const fn auto_enabled() -> Self {
         Self {
             enabled_rules: Self::DYNAMIC_FILTER_SHARING
                 | Self::MAINTAINED_AGGREGATE
                 | Self::ANTI_JOIN_SORT_MERGE
-                | Self::STATS_AGGREGATE,
+                | Self::STATS_AGGREGATE
+                | Self::DEDUP_FILTER_CONJUNCTS,
         }
     }
 
@@ -156,7 +158,8 @@ impl CayennePhysicalOptimizerRules {
                 | Self::MAINTAINED_AGGREGATE
                 | Self::ANTI_JOIN_SORT_MERGE
                 | Self::EXACT_JOIN_FILTER
-                | Self::STATS_AGGREGATE,
+                | Self::STATS_AGGREGATE
+                | Self::DEDUP_FILTER_CONJUNCTS,
         }
     }
 
@@ -320,6 +323,19 @@ impl CayenneOptimizerRules {
     pub fn set_exact_join_filter(&mut self, enabled: bool) {
         self.physical
             .set(CayennePhysicalOptimizerRules::EXACT_JOIN_FILTER, enabled);
+    }
+
+    #[must_use]
+    pub const fn dedup_filter_conjuncts(self) -> bool {
+        self.physical
+            .is_enabled(CayennePhysicalOptimizerRules::DEDUP_FILTER_CONJUNCTS)
+    }
+
+    pub fn set_dedup_filter_conjuncts(&mut self, enabled: bool) {
+        self.physical.set(
+            CayennePhysicalOptimizerRules::DEDUP_FILTER_CONJUNCTS,
+            enabled,
+        );
     }
 }
 
@@ -1038,12 +1054,14 @@ impl DataFusionBuilder {
             } else {
                 let _ = exact_join_filter_memory_limit;
             }
-            // Registered last among the Cayenne rules above (and after
-            // DataFusion's own `ProjectionPushdown`/`FilterPushdown`, which run
-            // as part of the default rule set already in `state`) so it cleans
-            // up a duplicated `FilterExec` predicate regardless of which
-            // upstream rewrite produced it.
-            state = state.with_physical_optimizer_rule(Arc::new(CayenneDedupFilterConjuncts));
+            if self.cayenne_optimizer_rules.dedup_filter_conjuncts() {
+                // Registered last among the Cayenne rules above (and after
+                // DataFusion's own `ProjectionPushdown`/`FilterPushdown`, which
+                // run as part of the default rule set already in `state`) so it
+                // cleans up a duplicated `FilterExec` predicate regardless of
+                // which upstream rewrite produced it.
+                state = state.with_physical_optimizer_rule(Arc::new(CayenneDedupFilterConjuncts));
+            }
         }
         #[cfg(windows)]
         let _ = exact_join_filter_memory_limit;
@@ -2617,8 +2635,9 @@ mod tests {
                 "CayenneMaintainedAggregateRewriter",
                 "CayenneStatsAggregateRewriter",
                 "CayenneAntiJoinSortMergeRewriter",
+                "CayenneDedupFilterConjuncts",
             ],
-            "Default Cayenne physical optimizer selection should preserve prior safe defaults (now including the metadata-only stats aggregate fold) without re-enabling the exact join filter"
+            "Default Cayenne physical optimizer selection should preserve prior safe defaults (now including the metadata-only stats aggregate fold and the redundant-filter cleanup) without re-enabling the exact join filter"
         );
     }
 
@@ -2725,6 +2744,8 @@ mod tests {
         anti_join_sort_merge.set_anti_join_sort_merge(true);
         let mut exact_join_filter = CayenneOptimizerRules::none();
         exact_join_filter.set_exact_join_filter(true);
+        let mut dedup_filter_conjuncts = CayenneOptimizerRules::none();
+        dedup_filter_conjuncts.set_dedup_filter_conjuncts(true);
 
         let cases = [
             (
@@ -2769,6 +2790,11 @@ mod tests {
                 vec!["CayenneAntiJoinSortMergeRewriter"],
             ),
             (exact_join_filter, vec![], vec!["CayenneJoinRewriter"]),
+            (
+                dedup_filter_conjuncts,
+                vec![],
+                vec!["CayenneDedupFilterConjuncts"],
+            ),
         ];
 
         for (rules, expected_logical_rules, expected_physical_rules) in cases {

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -35,8 +35,9 @@ use crate::{dataaccelerator::AcceleratorEngineRegistry, datafusion::SPICE_SCP_SC
 use cache::Caching;
 #[cfg(not(windows))]
 use cayenne::optimizer_rules::{
-    CayenneAntiJoinSortMergeRewriter, CayenneDynamicFilterSharing, CayenneJoinRewriter,
-    CayenneMaintainedAggregateRewriter, CayenneOptimizerConfig, CayenneStatsAggregateRewriter,
+    CayenneAntiJoinSortMergeRewriter, CayenneDedupFilterConjuncts, CayenneDynamicFilterSharing,
+    CayenneJoinRewriter, CayenneMaintainedAggregateRewriter, CayenneOptimizerConfig,
+    CayenneStatsAggregateRewriter,
 };
 #[cfg(not(windows))]
 use cayenne::{
@@ -1037,6 +1038,12 @@ impl DataFusionBuilder {
             } else {
                 let _ = exact_join_filter_memory_limit;
             }
+            // Registered last among the Cayenne rules above (and after
+            // DataFusion's own `ProjectionPushdown`/`FilterPushdown`, which run
+            // as part of the default rule set already in `state`) so it cleans
+            // up a duplicated `FilterExec` predicate regardless of which
+            // upstream rewrite produced it.
+            state = state.with_physical_optimizer_rule(Arc::new(CayenneDedupFilterConjuncts));
         }
         #[cfg(windows)]
         let _ = exact_join_filter_memory_limit;


### PR DESCRIPTION
## Summary
- A Cayenne scan over an inline/RAM-tier branch pre-attaches its own `FilterExec` so DataFusion's physical `FilterPushdown` `if_all` check can drop the redundant post-scan `FilterExec` (`wrap_memory_branch_with_scan_filters`). When that scan sits on a join's build side, `ProjectionPushdown` folds the join's embedded projection onto the outer `FilterExec` before that elimination runs, so the redundant filter survives and merges with the inner one into a single node carrying the predicate twice (e.g. `n_name = GERMANY AND n_name = GERMANY`) — doubling per-row filter evaluation on every affected query.
- Adds `CayenneDedupFilterConjuncts`, a physical optimizer rule that collapses a `FilterExec`'s duplicated top-level `AND` conjuncts, registered last among Cayenne's physical optimizer rules so it cleans up the duplicate regardless of which upstream rewrite produced it.
- This does not fix why the `if_all` elimination doesn't fire in this shape — it's a safety net that removes the resulting duplicate.

## Test plan
- [x] `cargo test -p cayenne --lib test_join_build_side_scan_filter_is_not_duplicated` — new regression test: builds a small inline-only table, filters it, joins it as a `HashJoinExec` build side, and asserts the resulting physical plan applies the predicate exactly once.
- [x] `make lint-rust-fix PACKAGES="cayenne runtime"` — clean.