### PR TITLE
fix(bench): q97 oversized-join spilling, fleet-generator seeds, self-healing bench data

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -303,29 +303,24 @@ jobs:
           if [ "$PGHOST" != "127.0.0.1" ]; then
             echo "::error::$DB_NAME is missing or empty on the hosted $PGHOST cluster. Scale factor $SCALE_FACTOR is too large to safely generate and load inline from a CI runner. Pre-provision it first, e.g.:"
             echo "  cd test/tpc-bench && DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME DBGEN_SCALE=$SCALE_FACTOR make tpch-clone tpch-fleet-gen pg-init && DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME TPCH_DATA_DIR=./tmp/fleet make pg-load && DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-create-index"
-            echo "(substitute the tpcds-* targets for a tpcds run)"
+            echo "(for a tpcds run: make tpcds-clone tpcds-fleet-gen pg-tpcds-init, then TPCDS_DATA_DIR=./tmp/tpcds-fleet make pg-tpcds-load, then make pg-tpcds-create-index)"
             exit 1
           fi
 
           echo "$DB_NAME is missing or empty on $PGHOST - seeding it now."
           sudo apt-get install -y git
-          if [ "$QUERY_SET" = "tpcds" ]; then
-            # tpcds-kit's tools/Makefile hardcodes CC=gcc-9 on Linux; ubuntu-24.04's
-            # default gcc isn't named gcc-9, so install it explicitly via the PPA.
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa -y
-            sudo apt-get update -y
-            sudo apt-get install -y flex bison byacc gcc-9 g++-9
-          else
-            # TPC-H data comes from the pinned DuckDB CLI (see tpch-fleet-gen), so
-            # nothing is compiled here - tpch-kit is only cloned for dss.ddl.
-            sudo apt-get install -y unzip
-          fi
+          # Both query sets seed from the pinned DuckDB CLI (tpch-fleet-gen /
+          # tpcds-fleet-gen), so nothing is compiled here - the kits are only
+          # cloned for their DDL (dss.ddl / tpcds.sql, tpcds_ri.sql). Seeding
+          # from any other generator produces data the recorded expected
+          # answers don't match (see the fleet-gen comments in the Makefile).
+          sudo apt-get install -y unzip
 
           if [ "$QUERY_SET" = "tpcds" ]; then
-            make tpcds-init
-            DBGEN_SCALE=$SCALE_FACTOR make tpcds-gen
+            make tpcds-clone
+            DBGEN_SCALE=$SCALE_FACTOR make tpcds-fleet-gen
             DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-tpcds-init
-            DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-tpcds-load
+            DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME TPCDS_DATA_DIR=./tmp/tpcds-fleet make pg-tpcds-load
             DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-tpcds-create-index
           else
             make tpch-clone

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -119,11 +119,16 @@ jobs:
       # factors (SF100+) target benchmarking-postgres directly instead. Either
       # way the target starts empty and is seeded by the "Seed postgres..."
       # step below (a plain postgres image with no pre-baked data, unlike the
-      # earlier iteration of this fix). Excludes ducklake[postgres+s3], which
-      # provisions its own local postgres catalog DB on the same port, and
-      # clickbench, whose postgres source uses a different (unseeded) database.
+      # earlier iteration of this fix). Also serves clickbench's
+      # s3[parquet]-postgres run, whose postgres is purely an acceleration
+      # target (source data comes from s3) and so needs only the empty
+      # *_accelerated database the "Create postgres acceleration databases"
+      # step provides. Excludes ducklake[postgres+s3], which provisions its own
+      # local postgres catalog DB on the same port, and clickbench's
+      # postgres-source configs, which read the pre-loaded hits data on the
+      # hosted cluster (too large to seed inline).
       postgres_tpch:
-        image: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') && (startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) && 'postgres:16' || '' }}
+        image: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') && (((startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) || (github.event.inputs.query_set == 'clickbench' && contains(github.event.inputs.spicepod_path, 's3[parquet]-postgres')))) && 'postgres:16' || '' }}
         ports:
           - 5432:5432
         env:
@@ -331,6 +336,41 @@ jobs:
           fi
           echo "Seed complete: $DB_NAME on $PGHOST."
 
+      # Postgres-accelerator spicepods (file[parquet]-postgres, s3[parquet]-postgres,
+      # ...) write into a dedicated database on POSTGRES_RW_HOST (pg_db:
+      # *_accelerated). The accelerator creates its own tables but not the database
+      # itself, and the local postgres:16 service container starts empty - so every
+      # *_accelerated database the spicepod names must be created before spiced
+      # starts, or dataset acceleration fails with "database ... does not exist".
+      # Idempotent, and no schema is loaded: the accelerator manages its own tables.
+      # PGHOST must resolve identically to the POSTGRES_RW_HOST the benchmark step
+      # hands the spicepod (local container for SF1/SF10 and the clickbench
+      # acceleration run; the hosted cluster otherwise).
+      - name: Create postgres acceleration databases
+        if: ${{ contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') }}
+        env:
+          PGHOST: ${{ (((startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) || (github.event.inputs.query_set == 'clickbench' && contains(github.event.inputs.spicepod_path, 's3[parquet]-postgres'))) && '127.0.0.1' || vars.TEST_POSTGRES_HOST }}
+          PGPASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
+        run: |
+          set -e
+          SPICEPOD="${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+          ACCEL_DBS="$(grep -oE 'pg_db: *[A-Za-z0-9_]+_accelerated' "$SPICEPOD" | awk '{print $2}' | sort -u)"
+          if [ -z "$ACCEL_DBS" ]; then
+            echo "No *_accelerated pg_db in $SPICEPOD - nothing to create."
+            exit 0
+          fi
+          if ! command -v psql >/dev/null; then
+            sudo apt-get update -y && sudo apt-get install -y postgresql-client
+          fi
+          for db in $ACCEL_DBS; do
+            if psql -U postgres -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$db'" | grep -q 1; then
+              echo "$db already exists on $PGHOST."
+            else
+              createdb -U postgres "$db"
+              echo "Created $db on $PGHOST."
+            fi
+          done
+
       - name: Setup ODBC
         if: ${{ contains(github.event.inputs.spicepod_path, 'odbc') }}
         uses: ./.github/actions/setup-odbc
@@ -505,7 +545,7 @@ jobs:
           MONGODB_HOST: ${{ vars.TEST_MONGODB_HOST }}
           MONGODB_PASSWORD: ${{ secrets.TEST_MONGODB_PASSWORD }}
           POSTGRES_HOST: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') && (startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) && '127.0.0.1' || vars.TEST_POSTGRES_HOST }}
-          POSTGRES_RW_HOST: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') && (startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) && '127.0.0.1' || vars.TEST_POSTGRES_HOST }}
+          POSTGRES_RW_HOST: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') && (((startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) || (github.event.inputs.query_set == 'clickbench' && contains(github.event.inputs.spicepod_path, 's3[parquet]-postgres')))) && '127.0.0.1' || vars.TEST_POSTGRES_HOST }}
           POSTGRES_PASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
           SPICEAI_TEST_ENDPOINT: ${{ vars.SPICE_SECRET_SPICEAI_TEST_ENDPOINT }}
           SPICEAI_TEST_TPCH_API_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_TEST_TPCH_BENCHMARK_KEY }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6211,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6259,7 +6259,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "futures",
  "log",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-compression",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6376,7 +6376,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6398,7 +6398,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6447,12 +6447,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6473,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6696,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "chrono",
@@ -6747,7 +6747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6782,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "chrono",
@@ -6798,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6818,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "chrono",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6947,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6965,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
  "regex",
  "toml 1.1.2+spec-1.1.0",
  "windows-registry",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -339,7 +339,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2675,7 +2675,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -4122,7 +4122,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6211,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6259,7 +6259,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "futures",
  "log",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-compression",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6376,7 +6376,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6398,7 +6398,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6447,12 +6447,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6473,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6696,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "chrono",
@@ -6747,7 +6747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6782,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "chrono",
@@ -6798,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6818,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "chrono",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6947,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6965,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -7404,7 +7404,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7902,7 +7902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8895,8 +8895,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -10029,7 +10029,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -10064,7 +10064,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -10715,7 +10715,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10729,15 +10729,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -12990,7 +12981,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15234,8 +15225,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.12.1",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -15256,7 +15247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15584,7 +15575,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -15623,7 +15614,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -17955,7 +17946,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18023,7 +18014,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19155,7 +19146,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -19246,7 +19237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19761,7 +19752,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20488,7 +20479,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20550,7 +20541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20764,7 +20755,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark 0.12.2",
@@ -23898,7 +23889,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -486,41 +486,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" } # branch: spiceai-54 + PR #190 test-merge (refs/pull/190/merge); repin to the real spiceai-54 SHA once #190 merges
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -486,41 +486,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" } # branch: spiceai-54 + PR #190 test-merge (refs/pull/190/merge); repin to the real spiceai-54 SHA once #190 merges
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/crates/cayenne/src/optimizer_rules.rs
+++ b/crates/cayenne/src/optimizer_rules.rs
@@ -1053,6 +1053,21 @@ fn fractional_bytes(bytes: usize, fraction: f64) -> usize {
 const HASH_JOIN_BUILD_SIDE_OVERHEAD_NUM: usize = 5;
 const HASH_JOIN_BUILD_SIDE_OVERHEAD_DEN: usize = 2;
 
+/// Fixed per-row overhead added on top of the payload multiplier.
+///
+/// A multiplicative model alone collapses for narrow build sides: TPC-DS q97's
+/// full-outer join builds over two 4-byte keys, so 2.5× the payload predicted
+/// 20 B/row (2.9 GB total) while the run's `HashJoinInput` reservations
+/// consumed hundreds of bytes per row (~51 GB) — the per-entry costs
+/// (hashbrown slot ≈ 18 B at its load factor, chain link 8 B, batch
+/// bookkeeping and growth headroom) do not scale with payload width and
+/// dominate it for key-only rows. 64 B/row covers those with headroom; the
+/// asymmetry is deliberate (an over-estimate merely spills a join that would
+/// have fit, an under-estimate OOMs the query) while staying far below any
+/// gate for genuinely small dimension builds (73K-row `date_dim` estimates
+/// ~9 MB against multi-GB gates).
+const HASH_JOIN_BUILD_SIDE_FIXED_OVERHEAD_BYTES_PER_ROW: usize = 64;
+
 fn build_side_memory_estimate(plan: &dyn ExecutionPlan, build_rows: usize) -> Option<usize> {
     let row_width = plan
         .schema()
@@ -1063,13 +1078,15 @@ fn build_side_memory_estimate(plan: &dyn ExecutionPlan, build_rows: usize) -> Op
         })?;
 
     let payload_bytes = row_width.saturating_mul(build_rows);
-    // (payload * 5) / 2 ≈ 2.5× payload, computed in u128 so a saturated payload
-    // stays monotonic: a plain usize `* 5` would saturate to usize::MAX and then
-    // HALVE on `/ 2`, dropping the estimate for extreme/unknown row counts. Clamp
-    // back to usize::MAX. (`usize as u128` is always lossless; std has no
+    // (payload * 5) / 2 ≈ 2.5× payload, plus the fixed per-row hash-table
+    // overhead, computed in u128 so a saturated payload stays monotonic: a
+    // plain usize `* 5` would saturate to usize::MAX and then HALVE on `/ 2`,
+    // dropping the estimate for extreme/unknown row counts. Clamp back to
+    // usize::MAX. (`usize as u128` is always lossless; std has no
     // `From<usize>` for the platform-dependent usize.)
     let estimated = payload_bytes as u128 * HASH_JOIN_BUILD_SIDE_OVERHEAD_NUM as u128
-        / HASH_JOIN_BUILD_SIDE_OVERHEAD_DEN as u128;
+        / HASH_JOIN_BUILD_SIDE_OVERHEAD_DEN as u128
+        + build_rows as u128 * HASH_JOIN_BUILD_SIDE_FIXED_OVERHEAD_BYTES_PER_ROW as u128;
     Some(usize::try_from(estimated).unwrap_or(usize::MAX))
 }
 
@@ -1735,7 +1752,8 @@ mod tests {
     use super::{
         ANTI_JOIN_SORT_MERGE_MIN_EXACT_ROWS, CayenneAntiJoinSortMergeRewriter,
         CayenneDynamicFilterSharing, CayenneMaintainedAggregateRewriter, CayenneOptimizerConfig,
-        CayenneStatsAggregateRewriter, FilterAddition, HASH_JOIN_BUILD_SIDE_OVERHEAD_DEN,
+        CayenneStatsAggregateRewriter, FilterAddition,
+        HASH_JOIN_BUILD_SIDE_FIXED_OVERHEAD_BYTES_PER_ROW, HASH_JOIN_BUILD_SIDE_OVERHEAD_DEN,
         HASH_JOIN_BUILD_SIDE_OVERHEAD_NUM, apply_filter_additions, build_side_memory_estimate,
         plan_schema_fields,
     };
@@ -3239,10 +3257,10 @@ mod tests {
             cayenne_file_exec_with_num_rows(&schema, "order_line.vortex", Precision::Exact(1_000));
         let estimated = build_side_memory_estimate(plan.as_ref(), 1_000)
             .expect("known fixed-width schema must estimate");
-        // payload = 1000 × 24 = 24_000; with 5/2 overhead → 60_000.
+        // payload = 1000 × 24 = 24_000; ×5/2 → 60_000; +1000 × 64 fixed → 124_000.
         assert_eq!(
-            estimated, 60_000,
-            "HT overhead must be exactly 2.5× the Arrow payload for Int64×3"
+            estimated, 124_000,
+            "estimate must be 2.5× the Arrow payload plus 64 B/row fixed overhead for Int64×3"
         );
         // Zero rows → zero estimate (and must not panic on divide path).
         let zero = build_side_memory_estimate(plan.as_ref(), 0).expect("zero rows");
@@ -3251,9 +3269,48 @@ mod tests {
         let huge_rows = usize::MAX / 16;
         let huge = build_side_memory_estimate(plan.as_ref(), huge_rows).expect("huge");
         assert!(huge > 0, "saturating estimate must stay positive");
-        // Factor itself is the documented 5/2.
+        // Factors themselves are the documented 5/2 and 64 B/row.
         assert_eq!(HASH_JOIN_BUILD_SIDE_OVERHEAD_NUM, 5);
         assert_eq!(HASH_JOIN_BUILD_SIDE_OVERHEAD_DEN, 2);
+        assert_eq!(HASH_JOIN_BUILD_SIDE_FIXED_OVERHEAD_BYTES_PER_ROW, 64);
+    }
+
+    /// Pinned to the SF100 benchmark's actual gate log (run 31666796112): the
+    /// q97 full-outer build side — 143,997,065 rows of two 4-byte keys — was
+    /// estimated at 2.88 GB against a 6.87 GB gate and left as a non-spillable
+    /// hash join that then consumed ~51 GB. With the fixed per-row overhead the
+    /// same inputs must clear the same gate, while the 73K-row `date_dim`
+    /// dimension build stays far below it.
+    #[test]
+    fn build_side_memory_estimate_clears_q97_gate_for_narrow_wide_builds() {
+        let q97_gate_bytes = 6_869_640_806_usize;
+        let key_pair_schema = Arc::new(Schema::new(vec![
+            Field::new("customer_sk", DataType::Int32, true),
+            Field::new("item_sk", DataType::Int32, true),
+        ]));
+        let build = cayenne_file_exec_with_num_rows(
+            &key_pair_schema,
+            "ssci.vortex",
+            Precision::Inexact(143_997_065),
+        );
+        let estimated = build_side_memory_estimate(build.as_ref(), 143_997_065)
+            .expect("two Int32 keys must estimate");
+        assert!(
+            estimated > q97_gate_bytes,
+            "q97's 144M-row key-only build side must clear the 6.87 GB gate (estimated {estimated})"
+        );
+
+        let dimension = cayenne_file_exec_with_num_rows(
+            &key_pair_schema,
+            "date_dim.vortex",
+            Precision::Exact(73_049),
+        );
+        let small = build_side_memory_estimate(dimension.as_ref(), 73_049)
+            .expect("dimension build must estimate");
+        assert!(
+            small < q97_gate_bytes / 100,
+            "a 73K-row dimension build must stay far below the gate (estimated {small})"
+        );
     }
 
     #[test]
@@ -3298,11 +3355,11 @@ mod tests {
             JoinType::LeftAnti,
             NullEquality::NullEqualsNothing,
         ));
-        // 10M rows × ~24 B/row × 2.5 HT overhead ≈ 600 MiB estimated. Gate is
-        // fraction 0.125 of the pool, so 8 GiB × 0.125 = 1 GiB keeps this a hash
-        // join (was 4 GiB / 512 MiB gate before the overhead factor, which now
-        // under-fires and rewrites).
-        let config = config_with_cayenne_optimizer(None, Some(0.125), Some(8 * 1024 * 1024 * 1024));
+        // 10M rows × (24 B/row × 2.5 HT overhead + 64 B/row fixed) ≈ 1.24 GB
+        // estimated. Gate is fraction 0.125 of the pool, so 16 GiB × 0.125 =
+        // 2 GiB keeps this a hash join.
+        let config =
+            config_with_cayenne_optimizer(None, Some(0.125), Some(16 * 1024 * 1024 * 1024));
 
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 
@@ -3745,10 +3802,11 @@ mod tests {
             JoinType::Inner,
             NullEquality::NullEqualsNothing,
         ));
-        // ~240 MB raw build → ~600 MB with the 2.5× HT overhead, still under the
-        // 0.9 × 1 GiB ≈ 921 MiB absolute gate (and its full-pool fair share for a
-        // lone join), so the join keeps its non-spillable hash join.
-        let config = config_with_cayenne_optimizer(None, Some(0.9), Some(1024 * 1024 * 1024));
+        // ~240 MB raw build → ~1.24 GB with the 2.5× HT overhead plus the 64 B/row
+        // fixed term, still under the 0.9 × 2 GiB ≈ 1.8 GiB absolute gate (and its
+        // full-pool fair share for a lone join), so the join keeps its
+        // non-spillable hash join.
+        let config = config_with_cayenne_optimizer(None, Some(0.9), Some(2 * 1024 * 1024 * 1024));
 
         let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
 

--- a/crates/cayenne/src/optimizer_rules.rs
+++ b/crates/cayenne/src/optimizer_rules.rs
@@ -799,11 +799,20 @@ fn try_rewrite_oversized_join(
             return Ok(None);
         }
         let Some(build_row_count) = build_input_row_estimate(hash_join) else {
+            tracing::info!(
+                join_type = ?hash_join.join_type(),
+                "Cayenne oversized-join gate declined: build-side row statistics are absent"
+            );
             return Ok(None);
         };
         let Some(estimated_build_bytes) =
             build_side_memory_estimate(hash_join.left().as_ref(), build_row_count)
         else {
+            tracing::info!(
+                join_type = ?hash_join.join_type(),
+                build_row_count,
+                "Cayenne oversized-join gate declined: build side has no byte estimate (unsupported key or column type)"
+            );
             return Ok(None);
         };
 
@@ -818,7 +827,10 @@ fn try_rewrite_oversized_join(
         let effective_gate = gate_bytes.min(fair_share);
         let fire = estimated_build_bytes > effective_gate;
 
-        tracing::debug!(
+        // Info-level on purpose: this fires once per hash join per planned
+        // query, and it is the only visibility into why an oversized join was
+        // or was not rewritten on a benchmark box where RUST_LOG cannot be set.
+        tracing::info!(
             join_type = ?hash_join.join_type(),
             build_row_count,
             estimated_build_bytes,
@@ -913,6 +925,12 @@ fn try_rewrite_oversized_join(
                     // An index past the combined join schema cannot be
                     // reconstructed; keep the original join rather than risk a
                     // wrong schema.
+                    tracing::warn!(
+                        join_type = ?hash_join.join_type(),
+                        index,
+                        join_schema_fields = join_schema.fields().len(),
+                        "Cayenne oversized-join rewrite declined: embedded projection index is out of range"
+                    );
                     return Ok(None);
                 };
                 exprs.push((
@@ -925,6 +943,12 @@ fn try_rewrite_oversized_join(
             // addresses columns by position. Decline rather than emit a
             // mismatched plan.
             if projected.schema() != hash_join.schema() {
+                tracing::warn!(
+                    join_type = ?hash_join.join_type(),
+                    expected_schema = ?hash_join.schema(),
+                    reconstructed_schema = ?projected.schema(),
+                    "Cayenne oversized-join rewrite declined: hoisted projection does not reproduce the join's output schema"
+                );
                 return Ok(None);
             }
             projected

--- a/crates/cayenne/src/optimizer_rules.rs
+++ b/crates/cayenne/src/optimizer_rules.rs
@@ -60,8 +60,9 @@ limitations under the License.
 //!    of the pool (the smaller of an absolute fraction and an even split across
 //!    all hash joins in the plan). With no pool configured it falls back to the
 //!    original conservative scope: same-source semi/anti joins above a 10M-row
-//!    exact build-side threshold. Joins carrying an embedded projection are left
-//!    alone and fall back to the `runtime.query.prefer_hash_join` knob.
+//!    exact build-side threshold. A join carrying an embedded projection is
+//!    rewritten to a `ProjectionExec` over the sort-merge join, hoisting the
+//!    projection back out of the join.
 //!
 //! The ordinary inner-join probe side is handled by `DataFusion`'s *native*
 //! hash-join dynamic-filter pushdown. For inner joins (the only shape
@@ -248,10 +249,10 @@ impl std::fmt::Debug for CayenneDynamicFilterSharing {
 /// estimated build side would not fit its share of the pool is rewritten to a
 /// `SortMergeJoinExec` with spillable `SortExec` inputs. Smaller joins, and
 /// (when no pool is configured) everything but same-source semi/anti joins, are
-/// left as hash joins because that is usually the faster plan. Joins that carry
-/// an embedded output projection are also left alone — `HashJoinExec` exposes
-/// no accessor to reconstruct the projection onto a sort-merge join — and fall
-/// back to the deterministic `runtime.query.prefer_hash_join` knob.
+/// left as hash joins because that is usually the faster plan. A join that
+/// carries an embedded output projection is rewritten to a `ProjectionExec`
+/// over the sort-merge join: the projection indices are hoisted back out of
+/// the join, preserving the output schema exactly.
 #[derive(Default)]
 pub struct CayenneAntiJoinSortMergeRewriter;
 
@@ -780,11 +781,7 @@ fn try_rewrite_oversized_join(
         return Ok(None);
     }
 
-    // `SortMergeJoinExec` carries no embedded output projection and
-    // `HashJoinExec` exposes no accessor to read one back, so a projected join
-    // cannot be rewritten without changing the output schema; leave it to the
-    // deterministic `runtime.query.prefer_hash_join` knob.
-    if hash_join.contains_projection() || hash_join.on().is_empty() {
+    if hash_join.on().is_empty() {
         return Ok(None);
     }
 
@@ -897,12 +894,51 @@ fn try_rewrite_oversized_join(
         hash_join.null_equality(),
     )?;
 
+    // A projected hash join emits only a subset of the combined join columns
+    // (`ProjectionPushdown` folds the trivial projection into the join).
+    // `SortMergeJoinExec` has no embedded projection, so hoist the index list
+    // back out into an explicit `ProjectionExec` over the sort-merge join —
+    // the plan shape that existed before the pushdown. The indices apply to
+    // the combined join schema, which the sort-merge join builds identically
+    // from the same inputs and join type, so they carry over unchanged. TPC-DS
+    // q97's full-outer join arrives here only in this projected form.
+    let rewritten: Arc<dyn ExecutionPlan> = match hash_join.projection.as_ref() {
+        Some(projection) => {
+            let join: Arc<dyn ExecutionPlan> = Arc::new(join);
+            let join_schema = join.schema();
+            let mut exprs: Vec<(Arc<dyn PhysicalExpr>, String)> =
+                Vec::with_capacity(projection.len());
+            for &index in projection.iter() {
+                let Some(field) = join_schema.fields().get(index) else {
+                    // An index past the combined join schema cannot be
+                    // reconstructed; keep the original join rather than risk a
+                    // wrong schema.
+                    return Ok(None);
+                };
+                exprs.push((
+                    Arc::new(Column::new(field.name(), index)),
+                    field.name().clone(),
+                ));
+            }
+            let projected = Arc::new(ProjectionExec::try_new(exprs, join)?);
+            // The rewrite must be schema-preserving: every parent operator
+            // addresses columns by position. Decline rather than emit a
+            // mismatched plan.
+            if projected.schema() != hash_join.schema() {
+                return Ok(None);
+            }
+            projected
+        }
+        None => Arc::new(join),
+    };
+
     tracing::debug!(
         join_type = ?hash_join.join_type(),
+        projected = hash_join.contains_projection(),
         "Replaced large Cayenne HashJoinExec with spillable SortMergeJoinExec"
     );
 
-    Ok(Some(Arc::new(join)))
+    Ok(Some(rewritten))
 }
 
 /// Build-side (LEFT input) row count for the spillable rewrite, accepting an
@@ -3530,6 +3566,58 @@ mod tests {
         assert!(
             optimized.is::<SortMergeJoinExec>(),
             "a large full-outer hash join over the memory gate should become a sort-merge join"
+        );
+    }
+
+    /// A hash join carrying an embedded output projection (`ProjectionPushdown`
+    /// folds one in whenever downstream needs a column subset — TPC-DS q97's
+    /// full-outer join always arrives in this form) must still be rewritten:
+    /// the projection is hoisted into a `ProjectionExec` over the sort-merge
+    /// join, and the output schema must survive byte-for-byte. The projection
+    /// here selects a subset, reorders it, and drops the join keys — the same
+    /// shape the q97 plan exhibits.
+    #[test]
+    fn rewrites_projected_full_outer_hash_join_hoisting_projection() {
+        let schema = order_line_schema();
+        let left = large_exact_cayenne_file_exec(&schema, "store_sales.vortex");
+        let right = large_exact_cayenne_file_exec(&schema, "catalog_sales.vortex");
+        let on = vec![(
+            col("order_id", &left.schema()).expect("left join key should exist"),
+            col("order_id", &right.schema()).expect("right join key should exist"),
+        )];
+        // Combined Full-join schema: left [order_id, warehouse_id, line_number]
+        // ++ right [order_id, warehouse_id, line_number]. Keep right.warehouse_id
+        // then left.line_number - a reordered subset without the join keys.
+        let join = Arc::new(
+            HashJoinExec::try_new(
+                left,
+                right,
+                on,
+                None,
+                &JoinType::Full,
+                Some(vec![4, 2]),
+                PartitionMode::Partitioned,
+                NullEquality::NullEqualsNothing,
+                false,
+            )
+            .expect("projected hash join should be valid"),
+        );
+        let original_schema = join.schema();
+        let config = config_with_cayenne_optimizer(None, Some(0.125), Some(64 * 1024 * 1024));
+
+        let optimized = optimize_anti_join_sort_merge_with_config(join, &config);
+
+        let projection = optimized
+            .downcast_ref::<datafusion::physical_plan::projection::ProjectionExec>()
+            .expect("a projected oversized hash join should become a ProjectionExec over the sort-merge join");
+        assert!(
+            projection.input().is::<SortMergeJoinExec>(),
+            "the hoisted projection's input should be the spillable sort-merge join"
+        );
+        assert_eq!(
+            optimized.schema(),
+            original_schema,
+            "the rewrite must preserve the projected output schema exactly"
         );
     }
 

--- a/crates/runtime-datafusion/src/schema_provider.rs
+++ b/crates/runtime-datafusion/src/schema_provider.rs
@@ -25,6 +25,7 @@ use datafusion::{
     execution::context::SessionContext,
     sql::TableReference,
 };
+use parking_lot::Mutex;
 use snafu::{OptionExt, Snafu};
 
 /// Copy of default `MemorySchemaProvider` that allows `register_table` to atomically overwrite any existing tables
@@ -105,6 +106,16 @@ pub fn ensure_schema_exists(
     catalog: &str,
     table_reference: &TableReference,
 ) -> Result<(), EnsureSchemaError> {
+    // Serializes the exists-check and the create below. `register_schema`
+    // REPLACES an existing schema provider wholesale, so two datasets racing
+    // into the same not-yet-created schema (datasets initialize concurrently)
+    // could both see "missing" and both register: the loser's fresh, empty
+    // provider would discard every table already registered into the winner's
+    // - a dataset that logged successful registration is then "not found" at
+    // query time. The critical section is two in-memory map operations; no
+    // I/O and no await happens under the lock.
+    static SCHEMA_CREATE_LOCK: Mutex<()> = Mutex::new(());
+
     let catalog_provider = ctx
         .catalog(catalog)
         .context(CatalogMissingSnafu { catalog })?;
@@ -113,6 +124,8 @@ pub fn ensure_schema_exists(
     let Some(schema_name) = table_reference.schema() else {
         return Ok(());
     };
+
+    let _guard = SCHEMA_CREATE_LOCK.lock();
 
     // If the schema exists, nothing to do.
     if catalog_provider.schema(schema_name).is_some() {
@@ -124,5 +137,76 @@ pub fn ensure_schema_exists(
     match catalog_provider.register_schema(schema_name, schema_provider) {
         Ok(_) => Ok(()),
         Err(_) => unreachable!("register_schema will never fail"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::MemTable;
+    use datafusion::execution::context::SessionContext;
+    use datafusion::sql::TableReference;
+
+    use super::ensure_schema_exists;
+
+    /// Regression test: datasets initialize concurrently, and several of them
+    /// can share a schema that does not exist yet (the benchmark harness's
+    /// `__test_reference.*` datasets, for example). Each task ensures the
+    /// schema then registers its table; no table may be lost to another task
+    /// re-creating the schema in between.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn ensure_schema_exists_concurrent_creators_lose_no_tables() {
+        const TASKS: usize = 8;
+        const ROUNDS: usize = 200;
+
+        let ctx = Arc::new(SessionContext::new());
+        let catalog = "datafusion"; // the SessionContext default catalog
+
+        for round in 0..ROUNDS {
+            let schema_name = format!("racing_{round}");
+            let barrier = Arc::new(tokio::sync::Barrier::new(TASKS));
+
+            let handles = (0..TASKS)
+                .map(|task| {
+                    let ctx = Arc::clone(&ctx);
+                    let barrier = Arc::clone(&barrier);
+                    let table_ref =
+                        TableReference::partial(schema_name.clone(), format!("t{task}"));
+                    tokio::spawn(async move {
+                        barrier.wait().await;
+                        ensure_schema_exists(&ctx, catalog, &table_ref)
+                            .expect("schema creation should succeed");
+
+                        let arrow_schema =
+                            Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+                        let table = MemTable::try_new(arrow_schema, vec![vec![]])
+                            .expect("MemTable should build");
+                        ctx.register_table(table_ref, Arc::new(table))
+                            .expect("table registration should succeed");
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for handle in handles {
+                handle.await.expect("task should not panic");
+            }
+
+            let schema = ctx
+                .catalog(catalog)
+                .expect("default catalog should exist")
+                .schema(&schema_name)
+                .expect("schema should exist after ensure_schema_exists");
+            let mut table_names = schema.table_names();
+            table_names.sort();
+            let expected = (0..TASKS)
+                .map(|task| format!("t{task}"))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                table_names, expected,
+                "a concurrently-registered table vanished from schema {schema_name}"
+            );
+        }
     }
 }

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -739,6 +739,7 @@ impl RuntimeBuilder {
             io_runtime.clone(),
         )
         .memory_limit(memory_limit)
+        .query_memory_pool(query.memory_pool.unwrap_or_default())
         .target_partitions(target_partitions)
         .max_concurrent_queries(max_concurrent_queries)
         .prefer_hash_join(query.prefer_hash_join)

--- a/crates/runtime/src/datafusion/builder.rs
+++ b/crates/runtime/src/datafusion/builder.rs
@@ -58,7 +58,7 @@ use datafusion::{
     execution::{
         DiskManager, FunctionRegistry, SessionStateBuilder,
         disk_manager::DiskManagerMode,
-        memory_pool::{GreedyMemoryPool, TrackConsumersPool},
+        memory_pool::{FairSpillPool, GreedyMemoryPool, MemoryPool, TrackConsumersPool},
         object_store::ObjectStoreRegistry,
         runtime_env::{RuntimeEnv, RuntimeEnvBuilder},
     },
@@ -104,6 +104,7 @@ use runtime_datafusion::{
 use runtime_datafusion_index::analyzer::IndexTableScanExtensionPlanner;
 use runtime_metrics::telemetry::track_bytes_processed;
 use runtime_object_store::registry::SpiceObjectStoreRegistry;
+use spicepod::component::runtime::QueryMemoryPool;
 use spicepod::component::runtime::SpillCompression as SpiceSpillCompression;
 use spicepod::metric::Metrics;
 use tokio::{
@@ -334,6 +335,7 @@ pub struct DataFusionBuilder {
     status: Arc<status::RuntimeStatus>,
     accelerator_engine_registry: Arc<AcceleratorEngineRegistry>,
     memory_limit: Option<u64>,
+    query_memory_pool: QueryMemoryPool,
     target_partitions: Option<usize>,
     prefer_hash_join: Option<bool>,
     eager_aggregation: Option<bool>,
@@ -423,6 +425,7 @@ impl DataFusionBuilder {
             status,
             accelerator_engine_registry,
             memory_limit: None,
+            query_memory_pool: QueryMemoryPool::default(),
             target_partitions: None,
             prefer_hash_join: None,
             eager_aggregation: None,
@@ -476,6 +479,12 @@ impl DataFusionBuilder {
     #[must_use]
     pub fn memory_limit(mut self, memory_limit: Option<u64>) -> Self {
         self.memory_limit = memory_limit;
+        self
+    }
+
+    #[must_use]
+    pub fn query_memory_pool(mut self, query_memory_pool: QueryMemoryPool) -> Self {
+        self.query_memory_pool = query_memory_pool;
         self
     }
 
@@ -951,6 +960,7 @@ impl DataFusionBuilder {
 
         let query_runtime_env = runtime_env_with_effective_memory_limit_and_object_store_registry(
             effective_memory_limit,
+            self.query_memory_pool,
             self.temp_directory.clone(),
             object_store_registry,
             self.cayenne_footer_cache_mb
@@ -1831,6 +1841,7 @@ fn configure_hash_join_memory_limits(config: &mut SessionConfig, effective_memor
 
 fn runtime_env_with_effective_memory_limit_and_object_store_registry(
     effective_memory_limit: u64,
+    query_memory_pool: QueryMemoryPool,
     temp_directory: Option<String>,
     object_store_registry: Arc<dyn ObjectStoreRegistry>,
     metadata_cache_limit_bytes: Option<usize>,
@@ -1850,12 +1861,22 @@ fn runtime_env_with_effective_memory_limit_and_object_store_registry(
     #[expect(clippy::cast_possible_truncation)]
     let effective_memory_bytes = effective_memory_limit as usize;
 
-    let memory_pool = Arc::new(TrackConsumersPool::new(
-        // The runtime supports only 64-bit platforms, so casting u64 to usize
-        // will not truncate on supported targets.
-        GreedyMemoryPool::new(effective_memory_bytes),
-        topn,
-    ));
+    // The runtime supports only 64-bit platforms, so casting u64 to usize
+    // will not truncate on supported targets.
+    let memory_pool: Arc<dyn MemoryPool> = match query_memory_pool {
+        QueryMemoryPool::Greedy => Arc::new(TrackConsumersPool::new(
+            GreedyMemoryPool::new(effective_memory_bytes),
+            topn,
+        )),
+        // Divides the budget fairly among spill-capable consumers so several
+        // concurrent external sorts (e.g. the inputs of a spilled sort-merge
+        // join) each spill at their share instead of one buffering the whole
+        // pool and denying a later sorter its first allocation.
+        QueryMemoryPool::FairSpill => Arc::new(TrackConsumersPool::new(
+            FairSpillPool::new(effective_memory_bytes),
+            topn,
+        )),
+    };
 
     let mut runtime_env_builder = RuntimeEnvBuilder::default()
         .with_object_store_registry(object_store_registry)
@@ -2266,6 +2287,7 @@ mod tests {
         );
         let runtime_env = runtime_env_with_effective_memory_limit_and_object_store_registry(
             1024 * 1024,
+            QueryMemoryPool::Greedy,
             None,
             object_store_registry,
             Some(8 * 1024 * 1024),
@@ -2284,6 +2306,7 @@ mod tests {
         );
         let query_env = runtime_env_with_effective_memory_limit_and_object_store_registry(
             1024 * 1024 * 1024,
+            QueryMemoryPool::Greedy,
             None,
             object_store_registry,
             None,

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -1082,6 +1082,24 @@ impl<'de> Deserialize<'de> for CpuQuantity {
     }
 }
 
+/// Query memory-pool accounting strategy (`runtime.query.memory_pool`).
+///
+/// `greedy` grants memory first-come-first-served: simple and fast, but a
+/// spill-capable operator that filled its buffers holds them until it decides
+/// to spill on its own, so several concurrent sorts can occupy the whole pool
+/// and deny a later operator its very first allocation. `fair_spill` divides
+/// the budget fairly among spill-capable operators, forcing each to spill at
+/// its share — the appropriate mode for workloads whose plans spill (external
+/// sorts, sort-merge joins over large inputs).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMemoryPool {
+    #[default]
+    Greedy,
+    FairSpill,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "snake_case")]
@@ -1090,6 +1108,14 @@ pub struct Query {
     /// for supported queries larger than memory.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory_limit: Option<String>,
+
+    /// Selects how the query memory pool grants its budget to operators.
+    /// `greedy` is first-come-first-served; `fair_spill` divides the budget
+    /// fairly among spill-capable operators (sorts, spillable joins) so
+    /// concurrent spilling operators each spill at their share instead of one
+    /// buffering the whole pool and starving the rest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_pool: Option<QueryMemoryPool>,
 
     /// Configures where the runtime will store temporary files needed for operations like
     /// spilling to disk for queries & accelerations that are larger than memory.

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -572,8 +572,7 @@ mod tests {
 
         // Different file counts must redact to the identical token.
         let input = "|               |   CayenneAccelerationExec: snapshots_scanned=1, files_scanned=30   |";
-        let expected =
-            "|               |   CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>   |";
+        let expected = "|               |   CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>   |";
         assert_eq!(regex.replace_all(input, replacement), expected);
 
         let input = "|               |   CayenneAccelerationExec: snapshots_scanned=1, files_scanned=35   |";
@@ -589,7 +588,8 @@ mod tests {
         assert_eq!(regex.replace_all(input, replacement), input);
 
         // Other operators' counters are not this filter's job.
-        let input = "DataSourceExec: file_groups={16 groups: [<redacted>]}, projection=[o_orderkey]";
+        let input =
+            "DataSourceExec: file_groups={16 groups: [<redacted>]}, projection=[o_orderkey]";
         assert_eq!(regex.replace_all(input, replacement), input);
 
         Ok(())

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -59,6 +59,17 @@ const CONNECTION_CONTEXT_FILTER_REPLACEMENT: &str = "compute_context=<CONNECTION
 const ENDPOINT_CONTEXT_FILTER_PATTERN: &str = r"compute_context=(?:url=|sc://)\S+";
 const ENDPOINT_CONTEXT_FILTER_REPLACEMENT: &str = CONNECTION_CONTEXT_FILTER_REPLACEMENT;
 
+/// Redact the scan counters `CayenneAccelerationExec` surfaces in its plan display.
+/// `snapshots_scanned`/`files_scanned` report read amplification, which depends on
+/// ingestion batching and how far compaction has progressed when the query runs —
+/// state that varies run to run, not plan structure. Left in the snapshot, the
+/// explain check fails whenever the accelerator happens to hold a different file
+/// count (e.g. `files_scanned=30` vs `=35`) even though the plan is identical.
+const CAYENNE_SCAN_COUNTERS_FILTER_PATTERN: &str =
+    r"CayenneAccelerationExec: snapshots_scanned=\d+, files_scanned=\d+";
+const CAYENNE_SCAN_COUNTERS_FILTER_REPLACEMENT: &str =
+    "CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>";
+
 /// Queries temporarily excluded from explain-plan snapshot validation because their
 /// plans are not yet stable enough to snapshot deterministically.
 const EXPLAIN_SNAPSHOT_SKIP_LIST: &[&str] = &["chbench_q5"];
@@ -85,6 +96,10 @@ fn build_explain_filters(temp_dir: &std::path::Path) -> Vec<(String, &'static st
         (
             ENDPOINT_CONTEXT_FILTER_PATTERN.to_string(),
             ENDPOINT_CONTEXT_FILTER_REPLACEMENT,
+        ),
+        (
+            CAYENNE_SCAN_COUNTERS_FILTER_PATTERN.to_string(),
+            CAYENNE_SCAN_COUNTERS_FILTER_REPLACEMENT,
         ),
         (r"required_guarantees=\[[^\]]*\]".to_string(), "required_guarantees=[N]"),
         (r"partition_sizes=\[[^\]]*\]".to_string(), "partition_sizes=[<redacted>]"),
@@ -544,6 +559,37 @@ mod tests {
         // The `host=` form stays the other pattern's job; this one must not half-match
         // it and leave a partially-redacted context behind.
         let input = "VirtualExecutionPlan name=mysql compute_context=host=db,port=3306,db=tpch,user=root base_sql=SELECT 1";
+        assert_eq!(regex.replace_all(input, replacement), input);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cayenne_scan_counters_filter() -> Result<(), String> {
+        let regex = regex::Regex::new(super::CAYENNE_SCAN_COUNTERS_FILTER_PATTERN)
+            .map_err(|e| format!("{e}"))?;
+        let replacement = super::CAYENNE_SCAN_COUNTERS_FILTER_REPLACEMENT;
+
+        // Different file counts must redact to the identical token.
+        let input = "|               |   CayenneAccelerationExec: snapshots_scanned=1, files_scanned=30   |";
+        let expected =
+            "|               |   CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>   |";
+        assert_eq!(regex.replace_all(input, replacement), expected);
+
+        let input = "|               |   CayenneAccelerationExec: snapshots_scanned=1, files_scanned=35   |";
+        assert_eq!(regex.replace_all(input, replacement), expected);
+
+        // A not-yet-refreshed accelerator reports zero for both counters.
+        let input = "CayenneAccelerationExec: snapshots_scanned=0, files_scanned=0";
+        let expected = "CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>";
+        assert_eq!(regex.replace_all(input, replacement), expected);
+
+        // Idempotent: an already-redacted snapshot is left unchanged.
+        let input = "CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>";
+        assert_eq!(regex.replace_all(input, replacement), input);
+
+        // Other operators' counters are not this filter's job.
+        let input = "DataSourceExec: file_groups={16 groups: [<redacted>]}, projection=[o_orderkey]";
         assert_eq!(regex.replace_all(input, replacement), input);
 
         Ok(())

--- a/test/local-bench/.gitignore
+++ b/test/local-bench/.gitignore
@@ -1,0 +1,2 @@
+logs/
+.work/

--- a/test/local-bench/00-env.sh
+++ b/test/local-bench/00-env.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Shared configuration for the local benchmark harness.
+# Source this from the other scripts; do not run it directly.
+
+# Repo root (scripts live in test/local-bench)
+LOCAL_BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${LOCAL_BENCH_DIR}/../.." && pwd)"
+TPC_BENCH_DIR="${REPO_ROOT}/test/tpc-bench"
+
+# All generated data lives here (gitignored via test/tpc-bench/tmp is NOT used;
+# this dir is self-contained and safe to delete to reclaim space).
+WORK_DIR="${LOCAL_BENCH_DIR}/.work"
+FLEET_PARQUET_DIR="${WORK_DIR}/tpcds-parquet"   # parquet for file:// benches + MinIO upload
+
+# Containers (unique names so we never touch unrelated containers)
+PG_CONTAINER=spice-bench-postgres
+MINIO_CONTAINER=spice-bench-minio
+
+# PostgreSQL (mirrors the CI service container: postgres:16, shm 1g)
+export POSTGRES_HOST=127.0.0.1
+export POSTGRES_PORT=5432
+export POSTGRES_USER=postgres
+export POSTGRES_PASSWORD=postgres
+export PGPASSWORD="${POSTGRES_PASSWORD}"        # for psql/createdb in the make targets
+PG_TPCDS_DB=tpcds_sf1                            # database name the spicepods expect
+
+# MinIO (mirrors CI's spice-minio: bucket "benchmarks", prefix tpcds_sf1/)
+MINIO_PORT=9000
+MINIO_CONSOLE_PORT=9001
+export S3_ENDPOINT="http://127.0.0.1:${MINIO_PORT}"
+export S3_KEY=minioadmin
+export S3_SECRET=minioadmin
+MINIO_BUCKET=benchmarks
+MINIO_PREFIX=tpcds_sf1
+
+# Pinned DuckDB CLI — the fleet dataset generator. Reuses the tpc-bench
+# Makefile's download target so the pin lives in exactly one place.
+DUCKDB_BIN="${TPC_BENCH_DIR}/tmp/bin/duckdb"
+
+# TPC-DS tables (matches TPCDS_TABLES in test/tpc-bench/Makefile)
+TPCDS_TABLES="call_center catalog_page catalog_returns catalog_sales customer \
+customer_address customer_demographics date_dim household_demographics \
+income_band inventory item promotion reason ship_mode store store_returns \
+store_sales time_dim warehouse web_page web_returns web_sales web_site"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || die "'$1' not found. $2"
+}

--- a/test/local-bench/10-setup-storage.sh
+++ b/test/local-bench/10-setup-storage.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Start the storage the target benchmarks need:
+#   - PostgreSQL 16 (source database for the postgres benches)
+#   - MinIO         (S3 source for the s3[parquet] benches)
+#
+# Usage: ./10-setup-storage.sh [all|postgres|minio] [--reset]
+#
+# Idempotent: reuses running containers. --reset removes and recreates them
+# (drops all previously loaded data).
+#
+# NOTE: the spicepods hard-code pg_port 5432 (matching the CI service
+# container), so the benchmark postgres container must own host port 5432.
+# If a local PostgreSQL is already running there, stop it first, e.g.:
+#     brew services stop postgresql@16
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/00-env.sh"
+
+require docker "Install Docker Desktop or colima."
+docker info >/dev/null 2>&1 || die "the Docker daemon is not running - start Docker Desktop (open -a Docker) or colima first."
+
+COMPONENT="all"; RESET=false
+for arg in "$@"; do
+    case "${arg}" in
+        all|postgres|minio) COMPONENT="${arg}" ;;
+        --reset) RESET=true ;;
+        *) die "unknown argument '${arg}' (usage: $0 [all|postgres|minio] [--reset])" ;;
+    esac
+done
+
+port_in_use_by_other() {
+    # True if the TCP port is bound by something other than the named container.
+    local port=$1 container=$2
+    if docker ps --format '{{.Names}} {{.Ports}}' | grep -v "^${container} " | grep -q ":${port}->"; then
+        return 0
+    fi
+    if ! docker ps --format '{{.Names}}' | grep -q "^${container}$"; then
+        (echo >"/dev/tcp/127.0.0.1/${port}") 2>/dev/null && return 0
+    fi
+    return 1
+}
+
+start_container() {
+    local name=$1; shift
+    if ${RESET}; then
+        docker rm -f "${name}" >/dev/null 2>&1 || true
+    fi
+    if docker ps --format '{{.Names}}' | grep -q "^${name}$"; then
+        echo "${name} already running - reusing (pass --reset to recreate)."
+        return 0
+    fi
+    docker rm -f "${name}" >/dev/null 2>&1 || true   # remove stopped leftover of OUR container only
+    docker run -d --name "${name}" "$@"
+}
+
+mkdir -p "${FLEET_PARQUET_DIR}"
+
+# --- PostgreSQL (mirrors the CI service container incl. --shm-size=1g: the
+# default 64MB /dev/shm makes parallel-worker TPC-DS queries fail with
+# "could not resize shared memory segment") ---
+if [[ "${COMPONENT}" == "all" || "${COMPONENT}" == "postgres" ]]; then
+    port_in_use_by_other "${POSTGRES_PORT}" "${PG_CONTAINER}" && \
+        die "port ${POSTGRES_PORT} is in use by something other than ${PG_CONTAINER} (a local PostgreSQL?).
+The spicepods hard-code pg_port 5432, so stop the other process first (e.g. brew services stop postgresql@16),
+or run './10-setup-storage.sh minio' to set up only the s3/file benches."
+
+    start_container "${PG_CONTAINER}" \
+        -p "${POSTGRES_PORT}:5432" \
+        -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+        --shm-size=1g \
+        postgres:16
+
+    echo "Waiting for PostgreSQL..."
+    for i in $(seq 1 60); do
+        docker exec "${PG_CONTAINER}" pg_isready -U postgres >/dev/null 2>&1 && break
+        [[ $i == 60 ]] && die "PostgreSQL not ready after 60s"
+        sleep 1
+    done
+    echo "  PostgreSQL: ${POSTGRES_HOST}:${POSTGRES_PORT} (user ${POSTGRES_USER})"
+fi
+
+# --- MinIO (FLEET_PARQUET_DIR mounted at /fleet so 20-populate-data.sh can
+# `mc cp` the generated parquet into the bucket from inside the container) ---
+if [[ "${COMPONENT}" == "all" || "${COMPONENT}" == "minio" ]]; then
+    port_in_use_by_other "${MINIO_PORT}" "${MINIO_CONTAINER}" && \
+        die "port ${MINIO_PORT} is in use by something other than ${MINIO_CONTAINER}. Stop it or change MINIO_PORT in 00-env.sh."
+
+    start_container "${MINIO_CONTAINER}" \
+        -p "${MINIO_PORT}:9000" -p "${MINIO_CONSOLE_PORT}:9001" \
+        -e MINIO_ROOT_USER="${S3_KEY}" -e MINIO_ROOT_PASSWORD="${S3_SECRET}" \
+        -v "${FLEET_PARQUET_DIR}:/fleet:ro" \
+        minio/minio server /data --console-address ":9001"
+
+    echo "Waiting for MinIO..."
+    for i in $(seq 1 60); do
+        curl -sf "${S3_ENDPOINT}/minio/health/ready" >/dev/null 2>&1 && break
+        [[ $i == 60 ]] && die "MinIO not ready after 60s"
+        sleep 1
+    done
+    echo "  MinIO:      ${S3_ENDPOINT} (console http://127.0.0.1:${MINIO_CONSOLE_PORT})"
+fi
+
+echo "Storage ready."

--- a/test/local-bench/20-populate-data.sh
+++ b/test/local-bench/20-populate-data.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Populate the storage started by 10-setup-storage.sh with the FLEET TPC-DS
+# SF1 dataset (DuckDB's tpcds dsdgen - the generator every recorded expected
+# answer was produced with; see tpcds-fleet-gen in test/tpc-bench/Makefile):
+#
+#   1. parquet files            -> ${FLEET_PARQUET_DIR}   (file:// benches, -d dir)
+#   2. the same parquet files   -> MinIO s3://benchmarks/tpcds_sf1/   (s3 benches)
+#   3. pipe-delimited .dat data -> PostgreSQL database tpcds_sf1     (postgres benches)
+#
+# Idempotent: skips each phase whose output already exists. Pass --force to
+# regenerate/reload everything.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/00-env.sh"
+
+require docker "Install Docker Desktop or colima."
+require psql "brew install libpq && brew link --force libpq (or: brew install postgresql@16)"
+require createdb "comes with libpq/postgresql (see psql hint above)"
+require make ""
+
+FORCE=false
+[[ "${1:-}" == "--force" ]] && FORCE=true
+
+mkdir -p "${WORK_DIR}" "${FLEET_PARQUET_DIR}"
+
+# --- 0. Pinned DuckDB CLI (downloaded by the tpc-bench Makefile so the version
+#        pin lives in one place) ---
+if [[ ! -x "${DUCKDB_BIN}" ]]; then
+    make -C "${TPC_BENCH_DIR}" ./tmp/bin/duckdb
+fi
+
+# --- 1. Parquet for the file:// and s3:// benches ---
+first_table=$(echo ${TPCDS_TABLES} | awk '{print $1}')
+if ${FORCE} || [[ ! -f "${FLEET_PARQUET_DIR}/${first_table}.parquet" ]]; then
+    echo "Generating TPC-DS SF1 parquet (DuckDB dsdgen) into ${FLEET_PARQUET_DIR}..."
+    GEN_DB="${WORK_DIR}/tpcds-parquet-gen.duckdb"
+    rm -f "${GEN_DB}" "${GEN_DB}.wal" "${FLEET_PARQUET_DIR}"/*.parquet
+    "${DUCKDB_BIN}" "${GEN_DB}" -c "INSTALL tpcds; LOAD tpcds; CALL dsdgen(sf=1);" > /dev/null
+    for table in ${TPCDS_TABLES}; do
+        echo "  ${table}.parquet"
+        "${DUCKDB_BIN}" "${GEN_DB}" -c "COPY ${table} TO '${FLEET_PARQUET_DIR}/${table}.parquet' (FORMAT parquet); DROP TABLE ${table}; CHECKPOINT;" > /dev/null
+    done
+    rm -f "${GEN_DB}" "${GEN_DB}.wal"
+else
+    echo "Parquet already present in ${FLEET_PARQUET_DIR} - skipping (pass --force to regenerate)."
+fi
+
+# --- 2. Upload parquet to MinIO (mc runs inside the MinIO container; the
+#        parquet dir is mounted there at /fleet by 10-setup-storage.sh) ---
+echo "Uploading parquet to MinIO s3://${MINIO_BUCKET}/${MINIO_PREFIX}/ ..."
+docker exec "${MINIO_CONTAINER}" mc alias set local "http://127.0.0.1:9000" "${S3_KEY}" "${S3_SECRET}" > /dev/null
+docker exec "${MINIO_CONTAINER}" mc mb -p "local/${MINIO_BUCKET}" > /dev/null
+docker exec "${MINIO_CONTAINER}" sh -c "mc cp /fleet/*.parquet local/${MINIO_BUCKET}/${MINIO_PREFIX}/" > /dev/null
+echo "  $(docker exec "${MINIO_CONTAINER}" sh -c "mc ls local/${MINIO_BUCKET}/${MINIO_PREFIX}/ | wc -l") objects in the bucket."
+
+# --- 3. Seed PostgreSQL with the same generator's data, via the exact make
+#        targets CI uses (tpcds-clone for the DDL, tpcds-fleet-gen for the
+#        .dat files, then init/load/index) ---
+# Guard: only ever seed OUR container. If port 5432 is served by anything else
+# (e.g. a personal brew postgres), refuse rather than write into it.
+if ! docker ps --format '{{.Names}}' | grep -q "^${PG_CONTAINER}$"; then
+    echo "SKIPPING PostgreSQL seed: container ${PG_CONTAINER} is not running."
+    echo "  (whatever is on ${POSTGRES_HOST}:${POSTGRES_PORT} is not the benchmark postgres - not touching it)"
+    echo "  Run './10-setup-storage.sh postgres' first; s3/file benches work without this step."
+    exit 0
+fi
+existing_rows=$(psql -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" -tAc \
+    "SELECT COALESCE((SELECT reltuples::bigint FROM pg_class WHERE relname='customer'), 0)" \
+    -d "${PG_TPCDS_DB}" 2>/dev/null || echo 0)
+if ! ${FORCE} && [[ "${existing_rows:-0}" -gt 0 ]]; then
+    echo "PostgreSQL ${PG_TPCDS_DB} already seeded (~${existing_rows} customer rows) - skipping (pass --force to reload)."
+else
+    echo "Seeding PostgreSQL ${PG_TPCDS_DB} from the fleet generator..."
+    make -C "${TPC_BENCH_DIR}" tpcds-clone
+    DBGEN_SCALE=1 make -C "${TPC_BENCH_DIR}" tpcds-fleet-gen
+    DB_HOST="${POSTGRES_HOST}" DB_PORT="${POSTGRES_PORT}" DB_USER="${POSTGRES_USER}" DB_NAME="${PG_TPCDS_DB}" \
+        make -C "${TPC_BENCH_DIR}" pg-tpcds-init
+    DB_HOST="${POSTGRES_HOST}" DB_PORT="${POSTGRES_PORT}" DB_USER="${POSTGRES_USER}" DB_NAME="${PG_TPCDS_DB}" \
+        TPCDS_DATA_DIR=./tmp/tpcds-fleet \
+        make -C "${TPC_BENCH_DIR}" pg-tpcds-load
+    DB_HOST="${POSTGRES_HOST}" DB_PORT="${POSTGRES_PORT}" DB_USER="${POSTGRES_USER}" DB_NAME="${PG_TPCDS_DB}" \
+        make -C "${TPC_BENCH_DIR}" pg-tpcds-create-index
+fi
+
+echo
+echo "Data ready. Sanity check (q17/q25/q85 knife-edge join rows must be > 0):"
+psql -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" -d "${PG_TPCDS_DB}" -tAc "
+SELECT 'q17-shape rows: ' || count(*)
+FROM store_sales ss
+JOIN store_returns sr ON ss.ss_customer_sk = sr.sr_customer_sk
+  AND ss.ss_item_sk = sr.sr_item_sk AND ss.ss_ticket_number = sr.sr_ticket_number
+JOIN catalog_sales cs ON sr.sr_customer_sk = cs.cs_bill_customer_sk
+  AND sr.sr_item_sk = cs.cs_item_sk
+JOIN date_dim d1 ON ss.ss_sold_date_sk = d1.d_date_sk AND d1.d_quarter_name = '1999Q1'
+JOIN date_dim d2 ON sr.sr_returned_date_sk = d2.d_date_sk AND d2.d_quarter_name IN ('1999Q1','1999Q2','1999Q3')
+JOIN date_dim d3 ON cs.cs_sold_date_sk = d3.d_date_sk AND d3.d_quarter_name IN ('1999Q1','1999Q2','1999Q3');"

--- a/test/local-bench/30-run-bench.sh
+++ b/test/local-bench/30-run-bench.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Run one of the target benchmarks locally, exactly the way CI runs it
+# (testoperator run bench + a spiced binary + the fleet dataset).
+#
+# Usage:
+#   ./30-run-bench.sh <config> [extra testoperator args...]
+#
+# Configs (the runs we expect the current fixes to change):
+#   s3-cayenne          tpcds accelerated/s3[parquet]-cayenne[file]     (eager-agg ROLLUP fix)
+#   file-cayenne        tpcds accelerated/file[parquet]-cayenne[file]   (eager-agg ROLLUP fix)
+#   postgres-federated  tpcds federated/postgres                        (fleet-seed fix: q17/q25/q85)
+#   postgres-arrow      tpcds accelerated/postgres-arrow                (fleet-seed fix)
+#   postgres-duckdb     tpcds accelerated/postgres-duckdb[file]         (fleet-seed fix)
+#
+# Env:
+#   SPICED_BIN    path to the spiced binary  (default: <repo>/target/release/spiced)
+#   INSTA_UPDATE  snapshot mode: no|always   (default: no - assert against checked-in snapshots)
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/00-env.sh"
+
+CONFIG="${1:-}"; shift || true
+
+SPICEPOD=""; OVERRIDES=""; READY_WAIT=600
+case "${CONFIG}" in
+    s3-cayenne)         SPICEPOD="accelerated/s3[parquet]-cayenne[file].yaml" ;;
+    file-cayenne)       SPICEPOD="accelerated/file[parquet]-cayenne[file].yaml" ;;
+    postgres-federated) SPICEPOD="federated/postgres.yaml";              OVERRIDES=postgresql ;;
+    postgres-arrow)     SPICEPOD="accelerated/postgres-arrow.yaml";      OVERRIDES=arrow ;;
+    postgres-duckdb)    SPICEPOD="accelerated/postgres-duckdb[file].yaml"; OVERRIDES=duckdb ;;
+    *)
+        sed -n '3,17p' "${BASH_SOURCE[0]}"
+        exit 1
+        ;;
+esac
+
+SPICED_BIN="${SPICED_BIN:-${REPO_ROOT}/target/release/spiced}"
+[[ -x "${SPICED_BIN}" ]] || die "spiced binary not found at ${SPICED_BIN}.
+Build it first (release recommended for benchmark timings):
+    cargo build --release -p spiced --features postgres,duckdb
+or point SPICED_BIN at an existing binary (e.g. ~/.spice/bin/spiced)."
+
+[[ -f "${FLEET_PARQUET_DIR}/store_sales.parquet" ]] || \
+    die "fleet parquet missing - run ./10-setup-storage.sh && ./20-populate-data.sh first."
+
+cd "${REPO_ROOT}"
+
+# Env consumed by the spicepods' ${secrets:...} params (spiced inherits it):
+#   POSTGRES_HOST / POSTGRES_PASSWORD  - postgres benches   (exported by 00-env.sh)
+#   S3_ENDPOINT / S3_KEY / S3_SECRET   - s3 benches         (exported by 00-env.sh)
+# INSTA_* mirrors CI so insta finds the checked-in snapshots under
+# crates/test-framework/src/snapshot/snapshots.
+export INSTA_WORKSPACE_ROOT="${REPO_ROOT}"
+export CARGO_MANIFEST_DIR="${REPO_ROOT}"
+export INSTA_UPDATE="${INSTA_UPDATE:-no}"
+
+echo "Running ${CONFIG}: test/spicepods/tpcds/sf1/${SPICEPOD}"
+echo "  spiced:       ${SPICED_BIN}"
+echo "  INSTA_UPDATE: ${INSTA_UPDATE}"
+
+rm -rf .spice/data
+
+cargo run -p testoperator -- run bench \
+    -s "${SPICED_BIN}" \
+    -p "test/spicepods/tpcds/sf1/${SPICEPOD}" \
+    -d "${FLEET_PARQUET_DIR}" \
+    --query-set tpcds \
+    ${OVERRIDES:+--query-overrides ${OVERRIDES}} \
+    --ready-wait "${READY_WAIT}" \
+    --validate=false \
+    --scale-factor 1 \
+    "$@"

--- a/test/local-bench/50-run-q97.sh
+++ b/test/local-bench/50-run-q97.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Fast local feedback loop for the SF100 nightly q97 OOM
+# (tpcds accelerated/s3[parquet]-cayenne[file], issue context: PR #11371).
+#
+# Runs ONLY q97, against ONLY its three tables, at SF10 with a 5GiB query
+# memory pool (see spicepod-q97-sf10.yaml for why that reproduces the SF100
+# failure). One iteration = rebuild spiced + this script: minutes, not the
+# ~45-minute CI loop.
+#
+# Usage:
+#   ./50-run-q97.sh              # generate/upload data if missing, run q97
+#   ./50-run-q97.sh --force-data # regenerate + re-upload the SF10 tables
+#
+# Env:
+#   SPICED_BIN  path to spiced (default: <repo>/target/release/spiced)
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/00-env.sh"
+
+require docker "Install Docker Desktop or colima."
+docker ps --format '{{.Names}}' | grep -q "^${MINIO_CONTAINER}$" || \
+    die "MinIO container not running - run ./10-setup-storage.sh minio first."
+
+Q97_TABLES="store_sales catalog_sales date_dim"
+SF10_DIR="${WORK_DIR}/tpcds-sf10-parquet"
+FORCE_DATA=false
+[[ "${1:-}" == "--force-data" ]] && FORCE_DATA=true
+
+# --- 1. Generate the three SF10 tables (pinned DuckDB dsdgen - the fleet
+#        generator; ~5-10 minutes and ~2 GB, once) ---
+if [[ ! -x "${DUCKDB_BIN}" ]]; then
+    make -C "${TPC_BENCH_DIR}" ./tmp/bin/duckdb
+fi
+if ${FORCE_DATA} || [[ ! -f "${SF10_DIR}/store_sales.parquet" ]]; then
+    echo "Generating TPC-DS SF10 (${Q97_TABLES}) into ${SF10_DIR}..."
+    mkdir -p "${SF10_DIR}"
+    GEN_DB="${WORK_DIR}/tpcds-sf10-gen.duckdb"
+    rm -f "${GEN_DB}" "${GEN_DB}.wal" "${SF10_DIR}"/*.parquet
+    "${DUCKDB_BIN}" "${GEN_DB}" -c "INSTALL tpcds; LOAD tpcds; CALL dsdgen(sf=10);" > /dev/null
+    for table in ${Q97_TABLES}; do
+        echo "  ${table}.parquet"
+        "${DUCKDB_BIN}" "${GEN_DB}" -c "COPY ${table} TO '${SF10_DIR}/${table}.parquet' (FORMAT parquet);" > /dev/null
+    done
+    rm -f "${GEN_DB}" "${GEN_DB}.wal"
+else
+    echo "SF10 parquet already present - skipping generation (--force-data to regenerate)."
+fi
+
+# --- 2. Upload to MinIO as tpcds_sf10/<table>/<table>.parquet (the sf10
+#        spicepods address tables as directories) ---
+echo "Uploading to MinIO s3://${MINIO_BUCKET}/tpcds_sf10/ ..."
+docker exec "${MINIO_CONTAINER}" mc alias set local "http://127.0.0.1:9000" "${S3_KEY}" "${S3_SECRET}" > /dev/null
+docker exec "${MINIO_CONTAINER}" mc mb -p "local/${MINIO_BUCKET}" > /dev/null
+# The SF10 dir is not the mounted /fleet dir; stream the files in via stdin.
+for table in ${Q97_TABLES}; do
+    docker exec -i "${MINIO_CONTAINER}" sh -c \
+        "mc pipe local/${MINIO_BUCKET}/tpcds_sf10/${table}/${table}.parquet" \
+        < "${SF10_DIR}/${table}.parquet"
+done
+echo "  uploaded: $(docker exec "${MINIO_CONTAINER}" sh -c "mc ls -r local/${MINIO_BUCKET}/tpcds_sf10/ | wc -l") objects"
+
+# --- 3. Run q97 alone via the scenario query set ---
+SPICED_BIN="${SPICED_BIN:-${REPO_ROOT}/target/release/spiced}"
+[[ -x "${SPICED_BIN}" ]] || die "spiced binary not found at ${SPICED_BIN}. Build it first:
+    cargo build --release -p spiced"
+
+cd "${REPO_ROOT}"
+export INSTA_WORKSPACE_ROOT="${REPO_ROOT}"
+export CARGO_MANIFEST_DIR="${REPO_ROOT}"
+# Scenario snapshots are local-only scaffolding; always accept them so the run's
+# verdict is execution (OOM vs completed), not snapshot bookkeeping.
+export INSTA_UPDATE=always
+
+LOG="${LOCAL_BENCH_DIR}/logs/q97-sf10.log"
+mkdir -p "${LOCAL_BENCH_DIR}/logs"
+rm -rf .spice/data
+
+set +e
+cargo run -p testoperator -- run bench \
+    -s "${SPICED_BIN}" \
+    -p "${LOCAL_BENCH_DIR}/spicepod-q97-sf10.yaml" \
+    --query-set scenario \
+    --scenario-query-file "${LOCAL_BENCH_DIR}/q97-scenario.yaml" \
+    --ready-wait 900 \
+    --validate=false \
+    > "${LOG}" 2>&1
+BENCH_EXIT=$?
+set -e
+
+echo
+echo "===== q97 verdict (full log: ${LOG}) ====="
+echo "-- oversized-join gate decisions (Full join must show fire=true):"
+grep -oE "Evaluated Cayenne oversized-join memory gate.*" "${LOG}" | sort -u | sed 's/^/   /' || echo "   (no gate evaluations logged)"
+grep -oE "oversized-join (gate|rewrite) declined.*" "${LOG}" | sort -u | sed 's/^/   /' || true
+echo "-- OOM check:"
+# Hash-join exhaustion reports "Resources exhausted"; sorter exhaustion reports
+# "Some resource has been exhausted" - both carry "Additional allocation failed".
+if grep -qE "Resources exhausted|resource has been exhausted|Additional allocation failed" "${LOG}"; then
+    echo "   STILL OOMs:"
+    grep -m1 -oE "Additional allocation failed for [A-Za-z]+\[[0-9]+\][^\"]{0,140}" "${LOG}" | sed 's/^/   /'
+else
+    echo "   no memory exhaustion - q97 completed."
+fi
+echo "-- q97 result rows:"
+grep -E "tpcds_q97" "${LOG}" | grep -oE "\| tpcds_q97 +\| (passed|failed).*" | head -2 | sed 's/^/   /' || grep -m2 "tpcds_q97" "${LOG}" | sed 's/^/   /'
+exit ${BENCH_EXIT}

--- a/test/local-bench/README.md
+++ b/test/local-bench/README.md
@@ -1,0 +1,60 @@
+# Local benchmark harness
+
+Reproduces the `testoperator_run_bench.yml` benchmark runs locally for the
+configurations affected by the current fixes, using the same fleet TPC-DS SF1
+dataset (DuckDB's `tpcds` dsdgen — the generator all recorded expected answers
+come from), the same seeding path (`test/tpc-bench/Makefile` targets), and the
+same runner (`testoperator run bench`).
+
+## Prerequisites
+
+- Docker (for `postgres:16` and MinIO containers)
+- `psql`/`createdb` (`brew install libpq && brew link --force libpq`)
+- A spiced binary: `cargo build --release -p spiced --features postgres,duckdb`
+
+## Usage
+
+```bash
+cd test/local-bench
+
+./10-setup-storage.sh          # start postgres:16 + MinIO   (idempotent; --reset to recreate)
+./20-populate-data.sh          # generate + load fleet SF1    (idempotent; --force to reload)
+```
+
+The spicepods hard-code `pg_port: 5432` (CI parity), so the benchmark postgres
+container must own host port 5432. If a personal PostgreSQL is running there,
+stop it first (`brew services stop postgresql@16`) — or set up only the
+non-postgres benches with `./10-setup-storage.sh minio`. The seed script only
+ever writes to the `spice-bench-postgres` container, never to another server
+that happens to be on 5432.
+
+```bash
+
+./30-run-bench.sh s3-cayenne           # eager-agg ROLLUP fix: q22/q36/q70/q86
+./30-run-bench.sh file-cayenne         # eager-agg ROLLUP fix
+./30-run-bench.sh postgres-federated   # fleet-seed fix: q17/q25/q85 zero rows
+./30-run-bench.sh postgres-arrow       # fleet-seed fix
+./30-run-bench.sh postgres-duckdb      # fleet-seed fix
+```
+
+## What "fixed" looks like
+
+Runs may still report failures from pre-existing explain-plan snapshot drift
+(`Explain plan snapshot assertion failed`) — that is cleared separately by the
+trunk-side snapshot regeneration pass. The fixes are verified when the failure
+list contains **none** of:
+
+- `Query execution failed ... col.name() == matching_name` (tpcds_q36, cayenne)
+- `Query driver task ended unexpectedly` (tpcds_q22/q70/q86, cayenne)
+- `returned 0 rows` (tpcds_q17/q25/q85, postgres configs)
+
+To view current plans instead of asserting old snapshots:
+`INSTA_UPDATE=always ./30-run-bench.sh <config>` rewrites the local `.snap`
+files (review with `git diff`, never commit unreviewed).
+
+## Cleanup
+
+```bash
+docker rm -f spice-bench-postgres spice-bench-minio
+rm -rf .work ../tpc-bench/tmp
+```

--- a/test/local-bench/q97-scenario.yaml
+++ b/test/local-bench/q97-scenario.yaml
@@ -1,0 +1,30 @@
+# TPC-DS q97 in isolation — the SF100 nightly's OOM query
+# (crates/test-framework/src/queries/tpcds/q97.sql, verbatim). Run via the
+# scenario query set so the feedback loop is one query, not the whole suite.
+name: tpcds_q97_oom_repro
+
+queries:
+  - name: tpcds_q97
+    sql: |
+      with ssci as (
+      select ss_customer_sk customer_sk
+            ,ss_item_sk item_sk
+      from store_sales,date_dim
+      where ss_sold_date_sk = d_date_sk
+        and d_month_seq between 1211 and 1211 + 11
+      group by ss_customer_sk
+              ,ss_item_sk),
+      csci as(
+       select cs_bill_customer_sk customer_sk
+            ,cs_item_sk item_sk
+      from catalog_sales,date_dim
+      where cs_sold_date_sk = d_date_sk
+        and d_month_seq between 1211 and 1211 + 11
+      group by cs_bill_customer_sk
+              ,cs_item_sk)
+       select  sum(case when ssci.customer_sk is not null and csci.customer_sk is null then 1 else 0 end) store_only
+            ,sum(case when ssci.customer_sk is null and csci.customer_sk is not null then 1 else 0 end) catalog_only
+            ,sum(case when ssci.customer_sk is not null and csci.customer_sk is not null then 1 else 0 end) store_and_catalog
+      from ssci full outer join csci on (ssci.customer_sk=csci.customer_sk
+                                     and ssci.item_sk = csci.item_sk)
+       LIMIT 100

--- a/test/local-bench/spicepod-q97-sf10.yaml
+++ b/test/local-bench/spicepod-q97-sf10.yaml
@@ -1,0 +1,45 @@
+# Local repro of the SF100 nightly q97 OOM at laptop scale.
+#
+# The failure is a ratio, not an absolute: a non-spillable hash-join build side
+# vs the query memory pool. SF10 data (build sides ~10x smaller than SF100's
+# 144M rows) with a ~10x smaller pool (5GiB vs the runner's 51GiB) reproduces
+# the same physics: without the sort-merge spill rewrite the full-outer join
+# exhausts the pool; with it, the gate fires and the query completes by
+# spilling. Only q97's three tables are accelerated so setup stays in minutes.
+#
+# Mirrors test/spicepods/tpcds/sf10/accelerated/s3[parquet]-cayenne[file].yaml
+# (same name so plans/logs read the same), pointed at the local MinIO from
+# 10-setup-storage.sh.
+version: v1
+kind: Spicepod
+name: s3[parquet]-cayenne[file]
+runtime:
+  query:
+    memory_limit: 5GiB
+    # The spilled sort-merge join runs several concurrent external sorts; under
+    # the default greedy pool they starve each other (early sorters buffer the
+    # whole pool, a late one cannot get its first allocation). Fair-spill gives
+    # each spill-capable operator its share and forces spilling at that share.
+    memory_pool: fair_spill
+datasets:
+  - from: s3://benchmarks/tpcds_sf10/store_sales/
+    name: store_sales
+    params: &s3_params
+      file_format: parquet
+      allow_http: true
+      s3_auth: key
+      s3_endpoint: ${secrets:S3_ENDPOINT}
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+    acceleration: &acceleration
+      enabled: true
+      engine: cayenne
+      mode: file
+  - from: s3://benchmarks/tpcds_sf10/catalog_sales/
+    name: catalog_sales
+    params: *s3_params
+    acceleration: *acceleration
+  - from: s3://benchmarks/tpcds_sf10/date_dim/
+    name: date_dim
+    params: *s3_params
+    acceleration: *acceleration

--- a/test/spicepods/tpcds/sf100/accelerated/s3[parquet]-cayenne[file].yaml
+++ b/test/spicepods/tpcds/sf100/accelerated/s3[parquet]-cayenne[file].yaml
@@ -1,6 +1,13 @@
 version: v1
 kind: Spicepod
 name: s3[parquet]-cayenne[file]
+runtime:
+  query:
+    # TPC-DS q97's full-outer join is rewritten to a spillable sort-merge join
+    # (crates/cayenne/src/optimizer_rules.rs); its concurrent external sorts
+    # starve each other under the default greedy pool. Fair-spill divides the
+    # budget among spill-capable operators so each spills at its share.
+    memory_pool: fair_spill
 datasets:
   - from: s3://benchmarks/tpcds_sf100/catalog_sales.parquet
     name: catalog_sales

--- a/test/tpc-bench/Makefile
+++ b/test/tpc-bench/Makefile
@@ -9,6 +9,12 @@ all: tpch-gen pg-load
 # $(TPCH_FLEET_DIR) instead, so a caller using it must pass TPCH_DATA_DIR to match.
 TPCH_DATA_DIR ?= tpch-kit/dbgen
 
+# Directory the *-tpcds-load targets read TPC-DS .dat files from. dsdgen writes to
+# tpcds-kit/tools/tmp/data (see tpcds-gen), so that is the default; tpcds-fleet-gen
+# writes to $(TPCDS_FLEET_DIR) instead, so a caller using it must pass
+# TPCDS_DATA_DIR to match.
+TPCDS_DATA_DIR ?= tpcds-kit/tools/tmp/data
+
 tpch-clone:
 	@if [ ! -d "tpch-kit" ]; then \
 		git clone https://github.com/spiceai/tpch-kit.git; \
@@ -31,11 +37,13 @@ tpch-init: tpch-clone
 
 	@echo "Initialized successfully."
 
-tpcds-init:
+tpcds-clone:
 	@if [ ! -d "tpcds-kit" ]; then \
 		git clone https://github.com/spiceai/tpcds-kit.git; \
 		cd tpcds-kit && git checkout dd01f906992e1e39837526bffb3f5b759e83b3a8; \
 	fi
+
+tpcds-init: tpcds-clone
 	@OS=`uname`; \
 	if [ -z "$(OS)" ]; then \
 		if [ "$$OS" = "Linux" ]; then \
@@ -146,6 +154,52 @@ tpch-fleet-gen: $(DUCKDB)
 	done
 	@rm -f "$(TPCH_FLEET_DIR)/gen.duckdb" "$(TPCH_FLEET_DIR)/gen.duckdb.wal"
 	@echo "Test data generated successfully in $(TPCH_FLEET_DIR) - pass TPCH_DATA_DIR=$(TPCH_FLEET_DIR) to the load targets."
+
+# tpcds-fleet-gen is the TPC-DS analog of tpch-fleet-gen above: it generates the
+# same TPC-DS dataset the rest of the benchmark fleet runs on - the s3/file
+# parquet copies and the hosted MySQL and Spice Cloud databases - which is what
+# crates/test-framework/src/queries/validation/tpcds/*.csv holds the expected
+# answers for. That dataset comes from DuckDB's tpcds extension, a
+# reimplementation whose RNG diverges from tpcds-kit's C dsdgen: schemas and row
+# counts are identical, but which customer bought which item on which ticket
+# differs, so cross-fact-table join incidence differs. Queries whose canonical
+# SF1 answers hold only 1-2 rows (q17, q25, q85 - store/catalog/web sales
+# joined to their returns) come back genuinely empty from a tpcds-kit-seeded
+# database no matter how correct the engine under test is, and value-level
+# result snapshots differ broadly. Seeding from the same generator the expected
+# answers were produced with is what makes a result mismatch mean a real bug.
+#
+# Data only - the DDL (tpcds.sql) and foreign keys (tpcds_ri.sql) still come
+# from tpcds-kit, which tpcds-clone fetches without compiling the C tools.
+# Example: DBGEN_SCALE=1 make tpcds-fleet-gen
+TPCDS_FLEET_DIR ?= ./tmp/tpcds-fleet
+
+TPCDS_TABLES = call_center catalog_page catalog_returns catalog_sales customer \
+	customer_address customer_demographics date_dim household_demographics \
+	income_band inventory item promotion reason ship_mode store store_returns \
+	store_sales time_dim warehouse web_page web_returns web_sales web_site
+
+tpcds-fleet-gen: $(DUCKDB)
+	@# Check if DBGEN_SCALE is set, else default to 1
+	$(eval DBGEN_SCALE ?= 1)
+	@mkdir -p "$(TPCDS_FLEET_DIR)"
+	@rm -f "$(TPCDS_FLEET_DIR)"/*.dat "$(TPCDS_FLEET_DIR)/gen.duckdb" "$(TPCDS_FLEET_DIR)/gen.duckdb.wal"
+	@echo "Generating TPC-DS scale factor $(DBGEN_SCALE)..."
+	@"$(DUCKDB)" "$(TPCDS_FLEET_DIR)/gen.duckdb" -c "INSTALL tpcds; LOAD tpcds; CALL dsdgen(sf=$(DBGEN_SCALE));" > /dev/null
+	@# QUOTE '' disables CSV quoting so no field is ever wrapped, and the trailing
+	@# empty column reproduces dsdgen's trailing '|'; NULLs export as empty fields,
+	@# exactly as dsdgen writes them. The result is byte-compatible with dsdgen's
+	@# .dat format, so every *-tpcds-load target reads it unchanged. Tables are
+	@# dropped as they are written to bound peak disk at the larger scales.
+	@for table in $(TPCDS_TABLES); do \
+		echo "Writing $$table.dat..."; \
+		"$(DUCKDB)" "$(TPCDS_FLEET_DIR)/gen.duckdb" -c "\
+			COPY (SELECT *, '' FROM $$table) TO '$(TPCDS_FLEET_DIR)/$$table.dat' (FORMAT CSV, DELIMITER '|', HEADER false, QUOTE ''); \
+			DROP TABLE $$table; \
+			CHECKPOINT;" > /dev/null || exit 1; \
+	done
+	@rm -f "$(TPCDS_FLEET_DIR)/gen.duckdb" "$(TPCDS_FLEET_DIR)/gen.duckdb.wal"
+	@echo "Test data generated successfully in $(TPCDS_FLEET_DIR) - pass TPCDS_DATA_DIR=$(TPCDS_FLEET_DIR) to the load targets."
 
 # Default value for DB_NAME
 DB_NAME ?= tpch
@@ -298,7 +352,7 @@ mysql-tpcds-load:
 	@mkdir -p ./tmp
 	@for table in call_center catalog_page catalog_returns catalog_sales customer customer_address customer_demographics date_dim household_demographics income_band inventory item promotion reason ship_mode store store_returns store_sales time_dim warehouse web_page web_returns web_sales web_site; do \
 		echo "Loading $$table..."; \
-		sed 's/|$$//' tpcds-kit/tools/tmp/data/$$table.dat > ./tmp/$$table.dat; \
+		sed 's/|$$//' "$(TPCDS_DATA_DIR)/$$table.dat" > ./tmp/$$table.dat; \
 		mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) -P$(DB_PORT) --local-infile=1 $(DB_NAME) -e "LOAD DATA LOCAL INFILE './tmp/$$table.dat' INTO TABLE $$table FIELDS TERMINATED BY '|' LINES TERMINATED BY '\n';"; \
 	done
 	@echo "Benchmark dataset has been successfully loaded to '$(DB_NAME)' database."
@@ -340,7 +394,7 @@ pg-tpcds-load:
 	@mkdir -p ./tmp
 	@for table in call_center catalog_page catalog_returns catalog_sales customer customer_address customer_demographics date_dim household_demographics income_band inventory item promotion reason ship_mode store store_returns store_sales time_dim warehouse web_page web_returns web_sales web_site; do \
 		echo "Loading $$table..."; \
-		sed 's/|$$//' tpcds-kit/tools/tmp/data/$$table.dat > ./tmp/$$table.dat; \
+		sed 's/|$$//' "$(TPCDS_DATA_DIR)/$$table.dat" > ./tmp/$$table.dat; \
 		psql -h $(DB_HOST) -p $(DB_PORT) -U $(DB_USER) $(DB_NAME) -c "\\copy $$table FROM './tmp/$$table.dat' CSV DELIMITER '|';"; \
 	done
 	@echo "Applying foreign keys from tpcds_ri.sql..."


### PR DESCRIPTION
Fixes the failing nightly `testoperator_run_bench.yml` benchmarks ahead of the release. Stacked on #12989 (base branch); this description covers only this branch's changes.

## Engine fixes

- **DataFusion pin → `spiceai-54` tip (`1c43ad804`)**: picks up the eager-aggregation grouping-set guard, fixing the Cayenne TPC-DS ROLLUP failures — q36's `col.name() == matching_name` internal error and the q22/q70/q86 "Query driver task ended unexpectedly" panics (#11827).
- **TPC-DS q97 at SF100 no longer OOMs** (#10965 context). Three layers, each verified against the benchmark's own gate logs:
  1. `CayenneAntiJoinSortMergeRewriter` now rewrites hash joins that carry an **embedded projection** by hoisting the projection into a `ProjectionExec` over the spillable sort-merge join (the fork's `HashJoinExec.projection` is public as of DataFusion 54). q97's full-outer join only ever appears in projected form, so the spill rewrite previously never fired for it.
  2. The build-side memory estimate adds a **fixed 64 B/row hash-table overhead** term: a multiplicative payload model predicted 20 B/row for q97's two-key build side while the run's reservations consumed hundreds of B/row, so the gate under-fired (estimated 2.9 GB vs 51 GB actual). Gate decisions and every decline path now log at `info` for on-box diagnosis.
  3. New `runtime.query.memory_pool: greedy | fair_spill` config: the rewritten join runs several concurrent external sorts, which starve each other under the greedy pool (an idle sorter holds its buffers; a late one is denied its first allocation). `fair_spill` (DataFusion's `FairSpillPool`) gives each spill-capable operator its share. Default stays `greedy`; the SF100 cayenne spicepod opts in.
- **Schema-registration race**: two datasets concurrently registering into the same not-yet-created schema could silently drop tables (`register_schema` replaces the provider wholesale). Seen as `__test_reference.nation` "not found" in the versioned-ABFS bench, flaky by timing. Now serialized, with a regression test that fails within a few rounds without the fix.

## Benchmark data & CI fixes

- **Postgres TPC-DS seeds from the fleet generator** (`tpcds-fleet-gen`, pinned DuckDB CLI): the CI seed previously used tpcds-kit's C `dsdgen`, whose RNG diverges from the DuckDB generator that produced every recorded expected answer — q17/q25/q85 (canonical SF1 answers of 1–2 rows) returned genuinely empty. Mirrors the existing `tpch-fleet-gen`.
- **Self-healing benchmark data**: the bench workflow now creates missing postgres acceleration databases (`*_accelerated`) by parsing them from the dispatched spicepod, and reseeds the hosted MongoDB TPC-H collections when empty (typed `mongoimport` so dates land as BSON dates). Both previously required out-of-band manual seeding that silently rotted.
- **Clickbench postgres-accelerator run** uses the local service container instead of the hosted cluster (its postgres is purely an acceleration target).
- **Snapshot hygiene**: `CayenneAccelerationExec: snapshots_scanned=/files_scanned=` counters are redacted in explain snapshots — they reflect compaction state, not plan structure, and re-broke snapshots on every file-count drift.

## Local reproduction harness

`test/local-bench/`: scripts that reproduce the CI benches at laptop scale (containers + fleet data + testoperator), including a q97-only SF10 scenario with a proportionally scaled memory pool that reproduces the SF100 oversized-join behavior in minutes.

## Validation

- `cargo test -p cayenne --lib optimizer_rules` 49/49; `-p runtime-datafusion --lib schema_provider` green; `-p test-framework --lib snapshot` green.
- Local SF10 q97: gate fires (`fire=true`, 1.5 GB estimate vs 640 MB gate), no memory exhaustion, 3/3 consecutive passes under `fair_spill`.
- Branch CI runs verified the postgres zero-rows and ROLLUP fixes at SF1 (no `returned 0 rows`, no execution errors; remaining failures are stale explain snapshots).

Benchmark snapshots are regenerated in a follow-up PR (CI `update_snapshots=always` pass) once this stack lands; snapshots regenerated from this branch's plans intentionally do not accompany this PR.
