### PR TITLE
fix(postgres): compare CDC positions against what the slot can stream, not what it retains

### DIFF
--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -929,6 +929,8 @@ fn replication_params_from_connector_params(
         // formatting. Not a user-facing parameter; the per-column text fallback
         // still handles types Postgres emits as text.
         pg_output_format: PgOutputFormat::Binary,
+        unclaimed_reservation_grace:
+            data_components::postgres_replication::shared::DEFAULT_UNCLAIMED_RESERVATION_GRACE,
     })
 }
 

--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -931,6 +931,8 @@ fn replication_params_from_connector_params(
         pg_output_format: PgOutputFormat::Binary,
         unclaimed_reservation_grace:
             data_components::postgres_replication::shared::DEFAULT_UNCLAIMED_RESERVATION_GRACE,
+        watermark_flush_interval:
+            data_components::postgres_replication::shared::DEFAULT_WATERMARK_FLUSH_INTERVAL,
     })
 }
 

--- a/crates/data_components/src/postgres_replication/config.rs
+++ b/crates/data_components/src/postgres_replication/config.rs
@@ -130,6 +130,17 @@ pub struct ReplicationParams {
     /// still emits text for types lacking a binary send function, so the text
     /// decode path stays live regardless of this setting.
     pub pg_output_format: PgOutputFormat,
+
+    /// How long the shared slot keeps holding its ack floor for a table that is
+    /// in the publication but has no attached member — see
+    /// `shared::DEFAULT_UNCLAIMED_RESERVATION_GRACE` for what the hold is for and
+    /// what letting it lapse costs.
+    ///
+    /// Internal, not a spicepod parameter: the connector always supplies the
+    /// default. It is a field only so a test can shorten it, since the behavior
+    /// that depends on the hold lapsing is otherwise unreachable in under five
+    /// minutes. Read from the params of whichever member opened the slot.
+    pub unclaimed_reservation_grace: Duration,
 }
 
 impl ReplicationParams {
@@ -837,6 +848,8 @@ TXTE85+Or9IUwDI9543jsyCvuQ8=
             shared: false,
             member_channel_capacity: 16,
             pg_output_format: PgOutputFormat::Binary,
+            unclaimed_reservation_grace:
+                crate::postgres_replication::shared::DEFAULT_UNCLAIMED_RESERVATION_GRACE,
         }
     }
 

--- a/crates/data_components/src/postgres_replication/config.rs
+++ b/crates/data_components/src/postgres_replication/config.rs
@@ -97,6 +97,18 @@ pub struct ReplicationParams {
     /// slot would be wrong.
     pub ephemeral_accelerator: bool,
     pub status_interval: Duration,
+    /// How often an idle member's durably-recorded applied position is carried
+    /// forward to what the slot has acknowledged on its behalf (see
+    /// `shared::flush_idle_watermarks`). Internal, not a user param.
+    ///
+    /// Coarse on purpose. The record only has to be current enough that the *next*
+    /// start does not mistake ordinary idle drift for a gap, and a graceful shutdown
+    /// flushes once more regardless — so this interval governs only how much a
+    /// *crash* can leave behind, where the cost is one rebuild and never a wrong
+    /// resume. Each tick writes at most one small blob per member whose position
+    /// actually moved, into that dataset's own accelerator; a busy member records its
+    /// position through its own commits and costs nothing here.
+    pub watermark_flush_interval: Duration,
     /// Lag-based readiness threshold: the dataset is marked Ready once its
     /// replication lag (now minus the newest applied commit's source time)
     /// falls below this, so a snapshotting or backlog-draining dataset stays
@@ -843,6 +855,7 @@ TXTE85+Or9IUwDI9543jsyCvuQ8=
             snapshot_on_resume: false,
             ephemeral_accelerator: false,
             status_interval: Duration::from_secs(5),
+            watermark_flush_interval: Duration::from_secs(30),
             ready_lag: Duration::from_secs(2),
             bootstrap_batch_size: 1024,
             shared: false,

--- a/crates/data_components/src/postgres_replication/mod.rs
+++ b/crates/data_components/src/postgres_replication/mod.rs
@@ -204,8 +204,11 @@ pub struct AppliedLsn {
 ///
 /// * `watermark` — the LSN the acceleration's contents are complete as of, or
 ///   `None` when none has been recorded.
-/// * `slot_restart_lsn` — the earliest LSN the slot can still stream from, or
-///   `None` when the slot does not exist.
+/// * `slot_earliest_streamable_lsn` — the earliest LSN the slot can still stream
+///   from, or `None` when the slot does not exist. This is the later of its
+///   `restart_lsn` and its `confirmed_flush_lsn`, not `restart_lsn` alone:
+///   Postgres forwards a start position below `confirmed_flush_lsn` up to it, so
+///   an acknowledged change cannot be re-streamed even while its WAL is retained.
 /// * `absence_implies_gap` — whether a *missing* watermark is evidence of one.
 ///   True when the acceleration survives restarts (so it can hold rows this
 ///   process did not load) and a position could have been recorded (so absence
@@ -225,7 +228,7 @@ pub struct AppliedLsn {
 #[must_use]
 pub fn needs_rebuild(
     position: &RecordedPosition,
-    slot_restart_lsn: Option<u64>,
+    slot_earliest_streamable_lsn: Option<u64>,
     absence_implies_gap: bool,
 ) -> bool {
     match position {
@@ -238,10 +241,10 @@ pub fn needs_rebuild(
         // leave the old source's rows in place while never loading the new
         // source's.
         RecordedPosition::ForeignSource => true,
-        // A gap when there is no slot at all, or when the slot's earliest
-        // retained position is already past the watermark.
+        // A gap when there is no slot at all, or when the slot can no longer
+        // stream from as far back as the watermark.
         RecordedPosition::At(watermark) => {
-            slot_restart_lsn.is_none_or(|earliest| earliest > watermark.lsn)
+            slot_earliest_streamable_lsn.is_none_or(|earliest| earliest > watermark.lsn)
         }
     }
 }
@@ -518,5 +521,26 @@ mod tests {
         // being mistaken for "never loaded".
         assert!(needs_rebuild_persist(at(0), Some(1)));
         assert!(needs_rebuild_persist(at(0), None));
+    }
+
+    /// The caller passes the later of `restart_lsn` and `confirmed_flush_lsn`,
+    /// because Postgres forwards a start position below `confirmed_flush_lsn` up to
+    /// it. Retained WAL that the slot has already acknowledged is therefore *not*
+    /// streamable, and treating it as such is a silent skip (#11289).
+    #[test]
+    fn an_acknowledged_change_is_a_gap_even_while_its_wal_is_retained() {
+        let at = |lsn| RecordedPosition::At(AppliedLsn { lsn });
+        // A slot retaining from 40 but acknowledged to 200 cannot supply a
+        // watermark of 100, even though 100 sits inside the retained range.
+        let restart_lsn: u64 = 40;
+        let confirmed_flush_lsn: u64 = 200;
+        assert!(
+            needs_rebuild(&at(100), Some(restart_lsn.max(confirmed_flush_lsn)), true),
+            "a watermark behind the acknowledged position is unreachable"
+        );
+        assert!(
+            !needs_rebuild(&at(100), Some(restart_lsn), true),
+            "control: comparing against retention alone calls the same gap resumable"
+        );
     }
 }

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -2073,17 +2073,46 @@ async fn attach_member(
             "this acceleration persists across restarts but has nowhere to record how far it has been advanced, so a replication slot that is dropped or invalidated cannot be detected and rows deleted at the source while it was gone would survive here"
         );
     }
-    // The earliest position this slot can actually stream from, which is *not* the
-    // same as the earliest it still retains. Postgres forwards a `START_REPLICATION`
-    // position below the slot's `confirmed_flush_lsn` up to it ("has been already
-    // streamed, forwarding to ..." in `CreateDecodingContext`), so once the slot has
-    // acknowledged past a change, no client can ask for it again — the WAL may still
-    // be on disk under `restart_lsn`, but it is unreachable through this slot.
-    // Comparing the watermark against `restart_lsn` alone would therefore call an
-    // unfillable gap resumable and skip the difference silently.
+    // Seat the member *before* classifying it, and classify against the floor it was
+    // actually seated at.
+    //
+    // `setup.slot.consistent_lsn` was read while the slot's DDL was being set up, and
+    // the pump does not take `setup_lock` — so it can acknowledge more WAL between
+    // that read and this registration. Classifying on the stale snapshot and then
+    // seating the member at the current floor is a silent skip in exactly the shape
+    // this change exists to fix: the watermark reads as reachable, while the member
+    // starts above it. Registering first closes the window, because the floor it is
+    // seated at is then a fact rather than a prediction.
+    //
+    // `register` also takes over any hold installed for this table through its rejoin
+    // branch, keeping the held floor — so the replay this member is owed starts where
+    // the slot resumed, not where a slot-mate was credited.
+    let (sender, receiver) = member_mailbox(params.member_channel_capacity);
+    // Grouping signal for the analysis: record which shared slot this dataset joined.
+    // (Membership liveness is marked by `mark_member_attached` below.)
+    metrics.set_slot_name(source.key.slot_name.clone());
+    source.ack.register(&member_key, snapshotting);
+    source.claim_reservation(&member_key);
+    let ack_slot = source.ack.slot(&member_key);
+
+    // The earliest position this member can actually be supplied from, which is *not*
+    // the earliest the slot still retains. Two distinct limits, and the later one
+    // binds:
+    //
+    //   * Postgres forwards a `START_REPLICATION` position below the slot's
+    //     `confirmed_flush_lsn` up to it ("has been already streamed, forwarding to
+    //     ..." in `CreateDecodingContext`), so once the slot has acknowledged past a
+    //     change no client can ask for it again — the WAL may still be on disk under
+    //     `restart_lsn`, but it is unreachable through this slot.
+    //   * this member's own seated floor, which a slot-mate's traffic may have
+    //     carried past the snapshot above.
+    //
+    // Comparing against `restart_lsn` alone would call an unfillable gap resumable
+    // and skip the difference silently.
+    let seated_floor = ack_slot.as_ref().map_or(0, |slot| slot.committed());
     let earliest_streamable_lsn = setup
         .slot_restart_lsn
-        .map(|restart_lsn| restart_lsn.max(setup.slot.consistent_lsn));
+        .map(|restart_lsn| restart_lsn.max(setup.slot.consistent_lsn).max(seated_floor));
     let rebuild_via_consumer = super::needs_rebuild(
         &watermark,
         earliest_streamable_lsn,
@@ -2101,7 +2130,9 @@ async fn attach_member(
         super::RecordedPosition::ForeignSource => {
             "the position it recorded belongs to a different source, so it does not describe these rows"
         }
-        super::RecordedPosition::At(watermark) if setup.slot.consistent_lsn > watermark.lsn => {
+        super::RecordedPosition::At(watermark)
+            if setup.slot.consistent_lsn.max(seated_floor) > watermark.lsn =>
+        {
             "the slot has been acknowledged past the position it recorded as applied, so the changes in between can no longer be streamed from it"
         }
         super::RecordedPosition::At(_) => {
@@ -2109,16 +2140,6 @@ async fn attach_member(
         }
     };
 
-    let (sender, receiver) = member_mailbox(params.member_channel_capacity);
-    // Grouping signal for the analysis: record which shared slot this dataset joined.
-    // (Membership liveness is marked by `mark_member_attached` just below.)
-    metrics.set_slot_name(source.key.slot_name.clone());
-    // `register` takes over any hold installed for this table through its
-    // rejoin branch, keeping the held floor — so the replay this member is
-    // owed starts where the slot resumed, not where a slot-mate was credited.
-    source.ack.register(&member_key, snapshotting);
-    source.claim_reservation(&member_key);
-    let ack_slot = source.ack.slot(&member_key);
     // A member resuming on a position a previous process recorded already has a
     // durable position, even though nothing has been committed in *this* process.
     // Seeding it lets an idle member carry that position forward (see
@@ -2439,6 +2460,17 @@ async fn run_applied_lsn_writer(source: Arc<SharedSource>, interval: std::time::
         publish_idle_positions(&source);
         write_published_positions(&source).await;
         if source.dead.load(Ordering::Acquire) {
+            // Nothing will retry after this, so an unwritten position is final.
+            let stranded: Vec<String> = lock(&source.orphaned_positions)
+                .iter()
+                .map(|orphan| orphan.dataset.clone())
+                .collect();
+            if !stranded.is_empty() {
+                tracing::warn!(
+                    datasets = ?stranded,
+                    "the shared replication slot is shutting down with how far these accelerations were advanced still unrecorded; each will be rebuilt from the source on the next start rather than resumed"
+                );
+            }
             return;
         }
     }
@@ -2482,9 +2514,20 @@ fn publish_idle_positions(source: &Arc<SharedSource>) {
 /// from the pump's shutdown, which never run concurrently: the pump sets `dead`
 /// before its final flush, and the writer exits on seeing it.
 async fn write_published_positions(source: &Arc<SharedSource>) {
+    // An orphan has no member left for the next sweep to rediscover, so a failed
+    // write has to be put back or the detached member's last position is lost to a
+    // transient sidecar error. Extend rather than assign, so a detach racing this
+    // pass is not clobbered.
     let orphans = std::mem::take(&mut *lock(&source.orphaned_positions));
+    let mut unwritten = Vec::new();
     for orphan in orphans {
         write_one(&orphan.dataset, &orphan.store, &orphan.slot).await;
+        if orphan.slot.pending() > orphan.slot.recorded() {
+            unwritten.push(orphan);
+        }
+    }
+    if !unwritten.is_empty() {
+        lock(&source.orphaned_positions).extend(unwritten);
     }
     for (member_key, member) in source.live_members() {
         let Some(slot) = source.ack.slot(&member_key) else {
@@ -2503,7 +2546,7 @@ async fn write_one(dataset: &str, store: &Arc<dyn AppliedLsnStore>, slot: &Arc<A
         Ok(()) => slot.note_recorded(pending),
         Err(e) => tracing::warn!(
             dataset = %dataset,
-            "could not record how far this acceleration has been advanced (lsn={pending}); it will be retried, and a restart before it succeeds rebuilds from the source rather than resuming: {e}"
+            "could not record how far this acceleration has been advanced (lsn={pending}); a restart before it is recorded rebuilds from the source rather than resuming: {e}"
         ),
     }
 }

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -489,9 +489,12 @@ struct MemberHandle {
     /// source-commit time is within this of now, so the dataset becomes Ready
     /// only once it has caught up to the source head.
     ready_lag: std::time::Duration,
-    /// Where this member's applied-LSN watermark is recorded; cloned into each
-    /// envelope's committer. See `SharedLsnCommitter::applied_lsn_store`.
+    /// Where this member's applied-LSN watermark is recorded. Only
+    /// [`run_applied_lsn_writer`] writes it, which is what keeps concurrent
+    /// producers from landing out of order.
     applied_lsn_store: Arc<dyn AppliedLsnStore>,
+    /// Wakes the applied-position writer when this member publishes a position.
+    watermark_notify: Arc<Notify>,
 }
 
 /// `LIVE`: the member is attached and routing to it is allowed. Cleared on
@@ -548,9 +551,21 @@ struct AckSlot {
     /// the premise [`flush_idle_watermarks`] needs before it may carry the position
     /// forward over an interval that contained nothing to apply.
     ///
-    /// Still within the one 64-byte line this type is aligned to (25 of 64 bytes
+    /// Still within the one 64-byte line this type is aligned to (33 of 64 bytes
     /// used), so it adds no false sharing.
     recorded: AtomicU64,
+    /// Highest position *proven durable and eligible to record*, published by
+    /// whichever producer established it — an envelope commit, a snapshot/rebuild
+    /// boundary, or the idle carry-forward sweep — and drained by the single
+    /// applied-position writer ([`run_applied_lsn_writer`]).
+    ///
+    /// Producers advance it with a monotonic max rather than a store, because they
+    /// run on different tasks and can publish out of order; taking the max makes
+    /// "the furthest position anyone has proven" observable at any instant without
+    /// a lock, and makes a late straggler a no-op instead of a regression. Starts at
+    /// 0: a position is only ever published by something that has proven it durable,
+    /// never by registration.
+    pending: AtomicU64,
 }
 
 impl AckSlot {
@@ -560,6 +575,7 @@ impl AckSlot {
             delivered: AtomicU64::new(at),
             state: AtomicU8::new(LIVE | if snapshotting { SNAPSHOTTING } else { 0 }),
             recorded: AtomicU64::new(0),
+            pending: AtomicU64::new(0),
         }
     }
 
@@ -573,6 +589,7 @@ impl AckSlot {
             delivered: AtomicU64::new(at),
             state: AtomicU8::new(0),
             recorded: AtomicU64::new(0),
+            pending: AtomicU64::new(0),
         }
     }
 
@@ -590,10 +607,21 @@ impl AckSlot {
     }
 
     /// Note that `lsn` is now durably recorded for this member (monotonic). Called
-    /// after a successful store write, and once at attach for a member resuming on
-    /// a position a previous process recorded.
+    /// by the writer after a successful store write, and once at attach for a member
+    /// resuming on a position a previous process recorded.
     fn note_recorded(&self, lsn: u64) {
         advance_monotonic(&self.recorded, lsn);
+    }
+
+    /// The highest position published for recording, 0 if none.
+    fn pending(&self) -> u64 {
+        self.pending.load(Ordering::Acquire)
+    }
+
+    /// Publish `lsn` as proven durable and eligible to record (monotonic). Cheap
+    /// enough for the commit path: one atomic max, no I/O and no lock.
+    fn note_pending(&self, lsn: u64) {
+        advance_monotonic(&self.pending, lsn);
     }
 
     /// Advance this member's committed floor (monotonic). Called lock-free from
@@ -844,43 +872,29 @@ struct SharedLsnCommitter {
     /// Source-commit timestamp (ms since the Unix epoch) of the batch this
     /// commit acks; `None` when the transaction carried no commit time.
     source_commit_ts_ms: Option<i64>,
-    /// Where this member's applied-LSN watermark is recorded.
+    /// Wakes the applied-position writer once this commit publishes its position.
     ///
-    /// Written from [`CommitChange::commit`] specifically, which is the only
-    /// point at which the acked changes are known durable: this committer
-    /// supports deferral, so under an in-memory CDC durability tier the runtime
-    /// holds it until the covering checkpoint is durable
-    /// (`SlotAdvancer::on_checkpoint_durable`). Recording the watermark anywhere
-    /// earlier — when a batch reaches the memory tier — would claim rows a
-    /// restart loses, and the next start would then resume *past* changes the
-    /// acceleration never durably received.
-    applied_lsn_store: Arc<dyn AppliedLsnStore>,
+    /// The position is published from [`CommitChange::commit`] specifically, which
+    /// is the only point at which the acked changes are known durable: this
+    /// committer supports deferral, so under an in-memory CDC durability tier the
+    /// runtime holds it until the covering checkpoint is durable
+    /// (`SlotAdvancer::on_checkpoint_durable`). Publishing anywhere earlier — when a
+    /// batch reaches the memory tier — would claim rows a restart loses, and the
+    /// next start would then resume *past* changes the acceleration never durably
+    /// received.
+    watermark_notify: Arc<Notify>,
 }
 
 #[async_trait]
 impl CommitChange for SharedLsnCommitter {
     async fn commit(&self) -> std::result::Result<(), CommitError> {
         self.slot.commit(self.flush_to);
-        // Record the watermark alongside the slot ack, never ahead of it. A
-        // failure here is logged rather than surfaced: the ack already happened,
-        // so failing the commit would stall CDC over bookkeeping, and a stale
-        // watermark only ever costs a redundant rebuild on the next start —
-        // whereas a watermark ahead of durable data would resume past changes
-        // the acceleration does not hold.
-        match self
-            .applied_lsn_store
-            .save(AppliedLsn { lsn: self.flush_to })
-            .await
-        {
-            // Marks the position durable so idle crediting may carry it forward
-            // later without a further write (see `flush_idle_watermarks`).
-            Ok(()) => self.slot.note_recorded(self.flush_to),
-            Err(e) => tracing::warn!(
-                dataset = %self.dataset,
-                "could not record how far this acceleration has been advanced (lsn={}); if the process restarts before this succeeds, the acceleration is rebuilt from the source rather than resumed: {e}",
-                self.flush_to,
-            ),
-        }
+        // Publish the position alongside the slot ack, never ahead of it, and let
+        // the writer persist it. Publishing is an atomic max and a wakeup, so the
+        // commit path does no I/O: positions established while a write is in flight
+        // coalesce into that write's successor instead of queueing behind it.
+        self.slot.note_pending(self.flush_to);
+        self.watermark_notify.notify_one();
         crate::cdc::log_committer_progress(
             "postgres",
             &self.dataset,
@@ -890,34 +904,11 @@ impl CommitChange for SharedLsnCommitter {
         Ok(())
     }
 
-    /// Same argument as the per-dataset `LsnCommitter`: the slot retains WAL
-    /// until the shared floor advances past this commit, so a crash before a
-    /// deferred commit re-streams the un-acked tail. Safe to defer.
+    /// The runtime may hold this commit until the covering checkpoint is durable;
+    /// see `slot`'s and `watermark_notify`'s docs for why that gate is what makes a
+    /// published position safe.
     fn supports_deferral(&self) -> bool {
         true
-    }
-
-    /// Fold another shared-slot commit that targets the *same* member slot into
-    /// this one by keeping the higher LSN. Sound because [`Self::commit`] is a
-    /// monotonic `max` into the slot's `committed` — infallible and
-    /// order-insensitive, so folding N consecutive commits to their max is
-    /// identical to running them in order. A different slot (or a non-shared
-    /// committer) is refused, so a mixed run never coalesces across members.
-    fn try_absorb(&mut self, other: &dyn CommitChange) -> bool {
-        match other
-            .as_any()
-            .and_then(|a| a.downcast_ref::<SharedLsnCommitter>())
-        {
-            Some(other) if Arc::ptr_eq(&self.slot, &other.slot) => {
-                self.flush_to = self.flush_to.max(other.flush_to);
-                true
-            }
-            _ => false,
-        }
-    }
-
-    fn as_any(&self) -> Option<&dyn std::any::Any> {
-        Some(self)
     }
 }
 
@@ -929,7 +920,7 @@ impl CommitChange for SharedLsnCommitter {
 /// cannot be built.
 fn snapshot_watermark_envelope(
     schema: &SchemaRef,
-    applied_lsn_store: Arc<dyn AppliedLsnStore>,
+    watermark_notify: Arc<Notify>,
     slot: Option<Arc<AckSlot>>,
     lsn: u64,
     dataset: String,
@@ -941,7 +932,7 @@ fn snapshot_watermark_envelope(
         .map_err(|e| StreamError::External(e.to_string()))?;
     Ok(ChangeEnvelope::from_parts(
         Box::new(SnapshotWatermarkCommitter {
-            applied_lsn_store,
+            watermark_notify,
             slot,
             lsn,
             dataset,
@@ -968,7 +959,7 @@ fn snapshot_watermark_envelope(
 /// durable before their watermark claims them. Same contract as
 /// `mysql_replication`'s snapshot-boundary committer.
 struct SnapshotWatermarkCommitter {
-    applied_lsn_store: Arc<dyn AppliedLsnStore>,
+    watermark_notify: Arc<Notify>,
     /// The member's ack slot, so a successful write marks the position durable for
     /// [`flush_idle_watermarks`]. Carried by both boundary envelopes — a snapshot's
     /// and a rebuild's — because for a table that then sees no changes this is the
@@ -987,22 +978,13 @@ struct SnapshotWatermarkCommitter {
 #[async_trait]
 impl CommitChange for SnapshotWatermarkCommitter {
     async fn commit(&self) -> std::result::Result<(), CommitError> {
-        match self
-            .applied_lsn_store
-            .save(AppliedLsn { lsn: self.lsn })
-            .await
-        {
-            Ok(()) => {
-                if let Some(slot) = &self.slot {
-                    slot.note_recorded(self.lsn);
-                }
-            }
-            Err(e) => tracing::warn!(
-                dataset = %self.dataset,
-                "could not record the snapshot's applied position (lsn={}); the acceleration is correct, but a restart before the next acknowledgement will rebuild it from the source rather than resume: {e}",
-                self.lsn,
-            ),
+        // This committer refuses deferral, so the rows this position describes are
+        // durable by the time it runs; publishing it here is what lets the idle
+        // carry-forward extend it later.
+        if let Some(slot) = &self.slot {
+            slot.note_pending(self.lsn);
         }
+        self.watermark_notify.notify_one();
         crate::cdc::log_committer_progress(
             "postgres",
             &self.dataset,
@@ -1018,8 +1000,8 @@ struct PendingPgEnvelope {
     slot: Arc<AckSlot>,
     flush_to: u64,
     dataset: String,
-    /// Cloned from the member; see `SharedLsnCommitter::applied_lsn_store`.
-    applied_lsn_store: Arc<dyn AppliedLsnStore>,
+    /// Cloned from the member; see [`run_applied_lsn_writer`].
+    watermark_notify: Arc<Notify>,
     is_dataset_ready: bool,
     first_received_at: std::time::Instant,
 }
@@ -1053,8 +1035,8 @@ impl PendingPgEnvelope {
             flush_to,
             dataset,
             // Same member (the `slot` pointer check above proves it), so both
-            // sides carry the same store; either may be kept.
-            applied_lsn_store,
+            // sides carry the same notify; either may be kept.
+            watermark_notify,
             is_dataset_ready,
             first_received_at,
         } = other;
@@ -1066,7 +1048,7 @@ impl PendingPgEnvelope {
                 slot,
                 flush_to,
                 dataset,
-                applied_lsn_store,
+                watermark_notify,
                 is_dataset_ready,
                 first_received_at,
             });
@@ -1090,7 +1072,7 @@ impl PendingPgEnvelope {
                 flush_to: self.flush_to,
                 dataset: self.dataset,
                 source_commit_ts_ms,
-                applied_lsn_store: self.applied_lsn_store,
+                watermark_notify: self.watermark_notify,
             }),
             Box::new(self.rows),
             self.is_dataset_ready,
@@ -1533,6 +1515,11 @@ struct SharedSource {
     /// Set when the pump has exited (fatal error or all members detached).
     /// Subscribers seeing this create a fresh source.
     dead: AtomicBool,
+    /// Wakes [`run_applied_lsn_writer`] when a member publishes a position.
+    watermark_notify: Arc<Notify>,
+    /// Positions published by members that have since detached, which the writer's
+    /// member sweep can no longer reach. See [`OrphanedPosition`].
+    orphaned_positions: Mutex<Vec<OrphanedPosition>>,
     /// Whether the slot was created fresh by this process. Members that join
     /// later must snapshot even if their table already sat in the publication:
     /// a fresh slot has no history for anyone.
@@ -1566,6 +1553,8 @@ impl SharedSource {
             pump_started: AtomicBool::new(false),
             restart_requested: AtomicBool::new(false),
             dead: AtomicBool::new(false),
+            watermark_notify: Arc::new(Notify::new()),
+            orphaned_positions: Mutex::new(Vec::new()),
             slot_created_fresh: AtomicBool::new(false),
             detached: Mutex::new(HashSet::new()),
             reservations: Mutex::new(HashMap::new()),
@@ -1645,6 +1634,20 @@ impl SharedSource {
     /// re-subscription, which re-attaches immediately — only WARN).
     fn detach_member(&self, key: &MemberKey, reason: &str, stalls_slot: bool) {
         let removed = lock(&self.members).remove(key);
+        // The writer sweeps members, so anything this one published but had not yet
+        // had written would be dropped on the floor by the removal above. Hand it
+        // over rather than writing it here, which would make a second writer.
+        if let Some(member) = &removed
+            && let Some(slot) = self.ack.slot(key)
+            && slot.pending() > slot.recorded()
+        {
+            lock(&self.orphaned_positions).push(OrphanedPosition {
+                dataset: member.dataset_name.clone(),
+                store: Arc::clone(&member.applied_lsn_store),
+                slot,
+            });
+            self.watermark_notify.notify_one();
+        }
         let was_snapshotting = self.ack.detach(key);
         lock(&self.detached).insert(key.clone());
         if let Some(member) = removed {
@@ -2124,6 +2127,7 @@ async fn attach_member(
         && !rebuild_via_consumer
     {
         slot.note_recorded(resumed.lsn);
+        slot.note_pending(resumed.lsn);
     }
     lock(&source.members).insert(
         member_key.clone(),
@@ -2137,6 +2141,7 @@ async fn attach_member(
             metrics: Arc::clone(&metrics),
             ready_lag: params.ready_lag,
             applied_lsn_store: Arc::clone(&applied_lsn_store),
+            watermark_notify: Arc::clone(&source.watermark_notify),
         }),
     );
     // Membership liveness is now observable (`dataset_postgres_replication_member_attached`):
@@ -2169,7 +2174,7 @@ async fn attach_member(
     if !source.pump_started.swap(true, Ordering::AcqRel) {
         let pump_source = Arc::clone(source);
         tokio::spawn(run_pump(pump_source));
-        tokio::spawn(run_watermark_flusher(
+        tokio::spawn(run_applied_lsn_writer(
             Arc::clone(source),
             params.watermark_flush_interval,
         ));
@@ -2230,7 +2235,7 @@ async fn attach_member(
         // ordering.
         let signal_item = snapshot_watermark_envelope(
             &schema,
-            Arc::clone(&applied_lsn_store),
+            Arc::clone(&source.watermark_notify),
             ack_slot,
             setup.slot.consistent_lsn,
             dataset_name.clone(),
@@ -2257,7 +2262,7 @@ async fn attach_member(
         // Built before `dataset_name` is moved into the snapshot input below.
         let watermark_boundary = snapshot_watermark_envelope(
             &schema,
-            Arc::clone(&applied_lsn_store),
+            Arc::clone(&source.watermark_notify),
             ack_slot,
             setup.slot.consistent_lsn,
             dataset_name.clone(),
@@ -2400,78 +2405,106 @@ async fn member_fatal(source: &Arc<SharedSource>, key: &MemberKey, message: Stri
 
 /// Mark the source dead and drop it from the registry (only if the registry
 /// still points at this instance — a replacement may already exist).
-/// Periodically carry idle members' recorded positions forward, off the pump's
-/// decode path, until the pump is done.
+/// A member's applied position that outlived its member, kept so the last thing it
+/// proved durable is still written. A detached member is removed from the source's
+/// member map, so the writer's normal sweep can no longer see it.
+struct OrphanedPosition {
+    dataset: String,
+    store: Arc<dyn AppliedLsnStore>,
+    slot: Arc<AckSlot>,
+}
+
+/// The **only** writer of applied positions for a source.
 ///
-/// A dedicated task rather than work inside the pump loop: the store write is I/O
-/// against the dataset's own accelerator, and the pump must reach an `.await` on the
-/// replication socket promptly or it stalls decode for every member on the slot.
-/// One task per source, ticking sequentially, also means no two flushes can overlap.
+/// Producers publish a position onto their member's [`AckSlot::pending`] with an
+/// atomic max and wake this task; it persists whatever the furthest published
+/// position is when it gets there. Two properties follow, and both matter:
 ///
-/// The tick is coarse on purpose — see `watermark_flush_interval`. A graceful
-/// shutdown does not rely on it: the pump flushes once more on its way out, so an
-/// ordinary restart resumes exactly. After a crash the record can be up to one tick
-/// behind what the slot acknowledged, which costs one rebuild and never a wrong
-/// resume.
-async fn run_watermark_flusher(source: Arc<SharedSource>, interval: std::time::Duration) {
+///   * **No reordering.** [`AppliedLsnStore::save`] overwrites rather than taking a
+///     maximum, so concurrent writers could land out of order and move a recorded
+///     position backwards — costing a rebuild that does not self-correct until the
+///     member advances past the lost value. One writer makes that unrepresentable.
+///   * **Coalescing.** Positions published while a write is in flight collapse into
+///     that write's successor, so a busy member costs writes at the store's pace
+///     rather than one per commit.
+///
+/// It also wakes on a timer for the idle carry-forward, which has no producer to
+/// wake it: see [`publish_idle_positions`].
+async fn run_applied_lsn_writer(source: Arc<SharedSource>, interval: std::time::Duration) {
     loop {
-        tokio::time::sleep(interval).await;
+        tokio::select! {
+            () = source.watermark_notify.notified() => {}
+            () = tokio::time::sleep(interval) => {}
+        }
+        publish_idle_positions(&source);
+        write_published_positions(&source).await;
         if source.dead.load(Ordering::Acquire) {
-            flush_idle_watermarks(&source).await;
             return;
         }
-        flush_idle_watermarks(&source).await;
     }
 }
 
-/// Carry each idle member's durably-recorded position forward to what the slot has
-/// acknowledged on its behalf.
+/// Carry each idle member's position forward to what the slot has acknowledged on
+/// its behalf, by publishing it like any other producer.
 ///
 /// The slot's acknowledgement advances for a member that had nothing to apply, via
-/// [`AckTable::credit_idle`], which routes no envelope and therefore runs no
-/// committer and records nothing. Left alone the two drift apart for any quiet
-/// table, and the next start reads a recorded position behind the slot's
+/// [`AckTable::credit_idle`], which routes no envelope and so runs no committer.
+/// Left alone the recorded position and the acknowledgement drift apart for any
+/// quiet table, and the next start reads a position behind the slot's
 /// `confirmed_flush_lsn` — indistinguishable from changes acknowledged but never
 /// applied, so a healthy acceleration is rebuilt on every restart.
 ///
-/// Advancing the record here claims nothing new: crediting requires
-/// `delivered == committed`, so everything routed to the member has been committed
-/// (durability-gated), and the interval being carried over contained no changes for
-/// it. Two conditions keep that reasoning honest, and both are enforced below:
+/// Publishing here claims nothing new: crediting requires `delivered == committed`,
+/// so everything routed to the member has been committed (durability-gated), and the
+/// interval carried over contained no changes for it. Two conditions keep that
+/// reasoning honest:
 ///
-///   * the member must be **streaming** — a member still bootstrapping has a held
-///     floor rather than an applied position;
-///   * something must already be **durably recorded** for it
-///     ([`AckSlot::recorded`] non-zero) — otherwise there is no established
-///     durable prefix to extend, and a snapshot whose rows are not durable yet
-///     would have its floor recorded as though they were (#11896).
-///
-/// Only members whose `committed` has moved past their recorded position are
-/// written, so a busy member (whose commits already record it) costs nothing here.
-async fn flush_idle_watermarks(source: &Arc<SharedSource>) {
+///   * the member must be **streaming** — one still bootstrapping has a held floor
+///     rather than an applied position;
+///   * a position must already have been **recorded** for it ([`AckSlot::recorded`]
+///     non-zero) — otherwise there is no established durable prefix to extend, and a
+///     snapshot whose rows are not durable yet would have its floor recorded as
+///     though they were (#11896).
+fn publish_idle_positions(source: &Arc<SharedSource>) {
+    for (member_key, _) in source.live_members() {
+        let Some(slot) = source.ack.slot(&member_key) else {
+            continue;
+        };
+        if !slot.has(STREAMING) || slot.recorded() == 0 {
+            continue;
+        }
+        slot.note_pending(slot.committed());
+    }
+}
+
+/// Persist every member whose published position has moved past what is recorded,
+/// plus any left behind by a detached member. Called only from the writer task and
+/// from the pump's shutdown, which never run concurrently: the pump sets `dead`
+/// before its final flush, and the writer exits on seeing it.
+async fn write_published_positions(source: &Arc<SharedSource>) {
+    let orphans = std::mem::take(&mut *lock(&source.orphaned_positions));
+    for orphan in orphans {
+        write_one(&orphan.dataset, &orphan.store, &orphan.slot).await;
+    }
     for (member_key, member) in source.live_members() {
         let Some(slot) = source.ack.slot(&member_key) else {
             continue;
         };
-        if !slot.has(STREAMING) {
-            continue;
-        }
-        let recorded = slot.recorded();
-        let committed = slot.committed();
-        if recorded == 0 || committed <= recorded {
-            continue;
-        }
-        match member
-            .applied_lsn_store
-            .save(AppliedLsn { lsn: committed })
-            .await
-        {
-            Ok(()) => slot.note_recorded(committed),
-            Err(e) => tracing::debug!(
-                dataset = %member.dataset_name,
-                "could not carry this acceleration's recorded position forward to the slot's acknowledged position (lsn={committed}); it will be retried, and a restart before it succeeds costs one rebuild: {e}"
-            ),
-        }
+        write_one(&member.dataset_name, &member.applied_lsn_store, &slot).await;
+    }
+}
+
+async fn write_one(dataset: &str, store: &Arc<dyn AppliedLsnStore>, slot: &Arc<AckSlot>) {
+    let pending = slot.pending();
+    if pending == 0 || pending <= slot.recorded() {
+        return;
+    }
+    match store.save(AppliedLsn { lsn: pending }).await {
+        Ok(()) => slot.note_recorded(pending),
+        Err(e) => tracing::warn!(
+            dataset = %dataset,
+            "could not record how far this acceleration has been advanced (lsn={pending}); it will be retried, and a restart before it succeeds rebuilds from the source rather than resuming: {e}"
+        ),
     }
 }
 
@@ -2614,8 +2647,9 @@ async fn run_pump(source: Arc<SharedSource>) {
                 slot = %slot_name,
                 "runtime shutdown; releasing shared replication connection and slot"
             );
-            flush_idle_watermarks(&source).await;
+            publish_idle_positions(&source);
             finish_pump(&source);
+            write_published_positions(&source).await;
             drop_slot_if_ephemeral(&source).await;
             return;
         }
@@ -2726,8 +2760,9 @@ async fn run_pump(source: Arc<SharedSource>) {
                     "runtime shutdown; releasing shared replication connection and slot"
                 );
                 drop(client);
-                flush_idle_watermarks(&source).await;
+                publish_idle_positions(&source);
                 finish_pump(&source);
+                write_published_positions(&source).await;
                 // After `drop(client)`: Postgres refuses to drop a slot its
                 // walsender still holds.
                 drop_slot_if_ephemeral(&source).await;
@@ -3694,7 +3729,7 @@ async fn deliver_commit(
             slot: Arc::clone(slot),
             flush_to: boundary.end_lsn,
             dataset: member.dataset_name.clone(),
-            applied_lsn_store: Arc::clone(&member.applied_lsn_store),
+            watermark_notify: Arc::clone(&member.watermark_notify),
             is_dataset_ready: is_ready,
             first_received_at: std::time::Instant::now(),
         };
@@ -3792,7 +3827,7 @@ mod tests {
                 Some(source_commit_ts_ms),
             ),
             slot: Arc::clone(slot),
-            applied_lsn_store: Arc::new(crate::postgres_replication::NoopAppliedLsnStore),
+            watermark_notify: Arc::new(Notify::new()),
             flush_to,
             dataset: "ds".to_string(),
             is_dataset_ready: ready,
@@ -3964,6 +3999,7 @@ mod tests {
                 member_key.clone(),
                 Arc::new(MemberHandle {
                     applied_lsn_store: Arc::new(crate::postgres_replication::NoopAppliedLsnStore),
+                    watermark_notify: Arc::new(Notify::new()),
                     dataset_name: format!("ds{i}"),
                     schema: Arc::clone(&schema),
                     primary_keys: vec![],
@@ -4002,6 +4038,7 @@ mod tests {
             member_key.clone(),
             Arc::new(MemberHandle {
                 applied_lsn_store: Arc::new(crate::postgres_replication::NoopAppliedLsnStore),
+                watermark_notify: Arc::new(Notify::new()),
                 dataset_name: "users".into(),
                 schema,
                 primary_keys: vec!["id".into()],
@@ -4121,6 +4158,7 @@ mod tests {
                 member_key.clone(),
                 Arc::new(MemberHandle {
                     applied_lsn_store: Arc::new(crate::postgres_replication::NoopAppliedLsnStore),
+                    watermark_notify: Arc::new(Notify::new()),
                     dataset_name: "users".into(),
                     schema,
                     primary_keys: vec!["id".into()],
@@ -5327,7 +5365,7 @@ mod tests {
         ack.seed(10);
         ack.register(&key("a"), false);
         let committer = SharedLsnCommitter {
-            applied_lsn_store: Arc::new(crate::postgres_replication::NoopAppliedLsnStore),
+            watermark_notify: Arc::new(Notify::new()),
             slot: ack.slot(&key("a")).expect("slot registered"),
             flush_to: 42,
             dataset: "test".to_string(),
@@ -5336,6 +5374,29 @@ mod tests {
         assert!(committer.supports_deferral());
         committer.commit().await.expect("commit");
         assert_eq!(ack.flush_lsn(), 42);
+    }
+
+    /// Producers publish positions from different tasks — envelope commits, the
+    /// snapshot/rebuild boundary, and the idle sweep — and can do so out of order.
+    /// Publishing takes the max rather than storing, so a straggler is a no-op
+    /// instead of moving the position backwards; a plain store here would make the
+    /// writer persist a stale position and rebuild the acceleration on the next
+    /// start, without self-correcting until the member advanced past the lost value.
+    #[test]
+    fn a_position_published_out_of_order_never_moves_backwards() {
+        let slot = AckSlot::new(0, false);
+        assert_eq!(slot.pending(), 0, "registration publishes nothing");
+
+        slot.note_pending(200);
+        slot.note_pending(100);
+        assert_eq!(
+            slot.pending(),
+            200,
+            "a position published late but superseded must not lower what is observable"
+        );
+
+        slot.note_pending(300);
+        assert_eq!(slot.pending(), 300);
     }
 
     #[test]

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -126,7 +126,7 @@ limitations under the License.
 //!   dataset that joins later is not seated at a position a slot-mate was
 //!   credited to — above changes it never consumed (#12609). Its member takes
 //!   the hold over on registration. A hold nothing claims within
-//!   [`UNCLAIMED_RESERVATION_GRACE`] (a table left in the publication by a
+//!   the configured unclaimed-reservation grace (a table left in the publication by a
 //!   removed dataset) would pin WAL forever, so the table is dropped from the
 //!   publication — which is what makes releasing its floor safe — and logged at
 //!   ERROR.
@@ -386,7 +386,8 @@ const RECV_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1
 /// hold. Sized to comfortably cover a runtime loading many datasets — and a
 /// catalog that discovers and attaches its members over several refreshes —
 /// since expiring a hold early costs that dataset a full re-snapshot.
-const UNCLAIMED_RESERVATION_GRACE: std::time::Duration = std::time::Duration::from_mins(5);
+pub const DEFAULT_UNCLAIMED_RESERVATION_GRACE: std::time::Duration =
+    std::time::Duration::from_mins(5);
 
 /// Yield to the Tokio scheduler after draining this many buffered events via the
 /// non-blocking `try_recv` fast path. Most `handle_decoded` branches (Insert /
@@ -2588,7 +2589,7 @@ async fn run_pump(source: Arc<SharedSource>) {
                 );
                 return;
             }
-            source.release_unclaimed_reservations(UNCLAIMED_RESERVATION_GRACE);
+            source.release_unclaimed_reservations(params.unclaimed_reservation_grace);
             // Busy streams may never enter the blocking receive path, so check
             // eager deadlines once per decoded event as well as through the
             // receive timeout below. `EagerHold` caches the earliest deadline, so
@@ -3658,6 +3659,7 @@ mod tests {
             ephemeral_accelerator: false,
             status_interval: std::time::Duration::from_secs(5),
             bootstrap_batch_size: 8192,
+            unclaimed_reservation_grace: DEFAULT_UNCLAIMED_RESERVATION_GRACE,
             shared: true,
             member_channel_capacity: DEFAULT_MEMBER_CHANNEL_CAPACITY,
             pg_output_format: crate::postgres_replication::PgOutputFormat::Binary,

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -389,6 +389,17 @@ const RECV_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1
 pub const DEFAULT_UNCLAIMED_RESERVATION_GRACE: std::time::Duration =
     std::time::Duration::from_mins(5);
 
+/// How often idle members' recorded applied positions are carried forward to the
+/// slot's acknowledged position (see [`flush_idle_watermarks`]).
+///
+/// Sized against what it protects rather than against freshness: a graceful shutdown
+/// flushes on its way out, so this only bounds how stale a *crash* leaves the record,
+/// and a stale record costs one rebuild rather than a wrong resume. Long enough that
+/// a slot with many quiet tables writes rarely, short enough that a crash-looping
+/// process does not rebuild every table every time.
+pub const DEFAULT_WATERMARK_FLUSH_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(30);
+
 /// Yield to the Tokio scheduler after draining this many buffered events via the
 /// non-blocking `try_recv` fast path. Most `handle_decoded` branches (Insert /
 /// Update / Delete during a transaction) never reach a real `.await`, so a large
@@ -525,6 +536,21 @@ struct AckSlot {
     /// the [`AckTable`] write lock (register/detach/promote/snapshot-finished);
     /// read lock-free everywhere else.
     state: AtomicU8,
+    /// Highest LSN *durably recorded* in this member's applied-position store, or
+    /// 0 when nothing has been recorded for it yet.
+    ///
+    /// Set only after a store write succeeds, which is what makes it usable as a
+    /// durability gate: both committers that write it are either deferral-gated
+    /// (`SharedLsnCommitter`, held until the covering checkpoint is durable) or
+    /// deferral-refusing (`SnapshotWatermarkCommitter`, so the snapshot's rows are
+    /// durable before its watermark claims them). A non-zero value therefore means
+    /// "everything at or below this LSN is durably in the acceleration", which is
+    /// the premise [`flush_idle_watermarks`] needs before it may carry the position
+    /// forward over an interval that contained nothing to apply.
+    ///
+    /// Still within the one 64-byte line this type is aligned to (25 of 64 bytes
+    /// used), so it adds no false sharing.
+    recorded: AtomicU64,
 }
 
 impl AckSlot {
@@ -533,6 +559,7 @@ impl AckSlot {
             committed: AtomicU64::new(at),
             delivered: AtomicU64::new(at),
             state: AtomicU8::new(LIVE | if snapshotting { SNAPSHOTTING } else { 0 }),
+            recorded: AtomicU64::new(0),
         }
     }
 
@@ -545,6 +572,7 @@ impl AckSlot {
             committed: AtomicU64::new(at),
             delivered: AtomicU64::new(at),
             state: AtomicU8::new(0),
+            recorded: AtomicU64::new(0),
         }
     }
 
@@ -554,6 +582,18 @@ impl AckSlot {
 
     fn delivered(&self) -> u64 {
         self.delivered.load(Ordering::Acquire)
+    }
+
+    /// The highest position durably recorded for this member, 0 if none.
+    fn recorded(&self) -> u64 {
+        self.recorded.load(Ordering::Acquire)
+    }
+
+    /// Note that `lsn` is now durably recorded for this member (monotonic). Called
+    /// after a successful store write, and once at attach for a member resuming on
+    /// a position a previous process recorded.
+    fn note_recorded(&self, lsn: u64) {
+        advance_monotonic(&self.recorded, lsn);
     }
 
     /// Advance this member's committed floor (monotonic). Called lock-free from
@@ -827,16 +867,19 @@ impl CommitChange for SharedLsnCommitter {
         // watermark only ever costs a redundant rebuild on the next start —
         // whereas a watermark ahead of durable data would resume past changes
         // the acceleration does not hold.
-        if let Err(e) = self
+        match self
             .applied_lsn_store
             .save(AppliedLsn { lsn: self.flush_to })
             .await
         {
-            tracing::warn!(
+            // Marks the position durable so idle crediting may carry it forward
+            // later without a further write (see `flush_idle_watermarks`).
+            Ok(()) => self.slot.note_recorded(self.flush_to),
+            Err(e) => tracing::warn!(
                 dataset = %self.dataset,
                 "could not record how far this acceleration has been advanced (lsn={}); if the process restarts before this succeeds, the acceleration is rebuilt from the source rather than resumed: {e}",
                 self.flush_to,
-            );
+            ),
         }
         crate::cdc::log_committer_progress(
             "postgres",
@@ -887,6 +930,7 @@ impl CommitChange for SharedLsnCommitter {
 fn snapshot_watermark_envelope(
     schema: &SchemaRef,
     applied_lsn_store: Arc<dyn AppliedLsnStore>,
+    slot: Option<Arc<AckSlot>>,
     lsn: u64,
     dataset: String,
     history_unavailable: bool,
@@ -898,6 +942,7 @@ fn snapshot_watermark_envelope(
     Ok(ChangeEnvelope::from_parts(
         Box::new(SnapshotWatermarkCommitter {
             applied_lsn_store,
+            slot,
             lsn,
             dataset,
         }),
@@ -924,6 +969,13 @@ fn snapshot_watermark_envelope(
 /// `mysql_replication`'s snapshot-boundary committer.
 struct SnapshotWatermarkCommitter {
     applied_lsn_store: Arc<dyn AppliedLsnStore>,
+    /// The member's ack slot, so a successful write marks the position durable for
+    /// [`flush_idle_watermarks`]. Carried by both boundary envelopes — a snapshot's
+    /// and a rebuild's — because for a table that then sees no changes this is the
+    /// only thing that ever records a position, and without it the member could never
+    /// carry that position forward over idle intervals. `Option` only because the
+    /// envelope is also built in tests without a slot.
+    slot: Option<Arc<AckSlot>>,
     /// The LSN the snapshot's contents are complete as of: the slot's consistent
     /// point, which is at or before the snapshot's visibility. Undershooting is
     /// safe — replay from it re-delivers changes the snapshot already reflects —
@@ -935,16 +987,21 @@ struct SnapshotWatermarkCommitter {
 #[async_trait]
 impl CommitChange for SnapshotWatermarkCommitter {
     async fn commit(&self) -> std::result::Result<(), CommitError> {
-        if let Err(e) = self
+        match self
             .applied_lsn_store
             .save(AppliedLsn { lsn: self.lsn })
             .await
         {
-            tracing::warn!(
+            Ok(()) => {
+                if let Some(slot) = &self.slot {
+                    slot.note_recorded(self.lsn);
+                }
+            }
+            Err(e) => tracing::warn!(
                 dataset = %self.dataset,
                 "could not record the snapshot's applied position (lsn={}); the acceleration is correct, but a restart before the next acknowledgement will rebuild it from the source rather than resume: {e}",
                 self.lsn,
-            );
+            ),
         }
         crate::cdc::log_committer_progress(
             "postgres",
@@ -1935,7 +1992,7 @@ async fn attach_member(
     }
 
     // Slot + publication DDL (idempotent, retried on transient errors).
-    let mut setup = slot::setup_shared_member(&source.params, &schema_name, &table_name).await?;
+    let setup = slot::setup_shared_member(&source.params, &schema_name, &table_name).await?;
     if setup.slot.created_fresh {
         source.slot_created_fresh.store(true, Ordering::Release);
     }
@@ -2013,37 +2070,41 @@ async fn attach_member(
             "this acceleration persists across restarts but has nowhere to record how far it has been advanced, so a replication slot that is dropped or invalidated cannot be detected and rows deleted at the source while it was gone would survive here"
         );
     }
+    // The earliest position this slot can actually stream from, which is *not* the
+    // same as the earliest it still retains. Postgres forwards a `START_REPLICATION`
+    // position below the slot's `confirmed_flush_lsn` up to it ("has been already
+    // streamed, forwarding to ..." in `CreateDecodingContext`), so once the slot has
+    // acknowledged past a change, no client can ask for it again — the WAL may still
+    // be on disk under `restart_lsn`, but it is unreachable through this slot.
+    // Comparing the watermark against `restart_lsn` alone would therefore call an
+    // unfillable gap resumable and skip the difference silently.
+    let earliest_streamable_lsn = setup
+        .slot_restart_lsn
+        .map(|restart_lsn| restart_lsn.max(setup.slot.consistent_lsn));
     let rebuild_via_consumer = super::needs_rebuild(
         &watermark,
-        setup.slot_restart_lsn,
+        earliest_streamable_lsn,
         !params.ephemeral_accelerator && tracks_positions,
     );
 
-    // Resume from the watermark, not from the server's acknowledged position,
-    // whenever the watermark is behind it.
-    //
-    // The two can disagree: the slot ack is advanced by the same commit that
-    // records the watermark, but the ack reaches the server through the pump's
-    // status updates while the watermark is a local write that can fail or be
-    // interrupted. The server's `confirmed_flush_lsn` is what streaming would
-    // otherwise resume from, so a watermark behind it means the interval between
-    // them was acknowledged but never recorded as applied — and resuming at the
-    // server's position would skip it silently. The WAL for that interval is
-    // still retained (`restart_lsn` is at or before the watermark, or this would
-    // have been a rebuild), so replaying it is both possible and idempotent
-    // through the primary-key upsert.
-    if let super::RecordedPosition::At(watermark) = &watermark
-        && !rebuild_via_consumer
-        && setup.slot.consistent_lsn > watermark.lsn
-    {
-        tracing::warn!(
-            dataset = %dataset_name,
-            server_position = %slot::format_lsn(setup.slot.consistent_lsn),
-            recorded_position = %slot::format_lsn(watermark.lsn),
-            "this slot was acknowledged past what the acceleration recorded as applied, so streaming resumes from the recorded position and replays the difference rather than skipping it"
-        );
-        setup.slot.consistent_lsn = watermark.lsn;
-    }
+    // Why the rebuild, in the terms the operator can act on. The four causes are
+    // genuinely different situations, and the acknowledged-past one is the easiest to
+    // mistake for a retention problem: the WAL is still on disk, but a slot cannot
+    // re-stream what it has already acknowledged.
+    let rebuild_reason = match &watermark {
+        super::RecordedPosition::Absent => {
+            "it has no recorded position, so the rows it already holds cannot be shown to be current"
+        }
+        super::RecordedPosition::ForeignSource => {
+            "the position it recorded belongs to a different source, so it does not describe these rows"
+        }
+        super::RecordedPosition::At(watermark) if setup.slot.consistent_lsn > watermark.lsn => {
+            "the slot has been acknowledged past the position it recorded as applied, so the changes in between can no longer be streamed from it"
+        }
+        super::RecordedPosition::At(_) => {
+            "the slot no longer retains the changes following the position it recorded as applied"
+        }
+    };
 
     let (sender, receiver) = member_mailbox(params.member_channel_capacity);
     // Grouping signal for the analysis: record which shared slot this dataset joined.
@@ -2054,6 +2115,16 @@ async fn attach_member(
     // owed starts where the slot resumed, not where a slot-mate was credited.
     source.ack.register(&member_key, snapshotting);
     source.claim_reservation(&member_key);
+    let ack_slot = source.ack.slot(&member_key);
+    // A member resuming on a position a previous process recorded already has a
+    // durable position, even though nothing has been committed in *this* process.
+    // Seeding it lets an idle member carry that position forward (see
+    // `flush_idle_watermarks`) instead of waiting for a change that may never come.
+    if let (Some(slot), super::RecordedPosition::At(resumed)) = (&ack_slot, &watermark)
+        && !rebuild_via_consumer
+    {
+        slot.note_recorded(resumed.lsn);
+    }
     lock(&source.members).insert(
         member_key.clone(),
         Arc::new(MemberHandle {
@@ -2098,6 +2169,10 @@ async fn attach_member(
     if !source.pump_started.swap(true, Ordering::AcqRel) {
         let pump_source = Arc::clone(source);
         tokio::spawn(run_pump(pump_source));
+        tokio::spawn(run_watermark_flusher(
+            Arc::clone(source),
+            params.watermark_flush_interval,
+        ));
     } else if !snapshotting {
         // A resuming/rejoining member needs the pump to reconnect so Postgres
         // re-sends Relation messages (and replays its held WAL) — joins
@@ -2156,6 +2231,7 @@ async fn attach_member(
         let signal_item = snapshot_watermark_envelope(
             &schema,
             Arc::clone(&applied_lsn_store),
+            ack_slot,
             setup.slot.consistent_lsn,
             dataset_name.clone(),
             true,
@@ -2165,7 +2241,12 @@ async fn attach_member(
             dataset = %dataset_name,
             table = %format_member(&member_key),
             slot = %source.key.slot_name,
-            "this replication slot has no history for the table, and the acceleration persists across restarts, so it will be rebuilt from the source before changes are applied"
+            recorded_position = %match &watermark {
+                super::RecordedPosition::At(watermark) => slot::format_lsn(watermark.lsn),
+                _ => "none".to_string(),
+            },
+            slot_acknowledged_position = %slot::format_lsn(setup.slot.consistent_lsn),
+            "this acceleration will be rebuilt from the source before changes are applied: {rebuild_reason}"
         );
         // No snapshot runs on this path — the consumer's reload replaces it — so
         // the gauge's documented "finished, or skipped" state is reached here.
@@ -2177,6 +2258,7 @@ async fn attach_member(
         let watermark_boundary = snapshot_watermark_envelope(
             &schema,
             Arc::clone(&applied_lsn_store),
+            ack_slot,
             setup.slot.consistent_lsn,
             dataset_name.clone(),
             false,
@@ -2318,6 +2400,81 @@ async fn member_fatal(source: &Arc<SharedSource>, key: &MemberKey, message: Stri
 
 /// Mark the source dead and drop it from the registry (only if the registry
 /// still points at this instance — a replacement may already exist).
+/// Periodically carry idle members' recorded positions forward, off the pump's
+/// decode path, until the pump is done.
+///
+/// A dedicated task rather than work inside the pump loop: the store write is I/O
+/// against the dataset's own accelerator, and the pump must reach an `.await` on the
+/// replication socket promptly or it stalls decode for every member on the slot.
+/// One task per source, ticking sequentially, also means no two flushes can overlap.
+///
+/// The tick is coarse on purpose — see `watermark_flush_interval`. A graceful
+/// shutdown does not rely on it: the pump flushes once more on its way out, so an
+/// ordinary restart resumes exactly. After a crash the record can be up to one tick
+/// behind what the slot acknowledged, which costs one rebuild and never a wrong
+/// resume.
+async fn run_watermark_flusher(source: Arc<SharedSource>, interval: std::time::Duration) {
+    loop {
+        tokio::time::sleep(interval).await;
+        if source.dead.load(Ordering::Acquire) {
+            flush_idle_watermarks(&source).await;
+            return;
+        }
+        flush_idle_watermarks(&source).await;
+    }
+}
+
+/// Carry each idle member's durably-recorded position forward to what the slot has
+/// acknowledged on its behalf.
+///
+/// The slot's acknowledgement advances for a member that had nothing to apply, via
+/// [`AckTable::credit_idle`], which routes no envelope and therefore runs no
+/// committer and records nothing. Left alone the two drift apart for any quiet
+/// table, and the next start reads a recorded position behind the slot's
+/// `confirmed_flush_lsn` — indistinguishable from changes acknowledged but never
+/// applied, so a healthy acceleration is rebuilt on every restart.
+///
+/// Advancing the record here claims nothing new: crediting requires
+/// `delivered == committed`, so everything routed to the member has been committed
+/// (durability-gated), and the interval being carried over contained no changes for
+/// it. Two conditions keep that reasoning honest, and both are enforced below:
+///
+///   * the member must be **streaming** — a member still bootstrapping has a held
+///     floor rather than an applied position;
+///   * something must already be **durably recorded** for it
+///     ([`AckSlot::recorded`] non-zero) — otherwise there is no established
+///     durable prefix to extend, and a snapshot whose rows are not durable yet
+///     would have its floor recorded as though they were (#11896).
+///
+/// Only members whose `committed` has moved past their recorded position are
+/// written, so a busy member (whose commits already record it) costs nothing here.
+async fn flush_idle_watermarks(source: &Arc<SharedSource>) {
+    for (member_key, member) in source.live_members() {
+        let Some(slot) = source.ack.slot(&member_key) else {
+            continue;
+        };
+        if !slot.has(STREAMING) {
+            continue;
+        }
+        let recorded = slot.recorded();
+        let committed = slot.committed();
+        if recorded == 0 || committed <= recorded {
+            continue;
+        }
+        match member
+            .applied_lsn_store
+            .save(AppliedLsn { lsn: committed })
+            .await
+        {
+            Ok(()) => slot.note_recorded(committed),
+            Err(e) => tracing::debug!(
+                dataset = %member.dataset_name,
+                "could not carry this acceleration's recorded position forward to the slot's acknowledged position (lsn={committed}); it will be retried, and a restart before it succeeds costs one rebuild: {e}"
+            ),
+        }
+    }
+}
+
 fn finish_pump(source: &Arc<SharedSource>) {
     source.dead.store(true, Ordering::Release);
     for (_, member) in source.live_members() {
@@ -2457,6 +2614,7 @@ async fn run_pump(source: Arc<SharedSource>) {
                 slot = %slot_name,
                 "runtime shutdown; releasing shared replication connection and slot"
             );
+            flush_idle_watermarks(&source).await;
             finish_pump(&source);
             drop_slot_if_ephemeral(&source).await;
             return;
@@ -2568,6 +2726,7 @@ async fn run_pump(source: Arc<SharedSource>) {
                     "runtime shutdown; releasing shared replication connection and slot"
                 );
                 drop(client);
+                flush_idle_watermarks(&source).await;
                 finish_pump(&source);
                 // After `drop(client)`: Postgres refuses to drop a slot its
                 // walsender still holds.
@@ -3658,6 +3817,7 @@ mod tests {
             snapshot_on_resume: false,
             ephemeral_accelerator: false,
             status_interval: std::time::Duration::from_secs(5),
+            watermark_flush_interval: std::time::Duration::from_secs(30),
             bootstrap_batch_size: 8192,
             unclaimed_reservation_grace: DEFAULT_UNCLAIMED_RESERVATION_GRACE,
             shared: true,

--- a/crates/data_components/src/postgres_replication/slot.rs
+++ b/crates/data_components/src/postgres_replication/slot.rs
@@ -95,9 +95,17 @@ pub struct SharedMemberSetup {
     /// has subscribed yet — the caller holds the ack floor for the ones that
     /// have not, so their changes are not acked away before they join.
     pub publication_tables: Vec<(String, String)>,
-    /// The earliest LSN this slot can still stream from — see
-    /// [`read_slot_restart_lsn`] — read *after* the slot is ensured, so a slot
-    /// just created reports its own creation point rather than `None`.
+    /// The earliest LSN this slot still *retains* — see [`read_slot_restart_lsn`]
+    /// — read *after* the slot is ensured, so a slot just created reports its own
+    /// creation point rather than `None`.
+    ///
+    /// This is **not** the earliest LSN the slot can be streamed from, and must not
+    /// be used as one: Postgres forwards a `START_REPLICATION` position below the
+    /// slot's `confirmed_flush_lsn` up to it (`CreateDecodingContext`), so an
+    /// acknowledged change can never be re-streamed even while its WAL is retained
+    /// here. Anything deciding whether a position is still reachable wants the later
+    /// of this and `confirmed_flush_lsn`; using retention alone reads an unfillable
+    /// gap as resumable and skips it silently (#11289).
     ///
     /// `None` only when the slot does not exist, which cannot normally follow
     /// `ensure_slot`; it is carried as an `Option` so a slot dropped underneath

--- a/crates/runtime/tests/postgres/replication.rs
+++ b/crates/runtime/tests/postgres/replication.rs
@@ -78,6 +78,8 @@ fn params_for(port: u16, slot_name: &str, publication_name: &str) -> Replication
         member_channel_capacity:
             data_components::postgres_replication::shared::DEFAULT_MEMBER_CHANNEL_CAPACITY,
         pg_output_format: PgOutputFormat::Binary,
+        unclaimed_reservation_grace:
+            data_components::postgres_replication::shared::DEFAULT_UNCLAIMED_RESERVATION_GRACE,
         ready_lag: Duration::from_secs(2),
     }
 }

--- a/crates/runtime/tests/postgres/replication.rs
+++ b/crates/runtime/tests/postgres/replication.rs
@@ -80,6 +80,8 @@ fn params_for(port: u16, slot_name: &str, publication_name: &str) -> Replication
         pg_output_format: PgOutputFormat::Binary,
         unclaimed_reservation_grace:
             data_components::postgres_replication::shared::DEFAULT_UNCLAIMED_RESERVATION_GRACE,
+        watermark_flush_interval:
+            data_components::postgres_replication::shared::DEFAULT_WATERMARK_FLUSH_INTERVAL,
         ready_lag: Duration::from_secs(2),
     }
 }

--- a/crates/runtime/tests/postgres/replication_shared.rs
+++ b/crates/runtime/tests/postgres/replication_shared.rs
@@ -38,8 +38,9 @@ use arrow::array::{Array, AsArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use data_components::cdc::{ChangeEnvelope, ChangesStream};
 use data_components::postgres_replication::{
-    NoopAppliedLsnStore, PgOutputFormat, ReplicationMetricsCollector, ReplicationParams,
-    ReplicationStreamInput, SchemaEvolutionPolicy, config, start_replication_stream,
+    AppliedLsn, AppliedLsnStore, NoopAppliedLsnStore, PgOutputFormat, RecordedPosition,
+    ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput, SchemaEvolutionPolicy,
+    config, start_replication_stream,
 };
 use futures::StreamExt;
 use secrecy::SecretString;
@@ -83,6 +84,8 @@ fn shared_params(port: u16) -> ReplicationParams {
         member_channel_capacity:
             data_components::postgres_replication::shared::DEFAULT_MEMBER_CHANNEL_CAPACITY,
         pg_output_format: PgOutputFormat::Binary,
+        unclaimed_reservation_grace:
+            data_components::postgres_replication::shared::DEFAULT_UNCLAIMED_RESERVATION_GRACE,
         ready_lag: Duration::from_secs(2),
     }
 }
@@ -111,6 +114,81 @@ fn independent_input(port: u16, table: &str) -> ReplicationStreamInput {
         policy: SchemaEvolutionPolicy::Block,
         applied_lsn_store: Arc::new(NoopAppliedLsnStore),
     }
+}
+
+/// An [`AppliedLsnStore`] held in memory, for exercising the watermark paths in
+/// this suite.
+///
+/// The default `NoopAppliedLsnStore` reports that it records nothing, which
+/// makes a missing watermark uninformative by design — so with it, none of the
+/// gap detection below can be reached. This records positions like the real
+/// sidecar does, and survives across `start_replication_stream` calls in one
+/// test so a "restart" can read what the previous stream wrote.
+#[derive(Default)]
+struct InMemoryAppliedLsnStore {
+    recorded: std::sync::Mutex<Option<AppliedLsn>>,
+}
+
+impl InMemoryAppliedLsnStore {
+    fn shared() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// A store that already holds `lsn`, for modelling an acceleration whose
+    /// recorded position is *behind* where the slot has got to — a dataset
+    /// re-added after its reservation lapsed, or one whose last acknowledgement
+    /// never reached its local record.
+    fn seeded(lsn: u64) -> Arc<Self> {
+        let store = Self::default();
+        *store.recorded.lock().expect("watermark mutex") = Some(AppliedLsn { lsn });
+        Arc::new(store)
+    }
+
+    fn recorded_lsn(&self) -> Option<u64> {
+        self.recorded
+            .lock()
+            .expect("watermark mutex")
+            .map(|applied| applied.lsn)
+    }
+}
+
+#[async_trait::async_trait]
+impl AppliedLsnStore for InMemoryAppliedLsnStore {
+    async fn load(
+        &self,
+    ) -> std::result::Result<RecordedPosition, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(self
+            .recorded
+            .lock()
+            .expect("watermark mutex")
+            .map_or(RecordedPosition::Absent, RecordedPosition::At))
+    }
+
+    async fn save(
+        &self,
+        applied: AppliedLsn,
+    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        *self.recorded.lock().expect("watermark mutex") = Some(applied);
+        Ok(())
+    }
+
+    async fn clear(&self) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        *self.recorded.lock().expect("watermark mutex") = None;
+        Ok(())
+    }
+}
+
+/// [`input_for`] with a watermark store that actually records, so the gap
+/// decision is reachable. Pass the same store across two streams to model a
+/// restart against acceleration files that survived.
+fn input_with_watermark(
+    port: u16,
+    table: &str,
+    store: &Arc<InMemoryAppliedLsnStore>,
+) -> ReplicationStreamInput {
+    let mut input = input_for(port, table);
+    input.applied_lsn_store = Arc::clone(store) as Arc<dyn AppliedLsnStore>;
+    input
 }
 
 fn input_with_schema(port: u16, table: &str, schema: SchemaRef) -> ReplicationStreamInput {
@@ -1073,6 +1151,234 @@ async fn slot_acked_past(
         )
         .await?;
     Ok((row.get(0), row.get(1)))
+}
+
+/// Regression for #11896: a durable acceleration whose CDC bootstrap was lost to
+/// a crash before it became durable must be re-loaded, not resumed over.
+///
+/// The reported failure was that the slot's *existence* suppressed the
+/// re-bootstrap: after a hard kill before the mem-tier seal, the acceleration was
+/// empty, the slot was already there, `need_snapshot` was therefore false, and no
+/// pass ever reconciled against the source — so the rows were gone permanently.
+///
+/// A crash before the seal is reproducible without killing anything: durability
+/// is what gates the acknowledgement, so an unsealed bootstrap is exactly a
+/// bootstrap whose envelopes were never committed. Dropping the stream without
+/// committing leaves the same state a `SIGKILL` would — the slot exists, nothing
+/// was acknowledged, and no position was recorded.
+///
+/// The acceleration must then be re-loaded (a fresh snapshot) or asked to rebuild.
+/// Resuming is the failure.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_bootstrap_lost_before_it_was_durable_is_reloaded_not_resumed()
+-> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("data_components::postgres_replication=debug,info"));
+
+    let port = common::get_random_port()?;
+    let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+    let port = u16::try_from(port).expect("port fits in u16");
+    let source = pg_client(port).await?;
+
+    create_table(&source, "lost_bootstrap", &[(1, "alice"), (2, "bob")]).await?;
+
+    // --- 1. First start: nothing has been recorded for this durable acceleration,
+    // so it is asked to load from the source rather than resume. Nothing is
+    // committed — the acknowledgement is what durability gates, so this leaves the
+    // state a crash before the seal leaves behind. ---
+    let store = InMemoryAppliedLsnStore::shared();
+    let mut first = start_replication_stream(input_with_watermark(port, "lost_bootstrap", &store));
+    let opening = next_envelope(&mut first, "first envelope before the crash").await?;
+    anyhow::ensure!(
+        opening.history_unavailable(),
+        "a durable acceleration with nothing recorded must be asked to load from the source"
+    );
+    drop(opening); // never committed — nothing became durable, nothing was recorded
+    drop(first);
+    wait_for_walsender_count(&source, 0).await?;
+
+    // The slot survives the crash, which is what used to suppress the re-load.
+    assert_eq!(slot_count(&source).await?, 1, "the slot must persist");
+    anyhow::ensure!(
+        store.recorded_lsn().is_none(),
+        "nothing may have been recorded: the acknowledgement that records a position is gated on \
+         the durability this test is simulating the loss of"
+    );
+
+    // --- 2. Restart against the same (durable, now empty) acceleration. It must
+    // be re-loaded rather than resumed. ---
+    let mut restarted =
+        start_replication_stream(input_with_watermark(port, "lost_bootstrap", &store));
+    let envelope = next_envelope(&mut restarted, "first envelope after the restart").await?;
+    let reloaded = envelope.history_unavailable() || num_rows(&envelope) == 2;
+    anyhow::ensure!(
+        reloaded,
+        "a durable acceleration whose load was lost before it became durable was neither \
+         re-snapshotted nor asked to rebuild — its rows are gone permanently (#11896). The slot's \
+         existence must not suppress the re-load. First envelope carried {} row(s), \
+         history_unavailable={}",
+        num_rows(&envelope),
+        envelope.history_unavailable()
+    );
+    envelope.commit().await?;
+
+    drop(restarted);
+    wait_for_walsender_count(&source, 0).await?;
+    drop_replication_slot_when_inactive(&source, SLOT).await?;
+    source
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {PUBLICATION}"))
+        .await?;
+    Ok(())
+}
+
+/// Regression for #11289 variant 2: a dataset removed from the Spicepod, whose
+/// table stays in the publication, must not silently miss the changes committed
+/// while it was gone once the slot's hold on its behalf lapses.
+///
+/// Reproducing this needs both halves of the protection to be absent, which is
+/// why a simpler construction does not work:
+///
+///   * **A real restart.** A merely detached member keeps its `AckSlot`, and
+///     `flush_lsn` is the minimum over *all* members including held ones — so its
+///     frozen floor pins the slot and nothing can ack past it. Every stream has
+///     to go away so the source, and its `AckTable`, are discarded.
+///   * **A lapsed reservation.** On the next attach the slot reserves the floor
+///     for every published table with no member, which protects the absent one
+///     until the grace expires. `unclaimed_reservation_grace` is shortened here
+///     because the behavior after expiry is otherwise unreachable in under five
+///     minutes.
+///
+/// Once both are gone the surviving member's traffic carries the slot's
+/// acknowledgement past the absent table's change. Rejoining must then either
+/// deliver that change or ask for a rebuild — what it must never do is resume
+/// into live traffic as if nothing were missing.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_dataset_re_added_after_its_reservation_lapsed_does_not_silently_skip_changes()
+-> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("data_components::postgres_replication=debug,info"));
+
+    let port = common::get_random_port()?;
+    let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+    let port = u16::try_from(port).expect("port fits in u16");
+    let source = pg_client(port).await?;
+
+    create_table(&source, "lapsed_mate", &[(1, "mate1")]).await?;
+    create_table(&source, "lapsed_absent", &[(1, "absent1")]).await?;
+
+    // Shorten the hold so expiry is reachable. It is read from the params of
+    // whichever member opens the slot, so both members carry it.
+    let brief_grace = Duration::from_secs(2);
+    let short_grace = |mut input: ReplicationStreamInput| {
+        input.params.unclaimed_reservation_grace = brief_grace;
+        input
+    };
+
+    // --- 1. Both tables join, establishing publication membership, slot history,
+    // and a recorded position for the table that is about to disappear. ---
+    let absent_store = InMemoryAppliedLsnStore::shared();
+    let mut mate = start_replication_stream(short_grace(input_for(port, "lapsed_mate")));
+    next_envelope(&mut mate, "bootstrap mate")
+        .await?
+        .commit()
+        .await?;
+
+    let mut absent = start_replication_stream(short_grace(input_with_watermark(
+        port,
+        "lapsed_absent",
+        &absent_store,
+    )));
+    next_envelope(&mut absent, "bootstrap absent")
+        .await?
+        .commit()
+        .await?;
+    wait_for_ready(&mut absent, "absent readiness")
+        .await?
+        .commit()
+        .await?;
+    let recorded = absent_store
+        .recorded_lsn()
+        .ok_or_else(|| anyhow::anyhow!("the member must record a position while attached"))?;
+
+    // --- 2. A restart: every stream goes away, so the pump exits and the source
+    // (with its AckTable and every held floor) is discarded. The slot and the
+    // publication both persist, which is what makes this a restart. ---
+    drop(mate);
+    drop(absent);
+    wait_for_walsender_count(&source, 0).await?;
+    assert_eq!(slot_count(&source).await?, 1, "the slot must persist");
+
+    // --- 3. The absent table changes while nothing is consuming it. ---
+    source
+        .simple_query("INSERT INTO public.lapsed_absent VALUES (2, 'missed-while-removed')")
+        .await?;
+    let missed_lsn: String = source
+        .query_one("SELECT pg_current_wal_lsn()::text", &[])
+        .await?
+        .get(0);
+
+    // --- 4. Only the surviving dataset comes back. Its attach reserves the floor
+    // for the absent table; after the grace lapses, its own traffic carries the
+    // slot's acknowledgement past the missed change. ---
+    let mut mate = start_replication_stream(short_grace(input_for(port, "lapsed_mate")));
+    expect_single_change(&mut mate, "mate resume", "c", 1)
+        .await
+        .or_else(|_| Ok::<(), anyhow::Error>(()))?;
+
+    // Committing the mate's envelopes — including its idle heartbeats — is what
+    // carries the slot's acknowledgement forward; the reservation for the absent
+    // table has to lapse first, which is why the grace is shortened above.
+    let deadline = std::time::Instant::now() + Duration::from_mins(1);
+    let mut acked_past = false;
+    let mut churn_id = 100;
+    while std::time::Instant::now() < deadline {
+        churn_id += 1;
+        source
+            .execute(
+                "INSERT INTO public.lapsed_mate (id, name) VALUES ($1, 'mate-churn')",
+                &[&churn_id],
+            )
+            .await?;
+        if let Ok(envelope) = next_envelope(&mut mate, "mate churn").await {
+            envelope.commit().await?;
+        }
+        let (past, _) = slot_acked_past(&source, &missed_lsn).await?;
+        if past {
+            acked_past = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    anyhow::ensure!(
+        acked_past,
+        "the test could not reach the state it exists to cover: the slot never acknowledged past \
+         the absent table's change, so the reservation never lapsed"
+    );
+
+    // --- 5. The dataset is re-added, carrying the position it recorded before it
+    // left. Either outcome is correct; resuming into live traffic is not. ---
+    let mut re_added = start_replication_stream(short_grace(input_with_watermark(
+        port,
+        "lapsed_absent",
+        &InMemoryAppliedLsnStore::seeded(recorded),
+    )));
+    let envelope = next_envelope(&mut re_added, "re-added dataset's first envelope").await?;
+    let recovered = envelope.history_unavailable() || ids_of(&envelope).contains(&2);
+    anyhow::ensure!(
+        recovered,
+        "a dataset re-added after its reservation lapsed neither received the change committed \
+         while it was gone (id=2) nor asked to be rebuilt — it resumed as if nothing were missing \
+         (#11289). First envelope carried ids {:?}",
+        ids_of(&envelope)
+    );
+    envelope.commit().await?;
+
+    drop(mate);
+    drop(re_added);
+    wait_for_walsender_count(&source, 0).await?;
+    drop_replication_slot_when_inactive(&source, SLOT).await?;
+    source
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {PUBLICATION}"))
+        .await?;
+    Ok(())
 }
 
 /// Regression for #12609: on a shared slot that is *resuming* — every member

--- a/crates/runtime/tests/postgres/replication_shared.rs
+++ b/crates/runtime/tests/postgres/replication_shared.rs
@@ -86,6 +86,9 @@ fn shared_params(port: u16) -> ReplicationParams {
         pg_output_format: PgOutputFormat::Binary,
         unclaimed_reservation_grace:
             data_components::postgres_replication::shared::DEFAULT_UNCLAIMED_RESERVATION_GRACE,
+        // Short enough that the idle carry-forward is exercised within a test rather
+        // than waited on; the production default is coarse on purpose.
+        watermark_flush_interval: Duration::from_secs(1),
         ready_lag: Duration::from_secs(2),
     }
 }
@@ -127,6 +130,9 @@ fn independent_input(port: u16, table: &str) -> ReplicationStreamInput {
 #[derive(Default)]
 struct InMemoryAppliedLsnStore {
     recorded: std::sync::Mutex<Option<AppliedLsn>>,
+    /// Successful writes, so a test can assert on how *often* a position is
+    /// recorded and not only on its value.
+    saves: std::sync::atomic::AtomicUsize,
 }
 
 impl InMemoryAppliedLsnStore {
@@ -150,6 +156,10 @@ impl InMemoryAppliedLsnStore {
             .expect("watermark mutex")
             .map(|applied| applied.lsn)
     }
+
+    fn saves(&self) -> usize {
+        self.saves.load(std::sync::atomic::Ordering::Acquire)
+    }
 }
 
 #[async_trait::async_trait]
@@ -169,6 +179,7 @@ impl AppliedLsnStore for InMemoryAppliedLsnStore {
         applied: AppliedLsn,
     ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
         *self.recorded.lock().expect("watermark mutex") = Some(applied);
+        self.saves.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
         Ok(())
     }
 
@@ -1136,6 +1147,11 @@ async fn shared_and_independent_slots_coexist() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Postgres `pg_lsn` text form of a numeric LSN, for comparisons in SQL.
+fn lsn_text(lsn: u64) -> String {
+    format!("{:X}/{:X}", lsn >> 32, lsn & 0xFFFF_FFFF)
+}
+
 /// Whether the slot has acknowledged everything up to `lsn` — the point past
 /// which Postgres is free to recycle that WAL. Returns the verdict and the
 /// slot's current `confirmed_flush_lsn` for the assertion message.
@@ -1218,6 +1234,140 @@ async fn a_bootstrap_lost_before_it_was_durable_is_reloaded_not_resumed()
          history_unavailable={}",
         num_rows(&envelope),
         envelope.history_unavailable()
+    );
+    envelope.commit().await?;
+
+    drop(restarted);
+    wait_for_walsender_count(&source, 0).await?;
+    drop_replication_slot_when_inactive(&source, SLOT).await?;
+    source
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {PUBLICATION}"))
+        .await?;
+    Ok(())
+}
+
+/// The counterpart to the rebuild tests: a dataset that simply restarts must
+/// **resume**, not rebuild. Without this, a rule that classifies gaps too eagerly
+/// passes every rebuild test while re-reading the whole table on every restart.
+///
+/// The case that makes this easy to get wrong is a *quiet* table. The slot's
+/// acknowledgement is advanced for an idle member by the pump's keepalive crediting,
+/// which routes no envelope and therefore records no watermark — so the slot's
+/// `confirmed_flush_lsn` legitimately drifts ahead of the last position the
+/// acceleration recorded as applied. That drift is not a gap: crediting only covers
+/// WAL that contained no changes for this table. Treating it as one would rebuild a
+/// healthy acceleration on every restart.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_quiet_dataset_resumes_across_a_restart_rather_than_rebuilding()
+-> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("data_components::postgres_replication=debug,info"));
+
+    let port = common::get_random_port()?;
+    let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+    let port = u16::try_from(port).expect("port fits in u16");
+    let source = pg_client(port).await?;
+
+    create_table(&source, "quiet", &[(1, "one")]).await?;
+
+    // --- 1. Bootstrap and commit, so a position is recorded, then let the table go
+    // quiet while a second table's traffic keeps the slot acknowledging forward. ---
+    let store = InMemoryAppliedLsnStore::shared();
+    let mut quiet = start_replication_stream(input_with_watermark(port, "quiet", &store));
+    next_envelope(&mut quiet, "bootstrap quiet")
+        .await?
+        .commit()
+        .await?;
+    wait_for_ready(&mut quiet, "quiet readiness")
+        .await?
+        .commit()
+        .await?;
+    let recorded = store
+        .recorded_lsn()
+        .ok_or_else(|| anyhow::anyhow!("the member must record a position while attached"))?;
+
+    // Drive the slot's acknowledgement past the quiet table's recorded position using
+    // WAL that contains nothing for it. This is the benign drift the rule must not
+    // mistake for a gap; the test asserts it was actually reached.
+    let flush_every = input_for(port, "quiet").params.watermark_flush_interval;
+    let drift_started = std::time::Instant::now();
+    create_table(&source, "noisy", &[(1, "n1")]).await?;
+    let mut noisy = start_replication_stream(input_for(port, "noisy"));
+    next_envelope(&mut noisy, "bootstrap noisy")
+        .await?
+        .commit()
+        .await?;
+
+    let deadline = std::time::Instant::now() + Duration::from_mins(1);
+    let mut drifted = false;
+    let mut churn_id = 100;
+    while std::time::Instant::now() < deadline {
+        churn_id += 1;
+        source
+            .execute(
+                "INSERT INTO public.noisy (id, name) VALUES ($1, 'churn')",
+                &[&churn_id],
+            )
+            .await?;
+        if let Ok(envelope) = next_envelope(&mut noisy, "noisy churn").await {
+            envelope.commit().await?;
+        }
+        if let Ok(envelope) = next_envelope(&mut quiet, "quiet heartbeat").await {
+            envelope.commit().await?;
+        }
+        let (past, _) = slot_acked_past(&source, &lsn_text(recorded)).await?;
+        if past {
+            drifted = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    anyhow::ensure!(
+        drifted,
+        "the test could not reach the state it exists to cover: the slot never acknowledged past \
+         the quiet table's recorded position, so no drift was constructed"
+    );
+
+    // --- 2. Restart the quiet dataset against the position it recorded. The slot is
+    // acknowledged past it, but only over WAL that held nothing for this table. ---
+    drop(quiet);
+    drop(noisy);
+    wait_for_walsender_count(&source, 0).await?;
+
+    // The carry-forward has to have actually run — otherwise this test would also
+    // pass on a build that simply never rebuilds — and it has to be paced by
+    // `watermark_flush_interval` rather than firing on every keepalive. The quiet
+    // table sees no changes, so every save past its boundary envelope is a
+    // carry-forward.
+    let saves = store.saves();
+    let elapsed_ticks = drift_started.elapsed().as_secs_f64() / flush_every.as_secs_f64();
+    anyhow::ensure!(
+        saves > 1,
+        "the quiet table's recorded position was never carried forward ({saves} write(s) total), \
+         so this test would pass for the wrong reason"
+    );
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "counter is small; the comparison is a loose bound"
+    )]
+    let saves_f = saves as f64;
+    // Integration-test worker logs are dropped, so print the measurement.
+    eprintln!(
+        "quiet-member position writes: {saves} over {elapsed_ticks:.1} flush interval(s) of {flush_every:?}"
+    );
+    anyhow::ensure!(
+        saves_f <= elapsed_ticks + 3.0,
+        "the recorded position is being written far more often than once per flush interval \
+         ({saves} writes over {elapsed_ticks:.1} intervals), which would put avoidable I/O on \
+         every idle member of every shared slot"
+    );
+
+    let mut restarted = start_replication_stream(input_with_watermark(port, "quiet", &store));
+    let envelope = next_envelope(&mut restarted, "first envelope after the restart").await?;
+    anyhow::ensure!(
+        !envelope.history_unavailable(),
+        "a quiet dataset was asked to rebuild after an ordinary restart. The slot's acknowledgement \
+         drifting ahead of the recorded position through idle crediting is not a gap, and treating \
+         it as one re-reads the whole table on every restart"
     );
     envelope.commit().await?;
 
@@ -1319,9 +1469,6 @@ async fn a_dataset_re_added_after_its_reservation_lapsed_does_not_silently_skip_
     // for the absent table; after the grace lapses, its own traffic carries the
     // slot's acknowledgement past the missed change. ---
     let mut mate = start_replication_stream(short_grace(input_for(port, "lapsed_mate")));
-    expect_single_change(&mut mate, "mate resume", "c", 1)
-        .await
-        .or_else(|_| Ok::<(), anyhow::Error>(()))?;
 
     // Committing the mate's envelopes — including its idle heartbeats — is what
     // carries the slot's acknowledgement forward; the reservation for the absent
@@ -1353,23 +1500,46 @@ async fn a_dataset_re_added_after_its_reservation_lapsed_does_not_silently_skip_
          the absent table's change, so the reservation never lapsed"
     );
 
-    // --- 5. The dataset is re-added, carrying the position it recorded before it
+    // --- 5. Releasing the hold also drops the table from the publication, which
+    // on its own would send a returning dataset through the initial-snapshot path
+    // (`table_added = true`) and recover it for a reason that has nothing to do
+    // with its recorded position. Put the table back with no member attached, so
+    // the re-add sees `table_added = false` and recovery has to come from the
+    // recorded position — either replaying from it, or reporting that the history
+    // it needs is gone.
+    source
+        .simple_query(&format!(
+            "ALTER PUBLICATION {PUBLICATION} ADD TABLE public.lapsed_absent"
+        ))
+        .await
+        .ok();
+
+    // --- 6. The dataset is re-added, carrying the position it recorded before it
     // left. Either outcome is correct; resuming into live traffic is not. ---
     let mut re_added = start_replication_stream(short_grace(input_with_watermark(
         port,
         "lapsed_absent",
         &InMemoryAppliedLsnStore::seeded(recorded),
     )));
-    let envelope = next_envelope(&mut re_added, "re-added dataset's first envelope").await?;
-    let recovered = envelope.history_unavailable() || ids_of(&envelope).contains(&2);
+    // Idle heartbeats carry no rows and are not an answer either way, so commit
+    // past them and wait for one of the two acceptable outcomes: the missed change
+    // replayed, or a report that the history needed to replay it is gone.
+    let deadline = std::time::Instant::now() + Duration::from_secs(45);
+    let mut recovered = false;
+    while std::time::Instant::now() < deadline {
+        let envelope = next_envelope(&mut re_added, "re-added dataset envelope").await?;
+        recovered = envelope.history_unavailable() || ids_of(&envelope).contains(&2);
+        envelope.commit().await?;
+        if recovered {
+            break;
+        }
+    }
     anyhow::ensure!(
         recovered,
         "a dataset re-added after its reservation lapsed neither received the change committed \
          while it was gone (id=2) nor asked to be rebuilt — it resumed as if nothing were missing \
-         (#11289). First envelope carried ids {:?}",
-        ids_of(&envelope)
+         (#11289)"
     );
-    envelope.commit().await?;
 
     drop(mate);
     drop(re_added);

--- a/crates/runtime/tests/postgres/replication_shared.rs
+++ b/crates/runtime/tests/postgres/replication_shared.rs
@@ -192,10 +192,10 @@ impl AppliedLsnStore for InMemoryAppliedLsnStore {
 /// [`input_for`] with a watermark store that actually records, so the gap
 /// decision is reachable. Pass the same store across two streams to model a
 /// restart against acceleration files that survived.
-fn input_with_watermark(
+fn input_with_watermark<S: AppliedLsnStore + 'static>(
     port: u16,
     table: &str,
-    store: &Arc<InMemoryAppliedLsnStore>,
+    store: &Arc<S>,
 ) -> ReplicationStreamInput {
     let mut input = input_for(port, table);
     input.applied_lsn_store = Arc::clone(store) as Arc<dyn AppliedLsnStore>;
@@ -1246,6 +1246,129 @@ async fn a_bootstrap_lost_before_it_was_durable_is_reloaded_not_resumed()
     Ok(())
 }
 
+/// An applied-position store whose writes are slow, for showing that the commit path
+/// does not wait on them.
+#[derive(Default)]
+struct SlowAppliedLsnStore {
+    recorded: std::sync::Mutex<Option<AppliedLsn>>,
+    saves: std::sync::atomic::AtomicUsize,
+}
+
+impl SlowAppliedLsnStore {
+    const DELAY: Duration = Duration::from_millis(250);
+
+    fn shared() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    fn saves(&self) -> usize {
+        self.saves.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
+#[async_trait::async_trait]
+impl AppliedLsnStore for SlowAppliedLsnStore {
+    async fn load(
+        &self,
+    ) -> std::result::Result<RecordedPosition, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(self
+            .recorded
+            .lock()
+            .expect("watermark mutex")
+            .map_or(RecordedPosition::Absent, RecordedPosition::At))
+    }
+
+    async fn save(
+        &self,
+        applied: AppliedLsn,
+    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        tokio::time::sleep(Self::DELAY).await;
+        *self.recorded.lock().expect("watermark mutex") = Some(applied);
+        self.saves.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        Ok(())
+    }
+
+    async fn clear(&self) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        *self.recorded.lock().expect("watermark mutex") = None;
+        Ok(())
+    }
+
+    fn records_positions(&self) -> bool {
+        true
+    }
+}
+
+/// Committing publishes a position and returns; only the applied-position writer
+/// touches the store. So a store that is slow to write must not make commits slow —
+/// if it did, every dataset on a shared slot would apply changes at the speed of its
+/// accelerator's bookkeeping writes.
+///
+/// The delay is fixed because store latency is the thing under test.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_slow_position_store_does_not_slow_the_commit_path() -> Result<(), anyhow::Error> {
+    const COMMITS: usize = 8;
+
+    let _tracing = init_tracing(Some("data_components::postgres_replication=debug,info"));
+
+    let port = common::get_random_port()?;
+    let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+    let port = u16::try_from(port).expect("port fits in u16");
+    let source = pg_client(port).await?;
+
+    create_table(&source, "slow_store", &[(1, "one")]).await?;
+
+    let store = SlowAppliedLsnStore::shared();
+    let mut member = start_replication_stream(input_with_watermark(port, "slow_store", &store));
+    next_envelope(&mut member, "bootstrap")
+        .await?
+        .commit()
+        .await?;
+
+    let mut committed = 0_usize;
+    let mut spent_committing = Duration::ZERO;
+    for id in 0..COMMITS {
+        source
+            .execute(
+                "INSERT INTO public.slow_store (id, name) VALUES ($1, 'row')",
+                &[&i32::try_from(id + 10).expect("id fits")],
+            )
+            .await?;
+        if let Ok(envelope) = next_envelope(&mut member, "change").await {
+            let started = std::time::Instant::now();
+            envelope.commit().await?;
+            spent_committing += started.elapsed();
+            committed += 1;
+        }
+    }
+    anyhow::ensure!(
+        committed > 0,
+        "no change was committed, so nothing about the commit path was measured"
+    );
+
+    let serialized = SlowAppliedLsnStore::DELAY * u32::try_from(committed).expect("fits");
+    eprintln!(
+        "commit path: {spent_committing:?} across {committed} commit(s); \
+         waiting for each {:?} store write would have cost {serialized:?}; \
+         store writes so far: {}",
+        SlowAppliedLsnStore::DELAY,
+        store.saves()
+    );
+    anyhow::ensure!(
+        spent_committing * 2 < serialized,
+        "commits are waiting on the applied-position store: {spent_committing:?} across \
+         {committed} commit(s), against {serialized:?} if each had waited for its write. \
+         Publishing the position must not put store I/O on the commit path"
+    );
+
+    drop(member);
+    wait_for_walsender_count(&source, 0).await?;
+    drop_replication_slot_when_inactive(&source, SLOT).await?;
+    source
+        .simple_query(&format!("DROP PUBLICATION IF EXISTS {PUBLICATION}"))
+        .await?;
+    Ok(())
+}
+
 /// The counterpart to the rebuild tests: a dataset that simply restarts must
 /// **resume**, not rebuild. Without this, a rule that classifies gaps too eagerly
 /// passes every rebuild test while re-reading the whole table on every restart.
@@ -1291,7 +1414,11 @@ async fn a_quiet_dataset_resumes_across_a_restart_rather_than_rebuilding()
     let flush_every = input_for(port, "quiet").params.watermark_flush_interval;
     let drift_started = std::time::Instant::now();
     create_table(&source, "noisy", &[(1, "n1")]).await?;
-    let mut noisy = start_replication_stream(input_for(port, "noisy"));
+    // The busy member records its position through its own commits. Counting its
+    // writes against its commits is what shows they are coalesced by the single
+    // writer rather than issued one per commit.
+    let noisy_store = InMemoryAppliedLsnStore::shared();
+    let mut noisy = start_replication_stream(input_with_watermark(port, "noisy", &noisy_store));
     next_envelope(&mut noisy, "bootstrap noisy")
         .await?
         .commit()
@@ -1300,6 +1427,7 @@ async fn a_quiet_dataset_resumes_across_a_restart_rather_than_rebuilding()
     let deadline = std::time::Instant::now() + Duration::from_mins(1);
     let mut drifted = false;
     let mut churn_id = 100;
+    let mut noisy_commits = 0_usize;
     while std::time::Instant::now() < deadline {
         churn_id += 1;
         source
@@ -1310,6 +1438,7 @@ async fn a_quiet_dataset_resumes_across_a_restart_rather_than_rebuilding()
             .await?;
         if let Ok(envelope) = next_envelope(&mut noisy, "noisy churn").await {
             envelope.commit().await?;
+            noisy_commits += 1;
         }
         if let Ok(envelope) = next_envelope(&mut quiet, "quiet heartbeat").await {
             envelope.commit().await?;
@@ -1350,10 +1479,12 @@ async fn a_quiet_dataset_resumes_across_a_restart_rather_than_rebuilding()
         reason = "counter is small; the comparison is a loose bound"
     )]
     let saves_f = saves as f64;
-    // Integration-test worker logs are dropped, so print the measurement.
+    // Integration-test worker logs are dropped, so print the measurements.
+    let noisy_saves = noisy_store.saves();
     eprintln!(
         "quiet-member position writes: {saves} over {elapsed_ticks:.1} flush interval(s) of {flush_every:?}"
     );
+    eprintln!("busy-member position writes: {noisy_saves} for {noisy_commits} commit(s)");
     anyhow::ensure!(
         saves_f <= elapsed_ticks + 3.0,
         "the recorded position is being written far more often than once per flush interval \


### PR DESCRIPTION
Closes #11896. Fixes #11289.

Started as a verify-and-close pass on two issues believed fixed by #12922. Writing the regression test for #11289 turned up a real silent skip, and a second defect in what #12922 merged.

## The bug

A shared-slot member decided whether to resume or rebuild by comparing its recorded applied position against the slot's `restart_lsn`. That is the slot's **physical WAL retention** bound, not the earliest position it can be **streamed** from.

Postgres forwards a `START_REPLICATION` position below the slot's `confirmed_flush_lsn` up to it, in `CreateDecodingContext`. Once a slot has acknowledged a change, no client can ask for it again — even while the WAL is still on disk. Verified against stock `postgres:16`, no Spice code in the loop:

```
restart_lsn      = 0/151C220   <-- below the requested start: the WAL is retained
requested start  = 0/151C258
confirmed_flush  = 0/2000000
server log: 0/151C258 has been already streamed, forwarding to 0/2000000
re-delivered: 0 bytes
```

Retention was never the binding constraint; the acknowledgement was. So a position behind `confirmed_flush_lsn` was classified as resumable and the difference skipped silently — reachable whenever the slot's acknowledgement is carried forward on behalf of a table no dataset is consuming.

This also means the `consistent_lsn` clamp added to #12922 in review could not do what it said. It lowered the requested start to the recorded position and logged that streaming *"resumes from the recorded position and replays the difference rather than skipping it."* The server forwards that start position straight back up, so no replay happened and the interval was skipped while the log asserted the opposite.

## What this changes

**Compare against the later of `restart_lsn` and `confirmed_flush_lsn`** — the earliest position the slot can actually stream from — so an acknowledged-past position rebuilds instead of resuming. The clamp is removed, and its condition now produces a rebuild with a message that says what actually happens. `SharedMemberSetup::slot_restart_lsn`'s doc no longer describes itself as "the earliest LSN this slot can stream from", which is the claim that caused this.

**Keep the recorded position level with the acknowledgement**, without which that comparison is not meaningful. `credit_idle` advances a member's committed LSN on keepalives over WAL that held nothing for its table; it routes no envelope, so no committer runs and nothing is recorded. Left alone the two drift apart for any quiet table, and the next start reads a position behind `confirmed_flush_lsn` — indistinguishable from a real gap. A per-source task now carries an idle member's recorded position forward, under two gates:

- the member must be **streaming** — a bootstrapping member's committed LSN is a held floor, not an applied position;
- a position must already be **durably recorded** for it. Both committers that record one are either deferral-gated (`SharedLsnCommitter`, held until the covering checkpoint is durable) or deferral-refusing (`SnapshotWatermarkCommitter`), so a recorded position means durable. Without this gate a snapshot whose rows are still in the memory tier would have its floor recorded as though they were, which is #11896 again.

Carrying the position forward claims nothing new: crediting requires `delivered == committed`, so everything routed has been committed, and the interval carried over contained no changes for that table.

## Performance

Recording a position used to be I/O **on the commit path** — every envelope commit awaited a write to the dataset's own accelerator, as did the snapshot and rebuild boundaries. With several writers per member, those writes also had to be serialized, since `save` overwrites rather than taking a maximum and a straggler landing last moved the recorded position backwards (thanks @Copilot for catching that).

Producers now publish a position onto the member's ack slot with an atomic max and wake a **single per-source writer**, which persists the furthest published position when it gets there. Reordering becomes unrepresentable rather than prevented, so no lock is needed, and positions established while a write is in flight coalesce into that write's successor.

Measured with a store that takes 250ms per write:

```
commit path: 64.96µs across 8 commit(s); waiting for each 250ms store write
would have cost 2s; store writes so far: 1
```

Eight commits cost 65µs rather than 2s, and collapsed into one write. To be precise about the benefit: with a *fast* store the write count is roughly unchanged — coalescing is what happens under back-pressure. The part that always holds is that the commit path never blocks on store I/O, which is what the slow-store test pins.

Other properties:

- An **idle** member costs one small write per flush interval, measured at one per interval per member.
- `AckSlot` gains two `AtomicU64`s (recorded, published) and stays inside the 64-byte line it is aligned to, so no new false sharing.
- The published position starts at zero and is only ever advanced by something that has proven durability. Registration publishes nothing, so a snapshot whose rows are still in the memory tier cannot have its floor recorded as durable — that would be #11896 again.
- A detached member is removed from the map the writer sweeps, so detaching hands its last published position to the writer through a queue rather than writing it inline, which would reintroduce a second writer.

The flush interval (30s) is sized against what it protects rather than freshness: a graceful shutdown flushes once more, so an ordinary restart resumes exactly; a crash can leave the record up to one interval stale, costing one rebuild and never a wrong resume.

## Testing

- **#11289 end-to-end**: a dataset whose reservation lapsed, re-added with its table still published (so `table_added = false` and recovery has to come from the recorded position). Asserts it reached the hazard — polling until the slot has genuinely acknowledged past the absent table's change — before asserting the outcome, and commits past idle heartbeats so a zero-row envelope cannot be mistaken for an answer. **Fails without this change**: the change is neither delivered nor rebuilt for.
- **Quiet-dataset resume**: the counterpart no previous test covered — an ordinary restart must resume, not rebuild. Also asserts the carry-forward actually ran (otherwise the test would pass on a build that simply never rebuilds) and that it is paced by the flush interval. **Fails without the carry-forward.**
- **#11896 end-to-end**: a bootstrap lost before it became durable is re-loaded, not resumed.
- **Commit-path latency** (`a_slow_position_store_does_not_slow_the_commit_path`): a store with a 250ms write; asserts total commit time is far below what waiting for each write would cost, so it fails if store I/O returns to the commit path.
- **Unit**: the decision arithmetic, with the retention-only comparison kept as an explicit control; and that a position published out of order never lowers what is observable.
- `data_components` lib: 162 pass. `replication_shared`: 9 pass. `catalog_changes`: 15 pass.
- One `catalog_changes` readiness timeout appears under high test concurrency (each test starts its own container plus a runtime against a 120s budget); a different test each run, and each passes in ~19s in isolation.

## Release Notes

**PostgreSQL CDC accelerations recover when a replication slot has been acknowledged past them**: a durable acceleration whose replication slot has already acknowledged the changes it had not applied is now rebuilt from the source rather than resuming and silently skipping them. Ordinary restarts continue to resume, including for datasets whose tables see no changes.
