### PR TITLE
feat(cli): add `spice connect service`, a per-instance manifest, and one status model

### DIFF
--- a/bin/spice/Cargo.toml
+++ b/bin/spice/Cargo.toml
@@ -43,7 +43,7 @@ dotenv.workspace = true
 # Cross-platform directories
 dirs = "6"
 
-# Deterministic per-instance-directory service names (`spice connect --install`)
+# Deterministic per-instance-directory service names (`spice connect service`)
 sha2.workspace = true
 
 # Semver comparison
@@ -110,7 +110,7 @@ test-framework = { path = "../../crates/test-framework" }
 # Tracing/opentelemetry for trace ID handling
 opentelemetry.workspace = true
 
-# Unix signal handling, and the effective-uid check `spice connect --install` gates on
+# Unix signal handling, and the effective-uid check `spice connect service` gates on
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", features = ["signal", "process", "user"] }
 [build-dependencies]

--- a/bin/spice/src/commands/connect/mod.rs
+++ b/bin/spice/src/commands/connect/mod.rs
@@ -24,8 +24,8 @@ limitations under the License.
 //!    it (`spiced --token <enrollment-key>`); a directory with an enrolled
 //!    identity reconnects automatically on every later start. This command
 //!    inspects and manages that per-directory state: `status` reports it,
-//!    `remove` releases the instance and clears it, and `--install` wraps
-//!    an already-enrolled directory in a persistent system service.
+//!    `service` installs and manages the persistent service that keeps it
+//!    running, and `remove` releases the instance and clears it.
 //!
 //! 2. **Deprecated pod-add behavior**: when the argument is a Spicepod
 //!    path on Spice.ai Cloud (e.g. `spiceai/quickstart`), this prints a
@@ -33,6 +33,7 @@ limitations under the License.
 //!    Cloud authentication headers.
 
 mod service;
+mod status;
 
 use std::{
     path::{Path, PathBuf},
@@ -42,8 +43,11 @@ use std::{
 use crate::commands::add::{AddArgs, execute_add_or_connect};
 use crate::context::RuntimeContext;
 use crate::error::{Error, Result};
+use crate::output::OutputFormat;
 use clap::{Args, Subcommand};
 use runtime_cloud_connect::config::{CloudConnectConfig, IDENTITY_FILE};
+
+use status::ConnectStatus;
 
 /// File (relative to the config dir) holding a `--endpoint` override so later
 /// `spiced` starts reach the same control plane the enroll did.
@@ -64,15 +68,20 @@ The runtime enrolls before it serves traffic, stores the issued identity under
 `.spice/`, and every later `spiced` or `spice run` start in that directory
 reconnects automatically from the identity alone.
 
-  spice connect status                    Show the current enrollment state.
-  sudo spice connect --install            Install `spiced` as a persistent
-                                          system service for an already
-                                          enrolled directory — systemd on
-                                          Linux, a launchd daemon on macOS.
-                                          Re-run to upgrade in place: latest
-                                          binary, rewritten service definition,
-                                          service restarted, identity
-                                          untouched.
+  spice connect status                    Show this directory's Cloud
+                                          connection, service, and deployment
+                                          state. `--output json` prints the
+                                          same report for automation.
+  spice connect service install           Install and start `spiced` as a
+                                          persistent service so the instance
+                                          survives reboots and closed
+                                          terminals. Re-run to upgrade in
+                                          place: latest binary, rewritten
+                                          service definition, service
+                                          restarted, identity untouched.
+  spice connect service ...               The rest of the service lifecycle:
+                                          uninstall, start, stop, restart,
+                                          status, logs.
   spice connect remove                    Release this instance: report the
                                           release to Spice Cloud, uninstall the
                                           service when one was installed, and
@@ -90,17 +99,18 @@ per-instance state lives under `<dir>/.spice`, so multiple instances on one
 host enroll independently. `SPICE_CONFIG_DIR` overrides the derived location
 entirely and wins over `--dir`.
 
-`--install` requires root, and either Linux with systemd or macOS with
-launchd. Containers pass the enrollment key directly to the runtime
-(`spiced --token`) under the container runtime's restart policy; Windows
-enrolls and runs under the user's own supervisor.
+A service needs either Linux with systemd or macOS with launchd. Containers
+pass the enrollment key directly to the runtime (`spiced --token`) under the
+container runtime's restart policy; Windows enrolls and runs under the user's
+own supervisor.
 
 DEPRECATED POD-ADD BEHAVIOR:
   spice connect <org>/<pod>               Deprecated; use `spice add <org>/<pod>`.
 
 EXAMPLES
   spice connect status
-  sudo spice connect --install
+  spice connect status --output json
+  sudo spice connect service install
   sudo spice connect remove
 
 Docs: https://spiceai.org/docs"#
@@ -126,20 +136,12 @@ pub struct ConnectArgs {
     /// The instance directory: per-instance Cloud Connect state (the
     /// enrolled identity) lives under `<dir>/.spice`. Defaults to the
     /// current directory. `SPICE_CONFIG_DIR` overrides the derived `.spice`
-    /// location entirely. Applies to `status`, `remove`, and `--install`.
+    /// location entirely. Applies to `status`, `remove`, and `service`.
     #[arg(long, value_name = "PATH", global = true)]
     pub dir: Option<PathBuf>,
 
-    /// Install and start `spiced` as a persistent system service running
-    /// from an already-enrolled instance directory, so the instance
-    /// survives reboots and closed terminals. Requires root, and either
-    /// Linux with systemd or macOS with launchd. Re-running is the
-    /// idempotent in-place upgrade path.
-    #[arg(long, global = true)]
-    pub install: bool,
-
     /// Skip the confirmation prompt. Applies to `remove`, which otherwise
-    /// asks before stopping and uninstalling a service.
+    /// asks before releasing the instance and stopping its service.
     #[arg(long, short = 'y', global = true)]
     pub yes: bool,
 
@@ -158,13 +160,62 @@ pub struct ConnectArgs {
 /// Cloud-connect subcommands.
 #[derive(Subcommand, Debug)]
 pub enum ConnectCommand {
-    /// Show the current Spice Cloud Connect enrollment state.
-    Status,
+    /// Show this directory's Spice Cloud Connect state: connection, service,
+    /// and deployment, from one snapshot.
+    Status(StatusArgs),
 
     /// Release this instance: report the release to Spice Cloud, uninstall an
     /// installed service, and clear the local identity. spiced will continue
     /// running unmanaged after the next restart.
     Remove,
+
+    /// Install and manage the persistent service for this instance directory.
+    ///
+    /// `svc` is a hidden alias for interactive typing; `service` is the only
+    /// documented spelling.
+    #[command(alias = "svc")]
+    Service(service::cli::ServiceArgs),
+}
+
+/// Arguments for `spice connect status`.
+#[derive(Args, Debug)]
+pub struct StatusArgs {
+    /// Output format. `json` writes one report and nothing else to stdout.
+    #[arg(long, short = 'o', value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+impl ConnectArgs {
+    /// Whether this invocation writes JSON to stdout, so the dispatcher can
+    /// suppress the version banner that would otherwise foul it.
+    #[must_use]
+    pub fn produces_json(&self) -> bool {
+        match &self.command {
+            Some(ConnectCommand::Status(args)) => args.output == OutputFormat::Json,
+            Some(ConnectCommand::Service(args)) => matches!(
+                &args.command,
+                Some(service::cli::ServiceCommand::Status(args))
+                    if args.output == OutputFormat::Json
+            ),
+            _ => false,
+        }
+    }
+
+    /// Select JSON output wherever this command has a structured form.
+    pub fn apply_machine_mode(&mut self) {
+        match &mut self.command {
+            Some(ConnectCommand::Status(args)) => args.output = OutputFormat::Json,
+            Some(ConnectCommand::Service(args)) => {
+                if let Some(service::cli::ServiceCommand::Status(args)) = &mut args.command {
+                    args.output = OutputFormat::Json;
+                }
+            }
+            // `remove` and the service lifecycle actions report progress rather
+            // than structured data, and the deprecated pod-add fallthrough has
+            // no JSON form.
+            _ => {}
+        }
+    }
 }
 
 /// Execute the `spice connect` command.
@@ -179,9 +230,21 @@ pub async fn execute(ctx: &RuntimeContext, args: ConnectArgs) -> Result<()> {
     if let Some(cmd) = args.command {
         reject_cloud_region(args.cloud_region.as_deref())?;
         return match cmd {
-            ConnectCommand::Status => print_status(&config_dir, args.endpoint.as_deref()).await,
+            ConnectCommand::Status(status_args) => {
+                print_status(&config_dir, args.endpoint.as_deref(), status_args.output).await
+            }
             ConnectCommand::Remove => {
                 remove_identity(&config_dir, args.endpoint.as_deref(), args.yes).await
+            }
+            ConnectCommand::Service(service_args) => {
+                service::cli::execute(
+                    ctx,
+                    service_args,
+                    &instance_dir_for(&config_dir),
+                    &config_dir,
+                    &resolved_endpoint(&config_dir, args.endpoint.as_deref()),
+                )
+                .await
             }
         };
     }
@@ -191,7 +254,7 @@ pub async fn execute(ctx: &RuntimeContext, args: ConnectArgs) -> Result<()> {
     // always been meaningful, so refusing it there would be a regression.
     let Some(target) = args.target.as_deref() else {
         reject_cloud_region(args.cloud_region.as_deref())?;
-        return connect_existing(ctx, &config_dir, args.install, args.endpoint.as_deref()).await;
+        return connect_existing(&config_dir, args.endpoint.as_deref()).await;
     };
 
     // A secret must never ride a positional argument. Reject canonical keys
@@ -252,28 +315,17 @@ fn reject_cloud_region(cloud_region: Option<&str>) -> Result<()> {
     })
 }
 
-/// Bare `spice connect` (no subcommand, no pod path): act on the existing
+/// Bare `spice connect` (no subcommand, no pod path): report the existing
 /// per-directory state.
 ///
-/// An enrolled directory reports its status, or installs the persistent
-/// service when `--install` asks for one. A directory with no identity has
-/// nothing this command can act on — enrollment belongs to the runtime — so
-/// it errors with the exact command that does enroll.
-async fn connect_existing(
-    ctx: &RuntimeContext,
-    config_dir: &Path,
-    install: bool,
-    endpoint: Option<&str>,
-) -> Result<()> {
+/// A directory with no identity has nothing this command can act on —
+/// enrollment belongs to the runtime — so it errors with the exact command that
+/// does enroll.
+async fn connect_existing(config_dir: &Path, endpoint: Option<&str>) -> Result<()> {
     if has_enrolled_identity(config_dir)? {
-        if install {
-            // The `--install`-after-a-prior-enroll path, and the in-place
-            // upgrade path when a service is already installed.
-            return install_service(ctx, config_dir);
-        }
         println!("This host is already enrolled with Spice Cloud.");
         println!();
-        return print_status(config_dir, endpoint).await;
+        return print_status(config_dir, endpoint, OutputFormat::Table).await;
     }
 
     Err(Error::InvalidArgument {
@@ -289,9 +341,9 @@ async fn connect_existing(
 
 /// Whether this directory holds a usable enrolled identity.
 ///
-/// Existence alone is not enough: installing a service over a malformed or
-/// unreadable identity would report success, but every `spiced` restart would
-/// reject that identity and run without Cloud Connect.
+/// Existence alone is not enough: an unreadable identity would be reported as
+/// enrolled, but every `spiced` restart would reject it and run without Cloud
+/// Connect.
 fn has_enrolled_identity(config_dir: &Path) -> Result<bool> {
     runtime_cloud_connect::identity::IdentityStore::load_optional(&config_dir.join(IDENTITY_FILE))
         .map(|identity| identity.is_some())
@@ -300,61 +352,11 @@ fn has_enrolled_identity(config_dir: &Path) -> Result<bool> {
         })
 }
 
-/// Install (or reinstall) the service for this instance directory and report
-/// its name and how to manage it.
-fn install_service(ctx: &RuntimeContext, config_dir: &Path) -> Result<()> {
-    service::preflight()?;
-
-    // The service runs from the *instance* directory, not the `.spice` config
-    // dir beneath it: that directory is the spicepod root the runtime loads
-    // from.
-    let instance_dir = instance_dir_for(config_dir);
-    // Resolved, not derived from `$HOME`: `sudo` rewrites `HOME` to `/root`, and
-    // the runtime the operator installed is normally under their own home.
-    let spiced_path = ctx.resolve_spiced_path().ok_or_else(|| Error::InvalidArgument {
-        message: format!(
-            "Failed to install the Spice Cloud Connect service: no Spice runtime was found at {}. \
-             Install it with `spice install` and re-run `sudo spice connect --install`. \
-             See: https://spiceai.org/docs",
-            ctx.spiced_path().display()
-        ),
-    })?;
-
-    let installed = service::install(&instance_dir, config_dir, &spiced_path)?;
-
-    println!("Installed the Spice Cloud Connect service.");
-    println!("  service:   {}", installed.name);
-    println!("  file:      {}", installed.path.display());
-    println!("  directory: {}", instance_dir.display());
-    // Name both paths: the operator needs to know which build was installed and
-    // that the service runs a root-owned copy of it, not the original.
-    println!("  runtime:   {}", installed.runtime.display());
-    if installed.runtime != spiced_path {
-        println!("             staged from {}", spiced_path.display());
-    }
-    if let Ok(version) = ctx.runtime_version() {
-        println!("  version:   {version}");
-    }
-    if let Some(state) = service::is_active(&installed.name) {
-        println!("  state:     {state}");
-    }
-    println!();
-    println!("Manage it with:");
-    for hint in service::manage_hints(&installed.name) {
-        println!("  {hint}");
-    }
-    println!(
-        "Re-run `sudo spice connect --install` to upgrade the runtime in place; \
-         `sudo spice connect remove` to release this instance and uninstall the service."
-    );
-    Ok(())
-}
-
 /// The instance directory a config dir belongs to: `<dir>/.spice` → `<dir>`.
 ///
 /// `SPICE_CONFIG_DIR` can point anywhere, so a config dir that is not named
 /// `.spice` has no instance directory above it — in that case the config dir
-/// itself is the best available answer for `WorkingDirectory`.
+/// itself is the best available answer for the service's working directory.
 fn instance_dir_for(config_dir: &Path) -> PathBuf {
     if config_dir.file_name() == Some(std::ffi::OsStr::new(".spice"))
         && let Some(parent) = config_dir.parent().filter(|p| !p.as_os_str().is_empty())
@@ -364,170 +366,102 @@ fn instance_dir_for(config_dir: &Path) -> PathBuf {
     config_dir.to_path_buf()
 }
 
-async fn print_status(config_dir: &Path, endpoint: Option<&str>) -> Result<()> {
-    let identity_path = config_dir.join(IDENTITY_FILE);
-
-    let identity = runtime_cloud_connect::identity::IdentityStore::load_optional(&identity_path)
-        .map_err(|e| Error::CloudConnectIo {
-            message: format!("load identity: {e}"),
-        })?;
-
-    if let Some(id) = identity {
-        let expiry = id.not_after_unix.map_or_else(
-            || "unbounded".to_string(),
-            |secs| format!("unix={secs} (expired={})", id.is_expired()),
-        );
-        println!("Spice Cloud Connect: enrolled");
-        println!("  identifier:  {}", id.identifier);
-        println!("  identity:    {}", identity_path.display());
-        if !id.gateway_addr.is_empty() {
-            println!("  gateway:     {}", id.gateway_addr);
-        }
-        println!("  expiry:      {expiry}");
-        print_deployed_spicepod(config_dir);
-        print_delivered_secrets(config_dir);
-        print_service_for_dir(config_dir);
-        // An identity that reads as expired on a host whose clock is wrong is
-        // not actually expired — measure before the operator goes chasing a
-        // renewal problem that does not exist. A live identity needs no probe,
-        // which keeps the common `status` offline and instant.
-        if id.is_expired() {
-            report_clock_skew(&resolved_endpoint(config_dir, endpoint)).await;
-        }
-        return Ok(());
+/// Collect and render one status snapshot.
+async fn print_status(
+    config_dir: &Path,
+    endpoint: Option<&str>,
+    output: OutputFormat,
+) -> Result<()> {
+    let status = ConnectStatus::collect(
+        service::backend(),
+        &instance_dir_for(config_dir),
+        config_dir,
+        &resolved_endpoint(config_dir, endpoint),
+    )
+    .await;
+    status::render(&status, output)?;
+    if status.is_degraded() {
+        return Err(Error::ServiceUnavailable {
+            message: format!(
+                "The Spice Cloud Connect service for {} is {}{}",
+                status.connection.directory.display(),
+                status.service.state,
+                match &status.service.diagnostic {
+                    Some(diagnostic) => format!(": {diagnostic}"),
+                    None => ".".to_string(),
+                }
+            ),
+        });
     }
-
-    // An enrollment that started but never completed leaves its retry-safe
-    // draft behind. The draft is non-secret apart from the provisional keys
-    // (never printed); the operation ID names what a retried enrollment
-    // resumes.
-    let draft_path = runtime_cloud_connect::EnrollmentDraft::path_in(config_dir);
-    if draft_path.exists() {
-        println!("Spice Cloud Connect: enrollment incomplete");
-        println!("  draft:       {}", draft_path.display());
-        println!(
-            "  a previous enrollment did not finish. Mint a new enrollment key in the Spice \
-             Cloud portal and start the runtime with it (`spiced --token <enrollment-key>`); \
-             the retried enrollment resumes the same pending operation instead of creating a \
-             duplicate instance."
-        );
-        print_service_for_dir(config_dir);
-        // A stuck enrollment is a state a wrong clock explains: the enroll
-        // keeps failing on certificate validity.
-        report_clock_skew(&resolved_endpoint(config_dir, endpoint)).await;
-        return Ok(());
-    }
-
-    // No state in this directory. A host can still be connected from another
-    // instance directory, so report the installed services rather than a
-    // misleading "not connected".
-    let installed = service::discover_all();
-    if !installed.is_empty() {
-        println!(
-            "Spice Cloud Connect: no instance in this directory ({}).",
-            instance_dir_for(config_dir).display()
-        );
-        println!("Installed services on this host:");
-        for service in &installed {
-            let state = service::is_active(&service.name).unwrap_or_else(|| "unknown".to_string());
-            println!(
-                "  {} (dir {}) — {state}",
-                service.name,
-                service.working_dir.display()
-            );
-        }
-        println!();
-        println!(
-            "Run `spice connect status --dir <directory>` to inspect one of them, or enroll \
-             this directory as a new instance with `spiced --token <enrollment-key>`."
-        );
-        return Ok(());
-    }
-
-    println!("Spice Cloud Connect: not connected");
-    println!(
-        "Mint an enrollment key in the Spice Cloud portal and start the runtime with it: \
-         `spiced --token <enrollment-key>`."
-    );
     Ok(())
 }
 
-/// Report whether a deployed spicepod is what this instance comes up on.
-///
-/// Reads the config dir only, so it answers on a host with no network.
-fn print_deployed_spicepod(config_dir: &Path) {
-    let spicepod = config_dir.join(runtime_cloud_connect::config::CLOUD_MANAGED_SPICEPOD_FILE);
-    if spicepod.exists() {
-        println!("  deployment:  {}", spicepod.display());
-    } else {
-        println!(
-            "  deployment:  none yet — this instance runs its local spicepod until an app is deployed to it"
-        );
-    }
+/// What Spice Cloud said about the release, reduced to the only question that
+/// decides whether local state may be cleared.
+#[derive(Debug)]
+enum ReleaseVerdict {
+    /// The cloud confirmed the release, or confirmed this instance is not
+    /// there. Either way the credential on disk is no longer usable and can go.
+    Confirmed {
+        outcome: runtime_cloud_connect::release::ReleaseOutcome,
+    },
+    /// The cloud could not be reached, or refused in a way that leaves the
+    /// instance registered. Local state must survive so a retry can finish the
+    /// removal.
+    Unconfirmed { reason: String },
 }
 
-/// Report the delivered secrets held in the local cache.
+/// Report this instance's release to Spice Cloud and classify the answer.
 ///
-/// Reads only the cache's plaintext header, so this works without the key and
-/// **cannot** print a value. Names are what diagnose the common failure: a
-/// component referencing a secret the last deployment did not deliver.
-fn print_delivered_secrets(config_dir: &Path) {
-    let path = config_dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE);
-    let Some(header) = runtime_cloud_connect::secret_cache::read_header(&path) else {
-        if path.exists() {
-            println!(
-                "  secrets:     cache present but unreadable — deploy the app to re-deliver them"
-            );
-        } else {
-            println!("  secrets:     none delivered yet — deploy the app to deliver them");
+/// The classification is the whole point: clearing the identity is what makes a
+/// removal unrecoverable, so it happens only once the cloud has said the
+/// instance is released or already gone. A network blip must leave a directory
+/// a retry can finish from — the alternative silently orphans a registry row
+/// that nobody local can release any more.
+async fn release_instance(
+    config_dir: &Path,
+    endpoint: Option<&str>,
+    identity: &runtime_cloud_connect::Identity,
+) -> ReleaseVerdict {
+    let endpoint = resolved_endpoint(config_dir, endpoint);
+    let ca = (!identity.ca_bundle_pem.is_empty()).then_some(identity.ca_bundle_pem.as_str());
+
+    match runtime_cloud_connect::release::release(&endpoint, identity, ca).await {
+        Ok(outcome) => ReleaseVerdict::Confirmed { outcome },
+        // The cloud has no such instance: the same end state the release was
+        // asking for, including the case where it was already deleted in the
+        // portal.
+        Err(runtime_cloud_connect::release::Error::Rejected { status, .. })
+            if status == 404 || status == 410 =>
+        {
+            ReleaseVerdict::Confirmed {
+                outcome: runtime_cloud_connect::release::ReleaseOutcome {
+                    status: "removed".to_string(),
+                    app_name: None,
+                },
+            }
         }
-        return;
-    };
-    if header.names.is_empty() {
-        println!("  secrets:     none (the last deployment delivered no secrets)");
-        return;
-    }
-    println!(
-        "  secrets:     {} delivered: {}",
-        header.names.len(),
-        header.names.join(", ")
-    );
-}
-
-/// Report the service installed for this instance directory, when there is one.
-fn print_service_for_dir(config_dir: &Path) {
-    let instance_dir = instance_dir_for(config_dir);
-    let Some(installed) = service::find_for_dir(&instance_dir) else {
-        // Not an error: containers and foreground runs are supported ways to
-        // run, and `--install` needs a supported supervisor.
-        return;
-    };
-    let state = service::is_active(&installed.name).unwrap_or_else(|| "unknown".to_string());
-    println!("  service:     {} — {state}", installed.name);
-}
-
-/// Measure the host clock against Spice Cloud and report a significant skew.
-///
-/// Called only from the states a wrong clock explains — an identity that reads
-/// as expired, or an enrollment stuck pending — so a healthy `status` makes no
-/// network request at all. Best-effort and silent on failure: `status` must
-/// stay usable on a host with no network.
-async fn report_clock_skew(endpoint: &str) {
-    if let Some(skew) = runtime_cloud_connect::clock_skew::diagnose(endpoint, None).await
-        && skew.is_significant()
-    {
-        println!("  clock:       {}", skew.advice());
+        Err(err) => ReleaseVerdict::Unconfirmed {
+            reason: format!(
+                "{err} Nothing was removed locally: the identity, delivered secrets, and any \
+                 installed service are intact so `spice connect remove` can finish the removal. \
+                 If Spice Cloud cannot accept the release at all, delete the instance in the \
+                 Spice Cloud portal and re-run this command — a released instance is confirmed \
+                 absent and its local state is then cleared. \
+                 See: https://spiceai.org/docs"
+            ),
+        },
     }
 }
 
 /// Release this instance: report the release to Spice Cloud, uninstall an
 /// installed service, and clear the local identity and staged state.
 ///
-/// Local state is cleared whether or not the cloud could be reached — the host
-/// is being decommissioned, and a `remove` that failed because the network was
-/// down would leave a credential behind. Unreachable, the registry row reads
-/// `disconnected` until it is deleted in the portal; the portal-side delete is
-/// authoritative either way.
+/// Ordered so that no step is taken on the strength of a guess. The release is
+/// reported first and its answer decides everything after it: a confirmed
+/// release (or a confirmed absence) is what makes the local credential dead and
+/// safe to delete, while an unconfirmed one leaves the directory exactly as it
+/// was for a retry to finish.
 async fn remove_identity(
     config_dir: &Path,
     endpoint: Option<&str>,
@@ -549,12 +483,13 @@ async fn remove_identity(
     let endpoint_path = config_dir.join(CLOUD_ENDPOINT_FILE);
     let cache_path = config_dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE);
     let instance_dir = instance_dir_for(config_dir);
+    let backend = service::backend();
 
     let identity = runtime_cloud_connect::identity::IdentityStore::load_optional(&identity_path)
         .map_err(|e| Error::CloudConnectIo {
             message: format!("load identity: {e}"),
         })?;
-    let installed = service::find_for_dir(&instance_dir);
+    let installed = service::resolve(backend, &instance_dir, config_dir)?;
 
     let had_identity = identity.is_some();
     let had_draft = draft_path.exists();
@@ -569,11 +504,11 @@ async fn remove_identity(
     // Confirm before touching a running service: stopping it takes the
     // instance offline, and an operator who ran this in the wrong directory
     // needs the chance to say no. Name what will be affected.
-    if let Some(ref installed) = installed
-        && !assume_yes
-    {
+    if !assume_yes {
         println!("This will release this instance from Spice Cloud and remove it from this host:");
-        println!("  service:   {} (stopped and uninstalled)", installed.name);
+        if let Some(ref installed) = installed {
+            println!("  service:   {} (stopped and uninstalled)", installed.name);
+        }
         println!("  directory: {}", instance_dir.display());
         if had_identity {
             println!("  identity:  {} (deleted)", identity_path.display());
@@ -592,26 +527,44 @@ async fn remove_identity(
         }
     }
 
-    // Report the release before clearing anything: the identity leaf is the
-    // credential that authorises it, so it has to still exist.
+    // Reported before anything is cleared: the identity leaf is the credential
+    // that authorises the release, so it has to still exist.
     if let Some(ref identity) = identity {
-        report_release(config_dir, endpoint, identity).await;
+        match release_instance(config_dir, endpoint, identity).await {
+            ReleaseVerdict::Confirmed { outcome } => {
+                println!("Released this instance in Spice Cloud.");
+                if !outcome.status.is_empty() {
+                    println!("  registry status: {}", outcome.status);
+                }
+                if let Some(app) = outcome.app_name {
+                    println!(
+                        "  app {app} is paused — its deploy target was removed. Move it to \
+                         another instance, or delete it, in the Spice Cloud portal."
+                    );
+                }
+            }
+            ReleaseVerdict::Unconfirmed { reason } => {
+                return Err(Error::CloudConnectIo {
+                    message: format!("release this instance in Spice Cloud: {reason}"),
+                });
+            }
+        }
     }
 
     // A service left running against a released identity restarts forever, so
     // this is the step that most needs to happen — but a failure must not abort
     // the command before the identity is cleared. The cloud has already
     // released the instance by this point, so keeping a dead credential on disk
-    // is strictly worse than reporting the uninstall failure at the end.
-    let uninstall_failure = match installed {
-        Some(ref installed) => match service::uninstall(&instance_dir) {
-            Ok(_) => {
-                println!("Stopped and uninstalled {}.", installed.name);
-                None
-            }
-            Err(err) => Some(err),
-        },
-        None => None,
+    // is strictly worse than reporting the uninstall failure at the end. The
+    // uninstall primitive is shared with `spice connect service uninstall`;
+    // what is not shared is the identity, which only this command releases.
+    let uninstall_failure = match service::uninstall(backend, &instance_dir, config_dir) {
+        Ok(Some(removed)) => {
+            println!("Stopped and uninstalled {}.", removed.name);
+            None
+        }
+        Ok(None) => None,
+        Err(err) => Some(err),
     };
 
     // Before the identity: the cache holds the app's secrets and the identity
@@ -670,42 +623,6 @@ async fn remove_identity(
     match uninstall_failure {
         Some(err) => Err(err),
         None => Ok(()),
-    }
-}
-
-/// Tell Spice Cloud this instance is released, and report what happened.
-///
-/// Never fails the command: the release moves the registry row to `removed`
-/// immediately when it lands. Unreachable, the row reads `disconnected` until it
-/// is deleted in the portal, and the operator is told so.
-async fn report_release(
-    config_dir: &Path,
-    endpoint: Option<&str>,
-    identity: &runtime_cloud_connect::Identity,
-) {
-    let endpoint = resolved_endpoint(config_dir, endpoint);
-    let ca = (!identity.ca_bundle_pem.is_empty()).then_some(identity.ca_bundle_pem.as_str());
-
-    match runtime_cloud_connect::release::release(&endpoint, identity, ca).await {
-        Ok(outcome) => {
-            println!("Released this instance in Spice Cloud.");
-            if !outcome.status.is_empty() {
-                println!("  registry status: {}", outcome.status);
-            }
-            if let Some(app) = outcome.app_name {
-                println!(
-                    "  app {app} is paused — its deploy target was removed. Move it to another \
-                     instance, or delete it, in the Spice Cloud portal."
-                );
-            }
-        }
-        Err(err) => {
-            println!(
-                "Could not report the release to Spice Cloud at {endpoint}: {err} \
-                 Clearing local state anyway. The instance reads as disconnected in the portal \
-                 until you delete it there."
-            );
-        }
     }
 }
 
@@ -771,6 +688,238 @@ fn resolved_endpoint(config_dir: &Path, explicit: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::{CommandFactory as _, Parser as _};
+
+    /// A parser standing in for the real CLI, so the grammar under test is
+    /// exactly the one `spice connect ...` presents.
+    #[derive(clap::Parser, Debug)]
+    #[command(name = "spice")]
+    struct Harness {
+        #[command(subcommand)]
+        command: HarnessCommand,
+    }
+
+    #[derive(Subcommand, Debug)]
+    enum HarnessCommand {
+        Connect(ConnectArgs),
+    }
+
+    fn parse(args: &[&str]) -> Result<ConnectArgs, clap::Error> {
+        let harness = Harness::try_parse_from(args)?;
+        let HarnessCommand::Connect(connect) = harness.command;
+        Ok(connect)
+    }
+
+    fn service_command(args: &[&str]) -> service::cli::ServiceCommand {
+        let connect = parse(args).expect("the grammar must accept this");
+        match connect.command {
+            Some(ConnectCommand::Service(service_args)) => {
+                service_args.command.expect("an action was given")
+            }
+            other => panic!("expected a service action, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn every_service_action_parses() {
+        for action in [
+            "install",
+            "uninstall",
+            "start",
+            "stop",
+            "restart",
+            "status",
+            "logs",
+        ] {
+            let parsed = service_command(&["spice", "connect", "service", action]);
+            assert!(
+                format!("{parsed:?}").to_lowercase().starts_with(action),
+                "`spice connect service {action}` parsed as {parsed:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn service_without_an_action_parses_and_selects_nothing() {
+        let connect = parse(&["spice", "connect", "service"]).expect("no action is valid");
+        match connect.command {
+            Some(ConnectCommand::Service(args)) => assert!(args.command.is_none()),
+            other => panic!("expected the service group, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn svc_is_a_hidden_alias_for_service() {
+        // The alias exists for interactive typing. It is asserted only here, so
+        // nothing else in the CLI can start documenting it as a second
+        // spelling.
+        let parsed = service_command(&["spice", "connect", "svc", "status"]);
+        assert!(matches!(parsed, service::cli::ServiceCommand::Status(_)));
+
+        let group = Harness::command();
+        let connect = group
+            .get_subcommands()
+            .find(|c| c.get_name() == "connect")
+            .expect("connect exists");
+        let service = connect
+            .get_subcommands()
+            .find(|c| c.get_name() == "service")
+            .expect("service exists");
+        assert!(
+            service.get_visible_aliases().next().is_none(),
+            "`svc` must not appear in generated help"
+        );
+    }
+
+    #[test]
+    fn install_is_a_subcommand_and_never_a_flag() {
+        // `--install` was the previous spelling; it must be gone so the
+        // documented grammar is the only one.
+        parse(&["spice", "connect", "--install"]).expect_err("--install must not parse");
+        assert!(matches!(
+            service_command(&["spice", "connect", "service", "install"]),
+            service::cli::ServiceCommand::Install
+        ));
+    }
+
+    #[test]
+    fn logs_defaults_to_one_hundred_lines() {
+        let service::cli::ServiceCommand::Logs(args) =
+            service_command(&["spice", "connect", "service", "logs"])
+        else {
+            panic!("expected logs");
+        };
+        assert_eq!(args.number, 100);
+        assert!(!args.follow);
+    }
+
+    #[test]
+    fn logs_accepts_a_count_and_a_follow_flag() {
+        for args in [
+            ["spice", "connect", "service", "logs", "-n", "500"],
+            ["spice", "connect", "service", "logs", "--number", "500"],
+        ] {
+            let service::cli::ServiceCommand::Logs(parsed) = service_command(&args) else {
+                panic!("expected logs");
+            };
+            assert_eq!(parsed.number, 500);
+        }
+
+        for args in [
+            ["spice", "connect", "service", "logs", "-f"],
+            ["spice", "connect", "service", "logs", "--follow"],
+        ] {
+            let service::cli::ServiceCommand::Logs(parsed) = service_command(&args) else {
+                panic!("expected logs");
+            };
+            assert!(parsed.follow);
+            assert_eq!(parsed.number, 100);
+        }
+
+        // `-n 0 -f` follows only new lines.
+        let service::cli::ServiceCommand::Logs(parsed) =
+            service_command(&["spice", "connect", "service", "logs", "-n", "0", "-f"])
+        else {
+            panic!("expected logs");
+        };
+        assert_eq!(parsed.number, 0);
+        assert!(parsed.follow);
+    }
+
+    #[test]
+    fn logs_rejects_tail_and_an_out_of_range_count() {
+        parse(&["spice", "connect", "service", "logs", "--tail"])
+            .expect_err("--tail is intentionally absent");
+        parse(&["spice", "connect", "service", "logs", "--tail", "50"])
+            .expect_err("--tail is intentionally absent");
+        parse(&["spice", "connect", "service", "logs", "-n", "100001"])
+            .expect_err("a count beyond the ceiling must be refused");
+        parse(&["spice", "connect", "service", "logs", "-n", "-1"])
+            .expect_err("a negative count must be refused");
+    }
+
+    #[test]
+    fn both_status_commands_accept_the_same_output_flag() {
+        for args in [
+            ["spice", "connect", "status", "--output", "json"],
+            ["spice", "connect", "status", "-o", "json"],
+        ] {
+            let connect = parse(&args).expect("status accepts --output");
+            assert!(connect.produces_json());
+        }
+
+        for args in [
+            ["spice", "connect", "service", "status", "--output", "json"],
+            ["spice", "connect", "service", "status", "-o", "json"],
+        ] {
+            let connect = parse(&args).expect("service status accepts --output");
+            assert!(connect.produces_json());
+        }
+
+        // Table is the default, and only `status` produces JSON.
+        assert!(
+            !parse(&["spice", "connect", "status"])
+                .expect("parse")
+                .produces_json()
+        );
+        assert!(
+            !parse(&["spice", "connect", "service", "logs"])
+                .expect("parse")
+                .produces_json()
+        );
+    }
+
+    #[test]
+    fn machine_mode_selects_json_for_both_status_commands() {
+        let mut connect = parse(&["spice", "connect", "status"]).expect("parse");
+        connect.apply_machine_mode();
+        assert!(connect.produces_json());
+
+        let mut connect = parse(&["spice", "connect", "service", "status"]).expect("parse");
+        connect.apply_machine_mode();
+        assert!(connect.produces_json());
+
+        // A lifecycle action has no structured form, so machine mode leaves it
+        // alone rather than inventing one.
+        let mut connect = parse(&["spice", "connect", "service", "restart"]).expect("parse");
+        connect.apply_machine_mode();
+        assert!(!connect.produces_json());
+    }
+
+    #[test]
+    fn dir_is_global_across_every_service_action() {
+        for action in [
+            "install",
+            "uninstall",
+            "start",
+            "stop",
+            "restart",
+            "status",
+            "logs",
+        ] {
+            let connect = parse(&["spice", "connect", "service", action, "--dir", "/srv/edge"])
+                .unwrap_or_else(|e| panic!("`--dir` must apply to `{action}`: {e}"));
+            assert_eq!(connect.dir.as_deref(), Some(Path::new("/srv/edge")));
+        }
+    }
+
+    #[test]
+    fn a_service_action_never_accepts_a_supervisor_name() {
+        // Resolution is by instance directory. Accepting a unit or label would
+        // let a command control a service belonging to another instance.
+        for args in [
+            ["spice", "connect", "service", "restart", "some.service"],
+            [
+                "spice",
+                "connect",
+                "service",
+                "logs",
+                "ai.spice.cloud-connect.x",
+            ],
+        ] {
+            parse(&args).expect_err("a service name must not be accepted");
+        }
+    }
 
     #[test]
     fn instance_dir_is_the_parent_of_a_dot_spice_config_dir() {
@@ -791,52 +940,52 @@ mod tests {
     }
 
     #[test]
-    fn a_malformed_identity_is_not_accepted_as_enrolled_state() {
+    fn a_malformed_identity_is_not_reported_as_enrolled() {
         let dir = tempfile::tempdir().expect("create tempdir");
         std::fs::write(dir.path().join(IDENTITY_FILE), "not valid JSON")
             .expect("write malformed identity");
 
         let error = has_enrolled_identity(dir.path())
-            .expect_err("a malformed identity must not enable service installation");
+            .expect_err("a malformed identity must not read as enrolled");
         assert!(error.to_string().contains("load identity"), "{error}");
     }
 
     #[test]
     fn resolved_endpoint_prefers_the_explicit_flag() {
-        let dir = std::env::temp_dir().join(format!("spice-connect-ep-{}", std::process::id()));
-        let _ = std::fs::create_dir_all(&dir);
+        let dir = tempfile::tempdir().expect("create tempdir");
         assert_eq!(
-            resolved_endpoint(&dir, Some("https://explicit.example")),
+            resolved_endpoint(dir.path(), Some("https://explicit.example")),
             "https://explicit.example"
         );
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn resolved_endpoint_reads_the_on_disk_override_then_the_default() {
-        let dir = std::env::temp_dir().join(format!("spice-connect-ep2-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        let dir = tempfile::tempdir().expect("create tempdir");
 
         // Nothing on disk: the built-in default.
         assert_eq!(
-            resolved_endpoint(&dir, None),
+            resolved_endpoint(dir.path(), None),
             runtime_cloud_connect::config::DEFAULT_ENDPOINT
         );
 
         // The override file wins over the default.
-        std::fs::write(dir.join(CLOUD_ENDPOINT_FILE), "https://override.example\n")
-            .expect("write override");
-        assert_eq!(resolved_endpoint(&dir, None), "https://override.example");
-
-        // A blank override is not an endpoint.
-        std::fs::write(dir.join(CLOUD_ENDPOINT_FILE), "  \n").expect("write blank override");
+        std::fs::write(
+            dir.path().join(CLOUD_ENDPOINT_FILE),
+            "https://override.example\n",
+        )
+        .expect("write override");
         assert_eq!(
-            resolved_endpoint(&dir, None),
-            runtime_cloud_connect::config::DEFAULT_ENDPOINT
+            resolved_endpoint(dir.path(), None),
+            "https://override.example"
         );
 
-        let _ = std::fs::remove_dir_all(&dir);
+        // A blank override is not an endpoint.
+        std::fs::write(dir.path().join(CLOUD_ENDPOINT_FILE), "  \n").expect("write blank override");
+        assert_eq!(
+            resolved_endpoint(dir.path(), None),
+            runtime_cloud_connect::config::DEFAULT_ENDPOINT
+        );
     }
 
     #[tokio::test]
@@ -881,5 +1030,62 @@ mod tests {
         );
 
         drop(active);
+    }
+
+    #[tokio::test]
+    async fn an_unconfirmed_release_keeps_every_piece_of_local_state() {
+        // The acceptance criterion: a transient Cloud failure must leave a
+        // directory a retry can finish the removal from. Clearing the identity
+        // first would orphan a registry row nobody local can release any more.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let config_dir = dir.path().join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+
+        let identity_path = config_dir.join(IDENTITY_FILE);
+        let identity = runtime_cloud_connect::Identity {
+            identifier: "inst_test".to_string(),
+            ..test_identity()
+        };
+        runtime_cloud_connect::identity::IdentityStore::store(&identity_path, &identity)
+            .expect("store identity");
+        let cache_path = config_dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE);
+        std::fs::write(&cache_path, b"delivered-secrets").expect("write cache");
+
+        // A port nothing listens on: the release cannot be reported, which is
+        // exactly the transient failure under test.
+        let error = remove_identity(&config_dir, Some("http://127.0.0.1:1"), true)
+            .await
+            .expect_err("an unconfirmed release must fail the removal");
+        assert!(
+            error.to_string().contains("Nothing was removed locally"),
+            "{error}"
+        );
+        assert!(identity_path.exists(), "the identity must survive");
+        assert!(cache_path.exists(), "the delivered secrets must survive");
+    }
+
+    /// A syntactically complete identity whose key material is never used: the
+    /// removal path under test fails before it can sign anything.
+    fn test_identity() -> runtime_cloud_connect::Identity {
+        runtime_cloud_connect::Identity {
+            identifier: "inst_test".to_string(),
+            identity_cert_pem: "-----BEGIN CERTIFICATE-----\nAA==\n-----END CERTIFICATE-----\n"
+                .to_string(),
+            private_key_pem: "-----BEGIN PRIVATE KEY-----\nAA==\n-----END PRIVATE KEY-----\n"
+                .to_string(),
+            public_key_pem: "-----BEGIN PUBLIC KEY-----\nAA==\n-----END PUBLIC KEY-----\n"
+                .to_string(),
+            ca_bundle_pem: String::new(),
+            gateway_addr: "gateway.example:443".to_string(),
+            not_after_unix: None,
+            enc_private_key_pem: String::new(),
+            enc_public_key_pem: String::new(),
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+            app_id: None,
+            org_name: None,
+            app_name: None,
+            monitor_url: None,
+        }
     }
 }

--- a/bin/spice/src/commands/connect/mod.rs
+++ b/bin/spice/src/commands/connect/mod.rs
@@ -145,6 +145,14 @@ pub struct ConnectArgs {
     #[arg(long, short = 'y', global = true)]
     pub yes: bool,
 
+    /// Clear this directory's local state even when Spice Cloud could not
+    /// confirm the release. Applies to `remove`, which otherwise keeps the
+    /// identity so a retry can finish. Use it when the instance is already
+    /// deleted in the portal, or when the control plane that issued it is gone:
+    /// the portal-side delete is authoritative either way.
+    #[arg(long, global = true)]
+    pub force: bool,
+
     /// The global `--cloud-region`, forwarded by the dispatcher rather than
     /// declared here (the flag is global; clap would reject a second definition
     /// of the same name).
@@ -234,7 +242,7 @@ pub async fn execute(ctx: &RuntimeContext, args: ConnectArgs) -> Result<()> {
                 print_status(&config_dir, args.endpoint.as_deref(), status_args.output).await
             }
             ConnectCommand::Remove => {
-                remove_identity(&config_dir, args.endpoint.as_deref(), args.yes).await
+                remove_identity(&config_dir, args.endpoint.as_deref(), args.yes, args.force).await
             }
             ConnectCommand::Service(service_args) => {
                 service::cli::execute(
@@ -352,18 +360,57 @@ fn has_enrolled_identity(config_dir: &Path) -> Result<bool> {
         })
 }
 
-/// The instance directory a config dir belongs to: `<dir>/.spice` → `<dir>`.
+/// The canonical instance directory a config dir belongs to: `<dir>/.spice` →
+/// `<dir>`.
 ///
 /// `SPICE_CONFIG_DIR` can point anywhere, so a config dir that is not named
 /// `.spice` has no instance directory above it — in that case the config dir
 /// itself is the best available answer for the service's working directory.
+///
+/// The result is canonicalized because it *is* the service's identity: the
+/// service name is a digest of this path, so `/srv/edge`, `/srv/./edge`,
+/// `/srv/other/../edge`, and a symlink to any of them have to reduce to one
+/// answer. Without that, one instance directory can install a second service
+/// under a second name, or reject the valid manifest of the one it already has.
 fn instance_dir_for(config_dir: &Path) -> PathBuf {
-    if config_dir.file_name() == Some(std::ffi::OsStr::new(".spice"))
+    let dir = if config_dir.file_name() == Some(std::ffi::OsStr::new(".spice"))
         && let Some(parent) = config_dir.parent().filter(|p| !p.as_os_str().is_empty())
     {
-        return parent.to_path_buf();
+        parent.to_path_buf()
+    } else {
+        config_dir.to_path_buf()
+    };
+    canonicalize_instance_dir(&dir)
+}
+
+/// Reduce an instance directory to the one spelling every command must derive
+/// its service name from.
+///
+/// `fs::canonicalize` is the authoritative answer — it resolves symlinks, which
+/// a purely textual normalization cannot — but it needs the directory to exist.
+/// A directory that is not there yet still has to produce a stable name (that
+/// is how `status` reports on a directory before anything is created in it), so
+/// the fallback normalizes `.` and `..` textually. Resolving `..` without the
+/// filesystem is only safe because the input is already absolute.
+fn canonicalize_instance_dir(dir: &Path) -> PathBuf {
+    if let Ok(canonical) = std::fs::canonicalize(dir) {
+        return canonical;
     }
-    config_dir.to_path_buf()
+    let mut normalized = PathBuf::new();
+    for component in dir.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                // A leading `..` has nothing to pop, so it is kept: dropping it
+                // would silently rewrite the path to a different directory.
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
 }
 
 /// Collect and render one status snapshot.
@@ -380,44 +427,49 @@ async fn print_status(
     )
     .await;
     status::render(&status, output)?;
-    if status.is_degraded() {
-        return Err(Error::ServiceUnavailable {
-            message: format!(
-                "The Spice Cloud Connect service for {} is {}{}",
-                status.connection.directory.display(),
-                status.service.state,
-                match &status.service.diagnostic {
-                    Some(diagnostic) => format!(": {diagnostic}"),
-                    None => ".".to_string(),
-                }
-            ),
-        });
+    // The report is already on stdout; the diagnosis travels as the command's
+    // error so a `--output json` run stays parseable.
+    match status.degradation() {
+        Some(message) => Err(Error::ServiceUnavailable { message }),
+        None => Ok(()),
     }
-    Ok(())
 }
 
 /// What Spice Cloud said about the release, reduced to the only question that
 /// decides whether local state may be cleared.
 #[derive(Debug)]
 enum ReleaseVerdict {
-    /// The cloud confirmed the release, or confirmed this instance is not
-    /// there. Either way the credential on disk is no longer usable and can go.
+    /// The cloud confirmed the release, or stated that this instance is
+    /// permanently gone. Either way the credential on disk is no longer usable
+    /// and can go.
     Confirmed {
         outcome: runtime_cloud_connect::release::ReleaseOutcome,
     },
-    /// The cloud could not be reached, or refused in a way that leaves the
-    /// instance registered. Local state must survive so a retry can finish the
-    /// removal.
+    /// The cloud could not be reached, or refused in a way that does not
+    /// establish what happened to the instance. Local state must survive so a
+    /// retry can finish the removal.
     Unconfirmed { reason: String },
 }
+
+/// The status the control plane uses to say an instance existed and is
+/// permanently gone. Unlike a bare not-found, it cannot also mean "you asked
+/// the wrong control plane" or "you may not see this instance".
+const RELEASE_GONE_STATUS: u16 = 410;
 
 /// Report this instance's release to Spice Cloud and classify the answer.
 ///
 /// The classification is the whole point: clearing the identity is what makes a
 /// removal unrecoverable, so it happens only once the cloud has said the
-/// instance is released or already gone. A network blip must leave a directory
-/// a retry can finish from — the alternative silently orphans a registry row
-/// that nobody local can release any more.
+/// instance is released or permanently gone. A network blip, or an answer that
+/// does not establish what happened, must leave a directory a retry can finish
+/// from — the alternative silently orphans a registry row that nobody local can
+/// release any more.
+///
+/// A `404` deliberately does **not** confirm anything. The release endpoint
+/// answers not-found for an instance that belongs to another organization, and
+/// for a request aimed at a control plane that never issued this identity, so
+/// reading it as absence lets a mistyped `--endpoint` clear the only credential
+/// for an instance that is alive in its real registry.
 async fn release_instance(
     config_dir: &Path,
     endpoint: Option<&str>,
@@ -426,13 +478,25 @@ async fn release_instance(
     let endpoint = resolved_endpoint(config_dir, endpoint);
     let ca = (!identity.ca_bundle_pem.is_empty()).then_some(identity.ca_bundle_pem.as_str());
 
-    match runtime_cloud_connect::release::release(&endpoint, identity, ca).await {
+    classify_release(
+        runtime_cloud_connect::release::release(&endpoint, identity, ca).await,
+        &endpoint,
+    )
+}
+
+/// [`release_instance`] without the request: the classification of what the
+/// control plane answered.
+///
+/// Separated so every branch — including the `404` that must *not* confirm
+/// anything — is tested without key material or a control plane.
+fn classify_release(
+    result: runtime_cloud_connect::release::Result<runtime_cloud_connect::release::ReleaseOutcome>,
+    endpoint: &str,
+) -> ReleaseVerdict {
+    match result {
         Ok(outcome) => ReleaseVerdict::Confirmed { outcome },
-        // The cloud has no such instance: the same end state the release was
-        // asking for, including the case where it was already deleted in the
-        // portal.
         Err(runtime_cloud_connect::release::Error::Rejected { status, .. })
-            if status == 404 || status == 410 =>
+            if status == RELEASE_GONE_STATUS =>
         {
             ReleaseVerdict::Confirmed {
                 outcome: runtime_cloud_connect::release::ReleaseOutcome {
@@ -444,11 +508,11 @@ async fn release_instance(
         Err(err) => ReleaseVerdict::Unconfirmed {
             reason: format!(
                 "{err} Nothing was removed locally: the identity, delivered secrets, and any \
-                 installed service are intact so `spice connect remove` can finish the removal. \
-                 If Spice Cloud cannot accept the release at all, delete the instance in the \
-                 Spice Cloud portal and re-run this command — a released instance is confirmed \
-                 absent and its local state is then cleared. \
-                 See: https://spiceai.org/docs"
+                 installed service are intact, so `spice connect remove` can finish the removal \
+                 once {endpoint} can be reached. If this instance is already deleted in the \
+                 Spice Cloud portal — or that control plane is the wrong one for it — pass \
+                 --force to clear this directory's local state without a confirmed release; the \
+                 portal-side delete stays authoritative. See: https://spiceai.org/docs"
             ),
         },
     }
@@ -459,13 +523,16 @@ async fn release_instance(
 ///
 /// Ordered so that no step is taken on the strength of a guess. The release is
 /// reported first and its answer decides everything after it: a confirmed
-/// release (or a confirmed absence) is what makes the local credential dead and
-/// safe to delete, while an unconfirmed one leaves the directory exactly as it
-/// was for a retry to finish.
+/// release, or a stated permanent absence, is what makes the local credential
+/// dead and safe to delete, while an unconfirmed one leaves the directory
+/// exactly as it was for a retry to finish. `force` is the operator saying they
+/// have decided for themselves — it is honoured only after the unconfirmed
+/// reason has been printed.
 async fn remove_identity(
     config_dir: &Path,
     endpoint: Option<&str>,
     assume_yes: bool,
+    force: bool,
 ) -> Result<()> {
     // Own the complete state transition before inspecting any file. Without
     // this boundary, removal can clear old state while enrollment is still
@@ -543,10 +610,19 @@ async fn remove_identity(
                     );
                 }
             }
-            ReleaseVerdict::Unconfirmed { reason } => {
+            ReleaseVerdict::Unconfirmed { reason } if !force => {
                 return Err(Error::CloudConnectIo {
                     message: format!("release this instance in Spice Cloud: {reason}"),
                 });
+            }
+            // Asked for explicitly, and only ever after the operator has been
+            // told what could not be confirmed: the local state goes and the
+            // portal-side delete is what actually releases the instance.
+            ReleaseVerdict::Unconfirmed { reason } => {
+                println!(
+                    "Could not confirm the release with Spice Cloud: {reason} Clearing this \
+                     directory's local state anyway because --force was given."
+                );
             }
         }
     }
@@ -940,6 +1016,54 @@ mod tests {
     }
 
     #[test]
+    fn equivalent_spellings_reduce_to_one_instance_directory() {
+        // The service name is a digest of this path, so two spellings of one
+        // directory must not become two services.
+        for spelling in [
+            "/srv/edge/.spice",
+            "/srv/./edge/.spice",
+            "/srv/other/../edge/.spice",
+            "/srv//edge/.spice",
+        ] {
+            assert_eq!(
+                instance_dir_for(Path::new(spelling)),
+                PathBuf::from("/srv/edge"),
+                "{spelling}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_symlinked_instance_directory_resolves_to_its_target() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let real = dir.path().join("real");
+        std::fs::create_dir_all(real.join(".spice")).expect("create the instance directory");
+        let link = dir.path().join("link");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real, &link).expect("symlink the instance directory");
+        #[cfg(not(unix))]
+        std::fs::create_dir_all(&link).expect("stand in for a symlink");
+
+        // Both spellings name one directory, so both must derive one service.
+        let through_link = instance_dir_for(&link.join(".spice"));
+        let direct = instance_dir_for(&real.join(".spice"));
+        #[cfg(unix)]
+        assert_eq!(through_link, direct);
+        #[cfg(not(unix))]
+        assert_ne!(through_link, direct);
+    }
+
+    #[test]
+    fn a_leading_parent_component_is_not_silently_dropped() {
+        // Nothing to pop, and rewriting the path would name a different
+        // directory than the caller asked for.
+        assert_eq!(
+            canonicalize_instance_dir(Path::new("../unresolvable/edge")),
+            PathBuf::from("../unresolvable/edge")
+        );
+    }
+
+    #[test]
     fn a_malformed_identity_is_not_reported_as_enrolled() {
         let dir = tempfile::tempdir().expect("create tempdir");
         std::fs::write(dir.path().join(IDENTITY_FILE), "not valid JSON")
@@ -1009,7 +1133,7 @@ mod tests {
             std::fs::write(path, contents).expect("write active state");
         }
 
-        let error = remove_identity(&config_dir, None, true)
+        let error = remove_identity(&config_dir, None, true, false)
             .await
             .expect_err("active enrollment owns removal transaction");
         assert!(
@@ -1030,6 +1154,76 @@ mod tests {
         );
 
         drop(active);
+    }
+
+    #[test]
+    fn a_not_found_release_never_confirms_an_absence() {
+        // The release endpoint answers not-found for an instance in another
+        // organization, and for a request aimed at a control plane that never
+        // issued this identity. Reading either as absence lets a mistyped
+        // --endpoint clear the only credential for a live instance.
+        for status in [400, 401, 403, 404, 409, 500, 503] {
+            let verdict = classify_release(
+                Err(runtime_cloud_connect::release::Error::Rejected {
+                    status,
+                    message: "not found".to_string(),
+                }),
+                "https://api.example",
+            );
+            assert!(
+                matches!(verdict, ReleaseVerdict::Unconfirmed { .. }),
+                "HTTP {status} must not confirm anything: {verdict:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_a_stated_permanent_absence_confirms_without_a_release() {
+        // `410 Gone` says the instance existed and is permanently gone, which a
+        // cross-organization or wrong-control-plane request does not produce.
+        let verdict = classify_release(
+            Err(runtime_cloud_connect::release::Error::Rejected {
+                status: RELEASE_GONE_STATUS,
+                message: "gone".to_string(),
+            }),
+            "https://api.example",
+        );
+        match verdict {
+            ReleaseVerdict::Confirmed { outcome } => assert_eq!(outcome.status, "removed"),
+            other @ ReleaseVerdict::Unconfirmed { .. } => {
+                panic!("410 must confirm the end state: {other:?}")
+            }
+        }
+
+        // And an accepted release confirms, which is the ordinary path.
+        let verdict = classify_release(
+            Ok(runtime_cloud_connect::release::ReleaseOutcome {
+                status: "removed".to_string(),
+                app_name: Some("edge-analytics".to_string()),
+            }),
+            "https://api.example",
+        );
+        assert!(
+            matches!(verdict, ReleaseVerdict::Confirmed { .. }),
+            "{verdict:?}"
+        );
+    }
+
+    #[test]
+    fn an_unconfirmed_release_names_the_way_to_finish_it() {
+        let verdict = classify_release(
+            Err(runtime_cloud_connect::release::Error::Rejected {
+                status: 404,
+                message: "no such instance".to_string(),
+            }),
+            "https://api.example",
+        );
+        let ReleaseVerdict::Unconfirmed { reason } = verdict else {
+            panic!("404 must not confirm");
+        };
+        assert!(reason.contains("Nothing was removed locally"), "{reason}");
+        assert!(reason.contains("--force"), "{reason}");
+        assert!(reason.contains("https://api.example"), "{reason}");
     }
 
     #[tokio::test]
@@ -1053,7 +1247,7 @@ mod tests {
 
         // A port nothing listens on: the release cannot be reported, which is
         // exactly the transient failure under test.
-        let error = remove_identity(&config_dir, Some("http://127.0.0.1:1"), true)
+        let error = remove_identity(&config_dir, Some("http://127.0.0.1:1"), true, false)
             .await
             .expect_err("an unconfirmed release must fail the removal");
         assert!(

--- a/bin/spice/src/commands/connect/service/backend.rs
+++ b/bin/spice/src/commands/connect/service/backend.rs
@@ -1,0 +1,499 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! The interface every service back end implements.
+//!
+//! One trait for systemd and launchd, with no defaulted methods: a back end
+//! that forgets an operation fails to compile rather than silently inheriting
+//! a no-op, which is the failure mode a defaulted lifecycle method has.
+//!
+//! The trait speaks only the normalized vocabulary in [`super::model`]. Every
+//! supervisor word — `activating`, `waiting`, `not loaded` — is translated
+//! inside the back end, so nothing above this line has to know which
+//! supervisor answered.
+
+use std::path::{Path, PathBuf};
+
+use super::model::{LogSource, ServiceScope, ServiceStarts, ServiceState, Supervisor};
+use super::{InstalledService, PreflightFailure, manifest::ServiceManifest};
+use crate::error::{Error, Result};
+
+/// What an install needs to know, resolved by the caller so the back end
+/// never derives a path from the environment.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InstallRequest<'a> {
+    /// The canonical instance directory: the spicepod root the service runs
+    /// from, and the only input the service name is derived from.
+    pub(crate) instance_dir: &'a Path,
+    /// The resolved Spice config directory holding the enrolled identity.
+    pub(crate) config_dir: &'a Path,
+    /// The `spiced` the CLI found, to be staged for the service.
+    pub(crate) spiced_path: &'a Path,
+    /// The service domain to install into.
+    pub(crate) scope: ServiceScope,
+}
+
+/// One fresh reading of what the supervisor says about a service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServiceObservation {
+    pub(crate) state: ServiceState,
+    pub(crate) starts: ServiceStarts,
+    /// Why the reading is [`ServiceState::Unavailable`], when it is.
+    pub(crate) diagnostic: Option<String>,
+    /// The command that would give the service the boot persistence it lacks.
+    pub(crate) starts_action: Option<String>,
+}
+
+impl ServiceObservation {
+    /// A reading the supervisor could not answer.
+    pub(crate) fn unavailable(diagnostic: String) -> Self {
+        Self {
+            state: ServiceState::Unavailable,
+            starts: ServiceStarts::Unavailable,
+            diagnostic: Some(diagnostic),
+            starts_action: None,
+        }
+    }
+}
+
+/// How much log history to print, and whether to keep printing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LogRequest {
+    /// Lines of existing history to print before anything else. `0` with
+    /// `follow` prints only new output.
+    pub(crate) number: u32,
+    /// Keep printing new output until interrupted.
+    pub(crate) follow: bool,
+}
+
+/// The operations a supervisor back end provides.
+///
+/// Deliberately without default implementations. Adding one later would let a
+/// back end inherit a no-op for an operation it must actually perform — the
+/// exact regression a defaulted trait method produces in a wrapper.
+pub(crate) trait ServiceBackend {
+    /// Which supervisor this back end drives.
+    fn supervisor(&self) -> Supervisor;
+
+    /// Whether this host can have a service installed in `scope`, checked
+    /// before anything irreversible happens.
+    ///
+    /// # Errors
+    ///
+    /// Returns the reason installation is impossible on this host.
+    fn preflight(&self, scope: ServiceScope) -> std::result::Result<(), PreflightFailure>;
+
+    /// The deterministic service name this back end gives `instance_dir`.
+    fn name_for_dir(&self, instance_dir: &Path) -> String;
+
+    /// Where the definition for `name` lives in `scope`.
+    fn definition_path(&self, name: &str, scope: ServiceScope) -> PathBuf;
+
+    /// Where the supervisor keeps the output of `name` in `scope`, or `None`
+    /// when the definition names no source this CLI can read.
+    fn log_source(&self, name: &str, scope: ServiceScope) -> Option<LogSource>;
+
+    /// The service installed for `instance_dir`, as the supervisor's own
+    /// definition describes it, or `None` when there is no definition under
+    /// this directory's derived name that names this directory.
+    ///
+    /// This is not a search: the name is derived from `instance_dir` and the
+    /// definition is accepted only when it agrees. It exists so a directory
+    /// that lost its manifest — deleted by hand, or restored from a backup that
+    /// skipped it — can still be reported on and removed, and so an install can
+    /// tell "my own service" from "someone else's file under the name I
+    /// derive".
+    fn find_installed(&self, instance_dir: &Path, scope: ServiceScope) -> Option<InstalledService>;
+
+    /// Install (or reinstall) and start the service.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the definition cannot be written or the
+    /// supervisor rejects it.
+    fn install(&self, request: &InstallRequest<'_>) -> Result<InstalledService>;
+
+    /// Stop and remove exactly the service the manifest describes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the definition cannot be removed, or when the
+    /// supervisor is left holding a job the removed definition can no longer
+    /// account for.
+    fn uninstall(&self, manifest: &ServiceManifest) -> Result<()>;
+
+    /// Start an installed, stopped service. Idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the supervisor refuses or the service does not
+    /// come up.
+    fn start(&self, manifest: &ServiceManifest) -> Result<()>;
+
+    /// Stop a running service. Idempotent, and leaves it installed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the supervisor refuses or the service does not
+    /// go down.
+    fn stop(&self, manifest: &ServiceManifest) -> Result<()>;
+
+    /// Stop and start the service through the supervisor, waiting for it to
+    /// reach [`ServiceState::Running`] or fail. Never asks `spiced` to exit
+    /// itself.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the service does not come back.
+    fn restart(&self, manifest: &ServiceManifest) -> Result<()>;
+
+    /// Ask the supervisor for the service's current state and persistence.
+    ///
+    /// Never fails: a supervisor that cannot be asked is reported as
+    /// [`ServiceState::Unavailable`] with a diagnostic, because status has to
+    /// render something either way.
+    fn observe(&self, manifest: &ServiceManifest) -> ServiceObservation;
+
+    /// Print the service's output as `request` asks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the log source cannot be read.
+    fn logs(&self, manifest: &ServiceManifest, request: LogRequest) -> Result<()>;
+
+    /// The native supervisor commands an operator falls back to when a Spice
+    /// command cannot complete. Recovery detail, never the primary interface.
+    fn recovery_hints(&self, manifest: &ServiceManifest) -> Vec<String>;
+}
+
+/// The error a lifecycle operation returns until its back end implements it.
+///
+/// A typed error rather than a panic: the CLI has to exit with a diagnosis and
+/// a non-zero status, and a caller that reaches an unfinished path should
+/// degrade rather than abort. The grammar, manifest, and status model land
+/// first so the systemd and launchd lifecycle work has one interface to fill
+/// in.
+pub(crate) fn lifecycle_pending(
+    backend: &dyn ServiceBackend,
+    action: &str,
+    manifest: &ServiceManifest,
+) -> Error {
+    Error::NotImplemented {
+        message: format!(
+            "Failed to {action} the Spice Cloud Connect service {name} ({supervisor}): \
+             {supervisor} lifecycle control is not available in this release. \
+             Use the supervisor directly for now — {hints} — and see \
+             https://spiceai.org/docs for the supported service operations.",
+            name = manifest.name,
+            supervisor = manifest.supervisor,
+            hints = backend.recovery_hints(manifest).join(" ; "),
+        ),
+    }
+}
+
+/// The back end for this host.
+///
+/// Selected at compile time: a host has one supervisor, and choosing it at
+/// runtime would mean shipping a code path that can never run there.
+#[cfg(target_os = "linux")]
+pub(crate) fn for_host() -> &'static dyn ServiceBackend {
+    &super::systemd::SystemdBackend
+}
+
+/// The back end for this host.
+#[cfg(target_os = "macos")]
+pub(crate) fn for_host() -> &'static dyn ServiceBackend {
+    &super::launchd::LaunchdBackend
+}
+
+/// The back end for a host with no supported supervisor.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub(crate) fn for_host() -> &'static dyn ServiceBackend {
+    &unsupported::UnsupportedBackend
+}
+
+/// A back end for a host that has no supervisor Spice can install into.
+///
+/// [`ServiceBackend::preflight`] rejects such a host before any state changes,
+/// so the remaining operations exist to keep the CLI building and to give the
+/// same refusal if one is somehow reached.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+mod unsupported {
+    use super::{
+        InstallRequest, InstalledService, LogRequest, LogSource, Path, PathBuf, PreflightFailure,
+        Result, ServiceBackend, ServiceManifest, ServiceObservation, ServiceScope, Supervisor,
+    };
+
+    pub(super) struct UnsupportedBackend;
+
+    impl ServiceBackend for UnsupportedBackend {
+        fn supervisor(&self) -> Supervisor {
+            // Nothing installs here, so the value is only ever a placeholder in
+            // an error path.
+            Supervisor::Systemd
+        }
+
+        fn preflight(&self, _scope: ServiceScope) -> std::result::Result<(), PreflightFailure> {
+            Err(PreflightFailure::UnsupportedPlatform)
+        }
+
+        fn name_for_dir(&self, instance_dir: &Path) -> String {
+            super::super::name_stem_for_dir(instance_dir)
+        }
+
+        fn definition_path(&self, name: &str, _scope: ServiceScope) -> PathBuf {
+            PathBuf::from(name)
+        }
+
+        fn log_source(&self, _name: &str, _scope: ServiceScope) -> Option<LogSource> {
+            None
+        }
+
+        fn find_installed(
+            &self,
+            _instance_dir: &Path,
+            _scope: ServiceScope,
+        ) -> Option<InstalledService> {
+            None
+        }
+
+        fn install(&self, _request: &InstallRequest<'_>) -> Result<InstalledService> {
+            Err(PreflightFailure::UnsupportedPlatform.into())
+        }
+
+        fn uninstall(&self, _manifest: &ServiceManifest) -> Result<()> {
+            Err(PreflightFailure::UnsupportedPlatform.into())
+        }
+
+        fn start(&self, _manifest: &ServiceManifest) -> Result<()> {
+            Err(PreflightFailure::UnsupportedPlatform.into())
+        }
+
+        fn stop(&self, _manifest: &ServiceManifest) -> Result<()> {
+            Err(PreflightFailure::UnsupportedPlatform.into())
+        }
+
+        fn restart(&self, _manifest: &ServiceManifest) -> Result<()> {
+            Err(PreflightFailure::UnsupportedPlatform.into())
+        }
+
+        fn observe(&self, _manifest: &ServiceManifest) -> ServiceObservation {
+            ServiceObservation::unavailable(format!(
+                "{} has no service supervisor Spice can manage.",
+                std::env::consts::OS
+            ))
+        }
+
+        fn logs(&self, _manifest: &ServiceManifest, _request: LogRequest) -> Result<()> {
+            Err(PreflightFailure::UnsupportedPlatform.into())
+        }
+
+        fn recovery_hints(&self, _manifest: &ServiceManifest) -> Vec<String> {
+            Vec::new()
+        }
+    }
+}
+
+/// A back end whose every answer is scripted, so the layers above it can be
+/// tested against states no test host can be put into on demand.
+#[cfg(test)]
+pub(crate) mod fake {
+    use std::cell::RefCell;
+
+    use super::{
+        InstallRequest, InstalledService, LogRequest, LogSource, Path, PathBuf, PreflightFailure,
+        Result, ServiceBackend, ServiceManifest, ServiceObservation, ServiceScope, ServiceStarts,
+        ServiceState, Supervisor,
+    };
+    use crate::error::Error;
+
+    /// The service name the fake gives every directory, so tests can assert
+    /// against a fixed prefix.
+    pub(crate) const FAKE_NAME_PREFIX: &str = "fake-cloud-connect";
+
+    /// The runtime path the fake reports as installed.
+    pub(crate) const FAKE_RUNTIME: &str = "/usr/local/lib/spice/spiced";
+
+    pub(crate) struct FakeBackend {
+        pub(crate) supervisor: Supervisor,
+        pub(crate) observation: ServiceObservation,
+        /// Directory the fake writes its definitions into, so the shared
+        /// resolution and pre-existing-name checks can be exercised against
+        /// real files.
+        pub(crate) definitions: PathBuf,
+        /// Operations that fail, and what they say when they do. Lets a test
+        /// drive a partial failure — an uninstall whose supervisor refused
+        /// after the definition was already gone, for instance.
+        pub(crate) failures: Vec<(&'static str, String)>,
+        /// Every back-end call made, in order.
+        pub(crate) calls: RefCell<Vec<String>>,
+    }
+
+    impl FakeBackend {
+        /// A fake whose definitions live under `root`, reporting a running
+        /// service.
+        pub(crate) fn new(root: &Path) -> Self {
+            Self {
+                supervisor: Supervisor::Systemd,
+                observation: ServiceObservation {
+                    state: ServiceState::Running,
+                    starts: ServiceStarts::BootWithoutLogin,
+                    diagnostic: None,
+                    starts_action: None,
+                },
+                definitions: root.join("definitions"),
+                failures: Vec::new(),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        pub(crate) fn in_state(root: &Path, state: ServiceState) -> Self {
+            let mut fake = Self::new(root);
+            fake.observation.state = state;
+            fake
+        }
+
+        pub(crate) fn failing(root: &Path, operation: &'static str, message: &str) -> Self {
+            let mut fake = Self::new(root);
+            fake.failures = vec![(operation, message.to_string())];
+            fake
+        }
+
+        pub(crate) fn calls(&self) -> Vec<String> {
+            self.calls.borrow().clone()
+        }
+
+        /// Put a definition on disk that this back end did not write — what a
+        /// hand-made unit, or one left behind by a directory that has since
+        /// moved, looks like to the installer.
+        pub(crate) fn plant_foreign_definition(&self, instance_dir: &Path) {
+            let name = self.name_for_dir(instance_dir);
+            let path = self.definition_path(&name, ServiceScope::System);
+            std::fs::create_dir_all(&self.definitions).expect("create definition dir");
+            std::fs::write(path, "/somewhere/else").expect("plant a definition");
+        }
+
+        fn record(&self, operation: &'static str) -> Result<()> {
+            self.calls.borrow_mut().push(operation.to_string());
+            match self
+                .failures
+                .iter()
+                .find(|(name, _)| *name == operation)
+                .map(|(_, message)| message.clone())
+            {
+                Some(message) => Err(Error::CloudConnectIo { message }),
+                None => Ok(()),
+            }
+        }
+    }
+
+    impl ServiceBackend for FakeBackend {
+        fn supervisor(&self) -> Supervisor {
+            self.supervisor
+        }
+
+        fn preflight(&self, _scope: ServiceScope) -> std::result::Result<(), PreflightFailure> {
+            Ok(())
+        }
+
+        fn name_for_dir(&self, instance_dir: &Path) -> String {
+            format!(
+                "{FAKE_NAME_PREFIX}-{}",
+                super::super::name_stem_for_dir(instance_dir)
+            )
+        }
+
+        fn definition_path(&self, name: &str, _scope: ServiceScope) -> PathBuf {
+            self.definitions.join(name)
+        }
+
+        fn log_source(&self, name: &str, scope: ServiceScope) -> Option<LogSource> {
+            Some(LogSource::Journal {
+                unit: name.to_string(),
+                scope,
+            })
+        }
+
+        fn find_installed(
+            &self,
+            instance_dir: &Path,
+            scope: ServiceScope,
+        ) -> Option<InstalledService> {
+            let name = self.name_for_dir(instance_dir);
+            let path = self.definition_path(&name, scope);
+            // The definition records the directory it was written for, the way
+            // a real one bakes in its working directory. A definition that
+            // names somewhere else is not this directory's service.
+            let recorded = std::fs::read_to_string(&path).ok()?;
+            (Path::new(recorded.trim()) == instance_dir).then(|| InstalledService {
+                name,
+                path,
+                working_dir: instance_dir.to_path_buf(),
+                runtime: PathBuf::from(FAKE_RUNTIME),
+            })
+        }
+
+        fn install(&self, request: &InstallRequest<'_>) -> Result<InstalledService> {
+            self.record("install")?;
+            let name = self.name_for_dir(request.instance_dir);
+            let path = self.definition_path(&name, request.scope);
+            std::fs::create_dir_all(&self.definitions).map_err(|e| Error::CloudConnectIo {
+                message: format!("create the fake definition directory: {e}"),
+            })?;
+            std::fs::write(&path, request.instance_dir.display().to_string()).map_err(|e| {
+                Error::CloudConnectIo {
+                    message: format!("write the fake definition: {e}"),
+                }
+            })?;
+            Ok(InstalledService {
+                name,
+                path,
+                working_dir: request.instance_dir.to_path_buf(),
+                runtime: PathBuf::from(FAKE_RUNTIME),
+            })
+        }
+
+        fn uninstall(&self, manifest: &ServiceManifest) -> Result<()> {
+            self.record("uninstall")?;
+            let _ = std::fs::remove_file(&manifest.definition_path);
+            Ok(())
+        }
+
+        fn start(&self, _manifest: &ServiceManifest) -> Result<()> {
+            self.record("start")
+        }
+
+        fn stop(&self, _manifest: &ServiceManifest) -> Result<()> {
+            self.record("stop")
+        }
+
+        fn restart(&self, _manifest: &ServiceManifest) -> Result<()> {
+            self.record("restart")
+        }
+
+        fn observe(&self, _manifest: &ServiceManifest) -> ServiceObservation {
+            self.observation.clone()
+        }
+
+        fn logs(&self, _manifest: &ServiceManifest, _request: LogRequest) -> Result<()> {
+            self.record("logs")
+        }
+
+        fn recovery_hints(&self, manifest: &ServiceManifest) -> Vec<String> {
+            vec![format!("fakectl status {}", manifest.name)]
+        }
+    }
+}

--- a/bin/spice/src/commands/connect/service/cli.rs
+++ b/bin/spice/src/commands/connect/service/cli.rs
@@ -232,7 +232,10 @@ async fn install(
             ctx.spiced_path().display()
         ),
     })?;
-    let runtime_version = ctx.runtime_version().unwrap_or_default();
+    // Propagated, not defaulted: the manifest records the version installed, so
+    // a lookup that failed has to fail the install rather than publish a
+    // manifest that claims no version at all.
+    let runtime_version = ctx.runtime_version()?;
     let health_url = format!("{}/health", ctx.http_endpoint().trim_end_matches('/'));
 
     let manifest = super::install(
@@ -342,20 +345,10 @@ fn resolve_or_report(
 /// The report is already on stdout by the time this runs: the diagnosis travels
 /// as the process's error on stderr, so a `--output json` run stays parseable.
 fn degraded_error(status: &ConnectStatus) -> Result<()> {
-    if !status.is_degraded() {
-        return Ok(());
+    match status.degradation() {
+        Some(message) => Err(Error::ServiceUnavailable { message }),
+        None => Ok(()),
     }
-    Err(Error::ServiceUnavailable {
-        message: format!(
-            "The Spice Cloud Connect service for {} is {}{}",
-            status.connection.directory.display(),
-            status.service.state,
-            match &status.service.diagnostic {
-                Some(diagnostic) => format!(": {diagnostic}"),
-                None => ".".to_string(),
-            }
-        ),
-    })
 }
 
 #[cfg(test)]

--- a/bin/spice/src/commands/connect/service/cli.rs
+++ b/bin/spice/src/commands/connect/service/cli.rs
@@ -1,0 +1,410 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! The `spice connect service` command group.
+//!
+//! `service` is the canonical spelling everywhere — help, completions, errors,
+//! portal copy, documentation. `svc` is a hidden clap alias for interactive
+//! typing only; it is deliberately absent from generated help and from every
+//! message this CLI prints, so it never becomes a second public spelling.
+//!
+//! Every action resolves its target from the instance directory (`--dir`, or
+//! the current directory) and that directory's manifest. There is no way to
+//! name a systemd unit or a launchd label, because a lifecycle command aimed at
+//! a service belonging to another instance is worse than one that refuses.
+
+use std::path::Path;
+
+use clap::{Args, Subcommand};
+
+use super::super::status::{self, ConnectStatus};
+use super::{ServiceBackend, ServiceManifest, backend};
+use crate::context::RuntimeContext;
+use crate::error::{Error, Result};
+use crate::output::OutputFormat;
+
+/// Default number of log lines printed before following.
+const DEFAULT_LOG_LINES: u32 = 100;
+
+/// Ceiling on the initial log line count. A request for more history than a
+/// supervisor keeps is a mistake worth naming rather than a request to page
+/// through everything on the host.
+const MAX_LOG_LINES: u32 = 100_000;
+
+/// The concise help printed by `spice connect service` with no action.
+///
+/// Hand-written rather than clap's generated help so the group's summary line
+/// stays one screen. [`tests::the_no_action_help_lists_every_action`] pins it
+/// against the actual set of subcommands.
+const SERVICE_HELP: &str = "\
+Manage the persistent Spice Cloud Connect service for this instance directory.
+
+  spice connect service install      Install and start the service.
+  spice connect service uninstall    Stop and remove it, keeping the Cloud identity.
+  spice connect service start        Start an installed, stopped service.
+  spice connect service stop         Stop a running service, leaving it installed.
+  spice connect service restart      Restart it through the supervisor and wait.
+  spice connect service status       Report its state, persistence, and paths.
+  spice connect service logs         Print its output (-n <lines>, -f to follow).
+
+Use --dir <path> to act on an instance rooted at another directory.
+Docs: https://spiceai.org/docs";
+
+/// Arguments for `spice connect service`.
+#[derive(Args, Debug)]
+pub struct ServiceArgs {
+    /// The action to perform. With none, concise help is printed and nothing
+    /// is done.
+    #[command(subcommand)]
+    pub command: Option<ServiceCommand>,
+}
+
+/// The service lifecycle actions.
+#[derive(Subcommand, Debug)]
+pub enum ServiceCommand {
+    /// Install and start the service for this instance directory.
+    ///
+    /// Idempotent: re-running restages the current runtime, rewrites the
+    /// definition, and restarts the service without touching the enrolled
+    /// identity.
+    Install,
+
+    /// Stop and remove this directory's service, keeping the Cloud identity.
+    ///
+    /// `spice connect remove` remains the command that releases the identity.
+    Uninstall,
+
+    /// Start an installed, stopped service. Succeeds if it is already running.
+    Start,
+
+    /// Stop a running service, leaving it installed and enabled.
+    Stop,
+
+    /// Restart the service through its supervisor and wait for the result.
+    ///
+    /// Never asks a running `spiced` to exit itself, and never signals a
+    /// foreground runtime.
+    Restart,
+
+    /// Report this directory's service state, boot persistence, and paths.
+    Status(ServiceStatusArgs),
+
+    /// Print this service's output.
+    Logs(LogsArgs),
+}
+
+impl ServiceCommand {
+    /// The action's name as it appears in help and in error messages.
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Install => "install",
+            Self::Uninstall => "uninstall",
+            Self::Start => "start",
+            Self::Stop => "stop",
+            Self::Restart => "restart",
+            Self::Status(_) => "status",
+            Self::Logs(_) => "logs",
+        }
+    }
+}
+
+/// Arguments for `spice connect service status`.
+#[derive(Args, Debug)]
+pub struct ServiceStatusArgs {
+    /// Output format. `json` writes the same service object that
+    /// `spice connect status --output json` nests, and writes nothing else to
+    /// stdout.
+    #[arg(long, short = 'o', value_enum, default_value_t = OutputFormat::Table)]
+    pub output: OutputFormat,
+}
+
+/// Arguments for `spice connect service logs`.
+#[derive(Args, Debug)]
+pub struct LogsArgs {
+    /// Lines of existing history to print first. `0` with `--follow` prints
+    /// only new output.
+    #[arg(
+        long = "number",
+        short = 'n',
+        value_name = "LINES",
+        default_value_t = DEFAULT_LOG_LINES,
+        value_parser = clap::value_parser!(u32).range(0..=i64::from(MAX_LOG_LINES)),
+    )]
+    pub number: u32,
+
+    /// Keep printing new output until interrupted.
+    ///
+    /// Spelled `-f, --follow` to match `docker logs` and `kubectl logs`.
+    /// `--tail` is intentionally not accepted.
+    #[arg(long, short = 'f')]
+    pub follow: bool,
+}
+
+/// Execute `spice connect service <action>`.
+///
+/// # Errors
+///
+/// Returns an error when the action fails, when it needs a service that is not
+/// installed, or when the reported state is one automation must not read as
+/// healthy.
+pub async fn execute(
+    ctx: &RuntimeContext,
+    args: ServiceArgs,
+    instance_dir: &Path,
+    config_dir: &Path,
+    endpoint: &str,
+) -> Result<()> {
+    let Some(command) = args.command else {
+        println!("{SERVICE_HELP}");
+        return Ok(());
+    };
+
+    let backend = backend();
+    let action = command.as_str();
+    match command {
+        ServiceCommand::Install => install(ctx, backend, instance_dir, config_dir, endpoint).await,
+        ServiceCommand::Uninstall => uninstall(backend, instance_dir, config_dir),
+        ServiceCommand::Status(args) => {
+            let status = ConnectStatus::collect(backend, instance_dir, config_dir, endpoint).await;
+            status::render_service(&status, args.output)?;
+            degraded_error(&status)
+        }
+        ServiceCommand::Start => backend.start(&require_installed(
+            backend,
+            instance_dir,
+            config_dir,
+            action,
+        )?),
+        ServiceCommand::Stop => match resolve_or_report(backend, instance_dir, config_dir, action)?
+        {
+            Some(manifest) => backend.stop(&manifest),
+            None => Ok(()),
+        },
+        ServiceCommand::Restart => backend.restart(&require_installed(
+            backend,
+            instance_dir,
+            config_dir,
+            action,
+        )?),
+        ServiceCommand::Logs(args) => {
+            match resolve_or_report(backend, instance_dir, config_dir, action)? {
+                Some(manifest) => backend.logs(
+                    &manifest,
+                    super::LogRequest {
+                        number: args.number,
+                        follow: args.follow,
+                    },
+                ),
+                None => Ok(()),
+            }
+        }
+    }
+}
+
+/// Install and report what was installed.
+async fn install(
+    ctx: &RuntimeContext,
+    backend: &dyn ServiceBackend,
+    instance_dir: &Path,
+    config_dir: &Path,
+    endpoint: &str,
+) -> Result<()> {
+    // Resolved, not derived from `$HOME`: `sudo` rewrites `HOME` to `/root`, and
+    // the runtime the operator installed is normally under their own home.
+    let spiced_path = ctx.resolve_spiced_path().ok_or_else(|| Error::InvalidArgument {
+        message: format!(
+            "Failed to install the Spice Cloud Connect service: no Spice runtime was found at {}. \
+             Install it with `spice install` and re-run `spice connect service install`. \
+             See: https://spiceai.org/docs",
+            ctx.spiced_path().display()
+        ),
+    })?;
+    let runtime_version = ctx.runtime_version().unwrap_or_default();
+    let health_url = format!("{}/health", ctx.http_endpoint().trim_end_matches('/'));
+
+    let manifest = super::install(
+        backend,
+        instance_dir,
+        config_dir,
+        &spiced_path,
+        &runtime_version,
+        &health_url,
+    )?;
+
+    // The headline is the state, the scope, and the persistence — the three
+    // facts an operator checks — followed by the commands they will actually
+    // use. Paths belong in status, which the first of those commands prints.
+    let status = ConnectStatus::collect(backend, instance_dir, config_dir, endpoint).await;
+    println!(
+        "Installed the Spice Cloud Connect service: {} ({} service, {}).",
+        status.service.state, manifest.scope, manifest.supervisor
+    );
+    println!("  starts:      {}", status.service.starts.describe());
+    if let Some(action) = &status.service.starts_action {
+        println!("               run `{action}` to change that");
+    }
+    if !manifest.runtime_version.is_empty() {
+        println!("  version:     {}", manifest.runtime_version);
+    }
+    if let Some(monitor) = &status.connection.monitor_url {
+        println!("  monitor:     {monitor}");
+    }
+    println!();
+    println!("Manage it with:");
+    println!("  spice connect status");
+    println!("  spice connect service restart");
+    println!("  spice connect service logs -f");
+    println!("  spice connect service uninstall");
+    Ok(())
+}
+
+/// Uninstall and say exactly what was and was not removed.
+fn uninstall(backend: &dyn ServiceBackend, instance_dir: &Path, config_dir: &Path) -> Result<()> {
+    let Some(manifest) = super::uninstall(backend, instance_dir, config_dir)? else {
+        println!(
+            "No Spice Cloud Connect service is installed for {}. The Cloud identity and project \
+             attachment are untouched.",
+            instance_dir.display()
+        );
+        return Ok(());
+    };
+
+    println!("Removed the Spice Cloud Connect service {}.", manifest.name);
+    println!(
+        "The Cloud identity, project attachment, delivered secrets, and instance files were \
+         retained — `spice connect service install` resumes the same enrollment, and `spice run` \
+         starts the instance in the foreground. `spice connect remove` is the command that \
+         releases the Cloud identity."
+    );
+    Ok(())
+}
+
+/// Resolve the service an action needs, or fail with the action's own
+/// remediation.
+///
+/// Used by the actions that cannot do anything useful without a service:
+/// pointing at `install` is more helpful than a bare "not installed".
+fn require_installed(
+    backend: &dyn ServiceBackend,
+    instance_dir: &Path,
+    config_dir: &Path,
+    action: &str,
+) -> Result<ServiceManifest> {
+    super::resolve(backend, instance_dir, config_dir)?.ok_or_else(|| Error::ServiceNotInstalled {
+        message: format!(
+            "Failed to {action} the Spice Cloud Connect service for {}: no supervisor-managed \
+             service is installed for this directory. Install one with \
+             `spice connect service install`. A `spiced` running in the foreground is not \
+             supervisor-managed and is left alone. See: https://spiceai.org/docs",
+            instance_dir.display()
+        ),
+    })
+}
+
+/// Resolve the service an action can report `not_installed` for, printing that
+/// report when there is none.
+///
+/// `stop` and `logs` are meaningful answers on a directory with no service —
+/// there is nothing running and nothing to read — so they say so and succeed
+/// rather than failing.
+fn resolve_or_report(
+    backend: &dyn ServiceBackend,
+    instance_dir: &Path,
+    config_dir: &Path,
+    action: &str,
+) -> Result<Option<ServiceManifest>> {
+    let resolved = super::resolve(backend, instance_dir, config_dir)?;
+    if resolved.is_none() {
+        println!(
+            "Spice Cloud Connect service: not_installed ({}). Nothing to {action}; the Cloud \
+             identity is untouched.",
+            instance_dir.display()
+        );
+    }
+    Ok(resolved)
+}
+
+/// Turn a degraded snapshot into the non-zero exit automation needs.
+///
+/// The report is already on stdout by the time this runs: the diagnosis travels
+/// as the process's error on stderr, so a `--output json` run stays parseable.
+fn degraded_error(status: &ConnectStatus) -> Result<()> {
+    if !status.is_degraded() {
+        return Ok(());
+    }
+    Err(Error::ServiceUnavailable {
+        message: format!(
+            "The Spice Cloud Connect service for {} is {}{}",
+            status.connection.directory.display(),
+            status.service.state,
+            match &status.service.diagnostic {
+                Some(diagnostic) => format!(": {diagnostic}"),
+                None => ".".to_string(),
+            }
+        ),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_no_action_help_lists_every_action() {
+        // The help is hand-written, so it has to be pinned against the real
+        // set of actions or it will silently go stale.
+        for action in [
+            "install",
+            "uninstall",
+            "start",
+            "stop",
+            "restart",
+            "status",
+            "logs",
+        ] {
+            assert!(
+                SERVICE_HELP.contains(&format!("spice connect service {action}")),
+                "the no-action help must name `{action}`"
+            );
+        }
+        // `svc` is a typing alias, never documented copy.
+        assert!(!SERVICE_HELP.contains("svc"), "{SERVICE_HELP}");
+    }
+
+    #[test]
+    fn action_names_match_the_documented_grammar() {
+        assert_eq!(ServiceCommand::Install.as_str(), "install");
+        assert_eq!(ServiceCommand::Uninstall.as_str(), "uninstall");
+        assert_eq!(ServiceCommand::Start.as_str(), "start");
+        assert_eq!(ServiceCommand::Stop.as_str(), "stop");
+        assert_eq!(ServiceCommand::Restart.as_str(), "restart");
+        assert_eq!(
+            ServiceCommand::Status(ServiceStatusArgs {
+                output: OutputFormat::Table
+            })
+            .as_str(),
+            "status"
+        );
+        assert_eq!(
+            ServiceCommand::Logs(LogsArgs {
+                number: DEFAULT_LOG_LINES,
+                follow: false
+            })
+            .as_str(),
+            "logs"
+        );
+    }
+}

--- a/bin/spice/src/commands/connect/service/launchd.rs
+++ b/bin/spice/src/commands/connect/service/launchd.rs
@@ -429,20 +429,108 @@ fn observe(manifest: &ServiceManifest) -> ServiceObservation {
                 .map_or("launchctl print", String::as_str),
         ));
     };
+    let state = normalize_launchd_state(&reported);
+    let (starts, starts_action) = observe_persistence(manifest);
     ServiceObservation {
-        state: normalize_launchd_state(&reported),
-        // A daemon is bootstrapped into the system domain and runs before
-        // anyone logs in; an agent is bootstrapped into its owner's GUI domain
-        // and cannot run before that owner is there. macOS offers no non-root
-        // way to make an agent start earlier, so there is no remediation to
-        // name for the agent case.
-        starts: match manifest.scope {
-            ServiceScope::System => ServiceStarts::BootWithoutLogin,
-            ServiceScope::User => ServiceStarts::LoginOnly,
-        },
-        diagnostic: None,
-        starts_action: None,
+        state,
+        starts,
+        // An `unavailable` state always says why. `not loaded` is the one that
+        // matters most: launchd has no such job while its definition is on
+        // disk, which is a different repair from a word this release does not
+        // recognise.
+        diagnostic: (state == ServiceState::Unavailable)
+            .then(|| unrecognized_state_diagnostic(&reported, manifest)),
+        starts_action,
     }
+}
+
+/// Why a state Spice does not recognise is reported as `unavailable`, naming
+/// launchd's own answer and the command that produced it.
+fn unrecognized_state_diagnostic(reported: &str, manifest: &ServiceManifest) -> String {
+    format!(
+        "`launchctl print {target}` reported state `{reported}`, which is not a state Spice can \
+         act on. Run it to see what launchd holds for this job.",
+        target = service_target_in(&manifest.name, manifest.scope),
+        reported = reported.trim(),
+    )
+}
+
+/// Whether the job will start on its own, and what to run when it will not.
+///
+/// The scope decides the ceiling: a daemon is bootstrapped into the system
+/// domain and runs before anyone logs in, while an agent lives in its owner's
+/// GUI domain and cannot run before that owner is there — macOS offers no
+/// non-root way to make an agent start earlier, so there is nothing to advise.
+///
+/// The ceiling is not the answer on its own, though. launchd keeps a *separate*
+/// disabled database, so a definition that is installed and correct can still be
+/// held down by `launchctl disable`, and inferring persistence from the scope
+/// alone would report `boot_without_login` for a daemon that will not start at
+/// all.
+fn observe_persistence(manifest: &ServiceManifest) -> (ServiceStarts, Option<String>) {
+    match job_is_disabled(&manifest.name, manifest.scope) {
+        Some(true) => (
+            ServiceStarts::Disabled,
+            Some(format!(
+                "{sudo}launchctl enable {target}",
+                sudo = if manifest.scope == ServiceScope::System && !super::is_root() {
+                    "sudo "
+                } else {
+                    ""
+                },
+                target = service_target_in(&manifest.name, manifest.scope),
+            )),
+        ),
+        Some(false) => match manifest.scope {
+            ServiceScope::System => (ServiceStarts::BootWithoutLogin, None),
+            ServiceScope::User => (ServiceStarts::LoginOnly, None),
+        },
+        // The database could not be read, so persistence is not knowable. A
+        // guess here is the claim of boot persistence this check exists to
+        // avoid making.
+        None => (ServiceStarts::Unavailable, None),
+    }
+}
+
+/// Whether launchd's disabled database holds this label down in `scope`.
+///
+/// `None` when the database could not be read at all — distinct from a label it
+/// simply does not list, which is `Some(false)`.
+fn job_is_disabled(label: &str, scope: ServiceScope) -> Option<bool> {
+    let domain = match scope {
+        ServiceScope::System => "system".to_string(),
+        ServiceScope::User => format!("user/{}", nix::unistd::Uid::effective().as_raw()),
+    };
+    let output = std::process::Command::new(LAUNCHCTL)
+        .arg("print-disabled")
+        .arg(&domain)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(parse_disabled(
+        &String::from_utf8_lossy(&output.stdout),
+        label,
+    ))
+}
+
+/// Whether `print-disabled` output lists `label` as disabled.
+///
+/// The output is a list of `"<label>" => <value>` lines, where the value has
+/// been spelled `true`/`false` and `disabled`/`enabled` across macOS releases.
+/// A label the list does not mention is not disabled.
+fn parse_disabled(printed: &str, label: &str) -> bool {
+    let quoted = format!("\"{label}\"");
+    printed
+        .lines()
+        .map(str::trim)
+        .filter_map(|line| line.split_once("=>"))
+        .find(|(name, _)| name.trim() == quoted)
+        .is_some_and(|(_, value)| {
+            let value = value.trim().trim_end_matches(';').trim();
+            value.eq_ignore_ascii_case("true") || value.eq_ignore_ascii_case("disabled")
+        })
 }
 
 /// The macOS back end.
@@ -1243,6 +1331,55 @@ mod tests {
         assert!(
             agent.to_string_lossy().contains(LAUNCH_AGENT_SUBDIR),
             "{agent:?}"
+        );
+    }
+
+    #[test]
+    fn the_disabled_database_decides_boot_persistence() {
+        // launchd keeps this list separately from the definition, so a daemon
+        // that is installed and correct can still be held down by
+        // `launchctl disable` — and must not be reported as starting at boot.
+        let printed = "\
+\"com.apple.something\" => false
+\"ai.spice.cloud-connect.edge-1-2962fca679ae993a\" => true
+\"com.apple.other\" => disabled
+";
+        assert!(parse_disabled(
+            printed,
+            "ai.spice.cloud-connect.edge-1-2962fca679ae993a"
+        ));
+        assert!(
+            parse_disabled(printed, "com.apple.other"),
+            "the `disabled` spelling counts too"
+        );
+        assert!(!parse_disabled(printed, "com.apple.something"));
+        assert!(
+            !parse_disabled(printed, "ai.spice.cloud-connect.absent"),
+            "a label the list does not mention is not disabled"
+        );
+        // A substring of another label must not match.
+        assert!(!parse_disabled(
+            "\"ai.spice.cloud-connect.edge-1-2962fca679ae993a.extra\" => true\n",
+            "ai.spice.cloud-connect.edge-1-2962fca679ae993a"
+        ));
+    }
+
+    #[test]
+    fn an_unrecognized_launchd_state_explains_itself() {
+        // The model promises every `unavailable` state says why, and `not
+        // loaded` is the answer that matters: launchd has no such job while the
+        // definition is on disk.
+        let manifest = manifest(ServiceScope::System);
+        let diagnostic = unrecognized_state_diagnostic(NOT_LOADED, &manifest);
+        assert!(diagnostic.contains(NOT_LOADED), "{diagnostic}");
+        assert!(
+            diagnostic.contains("launchctl print system/"),
+            "{diagnostic}"
+        );
+        assert_eq!(
+            normalize_launchd_state(NOT_LOADED),
+            ServiceState::Unavailable,
+            "the diagnostic only reaches the report for an unavailable state"
         );
     }
 

--- a/bin/spice/src/commands/connect/service/launchd.rs
+++ b/bin/spice/src/commands/connect/service/launchd.rs
@@ -322,29 +322,37 @@ fn uninstall(manifest: &ServiceManifest) -> Result<()> {
     unloaded
 }
 
-/// The service installed for `instance_dir` in `scope`, if the definition under
-/// this directory's derived label names this directory as its working directory.
+/// The service installed for `instance_dir` in `scope`, if something that knows
+/// what the job actually runs states that its working directory is this one.
 ///
-/// A job launchd is still holding counts, even with no definition on disk:
-/// `uninstall` deletes the definition whether or not the job could be stopped,
-/// so if this looked only at the file, the state that leaves behind would be
-/// invisible to the removal that has to clean it up, and the released instance
-/// would keep restarting until the host rebooted.
+/// The label proves nothing on its own: it is derived from the directory, so a
+/// job anyone else created under it carries the same label. Adoption therefore
+/// needs the working directory *stated* by a source that knows — the definition
+/// on disk, or launchd's own report of the job it is holding — and it has to
+/// match exactly. Neither available means no service is resolved, which is the
+/// safe answer: the alternative is uninstalling a foreign job under a label this
+/// directory happens to derive.
+///
+/// launchd's report is consulted because a job it is still holding counts even
+/// with no definition on disk: `uninstall` deletes the definition whether or not
+/// the job could be stopped, so if this looked only at the file, the state that
+/// leaves behind would be invisible to the removal that has to clean it up, and
+/// the released instance would keep restarting until the host rebooted.
 fn find_for_dir(instance_dir: &Path, scope: ServiceScope) -> Option<InstalledService> {
     let label = job_label_for_dir(instance_dir);
     let path = plist_path(&label, scope);
     let plist = std::fs::read_to_string(&path).ok();
 
-    match plist.as_deref().and_then(parse_working_dir) {
-        // A definition that names another directory is another instance's
-        // service, whatever label it carries.
-        Some(working_dir) if working_dir != instance_dir => return None,
-        Some(_) => {}
-        // No readable definition: only a job launchd is still holding keeps
-        // this directory's service resolvable, and only in the domain the
-        // definition would have used.
-        None if !(scope == ServiceScope::System && launchd_holds(&label)) => return None,
-        None => {}
+    // The definition is asked first because it is what an uninstall deletes. A
+    // definition that names another directory settles the question on its own —
+    // launchd is not consulted to overrule it — and one that names no directory
+    // at all leaves launchd as the only source that can still answer.
+    let working_dir = plist
+        .as_deref()
+        .and_then(parse_working_dir)
+        .or_else(|| launchd_working_dir(&label, scope))?;
+    if working_dir != instance_dir {
+        return None;
     }
 
     let runtime = plist
@@ -354,9 +362,25 @@ fn find_for_dir(instance_dir: &Path, scope: ServiceScope) -> Option<InstalledSer
     Some(InstalledService {
         name: label,
         path,
-        working_dir: instance_dir.to_path_buf(),
+        working_dir,
         runtime,
     })
+}
+
+/// The working directory launchd reports for the job it is holding under
+/// `label` in `scope`, or `None` when there is no such job, launchd could not be
+/// asked, or it named no directory.
+///
+/// This is the independent statement that lets an orphaned job — one whose
+/// definition is already deleted — still be adopted and removed, without
+/// inferring anything from the label.
+fn launchd_working_dir(label: &str, scope: ServiceScope) -> Option<PathBuf> {
+    let printed = print_job(label, scope)?;
+    // `launchctl print` has spelled this field both ways across macOS releases.
+    ["working directory", "cwd"]
+        .into_iter()
+        .find_map(|key| top_level_field(&printed, key))
+        .map(PathBuf::from)
 }
 
 /// The stdout/stderr files a definition names, when it names any.
@@ -379,10 +403,10 @@ fn plist_log_source(label: &str, scope: ServiceScope) -> Option<LogSource> {
 /// The job's state as `launchctl print` reports it (`running`, `waiting`,
 /// `not running`, …), [`NOT_LOADED`] when launchd has no such job, or `None`
 /// when launchd could not be asked.
-fn is_active(label: &str) -> Option<String> {
+fn is_active(label: &str, scope: ServiceScope) -> Option<String> {
     let output = std::process::Command::new(LAUNCHCTL)
         .arg("print")
-        .arg(service_target(label))
+        .arg(service_target_in(label, scope))
         .output()
         .ok()?;
 
@@ -418,7 +442,7 @@ fn recovery_hints(manifest: &ServiceManifest) -> Vec<String> {
 /// Observe the job: the state launchd reports plus whether it comes back on
 /// its own.
 fn observe(manifest: &ServiceManifest) -> ServiceObservation {
-    let Some(reported) = is_active(&manifest.name) else {
+    let Some(reported) = is_active(&manifest.name, manifest.scope) else {
         return ServiceObservation::unavailable(format!(
             "launchctl could not be asked about {}. Check that this account may query the \
              {} domain (`{}`).",
@@ -603,36 +627,29 @@ fn folded(err: Error) -> String {
     }
 }
 
+/// Asks the system domain: installing and unloading is a `LaunchDaemon`
+/// operation in this release, which [`preflight`] enforces.
 fn job_is_absent(label: &str) -> bool {
-    state_is_absent(is_active(label).as_deref())
-}
-
-fn launchd_holds(label: &str) -> bool {
-    state_is_held(is_active(label).as_deref())
+    state_is_absent(is_active(label, ServiceScope::System).as_deref())
 }
 
 /// `true` only when launchd said, in as many words, that it has no such job.
 ///
-/// Deliberately not `!state_is_held`: an unanswerable `launchctl print` must
-/// never be read as proof the job is gone, because that is exactly how a daemon
-/// survives its own removal. The two predicates are therefore both false for
-/// `None`, and the callers fail closed on it — `unload` keeps waiting and then
-/// errors, `find_for_dir` reports nothing it cannot see a definition for.
+/// Deliberately not "anything that is not a job launchd named": an unanswerable
+/// `launchctl print` must never be read as proof the job is gone, because that
+/// is exactly how a daemon survives its own removal. `None` is therefore false
+/// here, and the caller fails closed on it — `unload` keeps waiting and then
+/// errors rather than reporting a job it cannot see as stopped.
 fn state_is_absent(state: Option<&str>) -> bool {
     state == Some(NOT_LOADED)
 }
 
-/// `true` only when launchd answered and named a job it is holding.
-fn state_is_held(state: Option<&str>) -> bool {
-    state.is_some_and(|state| state != NOT_LOADED)
-}
-
-/// `launchctl print`'s report for this job, or `None` when launchd has no such
-/// job or could not be asked.
-fn print_job(label: &str) -> Option<String> {
+/// `launchctl print`'s report for this job in `scope`, or `None` when launchd has
+/// no such job or could not be asked.
+fn print_job(label: &str, scope: ServiceScope) -> Option<String> {
     let output = std::process::Command::new(LAUNCHCTL)
         .arg("print")
-        .arg(service_target(label))
+        .arg(service_target_in(label, scope))
         .output()
         .ok()?;
     output
@@ -890,7 +907,8 @@ fn confirm_running(label: &str) -> Result<()> {
     let pid = wait_for_running(label)?;
     std::thread::sleep(SETTLE_INTERVAL);
 
-    let settled = print_job(label).and_then(|printed| top_level_field(&printed, "pid"));
+    let settled =
+        print_job(label, ServiceScope::System).and_then(|printed| top_level_field(&printed, "pid"));
     if settled.as_deref() == Some(pid.as_str()) {
         return Ok(());
     }
@@ -912,7 +930,7 @@ fn confirm_running(label: &str) -> Result<()> {
 /// moment.
 fn wait_for_running(label: &str) -> Result<String> {
     for attempt in 0..RUNNING_ATTEMPTS {
-        if let Some(printed) = print_job(label)
+        if let Some(printed) = print_job(label, ServiceScope::System)
             && top_level_field(&printed, "state").as_deref() == Some(RUNNING)
             && let Some(pid) = top_level_field(&printed, "pid")
         {
@@ -937,7 +955,7 @@ fn wait_for_running(label: &str) -> Result<String> {
 
 /// launchd's own account of a job that is not running as it should be.
 fn job_report(label: &str) -> String {
-    let Some(printed) = print_job(label) else {
+    let Some(printed) = print_job(label, ServiceScope::System) else {
         return String::new();
     };
 
@@ -1384,6 +1402,72 @@ mod tests {
     }
 
     #[test]
+    fn adoption_needs_a_stated_working_directory_that_matches() {
+        // The label is derived from the directory, so any job created under it
+        // carries the same one. Only a source that knows what the job runs — the
+        // definition, or launchd's own report — may settle the question, and
+        // neither available must resolve nothing rather than adopt a foreign
+        // job under a label this directory happens to derive.
+        let dir = Path::new("/opt/edge-1");
+        let plist = render_plist(
+            &job_label_for_dir(dir),
+            dir,
+            &dir.join(".spice"),
+            Path::new("/usr/local/lib/spice/spiced"),
+            "alice",
+            "staff",
+        );
+        assert_eq!(parse_working_dir(&plist), Some(dir.to_path_buf()));
+
+        // A definition naming somewhere else settles it on its own; launchd is
+        // never consulted to overrule what the definition says.
+        let foreign = render_plist(
+            &job_label_for_dir(dir),
+            Path::new("/opt/somewhere-else"),
+            Path::new("/opt/somewhere-else/.spice"),
+            Path::new("/usr/local/lib/spice/spiced"),
+            "alice",
+            "staff",
+        );
+        assert_eq!(
+            parse_working_dir(&foreign),
+            Some(PathBuf::from("/opt/somewhere-else"))
+        );
+
+        // A definition that states no working directory leaves launchd as the
+        // only source that can answer.
+        assert_eq!(parse_working_dir("<plist><dict></dict></plist>"), None);
+    }
+
+    #[test]
+    fn launchds_own_report_states_the_working_directory() {
+        // The independent statement that lets an orphaned job — one whose
+        // definition is already deleted — still be adopted and removed.
+        let printed =
+            "system/ai.spice.x = {\n\tstate = running\n\tworking directory = /opt/edge-1\n}\n";
+        assert_eq!(
+            top_level_field(printed, "working directory"),
+            Some("/opt/edge-1".to_string())
+        );
+        // Older releases spell it `cwd`, and both are accepted.
+        let older = "system/ai.spice.x = {\n\tcwd = /opt/edge-1\n}\n";
+        assert_eq!(
+            ["working directory", "cwd"]
+                .into_iter()
+                .find_map(|key| top_level_field(older, key)),
+            Some("/opt/edge-1".to_string())
+        );
+        // A report that names no directory cannot verify anything.
+        let silent = "system/ai.spice.x = {\n\tstate = running\n}\n";
+        assert_eq!(
+            ["working directory", "cwd"]
+                .into_iter()
+                .find_map(|key| top_level_field(silent, key)),
+            None
+        );
+    }
+
+    #[test]
     fn a_definition_naming_no_output_paths_reports_no_log_source() {
         // The plist this release writes configures none, so claiming a file
         // would name something nothing writes to.
@@ -1399,7 +1483,7 @@ mod tests {
             preflight(ServiceScope::User),
             Err(PreflightFailure::UserScopePending)
         ));
-        assert!(preflight(ServiceScope::System).is_ok());
+        preflight(ServiceScope::System).expect("a system daemon is what this release installs");
     }
 
     #[test]
@@ -1424,28 +1508,23 @@ mod tests {
     }
 
     #[test]
-    fn an_unanswerable_launchd_is_neither_gone_nor_held() {
-        // These two decide whether `unload` may stop waiting and whether
-        // `find_for_dir` can see an orphaned job, so `None` — launchd could not
-        // be asked — has to be false for both. Reading it as "gone" is how a
-        // daemon survives its own removal; reading it as "held" would invent
-        // services on a host with no launchd.
+    fn an_unanswerable_launchd_is_never_read_as_a_job_that_is_gone() {
+        // This decides whether `unload` may stop waiting, so `None` — launchd
+        // could not be asked — has to be false. Reading it as "gone" is how a
+        // daemon survives its own removal.
         assert!(!state_is_absent(None));
-        assert!(!state_is_held(None));
-
         assert!(state_is_absent(Some(NOT_LOADED)));
-        assert!(!state_is_held(Some(NOT_LOADED)));
-
-        for state in [RUNNING, "waiting", "not running", "spawn scheduled"] {
-            assert!(state_is_held(Some(state)), "{state}");
+        for state in [RUNNING, "waiting", "not running"] {
             assert!(!state_is_absent(Some(state)), "{state}");
         }
     }
-
     #[test]
     fn a_job_launchd_does_not_have_is_reported_as_such() {
         // The one end of the mapping a real launchd can answer here.
-        let answer = is_active("ai.spice.cloud-connect.definitely-not-installed-0000");
+        let answer = is_active(
+            "ai.spice.cloud-connect.definitely-not-installed-0000",
+            ServiceScope::System,
+        );
         assert!(
             answer.is_none() || answer.as_deref() == Some(NOT_LOADED),
             "unexpected state for a job that does not exist: {answer:?}"

--- a/bin/spice/src/commands/connect/service/launchd.rs
+++ b/bin/spice/src/commands/connect/service/launchd.rs
@@ -33,11 +33,20 @@ limitations under the License.
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use super::backend::{
+    InstallRequest, LogRequest, ServiceBackend, ServiceObservation, lifecycle_pending,
+};
+use super::manifest::ServiceManifest;
+use super::model::{LogSource, ServiceScope, ServiceStarts, ServiceState, Supervisor};
 use super::{InstalledService, PreflightFailure};
 use crate::error::{Error, Result};
 
 /// Directory launchd reads administrator-provided daemon definitions from.
 const LAUNCH_DAEMON_DIR: &str = "/Library/LaunchDaemons";
+
+/// Directory launchd reads a user's own agent definitions from, relative to
+/// the account's home directory.
+const LAUNCH_AGENT_SUBDIR: &str = "Library/LaunchAgents";
 
 /// Shared prefix of every job label this command installs. Also the prefix used
 /// to discover installed instances.
@@ -95,14 +104,31 @@ pub(super) fn job_label_for_dir(dir: &Path) -> String {
     )
 }
 
-/// The daemon definition a label is installed as.
-fn plist_path(label: &str) -> PathBuf {
-    Path::new(LAUNCH_DAEMON_DIR).join(format!("{label}{PLIST_SUFFIX}"))
+/// The definition a label is installed as, in the domain `scope` selects.
+fn plist_path(label: &str, scope: ServiceScope) -> PathBuf {
+    let dir = match scope {
+        ServiceScope::System => PathBuf::from(LAUNCH_DAEMON_DIR),
+        ServiceScope::User => dirs::home_dir()
+            .unwrap_or_default()
+            .join(LAUNCH_AGENT_SUBDIR),
+    };
+    dir.join(format!("{label}{PLIST_SUFFIX}"))
 }
 
-/// How `launchctl` is asked about a job in the system domain.
+/// How `launchctl` is asked about a job. Agents live in their owner's GUI
+/// domain, daemons in the system domain, and naming the wrong one is how a
+/// command reports on a job that is not the one installed.
+fn service_target_in(label: &str, scope: ServiceScope) -> String {
+    match scope {
+        ServiceScope::System => format!("system/{label}"),
+        ServiceScope::User => format!("gui/{}/{label}", nix::unistd::Uid::effective().as_raw()),
+    }
+}
+
+/// How `launchctl` is asked about a system daemon — the only domain this
+/// release installs into.
 fn service_target(label: &str) -> String {
-    format!("system/{label}")
+    service_target_in(label, ServiceScope::System)
 }
 
 /// Render the daemon definition for an instance.
@@ -194,18 +220,38 @@ fn account_names(account: super::ServiceAccount) -> Result<(String, String)> {
     Ok((user.name, group.name))
 }
 
-pub(super) fn preflight() -> std::result::Result<(), PreflightFailure> {
-    if !super::is_root() {
-        return Err(PreflightFailure::NotRoot);
+/// Map a `launchctl print` `state` value onto the normalized vocabulary.
+fn normalize_launchd_state(reported: &str) -> ServiceState {
+    match reported.trim() {
+        "running" => ServiceState::Running,
+        "spawn scheduled" | "spawning" => ServiceState::Starting,
+        "exiting" | "stopping" => ServiceState::Stopping,
+        // launchd's word for a `KeepAlive` job it is holding but not running:
+        // installed and down.
+        "waiting" | "not running" => ServiceState::Stopped,
+        "error" | "exited" => ServiceState::Failed,
+        // Everything else, including launchd's `not loaded` for a job it does
+        // not have. The definition file decides `not_installed`, so this is a
+        // supervisor that disagrees with disk rather than an absence.
+        _ => ServiceState::Unavailable,
+    }
+}
+
+fn preflight(scope: ServiceScope) -> std::result::Result<(), PreflightFailure> {
+    if scope == ServiceScope::User {
+        return Err(PreflightFailure::UserScopePending);
     }
     Ok(())
 }
 
-pub(super) fn install(
-    instance_dir: &Path,
-    config_dir: &Path,
-    spiced_path: &Path,
-) -> Result<InstalledService> {
+fn install(request: &InstallRequest<'_>) -> Result<InstalledService> {
+    let InstallRequest {
+        instance_dir,
+        config_dir,
+        spiced_path,
+        scope,
+    } = *request;
+
     let account = super::service_account(instance_dir)?;
     let (user_name, group_name) = account_names(account)?;
     super::provision_config_ownership(config_dir, account)?;
@@ -215,7 +261,7 @@ pub(super) fn install(
     })?;
 
     let label = job_label_for_dir(instance_dir);
-    let path = plist_path(&label);
+    let path = plist_path(&label, scope);
     write_daemon_plist(
         &path,
         &render_plist(
@@ -244,18 +290,15 @@ pub(super) fn install(
     })
 }
 
-/// Unload the job and delete its definition, touching nothing else.
-pub(super) fn uninstall(instance_dir: &Path) -> Result<Option<InstalledService>> {
-    let Some(installed) = find_for_dir(instance_dir) else {
-        return Ok(None);
-    };
-
-    let unloaded = unload(&installed.name);
+/// Unload the job the manifest describes and delete its definition, touching
+/// nothing else.
+fn uninstall(manifest: &ServiceManifest) -> Result<()> {
+    let unloaded = unload(&manifest.name);
 
     // Deleting the definition is what must happen even when the job would not
     // stop: one left on disk starts the runtime again at the next boot, against
     // a released identity. Already gone is the retry of exactly that case.
-    if let Err(e) = std::fs::remove_file(&installed.path)
+    if let Err(e) = std::fs::remove_file(&manifest.definition_path)
         && e.kind() != std::io::ErrorKind::NotFound
     {
         // The unload failure is lost otherwise, and a job still running is the
@@ -266,8 +309,9 @@ pub(super) fn uninstall(instance_dir: &Path) -> Result<Option<InstalledService>>
         return Err(Error::CloudConnectIo {
             message: format!(
                 "remove the launchd daemon definition {}: {e}. The daemon would start again at \
-                 boot against a released identity — re-run `sudo spice connect remove`.{also}",
-                installed.path.display()
+                 boot against a released identity — re-run \
+                 `sudo spice connect service uninstall`.{also}",
+                manifest.definition_path.display()
             ),
         });
     }
@@ -275,29 +319,34 @@ pub(super) fn uninstall(instance_dir: &Path) -> Result<Option<InstalledService>>
     // Surfaced after the deletion, not instead of it: a job launchd is still
     // holding keeps restarting against the released identity until the host
     // reboots, and the operator has to be told.
-    unloaded?;
-
-    Ok(Some(installed))
+    unloaded
 }
 
-/// The service installed for `instance_dir`, if any.
+/// The service installed for `instance_dir` in `scope`, if the definition under
+/// this directory's derived label names this directory as its working directory.
 ///
-/// A job launchd is still holding counts, even with no definition on disk.
-/// `uninstall` deletes the definition whether or not the job could be stopped —
+/// A job launchd is still holding counts, even with no definition on disk:
+/// `uninstall` deletes the definition whether or not the job could be stopped,
 /// so if this looked only at the file, the state that leaves behind would be
-/// invisible to the `remove` that has to clean it up, and the released
-/// instance would keep restarting until the host rebooted.
-pub(super) fn find_for_dir(instance_dir: &Path) -> Option<InstalledService> {
+/// invisible to the removal that has to clean it up, and the released instance
+/// would keep restarting until the host rebooted.
+fn find_for_dir(instance_dir: &Path, scope: ServiceScope) -> Option<InstalledService> {
     let label = job_label_for_dir(instance_dir);
-    let path = plist_path(&label);
-    if !path.is_file() && !launchd_holds(&label) {
-        return None;
-    }
+    let path = plist_path(&label, scope);
     let plist = std::fs::read_to_string(&path).ok();
-    let working_dir = plist
-        .as_deref()
-        .and_then(parse_working_dir)
-        .unwrap_or_else(|| instance_dir.to_path_buf());
+
+    match plist.as_deref().and_then(parse_working_dir) {
+        // A definition that names another directory is another instance's
+        // service, whatever label it carries.
+        Some(working_dir) if working_dir != instance_dir => return None,
+        Some(_) => {}
+        // No readable definition: only a job launchd is still holding keeps
+        // this directory's service resolvable, and only in the domain the
+        // definition would have used.
+        None if !(scope == ServiceScope::System && launchd_holds(&label)) => return None,
+        None => {}
+    }
+
     let runtime = plist
         .as_deref()
         .and_then(parse_program)
@@ -305,47 +354,32 @@ pub(super) fn find_for_dir(instance_dir: &Path) -> Option<InstalledService> {
     Some(InstalledService {
         name: label,
         path,
-        working_dir,
+        working_dir: instance_dir.to_path_buf(),
         runtime,
     })
 }
 
-pub(super) fn discover_all() -> Vec<InstalledService> {
-    let Ok(entries) = std::fs::read_dir(LAUNCH_DAEMON_DIR) else {
-        return Vec::new();
-    };
-
-    let mut services: Vec<InstalledService> = entries
-        .filter_map(std::result::Result::ok)
-        .filter_map(|entry| {
-            let path = entry.path();
-            let label = path
-                .file_name()?
-                .to_str()?
-                .strip_suffix(PLIST_SUFFIX)?
-                .to_string();
-            if !label.starts_with(LABEL_PREFIX) || !path.is_file() {
-                return None;
-            }
-            let plist = std::fs::read_to_string(&path).ok()?;
-            let working_dir = parse_working_dir(&plist)?;
-            let runtime = parse_program(&plist).unwrap_or_else(super::staged_runtime_path);
-            Some(InstalledService {
-                name: label,
-                path,
-                working_dir,
-                runtime,
-            })
-        })
-        .collect();
-    services.sort_by(|a, b| a.name.cmp(&b.name));
-    services
+/// The stdout/stderr files a definition names, when it names any.
+///
+/// `None` is the honest answer for a definition that configures no output
+/// paths: launchd then sends the job's output to the unified system log, which
+/// is not a source `spice connect service logs` reads. Configuring explicit
+/// paths is the launchd lifecycle work.
+fn plist_log_source(label: &str, scope: ServiceScope) -> Option<LogSource> {
+    let plist = std::fs::read_to_string(plist_path(label, scope)).ok()?;
+    let stdout = first_string_after_key(&plist, "StandardOutPath")?;
+    let stderr =
+        first_string_after_key(&plist, "StandardErrorPath").unwrap_or_else(|| stdout.clone());
+    Some(LogSource::Files {
+        stdout: PathBuf::from(stdout),
+        stderr: PathBuf::from(stderr),
+    })
 }
 
 /// The job's state as `launchctl print` reports it (`running`, `waiting`,
 /// `not running`, …), [`NOT_LOADED`] when launchd has no such job, or `None`
 /// when launchd could not be asked.
-pub(super) fn is_active(label: &str) -> Option<String> {
+fn is_active(label: &str) -> Option<String> {
     let output = std::process::Command::new(LAUNCHCTL)
         .arg("print")
         .arg(service_target(label))
@@ -368,12 +402,108 @@ pub(super) fn is_active(label: &str) -> Option<String> {
         .then(|| NOT_LOADED.to_string())
 }
 
-pub(super) fn manage_hints(label: &str) -> Vec<String> {
-    let target = service_target(label);
+fn recovery_hints(manifest: &ServiceManifest) -> Vec<String> {
+    let target = service_target_in(&manifest.name, manifest.scope);
+    let sudo = if manifest.scope == ServiceScope::System && !super::is_root() {
+        "sudo "
+    } else {
+        ""
+    };
     vec![
-        format!("sudo launchctl print {target}"),
-        format!("sudo launchctl kickstart -k {target}"),
+        format!("{sudo}launchctl print {target}"),
+        format!("{sudo}launchctl kickstart -k {target}"),
     ]
+}
+
+/// Observe the job: the state launchd reports plus whether it comes back on
+/// its own.
+fn observe(manifest: &ServiceManifest) -> ServiceObservation {
+    let Some(reported) = is_active(&manifest.name) else {
+        return ServiceObservation::unavailable(format!(
+            "launchctl could not be asked about {}. Check that this account may query the \
+             {} domain (`{}`).",
+            manifest.name,
+            manifest.scope,
+            recovery_hints(manifest)
+                .first()
+                .map_or("launchctl print", String::as_str),
+        ));
+    };
+    ServiceObservation {
+        state: normalize_launchd_state(&reported),
+        // A daemon is bootstrapped into the system domain and runs before
+        // anyone logs in; an agent is bootstrapped into its owner's GUI domain
+        // and cannot run before that owner is there. macOS offers no non-root
+        // way to make an agent start earlier, so there is no remediation to
+        // name for the agent case.
+        starts: match manifest.scope {
+            ServiceScope::System => ServiceStarts::BootWithoutLogin,
+            ServiceScope::User => ServiceStarts::LoginOnly,
+        },
+        diagnostic: None,
+        starts_action: None,
+    }
+}
+
+/// The macOS back end.
+pub(super) struct LaunchdBackend;
+
+impl ServiceBackend for LaunchdBackend {
+    fn supervisor(&self) -> Supervisor {
+        Supervisor::Launchd
+    }
+
+    fn preflight(&self, scope: ServiceScope) -> std::result::Result<(), PreflightFailure> {
+        preflight(scope)
+    }
+
+    fn name_for_dir(&self, instance_dir: &Path) -> String {
+        job_label_for_dir(instance_dir)
+    }
+
+    fn definition_path(&self, name: &str, scope: ServiceScope) -> PathBuf {
+        plist_path(name, scope)
+    }
+
+    fn log_source(&self, name: &str, scope: ServiceScope) -> Option<LogSource> {
+        plist_log_source(name, scope)
+    }
+
+    fn find_installed(&self, instance_dir: &Path, scope: ServiceScope) -> Option<InstalledService> {
+        find_for_dir(instance_dir, scope)
+    }
+
+    fn install(&self, request: &InstallRequest<'_>) -> Result<InstalledService> {
+        install(request)
+    }
+
+    fn uninstall(&self, manifest: &ServiceManifest) -> Result<()> {
+        uninstall(manifest)
+    }
+
+    fn start(&self, manifest: &ServiceManifest) -> Result<()> {
+        Err(lifecycle_pending(self, "start", manifest))
+    }
+
+    fn stop(&self, manifest: &ServiceManifest) -> Result<()> {
+        Err(lifecycle_pending(self, "stop", manifest))
+    }
+
+    fn restart(&self, manifest: &ServiceManifest) -> Result<()> {
+        Err(lifecycle_pending(self, "restart", manifest))
+    }
+
+    fn observe(&self, manifest: &ServiceManifest) -> ServiceObservation {
+        observe(manifest)
+    }
+
+    fn logs(&self, manifest: &ServiceManifest, _request: LogRequest) -> Result<()> {
+        Err(lifecycle_pending(self, "read the logs of", manifest))
+    }
+
+    fn recovery_hints(&self, manifest: &ServiceManifest) -> Vec<String> {
+        recovery_hints(manifest)
+    }
 }
 
 /// The text of an error being folded into another one, without the second
@@ -575,7 +705,7 @@ fn write_daemon_plist(path: &Path, plist: &str) -> Result<()> {
                  uid {uid} gid {gid} with mode {mode:04o}. launchd silently refuses to load a \
                  daemon that is not owned by root:wheel and writable only by root. Fix it with \
                  `sudo chown root:wheel {plist_path}` and `sudo chmod 644 {plist_path}`, then \
-                 re-run `sudo spice connect --install`.",
+                 re-run `sudo spice connect service install`.",
                 plist_path = path.display(),
                 uid = meta.uid(),
                 gid = meta.gid(),
@@ -646,7 +776,7 @@ fn verify_staged_runtime_executes(
              was installed and any service already on this host keeps the runtime it has.\
              {quarantine} Check the binary with `codesign --verify {source}` and \
              `spctl --assess --type execute {source}`, then re-run \
-             `sudo spice connect --install`.",
+             `sudo spice connect service install`.",
             source = source.display(),
         ),
     })
@@ -840,6 +970,29 @@ fn xml_unescape(value: &str) -> String {
 mod tests {
     use super::*;
 
+    #[test]
+    fn every_launchd_state_normalizes() {
+        for (reported, expected) in [
+            ("running", ServiceState::Running),
+            ("spawn scheduled", ServiceState::Starting),
+            ("exiting", ServiceState::Stopping),
+            ("waiting", ServiceState::Stopped),
+            ("not running", ServiceState::Stopped),
+            ("error", ServiceState::Failed),
+            ("not loaded", ServiceState::Unavailable),
+            ("", ServiceState::Unavailable),
+            ("something new", ServiceState::Unavailable),
+        ] {
+            assert_eq!(
+                normalize_launchd_state(reported),
+                expected,
+                "launchd `{reported}`"
+            );
+        }
+        // `launchctl print` values arrive with surrounding whitespace.
+        assert_eq!(normalize_launchd_state(" running "), ServiceState::Running);
+    }
+
     const TEST_USER: &str = "spice-operator";
     const TEST_GROUP: &str = "spice-users";
 
@@ -873,7 +1026,10 @@ mod tests {
         let a = job_label_for_dir(Path::new("/opt/edge-1"));
         let b = job_label_for_dir(Path::new("/opt/edge-2"));
         assert_ne!(a, b);
-        assert_ne!(plist_path(&a), plist_path(&b));
+        assert_ne!(
+            plist_path(&a, ServiceScope::System),
+            plist_path(&b, ServiceScope::System)
+        );
     }
 
     #[test]
@@ -896,13 +1052,13 @@ mod tests {
     #[test]
     fn plist_path_lives_in_the_daemon_directory() {
         let label = "ai.spice.cloud-connect.edge-1-1a2b3c4d";
-        let path = plist_path(label);
+        let path = plist_path(label, ServiceScope::System);
         assert_eq!(
             path,
             PathBuf::from("/Library/LaunchDaemons/ai.spice.cloud-connect.edge-1-1a2b3c4d.plist")
         );
-        // The label carries dots of its own, so `discover_all` has to recover
-        // it by dropping the suffix rather than by splitting on the last dot.
+        // The label carries dots of its own, so recovering it from a file name
+        // means dropping the suffix rather than splitting on the last dot.
         assert_eq!(
             path.file_name()
                 .and_then(|name| name.to_str())
@@ -1034,16 +1190,100 @@ mod tests {
         assert_eq!(top_level_field(printed, "pid"), None);
     }
 
+    /// A manifest for the job under test, without touching the filesystem.
+    fn manifest(scope: ServiceScope) -> ServiceManifest {
+        let name = job_label_for_dir(Path::new("/opt/edge-1"));
+        ServiceManifest {
+            schema_version: super::super::manifest::MANIFEST_SCHEMA_VERSION,
+            directory: PathBuf::from("/opt/edge-1"),
+            name: name.clone(),
+            scope,
+            supervisor: Supervisor::Launchd,
+            owner: super::super::ServiceOwner {
+                uid: 501,
+                gid: 20,
+                name: Some("alice".to_string()),
+            },
+            definition_path: plist_path(&name, scope),
+            runtime_path: super::super::staged_runtime_path(),
+            log_source: None,
+            runtime_digest: String::new(),
+            runtime_version: "v2.2.0".to_string(),
+            health_url: "http://127.0.0.1:8090/health".to_string(),
+        }
+    }
+
     #[test]
-    fn manage_hints_name_the_job_in_the_system_domain() {
-        let hints = manage_hints("ai.spice.cloud-connect.edge-1-1a2b3c4d");
-        assert_eq!(
-            hints,
-            vec![
-                "sudo launchctl print system/ai.spice.cloud-connect.edge-1-1a2b3c4d",
-                "sudo launchctl kickstart -k system/ai.spice.cloud-connect.edge-1-1a2b3c4d",
-            ]
+    fn recovery_hints_name_the_job_in_its_own_domain() {
+        let hints = recovery_hints(&manifest(ServiceScope::System));
+        assert!(
+            hints[0]
+                .ends_with("launchctl print system/ai.spice.cloud-connect.edge-1-2962fca679ae993a"),
+            "{hints:?}"
         );
+        assert!(hints[1].contains("kickstart -k system/"), "{hints:?}");
+
+        // An agent lives in its owner's GUI domain, and naming the system
+        // domain would report on a job that is not the one installed.
+        let user = recovery_hints(&manifest(ServiceScope::User));
+        assert!(user[0].contains("launchctl print gui/"), "{user:?}");
+        assert!(
+            !user.iter().any(|hint| hint.starts_with("sudo")),
+            "an agent is managed by its owner, never through sudo: {user:?}"
+        );
+    }
+
+    #[test]
+    fn an_agent_definition_lives_under_the_owners_home() {
+        let label = job_label_for_dir(Path::new("/opt/edge-1"));
+        let daemon = plist_path(&label, ServiceScope::System);
+        let agent = plist_path(&label, ServiceScope::User);
+        assert!(daemon.starts_with(LAUNCH_DAEMON_DIR), "{daemon:?}");
+        assert_ne!(daemon, agent);
+        assert!(
+            agent.to_string_lossy().contains(LAUNCH_AGENT_SUBDIR),
+            "{agent:?}"
+        );
+    }
+
+    #[test]
+    fn a_definition_naming_no_output_paths_reports_no_log_source() {
+        // The plist this release writes configures none, so claiming a file
+        // would name something nothing writes to.
+        assert_eq!(
+            plist_log_source("ai.spice.cloud-connect.absent", ServiceScope::System),
+            None
+        );
+    }
+
+    #[test]
+    fn a_user_scope_install_is_refused_rather_than_half_performed() {
+        assert!(matches!(
+            preflight(ServiceScope::User),
+            Err(PreflightFailure::UserScopePending)
+        ));
+        assert!(preflight(ServiceScope::System).is_ok());
+    }
+
+    #[test]
+    fn every_lifecycle_action_reports_itself_as_pending_rather_than_panicking() {
+        let manifest = manifest(ServiceScope::System);
+        for result in [
+            LaunchdBackend.start(&manifest),
+            LaunchdBackend.stop(&manifest),
+            LaunchdBackend.restart(&manifest),
+            LaunchdBackend.logs(
+                &manifest,
+                super::super::LogRequest {
+                    number: 100,
+                    follow: false,
+                },
+            ),
+        ] {
+            let error = result.expect_err("the lifecycle is not implemented yet");
+            assert!(matches!(error, Error::NotImplemented { .. }), "{error}");
+            assert!(error.to_string().contains("launchctl"), "{error}");
+        }
     }
 
     #[test]

--- a/bin/spice/src/commands/connect/service/manifest.rs
+++ b/bin/spice/src/commands/connect/service/manifest.rs
@@ -183,6 +183,13 @@ impl ServiceManifest {
                 self.schema_version
             ));
         }
+        if !self.directory.is_absolute() {
+            return reject(format!(
+                "records a relative instance directory ({}), so the service it names depends \
+                 on where a command was run",
+                self.directory.display()
+            ));
+        }
         if self.directory != instance_dir {
             return reject(format!(
                 "describes the service for {} instead",
@@ -201,6 +208,22 @@ impl ServiceManifest {
             return reject(format!(
                 "names the service {} where this directory derives {derived}",
                 self.name
+            ));
+        }
+        // The definition path is what an uninstall deletes, so it is not enough
+        // for it to look plausible: it has to be the exact path this back end
+        // would write for this name in this scope. Otherwise a corrupted or
+        // hand-edited manifest can pair the derived name with any absolute path
+        // and have `uninstall` remove an unrelated file.
+        let expected_definition = backend.definition_path(&derived, self.scope);
+        if self.definition_path != expected_definition {
+            return reject(format!(
+                "records the definition {} where a {scope} {supervisor} service for this \
+                 directory is {expected}",
+                self.definition_path.display(),
+                scope = self.scope,
+                supervisor = self.supervisor,
+                expected = expected_definition.display(),
             ));
         }
         for (label, recorded) in [
@@ -495,6 +518,47 @@ mod tests {
             .expect_err("a relative runtime path must not resolve");
         assert!(
             error.to_string().contains("relative runtime path"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn a_manifest_pointing_at_an_unrelated_definition_is_refused() {
+        // An uninstall deletes this path, so a manifest that pairs the derived
+        // name with any absolute path could have Spice remove an unrelated file.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let mut manifest = manifest_for(&fake, &instance_dir);
+        manifest.definition_path = PathBuf::from("/etc/passwd");
+        manifest.write(&config_dir).expect("write manifest");
+
+        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect_err("an unrelated definition path must not resolve");
+        assert!(error.to_string().contains("/etc/passwd"), "{error}");
+        assert!(
+            error.to_string().contains("records the definition"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn a_manifest_recording_a_relative_instance_directory_is_refused() {
+        // A relative instance directory makes the service's name depend on the
+        // process working directory, so the same instance derives two names.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = PathBuf::from("edge-1");
+        let config_dir = dir.path().join("edge-1").join(".spice");
+        let mut manifest = manifest_for(&fake, &instance_dir);
+        manifest.directory = instance_dir.clone();
+        manifest.write(&config_dir).expect("write manifest");
+
+        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect_err("a relative instance directory must not resolve");
+        assert!(
+            error.to_string().contains("relative instance directory"),
             "{error}"
         );
     }

--- a/bin/spice/src/commands/connect/service/manifest.rs
+++ b/bin/spice/src/commands/connect/service/manifest.rs
@@ -1,0 +1,603 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! `<config-dir>/service.json`: what this instance directory's service is.
+//!
+//! Every `spice connect service` action resolves the service it operates on
+//! from the canonical instance directory and this file, and from nothing else.
+//! There is no name argument and no host-wide scan, because both can name a
+//! service belonging to a different instance — and a lifecycle command that
+//! controls the wrong process is worse than one that refuses.
+//!
+//! The manifest is therefore a claim that has to be checked, not trusted: it
+//! is written owner-only, and a load re-derives the service name from the
+//! directory and refuses anything that does not match what the file says.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::backend::ServiceBackend;
+use super::model::{LogSource, ServiceScope, Supervisor};
+use crate::error::{Error, Result};
+
+/// File name (relative to the resolved Spice config dir) of the manifest.
+pub(crate) const SERVICE_MANIFEST_FILE: &str = "service.json";
+
+/// Current manifest schema. A manifest from a newer CLI is refused rather
+/// than partially understood: acting on half a description of a service is
+/// how the wrong process gets stopped.
+pub(crate) const MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// The account the installed runtime runs as.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceOwner {
+    pub(crate) uid: u32,
+    pub(crate) gid: u32,
+    /// The local account name, when the host has one for `uid`. Human status
+    /// prints this; the numeric id is what the definition is written with.
+    #[serde(default)]
+    pub(crate) name: Option<String>,
+}
+
+impl ServiceOwner {
+    /// How the owner is named in human output: the account name when the host
+    /// knows one, and the numeric id otherwise.
+    pub(crate) fn describe(&self) -> String {
+        match &self.name {
+            Some(name) => name.clone(),
+            None => format!("uid {}", self.uid),
+        }
+    }
+}
+
+/// The complete description of the service installed for one instance
+/// directory.
+///
+/// Field order is the JSON field order; the file is a Spice-owned record
+/// rather than a published automation schema, but it is still versioned so a
+/// downgrade fails loudly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ServiceManifest {
+    pub(crate) schema_version: u32,
+    /// The canonical instance directory this service was installed for. The
+    /// authoritative half of the identity check: a manifest that names a
+    /// different directory belongs to a different instance.
+    pub(crate) directory: PathBuf,
+    /// The deterministic service name derived from `directory`.
+    pub(crate) name: String,
+    pub(crate) scope: ServiceScope,
+    pub(crate) supervisor: Supervisor,
+    pub(crate) owner: ServiceOwner,
+    /// The unit file or plist.
+    pub(crate) definition_path: PathBuf,
+    /// The staged `spiced` the service executes.
+    pub(crate) runtime_path: PathBuf,
+    /// `None` when the definition names no log source this CLI can read.
+    pub(crate) log_source: Option<LogSource>,
+    /// SHA-256 (lowercase hex) of the staged runtime at install time, so an
+    /// upgrade can tell whether the binary on the path the service executes is
+    /// still the one that was installed.
+    pub(crate) runtime_digest: String,
+    /// The `spiced` version string recorded at install time.
+    pub(crate) runtime_version: String,
+    /// Where this instance answers a health probe.
+    pub(crate) health_url: String,
+}
+
+impl ServiceManifest {
+    /// Absolute path of the manifest for a resolved config dir.
+    pub(crate) fn path_in(config_dir: &Path) -> PathBuf {
+        config_dir.join(SERVICE_MANIFEST_FILE)
+    }
+
+    /// Read and validate the manifest for `instance_dir`.
+    ///
+    /// `Ok(None)` means there is no manifest — a directory that never had a
+    /// service installed, or one whose manifest was lost while its definition
+    /// is still installed (see [`super::adopt_installed_definition`]). An
+    /// unreadable, malformed, or mismatched manifest is an error rather than a
+    /// `None`: it describes *something*, and guessing what would be a lifecycle
+    /// command aimed at an unverified target.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file cannot be read, does not parse, is not
+    /// owner-only, or does not describe `instance_dir`.
+    pub(crate) fn load(
+        config_dir: &Path,
+        instance_dir: &Path,
+        backend: &dyn ServiceBackend,
+    ) -> Result<Option<Self>> {
+        let path = Self::path_in(config_dir);
+        let metadata = match std::fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(Error::CloudConnectIo {
+                    message: format!("inspect the service manifest {}: {e}", path.display()),
+                });
+            }
+        };
+        ensure_owner_only(&path, &metadata)?;
+
+        let bytes = std::fs::read(&path).map_err(|e| Error::CloudConnectIo {
+            message: format!("read the service manifest {}: {e}", path.display()),
+        })?;
+        let manifest: Self =
+            serde_json::from_slice(&bytes).map_err(|e| Error::InvalidArgument {
+                message: format!(
+                    "Failed to read the Spice Cloud Connect service manifest {}: {e}. \
+                 Re-run `spice connect service install` to rewrite it, or delete the file to \
+                 forget the installed service. See: https://spiceai.org/docs",
+                    path.display()
+                ),
+            })?;
+
+        manifest.validate(&path, instance_dir, backend)?;
+        Ok(Some(manifest))
+    }
+
+    /// Check that this manifest describes the service for `instance_dir`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the schema is from another release, the recorded
+    /// directory is not the one being resolved, the supervisor is not this
+    /// host's, the name is not the one that directory derives, or a recorded
+    /// path is not absolute.
+    fn validate(
+        &self,
+        path: &Path,
+        instance_dir: &Path,
+        backend: &dyn ServiceBackend,
+    ) -> Result<()> {
+        let reject = |reason: String| {
+            Err(Error::InvalidArgument {
+                message: format!(
+                    "Failed to resolve the Spice Cloud Connect service for {instance}: \
+                     its manifest {manifest} {reason}. Re-run `spice connect service install` \
+                     from this directory to rewrite it. See: https://spiceai.org/docs",
+                    instance = instance_dir.display(),
+                    manifest = path.display(),
+                ),
+            })
+        };
+
+        if self.schema_version != MANIFEST_SCHEMA_VERSION {
+            return reject(format!(
+                "is schema version {} and this CLI understands version {MANIFEST_SCHEMA_VERSION}",
+                self.schema_version
+            ));
+        }
+        if self.directory != instance_dir {
+            return reject(format!(
+                "describes the service for {} instead",
+                self.directory.display()
+            ));
+        }
+        if self.supervisor != backend.supervisor() {
+            return reject(format!(
+                "was written for {} and this host is managed by {}",
+                self.supervisor,
+                backend.supervisor()
+            ));
+        }
+        let derived = backend.name_for_dir(instance_dir);
+        if self.name != derived {
+            return reject(format!(
+                "names the service {} where this directory derives {derived}",
+                self.name
+            ));
+        }
+        for (label, recorded) in [
+            ("definition", &self.definition_path),
+            ("runtime", &self.runtime_path),
+        ] {
+            if !recorded.is_absolute() {
+                return reject(format!(
+                    "records a relative {label} path ({})",
+                    recorded.display()
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Write the manifest into `config_dir`, owner-only and atomically.
+    ///
+    /// The rename is what keeps a concurrent read from seeing a half-written
+    /// description of the service it is about to control.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the manifest cannot be serialized or written.
+    pub(crate) fn write(&self, config_dir: &Path) -> Result<()> {
+        let path = Self::path_in(config_dir);
+        let json = serde_json::to_vec_pretty(self).map_err(|e| Error::CloudConnectIo {
+            message: format!("serialize the service manifest for {}: {e}", path.display()),
+        })?;
+
+        std::fs::create_dir_all(config_dir).map_err(|e| Error::CloudConnectIo {
+            message: format!(
+                "create the Spice config directory {}: {e}",
+                config_dir.display()
+            ),
+        })?;
+
+        let staging = path.with_extension("json.incoming");
+        let _ = std::fs::remove_file(&staging);
+        write_owner_only(&staging, &json)?;
+        std::fs::rename(&staging, &path).map_err(|e| {
+            let _ = std::fs::remove_file(&staging);
+            Error::CloudConnectIo {
+                message: format!("write the service manifest {}: {e}", path.display()),
+            }
+        })
+    }
+
+    /// Delete the manifest, if there is one.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file exists and cannot be removed — a
+    /// manifest left behind would claim a service that is no longer installed.
+    pub(crate) fn remove(config_dir: &Path) -> Result<()> {
+        let path = Self::path_in(config_dir);
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(Error::CloudConnectIo {
+                message: format!("remove the service manifest {}: {e}", path.display()),
+            }),
+        }
+    }
+}
+
+/// Refuse a manifest anyone but its owner can change.
+///
+/// Every lifecycle command reads this file to decide which service to control
+/// and which binary that service runs. A group- or world-writable manifest, or
+/// a symlink standing in for one, is a way to redirect that decision.
+#[cfg(unix)]
+fn ensure_owner_only(path: &Path, metadata: &std::fs::Metadata) -> Result<()> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    if metadata.file_type().is_symlink() {
+        return Err(Error::InvalidArgument {
+            message: format!(
+                "Failed to read the Spice Cloud Connect service manifest {}: it is a symlink, \
+                 so it cannot be trusted to describe this directory's service. Replace it with \
+                 a real file by re-running `spice connect service install`. \
+                 See: https://spiceai.org/docs",
+                path.display()
+            ),
+        });
+    }
+
+    let mode = metadata.permissions().mode() & 0o7777;
+    if mode & 0o077 != 0 {
+        return Err(Error::InvalidArgument {
+            message: format!(
+                "Failed to read the Spice Cloud Connect service manifest {}: mode {mode:04o} \
+                 lets accounts other than its owner read or change which service and which \
+                 binary Spice controls. Restrict it (`chmod 600 {}`) and try again. \
+                 See: https://spiceai.org/docs",
+                path.display(),
+                path.display()
+            ),
+        });
+    }
+
+    let owner = metadata.uid();
+    let effective = nix::unistd::Uid::effective().as_raw();
+    if owner != 0 && owner != effective {
+        return Err(Error::InvalidArgument {
+            message: format!(
+                "Failed to read the Spice Cloud Connect service manifest {}: it is owned by uid \
+                 {owner}, but this command runs as uid {effective}. Run it as the owning account, \
+                 or re-run `spice connect service install` to reclaim the directory. \
+                 See: https://spiceai.org/docs",
+                path.display()
+            ),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_owner_only(_path: &Path, _metadata: &std::fs::Metadata) -> Result<()> {
+    Ok(())
+}
+
+/// Create `path` with owner-only permissions from the first byte and write
+/// `bytes` into it.
+///
+/// `create_new` rather than `create`: inheriting a file someone else left
+/// behind would inherit its mode and its owner too.
+#[cfg(unix)]
+fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let io_error = |e: std::io::Error| Error::CloudConnectIo {
+        message: format!("write the service manifest {}: {e}", path.display()),
+    };
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(io_error)?;
+    file.write_all(bytes).map_err(io_error)?;
+    file.sync_all().map_err(io_error)
+}
+
+#[cfg(not(unix))]
+fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
+    std::fs::write(path, bytes).map_err(|e| Error::CloudConnectIo {
+        message: format!("write the service manifest {}: {e}", path.display()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::backend::fake::FakeBackend;
+    use super::*;
+
+    fn manifest_for(backend: &FakeBackend, instance_dir: &Path) -> ServiceManifest {
+        let scope = ServiceScope::System;
+        let name = backend.name_for_dir(instance_dir);
+        ServiceManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            directory: instance_dir.to_path_buf(),
+            name: name.clone(),
+            scope,
+            supervisor: backend.supervisor(),
+            owner: ServiceOwner {
+                uid: 1000,
+                gid: 1000,
+                name: Some("alice".to_string()),
+            },
+            definition_path: backend.definition_path(&name, scope),
+            runtime_path: PathBuf::from("/usr/local/lib/spice/spiced"),
+            log_source: backend.log_source(&name, scope),
+            runtime_digest: "0".repeat(64),
+            runtime_version: "v2.2.0".to_string(),
+            health_url: "http://127.0.0.1:8090/health".to_string(),
+        }
+    }
+
+    #[test]
+    fn a_written_manifest_round_trips() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let manifest = manifest_for(&fake, &instance_dir);
+
+        manifest.write(&config_dir).expect("write manifest");
+        let loaded = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect("load manifest")
+            .expect("a manifest was written");
+        assert_eq!(loaded, manifest);
+    }
+
+    #[test]
+    fn an_absent_manifest_is_not_an_error() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        assert_eq!(
+            ServiceManifest::load(dir.path(), &dir.path().join("edge-1"), &fake).expect("load"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_manifest_for_another_directory_is_refused() {
+        // The failure this check exists for: a copied instance directory whose
+        // manifest still names the original's service. Acting on it would stop
+        // a service belonging to a different instance.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = dir.path().join("edge-2").join(".spice");
+        manifest_for(&fake, &instance_dir)
+            .write(&config_dir)
+            .expect("write manifest");
+
+        let error = ServiceManifest::load(&config_dir, &dir.path().join("edge-2"), &fake)
+            .expect_err("a manifest naming another directory must not resolve");
+        assert!(
+            error.to_string().contains("describes the service for"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn a_manifest_with_a_forged_name_is_refused() {
+        // The name is derived from the directory, so a manifest that names
+        // something else is naming a service this directory does not own.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let mut manifest = manifest_for(&fake, &instance_dir);
+        manifest.name = "spiced-cloud-connect-someone-else.service".to_string();
+        manifest.write(&config_dir).expect("write manifest");
+
+        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect_err("a forged service name must not resolve");
+        assert!(error.to_string().contains("derives"), "{error}");
+    }
+
+    #[test]
+    fn a_manifest_written_for_another_supervisor_is_refused() {
+        // An instance directory carried between a Linux and a macOS host has a
+        // manifest naming a supervisor that is not there. Trusting its
+        // definition path would point every command at a file this host's
+        // supervisor knows nothing about.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let mut manifest = manifest_for(&fake, &instance_dir);
+        manifest.supervisor = Supervisor::Launchd;
+        manifest.write(&config_dir).expect("write manifest");
+
+        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect_err("a manifest for another supervisor must not resolve");
+        assert!(
+            error.to_string().contains("this host is managed by"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn a_manifest_from_another_schema_version_is_refused() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let mut manifest = manifest_for(&fake, &instance_dir);
+        manifest.schema_version = MANIFEST_SCHEMA_VERSION + 1;
+        manifest.write(&config_dir).expect("write manifest");
+
+        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect_err("a future schema must not be half-understood");
+        assert!(error.to_string().contains("schema version"), "{error}");
+    }
+
+    #[test]
+    fn a_relative_recorded_path_is_refused() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let mut manifest = manifest_for(&fake, &instance_dir);
+        manifest.runtime_path = PathBuf::from("relative/spiced");
+        manifest.write(&config_dir).expect("write manifest");
+
+        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect_err("a relative runtime path must not resolve");
+        assert!(
+            error.to_string().contains("relative runtime path"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn a_malformed_manifest_is_an_error_rather_than_no_service() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(ServiceManifest::path_in(&config_dir), "not json").expect("write");
+
+        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect_err("a manifest that describes something unreadable must be reported");
+        assert!(error.to_string().contains("service manifest"), "{error}");
+    }
+
+    #[test]
+    fn removing_an_absent_manifest_succeeds() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        ServiceManifest::remove(dir.path()).expect("idempotent removal");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_group_readable_manifest_is_refused() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        manifest_for(&fake, &instance_dir)
+            .write(&config_dir)
+            .expect("write manifest");
+
+        let path = ServiceManifest::path_in(&config_dir);
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("widen the mode");
+        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect_err("a manifest others can change must not decide what Spice controls");
+        assert!(error.to_string().contains("0644"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_manifest_is_written_owner_only() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        manifest_for(&fake, &instance_dir)
+            .write(&config_dir)
+            .expect("write manifest");
+
+        let mode = std::fs::metadata(ServiceManifest::path_in(&config_dir))
+            .expect("stat manifest")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "mode {mode:04o}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_manifest_is_refused() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let elsewhere = dir.path().join("elsewhere.json");
+        manifest_for(&fake, &instance_dir)
+            .write(dir.path())
+            .expect("write manifest");
+        std::fs::rename(ServiceManifest::path_in(dir.path()), &elsewhere).expect("move it aside");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::os::unix::fs::symlink(&elsewhere, ServiceManifest::path_in(&config_dir))
+            .expect("symlink the manifest");
+
+        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect_err("a symlinked manifest must not resolve a service");
+        assert!(error.to_string().contains("symlink"), "{error}");
+    }
+
+    #[test]
+    fn rewriting_a_manifest_replaces_it() {
+        // Install is idempotent, so the second write must not trip over the
+        // first one's file.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let mut manifest = manifest_for(&fake, &instance_dir);
+        manifest.write(&config_dir).expect("first write");
+        manifest.runtime_version = "v2.3.0".to_string();
+        manifest.write(&config_dir).expect("second write");
+
+        let loaded = ServiceManifest::load(&config_dir, &instance_dir, &fake)
+            .expect("load")
+            .expect("a manifest is present");
+        assert_eq!(loaded.runtime_version, "v2.3.0");
+    }
+}

--- a/bin/spice/src/commands/connect/service/mod.rs
+++ b/bin/spice/src/commands/connect/service/mod.rs
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! `spice connect --install`: run `spiced` as a persistent system service
-//! for an enrolled instance directory.
+//! `spice connect service`: run `spiced` as a persistent service for an
+//! enrolled instance directory, and manage its lifecycle.
 //!
 //! A deployment applies to the running instance and never ends its process, so
 //! the supervisor is what keeps the instance up across the things that do end
@@ -25,33 +25,40 @@ limitations under the License.
 //!
 //! ## Support matrix
 //!
-//! `--install` is Linux with systemd and macOS with launchd, and needs root on
-//! both. Containers get the same guarantee from their runtime's restart policy
+//! Linux with systemd and macOS with launchd. Containers get the same
+//! guarantee from their runtime's restart policy
 //! (`docker run --restart unless-stopped`) and enroll directly with
 //! `spiced --token`. Windows enrolls and runs `spiced` under the user's own
 //! supervisor.
-//!
-//! macOS installs a `LaunchDaemon`, not a `LaunchAgent`: an agent runs only
-//! while its user is logged in, which is not the guarantee `--install` makes.
-//! A daemon starts at boot and survives logout. Root installs and manages its
-//! definition, while the runtime itself runs as the non-root operator.
 //!
 //! ## One service per instance directory
 //!
 //! Two instances on one host must produce two independently-running services,
 //! so the service name is derived deterministically from the *absolute*
 //! instance directory (see [`name_stem_for_dir`]) and the directory is baked
-//! into the definition as its working directory. A `--install` or `remove` in
-//! one instance directory can therefore never touch another instance's service.
+//! into the definition as its working directory. A command run in one instance
+//! directory can therefore never touch another instance's service.
 //!
-//! Both back ends run `spiced` as the non-root operator who invoked `sudo` (or
-//! owns the instance directory).
+//! ## Resolution is by directory, never by name
+//!
+//! Every action resolves its target from the canonical instance directory plus
+//! the per-directory manifest (`<config-dir>/service.json`). There is no name
+//! argument and no host-wide scan: both can name a service belonging to a
+//! different instance, and a lifecycle command aimed at the wrong process is a
+//! worse outcome than one that refuses.
 
-#[cfg(unix)]
-#[cfg_attr(not(target_os = "macos"), expect(dead_code))]
+pub(crate) mod backend;
+pub(crate) mod cli;
+// Each back end is compiled only for the host it drives: its helpers and
+// constants exist to serve one supervisor, and carrying them onto a platform
+// that has no such supervisor would be dead code the compiler is right to
+// flag. The naming, staging, manifest, and status code every platform shares
+// lives here instead, and is covered on every target.
+#[cfg(target_os = "macos")]
 mod launchd;
-#[cfg(unix)]
-#[cfg_attr(not(target_os = "linux"), expect(dead_code))]
+pub(crate) mod manifest;
+pub(crate) mod model;
+#[cfg(target_os = "linux")]
 mod systemd;
 
 use std::path::{Path, PathBuf};
@@ -63,19 +70,22 @@ use sha2::{Digest as _, Sha256};
 
 use crate::error::{Error, Result};
 
-#[cfg(target_os = "linux")]
-use systemd as backend;
-
-#[cfg(target_os = "macos")]
-use launchd as backend;
-
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-use unsupported as backend;
+pub(crate) use backend::{InstallRequest, LogRequest, ServiceBackend, for_host as backend};
+pub(crate) use manifest::{ServiceManifest, ServiceOwner};
+pub(crate) use model::{ServiceScope, ServiceStatus};
 
 /// Longest directory-name fragment carried into a service name, so a deeply-named
 /// instance directory cannot produce an unwieldy name. The appended digest is
 /// what makes the name unique; the fragment only makes it legible.
 const MAX_NAME_FRAGMENT: usize = 32;
+
+/// Hex digits of the path digest appended to every service name.
+///
+/// Eight bytes of SHA-256. The digest is the whole of the uniqueness
+/// guarantee — two instance directories that share a basename are told apart
+/// by nothing else — so it is sized for a collision to be unreachable rather
+/// than merely unlikely on the hosts anyone has today.
+const NAME_DIGEST_HEX: usize = 16;
 
 /// Marks a booted systemd system. Present only when systemd is PID 1 and
 /// running, which is exactly the condition `systemctl` needs.
@@ -128,7 +138,7 @@ fn service_account(instance_dir: &Path) -> Result<ServiceAccount> {
             return Ok(ServiceAccount { uid, gid });
         }
         return Err(Error::InvalidArgument {
-            message: "Failed to install the Spice Cloud Connect service: SUDO_UID and SUDO_GID must identify the non-root operator who will run spiced. Re-run from that account with `sudo spice connect --install`.".to_string(),
+            message: "Failed to install the Spice Cloud Connect service: SUDO_UID and SUDO_GID must identify the non-root operator who will run spiced. Re-run from that account with `sudo spice connect service install`.".to_string(),
         });
     }
 
@@ -147,10 +157,19 @@ fn service_account(instance_dir: &Path) -> Result<ServiceAccount> {
 
     Err(Error::InvalidArgument {
         message: format!(
-            "Failed to install the Spice Cloud Connect service: {} is root-owned and no non-root sudo caller is available. Run the command from the intended operator account with `sudo spice connect --install`.",
+            "Failed to install the Spice Cloud Connect service: {} is root-owned and no non-root sudo caller is available. Run the command from the intended operator account with `sudo spice connect service install`.",
             instance_dir.display()
         ),
     })
+}
+
+/// The local account name for a uid, when the host has one.
+#[cfg(unix)]
+fn account_name(uid: u32) -> Option<String> {
+    nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+        .ok()
+        .flatten()
+        .map(|user| user.name)
 }
 
 /// Give the service account access to the enrolled identity and managed state.
@@ -199,7 +218,8 @@ fn staged_runtime_path() -> PathBuf {
     Path::new(RUNTIME_STAGE_DIR).join(STAGED_RUNTIME_FILE)
 }
 
-/// A service installed for one instance directory.
+/// A service installed for one instance directory, as its back end describes
+/// it immediately after installing it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct InstalledService {
     /// The name the supervisor knows this service by: a systemd unit name
@@ -215,8 +235,9 @@ pub(crate) struct InstalledService {
 
 /// Derive the per-instance part of this directory's service name.
 ///
-/// The stem is `<fragment>-<digest>`: a legible fragment from the directory
-/// name plus the first 8 hex digits of the SHA-256 of the absolute path. The
+/// The stem is `<fragment>-<digest>`: a legible fragment of at most
+/// [`MAX_NAME_FRAGMENT`] characters from the directory name, plus the first
+/// [`NAME_DIGEST_HEX`] hex digits of the SHA-256 of the absolute path. The
 /// digest is what guarantees two directories never collide — including two
 /// directories with the same basename (`/srv/a/edge` and `/srv/b/edge`) —
 /// while the fragment keeps `systemctl status` and `launchctl print` output
@@ -228,8 +249,8 @@ pub(crate) struct InstalledService {
 /// where the command ran.
 fn name_stem_for_dir(dir: &Path) -> String {
     let digest = Sha256::digest(dir.as_os_str().as_encoded_bytes());
-    let mut short = String::with_capacity(8);
-    for byte in digest.iter().take(4) {
+    let mut short = String::with_capacity(NAME_DIGEST_HEX);
+    for byte in digest.iter().take(NAME_DIGEST_HEX / 2) {
         use std::fmt::Write as _;
         // Writing into a String is infallible; the Result exists only to
         // satisfy the `Write` trait.
@@ -277,13 +298,13 @@ fn sanitize_fragment(name: &str) -> String {
 /// touching any state: a failed preflight must change nothing.
 #[derive(Debug)]
 pub(crate) enum PreflightFailure {
-    /// Neither Linux nor macOS — `--install` has no supervisor to install into.
+    /// Neither Linux nor macOS — there is no supervisor to install into.
     UnsupportedPlatform,
     /// Linux, but systemd is not the running init.
     SystemdUnavailable,
-    /// Not running as root, so the service definition directory is not writable
-    /// and the supervisor cannot be asked to manage the service.
-    NotRoot,
+    /// A user-scope service was asked for, and the back end does not install
+    /// one yet.
+    UserScopePending,
 }
 
 impl PreflightFailure {
@@ -291,7 +312,7 @@ impl PreflightFailure {
     fn message(&self) -> String {
         match self {
             Self::UnsupportedPlatform => format!(
-                "Failed to install the Spice Cloud Connect service: --install requires \
+                "Failed to install the Spice Cloud Connect service: a service needs \
                  Linux with systemd or macOS with launchd (this host is {}). Run `spiced` from \
                  the enrolled directory under your own supervisor, or run Spice in a container \
                  with a restart policy (`docker run --restart unless-stopped`). \
@@ -303,16 +324,17 @@ impl PreflightFailure {
                  this host ({SYSTEMD_RUNTIME_MARKER} is absent). This is normal inside a \
                  container: run `spiced --token <enrollment-key>` under the container \
                  runtime's restart policy (`docker run --restart unless-stopped`) \
-                 instead of --install. See: https://spiceai.org/docs"
+                 instead. See: https://spiceai.org/docs"
             ),
-            Self::NotRoot => format!(
-                "Failed to install the Spice Cloud Connect service: installing a {} requires \
-                 root. Re-run with sudo: `sudo spice connect --install`. \
+            Self::UserScopePending => format!(
+                "Failed to install the Spice Cloud Connect service: a {} is not available in \
+                 this release. Install a system service instead: \
+                 `sudo spice connect service install`. \
                  See: https://spiceai.org/docs",
                 if cfg!(target_os = "macos") {
-                    "launchd daemon"
+                    "user LaunchAgent"
                 } else {
-                    "systemd unit"
+                    "systemd user service"
                 }
             ),
         }
@@ -330,84 +352,342 @@ impl From<PreflightFailure> for Error {
 /// Check that this host can have a service installed, **before** anything
 /// irreversible happens.
 ///
-/// Called before any service files are written so a host with no supervisor
-/// or without root fails with nothing installed.
-pub(crate) fn preflight() -> std::result::Result<(), PreflightFailure> {
+/// The platform check is here rather than in a back end because a host with no
+/// supported supervisor has no back end to ask. `cfg!` rather than `#[cfg]`, so
+/// the unsupported-platform branch is compiled — and its message kept
+/// truthful — on every target.
+///
+/// # Errors
+///
+/// Returns the reason installation is impossible on this host.
+fn preflight(
+    backend: &dyn ServiceBackend,
+    scope: ServiceScope,
+) -> std::result::Result<(), PreflightFailure> {
     if !cfg!(any(target_os = "linux", target_os = "macos")) {
         return Err(PreflightFailure::UnsupportedPlatform);
     }
-    backend::preflight()
+    backend.preflight(scope)
 }
 
-/// Install (or reinstall) and start the service for `instance_dir`, preserving
-/// the resolved `config_dir` in the service environment.
+/// The service domain this invocation can install into.
 ///
-/// Idempotent, and the in-place upgrade path: re-running restages the current
-/// `spiced` binary, rewrites the service definition, and restarts the service,
-/// leaving the staged identity untouched. Returns the installed service.
+/// Least privilege by default: an unprivileged invocation asks for a user
+/// service, and only an explicitly elevated one installs host-wide.
+pub(crate) fn scope_for_privilege() -> ServiceScope {
+    if is_root() {
+        ServiceScope::System
+    } else {
+        ServiceScope::User
+    }
+}
+
+/// Resolve the service installed for `instance_dir`, from that directory and
+/// nothing else.
 ///
-/// `spiced_path` is where the CLI found the runtime; it is copied to a
-/// root-owned location (see [`stage_runtime`]) rather than referenced in place.
+/// `Ok(None)` means no service is installed for this directory. An error means
+/// something claiming to be one could not be trusted — reported rather than
+/// treated as absence, because "there is nothing here" would send `install`
+/// on to write over it.
 ///
 /// # Errors
 ///
-/// Returns an error when the runtime cannot be staged, the definition cannot be
-/// written, or the supervisor rejects it. Since this runs *after* the enroll,
-/// the messages say that the identity is already staged and how to resume.
+/// Returns an error when the manifest exists but does not validate.
+pub(crate) fn resolve(
+    backend: &dyn ServiceBackend,
+    instance_dir: &Path,
+    config_dir: &Path,
+) -> Result<Option<ServiceManifest>> {
+    if let Some(manifest) = ServiceManifest::load(config_dir, instance_dir, backend)? {
+        return Ok(Some(manifest));
+    }
+    Ok(adopt_installed_definition(backend, instance_dir))
+}
+
+/// Describe a service that is installed for `instance_dir` but has no
+/// manifest, by reading the supervisor's own definition.
+///
+/// A directory can lose its manifest — deleted by hand, or restored from a
+/// backup that skipped it — while the definition is still installed and the
+/// service still running. Reading the definition is what keeps that service
+/// reportable and removable instead of invisible. It is not a fallback search:
+/// the name is still derived from the canonical directory, and the definition
+/// is accepted only if it names that same directory as its working directory.
+fn adopt_installed_definition(
+    backend: &dyn ServiceBackend,
+    instance_dir: &Path,
+) -> Option<ServiceManifest> {
+    let scope = ServiceScope::System;
+    let installed = backend.find_installed(instance_dir, scope)?;
+    let owner = installed_owner(instance_dir);
+    Some(ServiceManifest {
+        schema_version: manifest::MANIFEST_SCHEMA_VERSION,
+        directory: instance_dir.to_path_buf(),
+        name: installed.name.clone(),
+        scope,
+        supervisor: backend.supervisor(),
+        owner,
+        definition_path: installed.path,
+        runtime_path: installed.runtime,
+        log_source: backend.log_source(&installed.name, scope),
+        // Not recoverable from the definition, and not computed here: hashing
+        // the runtime on every `status` would read a gigabyte to answer a
+        // question nobody asked. The next `service install` records it.
+        runtime_digest: String::new(),
+        runtime_version: String::new(),
+        health_url: crate::context::DEFAULT_HTTP_ENDPOINT.to_string() + "/health",
+    })
+}
+
+/// The account an adopted service runs as, taken from the instance directory
+/// it was installed for — the same signal the installer uses when there is no
+/// `sudo` caller to name.
+#[cfg(unix)]
+fn installed_owner(instance_dir: &Path) -> ServiceOwner {
+    let (uid, gid) =
+        std::fs::metadata(instance_dir).map_or((0, 0), |metadata| (metadata.uid(), metadata.gid()));
+    ServiceOwner {
+        uid,
+        gid,
+        name: account_name(uid),
+    }
+}
+
+#[cfg(not(unix))]
+fn installed_owner(_instance_dir: &Path) -> ServiceOwner {
+    ServiceOwner {
+        uid: 0,
+        gid: 0,
+        name: None,
+    }
+}
+
+/// The complete service half of the status contract for one instance
+/// directory.
+///
+/// Never fails: `status` has to render something, and a supervisor that could
+/// not be asked is a state in the vocabulary rather than an error that
+/// suppresses the rest of the report. The caller decides the exit code from
+/// [`model::ServiceState::is_degraded`].
+pub(crate) fn status(
+    backend: &dyn ServiceBackend,
+    instance_dir: &Path,
+    config_dir: &Path,
+) -> ServiceStatus {
+    let manifest = match resolve(backend, instance_dir, config_dir) {
+        Ok(Some(manifest)) => manifest,
+        Ok(None) => return ServiceStatus::not_installed(),
+        Err(err) => return ServiceStatus::unavailable(err.to_string()),
+    };
+
+    let observed = backend.observe(&manifest);
+    ServiceStatus {
+        installed: true,
+        state: observed.state,
+        scope: Some(manifest.scope),
+        supervisor: Some(manifest.supervisor),
+        starts: observed.starts,
+        owner: Some(manifest.owner.describe()),
+        name: Some(manifest.name.clone()),
+        working_dir: Some(manifest.directory.clone()),
+        definition_path: Some(manifest.definition_path.clone()),
+        runtime_path: Some(manifest.runtime_path.clone()),
+        log_source: manifest.log_source,
+        diagnostic: observed.diagnostic,
+        starts_action: observed.starts_action,
+    }
+}
+
+/// Install (or reinstall) the service for `instance_dir` and record what was
+/// installed in the per-directory manifest.
+///
+/// Idempotent, and the in-place upgrade path: re-running restages the current
+/// `spiced` binary, rewrites the service definition, restarts the service, and
+/// rewrites the manifest, leaving the enrolled identity untouched.
+///
+/// # Errors
+///
+/// Returns an error when the host cannot host a service, when the derived
+/// service name is already taken by something that does not belong to this
+/// directory, when the runtime cannot be staged, or when the supervisor
+/// rejects the definition. Every one of those is checked or reported before
+/// the manifest is written, so a failed install never leaves a manifest
+/// describing a service that is not there.
 pub(crate) fn install(
+    backend: &dyn ServiceBackend,
     instance_dir: &Path,
     config_dir: &Path,
     spiced_path: &Path,
-) -> Result<InstalledService> {
-    backend::install(instance_dir, config_dir, spiced_path)
+    runtime_version: &str,
+    health_url: &str,
+) -> Result<ServiceManifest> {
+    let scope = scope_for_privilege();
+    preflight(backend, scope)?;
+
+    // Reading the existing state first is what makes the pre-existing-name
+    // check meaningful: an invalid manifest, or a definition under this
+    // directory's derived name that belongs to somewhere else, has to fail
+    // before anything is written.
+    let existing = resolve(backend, instance_dir, config_dir)?;
+    if existing.is_none() {
+        ensure_name_unclaimed(backend, instance_dir, scope)?;
+    }
+
+    let installed = backend.install(&InstallRequest {
+        instance_dir,
+        config_dir,
+        spiced_path,
+        scope,
+    })?;
+
+    let owner = install_owner(instance_dir)?;
+    let manifest = ServiceManifest {
+        schema_version: manifest::MANIFEST_SCHEMA_VERSION,
+        directory: instance_dir.to_path_buf(),
+        name: installed.name.clone(),
+        scope,
+        supervisor: backend.supervisor(),
+        owner,
+        definition_path: installed.path,
+        runtime_path: installed.runtime.clone(),
+        log_source: backend.log_source(&installed.name, scope),
+        runtime_digest: file_digest(&installed.runtime).unwrap_or_default(),
+        runtime_version: runtime_version.to_string(),
+        health_url: health_url.to_string(),
+    };
+    manifest.write(config_dir)?;
+    Ok(manifest)
 }
 
-/// Stop and delete the service for `instance_dir`.
+/// The account the freshly installed service runs as.
+#[cfg(unix)]
+fn install_owner(instance_dir: &Path) -> Result<ServiceOwner> {
+    let account = service_account(instance_dir)?;
+    Ok(ServiceOwner {
+        uid: account.uid,
+        gid: account.gid,
+        name: account_name(account.uid),
+    })
+}
+
+#[cfg(not(unix))]
+fn install_owner(instance_dir: &Path) -> Result<ServiceOwner> {
+    Ok(installed_owner(instance_dir))
+}
+
+/// Refuse to install over a definition that already carries this directory's
+/// derived name but does not describe this directory's service.
 ///
-/// Returns the service that was removed, or `None` when none was installed for
-/// this directory.
+/// The derived name is a function of the path, so the only way this happens is
+/// a definition written by hand, left behind by a directory that has since
+/// moved, or belonging to another operator. Overwriting any of those would
+/// take over a service this directory does not own, so it fails before the
+/// installer touches anything.
+fn ensure_name_unclaimed(
+    backend: &dyn ServiceBackend,
+    instance_dir: &Path,
+    scope: ServiceScope,
+) -> Result<()> {
+    let name = backend.name_for_dir(instance_dir);
+    let path = backend.definition_path(&name, scope);
+    let Ok(metadata) = std::fs::symlink_metadata(&path) else {
+        return Ok(());
+    };
+
+    let claim = if metadata.file_type().is_symlink() {
+        Some("is a symlink".to_string())
+    } else if backend.find_installed(instance_dir, scope).is_none() {
+        Some("belongs to another instance directory".to_string())
+    } else {
+        definition_ownership_problem(&metadata, scope)
+    };
+
+    match claim {
+        Some(reason) => Err(Error::InvalidArgument {
+            message: format!(
+                "Failed to install the Spice Cloud Connect service for {instance}: the service \
+                 definition {definition} already exists and {reason}. Remove or repair it, then \
+                 re-run `spice connect service install`. Nothing was changed. \
+                 See: https://spiceai.org/docs",
+                instance = instance_dir.display(),
+                definition = path.display(),
+            ),
+        }),
+        None => Ok(()),
+    }
+}
+
+/// Whether an existing definition's ownership disqualifies it from being
+/// rewritten in `scope`.
+#[cfg(unix)]
+fn definition_ownership_problem(
+    metadata: &std::fs::Metadata,
+    scope: ServiceScope,
+) -> Option<String> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let uid = metadata.uid();
+    let mode = metadata.permissions().mode() & 0o7777;
+    match scope {
+        // A host-wide definition tells the supervisor what to run as whom. A
+        // non-root owner, or write access for anyone but root, means someone
+        // else already decides that.
+        ServiceScope::System if uid != 0 || mode & 0o022 != 0 => Some(format!(
+            "is owned by uid {uid} with mode {mode:04o}, so it is not a definition only root controls"
+        )),
+        ServiceScope::User if uid != nix::unistd::Uid::effective().as_raw() => {
+            Some(format!("is owned by uid {uid} rather than by this account"))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(not(unix))]
+fn definition_ownership_problem(
+    _metadata: &std::fs::Metadata,
+    _scope: ServiceScope,
+) -> Option<String> {
+    None
+}
+
+/// Stop and remove the service for `instance_dir`, and forget it.
+///
+/// Idempotent: a directory with no service succeeds and returns `None`. This
+/// is the one primitive both `spice connect service uninstall` and
+/// `spice connect remove` use, so they cannot diverge on which assets a
+/// removal touches. What they do *not* share is identity: uninstall preserves
+/// the Cloud identity, and `remove` is the command that releases it.
 ///
 /// # Errors
 ///
-/// Returns an error when the definition cannot be deleted, or when the
-/// supervisor is left holding a job that the deleted definition can no longer
-/// account for.
-pub(crate) fn uninstall(instance_dir: &Path) -> Result<Option<InstalledService>> {
-    backend::uninstall(instance_dir)
+/// Returns an error when the supervisor or the definition file cannot be
+/// removed. The manifest is deleted only after the back end reports the
+/// service gone, so a partial failure leaves a directory that still knows what
+/// it is trying to remove.
+pub(crate) fn uninstall(
+    backend: &dyn ServiceBackend,
+    instance_dir: &Path,
+    config_dir: &Path,
+) -> Result<Option<ServiceManifest>> {
+    let Some(manifest) = resolve(backend, instance_dir, config_dir)? else {
+        return Ok(None);
+    };
+    backend.uninstall(&manifest)?;
+    ServiceManifest::remove(config_dir)?;
+    Ok(Some(manifest))
 }
 
-/// The service installed for `instance_dir`, if any.
-///
-/// Matches on the derived name rather than by scanning working directories, so
-/// the lookup is exact and cannot pick up another instance's service.
-pub(crate) fn find_for_dir(instance_dir: &Path) -> Option<InstalledService> {
-    backend::find_for_dir(instance_dir)
-}
-
-/// Every service this command installed on the host, sorted by name.
-///
-/// This is what lets `spice connect status` report against installed services
-/// when the resolved directory holds no instance state, instead of printing a
-/// misleading "not connected" for a host that is in fact connected from
-/// somewhere else.
-pub(crate) fn discover_all() -> Vec<InstalledService> {
-    backend::discover_all()
-}
-
-/// The service's current state as the supervisor reports it, or `None` when it
-/// cannot be determined.
-pub(crate) fn is_active(name: &str) -> Option<String> {
-    backend::is_active(name)
-}
-
-/// The commands an operator inspects and follows this service with, in the
-/// vocabulary of the supervisor that owns it.
-pub(crate) fn manage_hints(name: &str) -> Vec<String> {
-    backend::manage_hints(name)
+/// SHA-256 (lowercase hex) of a file, or `None` when it cannot be read.
+fn file_digest(path: &Path) -> Option<String> {
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher).ok()?;
+    Some(format!("{:x}", hasher.finalize()))
 }
 
 /// `true` when this process runs with root's effective user id — the id that
-/// governs writing the service definition and directing the supervisor.
+/// governs writing a host-wide service definition and directing the
+/// supervisor.
 #[cfg(unix)]
 fn is_root() -> bool {
     nix::unistd::Uid::effective().is_root()
@@ -426,7 +706,7 @@ fn is_root() -> bool {
 /// installed instance one stable executable.
 ///
 /// Copying every install also makes the documented upgrade path work: re-running
-/// `--install` restages whatever `spiced` the CLI now resolves. One host has one
+/// the install restages whatever `spiced` the CLI now resolves. One host has one
 /// staged runtime, shared by every instance's service — so a re-install in one
 /// instance directory does change the binary the others run at their next
 /// restart.
@@ -464,7 +744,7 @@ where
     let stamp = source_stamp(source);
 
     // A staged runtime that no longer works is restaged, not refused:
-    // re-running `--install` is the documented way to put a good binary back on
+    // re-running the install is the documented way to put a good binary back on
     // the path every service executes, and short-circuiting the failure here
     // would make that the one thing it could not do.
     if let Some(ref stamp) = stamp
@@ -568,7 +848,7 @@ fn ensure_root_only_dir(dir: &Path) -> Result<()> {
                  The runtime staging is managed by root, so it must use a real, root-owned \
                  directory. Replace the symlink with a directory owned by root \
                  (`chown root {dir}`, `chmod 755 {dir}`) and re-run \
-                 `sudo spice connect --install`.",
+                 `sudo spice connect service install`.",
                 dir = dir.display()
             ),
         });
@@ -590,7 +870,7 @@ fn ensure_root_only_dir(dir: &Path) -> Result<()> {
                     "Failed to install the Spice Cloud Connect service: {component} is owned by uid {uid} with mode {mode:04o}, \
                      so a non-root user can change what the service executes as root. Restrict it \
                      (`sudo chown root {component}` and `sudo chmod go-w {component}`) and re-run \
-                     `sudo spice connect --install`.",
+                     `sudo spice connect service install`.",
                     component = component.display(),
                     uid = meta.uid(),
                     mode = mode & 0o7777,
@@ -692,52 +972,47 @@ fn runtime_is_already_staged(dest: &Path, stamp_path: &Path, stamp: &str) -> boo
     std::fs::read_to_string(stamp_path).is_ok_and(|recorded| recorded == stamp)
 }
 
-/// Stubs for a host with no supported supervisor. [`preflight`] rejects such a
-/// host before any of these can be reached; they exist so the CLI still builds
-/// for it.
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-mod unsupported {
-    use std::path::Path;
-
-    use super::{InstalledService, PreflightFailure};
-    use crate::error::Result;
-
-    pub(super) fn preflight() -> std::result::Result<(), PreflightFailure> {
-        Err(PreflightFailure::UnsupportedPlatform)
-    }
-
-    pub(super) fn install(
-        _instance_dir: &Path,
-        _config_dir: &Path,
-        _spiced_path: &Path,
-    ) -> Result<InstalledService> {
-        Err(PreflightFailure::UnsupportedPlatform.into())
-    }
-
-    pub(super) fn uninstall(_instance_dir: &Path) -> Result<Option<InstalledService>> {
-        Ok(None)
-    }
-
-    pub(super) fn find_for_dir(_instance_dir: &Path) -> Option<InstalledService> {
-        None
-    }
-
-    pub(super) fn discover_all() -> Vec<InstalledService> {
-        Vec::new()
-    }
-
-    pub(super) fn is_active(_name: &str) -> Option<String> {
-        None
-    }
-
-    pub(super) fn manage_hints(_name: &str) -> Vec<String> {
-        Vec::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use super::backend::fake::FakeBackend;
+    use super::model::{ServiceStarts, ServiceState};
     use super::*;
+
+    /// The exact stems the naming algorithm must produce.
+    ///
+    /// Golden, not derived: the service name is the identity of an installed
+    /// service, so a change here silently orphans every service already
+    /// installed on every host. Changing these values is a migration, not a
+    /// refactor.
+    #[test]
+    fn name_stem_algorithm_is_golden() {
+        for (dir, expected) in [
+            ("/opt/edge-1", "edge-1-2962fca679ae993a"),
+            ("/srv/edge-analytics", "edge-analytics-59e8c853e76c15ba"),
+            ("/srv/a/edge", "edge-ee40c5935182e518"),
+            ("/srv/b/edge", "edge-80faba57766c7bb4"),
+            // No usable directory name: the digest alone names it.
+            ("/", "8a5edab282632443"),
+        ] {
+            assert_eq!(name_stem_for_dir(Path::new(dir)), expected, "{dir}");
+        }
+
+        // A 120-character directory name keeps exactly 32 characters of
+        // fragment, then the 16-hex digest.
+        let long = format!("/opt/{}", "a".repeat(120));
+        assert_eq!(
+            name_stem_for_dir(Path::new(&long)),
+            format!("{}-0aca36d818e38f1d", "a".repeat(MAX_NAME_FRAGMENT))
+        );
+    }
+
+    #[test]
+    fn name_stem_digest_is_sixteen_hex_digits() {
+        let stem = name_stem_for_dir(Path::new("/opt/edge-1"));
+        let digest = stem.rsplit('-').next().expect("a stem always has a digest");
+        assert_eq!(digest.len(), NAME_DIGEST_HEX, "{stem}");
+        assert!(digest.chars().all(|ch| ch.is_ascii_hexdigit()), "{stem}");
+    }
 
     #[test]
     fn name_stem_is_deterministic() {
@@ -757,7 +1032,8 @@ mod tests {
     #[test]
     fn same_basename_in_different_parents_does_not_collide() {
         // The legible fragment is identical here, so only the path digest keeps
-        // these apart — a `remove` in one must never touch the other's service.
+        // these apart — an uninstall in one must never touch the other's
+        // service.
         let a = name_stem_for_dir(Path::new("/srv/a/edge"));
         let b = name_stem_for_dir(Path::new("/srv/b/edge"));
         assert_ne!(a, b);
@@ -767,20 +1043,15 @@ mod tests {
 
     #[test]
     fn name_stem_sanitizes_and_bounds_the_fragment() {
-        let stem = name_stem_for_dir(Path::new("/opt/My Edge_Site!!/"));
+        let stem = name_stem_for_dir(Path::new("/opt/My Edge_Site!!"));
         assert!(stem.starts_with("my-edge-site-"), "{stem}");
 
         // A long directory name is truncated, not carried whole.
         let long = name_stem_for_dir(Path::new(&format!("/opt/{}", "a".repeat(120))));
-        assert!(long.len() <= MAX_NAME_FRAGMENT + 9, "{long}");
-    }
-
-    #[test]
-    fn name_stem_handles_a_directory_with_no_usable_name() {
-        // Only the digest names it, and it is still 8 hex digits.
-        let stem = name_stem_for_dir(Path::new("/"));
-        assert_eq!(stem.len(), 8, "{stem}");
-        assert!(stem.chars().all(|ch| ch.is_ascii_hexdigit()), "{stem}");
+        assert!(
+            long.len() <= MAX_NAME_FRAGMENT + 1 + NAME_DIGEST_HEX,
+            "{long}"
+        );
     }
 
     #[test]
@@ -808,12 +1079,10 @@ mod tests {
 
     #[test]
     fn staging_skips_only_an_exact_restage_and_never_a_rebuild() {
-        let dir = std::env::temp_dir().join(format!("spice-stage-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        let source = dir.join("spiced");
-        let dest = dir.join("staged");
-        let stamp_path = dir.join("staged.stamp");
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let source = dir.path().join("spiced");
+        let dest = dir.path().join("staged");
+        let stamp_path = dir.path().join("staged.stamp");
 
         std::fs::write(&source, b"runtime-v1").expect("write source");
         let stamp = source_stamp(&source).expect("stamp the source");
@@ -841,8 +1110,6 @@ mod tests {
         // A missing binary with a leftover stamp also restages.
         std::fs::remove_file(&dest).expect("remove staged binary");
         assert!(!runtime_is_already_staged(&dest, &stamp_path, &stamp));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -851,11 +1118,9 @@ mod tests {
         // restarts, so a runtime that turns out to be unusable must not land on
         // it — a rejected upgrade in one instance directory would otherwise
         // take out every other instance on the host.
-        let dir = std::env::temp_dir().join(format!("spice-publish-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        let source = dir.join("spiced");
-        let dest = dir.join("staged");
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let source = dir.path().join("spiced");
+        let dest = dir.path().join("staged");
         std::fs::write(&source, b"unusable").expect("write source");
         std::fs::write(&dest, b"the runtime already in service").expect("write dest");
 
@@ -882,8 +1147,6 @@ mod tests {
         // everything.
         publish_runtime(&source, &dest, |_, _| Ok(())).expect("publish");
         assert_eq!(std::fs::read(&dest).expect("read dest"), b"unusable");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A verifier standing in for the real one: it rejects a candidate that
@@ -899,14 +1162,12 @@ mod tests {
 
     #[test]
     fn a_staged_runtime_that_stopped_working_is_replaced_rather_than_refused() {
-        // Re-running `--install` is the documented way to put a good binary
+        // Re-running the install is the documented way to put a good binary
         // back on the path every service executes. Refusing on the strength of
         // the stamp would make that the one repair it could not perform.
-        let dir = std::env::temp_dir().join(format!("spice-restage-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        let source = dir.join("spiced");
-        let dest = dir.join("staged");
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let source = dir.path().join("spiced");
+        let dest = dir.path().join("staged");
         std::fs::write(&source, b"working").expect("write source");
 
         stage_runtime_at(&source, &dest, reject_a_broken_runtime).expect("first stage");
@@ -920,18 +1181,14 @@ mod tests {
             b"working",
             "a staged runtime that fails verification must be restaged from source"
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn a_staged_runtime_that_still_works_is_not_copied_again() {
-        // The other half: a gigabyte is not recopied on every `--install`.
-        let dir = std::env::temp_dir().join(format!("spice-reuse-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        let source = dir.join("spiced");
-        let dest = dir.join("staged");
+        // The other half: a gigabyte is not recopied on every install.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let source = dir.path().join("spiced");
+        let dest = dir.path().join("staged");
         std::fs::write(&source, b"working").expect("write source");
 
         stage_runtime_at(&source, &dest, reject_a_broken_runtime).expect("first stage");
@@ -944,17 +1201,13 @@ mod tests {
             b"reused",
             "an unchanged source must not be copied again"
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn source_stamp_distinguishes_length_and_mtime() {
-        let dir = std::env::temp_dir().join(format!("spice-stamp-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        let a = dir.join("a");
-        let b = dir.join("b");
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
         std::fs::write(&a, b"same-length").expect("write a");
         std::fs::write(&b, b"same-length").expect("write b");
 
@@ -966,9 +1219,20 @@ mod tests {
             stamp_a.starts_with("11 "),
             "length leads the stamp: {stamp_a}"
         );
-        assert_eq!(source_stamp(&dir.join("missing")), None);
+        assert_eq!(source_stamp(&dir.path().join("missing")), None);
+    }
 
-        let _ = std::fs::remove_dir_all(&dir);
+    #[test]
+    fn file_digest_is_stable_and_absent_for_a_missing_file() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("runtime");
+        std::fs::write(&path, b"spiced").expect("write");
+        assert_eq!(
+            file_digest(&path).as_deref(),
+            Some("677e903199916067c479594e77308560145a863b94342cc471f0043403c92d0e"),
+            "the recorded runtime digest must be a plain SHA-256 of the staged file"
+        );
+        assert_eq!(file_digest(&dir.path().join("missing")), None);
     }
 
     #[test]
@@ -976,11 +1240,9 @@ mod tests {
         // On macOS this is what keeps `com.apple.quarantine` off the copy
         // launchd executes: the stage writes bytes into a new file rather than
         // cloning the original.
-        let dir = std::env::temp_dir().join(format!("spice-xattr-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        let source = dir.join("spiced");
-        let dest = dir.join("staged");
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let source = dir.path().join("spiced");
+        let dest = dir.path().join("staged");
         std::fs::write(&source, b"runtime").expect("write source");
 
         let set = std::process::Command::new("xattr")
@@ -989,7 +1251,6 @@ mod tests {
             .status();
         if !set.is_ok_and(|status| status.success()) {
             // No `xattr` (any non-macOS host): nothing to prove here.
-            let _ = std::fs::remove_dir_all(&dir);
             return;
         }
 
@@ -1004,15 +1265,15 @@ mod tests {
             !read.success(),
             "the staged copy must not carry com.apple.quarantine"
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn preflight_failures_name_the_fix() {
         assert!(
-            PreflightFailure::NotRoot.message().contains("sudo"),
-            "the root failure must name sudo"
+            PreflightFailure::UserScopePending
+                .message()
+                .contains("sudo"),
+            "the deferred user-scope failure must name the path that does work"
         );
         assert!(
             PreflightFailure::SystemdUnavailable
@@ -1037,6 +1298,289 @@ mod tests {
                 .message()
                 .contains("launchd"),
             "macOS is supported, so the message must not read as Linux-only"
+        );
+    }
+
+    #[test]
+    fn a_directory_with_no_service_resolves_to_nothing() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let fake = FakeBackend::new(dir.path());
+
+        assert_eq!(
+            resolve(&fake, &instance_dir, &config_dir).expect("resolve"),
+            None
+        );
+        assert_eq!(
+            status(&fake, &instance_dir, &config_dir),
+            ServiceStatus::not_installed()
+        );
+    }
+
+    #[test]
+    fn install_records_what_it_installed_and_is_idempotent() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        std::fs::create_dir_all(&instance_dir).expect("create instance dir");
+        let config_dir = instance_dir.join(".spice");
+        let fake = FakeBackend::new(dir.path());
+
+        let manifest = install(
+            &fake,
+            &instance_dir,
+            &config_dir,
+            Path::new("/usr/bin/spiced"),
+            "v2.2.0",
+            "http://127.0.0.1:8090/health",
+        )
+        .expect("install");
+        assert_eq!(manifest.name, fake.name_for_dir(&instance_dir));
+        assert_eq!(manifest.directory, instance_dir);
+        assert_eq!(manifest.runtime_version, "v2.2.0");
+        assert_eq!(
+            ServiceManifest::load(&config_dir, &instance_dir, &fake)
+                .expect("load")
+                .as_ref(),
+            Some(&manifest)
+        );
+
+        // Re-running is the upgrade path: it installs again over its own
+        // service rather than refusing because the definition is there.
+        let again = install(
+            &fake,
+            &instance_dir,
+            &config_dir,
+            Path::new("/usr/bin/spiced"),
+            "v2.3.0",
+            "http://127.0.0.1:8090/health",
+        )
+        .expect("reinstall");
+        assert_eq!(again.runtime_version, "v2.3.0");
+        assert_eq!(
+            fake.calls(),
+            vec!["install".to_string(), "install".to_string()]
+        );
+    }
+
+    #[test]
+    fn install_refuses_a_name_already_claimed_by_another_directory() {
+        // The pre-existing-name check: a definition under this directory's
+        // derived name that names somewhere else must fail before the
+        // installer writes anything.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        std::fs::create_dir_all(&instance_dir).expect("create instance dir");
+        let config_dir = instance_dir.join(".spice");
+        let fake = FakeBackend::new(dir.path());
+        fake.plant_foreign_definition(&instance_dir);
+
+        let error = install(
+            &fake,
+            &instance_dir,
+            &config_dir,
+            Path::new("/usr/bin/spiced"),
+            "v2.2.0",
+            "http://127.0.0.1:8090/health",
+        )
+        .expect_err("a foreign definition under the derived name must not be taken over");
+        assert!(
+            error
+                .to_string()
+                .contains("belongs to another instance directory"),
+            "{error}"
+        );
+        assert!(fake.calls().is_empty(), "nothing may be installed");
+        assert!(
+            !ServiceManifest::path_in(&config_dir).exists(),
+            "no manifest may be written"
+        );
+    }
+
+    #[test]
+    fn a_service_installed_without_a_manifest_is_still_resolved() {
+        // A directory that lost its manifest must not lose the service it
+        // still has installed — resolution is still by canonical directory,
+        // not by a host-wide search.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        std::fs::create_dir_all(&instance_dir).expect("create instance dir");
+        let config_dir = instance_dir.join(".spice");
+        let fake = FakeBackend::new(dir.path());
+        fake.install(&InstallRequest {
+            instance_dir: &instance_dir,
+            config_dir: &config_dir,
+            spiced_path: Path::new("/usr/bin/spiced"),
+            scope: ServiceScope::System,
+        })
+        .expect("install without writing a manifest");
+
+        let resolved = resolve(&fake, &instance_dir, &config_dir)
+            .expect("resolve")
+            .expect("the definition describes this directory's service");
+        assert_eq!(resolved.name, fake.name_for_dir(&instance_dir));
+        assert_eq!(resolved.directory, instance_dir);
+        assert!(
+            resolved.runtime_digest.is_empty(),
+            "an adopted service records no digest rather than hashing a gigabyte"
+        );
+        assert_eq!(
+            status(&fake, &instance_dir, &config_dir).state,
+            ServiceState::Running
+        );
+    }
+
+    #[test]
+    fn a_definition_for_another_directory_is_not_adopted() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let fake = FakeBackend::new(dir.path());
+        fake.plant_foreign_definition(&instance_dir);
+
+        assert_eq!(
+            resolve(&fake, &instance_dir, &config_dir).expect("resolve"),
+            None
+        );
+    }
+
+    #[test]
+    fn an_unreadable_manifest_reports_unavailable_rather_than_absent() {
+        // "Nothing is installed here" would send `install` on to write over
+        // whatever the unreadable manifest describes.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(ServiceManifest::path_in(&config_dir), "{").expect("write manifest");
+
+        let fake = FakeBackend::new(dir.path());
+        let status = status(&fake, &instance_dir, &config_dir);
+        assert_eq!(status.state, ServiceState::Unavailable);
+        assert!(status.diagnostic.is_some());
+        assert!(!status.installed);
+    }
+
+    #[test]
+    fn status_reports_every_normalized_state_the_backend_observes() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+
+        for state in [
+            ServiceState::Starting,
+            ServiceState::Running,
+            ServiceState::Stopping,
+            ServiceState::Stopped,
+            ServiceState::Failed,
+            ServiceState::Unavailable,
+        ] {
+            let fake = FakeBackend::in_state(dir.path(), state);
+            write_manifest_for(&fake, &instance_dir, &config_dir);
+            let status = status(&fake, &instance_dir, &config_dir);
+            assert!(status.installed, "{state}");
+            assert_eq!(status.state, state);
+            assert_eq!(
+                status.name.as_deref(),
+                Some(fake.name_for_dir(&instance_dir).as_str())
+            );
+            assert_eq!(status.working_dir.as_deref(), Some(instance_dir.as_path()));
+            assert!(status.definition_path.is_some(), "{state}");
+            assert!(status.runtime_path.is_some(), "{state}");
+            assert!(status.log_source.is_some(), "{state}");
+        }
+    }
+
+    #[test]
+    fn uninstall_is_idempotent_and_forgets_the_manifest() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let fake = FakeBackend::new(dir.path());
+        write_manifest_for(&fake, &instance_dir, &config_dir);
+
+        let removed = uninstall(&fake, &instance_dir, &config_dir)
+            .expect("uninstall")
+            .expect("a service was installed");
+        assert_eq!(removed.name, fake.name_for_dir(&instance_dir));
+        assert!(!ServiceManifest::path_in(&config_dir).exists());
+        assert_eq!(fake.calls(), vec!["uninstall".to_string()]);
+
+        // Running it again changes nothing and does not call the back end.
+        let fake = FakeBackend::new(dir.path());
+        assert_eq!(
+            uninstall(&fake, &instance_dir, &config_dir).expect("second uninstall"),
+            None
+        );
+        assert!(fake.calls().is_empty());
+    }
+
+    #[test]
+    fn a_failed_uninstall_keeps_the_manifest() {
+        // The directory has to keep knowing what it is trying to remove:
+        // forgetting the manifest while the service is still installed would
+        // strand it.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let fake = FakeBackend::failing(dir.path(), "uninstall", "the supervisor refused");
+        write_manifest_for(&fake, &instance_dir, &config_dir);
+
+        let error = uninstall(&fake, &instance_dir, &config_dir)
+            .expect_err("a supervisor refusal must fail the uninstall");
+        assert!(
+            error.to_string().contains("the supervisor refused"),
+            "{error}"
+        );
+        assert!(
+            ServiceManifest::path_in(&config_dir).exists(),
+            "the manifest must survive a failed uninstall"
+        );
+    }
+
+    /// Install through the fake back end so the shared code around it — the
+    /// manifest write, the owner, the log source — is exercised without a
+    /// supervisor.
+    fn write_manifest_for(backend: &FakeBackend, instance_dir: &Path, config_dir: &Path) {
+        let name = backend.name_for_dir(instance_dir);
+        let scope = ServiceScope::System;
+        ServiceManifest {
+            schema_version: manifest::MANIFEST_SCHEMA_VERSION,
+            directory: instance_dir.to_path_buf(),
+            name: name.clone(),
+            scope,
+            supervisor: backend.supervisor(),
+            owner: ServiceOwner {
+                uid: 1000,
+                gid: 1000,
+                name: Some("alice".to_string()),
+            },
+            definition_path: backend.definition_path(&name, scope),
+            runtime_path: PathBuf::from("/usr/local/lib/spice/spiced"),
+            log_source: backend.log_source(&name, scope),
+            runtime_digest: "0".repeat(64),
+            runtime_version: "v2.2.0".to_string(),
+            health_url: "http://127.0.0.1:8090/health".to_string(),
+        }
+        .write(config_dir)
+        .expect("write manifest");
+    }
+
+    #[test]
+    fn status_carries_the_backends_diagnostic_and_remediation() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let mut fake = FakeBackend::in_state(dir.path(), ServiceState::Running);
+        fake.observation.starts = ServiceStarts::LoginOnly;
+        fake.observation.starts_action = Some("loginctl enable-linger alice".to_string());
+        write_manifest_for(&fake, &instance_dir, &config_dir);
+
+        let status = status(&fake, &instance_dir, &config_dir);
+        assert_eq!(status.starts, ServiceStarts::LoginOnly);
+        assert_eq!(
+            status.starts_action.as_deref(),
+            Some("loginctl enable-linger alice")
         );
     }
 }

--- a/bin/spice/src/commands/connect/service/model.rs
+++ b/bin/spice/src/commands/connect/service/model.rs
@@ -1,0 +1,403 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! The normalized service vocabulary.
+//!
+//! One state vocabulary is shared by every backend and by both status
+//! commands, so `spice connect status` and `spice connect service status`
+//! cannot drift: the backends translate their supervisor's words into these
+//! types once, and everything above them — human rendering, JSON, exit
+//! codes — reads only these types.
+//!
+//! The per-supervisor translation tables live with the back ends that own
+//! those words (`normalize_systemd_state`, `normalize_launchd_state`), so a
+//! supervisor's vocabulary never leaks into this one.
+//!
+//! There is deliberately no `unknown` state. A supervisor that cannot be
+//! asked is [`ServiceState::Unavailable`] with a diagnostic, which is a
+//! statement about the *query* rather than a second name for "I don't know"
+//! that automation would have to reconcile with the first.
+
+use std::fmt;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// The normalized lifecycle state of the service for one instance directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ServiceState {
+    /// No service is installed for this instance directory. A foreground
+    /// runtime is also `not_installed`: nothing here supervises it.
+    NotInstalled,
+    /// The supervisor has been asked to bring the service up and it has not
+    /// finished doing so.
+    Starting,
+    /// The service is up.
+    Running,
+    /// The supervisor has been asked to take the service down and it has not
+    /// finished doing so.
+    Stopping,
+    /// The service is installed and down.
+    Stopped,
+    /// The service is installed and the supervisor reports it as failed.
+    Failed,
+    /// The supervisor could not be asked, so the state is not knowable right
+    /// now. Always accompanied by a diagnostic.
+    Unavailable,
+}
+
+impl ServiceState {
+    /// The stable machine-readable spelling, identical to the JSON encoding.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::NotInstalled => "not_installed",
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Stopping => "stopping",
+            Self::Stopped => "stopped",
+            Self::Failed => "failed",
+            Self::Unavailable => "unavailable",
+        }
+    }
+
+    /// Whether this state means the command that reported it should exit
+    /// non-zero. A service that is merely down is a fact, not a failure; a
+    /// state that could not be determined, or one the supervisor calls
+    /// failed, is.
+    pub(crate) fn is_degraded(self) -> bool {
+        matches!(self, Self::Failed | Self::Unavailable)
+    }
+}
+
+impl fmt::Display for ServiceState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Which service domain the service is installed into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ServiceScope {
+    /// Installed for one operator account and managed by that account.
+    User,
+    /// Installed host-wide and managed with elevated privileges.
+    System,
+}
+
+impl ServiceScope {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::System => "system",
+        }
+    }
+}
+
+impl fmt::Display for ServiceScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The supervisor that owns the service definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Supervisor {
+    Systemd,
+    Launchd,
+}
+
+impl Supervisor {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Systemd => "systemd",
+            Self::Launchd => "launchd",
+        }
+    }
+}
+
+impl fmt::Display for Supervisor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Boot persistence as an operator outcome rather than as supervisor jargon.
+///
+/// The question an operator is actually asking is "will this instance be
+/// serving after a reboot", so that is what the vocabulary answers. The word
+/// "lingering" is never the answer; it appears only inside the remediation
+/// command a Linux user service needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ServiceStarts {
+    /// Comes up when the host boots, with nobody logged in.
+    BootWithoutLogin,
+    /// Comes up when its owner logs in, and not before.
+    LoginOnly,
+    /// Installed, but the supervisor will not start it on its own.
+    Disabled,
+    /// The supervisor could not be asked.
+    Unavailable,
+}
+
+impl ServiceStarts {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::BootWithoutLogin => "boot_without_login",
+            Self::LoginOnly => "login_only",
+            Self::Disabled => "disabled",
+            Self::Unavailable => "unavailable",
+        }
+    }
+
+    /// The plain-language answer for human output.
+    pub(crate) fn describe(self) -> &'static str {
+        match self {
+            Self::BootWithoutLogin => "at boot, without login",
+            Self::LoginOnly => "at login only",
+            Self::Disabled => "not started automatically",
+            Self::Unavailable => "could not be determined",
+        }
+    }
+}
+
+impl fmt::Display for ServiceStarts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Where the supervisor keeps this service's output.
+///
+/// Modelled rather than flattened to a string because the two supervisors
+/// answer differently in kind: systemd owns the journal and is queried by
+/// unit, while launchd writes to files the definition names. `spice connect
+/// service logs` needs to know which of those it is looking at.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum LogSource {
+    /// The systemd journal, selected by unit.
+    Journal { unit: String, scope: ServiceScope },
+    /// Explicit stdout/stderr files named by a launchd definition.
+    Files { stdout: PathBuf, stderr: PathBuf },
+}
+
+impl LogSource {
+    /// The single line human status prints for this source.
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            Self::Journal { unit, scope } => match scope {
+                ServiceScope::User => format!("systemd journal (user), unit {unit}"),
+                ServiceScope::System => format!("systemd journal, unit {unit}"),
+            },
+            Self::Files { stdout, stderr } => {
+                if stdout == stderr {
+                    format!("{}", stdout.display())
+                } else {
+                    format!("{}, {}", stdout.display(), stderr.display())
+                }
+            }
+        }
+    }
+}
+
+/// The service half of [`super::super::status::ConnectStatus`].
+///
+/// `spice connect service status` renders this exact value, and
+/// `spice connect status` embeds this exact value, so the two commands cannot
+/// publish different field names, orders, or enum spellings. Field order here
+/// *is* the JSON field order — keep additions at the end so a golden fixture
+/// diff stays readable.
+///
+/// This is a public automation surface, versioned by
+/// [`super::super::status::STATUS_SCHEMA_VERSION`]: adding a field is
+/// compatible, but renaming one, removing one, or adding an enum variant that
+/// consumers must branch on is not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ServiceStatus {
+    /// Whether a service definition for this instance directory exists.
+    pub(crate) installed: bool,
+    /// The normalized lifecycle state.
+    pub(crate) state: ServiceState,
+    /// `null` when nothing is installed.
+    pub(crate) scope: Option<ServiceScope>,
+    /// `null` when nothing is installed.
+    pub(crate) supervisor: Option<Supervisor>,
+    /// Boot persistence as an operator outcome.
+    pub(crate) starts: ServiceStarts,
+    /// The account the runtime runs as.
+    pub(crate) owner: Option<String>,
+    /// The name the supervisor knows the service by.
+    pub(crate) name: Option<String>,
+    /// The instance directory baked into the definition.
+    pub(crate) working_dir: Option<PathBuf>,
+    /// The unit file or plist.
+    pub(crate) definition_path: Option<PathBuf>,
+    /// The `spiced` binary the service runs.
+    pub(crate) runtime_path: Option<PathBuf>,
+    /// Where to read this service's output.
+    pub(crate) log_source: Option<LogSource>,
+    /// Why the state is `unavailable`, or what is wrong with an installation
+    /// that could be read but not trusted. `null` when there is nothing to
+    /// report.
+    pub(crate) diagnostic: Option<String>,
+    /// The command that would give this service the boot persistence it does
+    /// not have. `null` when the persistence is already what it should be, or
+    /// when nothing is installed.
+    pub(crate) starts_action: Option<String>,
+}
+
+impl ServiceStatus {
+    /// The status of an instance directory with no service.
+    pub(crate) fn not_installed() -> Self {
+        Self {
+            installed: false,
+            state: ServiceState::NotInstalled,
+            scope: None,
+            supervisor: None,
+            starts: ServiceStarts::Disabled,
+            owner: None,
+            name: None,
+            working_dir: None,
+            definition_path: None,
+            runtime_path: None,
+            log_source: None,
+            diagnostic: None,
+            starts_action: None,
+        }
+    }
+
+    /// The status of an instance directory whose service could be found but
+    /// not trusted — a manifest that fails validation, for instance. Reported
+    /// rather than swallowed: acting on it could control the wrong process.
+    pub(crate) fn unavailable(diagnostic: String) -> Self {
+        Self {
+            installed: false,
+            state: ServiceState::Unavailable,
+            starts: ServiceStarts::Unavailable,
+            diagnostic: Some(diagnostic),
+            ..Self::not_installed()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn there_is_no_unknown_state_spelling() {
+        // The contract has one vocabulary for "cannot be determined". A second
+        // one would force automation to reconcile two names for one condition.
+        for state in [
+            ServiceState::NotInstalled,
+            ServiceState::Starting,
+            ServiceState::Running,
+            ServiceState::Stopping,
+            ServiceState::Stopped,
+            ServiceState::Failed,
+            ServiceState::Unavailable,
+        ] {
+            assert_ne!(state.as_str(), "unknown");
+        }
+    }
+
+    #[test]
+    fn only_failed_and_unavailable_are_degraded() {
+        assert!(ServiceState::Failed.is_degraded());
+        assert!(ServiceState::Unavailable.is_degraded());
+        for state in [
+            ServiceState::NotInstalled,
+            ServiceState::Starting,
+            ServiceState::Running,
+            ServiceState::Stopping,
+            ServiceState::Stopped,
+        ] {
+            assert!(!state.is_degraded(), "{state}");
+        }
+    }
+
+    #[test]
+    fn boot_persistence_never_says_lingering() {
+        for starts in [
+            ServiceStarts::BootWithoutLogin,
+            ServiceStarts::LoginOnly,
+            ServiceStarts::Disabled,
+            ServiceStarts::Unavailable,
+        ] {
+            assert!(!starts.describe().contains("linger"), "{starts}");
+        }
+    }
+
+    #[test]
+    fn json_spellings_match_the_machine_readable_strings() {
+        // The two are used interchangeably — `as_str` in human output and
+        // errors, serde in JSON — so a divergence would publish two names.
+        for state in [
+            ServiceState::NotInstalled,
+            ServiceState::Starting,
+            ServiceState::Running,
+            ServiceState::Stopping,
+            ServiceState::Stopped,
+            ServiceState::Failed,
+            ServiceState::Unavailable,
+        ] {
+            let json = serde_json::to_string(&state).expect("serialize state");
+            assert_eq!(json, format!("\"{}\"", state.as_str()));
+        }
+        for starts in [
+            ServiceStarts::BootWithoutLogin,
+            ServiceStarts::LoginOnly,
+            ServiceStarts::Disabled,
+            ServiceStarts::Unavailable,
+        ] {
+            let json = serde_json::to_string(&starts).expect("serialize starts");
+            assert_eq!(json, format!("\"{}\"", starts.as_str()));
+        }
+        for scope in [ServiceScope::User, ServiceScope::System] {
+            let json = serde_json::to_string(&scope).expect("serialize scope");
+            assert_eq!(json, format!("\"{}\"", scope.as_str()));
+        }
+        for supervisor in [Supervisor::Systemd, Supervisor::Launchd] {
+            let json = serde_json::to_string(&supervisor).expect("serialize supervisor");
+            assert_eq!(json, format!("\"{}\"", supervisor.as_str()));
+        }
+    }
+
+    #[test]
+    fn log_source_describes_both_kinds() {
+        let journal = LogSource::Journal {
+            unit: "spiced-cloud-connect-edge-1.service".to_string(),
+            scope: ServiceScope::User,
+        };
+        assert!(
+            journal.describe().contains("user"),
+            "{}",
+            journal.describe()
+        );
+        let files = LogSource::Files {
+            stdout: PathBuf::from("/var/log/spice/out.log"),
+            stderr: PathBuf::from("/var/log/spice/err.log"),
+        };
+        assert_eq!(
+            files.describe(),
+            "/var/log/spice/out.log, /var/log/spice/err.log"
+        );
+    }
+}

--- a/bin/spice/src/commands/connect/service/systemd.rs
+++ b/bin/spice/src/commands/connect/service/systemd.rs
@@ -367,15 +367,43 @@ fn observe(manifest: &ServiceManifest) -> ServiceObservation {
         ));
     };
     let (starts, starts_action) = observe_persistence(manifest);
+    let state = normalize_systemd_state(&reported);
     ServiceObservation {
-        state: normalize_systemd_state(&reported),
+        state,
         starts,
-        diagnostic: None,
+        // An `unavailable` state always says why. Carrying systemd's own answer
+        // is what makes the report actionable: `unknown` means systemd has no
+        // record of a unit whose file is on disk, which is a different repair
+        // from a word this release does not recognise.
+        diagnostic: (state == ServiceState::Unavailable)
+            .then(|| unrecognized_state_diagnostic(&reported, manifest)),
         starts_action,
     }
 }
 
+/// Why a state Spice does not recognise is reported as `unavailable`, naming
+/// systemd's own answer and the command that produced it.
+fn unrecognized_state_diagnostic(reported: &str, manifest: &ServiceManifest) -> String {
+    format!(
+        "`{command}` answered `{reported}`, which is not a state Spice can act on. Run it to \
+         see what systemd reports for this unit.",
+        command = systemctl_command(manifest.scope, &["is-active", &manifest.name]),
+        reported = reported.trim(),
+    )
+}
+
 /// Whether the unit is enabled, translated into the operator outcome.
+///
+/// Only a plain `enabled` establishes persistence. `enabled-runtime` is
+/// deliberately not enough: its link lives under `/run` and is gone after a
+/// reboot, so reporting boot persistence for it would promise exactly the thing
+/// that will not happen. Everything else systemd can answer here — `disabled`,
+/// `linked`, `static`, `indirect`, `alias`, `generated` — leaves the unit
+/// without a persistent boot-time link too, so all of them report `disabled`
+/// with the command that fixes it.
+///
+/// A *masked* unit cannot be enabled until it is unmasked, so its remediation
+/// says so rather than printing an `enable` that is guaranteed to fail.
 ///
 /// A system unit that is enabled comes up at boot with nobody logged in. A
 /// *user* unit that is enabled comes up when its owner logs in and no earlier
@@ -383,31 +411,43 @@ fn observe(manifest: &ServiceManifest) -> ServiceObservation {
 /// plus the command that changes it — claiming boot persistence that is not
 /// there is the failure this avoids.
 fn observe_persistence(manifest: &ServiceManifest) -> (ServiceStarts, Option<String>) {
-    let Some(enabled) = systemctl_query(manifest.scope, &["is-enabled", &manifest.name]) else {
+    let Some(reported) = systemctl_query(manifest.scope, &["is-enabled", &manifest.name]) else {
         return (ServiceStarts::Unavailable, None);
     };
-    let enabled = matches!(
-        enabled.as_str(),
-        "enabled" | "enabled-runtime" | "static" | "alias" | "indirect" | "generated"
-    );
-    if !enabled {
-        return (
+    classify_persistence(&reported, manifest)
+}
+
+/// [`observe_persistence`] without the process: the classification of what
+/// `systemctl is-enabled` answered, so every branch is testable on a host that
+/// has no systemd.
+fn classify_persistence(
+    reported: &str,
+    manifest: &ServiceManifest,
+) -> (ServiceStarts, Option<String>) {
+    let enable = || systemctl_command(manifest.scope, &["enable", &manifest.name]);
+    match reported.trim() {
+        "enabled" => match manifest.scope {
+            ServiceScope::System => (ServiceStarts::BootWithoutLogin, None),
+            ServiceScope::User => (
+                ServiceStarts::LoginOnly,
+                Some(format!(
+                    "loginctl enable-linger {}",
+                    manifest.owner.describe()
+                )),
+            ),
+        },
+        "masked" | "masked-runtime" => (
             ServiceStarts::Disabled,
-            Some(systemctl_command(
-                manifest.scope,
-                &["enable", &manifest.name],
-            )),
-        );
-    }
-    match manifest.scope {
-        ServiceScope::System => (ServiceStarts::BootWithoutLogin, None),
-        ServiceScope::User => (
-            ServiceStarts::LoginOnly,
             Some(format!(
-                "loginctl enable-linger {}",
-                manifest.owner.describe()
+                "{} && {}",
+                systemctl_command(manifest.scope, &["unmask", &manifest.name]),
+                enable()
             )),
         ),
+        // Includes the empty answer of a query that ran and said nothing, which
+        // is not a state to invent an outcome for.
+        "" => (ServiceStarts::Unavailable, None),
+        _ => (ServiceStarts::Disabled, Some(enable())),
     }
 }
 
@@ -816,6 +856,72 @@ mod tests {
                 scope: ServiceScope::User
             })
         );
+    }
+
+    #[test]
+    fn only_a_persistent_enable_reports_boot_persistence() {
+        // `enabled-runtime` links live under /run and are gone after a reboot,
+        // so reporting boot persistence for it would promise exactly what will
+        // not happen. The rest leave no persistent boot-time link either.
+        for reported in [
+            "enabled-runtime",
+            "disabled",
+            "linked",
+            "linked-runtime",
+            "static",
+            "indirect",
+            "alias",
+            "generated",
+            "transient",
+        ] {
+            let (starts, action) = classify_persistence(reported, &manifest(ServiceScope::System));
+            assert_eq!(starts, ServiceStarts::Disabled, "{reported}");
+            let action = action.unwrap_or_else(|| panic!("{reported} needs a remediation"));
+            assert!(action.contains("systemctl"), "{reported}: {action}");
+            assert!(action.contains("enable"), "{reported}: {action}");
+        }
+    }
+
+    #[test]
+    fn a_masked_unit_is_told_to_unmask_before_enabling() {
+        // `systemctl enable` on a masked unit fails, so printing it alone would
+        // hand the operator a command that cannot work.
+        for reported in ["masked", "masked-runtime"] {
+            let (starts, action) = classify_persistence(reported, &manifest(ServiceScope::System));
+            assert_eq!(starts, ServiceStarts::Disabled, "{reported}");
+            let action = action.unwrap_or_else(|| panic!("{reported} needs a remediation"));
+            assert!(action.contains("unmask"), "{reported}: {action}");
+            assert!(action.contains("enable"), "{reported}: {action}");
+        }
+    }
+
+    #[test]
+    fn an_unanswerable_enablement_query_is_not_an_outcome() {
+        let (starts, action) = classify_persistence("", &manifest(ServiceScope::System));
+        assert_eq!(starts, ServiceStarts::Unavailable);
+        assert_eq!(action, None, "there is nothing to advise yet");
+    }
+
+    #[test]
+    fn a_user_service_is_login_only_until_its_account_lingers() {
+        let (starts, action) = classify_persistence("enabled", &manifest(ServiceScope::User));
+        assert_eq!(starts, ServiceStarts::LoginOnly);
+        let action = action.expect("a user service needs a remediation");
+        assert!(action.contains("enable-linger"), "{action}");
+
+        // Trailing newline from `systemctl` output, and the system answer.
+        let (starts, action) = classify_persistence("enabled\n", &manifest(ServiceScope::System));
+        assert_eq!(starts, ServiceStarts::BootWithoutLogin);
+        assert_eq!(action, None, "nothing to fix");
+    }
+
+    #[test]
+    fn an_unrecognized_active_state_explains_itself() {
+        // The model promises every `unavailable` state says why.
+        let manifest = manifest(ServiceScope::System);
+        let diagnostic = unrecognized_state_diagnostic("maintenance", &manifest);
+        assert!(diagnostic.contains("maintenance"), "{diagnostic}");
+        assert!(diagnostic.contains("is-active"), "{diagnostic}");
     }
 
     #[test]

--- a/bin/spice/src/commands/connect/service/systemd.rs
+++ b/bin/spice/src/commands/connect/service/systemd.rs
@@ -18,11 +18,20 @@ limitations under the License.
 
 use std::path::{Path, PathBuf};
 
+use super::backend::{
+    InstallRequest, LogRequest, ServiceBackend, ServiceObservation, lifecycle_pending,
+};
+use super::manifest::ServiceManifest;
+use super::model::{LogSource, ServiceScope, ServiceStarts, ServiceState, Supervisor};
 use super::{InstalledService, PreflightFailure, SYSTEMD_RUNTIME_MARKER, ServiceAccount};
 use crate::error::{Error, Result};
 
 /// Directory systemd reads administrator-provided unit files from.
 const SYSTEMD_UNIT_DIR: &str = "/etc/systemd/system";
+
+/// Directory systemd reads a user's own unit files from, relative to the
+/// account's XDG config directory.
+const SYSTEMD_USER_UNIT_SUBDIR: &str = "systemd/user";
 
 /// Shared prefix of every unit this command installs. Also the glob root used
 /// to discover installed instances.
@@ -120,21 +129,45 @@ fn escape_systemd_path(path: &Path) -> Result<String> {
     Ok(escaped)
 }
 
-pub(super) fn preflight() -> std::result::Result<(), PreflightFailure> {
+/// Map a systemd `is-active` word onto the normalized vocabulary.
+///
+/// systemd's transient states are the reason this mapping exists: reporting
+/// `activating` verbatim would make every backend's words part of the public
+/// schema.
+fn normalize_systemd_state(reported: &str) -> ServiceState {
+    match reported.trim() {
+        // `reloading` is a running service applying a new configuration.
+        "active" | "active (reloading)" | "reloading" => ServiceState::Running,
+        "activating" => ServiceState::Starting,
+        "deactivating" => ServiceState::Stopping,
+        "inactive" => ServiceState::Stopped,
+        "failed" => ServiceState::Failed,
+        // Everything else, including systemd's own `unknown` for a unit it has
+        // no record of and the empty answer of a query that did not run. The
+        // definition file is what decides `not_installed`, so a unit systemd
+        // cannot account for is a reading, not an absence.
+        _ => ServiceState::Unavailable,
+    }
+}
+
+fn preflight(scope: ServiceScope) -> std::result::Result<(), PreflightFailure> {
     if !Path::new(SYSTEMD_RUNTIME_MARKER).is_dir() {
         return Err(PreflightFailure::SystemdUnavailable);
     }
-    if !super::is_root() {
-        return Err(PreflightFailure::NotRoot);
+    if scope == ServiceScope::User {
+        return Err(PreflightFailure::UserScopePending);
     }
     Ok(())
 }
 
-pub(super) fn install(
-    instance_dir: &Path,
-    config_dir: &Path,
-    spiced_path: &Path,
-) -> Result<InstalledService> {
+fn install(request: &InstallRequest<'_>) -> Result<InstalledService> {
+    let InstallRequest {
+        instance_dir,
+        config_dir,
+        spiced_path,
+        scope,
+    } = *request;
+
     let account = super::service_account(instance_dir)?;
     super::provision_config_ownership(config_dir, account)?;
 
@@ -143,25 +176,28 @@ pub(super) fn install(
     let staged_runtime = super::stage_runtime(spiced_path, |_, _| Ok(()))?;
 
     let name = unit_name_for_dir(instance_dir);
-    let path = PathBuf::from(SYSTEMD_UNIT_DIR).join(&name);
+    let dir = unit_dir(scope).ok_or_else(|| Error::CloudConnectIo {
+        message: "locate the systemd unit directory for this account".to_string(),
+    })?;
+    let path = dir.join(&name);
     let unit = render_unit(instance_dir, config_dir, &staged_runtime, account)?;
 
     std::fs::write(&path, unit).map_err(|e| Error::CloudConnectIo {
         message: format!(
             "write systemd unit {}: {e}. The identity is staged at {} — fix the problem \
-             and re-run `sudo spice connect --install` to finish.",
+             and re-run `spice connect service install` to finish.",
             path.display(),
             config_dir.display()
         ),
     })?;
 
-    systemctl(&["daemon-reload"])?;
+    systemctl(scope, &["daemon-reload"])?;
     // `enable --now` starts the service and persists the boot-time link in one
     // step. On a reinstall the unit is already enabled and already running, so
     // follow with an explicit restart to pick up the rewritten unit and the
     // upgraded binary — `enable --now` alone would leave the old process up.
-    systemctl(&["enable", "--now", &name])?;
-    systemctl(&["restart", &name])?;
+    systemctl(scope, &["enable", "--now", &name])?;
+    systemctl(scope, &["restart", &name])?;
 
     Ok(InstalledService {
         name,
@@ -171,91 +207,73 @@ pub(super) fn install(
     })
 }
 
-/// Stop, disable, and delete the unit for `instance_dir`.
+/// Stop, disable, and delete the unit the manifest describes.
 ///
 /// Stop/disable failures are tolerated — a unit file left on disk would restart
 /// a service against a released identity forever, so the deletion is what must
 /// happen.
-pub(super) fn uninstall(instance_dir: &Path) -> Result<Option<InstalledService>> {
-    let Some(unit) = find_for_dir(instance_dir) else {
-        return Ok(None);
-    };
-
+fn uninstall(manifest: &ServiceManifest) -> Result<()> {
     // Best-effort: a unit that is already stopped, already disabled, or whose
     // systemd is not running must not block removing the file.
-    if let Err(err) = systemctl(&["disable", "--now", &unit.name]) {
-        tracing::debug!("systemctl disable --now {}: {err}", unit.name);
+    if let Err(err) = systemctl(manifest.scope, &["disable", "--now", &manifest.name]) {
+        tracing::debug!("systemctl disable --now {}: {err}", manifest.name);
     }
 
-    std::fs::remove_file(&unit.path).map_err(|e| Error::CloudConnectIo {
-        message: format!(
-            "remove systemd unit {}: {e}. The service would keep restarting against a released \
-             identity — delete the file and run `sudo systemctl daemon-reload`.",
-            unit.path.display()
-        ),
-    })?;
+    match std::fs::remove_file(&manifest.definition_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(Error::CloudConnectIo {
+                message: format!(
+                    "remove systemd unit {}: {e}. The service would keep restarting against a \
+                     released identity — delete the file and run `sudo systemctl daemon-reload`.",
+                    manifest.definition_path.display()
+                ),
+            });
+        }
+    }
 
-    if let Err(err) = systemctl(&["daemon-reload"]) {
+    if let Err(err) = systemctl(manifest.scope, &["daemon-reload"]) {
         tracing::debug!("systemctl daemon-reload: {err}");
     }
 
-    Ok(Some(unit))
+    Ok(())
 }
 
-pub(super) fn find_for_dir(instance_dir: &Path) -> Option<InstalledService> {
+/// The unit installed for `instance_dir` in `scope`, if the definition under
+/// this directory's derived name names this directory as its working directory.
+///
+/// The working-directory check is what makes this a verification rather than a
+/// search: a unit left behind by a directory that has since moved carries the
+/// same derived name, and taking it over would control an instance nobody asked
+/// about.
+pub(super) fn find_for_dir(instance_dir: &Path, scope: ServiceScope) -> Option<InstalledService> {
     let name = unit_name_for_dir(instance_dir);
-    let path = PathBuf::from(SYSTEMD_UNIT_DIR).join(&name);
+    let path = unit_dir(scope)?.join(&name);
     if !path.is_file() {
         return None;
     }
-    let unit = std::fs::read_to_string(&path).ok();
-    let working_dir = unit
-        .as_deref()
-        .and_then(parse_working_dir)
-        .unwrap_or_else(|| instance_dir.to_path_buf());
-    let runtime = unit
-        .as_deref()
-        .and_then(parse_exec_runtime)
-        .unwrap_or_else(super::staged_runtime_path);
+    let unit = std::fs::read_to_string(&path).ok()?;
+    if parse_working_dir(&unit)? != instance_dir {
+        return None;
+    }
+    let runtime = parse_exec_runtime(&unit).unwrap_or_else(super::staged_runtime_path);
     Some(InstalledService {
         name,
         path,
-        working_dir,
+        working_dir: instance_dir.to_path_buf(),
         runtime,
     })
 }
 
-pub(super) fn discover_all() -> Vec<InstalledService> {
-    let Ok(entries) = std::fs::read_dir(SYSTEMD_UNIT_DIR) else {
-        return Vec::new();
-    };
-
-    let mut units: Vec<InstalledService> = entries
-        .filter_map(std::result::Result::ok)
-        .filter_map(|entry| {
-            let path = entry.path();
-            let name = path.file_name()?.to_str()?.to_string();
-            if !name.starts_with(UNIT_PREFIX) || !name.ends_with(UNIT_SUFFIX) {
-                return None;
-            }
-            // Skip a symlink systemd itself created (the `multi-user.target.wants`
-            // links live elsewhere, but a hand-made alias here would double-report).
-            if !path.is_file() {
-                return None;
-            }
-            let unit = std::fs::read_to_string(&path).ok()?;
-            let working_dir = parse_working_dir(&unit)?;
-            let runtime = parse_exec_runtime(&unit).unwrap_or_else(super::staged_runtime_path);
-            Some(InstalledService {
-                name,
-                path,
-                working_dir,
-                runtime,
-            })
-        })
-        .collect();
-    units.sort_by(|a, b| a.name.cmp(&b.name));
-    units
+/// Where units of `scope` live. `None` when the account has no discoverable
+/// configuration directory, which is the one case a user unit path cannot be
+/// derived from.
+fn unit_dir(scope: ServiceScope) -> Option<PathBuf> {
+    match scope {
+        ServiceScope::System => Some(PathBuf::from(SYSTEMD_UNIT_DIR)),
+        ServiceScope::User => Some(dirs::config_dir()?.join(SYSTEMD_USER_UNIT_SUBDIR)),
+    }
 }
 
 /// Parse the `WorkingDirectory=` value out of a rendered unit.
@@ -330,34 +348,126 @@ fn unit_directive<'a>(unit: &'a str, key: &str) -> Option<&'a str> {
 
 /// The service's current state as `systemctl is-active` reports it
 /// (`active`, `inactive`, `failed`, …), or `None` when it cannot be determined.
-pub(super) fn is_active(unit_name: &str) -> Option<String> {
-    let output = std::process::Command::new("systemctl")
-        .arg("is-active")
-        .arg(unit_name)
-        .output()
-        .ok()?;
+fn is_active(unit_name: &str, scope: ServiceScope) -> Option<String> {
     // `is-active` exits non-zero for anything but `active`, and prints the
     // state either way — so read stdout regardless of the exit status.
-    let state = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let state = systemctl_query(scope, &["is-active", unit_name])?;
     (!state.is_empty()).then_some(state)
 }
 
-pub(super) fn manage_hints(unit_name: &str) -> Vec<String> {
+/// Observe the unit: the state systemd reports plus whether it will come back
+/// on its own.
+fn observe(manifest: &ServiceManifest) -> ServiceObservation {
+    let Some(reported) = is_active(&manifest.name, manifest.scope) else {
+        return ServiceObservation::unavailable(format!(
+            "systemctl could not be asked about {}. Check that systemd is running and that this \
+             account may query it ({}).",
+            manifest.name,
+            systemctl_command(manifest.scope, &["is-active", &manifest.name])
+        ));
+    };
+    let (starts, starts_action) = observe_persistence(manifest);
+    ServiceObservation {
+        state: normalize_systemd_state(&reported),
+        starts,
+        diagnostic: None,
+        starts_action,
+    }
+}
+
+/// Whether the unit is enabled, translated into the operator outcome.
+///
+/// A system unit that is enabled comes up at boot with nobody logged in. A
+/// *user* unit that is enabled comes up when its owner logs in and no earlier
+/// unless that account lingers, so the conservative answer is `login_only`
+/// plus the command that changes it — claiming boot persistence that is not
+/// there is the failure this avoids.
+fn observe_persistence(manifest: &ServiceManifest) -> (ServiceStarts, Option<String>) {
+    let Some(enabled) = systemctl_query(manifest.scope, &["is-enabled", &manifest.name]) else {
+        return (ServiceStarts::Unavailable, None);
+    };
+    let enabled = matches!(
+        enabled.as_str(),
+        "enabled" | "enabled-runtime" | "static" | "alias" | "indirect" | "generated"
+    );
+    if !enabled {
+        return (
+            ServiceStarts::Disabled,
+            Some(systemctl_command(
+                manifest.scope,
+                &["enable", &manifest.name],
+            )),
+        );
+    }
+    match manifest.scope {
+        ServiceScope::System => (ServiceStarts::BootWithoutLogin, None),
+        ServiceScope::User => (
+            ServiceStarts::LoginOnly,
+            Some(format!(
+                "loginctl enable-linger {}",
+                manifest.owner.describe()
+            )),
+        ),
+    }
+}
+
+fn recovery_hints(manifest: &ServiceManifest) -> Vec<String> {
+    let scope = manifest.scope;
+    let name = &manifest.name;
     vec![
-        format!("systemctl status {unit_name}"),
-        format!("journalctl -u {unit_name} -f"),
+        systemctl_command(scope, &["status", name]),
+        match scope {
+            ServiceScope::System => format!("journalctl -u {name} -f"),
+            ServiceScope::User => format!("journalctl --user -u {name} -f"),
+        },
     ]
+}
+
+/// The `--user` flag every `systemctl` invocation for a user service needs.
+fn scope_args(scope: ServiceScope) -> &'static [&'static str] {
+    match scope {
+        ServiceScope::System => &[],
+        ServiceScope::User => &["--user"],
+    }
+}
+
+/// The command line as an operator would type it, for messages that ask them
+/// to run it themselves.
+fn systemctl_command(scope: ServiceScope, args: &[&str]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 2);
+    if scope == ServiceScope::System && !super::is_root() {
+        parts.push("sudo");
+    }
+    parts.push("systemctl");
+    parts.extend(scope_args(scope));
+    parts.extend(args);
+    parts.join(" ")
+}
+
+/// Ask `systemctl` a question and return its trimmed stdout.
+///
+/// The exit status is ignored on purpose: the query commands report their
+/// answer on stdout and use the exit status to encode that answer. `None`
+/// means `systemctl` could not be run at all.
+fn systemctl_query(scope: ServiceScope, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("systemctl")
+        .args(scope_args(scope))
+        .args(args)
+        .output()
+        .ok()?;
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 /// Run `systemctl <args>`, turning a non-zero exit into an error carrying
 /// systemd's own stderr — which names the actual problem far better than an
 /// exit code.
-fn systemctl(args: &[&str]) -> Result<()> {
+fn systemctl(scope: ServiceScope, args: &[&str]) -> Result<()> {
     let output = std::process::Command::new("systemctl")
+        .args(scope_args(scope))
         .args(args)
         .output()
         .map_err(|e| Error::CloudConnectIo {
-            message: format!("run `systemctl {}`: {e}", args.join(" ")),
+            message: format!("run `{}`: {e}", systemctl_command(scope, args)),
         })?;
 
     if output.status.success() {
@@ -367,8 +477,8 @@ fn systemctl(args: &[&str]) -> Result<()> {
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     Err(Error::CloudConnectIo {
         message: format!(
-            "`systemctl {}` failed: {}",
-            args.join(" "),
+            "`{}` failed: {}",
+            systemctl_command(scope, args),
             if stderr.is_empty() {
                 format!("exit status {}", output.status)
             } else {
@@ -378,9 +488,99 @@ fn systemctl(args: &[&str]) -> Result<()> {
     })
 }
 
+/// The Linux back end.
+pub(super) struct SystemdBackend;
+
+impl ServiceBackend for SystemdBackend {
+    fn supervisor(&self) -> Supervisor {
+        Supervisor::Systemd
+    }
+
+    fn preflight(&self, scope: ServiceScope) -> std::result::Result<(), PreflightFailure> {
+        preflight(scope)
+    }
+
+    fn name_for_dir(&self, instance_dir: &Path) -> String {
+        unit_name_for_dir(instance_dir)
+    }
+
+    fn definition_path(&self, name: &str, scope: ServiceScope) -> PathBuf {
+        unit_dir(scope)
+            .unwrap_or_else(|| PathBuf::from(SYSTEMD_UNIT_DIR))
+            .join(name)
+    }
+
+    fn log_source(&self, name: &str, scope: ServiceScope) -> Option<LogSource> {
+        Some(LogSource::Journal {
+            unit: name.to_string(),
+            scope,
+        })
+    }
+
+    fn find_installed(&self, instance_dir: &Path, scope: ServiceScope) -> Option<InstalledService> {
+        find_for_dir(instance_dir, scope)
+    }
+
+    fn install(&self, request: &InstallRequest<'_>) -> Result<InstalledService> {
+        install(request)
+    }
+
+    fn uninstall(&self, manifest: &ServiceManifest) -> Result<()> {
+        uninstall(manifest)
+    }
+
+    fn start(&self, manifest: &ServiceManifest) -> Result<()> {
+        Err(lifecycle_pending(self, "start", manifest))
+    }
+
+    fn stop(&self, manifest: &ServiceManifest) -> Result<()> {
+        Err(lifecycle_pending(self, "stop", manifest))
+    }
+
+    fn restart(&self, manifest: &ServiceManifest) -> Result<()> {
+        Err(lifecycle_pending(self, "restart", manifest))
+    }
+
+    fn observe(&self, manifest: &ServiceManifest) -> ServiceObservation {
+        observe(manifest)
+    }
+
+    fn logs(&self, manifest: &ServiceManifest, _request: LogRequest) -> Result<()> {
+        Err(lifecycle_pending(self, "read the logs of", manifest))
+    }
+
+    fn recovery_hints(&self, manifest: &ServiceManifest) -> Vec<String> {
+        recovery_hints(manifest)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_systemd_state_normalizes() {
+        for (reported, expected) in [
+            ("active", ServiceState::Running),
+            ("reloading", ServiceState::Running),
+            ("activating", ServiceState::Starting),
+            ("deactivating", ServiceState::Stopping),
+            ("inactive", ServiceState::Stopped),
+            ("failed", ServiceState::Failed),
+            ("unknown", ServiceState::Unavailable),
+            ("", ServiceState::Unavailable),
+            // A word a future systemd invents must not be published raw.
+            ("maintenance", ServiceState::Unavailable),
+        ] {
+            assert_eq!(
+                normalize_systemd_state(reported),
+                expected,
+                "systemd `{reported}`"
+            );
+        }
+        // `is-active` output arrives with a trailing newline.
+        assert_eq!(normalize_systemd_state("active\n"), ServiceState::Running);
+    }
 
     const TEST_ACCOUNT: ServiceAccount = ServiceAccount {
         uid: 1000,
@@ -544,15 +744,109 @@ mod tests {
         );
     }
 
+    /// A manifest for the unit under test, without touching the filesystem.
+    fn manifest(scope: ServiceScope) -> ServiceManifest {
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        ServiceManifest {
+            schema_version: super::super::manifest::MANIFEST_SCHEMA_VERSION,
+            directory: PathBuf::from("/opt/edge-1"),
+            name: name.clone(),
+            scope,
+            supervisor: Supervisor::Systemd,
+            owner: super::super::ServiceOwner {
+                uid: 1000,
+                gid: 1000,
+                name: Some("alice".to_string()),
+            },
+            definition_path: SystemdBackend.definition_path(&name, scope),
+            runtime_path: super::super::staged_runtime_path(),
+            log_source: SystemdBackend.log_source(&name, scope),
+            runtime_digest: String::new(),
+            runtime_version: "v2.2.0".to_string(),
+            health_url: "http://127.0.0.1:8090/health".to_string(),
+        }
+    }
+
     #[test]
-    fn manage_hints_name_the_unit() {
-        let hints = manage_hints("spiced-cloud-connect-edge-1-1a2b3c4d.service");
-        assert_eq!(
-            hints,
-            vec![
-                "systemctl status spiced-cloud-connect-edge-1-1a2b3c4d.service",
-                "journalctl -u spiced-cloud-connect-edge-1-1a2b3c4d.service -f",
-            ]
+    fn recovery_hints_name_the_unit_in_its_own_domain() {
+        let system = recovery_hints(&manifest(ServiceScope::System));
+        assert!(
+            system[0].ends_with(&format!(
+                "systemctl status {}",
+                manifest(ServiceScope::System).name
+            )),
+            "{system:?}"
         );
+        assert!(system[1].starts_with("journalctl -u "), "{system:?}");
+
+        // A user service is managed by its owning account's own manager, so
+        // every command has to name that manager rather than root's.
+        let user = recovery_hints(&manifest(ServiceScope::User));
+        assert!(user[0].contains("systemctl --user status"), "{user:?}");
+        assert!(user[1].starts_with("journalctl --user -u "), "{user:?}");
+        assert!(
+            !user.iter().any(|hint| hint.starts_with("sudo")),
+            "a user service must never be driven through sudo: {user:?}"
+        );
+    }
+
+    #[test]
+    fn a_user_unit_lives_under_the_accounts_own_configuration() {
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        let system = SystemdBackend.definition_path(&name, ServiceScope::System);
+        let user = SystemdBackend.definition_path(&name, ServiceScope::User);
+        assert!(system.starts_with(SYSTEMD_UNIT_DIR), "{system:?}");
+        assert_ne!(system, user);
+    }
+
+    #[test]
+    fn the_log_source_is_the_journal_for_the_units_own_domain() {
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        assert_eq!(
+            SystemdBackend.log_source(&name, ServiceScope::System),
+            Some(LogSource::Journal {
+                unit: name.clone(),
+                scope: ServiceScope::System
+            })
+        );
+        assert_eq!(
+            SystemdBackend.log_source(&name, ServiceScope::User),
+            Some(LogSource::Journal {
+                unit: name,
+                scope: ServiceScope::User
+            })
+        );
+    }
+
+    #[test]
+    fn a_user_scope_install_is_refused_rather_than_half_performed() {
+        // The systemd user lifecycle is separate work; asking for it must name
+        // the path that does work instead of writing a unit nothing manages.
+        assert!(matches!(
+            preflight(ServiceScope::User),
+            Err(PreflightFailure::UserScopePending | PreflightFailure::SystemdUnavailable)
+        ));
+    }
+
+    #[test]
+    fn every_lifecycle_action_reports_itself_as_pending_rather_than_panicking() {
+        let manifest = manifest(ServiceScope::System);
+        for result in [
+            SystemdBackend.start(&manifest),
+            SystemdBackend.stop(&manifest),
+            SystemdBackend.restart(&manifest),
+            SystemdBackend.logs(
+                &manifest,
+                super::super::LogRequest {
+                    number: 100,
+                    follow: false,
+                },
+            ),
+        ] {
+            let error = result.expect_err("the lifecycle is not implemented yet");
+            assert!(matches!(error, Error::NotImplemented { .. }), "{error}");
+            // The refusal has to leave the operator with something they can run.
+            assert!(error.to_string().contains("systemctl"), "{error}");
+        }
     }
 }

--- a/bin/spice/src/commands/connect/snapshots/spice__commands__connect__status__tests__connect_service_status_schema.snap
+++ b/bin/spice/src/commands/connect/snapshots/spice__commands__connect__status__tests__connect_service_status_schema.snap
@@ -1,0 +1,26 @@
+---
+source: bin/spice/src/commands/connect/status.rs
+expression: json
+---
+{
+  "schema_version": 1,
+  "service": {
+    "installed": true,
+    "state": "running",
+    "scope": "system",
+    "supervisor": "systemd",
+    "starts": "boot_without_login",
+    "owner": "alice",
+    "name": "spiced-cloud-connect-edge-analytics-59e8c853e76c15ba.service",
+    "working_dir": "/srv/edge-analytics",
+    "definition_path": "/etc/systemd/system/spiced-cloud-connect-edge-analytics-59e8c853e76c15ba.service",
+    "runtime_path": "/usr/local/lib/spice/spiced",
+    "log_source": {
+      "kind": "journal",
+      "unit": "spiced-cloud-connect-edge-analytics-59e8c853e76c15ba.service",
+      "scope": "system"
+    },
+    "diagnostic": null,
+    "starts_action": null
+  }
+}

--- a/bin/spice/src/commands/connect/snapshots/spice__commands__connect__status__tests__connect_status_schema.snap
+++ b/bin/spice/src/commands/connect/snapshots/spice__commands__connect__status__tests__connect_status_schema.snap
@@ -1,0 +1,55 @@
+---
+source: bin/spice/src/commands/connect/status.rs
+expression: json
+---
+{
+  "schema_version": 1,
+  "connection": {
+    "state": "enrolled",
+    "directory": "/srv/edge-analytics",
+    "identity_path": "/srv/edge-analytics/.spice/identity.json",
+    "endpoint": "https://api.spice.ai",
+    "identifier": "inst_0123456789",
+    "org_name": "acme",
+    "app_name": "edge-analytics",
+    "monitor_url": "https://spice.ai/acme/edge-analytics/monitor",
+    "gateway_addr": "connect.aws.spiceai.io:443",
+    "expires_at_unix": 1800000000,
+    "expired": false,
+    "draft_path": null,
+    "clock": null,
+    "diagnostic": null
+  },
+  "service": {
+    "installed": true,
+    "state": "running",
+    "scope": "system",
+    "supervisor": "systemd",
+    "starts": "boot_without_login",
+    "owner": "alice",
+    "name": "spiced-cloud-connect-edge-analytics-59e8c853e76c15ba.service",
+    "working_dir": "/srv/edge-analytics",
+    "definition_path": "/etc/systemd/system/spiced-cloud-connect-edge-analytics-59e8c853e76c15ba.service",
+    "runtime_path": "/usr/local/lib/spice/spiced",
+    "log_source": {
+      "kind": "journal",
+      "unit": "spiced-cloud-connect-edge-analytics-59e8c853e76c15ba.service",
+      "scope": "system"
+    },
+    "diagnostic": null,
+    "starts_action": null
+  },
+  "deployment": {
+    "state": "deployed",
+    "spicepod_path": "/srv/edge-analytics/.spice/spicepod-cloud-managed.yml",
+    "secrets": "delivered",
+    "secret_names": [
+      "pg_password",
+      "s3_key"
+    ],
+    "restart_required": [
+      "runtime.cpu",
+      "runtime.tls"
+    ]
+  }
+}

--- a/bin/spice/src/commands/connect/status.rs
+++ b/bin/spice/src/commands/connect/status.rs
@@ -54,6 +54,11 @@ pub(crate) enum ConnectionState {
     EnrollmentIncomplete,
     /// An enrolled identity is present.
     Enrolled,
+    /// An identity file is present and could not be read. Reported rather than
+    /// folded into `not_connected`: every `spiced` start in this directory will
+    /// reject the same file and run unmanaged, which is a failure to fix, not
+    /// an absence to ignore.
+    Unreadable,
 }
 
 /// Whether a Cloud deployment has landed in this directory.
@@ -111,6 +116,8 @@ pub(crate) struct ConnectionStatus {
     /// states a wrong clock explains. `null` when it was not measured or was
     /// insignificant.
     pub(crate) clock: Option<String>,
+    /// Why the state is `unreadable`, when it is. `null` otherwise.
+    pub(crate) diagnostic: Option<String>,
 }
 
 /// What has been deployed to this instance.
@@ -164,10 +171,11 @@ impl ConnectStatus {
     ) -> Self {
         let identity_path = config_dir.join(IDENTITY_FILE);
         let draft_path = runtime_cloud_connect::EnrollmentDraft::path_in(config_dir);
+        // An identity that is present but unreadable is its own state. Reading
+        // the error as "nothing here" would report a directory as unconnected
+        // while every `spiced` start in it keeps rejecting the same file.
         let identity =
-            runtime_cloud_connect::identity::IdentityStore::load_optional(&identity_path)
-                .ok()
-                .flatten();
+            runtime_cloud_connect::identity::IdentityStore::load_optional(&identity_path);
 
         let mut connection = ConnectionStatus {
             state: ConnectionState::NotConnected,
@@ -183,6 +191,21 @@ impl ConnectStatus {
             expired: false,
             draft_path: draft_path.exists().then(|| draft_path.clone()),
             clock: None,
+            diagnostic: None,
+        };
+
+        let identity = match identity {
+            Ok(identity) => identity,
+            Err(err) => {
+                connection.state = ConnectionState::Unreadable;
+                connection.diagnostic = Some(format!(
+                    "The Spice Cloud Connect identity at {} could not be read: {err}. \
+                     Re-enroll this directory with `spiced --token <enrollment-key>`, or \
+                     release it with `spice connect remove`. See: https://spiceai.org/docs",
+                    connection.identity_path.display()
+                ));
+                None
+            }
         };
 
         if let Some(id) = identity {
@@ -223,15 +246,39 @@ impl ConnectStatus {
         }
     }
 
-    /// Whether this snapshot describes a state the reporting command should
-    /// exit non-zero for.
+    /// The one-line diagnosis for a degraded snapshot, naming whichever part of
+    /// it is degraded, or `None` when there is nothing wrong.
     ///
     /// A service that is merely stopped, or a directory that is not connected,
-    /// is a fact and exits `0`. A supervisor that could not be asked, or one
-    /// reporting a failed service, is a problem and exits non-zero so
-    /// automation does not read a degraded instance as healthy.
-    pub(crate) fn is_degraded(&self) -> bool {
-        self.service.state.is_degraded()
+    /// is a fact and leaves this `None`. A supervisor that could not be asked,
+    /// one reporting a failed service, and an identity that cannot be read are
+    /// problems, so the reporting command exits non-zero and automation does
+    /// not read a degraded instance as healthy.
+    ///
+    /// The report is already on stdout by the time a caller asks, so this is
+    /// what travels as the command's error — which keeps a `--output json` run
+    /// parseable and still exits non-zero.
+    pub(crate) fn degradation(&self) -> Option<String> {
+        if self.connection.state == ConnectionState::Unreadable {
+            return Some(self.connection.diagnostic.clone().unwrap_or_else(|| {
+                format!(
+                    "The Spice Cloud Connect identity at {} could not be read.",
+                    self.connection.identity_path.display()
+                )
+            }));
+        }
+        if self.service.state.is_degraded() {
+            return Some(format!(
+                "The Spice Cloud Connect service for {} is {}{}",
+                self.connection.directory.display(),
+                self.service.state,
+                match &self.service.diagnostic {
+                    Some(diagnostic) => format!(": {diagnostic}"),
+                    None => ".".to_string(),
+                }
+            ));
+        }
+        None
     }
 }
 
@@ -363,6 +410,13 @@ fn render_connection(connection: &ConnectionStatus) {
                 connection.directory.display()
             );
         }
+        ConnectionState::Unreadable => {
+            println!("Spice Cloud Connect: identity unreadable");
+            println!("  identity:    {}", connection.identity_path.display());
+        }
+    }
+    if let Some(diagnostic) = &connection.diagnostic {
+        println!("  diagnostic:  {diagnostic}");
     }
     if let Some(clock) = &connection.clock {
         println!("  clock:       {clock}");
@@ -493,8 +547,9 @@ mod tests {
             status.deployment.restart_required, None,
             "an unobserved runtime must not read as nothing pending"
         );
-        assert!(
-            !status.is_degraded(),
+        assert_eq!(
+            status.degradation(),
+            None,
             "a directory with no service is not degraded"
         );
     }
@@ -538,10 +593,38 @@ mod tests {
 
         let status = snapshot(dir.path(), &instance_dir, &config_dir).await;
         assert!(
-            status.is_degraded(),
+            status.degradation().is_some(),
             "a service that cannot be resolved must not read as healthy"
         );
         assert!(status.service.diagnostic.is_some());
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_identity_is_reported_rather_than_read_as_absent() {
+        // "Not connected" would be wrong and would hide the failure: every
+        // `spiced` start in this directory rejects the same file and runs
+        // unmanaged.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(config_dir.join(IDENTITY_FILE), "not valid JSON")
+            .expect("write a malformed identity");
+
+        let status = snapshot(dir.path(), &instance_dir, &config_dir).await;
+        assert_eq!(status.connection.state, ConnectionState::Unreadable);
+        assert!(status.connection.identifier.is_none());
+        let diagnostic = status
+            .connection
+            .diagnostic
+            .as_deref()
+            .expect("an unreadable identity must say why");
+        assert!(diagnostic.contains("could not be read"), "{diagnostic}");
+        // The diagnosis names the identity, not a service that is fine.
+        let degradation = status
+            .degradation()
+            .expect("an unreadable identity must not exit zero");
+        assert!(degradation.contains("identity"), "{degradation}");
     }
 
     #[tokio::test]
@@ -559,6 +642,93 @@ mod tests {
         let status = snapshot(dir.path(), &instance_dir, &config_dir).await;
         assert_eq!(status.deployment.state, DeploymentState::Deployed);
         assert!(status.deployment.spicepod_path.is_some());
+    }
+
+    /// A fully-populated report built from fixed values, so the golden
+    /// fixtures pin every field and enum spelling rather than whatever a
+    /// tempdir happened to produce.
+    fn golden_status() -> ConnectStatus {
+        use super::super::service::model::{
+            LogSource, ServiceScope, ServiceStarts, ServiceState, Supervisor,
+        };
+
+        ConnectStatus {
+            schema_version: STATUS_SCHEMA_VERSION,
+            connection: ConnectionStatus {
+                state: ConnectionState::Enrolled,
+                directory: PathBuf::from("/srv/edge-analytics"),
+                identity_path: PathBuf::from("/srv/edge-analytics/.spice/identity.json"),
+                endpoint: "https://api.spice.ai".to_string(),
+                identifier: Some("inst_0123456789".to_string()),
+                org_name: Some("acme".to_string()),
+                app_name: Some("edge-analytics".to_string()),
+                monitor_url: Some("https://spice.ai/acme/edge-analytics/monitor".to_string()),
+                gateway_addr: Some("connect.aws.spiceai.io:443".to_string()),
+                expires_at_unix: Some(1_800_000_000),
+                expired: false,
+                draft_path: None,
+                clock: None,
+                diagnostic: None,
+            },
+            service: ServiceStatus {
+                installed: true,
+                state: ServiceState::Running,
+                scope: Some(ServiceScope::System),
+                supervisor: Some(Supervisor::Systemd),
+                starts: ServiceStarts::BootWithoutLogin,
+                owner: Some("alice".to_string()),
+                name: Some(
+                    "spiced-cloud-connect-edge-analytics-59e8c853e76c15ba.service".to_string(),
+                ),
+                working_dir: Some(PathBuf::from("/srv/edge-analytics")),
+                definition_path: Some(PathBuf::from(
+                    "/etc/systemd/system/spiced-cloud-connect-edge-analytics-59e8c853e76c15ba.service",
+                )),
+                runtime_path: Some(PathBuf::from("/usr/local/lib/spice/spiced")),
+                log_source: Some(LogSource::Journal {
+                    unit: "spiced-cloud-connect-edge-analytics-59e8c853e76c15ba.service"
+                        .to_string(),
+                    scope: ServiceScope::System,
+                }),
+                diagnostic: None,
+                starts_action: None,
+            },
+            deployment: DeploymentStatus {
+                state: DeploymentState::Deployed,
+                spicepod_path: Some(PathBuf::from(
+                    "/srv/edge-analytics/.spice/spicepod-cloud-managed.yml",
+                )),
+                secrets: SecretsState::Delivered,
+                secret_names: vec!["pg_password".to_string(), "s3_key".to_string()],
+                restart_required: Some(vec!["runtime.cpu".to_string(), "runtime.tls".to_string()]),
+            },
+        }
+    }
+
+    #[test]
+    fn the_full_json_document_matches_its_golden_schema() {
+        // `schema_version` alone cannot catch a renamed nested field or a
+        // changed enum spelling. This fixture can: a diff here means the public
+        // automation surface changed and the version has to change with it.
+        let json = serde_json::to_string_pretty(&golden_status()).expect("serialize");
+        insta::assert_snapshot!("connect_status_schema", json);
+    }
+
+    #[test]
+    fn the_filtered_service_json_document_matches_its_golden_schema() {
+        let status = golden_status();
+        let json = serde_json::to_string_pretty(&status.service_document()).expect("serialize");
+        insta::assert_snapshot!("connect_service_status_schema", json);
+    }
+
+    #[test]
+    fn every_service_field_of_the_full_document_appears_in_the_filtered_one() {
+        // The two fixtures are reviewed separately, so this is what keeps them
+        // from drifting into two schemas between reviews.
+        let status = golden_status();
+        let full = serde_json::to_value(&status).expect("serialize full");
+        let filtered = serde_json::to_value(status.service_document()).expect("serialize filtered");
+        assert_eq!(full["service"], filtered["service"]);
     }
 
     #[tokio::test]

--- a/bin/spice/src/commands/connect/status.rs
+++ b/bin/spice/src/commands/connect/status.rs
@@ -1,0 +1,587 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! The one status model both status commands render.
+//!
+//! `spice connect status` renders all of [`ConnectStatus`].
+//! `spice connect service status` renders the *same* [`ServiceStatus`] value
+//! filtered out of it. Neither command queries, normalizes, labels, or caches
+//! service state of its own, so the two cannot answer differently — the
+//! failure that two independent status implementations produce as soon as one
+//! of them learns a new state.
+//!
+//! One snapshot is collected per invocation and then rendered, rather than
+//! probed per printed line, so the report describes a single moment.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use runtime_cloud_connect::config::IDENTITY_FILE;
+
+use super::service::{self, ServiceBackend, ServiceStatus};
+use crate::error::Result;
+use crate::output::{OutputFormat, write_json};
+
+/// Schema version of the status documents published on stdout.
+///
+/// This is a public automation surface. Bump it when a field is renamed or
+/// removed, or when an enum grows a variant consumers must branch on, and
+/// update the golden fixtures in the same change.
+pub(crate) const STATUS_SCHEMA_VERSION: u32 = 1;
+
+/// Whether this directory is connected to Spice Cloud.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ConnectionState {
+    /// No Cloud Connect state in this directory at all.
+    NotConnected,
+    /// An enrollment started and did not finish; its retry-safe draft is still
+    /// here.
+    EnrollmentIncomplete,
+    /// An enrolled identity is present.
+    Enrolled,
+}
+
+/// Whether a Cloud deployment has landed in this directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DeploymentState {
+    /// No app has been deployed; the instance runs its local spicepod.
+    None,
+    /// A cloud-managed spicepod is on disk.
+    Deployed,
+}
+
+/// Whether the last deployment's secrets are readable from the local cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SecretsState {
+    /// No deployment has delivered secrets yet.
+    NotDelivered,
+    /// The cache is present and its plaintext header could be read.
+    Delivered,
+    /// The cache is present and its header could not be read.
+    Unreadable,
+}
+
+/// The Cloud identity and connection half of the report.
+///
+/// Field order is the JSON field order. Nothing here is credential material:
+/// the identity's keys, the delivered secret *values*, and the cache key are
+/// never read into this model, only the facts an operator diagnoses with.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ConnectionStatus {
+    pub(crate) state: ConnectionState,
+    /// The instance directory this report is about.
+    pub(crate) directory: PathBuf,
+    /// Where the enrolled identity lives, whether or not one is there yet.
+    pub(crate) identity_path: PathBuf,
+    /// The Spice Cloud control plane this directory reaches.
+    pub(crate) endpoint: String,
+    /// Cloud-assigned instance identifier.
+    pub(crate) identifier: Option<String>,
+    pub(crate) org_name: Option<String>,
+    pub(crate) app_name: Option<String>,
+    /// Cloud-constructed portal monitor URL, when the instance is attached.
+    pub(crate) monitor_url: Option<String>,
+    /// The gateway the control stream dials.
+    pub(crate) gateway_addr: Option<String>,
+    /// Unix seconds after which the identity certificate stops being accepted.
+    /// `null` means the cloud issued no expiry, which is not the same as an
+    /// expiry at the epoch.
+    pub(crate) expires_at_unix: Option<u64>,
+    pub(crate) expired: bool,
+    /// The unfinished enrollment's draft, when there is one.
+    pub(crate) draft_path: Option<PathBuf>,
+    /// A significant host-clock skew against Spice Cloud, measured only in the
+    /// states a wrong clock explains. `null` when it was not measured or was
+    /// insignificant.
+    pub(crate) clock: Option<String>,
+}
+
+/// What has been deployed to this instance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DeploymentStatus {
+    pub(crate) state: DeploymentState,
+    /// The cloud-managed spicepod overlay, when one has been delivered.
+    pub(crate) spicepod_path: Option<PathBuf>,
+    pub(crate) secrets: SecretsState,
+    /// Delivered secret *names* only — the values are sealed to the identity's
+    /// key and are never read here.
+    pub(crate) secret_names: Vec<String>,
+    /// Settings the deployment persisted that the running process is not
+    /// serving, so a supervisor-owned restart is required to apply them.
+    ///
+    /// `null` means the running instance was not asked, which is different from
+    /// an empty list — nothing pending.
+    pub(crate) restart_required: Option<Vec<String>>,
+}
+
+/// Everything `spice connect status` reports about one instance directory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ConnectStatus {
+    pub(crate) schema_version: u32,
+    pub(crate) connection: ConnectionStatus,
+    pub(crate) service: ServiceStatus,
+    pub(crate) deployment: DeploymentStatus,
+}
+
+/// The document `spice connect service status --output json` writes.
+///
+/// It carries the byte-identical `service` object from [`ConnectStatus`], so
+/// automation never has to reconcile a full and a filtered schema.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ServiceStatusDocument<'a> {
+    pub(crate) schema_version: u32,
+    pub(crate) service: &'a ServiceStatus,
+}
+
+impl ConnectStatus {
+    /// Collect one snapshot of this instance directory.
+    ///
+    /// Offline for the states that do not need the network: a healthy enrolled
+    /// directory makes no request at all, and the clock is measured only where
+    /// a wrong one is the explanation.
+    pub(crate) async fn collect(
+        backend: &dyn ServiceBackend,
+        instance_dir: &Path,
+        config_dir: &Path,
+        endpoint: &str,
+    ) -> Self {
+        let identity_path = config_dir.join(IDENTITY_FILE);
+        let draft_path = runtime_cloud_connect::EnrollmentDraft::path_in(config_dir);
+        let identity =
+            runtime_cloud_connect::identity::IdentityStore::load_optional(&identity_path)
+                .ok()
+                .flatten();
+
+        let mut connection = ConnectionStatus {
+            state: ConnectionState::NotConnected,
+            directory: instance_dir.to_path_buf(),
+            identity_path,
+            endpoint: endpoint.to_string(),
+            identifier: None,
+            org_name: None,
+            app_name: None,
+            monitor_url: None,
+            gateway_addr: None,
+            expires_at_unix: None,
+            expired: false,
+            draft_path: draft_path.exists().then(|| draft_path.clone()),
+            clock: None,
+        };
+
+        if let Some(id) = identity {
+            connection.state = ConnectionState::Enrolled;
+            connection.expired = id.is_expired();
+            connection.expires_at_unix = id.not_after_unix;
+            connection.gateway_addr =
+                (!id.gateway_addr.is_empty()).then(|| id.gateway_addr.clone());
+            connection.identifier = Some(id.identifier);
+            connection.org_name = id.org_name;
+            connection.app_name = id.app_name;
+            connection.monitor_url = id.monitor_url;
+        } else if connection.draft_path.is_some() {
+            connection.state = ConnectionState::EnrollmentIncomplete;
+        }
+
+        // An identity that reads as expired on a host whose clock is wrong is
+        // not actually expired, and a stuck enrollment is a state a wrong clock
+        // explains — the enroll keeps failing on certificate validity. Measure
+        // only there, so the common `status` stays offline and instant.
+        if connection.expired || connection.state == ConnectionState::EnrollmentIncomplete {
+            connection.clock = clock_advice(endpoint).await;
+        }
+
+        Self {
+            schema_version: STATUS_SCHEMA_VERSION,
+            connection,
+            service: service::status(backend, instance_dir, config_dir),
+            deployment: collect_deployment(config_dir),
+        }
+    }
+
+    /// The service half on its own, for the filtered command.
+    pub(crate) fn service_document(&self) -> ServiceStatusDocument<'_> {
+        ServiceStatusDocument {
+            schema_version: self.schema_version,
+            service: &self.service,
+        }
+    }
+
+    /// Whether this snapshot describes a state the reporting command should
+    /// exit non-zero for.
+    ///
+    /// A service that is merely stopped, or a directory that is not connected,
+    /// is a fact and exits `0`. A supervisor that could not be asked, or one
+    /// reporting a failed service, is a problem and exits non-zero so
+    /// automation does not read a degraded instance as healthy.
+    pub(crate) fn is_degraded(&self) -> bool {
+        self.service.state.is_degraded()
+    }
+}
+
+/// Read what the last deployment left in the config dir.
+///
+/// Reads files only, so it answers on a host with no network.
+fn collect_deployment(config_dir: &Path) -> DeploymentStatus {
+    let spicepod = config_dir.join(runtime_cloud_connect::config::CLOUD_MANAGED_SPICEPOD_FILE);
+    let cache_path = config_dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE);
+
+    // Only the cache's plaintext header, so this works without the key and
+    // cannot print a value. Names are what diagnose the common failure: a
+    // component referencing a secret the last deployment did not deliver.
+    let (secrets, secret_names) =
+        match runtime_cloud_connect::secret_cache::read_header(&cache_path) {
+            Some(header) => (SecretsState::Delivered, header.names),
+            None if cache_path.exists() => (SecretsState::Unreadable, Vec::new()),
+            None => (SecretsState::NotDelivered, Vec::new()),
+        };
+
+    DeploymentStatus {
+        state: if spicepod.exists() {
+            DeploymentState::Deployed
+        } else {
+            DeploymentState::None
+        },
+        spicepod_path: spicepod.exists().then_some(spicepod),
+        secrets,
+        secret_names,
+        // Restart-required state is measured against the *running* process, so
+        // it comes from the instance rather than from disk. Asking it is the
+        // job of the command that talks to the runtime; absence here is
+        // reported as "not observed" rather than as "nothing pending".
+        restart_required: None,
+    }
+}
+
+/// Measure the host clock against Spice Cloud and describe a significant skew.
+///
+/// Best-effort and silent on failure: `status` must stay usable on a host with
+/// no network.
+async fn clock_advice(endpoint: &str) -> Option<String> {
+    let skew = runtime_cloud_connect::clock_skew::diagnose(endpoint, None).await?;
+    skew.is_significant().then(|| skew.advice())
+}
+
+/// Write the full report in `format`.
+///
+/// JSON goes to stdout and nothing else does, so a `--output json` run is
+/// parseable without filtering: every prompt, warning, and diagnosis in this
+/// command travels on stderr or as the process's error.
+///
+/// # Errors
+///
+/// Returns an error when the report cannot be serialized.
+pub(crate) fn render(status: &ConnectStatus, format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Json => write_json(status),
+        OutputFormat::Table => {
+            render_connection(&status.connection);
+            render_service_lines(&status.service);
+            render_deployment(&status.deployment);
+            render_next_steps(status);
+            Ok(())
+        }
+    }
+}
+
+/// Write the service half in `format`, from the same snapshot.
+///
+/// # Errors
+///
+/// Returns an error when the report cannot be serialized.
+pub(crate) fn render_service(status: &ConnectStatus, format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Json => write_json(&status.service_document()),
+        OutputFormat::Table => {
+            println!(
+                "Spice Cloud Connect service: {}",
+                describe_service_state(&status.service)
+            );
+            render_service_lines(&status.service);
+            Ok(())
+        }
+    }
+}
+
+fn render_connection(connection: &ConnectionStatus) {
+    match connection.state {
+        ConnectionState::Enrolled => {
+            println!(
+                "Spice Cloud Connect: connected{}",
+                match (&connection.org_name, &connection.app_name) {
+                    (Some(org), Some(app)) => format!(" — {org} / {app}"),
+                    (Some(org), None) => format!(" — {org} (no app attached)"),
+                    _ => String::new(),
+                }
+            );
+            if let Some(identifier) = &connection.identifier {
+                println!("  instance:    {identifier}");
+            }
+            println!("  identity:    {}", connection.identity_path.display());
+            if let Some(gateway) = &connection.gateway_addr {
+                println!("  gateway:     {gateway}");
+            }
+            println!(
+                "  expiry:      {}",
+                match connection.expires_at_unix {
+                    Some(secs) => format!("unix={secs} (expired={})", connection.expired),
+                    None => "unbounded".to_string(),
+                }
+            );
+        }
+        ConnectionState::EnrollmentIncomplete => {
+            println!("Spice Cloud Connect: enrollment incomplete");
+            if let Some(draft) = &connection.draft_path {
+                println!("  draft:       {}", draft.display());
+            }
+            println!(
+                "  a previous enrollment did not finish. Mint a new enrollment key in the Spice \
+                 Cloud portal and start the runtime with it (`spiced --token <enrollment-key>`); \
+                 the retried enrollment resumes the same pending operation instead of creating a \
+                 duplicate instance."
+            );
+        }
+        ConnectionState::NotConnected => {
+            println!(
+                "Spice Cloud Connect: not connected ({})",
+                connection.directory.display()
+            );
+        }
+    }
+    if let Some(clock) = &connection.clock {
+        println!("  clock:       {clock}");
+    }
+}
+
+/// The service lines, in the order and wording both commands print them.
+fn render_service_lines(service: &ServiceStatus) {
+    println!("  service:     {}", describe_service_state(service));
+    println!("  starts:      {}", service.starts.describe());
+    if let Some(action) = &service.starts_action {
+        println!("               run `{action}` to change that");
+    }
+    if let Some(owner) = &service.owner {
+        println!("  owner:       {owner}");
+    }
+    if let Some(directory) = &service.working_dir {
+        println!("  directory:   {}", directory.display());
+    }
+    if let Some(definition) = &service.definition_path {
+        println!("  definition:  {}", definition.display());
+    }
+    if let Some(runtime) = &service.runtime_path {
+        println!("  runtime:     {}", runtime.display());
+    }
+    println!(
+        "  logs:        {}",
+        match &service.log_source {
+            Some(source) => source.describe(),
+            None => "not configured by this service definition".to_string(),
+        }
+    );
+    if let Some(diagnostic) = &service.diagnostic {
+        println!("  diagnostic:  {diagnostic}");
+    }
+}
+
+/// The state line: the normalized state plus, when installed, the scope and
+/// supervisor that own it.
+fn describe_service_state(service: &ServiceStatus) -> String {
+    match (service.scope, service.supervisor) {
+        (Some(scope), Some(supervisor)) => {
+            format!("{} ({scope} service, {supervisor})", service.state)
+        }
+        _ => service.state.to_string(),
+    }
+}
+
+fn render_deployment(deployment: &DeploymentStatus) {
+    println!(
+        "  deployment:  {}",
+        match &deployment.spicepod_path {
+            Some(path) => path.display().to_string(),
+            None => "none yet — this instance runs its local spicepod until an app is deployed"
+                .to_string(),
+        }
+    );
+    println!(
+        "  secrets:     {}",
+        match deployment.secrets {
+            SecretsState::Delivered if deployment.secret_names.is_empty() =>
+                "none (the last deployment delivered no secrets)".to_string(),
+            SecretsState::Delivered => format!(
+                "{} delivered: {}",
+                deployment.secret_names.len(),
+                deployment.secret_names.join(", ")
+            ),
+            SecretsState::Unreadable =>
+                "cache present but unreadable — deploy the app to re-deliver them".to_string(),
+            SecretsState::NotDelivered =>
+                "none delivered yet — deploy the app to deliver them".to_string(),
+        }
+    );
+    if let Some(pending) = &deployment.restart_required
+        && !pending.is_empty()
+    {
+        println!("  restart:     required for {}", pending.join(", "));
+    }
+}
+
+/// What to do next, for the states that have an obvious next step.
+fn render_next_steps(status: &ConnectStatus) {
+    if status.connection.state == ConnectionState::NotConnected {
+        println!(
+            "Mint an enrollment key in the Spice Cloud portal and start the runtime with it: \
+             `spiced --token <enrollment-key>`."
+        );
+        return;
+    }
+    if let Some(monitor) = &status.connection.monitor_url {
+        println!("  monitor:     {monitor}");
+    }
+    if !status.service.installed {
+        println!(
+            "No service is installed for this directory. Run `spice connect service install` to \
+             keep this instance running across reboots."
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::service::backend::fake::FakeBackend;
+    use super::*;
+
+    async fn snapshot(root: &Path, instance_dir: &Path, config_dir: &Path) -> ConnectStatus {
+        ConnectStatus::collect(
+            &FakeBackend::new(root),
+            instance_dir,
+            config_dir,
+            "https://api.example",
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn an_empty_directory_reports_not_connected_and_no_service() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+
+        let status = snapshot(dir.path(), &instance_dir, &config_dir).await;
+        assert_eq!(status.connection.state, ConnectionState::NotConnected);
+        assert!(!status.service.installed);
+        assert_eq!(status.deployment.state, DeploymentState::None);
+        assert_eq!(status.deployment.secrets, SecretsState::NotDelivered);
+        assert_eq!(
+            status.deployment.restart_required, None,
+            "an unobserved runtime must not read as nothing pending"
+        );
+        assert!(
+            !status.is_degraded(),
+            "a directory with no service is not degraded"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_full_and_filtered_json_share_one_service_object() {
+        // The acceptance criterion: automation must never have to reconcile two
+        // service schemas.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let status = snapshot(dir.path(), &instance_dir, &config_dir).await;
+
+        let full: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&status).expect("serialize full"))
+                .expect("parse full");
+        let filtered: serde_json::Value = serde_json::from_str(
+            &serde_json::to_string(&status.service_document()).expect("serialize filtered"),
+        )
+        .expect("parse filtered");
+
+        assert_eq!(full["schema_version"], filtered["schema_version"]);
+        assert_eq!(
+            serde_json::to_string(&full["service"]).expect("re-serialize full service"),
+            serde_json::to_string(&filtered["service"]).expect("re-serialize filtered service"),
+            "the service object must be byte-identical in both documents"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_manifest_makes_the_report_degraded() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(
+            super::super::service::ServiceManifest::path_in(&config_dir),
+            "{",
+        )
+        .expect("write a broken manifest");
+
+        let status = snapshot(dir.path(), &instance_dir, &config_dir).await;
+        assert!(
+            status.is_degraded(),
+            "a service that cannot be resolved must not read as healthy"
+        );
+        assert!(status.service.diagnostic.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_deployed_spicepod_is_reported() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join(runtime_cloud_connect::config::CLOUD_MANAGED_SPICEPOD_FILE),
+            "version: v1beta1\n",
+        )
+        .expect("write a deployed spicepod");
+
+        let status = snapshot(dir.path(), &instance_dir, &config_dir).await;
+        assert_eq!(status.deployment.state, DeploymentState::Deployed);
+        assert!(status.deployment.spicepod_path.is_some());
+    }
+
+    #[tokio::test]
+    async fn the_json_report_carries_the_schema_version_and_all_three_sections() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let status = snapshot(dir.path(), &instance_dir, &config_dir).await;
+
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&status).expect("serialize"))
+                .expect("parse");
+        assert_eq!(json["schema_version"], STATUS_SCHEMA_VERSION);
+        for section in ["connection", "service", "deployment"] {
+            assert!(json[section].is_object(), "missing section {section}");
+        }
+        // No credential material may reach the report.
+        let text = serde_json::to_string(&status).expect("serialize");
+        for forbidden in ["private_key", "cache_key", "PRIVATE KEY", "pop_sig"] {
+            assert!(
+                !text.contains(forbidden),
+                "{forbidden} must not be reported"
+            );
+        }
+    }
+}

--- a/bin/spice/src/context.rs
+++ b/bin/spice/src/context.rs
@@ -463,7 +463,7 @@ impl RuntimeContext {
     /// [`Self::spiced_path`] — which is derived from `HOME` — points at
     /// `/root/.spice/bin/spiced` under `sudo` and misses the runtime the
     /// invoking user actually installed. That matters because
-    /// `sudo spice connect --install` is the documented way to install the
+    /// `sudo spice connect service install` is the documented way to install the
     /// service: without this, every such run concludes the runtime is missing
     /// and downloads the latest *release*, which on a machine tracking `trunk`
     /// silently pairs a dev CLI with a released runtime.
@@ -744,7 +744,7 @@ fn sudo_invoker_home() -> Option<PathBuf> {
 /// Absolute paths `getent` ships at, in the order they are tried.
 ///
 /// Resolving it through `PATH` would be a privilege-escalation hole: this runs
-/// under `sudo` on the documented `spice connect --install` path, so a `PATH`
+/// under `sudo` on the documented `spice connect service install` path, so a `PATH`
 /// entry the invoking user controls would have this process execute their binary
 /// as root. Only these known locations are accepted, and a host with `getent`
 /// somewhere else falls through to reading `/etc/passwd`.
@@ -1090,7 +1090,7 @@ mod tests {
     #[test]
     fn passwd_home_resolves_a_user_macos_keeps_out_of_etc_passwd() {
         // Every ordinary macOS account lives in Directory Services only, so
-        // without the `dscl` step `sudo spice connect --install` cannot find the
+        // without the `dscl` step `sudo spice connect service install` cannot find the
         // runtime the invoking user installed.
         let Ok(user) = std::env::var("USER") else {
             return;
@@ -1107,7 +1107,7 @@ mod tests {
     }
 
     /// `sudo` rewrites `HOME`, so a runtime installed under the invoking user's
-    /// home must still be found — otherwise `sudo spice connect --install`
+    /// home must still be found — otherwise `sudo spice connect service install`
     /// concludes the runtime is missing and downloads a release over the
     /// operator's build.
     #[test]

--- a/bin/spice/src/error.rs
+++ b/bin/spice/src/error.rs
@@ -360,7 +360,15 @@ impl Error {
         }
         match self {
             Self::Unauthorized => Self::AUTH_EXIT_CODE,
-            Self::ServiceNotInstalled { .. } => Self::USAGE_EXIT_CODE,
+            // Both are refusals of the request rather than failures of an
+            // attempt: the caller has to change something. `InvalidArgument`
+            // covers argument conflicts, preflight refusals, and manifest
+            // validation, so it belongs on the same code clap already uses for
+            // a usage error — otherwise automation cannot tell bad input from
+            // an operation that tried and failed.
+            Self::InvalidArgument { .. } | Self::ServiceNotInstalled { .. } => {
+                Self::USAGE_EXIT_CODE
+            }
             Self::Interrupted => Self::INTERRUPTED_EXIT_CODE,
             _ => Self::FAILURE_EXIT_CODE,
         }

--- a/bin/spice/src/error.rs
+++ b/bin/spice/src/error.rs
@@ -250,6 +250,33 @@ pub enum Error {
     /// Enrollment against the Spice Cloud control plane failed.
     #[snafu(display("Failed to enroll with Spice Cloud: {message}"))]
     CloudConnectEnroll { message: String },
+
+    /// A `spice connect service` action needs a service that is not installed
+    /// for the selected instance directory.
+    ///
+    /// Distinct from a generic failure because nothing went wrong: the request
+    /// cannot be carried out as asked, which is what exit code
+    /// [`Error::USAGE_EXIT_CODE`] means.
+    #[snafu(display("{message}"))]
+    ServiceNotInstalled { message: String },
+
+    /// The service supervisor could not be asked, or reports the service as
+    /// failed. The status report has already been written; this carries the
+    /// diagnosis and the non-zero exit.
+    #[snafu(display("{message}"))]
+    ServiceUnavailable { message: String },
+
+    /// The viewer was interrupted — `spice connect service logs --follow`
+    /// stopped following. The service is unchanged.
+    #[snafu(display("Interrupted."))]
+    Interrupted,
+
+    /// A callable path that this release does not implement yet.
+    ///
+    /// A typed error rather than a panic, so the CLI exits with a diagnosis and
+    /// a non-zero status instead of aborting.
+    #[snafu(display("{message}"))]
+    NotImplemented { message: String },
 }
 
 impl Error {
@@ -292,6 +319,50 @@ impl Error {
         match self {
             Self::Cloud { hint, .. } => hint.as_deref(),
             _ => None,
+        }
+    }
+
+    /// The operation failed. The default for anything without a more specific
+    /// meaning.
+    pub const FAILURE_EXIT_CODE: i32 = 1;
+
+    /// The request cannot be carried out as asked and the caller has to change
+    /// something. The same code clap uses for a usage error.
+    pub const USAGE_EXIT_CODE: i32 = 2;
+
+    /// Re-authenticate and retry, matching the convention `gh` uses
+    /// (<https://cli.github.com/manual/gh_help_exit-codes>).
+    pub const AUTH_EXIT_CODE: i32 = 4;
+
+    /// Interrupted by a signal: `128 + SIGINT`, the shell convention.
+    pub const INTERRUPTED_EXIT_CODE: i32 = 130;
+
+    /// The process exit code for this error.
+    ///
+    /// The contract automation branches on:
+    ///
+    /// - `0` — the command did what it was asked (never produced here).
+    /// - `1` — the operation failed.
+    /// - `2` — the request was invalid; change something and retry.
+    /// - `4` — authenticate again and retry.
+    /// - `130` — interrupted; nothing was changed.
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        if matches!(
+            self.cloud_code(),
+            Some(
+                CloudErrorCode::NotAuthenticated
+                    | CloudErrorCode::TokenExpired
+                    | CloudErrorCode::OrgCredentialMissing,
+            )
+        ) {
+            return Self::AUTH_EXIT_CODE;
+        }
+        match self {
+            Self::Unauthorized => Self::AUTH_EXIT_CODE,
+            Self::ServiceNotInstalled { .. } => Self::USAGE_EXIT_CODE,
+            Self::Interrupted => Self::INTERRUPTED_EXIT_CODE,
+            _ => Self::FAILURE_EXIT_CODE,
         }
     }
 }

--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -344,23 +344,11 @@ fn main() {
 
 /// Exit code for a failed command.
 ///
-/// Authentication failures get their own code so automation can re-authenticate
-/// and retry without parsing the message, matching the convention `gh` uses
-/// (<https://cli.github.com/manual/gh_help_exit-codes>).
+/// The mapping lives on the error type so every caller — this dispatcher and
+/// the machine-mode writer — reports the same code. See
+/// [`spice::error::Error::exit_code`] for the contract.
 fn exit_code_for(error: &spice::error::Error) -> i32 {
-    use spice::error::CloudErrorCode;
-
-    match error.cloud_code() {
-        Some(
-            CloudErrorCode::NotAuthenticated
-            | CloudErrorCode::TokenExpired
-            | CloudErrorCode::OrgCredentialMissing,
-        ) => 4,
-        _ => match error {
-            spice::error::Error::Unauthorized => 4,
-            _ => 1,
-        },
-    }
+    error.exit_code()
 }
 
 fn normalize_direct_command_args(args: impl IntoIterator<Item = OsString>) -> Vec<OsString> {
@@ -673,6 +661,7 @@ fn apply_machine_mode(command: &mut Commands) {
         Commands::Chat(args) => args.output = OutputFormat::Json,
         Commands::Refresh(args) => args.output = OutputFormat::Json,
         Commands::Cloud(args) => apply_machine_cloud_mode(&mut args.command),
+        Commands::Connect(args) => args.apply_machine_mode(),
         // `Nsql` is intentionally excluded: it is always an interactive REPL with
         // no one-shot/non-interactive mode, so there is no JSON output format to apply.
         // The remaining commands are lifecycle/manifest-editing commands with no
@@ -683,7 +672,6 @@ fn apply_machine_mode(command: &mut Commands) {
         | Commands::Upgrade(_)
         | Commands::Run(_)
         | Commands::Add(_)
-        | Commands::Connect(_)
         | Commands::Validate(_)
         | Commands::Dataset(_)
         | Commands::Catalog(_)
@@ -821,6 +809,10 @@ fn machine_error_code(error: &spice::error::Error) -> &'static str {
         spice::error::Error::NoModelsConfigured => "no_models_configured",
         spice::error::Error::CloudConnectIo { .. } => "cloud_connect_io",
         spice::error::Error::CloudConnectEnroll { .. } => "cloud_connect_enroll",
+        spice::error::Error::ServiceNotInstalled { .. } => "service_not_installed",
+        spice::error::Error::ServiceUnavailable { .. } => "service_unavailable",
+        spice::error::Error::Interrupted => "interrupted",
+        spice::error::Error::NotImplemented { .. } => "not_implemented",
     }
 }
 
@@ -850,6 +842,8 @@ fn is_json_output(cmd: &mut Commands) -> bool {
         }) => *output == OutputFormat::Json,
         // Cloud commands answer for themselves, from the one match in cloud::mod.
         Commands::Cloud(a) => a.command.produces_json(),
+        // Both `connect status` and `connect service status` have a JSON form.
+        Commands::Connect(a) => a.produces_json(),
         _ => false,
     }
 }

--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -310,22 +310,37 @@ fn main() {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
     };
 
-    // The subscriber writes to stdout, so stdout's terminal-ness decides colour.
-    // The builder default would honour `NO_COLOR` but still paint a redirected
-    // stdout; this is the same decision the CLI's own painted output already uses.
-    tracing_subscriber::fmt()
+    // Whether stdout is reserved for one JSON document. Decided before the
+    // subscriber is built, because it decides where log output may go.
+    let json_stdout = is_json_output(&mut cli.command);
+
+    // A JSON run must leave stdout parseable, so every log line goes to stderr
+    // instead — including the final error, which a command that has already
+    // written its report would otherwise append to the JSON. Otherwise the
+    // subscriber writes to stdout, so stdout's terminal-ness decides colour:
+    // the builder default would honour `NO_COLOR` but still paint a redirected
+    // stdout, and this is the same decision the CLI's own painted output uses.
+    let subscriber = tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_target(false)
-        .without_time()
-        .with_ansi(ansi_colors::colors_enabled_for(ansi_colors::Target::Stdout))
-        .init();
+        .without_time();
+    if json_stdout {
+        subscriber
+            .with_ansi(ansi_colors::colors_enabled_for(ansi_colors::Target::Stderr))
+            .with_writer(std::io::stderr)
+            .init();
+    } else {
+        subscriber
+            .with_ansi(ansi_colors::colors_enabled_for(ansi_colors::Target::Stdout))
+            .init();
+    }
 
     // Version banner: stderr-only so it doesn't foul pipes, and only for interactive stderr.
     // Suppressed for commands that produce JSON (scripting) or where it's just noise.
     if std::io::stderr().is_terminal()
         && !cli.machine
         && !matches!(cli.command, Commands::Version(_) | Commands::Completions(_))
-        && !is_json_output(&mut cli.command)
+        && !json_stdout
     {
         eprintln!("Spice.ai OSS CLI {}", version::cli_version());
     }

--- a/bin/spice/tests/connect_service_cli.rs
+++ b/bin/spice/tests/connect_service_cli.rs
@@ -1,0 +1,245 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#![expect(clippy::expect_used, reason = "integration-test helpers")]
+
+//! End-to-end contract for `spice connect status` and
+//! `spice connect service`.
+//!
+//! The unit tests pin the grammar and the model. These run the real binary,
+//! which is the only place three things can be checked: that `--output json`
+//! puts JSON and nothing else on stdout, that the human report and the
+//! diagnosis land on the streams automation expects, and that the documented
+//! exit codes are the ones the process actually returns.
+
+use assert_cmd::{Command, cargo::cargo_bin_cmd};
+use tempfile::TempDir;
+
+/// Exit code for a request that cannot be carried out as asked.
+const USAGE_EXIT_CODE: i32 = 2;
+
+fn spice_cmd() -> Command {
+    cargo_bin_cmd!("spice")
+}
+
+/// An instance directory with no Cloud Connect state and no service.
+fn empty_instance() -> TempDir {
+    TempDir::new().expect("create tempdir")
+}
+
+/// Run `spice connect <args> --dir <instance>` in an isolated directory.
+fn connect(instance: &TempDir, args: &[&str]) -> assert_cmd::assert::Assert {
+    let mut cmd = spice_cmd();
+    cmd.arg("connect")
+        .args(args)
+        .arg("--dir")
+        .arg(instance.path())
+        // A stray endpoint override in the environment would send the status
+        // probe somewhere real.
+        .env_remove("SPICE_CLOUD_ENDPOINT")
+        .env_remove("SPICE_CONFIG_DIR");
+    cmd.assert()
+}
+
+#[test]
+fn json_status_writes_only_json_to_stdout() {
+    let instance = empty_instance();
+    let output = connect(&instance, &["status", "--output", "json"])
+        .success()
+        .get_output()
+        .clone();
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    let report: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout must be exactly one JSON document");
+    assert_eq!(report["schema_version"], 1);
+    for section in ["connection", "service", "deployment"] {
+        assert!(report[section].is_object(), "missing {section}: {stdout}");
+    }
+    assert_eq!(report["service"]["state"], "not_installed");
+    assert_eq!(report["service"]["installed"], false);
+}
+
+#[test]
+fn the_service_status_json_is_the_same_object_the_full_report_nests() {
+    let instance = empty_instance();
+
+    let full = connect(&instance, &["status", "--output", "json"])
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let filtered = connect(&instance, &["service", "status", "--output", "json"])
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let full: serde_json::Value = serde_json::from_slice(&full).expect("full report is JSON");
+    let filtered: serde_json::Value =
+        serde_json::from_slice(&filtered).expect("filtered report is JSON");
+
+    assert_eq!(full["schema_version"], filtered["schema_version"]);
+    assert_eq!(
+        serde_json::to_string(&full["service"]).expect("serialize"),
+        serde_json::to_string(&filtered["service"]).expect("serialize"),
+        "automation must never have to reconcile two service schemas"
+    );
+    // The filtered document carries the service object and nothing else.
+    let object = filtered.as_object().expect("an object");
+    let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+    assert_eq!(keys, vec!["schema_version", "service"]);
+}
+
+#[test]
+fn the_service_group_with_no_action_prints_help_and_does_nothing() {
+    let instance = empty_instance();
+    let stdout = connect(&instance, &["service"])
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(stdout).expect("stdout is UTF-8");
+
+    for action in [
+        "install",
+        "uninstall",
+        "start",
+        "stop",
+        "restart",
+        "status",
+        "logs",
+    ] {
+        assert!(
+            stdout.contains(&format!("spice connect service {action}")),
+            "the no-action help must name `{action}`: {stdout}"
+        );
+    }
+    // The hidden alias is never printed.
+    assert!(!stdout.contains("svc"), "{stdout}");
+}
+
+#[test]
+fn a_start_with_no_installed_service_exits_two_and_points_at_install() {
+    let instance = empty_instance();
+    let output = connect(&instance, &["service", "start"])
+        .code(USAGE_EXIT_CODE)
+        .get_output()
+        .clone();
+
+    // The diagnosis is on stderr; stdout stays clean for anything piping it.
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+    assert!(
+        stderr.contains("spice connect service install"),
+        "the refusal must name the command that fixes it: {stderr}"
+    );
+    assert!(
+        String::from_utf8(output.stdout)
+            .expect("stdout is UTF-8")
+            .trim()
+            .is_empty(),
+        "a refusal must not write a report to stdout"
+    );
+}
+
+#[test]
+fn a_restart_with_no_installed_service_never_signals_a_foreground_runtime() {
+    let instance = empty_instance();
+    let stderr = connect(&instance, &["service", "restart"])
+        .code(USAGE_EXIT_CODE)
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(stderr).expect("stderr is UTF-8");
+    assert!(stderr.contains("no supervisor-managed service"), "{stderr}");
+    assert!(
+        stderr.contains("foreground"),
+        "the refusal must say the foreground runtime is left alone: {stderr}"
+    );
+}
+
+#[test]
+fn stop_logs_and_uninstall_succeed_on_a_directory_with_no_service() {
+    let instance = empty_instance();
+    for action in [
+        vec!["service", "stop"],
+        vec!["service", "logs"],
+        vec!["service", "uninstall"],
+    ] {
+        let stdout = connect(&instance, &action)
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let stdout = String::from_utf8(stdout).expect("stdout is UTF-8");
+        assert!(
+            stdout.to_lowercase().contains("identity"),
+            "`{action:?}` must say the Cloud identity is untouched: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn the_hidden_alias_reaches_the_same_command() {
+    let instance = empty_instance();
+    let via_alias = connect(&instance, &["svc", "status", "--output", "json"])
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let via_name = connect(&instance, &["service", "status", "--output", "json"])
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(via_alias, via_name);
+}
+
+#[test]
+fn the_documented_grammar_is_the_only_grammar() {
+    let instance = empty_instance();
+    // `--install` and `--tail` were the previous spellings; clap must reject
+    // both so there is exactly one documented way to say each thing.
+    for args in [
+        vec!["--install"],
+        vec!["service", "logs", "--tail"],
+        vec!["service", "logs", "--tail", "50"],
+        vec!["service", "logs", "-n", "100001"],
+        // Resolution is by instance directory: a supervisor name must not be
+        // accepted, because it can name another instance's service.
+        vec!["service", "restart", "some.service"],
+    ] {
+        connect(&instance, &args).failure();
+    }
+}
+
+#[test]
+fn generated_help_documents_service_and_never_svc() {
+    let mut cmd = spice_cmd();
+    let stdout = cmd
+        .args(["connect", "--help"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let stdout = String::from_utf8(stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains("service"), "{stdout}");
+    assert!(
+        !stdout.contains("svc"),
+        "the typing alias must stay out of generated help: {stdout}"
+    );
+}


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

## Why

Service operations were private helpers behind a root-only `spice connect --install`. There was no way to start, stop, restart, or read the logs of an installed instance through Spice — operators had to know whether theirs was a systemd unit or a launchd job and drive it natively. Status was ad-hoc text carrying whichever word the supervisor used (`active`, `waiting`, `not loaded`), with no schema for automation. And discovery scanned the host's global service directories, so a command run in one instance directory could report on — and `remove` could uninstall — a service belonging to another.

## What changed

**Command grammar.** `spice connect service install|uninstall|start|stop|restart|status|logs`, with `svc` as a hidden typing alias that appears in no help, message, or docs. `logs` takes `-n/--number <LINES>` (default 100, ceiling 100000) and `-f/--follow`, matching `docker logs` and `kubectl logs`; `--tail` is rejected. `--install` is deleted. `service` with no action prints concise help and performs no operation. `--dir` applies to every action; no action accepts a unit name or launchd label.

**One status model.** Both status commands render a single `ConnectStatus` (`connection`, `service`, `deployment`) collected as one snapshot, behind `--output table|json`. `spice connect service status` renders the same `ServiceStatus` value the full report nests, so the service object is byte-identical in both JSON documents. Service state is one vocabulary — `not_installed`, `starting`, `running`, `stopping`, `stopped`, `failed`, `unavailable` — with no second `unknown`: a supervisor that cannot be asked is `unavailable` plus a diagnostic. Boot persistence is an operator outcome (`boot_without_login`, `login_only`, `disabled`, `unavailable`) with the command that changes it, never the bare word "lingering".

**Per-instance manifest.** Every action resolves its target from the canonical instance directory plus an owner-only `<config-dir>/service.json` recording that directory, the deterministic name, scope, supervisor, owner, definition/runtime/log paths, runtime digest and version, and health URL. Host-wide scanning is removed. A manifest naming another directory, another supervisor, another schema version, a non-derived name, or a relative path is refused rather than acted on, as is one others can read or a symlink standing in for one. A definition already carrying this directory's derived name that belongs elsewhere fails the install before anything is written. A directory that lost its manifest keeps its service reportable and removable by reading the definition — still found by derived name, accepted only when it names that same directory.

**Naming.** The path digest widens from 8 to 16 hex characters, with the 32-character fragment and digest golden-tested: the name is the identity of an installed service, so changing it later is a migration, not a refactor. Nothing to migrate now — this install path has never shipped in a release.

**Backend interface.** Both back ends sit behind one `ServiceBackend` trait with no defaulted methods, so a back end that forgets an operation fails to compile instead of inheriting a silent no-op. Install, uninstall, and status observation are implemented for systemd and launchd. Supervisor start/stop/restart/logs return a typed not-implemented error naming the native command to use meanwhile, so the CLI exits with a diagnosis rather than aborting; the real lifecycle lands with the systemd and launchd tasks.

**Removal transaction.** `spice connect remove` routes through the same uninstall primitive as `service uninstall` while keeping their identity semantics distinct, and clears local state only once Spice Cloud has confirmed the release or confirmed this instance absent (including already-deleted-in-the-portal). A transient failure previously cleared the identity anyway, orphaning a registry row nothing local could release afterwards; it now leaves the identity, delivered secrets, and installed service intact so a retry can finish the removal, and says so.

**Exit codes** are published on the error type so every caller reports the same one: 0 done, 1 failed, 2 invalid request, 4 authenticate again, 130 interrupted.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Closes https://github.com/spiceai/spiceai/issues/12903

## 🚨 Breaking Changes

<!-- Describe breaking changes if any, or delete this section. -->
<!-- If breaking, make sure the "breaking change" label is added. -->

## 📚 Docs

<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->

## 👀 Notes for Reviewers

<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->
