### PR TITLE
refactor: narrow the DataConnector trait off the runtime's types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5998,11 +5998,14 @@ dependencies = [
 name = "data-connector-api"
 version = "2.2.0-unstable"
 dependencies = [
+ "async-trait",
  "data_components",
+ "datafusion",
  "globset",
  "runtime-component",
  "serde_json",
  "snafu",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,6 +4856,7 @@ dependencies = [
 name = "connector-sharepoint"
 version = "2.2.0-unstable"
 dependencies = [
+ "app",
  "arrow",
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4630,6 +4630,7 @@ dependencies = [
  "arrow-schema",
  "async-stream",
  "async-trait",
+ "data-connector-api",
  "data_components",
  "dataformat-json",
  "datafusion",
@@ -4701,6 +4702,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "chrono",
+ "data-connector-api",
  "data_components",
  "datafusion",
  "datafusion-table-providers",
@@ -4784,6 +4786,7 @@ version = "2.2.0-unstable"
 dependencies = [
  "async-stream",
  "async-trait",
+ "data-connector-api",
  "data_components",
  "datafusion",
  "datafusion-table-providers",

--- a/crates/data-connector-api/Cargo.toml
+++ b/crates/data-connector-api/Cargo.toml
@@ -10,11 +10,14 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+async-trait.workspace = true
 data_components = { path = "../data_components" }
+datafusion.workspace = true
 globset = { workspace = true }
 runtime-component = { path = "../runtime-component" }
 serde_json.workspace = true
 snafu.workspace = true
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/crates/data-connector-api/src/accelerated.rs
+++ b/crates/data-connector-api/src/accelerated.rs
@@ -1,0 +1,93 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! What a connector needs of the accelerated table built for its dataset.
+//!
+//! A connector gets two chances to touch a dataset's acceleration: once before
+//! the accelerated table is built, to wrap the provider the accelerator will
+//! write to ([`AcceleratorSetup`]), and once after it is registered, to attach
+//! background work to it ([`RegisteredAcceleratedTable`]).
+//!
+//! Both hooks used to take the accelerated-table types themselves — the builder
+//! and the table. Those live beside the runtime that orchestrates them, so a
+//! connector naming either would depend on the orchestrator for the sake of two
+//! getters and a `Vec::push`. Each trait here is the slice of one of those types
+//! that connectors actually reach for, so the contract names only Arrow,
+//! `DataFusion` and Tokio types. The runtime side satisfies them by forwarding.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::datasource::TableProvider;
+use snafu::Snafu;
+use tokio::task::JoinHandle;
+
+/// The accelerator being prepared for a dataset, before its accelerated table
+/// is built.
+///
+/// A connector wraps the provider here — rather than after registration — when
+/// the wrapper has to be visible to the refresh pipeline, which is handed the
+/// same provider when the table is built.
+///
+/// `Send` but not `Sync`: the hook takes `&mut dyn AcceleratorSetup`, which is
+/// `Send` on `Send` alone, and the runtime-side implementor carries a changes
+/// stream that is not `Sync`.
+pub trait AcceleratorSetup: Send {
+    /// The provider the accelerator will read and write.
+    fn accelerator(&self) -> Arc<dyn TableProvider>;
+
+    /// Replace the accelerator's provider, usually with a wrapper around the
+    /// provider [`accelerator`](Self::accelerator) returned.
+    fn set_accelerator(&mut self, accelerator: Arc<dyn TableProvider>);
+}
+
+/// A dataset's accelerated table, once it is registered and running.
+///
+/// `Send` but not `Sync`, for the same reason as [`AcceleratorSetup`].
+pub trait RegisteredAcceleratedTable: Send {
+    /// A handle that asks this table to refresh, or `None` when it has no
+    /// on-demand refresh to ask for — it is not refreshed on a schedule, or it
+    /// is synchronized with another table that drives its data.
+    fn refresh_requester(&self) -> Option<Arc<dyn RefreshRequester>>;
+
+    /// Tie `task` to this table's lifetime. The task is aborted when the table
+    /// is dropped, so a connector can spawn a watcher without having to track
+    /// the table's shutdown itself.
+    fn attach_task(&mut self, task: JoinHandle<()>);
+}
+
+/// Asks an accelerated table to refresh now.
+#[async_trait]
+pub trait RefreshRequester: Debug + Send + Sync {
+    /// Request a refresh, returning once the request is accepted — not once the
+    /// refresh completes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RefreshRequestError`] if the table is no longer listening,
+    /// which means it has been dropped or replaced.
+    async fn request_refresh(&self) -> Result<(), RefreshRequestError>;
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum RefreshRequestError {
+    #[snafu(display(
+        "The accelerated table is no longer accepting refresh requests. It has been dropped or replaced."
+    ))]
+    TableGone,
+}

--- a/crates/data-connector-api/src/accelerated.rs
+++ b/crates/data-connector-api/src/accelerated.rs
@@ -21,12 +21,12 @@ limitations under the License.
 //! write to ([`AcceleratorSetup`]), and once after it is registered, to attach
 //! background work to it ([`RegisteredAcceleratedTable`]).
 //!
-//! Both hooks used to take the accelerated-table types themselves — the builder
-//! and the table. Those live beside the runtime that orchestrates them, so a
-//! connector naming either would depend on the orchestrator for the sake of two
-//! getters and a `Vec::push`. Each trait here is the slice of one of those types
-//! that connectors actually reach for, so the contract names only Arrow,
-//! `DataFusion` and Tokio types. The runtime side satisfies them by forwarding.
+//! Each hook takes one of these traits rather than the accelerated-table type it
+//! acts on. The builder and the table live beside the runtime that orchestrates
+//! them, and a connector naming either would depend on the orchestrator to reach
+//! two getters and a `Vec::push`. Naming only the capability keeps the contract
+//! to Arrow, `DataFusion` and Tokio types; the runtime side satisfies it by
+//! forwarding.
 
 use std::fmt::Debug;
 use std::sync::Arc;

--- a/crates/data-connector-api/src/federated.rs
+++ b/crates/data-connector-api/src/federated.rs
@@ -1,0 +1,49 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! The federated table a connector's change stream reads from.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::datasource::TableProvider;
+
+/// A dataset's federated table, narrowed to the provider behind it.
+///
+/// A connector opening a changes or append stream needs one thing of the table
+/// it is streaming into: the provider, so it can recover its own concrete
+/// provider type and start reading. The table itself may not be resolved yet —
+/// a deferred dataset registers before its source is contacted — so resolving it
+/// is asynchronous.
+///
+/// This is a dependency inversion in the same spirit as `runtime-table`'s
+/// `RefreshSource`, pointing the other way: the federated table lives beside the
+/// runtime that builds it, and naming it in the connector contract would pull the
+/// orchestrator into every CDC connector for a single getter. The runtime side
+/// satisfies this by forwarding.
+#[async_trait]
+pub trait FederatedTableProvider: Debug + Send + Sync {
+    /// The provider for this table, awaiting resolution if the dataset was
+    /// registered before its source was contacted.
+    async fn table_provider(&self) -> Arc<dyn TableProvider>;
+
+    /// The provider if it is already resolved, without awaiting.
+    ///
+    /// `None` means resolution is still pending, so a caller that cannot await
+    /// — a synchronous stream-construction path — has nothing to inspect yet.
+    fn try_table_provider_sync(&self) -> Option<Arc<dyn TableProvider>>;
+}

--- a/crates/data-connector-api/src/lib.rs
+++ b/crates/data-connector-api/src/lib.rs
@@ -23,6 +23,7 @@ limitations under the License.
 //! depending on the runtime that orchestrates it.
 
 pub mod accelerated;
+pub mod federated;
 pub mod schema_projection;
 
 use std::sync::Arc;

--- a/crates/data-connector-api/src/lib.rs
+++ b/crates/data-connector-api/src/lib.rs
@@ -22,6 +22,7 @@ limitations under the License.
 //! reports ([`DataConnectorError`]), so a connector crate can name both without
 //! depending on the runtime that orchestrates it.
 
+pub mod accelerated;
 pub mod schema_projection;
 
 use std::sync::Arc;

--- a/crates/data-connectors/connector-abfs/Cargo.toml
+++ b/crates/data-connectors/connector-abfs/Cargo.toml
@@ -7,6 +7,7 @@ license-file.workspace = true
 description = "Azure Blob Filesystem (ABFS) data connector for Spice.ai runtime"
 
 [dependencies]
+app = { path = "../../app" }
 linkme.workspace = true
 object_store = { workspace = true }
 runtime = { path = "../../runtime" }
@@ -18,7 +19,6 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-app = { path = "../../app" }
 runtime-secrets = { path = "../../runtime-secrets", default-features = false }
 
 [lints]

--- a/crates/data-connectors/connector-abfs/src/lib.rs
+++ b/crates/data-connectors/connector-abfs/src/lib.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use runtime::Runtime;
+use app::App;
 use runtime::component::dataset::Dataset;
 use runtime::dataconnector::listing::{
     LISTING_TABLE_PARAMETERS, ListingTableConnector, ObjectVersionType, build_fragments,
@@ -97,7 +97,7 @@ pub enum Error {
 
 pub struct AzureBlobFS {
     params: Parameters,
-    runtime: Option<Runtime>,
+    app: Option<Arc<App>>,
     tokio_io_runtime: Handle,
 }
 
@@ -235,10 +235,10 @@ impl DataConnectorFactory for AzureBlobFSFactory {
                 validator.validate(&mut params).await?;
             }
 
-            let runtime = params.runtime().map(Arc::unwrap_or_clone);
+            let app = params.app();
             let azure = AzureBlobFS {
                 params: params.parameters,
-                runtime,
+                app,
                 tokio_io_runtime: params.io_runtime,
             };
             Ok(Arc::new(azure) as Arc<dyn DataConnector>)
@@ -333,8 +333,8 @@ impl ListingTableConnector for AzureBlobFS {
         Ok(azure_url)
     }
 
-    fn get_runtime(&self) -> Option<Runtime> {
-        self.runtime.clone()
+    fn get_app(&self) -> Option<Arc<App>> {
+        self.app.clone()
     }
 
     fn handle_object_store_error(
@@ -445,7 +445,7 @@ mod tests {
     fn create_test_connector(params: Parameters) -> AzureBlobFS {
         AzureBlobFS {
             params,
-            runtime: None,
+            app: None,
             tokio_io_runtime: Handle::current(),
         }
     }

--- a/crates/data-connectors/connector-databricks/src/lib.rs
+++ b/crates/data-connectors/connector-databricks/src/lib.rs
@@ -867,7 +867,6 @@ impl DataConnectorFactory for DatabricksFactory {
 
             Box::pin(async move {
                 let app = context.app();
-                let runtime = context.runtime();
 
                 // Initialize AWS SDK credentials if not using explicit credentials
                 if !aws_sdk_credential_bridge::has_explicit_credentials(
@@ -913,7 +912,7 @@ impl DataConnectorFactory for DatabricksFactory {
                 let rate_control_reservation = reserve_databricks_rate_controller(
                     &params.parameters,
                     Some(&app.runtime.params),
-                    runtime.http_rate_control_registry(),
+                    context.http_rate_control_registry(),
                     &params.component,
                     app.name.as_str(),
                 )
@@ -925,7 +924,7 @@ impl DataConnectorFactory for DatabricksFactory {
                 let databricks_result = Databricks::new(
                     params.parameters,
                     params.io_runtime,
-                    runtime.token_provider_registry(),
+                    context.token_provider_registry(),
                     shared_semaphore,
                     rate_controller,
                 )

--- a/crates/data-connectors/connector-delta-lake/src/lib.rs
+++ b/crates/data-connectors/connector-delta-lake/src/lib.rs
@@ -154,7 +154,7 @@ impl DataConnectorFactory for DeltaLakeFactory {
                 );
             }
 
-            let parquet_opts = build_table_parquet_options(params.app())?;
+            let parquet_opts = build_table_parquet_options(params.app().as_ref())?;
 
             tracing::debug!(
                 ?parquet_opts,

--- a/crates/data-connectors/connector-delta-lake/src/lib.rs
+++ b/crates/data-connectors/connector-delta-lake/src/lib.rs
@@ -154,8 +154,7 @@ impl DataConnectorFactory for DeltaLakeFactory {
                 );
             }
 
-            let runtime = params.runtime();
-            let parquet_opts = build_table_parquet_options(runtime.as_deref()).await?;
+            let parquet_opts = build_table_parquet_options(params.app())?;
 
             tracing::debug!(
                 ?parquet_opts,

--- a/crates/data-connectors/connector-dynamodb/src/connector.rs
+++ b/crates/data-connectors/connector-dynamodb/src/connector.rs
@@ -22,6 +22,7 @@ use data_components::cdc::{
     ChangeEnvelope, ChangesStream, CommitChange, CommitError, InitialSnapshotMode,
     InvalidCheckpointBehavior, NoOpCommitter,
 };
+use data_connector_api::federated::FederatedTableProvider;
 use data_connector_api::schema_projection::{ProjectionPolicy, parse_schema_projection};
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
@@ -35,7 +36,6 @@ use runtime::dataconnector::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
     parameters::aws::initiate_config_with_auth_method,
 };
-use runtime::federated::FederatedTable;
 use runtime_api_types::v1::ComponentType;
 use runtime_checkpoint_api::BlobCheckpointStore;
 use runtime_metrics::component::{MetricSpec, MetricType, MetricsProvider, ObserveMetricCallback};
@@ -455,7 +455,7 @@ impl DataConnector for DynamoDB {
 
     fn changes_stream(
         &self,
-        federated_table: Arc<FederatedTable>,
+        federated_table: Arc<dyn FederatedTableProvider>,
         dataset: &Dataset,
     ) -> Option<ChangesStream> {
         let dataset = dataset.clone();

--- a/crates/data-connectors/connector-gcs/Cargo.toml
+++ b/crates/data-connectors/connector-gcs/Cargo.toml
@@ -7,6 +7,7 @@ license-file.workspace = true
 description = "Google Cloud Storage (GCS) data connector for Spice.ai runtime"
 
 [dependencies]
+app = { path = "../../app" }
 linkme.workspace = true
 object_store = { workspace = true }
 runtime = { path = "../../runtime" }
@@ -16,7 +17,6 @@ tokio.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-app = { path = "../../app" }
 runtime-secrets = { path = "../../runtime-secrets", default-features = false }
 secrecy.workspace = true
 

--- a/crates/data-connectors/connector-gcs/src/lib.rs
+++ b/crates/data-connectors/connector-gcs/src/lib.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use runtime::Runtime;
+use app::App;
 use runtime::component::dataset::Dataset;
 use runtime::dataconnector::listing::{
     LISTING_TABLE_PARAMETERS, ListingTableConnector, ObjectVersionType, build_fragments,
@@ -78,7 +78,7 @@ pub enum Error {
 
 pub struct GoogleCloudStorage {
     params: Parameters,
-    runtime: Option<Runtime>,
+    app: Option<Arc<App>>,
     tokio_io_runtime: Handle,
 }
 
@@ -156,10 +156,10 @@ impl DataConnectorFactory for GoogleCloudStorageFactory {
                 validator.validate(&mut params).await?;
             }
 
-            let runtime = params.runtime().map(Arc::unwrap_or_clone);
+            let app = params.app();
             let gcs = GoogleCloudStorage {
                 params: params.parameters,
-                runtime,
+                app,
                 tokio_io_runtime: params.io_runtime,
             };
             Ok(Arc::new(gcs) as Arc<dyn DataConnector>)
@@ -235,8 +235,8 @@ impl ListingTableConnector for GoogleCloudStorage {
         Ok(gcs_url)
     }
 
-    fn get_runtime(&self) -> Option<Runtime> {
-        self.runtime.clone()
+    fn get_app(&self) -> Option<Arc<App>> {
+        self.app.clone()
     }
 
     fn handle_object_store_error(
@@ -347,7 +347,7 @@ mod tests {
     fn create_test_connector(params: Parameters) -> GoogleCloudStorage {
         GoogleCloudStorage {
             params,
-            runtime: None,
+            app: None,
             tokio_io_runtime: Handle::current(),
         }
     }

--- a/crates/data-connectors/connector-graphql/src/lib.rs
+++ b/crates/data-connectors/connector-graphql/src/lib.rs
@@ -113,10 +113,8 @@ impl DataConnectorFactory for GraphQLFactory {
         Box::pin(async move {
             let runtime_rate_control_params = params.app().map(|app| app.runtime.params.clone());
             let rate_control_registry = params
-                .runtime()
-                .map_or_else(http_rate_control::global_registry, |runtime| {
-                    runtime.http_rate_control_registry()
-                });
+                .http_rate_control_registry()
+                .unwrap_or_else(http_rate_control::global_registry);
             let (metrics, emit_rate_control_metrics, rate_control_metric_source) =
                 if let ConnectorComponent::Dataset(dataset) = &params.component {
                     Url::parse(dataset.path()).map_or_else(

--- a/crates/data-connectors/connector-kafka/Cargo.toml
+++ b/crates/data-connectors/connector-kafka/Cargo.toml
@@ -11,6 +11,7 @@ linkme.workspace = true
 arrow-schema.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
+data-connector-api = { path = "../../data-connector-api" }
 data_components = { path = "../../data_components", features = ["kafka"] }
 dataformat-json = { path = "../../dataformat-json" }
 datafusion.workspace = true

--- a/crates/data-connectors/connector-kafka/src/lib.rs
+++ b/crates/data-connectors/connector-kafka/src/lib.rs
@@ -24,6 +24,7 @@ use data_components::{
     cdc::{ChangesStream, CommitError},
     kafka::{KafkaConfig, KafkaConsumer, KafkaMetrics, KafkaOffset, KafkaOffsetCommitHook},
 };
+use data_connector_api::federated::FederatedTableProvider;
 use dataformat_json::{SpiceJsonOptions, unnest_struct_schema};
 use datafusion::catalog::TableProvider;
 use futures::StreamExt;
@@ -35,7 +36,6 @@ use runtime::{
         DataConnectorResult, InvalidConfigurationNoSourceSnafu, NewDataConnectorResult,
         UnableToGetReadProviderSnafu, parameters::ConnectorParams,
     },
-    federated::FederatedTable,
 };
 use runtime_api_types::v1::ComponentType;
 use runtime_datafusion::refresh_sql;
@@ -413,7 +413,10 @@ impl DataConnector for Kafka {
         true
     }
 
-    fn append_stream(&self, federated_table: Arc<FederatedTable>) -> Option<ChangesStream> {
+    fn append_stream(
+        &self,
+        federated_table: Arc<dyn FederatedTableProvider>,
+    ) -> Option<ChangesStream> {
         Some(Box::pin(stream! {
             let table_provider = federated_table.table_provider().await;
             let Some(kafka) = table_provider.downcast_ref::<data_components::kafka::Kafka>() else {

--- a/crates/data-connectors/connector-mongodb/src/changes.rs
+++ b/crates/data-connectors/connector-mongodb/src/changes.rs
@@ -23,6 +23,7 @@ use data_components::cdc::{
     ChangeEnvelope, ChangesStream, CommitChange, CommitError, NoOpCommitter, StreamError,
     build_ready_signal_envelope, wrap_data_as_change_batch,
 };
+use data_connector_api::federated::FederatedTableProvider;
 use data_connector_api::schema_projection::{ProjectionPolicy, parse_schema_projection};
 use datafusion::{
     arrow::datatypes::SchemaRef, datasource::TableProvider,
@@ -45,7 +46,6 @@ use runtime::{
         OpenOption,
         mongodb::{MongoCheckpointMetadata, MongoSys},
     },
-    federated::FederatedTable,
 };
 use runtime_parameters::{ExposedParamLookup, Parameters};
 use std::{sync::Arc, time::Duration};
@@ -60,7 +60,7 @@ pub fn build_changes_stream(
     pool: Arc<MongoDBConnectionPool>,
     params: Parameters,
     dataset: Dataset,
-    federated_table: Arc<FederatedTable>,
+    federated_table: Arc<dyn FederatedTableProvider>,
 ) -> ChangesStream {
     // `try_stream!` keeps MongoDB cursor polling, snapshot reads, and commit-aware
     // CDC yields in one backpressured stream; a spawned channel would risk buffering

--- a/crates/data-connectors/connector-mongodb/src/lib.rs
+++ b/crates/data-connectors/connector-mongodb/src/lib.rs
@@ -28,6 +28,7 @@ pub mod stream;
 
 use async_trait::async_trait;
 use data_components::inferred_schema::{InferredIndex, InferredSchema, InferredSortColumn};
+use data_connector_api::federated::FederatedTableProvider;
 use data_connector_api::schema_projection::{ProjectionPolicy, parse_schema_projection};
 use datafusion::datasource::TableProvider;
 use datafusion_table_providers::mongodb::{
@@ -40,7 +41,6 @@ use runtime::dataconnector::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
     DataConnectorResult,
 };
-use runtime::federated::FederatedTable;
 use runtime_parameters::{ParameterSpec, Parameters};
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
@@ -798,7 +798,7 @@ impl DataConnector for MongoDB {
 
     fn changes_stream(
         &self,
-        federated_table: Arc<FederatedTable>,
+        federated_table: Arc<dyn FederatedTableProvider>,
         dataset: &Dataset,
     ) -> Option<data_components::cdc::ChangesStream> {
         Some(changes::build_changes_stream(

--- a/crates/data-connectors/connector-mysql/Cargo.toml
+++ b/crates/data-connectors/connector-mysql/Cargo.toml
@@ -26,6 +26,7 @@ description = "MySQL data connector for Spice.ai runtime"
 async-stream.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
+data-connector-api = { path = "../../data-connector-api" }
 data_components = { path = "../../data_components", features = ["mysql"] }
 datafusion.workspace = true
 datafusion-table-providers = { workspace = true, features = ["mysql", "mysql-federation"] }

--- a/crates/data-connectors/connector-mysql/src/lib.rs
+++ b/crates/data-connectors/connector-mysql/src/lib.rs
@@ -612,7 +612,7 @@ impl DataConnector for MySQL {
 
     fn changes_stream(
         &self,
-        federated_table: Arc<runtime::federated::FederatedTable>,
+        federated_table: Arc<dyn data_connector_api::federated::FederatedTableProvider>,
         dataset: &Dataset,
     ) -> Option<data_components::cdc::ChangesStream> {
         Some(replication::build_changes_stream(

--- a/crates/data-connectors/connector-mysql/src/replication.rs
+++ b/crates/data-connectors/connector-mysql/src/replication.rs
@@ -36,6 +36,7 @@ use data_components::mysql_replication::{
     ReplicationMetrics, ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput,
     StoreError, derive_server_id, process_nonce, start_replication_stream,
 };
+use data_connector_api::federated::FederatedTableProvider;
 use datafusion::sql::TableReference;
 use futures::StreamExt;
 use mysql_async::{Opts, OptsBuilder, SslOpts};
@@ -45,7 +46,6 @@ use runtime::dataaccelerator::spice_sys::{
     OpenOption,
     mysql_binlog::{MySqlBinlogCheckpoint, MySqlBinlogSys},
 };
-use runtime::federated::FederatedTable;
 use runtime_metrics::component::{MetricSpec, MetricType, ObserveMetricCallback};
 use runtime_parameters::Parameters;
 use std::collections::hash_map::DefaultHasher;
@@ -58,7 +58,7 @@ const MAX_BOOTSTRAP_BATCH_SIZE: usize = 1_048_576;
 pub fn build_changes_stream(
     params: &Parameters,
     dataset: &Dataset,
-    federated_table: Arc<FederatedTable>,
+    federated_table: Arc<dyn FederatedTableProvider>,
     metrics: Arc<ReplicationMetricsCollector>,
 ) -> ChangesStream {
     let dataset_name = dataset.name.to_string();

--- a/crates/data-connectors/connector-postgres/Cargo.toml
+++ b/crates/data-connectors/connector-postgres/Cargo.toml
@@ -28,6 +28,7 @@ async-stream.workspace = true
 async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+data-connector-api = { path = "../../data-connector-api" }
 data_components = { path = "../../data_components", features = ["postgres"] }
 datafusion.workspace = true
 datafusion-table-providers = { workspace = true, features = ["postgres", "postgres-federation"] }

--- a/crates/data-connectors/connector-postgres/src/lib.rs
+++ b/crates/data-connectors/connector-postgres/src/lib.rs
@@ -1078,7 +1078,7 @@ impl DataConnector for Postgres {
 
     fn changes_stream(
         &self,
-        federated_table: Arc<runtime::federated::FederatedTable>,
+        federated_table: Arc<dyn data_connector_api::federated::FederatedTableProvider>,
         dataset: &Dataset,
     ) -> Option<data_components::cdc::ChangesStream> {
         Some(replication::build_changes_stream(

--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -32,11 +32,11 @@ use data_components::postgres_replication::{
     ReplicationMetrics, ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput,
     SchemaEvolutionPolicy, config, start_replication_stream,
 };
+use data_connector_api::federated::FederatedTableProvider;
 use datafusion::sql::TableReference;
 use futures::StreamExt;
 use opentelemetry::KeyValue;
 use runtime::component::dataset::Dataset;
-use runtime::federated::FederatedTable;
 use runtime_api_types::v1::ComponentType;
 use runtime_metrics::component::{MetricSpec, MetricType, MetricsProvider, ObserveMetricCallback};
 use runtime_parameters::{ExposedParamLookup, Parameters};
@@ -148,7 +148,7 @@ impl AppliedLsnStore for SidecarAppliedLsnStore {
 pub fn build_changes_stream(
     params: &Parameters,
     dataset: &Dataset,
-    federated_table: Arc<FederatedTable>,
+    federated_table: Arc<dyn FederatedTableProvider>,
     metrics: Arc<ReplicationMetricsCollector>,
 ) -> ChangesStream {
     let dataset_name = dataset.name.to_string();

--- a/crates/data-connectors/connector-sharepoint/Cargo.toml
+++ b/crates/data-connectors/connector-sharepoint/Cargo.toml
@@ -7,6 +7,7 @@ license-file.workspace = true
 description = "SharePoint data connector for Spice.ai runtime"
 
 [dependencies]
+app = { path = "../../app" }
 arrow.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true

--- a/crates/data-connectors/connector-sharepoint/src/lib.rs
+++ b/crates/data-connectors/connector-sharepoint/src/lib.rs
@@ -47,12 +47,13 @@ use crate::sharepoint::object_store::{
 };
 use crate::sharepoint::table::SharepointTableProvider;
 use crate::sharepoint::url::DriveRef;
+use app::App;
 use async_trait::async_trait;
 use datafusion::datasource::TableProvider;
+use datafusion::execution::context::SessionContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use document_parse::DocumentParser;
 use graph_rs_sdk::GraphClient;
-use runtime::Runtime;
 use runtime::component::dataset::Dataset;
 use runtime::dataconnector::listing::{
     LISTING_TABLE_PARAMETERS, ListingTableConnector, ObjectVersionType,
@@ -119,7 +120,10 @@ pub struct Sharepoint {
     client: Arc<GraphClient>,
     params: Parameters,
     tokio_io_runtime: tokio::runtime::Handle,
-    runtime: Option<Runtime>,
+    app: Option<Arc<App>>,
+    /// The runtime's own session, whose `RuntimeEnv` is where a store must be
+    /// registered for a scan against the registered `ListingTable` to resolve it.
+    datafusion_session_context: Option<Arc<SessionContext>>,
 }
 
 impl fmt::Debug for Sharepoint {
@@ -140,7 +144,8 @@ impl Sharepoint {
     async fn new(
         params: Parameters,
         tokio_io_runtime: tokio::runtime::Handle,
-        runtime: Option<Runtime>,
+        app: Option<Arc<App>>,
+        datafusion_session_context: Option<Arc<SessionContext>>,
     ) -> Result<Self> {
         let auth = build_auth_from_params(&params)?;
         let client = auth.build_graph_client().await.context(AuthBuildSnafu)?;
@@ -148,7 +153,8 @@ impl Sharepoint {
             client,
             params,
             tokio_io_runtime,
-            runtime,
+            app,
+            datafusion_session_context,
         })
     }
 
@@ -217,10 +223,10 @@ impl Sharepoint {
         // register_object_stores() is only called on the cluster path, not on the
         // normal single-node dataset init path, so this is the only place where the
         // collision is reliably caught in the standard runtime.
-        if let Some(rt) = &self.runtime {
+        if let Some(session_context) = &self.datafusion_session_context {
             let fingerprint = store_fingerprint(&self.params, kind, &config);
             let key_url = registry_key_for(&store_url);
-            let env_id = Arc::as_ptr(&rt.datafusion().ctx.runtime_env()) as usize;
+            let env_id = Arc::as_ptr(&session_context.runtime_env()) as usize;
             let map_key = (env_id, key_url.clone());
             let fps = SHAREPOINT_STORE_FINGERPRINTS
                 .lock()
@@ -256,7 +262,8 @@ impl Sharepoint {
             config,
             params,
             tokio_io_runtime: self.tokio_io_runtime.clone(),
-            runtime: self.runtime.clone(),
+            app: self.app.clone(),
+            datafusion_session_context: self.datafusion_session_context.clone(),
         })
     }
 }
@@ -710,8 +717,10 @@ impl DataConnectorFactory for SharepointFactory {
     ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>> {
         Box::pin(async move {
             let io_runtime = params.io_runtime.clone();
-            let runtime = params.runtime().map(Arc::unwrap_or_clone);
-            let connector = Sharepoint::new(params.parameters, io_runtime, runtime).await?;
+            let app = params.app();
+            let session_context = params.datafusion_session_context();
+            let connector =
+                Sharepoint::new(params.parameters, io_runtime, app, session_context).await?;
             Ok(Arc::new(connector) as Arc<dyn DataConnector>)
         })
     }
@@ -849,7 +858,8 @@ struct SharepointListingConnector {
     config: SharepointObjectStoreConfig,
     params: Parameters,
     tokio_io_runtime: tokio::runtime::Handle,
-    runtime: Option<Runtime>,
+    app: Option<Arc<App>>,
+    datafusion_session_context: Option<Arc<SessionContext>>,
 }
 
 impl fmt::Debug for SharepointListingConnector {
@@ -888,8 +898,8 @@ impl ListingTableConnector for SharepointListingConnector {
         self.tokio_io_runtime.clone()
     }
 
-    fn get_runtime(&self) -> Option<Runtime> {
-        self.runtime.clone()
+    fn get_app(&self) -> Option<Arc<App>> {
+        self.app.clone()
     }
 
     fn object_versioning_type(&self) -> Option<ObjectVersionType> {
@@ -957,8 +967,7 @@ impl ListingTableConnector for SharepointListingConnector {
         // Record the fingerprint after registering so that listing_connector()'s
         // collision check can find it on the next dataset — without this the map
         // stays empty on the single-node path and the check never fires.
-        if let Some(rt) = &self.runtime {
-            let ctx = Arc::clone(&rt.datafusion().ctx);
+        if let Some(ctx) = self.datafusion_session_context.clone() {
             let key_url = registry_key_for(&self.store_url);
             let fingerprint = store_fingerprint(&self.params, self.kind, &self.config);
             let env_id = Arc::as_ptr(&ctx.runtime_env()) as usize;

--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -29,6 +29,10 @@ use arrow::error::ArrowError;
 use async_trait::async_trait;
 use data_accelerator_api::{BootstrapStatus, get_primary_keys_from_constraints};
 use data_components::cdc::ChangesStream;
+use data_connector_api::accelerated::{
+    AcceleratorSetup, RefreshRequestError, RefreshRequester, RegisteredAcceleratedTable,
+    TableGoneSnafu,
+};
 use datafusion::catalog::Session;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::TableProviderFilterPushDown;
@@ -1511,6 +1515,44 @@ impl Drop for AcceleratedTable {
         for handler in self.handlers.drain(..) {
             handler.abort();
         }
+    }
+}
+
+impl AcceleratorSetup for Builder {
+    fn accelerator(&self) -> Arc<dyn TableProvider> {
+        self.get_accelerator()
+    }
+
+    fn set_accelerator(&mut self, accelerator: Arc<dyn TableProvider>) {
+        Builder::set_accelerator(self, accelerator);
+    }
+}
+
+impl RegisteredAcceleratedTable for AcceleratedTable {
+    fn refresh_requester(&self) -> Option<Arc<dyn RefreshRequester>> {
+        self.refresh_trigger()
+            .cloned()
+            .map(|trigger| Arc::new(RefreshTrigger { trigger }) as Arc<dyn RefreshRequester>)
+    }
+
+    fn attach_task(&mut self, task: JoinHandle<()>) {
+        self.handlers.push(task);
+    }
+}
+
+/// [`RefreshRequester`] over an accelerated table's refresh-trigger channel.
+///
+/// A request carries no overrides: the connector-side callers ask for the
+/// dataset's configured refresh, not a modified one.
+#[derive(Debug)]
+struct RefreshTrigger {
+    trigger: mpsc::Sender<Option<RefreshOverrides>>,
+}
+
+#[async_trait]
+impl RefreshRequester for RefreshTrigger {
+    async fn request_refresh(&self) -> Result<(), RefreshRequestError> {
+        self.trigger.send(None).await.ok().context(TableGoneSnafu)
     }
 }
 

--- a/crates/runtime-table/src/federated/mod.rs
+++ b/crates/runtime-table/src/federated/mod.rs
@@ -43,7 +43,9 @@ use tokio_util::sync::CancellationToken;
 use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
 
 use crate::refresh_source::RefreshSource;
+use async_trait::async_trait;
 use data_connector_api::DataConnectorError;
+use data_connector_api::federated::FederatedTableProvider;
 use runtime_component::dataset::{DatasetSpec, OnSchemaChange, acceleration::RefreshMode};
 use runtime_component::schema_evolution::{
     SCHEMA_EVOLUTION_DETECTED, SCHEMA_EVOLUTION_FAILED, dataset_constraint_columns,
@@ -616,5 +618,16 @@ impl FederatedTable {
             dataset_name: dataset_name_str,
             schema_change_failure: None,
         }
+    }
+}
+
+#[async_trait]
+impl FederatedTableProvider for FederatedTable {
+    async fn table_provider(&self) -> Arc<dyn TableProvider> {
+        FederatedTable::table_provider(self).await
+    }
+
+    fn try_table_provider_sync(&self) -> Option<Arc<dyn TableProvider>> {
+        FederatedTable::try_table_provider_sync(self)
     }
 }

--- a/crates/runtime-table/src/refresh_source.rs
+++ b/crates/runtime-table/src/refresh_source.rs
@@ -36,12 +36,17 @@ limitations under the License.
 //! forwarding. What it buys is that the accelerated-table crate compiles without
 //! the `DataConnector` trait, and therefore without `runtime`.
 //!
-//! When `DataConnector` itself moves below `runtime` (plan step 5.4 — it needs
-//! `&Dataset` retyped to `&DatasetSpec` across 8 of its 16 methods and 45
-//! implementors, and its two accelerated-table hooks split into a runtime-side
-//! extension trait), this trait either collapses into a plain `DataConnector`
-//! bound or stays on as the narrower interface at the point of use. Either way
-//! the runtime-side adapter goes away, and nothing here has to change first.
+//! `data-connector-api` now carries the same inversion pointing the other way:
+//! `FederatedTableProvider` is what a *connector* needs of a federated table, and
+//! this crate satisfies it for [`FederatedTable`](crate::federated::FederatedTable).
+//!
+//! When `DataConnector` itself moves below `runtime`, this trait either collapses
+//! into a plain `DataConnector` bound or stays on as the narrower interface at the
+//! point of use. Either way the runtime-side adapter goes away, and nothing here
+//! has to change first. What still blocks that move is the three methods handing
+//! back a provider — `read_provider`, `read_write_provider` and `changes_stream` —
+//! which take the bound `Dataset` because a connector may reach the accelerator's
+//! `spice_sys` state (the CDC checkpoint stores) through it.
 
 use std::sync::Arc;
 

--- a/crates/runtime/src/dataconnector/cdc_ingest.rs
+++ b/crates/runtime/src/dataconnector/cdc_ingest.rs
@@ -49,6 +49,7 @@ use crate::component::dataset::{
     acceleration::{Engine, RefreshMode},
 };
 use crate::federated::FederatedTable;
+use data_connector_api::federated::FederatedTableProvider;
 
 use super::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorFactory, ParameterSpec,
@@ -433,7 +434,7 @@ impl DataConnector for CdcIngest {
 
     fn changes_stream(
         &self,
-        federated_table: Arc<FederatedTable>,
+        federated_table: Arc<dyn FederatedTableProvider>,
         dataset: &Dataset,
     ) -> Option<ChangesStream> {
         let dataset_name = dataset.name.to_string();

--- a/crates/runtime/src/dataconnector/cdc_ingest.rs
+++ b/crates/runtime/src/dataconnector/cdc_ingest.rs
@@ -48,7 +48,6 @@ use crate::component::dataset::{
     Dataset,
     acceleration::{Engine, RefreshMode},
 };
-use crate::federated::FederatedTable;
 use data_connector_api::federated::FederatedTableProvider;
 
 use super::{

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -25,7 +25,6 @@ use crate::dataconnector::{
     kafka::{SidecarOffsetCommitHook, SidecarOffsetStore},
 };
 use crate::datafusion::refresh_sql;
-use crate::federated::FederatedTable;
 use crate::schema_evolution::{
     SCHEMA_EVOLUTION_APPLIED, SCHEMA_EVOLUTION_DETECTED, SCHEMA_EVOLUTION_FAILED,
     evolution_allowed, schema_evolution_labels, widening_plan_kind,

--- a/crates/runtime/src/dataconnector/debezium.rs
+++ b/crates/runtime/src/dataconnector/debezium.rs
@@ -40,6 +40,7 @@ use data_components::debezium::{self, change_event};
 use data_components::debezium_kafka::DebeziumKafka;
 use data_components::kafka::{KafkaConfig, KafkaConsumer, KafkaMetrics, KafkaOffset};
 use data_components::schema_discovery::merge_inferred_and_declared_schemas;
+use data_connector_api::federated::FederatedTableProvider;
 use datafusion::datasource::TableProvider;
 use futures::StreamExt;
 use runtime_metrics::component::MetricsProvider;
@@ -564,7 +565,7 @@ impl DataConnector for Debezium {
 
     fn changes_stream(
         &self,
-        federated_table: Arc<FederatedTable>,
+        federated_table: Arc<dyn FederatedTableProvider>,
         _dataset: &Dataset,
     ) -> Option<ChangesStream> {
         Some(Box::pin(stream! {

--- a/crates/runtime/src/dataconnector/deferred.rs
+++ b/crates/runtime/src/dataconnector/deferred.rs
@@ -105,7 +105,7 @@ impl DataConnector for DeferredConnector {
 
     fn changes_stream(
         &self,
-        _federated_table: Arc<crate::federated::FederatedTable>,
+        _federated_table: Arc<dyn data_connector_api::federated::FederatedTableProvider>,
         _dataset: &Dataset,
     ) -> Option<data_components::cdc::ChangesStream> {
         None
@@ -117,7 +117,7 @@ impl DataConnector for DeferredConnector {
 
     fn append_stream(
         &self,
-        _federated_table: Arc<crate::federated::FederatedTable>,
+        _federated_table: Arc<dyn data_connector_api::federated::FederatedTableProvider>,
     ) -> Option<data_components::cdc::ChangesStream> {
         None
     }

--- a/crates/runtime/src/dataconnector/deferred.rs
+++ b/crates/runtime/src/dataconnector/deferred.rs
@@ -132,15 +132,15 @@ impl DataConnector for DeferredConnector {
     async fn on_accelerator_setup(
         &self,
         dataset: &Dataset,
-        builder: &mut crate::accelerated::Builder,
+        accelerator: &mut dyn data_connector_api::accelerated::AcceleratorSetup,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        self.inner.on_accelerator_setup(dataset, builder).await
+        self.inner.on_accelerator_setup(dataset, accelerator).await
     }
 
     async fn on_accelerated_table_registration(
         &self,
         dataset: &Dataset,
-        accelerated_table: &mut crate::accelerated::AcceleratedTable,
+        accelerated_table: &mut dyn data_connector_api::accelerated::RegisteredAcceleratedTable,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.inner
             .on_accelerated_table_registration(dataset, accelerated_table)

--- a/crates/runtime/src/dataconnector/file.rs
+++ b/crates/runtime/src/dataconnector/file.rs
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::accelerated::AcceleratedTable;
 use crate::component::dataset::Dataset;
 use crate::dataconnector::ConnectorComponent;
 use crate::dataconnector::listing::LISTING_TABLE_PARAMETERS;
 use async_trait::async_trait;
+use data_connector_api::accelerated::RegisteredAcceleratedTable;
 
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use snafu::prelude::*;
@@ -150,13 +150,12 @@ impl ListingTableConnector for File {
 
     /// Set up a file watcher to refresh the accelerated table when the file is updated.
     ///
-    /// Spawns an async top-level Tokio task to watch the file(s) and adds it to the join
-    /// handles of the `AcceleratedTable`. When the `AcceleratedTable` is dropped, the file
-    /// watcher is aborted.
+    /// Spawns an async top-level Tokio task to watch the file(s) and attaches it to the
+    /// accelerated table, so the watcher is aborted when that table is dropped.
     async fn on_accelerated_table_registration(
         &self,
         dataset: &Dataset,
-        accelerated_table: &mut AcceleratedTable,
+        accelerated_table: &mut dyn RegisteredAcceleratedTable,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Only enable the file watcher if the acceleration has the file_watcher parameter set to "enabled"
         let enabled = dataset.acceleration.as_ref().is_some_and(|acceleration| {
@@ -173,7 +172,7 @@ impl ListingTableConnector for File {
 
         let path = get_path(dataset);
         let (tx, mut rx) = mpsc::channel(100);
-        let Some(refresh_trigger) = accelerated_table.refresh_trigger().cloned() else {
+        let Some(refresh_requester) = accelerated_table.refresh_requester() else {
             return Ok(());
         };
 
@@ -219,7 +218,7 @@ impl ListingTableConnector for File {
                             continue;
                         }
                         tracing::debug!("Triggering refresh for file {}", path.display());
-                        if let Err(e) = refresh_trigger.send(None).await {
+                        if let Err(e) = refresh_requester.request_refresh().await {
                             tracing::error!("Failed to trigger refresh: {e}");
                         }
                         last_refresh = Instant::now();
@@ -229,7 +228,7 @@ impl ListingTableConnector for File {
             }
         });
 
-        accelerated_table.handlers.push(watcher_task);
+        accelerated_table.attach_task(watcher_task);
 
         Ok(())
     }

--- a/crates/runtime/src/dataconnector/glue.rs
+++ b/crates/runtime/src/dataconnector/glue.rs
@@ -533,7 +533,7 @@ async fn create_s3_provider(
     params.insert("file_format".into(), input_format.file_format().into());
     let s3 = S3 {
         params,
-        runtime: Some(Arc::unwrap_or_clone(dataset.runtime())),
+        app: Some(dataset.app()),
         tokio_io_runtime,
     };
 

--- a/crates/runtime/src/dataconnector/https.rs
+++ b/crates/runtime/src/dataconnector/https.rs
@@ -1780,10 +1780,8 @@ impl DataConnectorFactory for HttpsFactory {
         Box::pin(async move {
             let runtime_rate_control_params = params.app().map(|app| app.runtime.params.clone());
             let rate_control_registry = params
-                .runtime()
-                .map_or_else(http_rate_control::global_registry, |runtime| {
-                    runtime.http_rate_control_registry()
-                });
+                .http_rate_control_registry()
+                .unwrap_or_else(http_rate_control::global_registry);
             let (metrics, emit_rate_control_metrics, rate_control_metric_source) =
                 if let ConnectorComponent::Dataset(dataset) = &params.component {
                     let structured_format = {

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -3025,33 +3025,27 @@ mod tests {
         assert_eq!(get_url_prefix(&url), "file:///");
     }
 
-    #[tokio::test]
-    async fn test_parquet_page_index_options_default() {
-        let app = app::AppBuilder::new("test").build();
-        let runtime = crate::Runtime::builder()
-            .with_app_opt(Some(Arc::new(app)))
-            .build()
-            .await;
+    #[test]
+    fn test_parquet_page_index_options_default() {
+        let app = Arc::new(app::AppBuilder::new("test").build());
 
-        let options = parquet_page_index_options(&runtime).await;
+        let options = parquet_page_index_options(&app);
         assert!(options.enable_page_index);
     }
 
-    #[tokio::test]
-    async fn test_parquet_page_index_options_auto() {
+    #[test]
+    fn test_parquet_page_index_options_auto() {
         let mut params = std::collections::HashMap::new();
         params.insert("parquet_page_index".to_string(), "auto".to_string());
-        let app = app::AppBuilder::new("test")
-            .with_runtime_params(params)
-            .build();
-        let runtime = crate::Runtime::builder()
-            .with_app_opt(Some(Arc::new(app)))
-            .build()
-            .await;
+        let app = Arc::new(
+            app::AppBuilder::new("test")
+                .with_runtime_params(params)
+                .build(),
+        );
 
         // "auto" and "required" now behave the same since tolerate_missing_page_index
         // was removed in DataFusion v51. Page index reading handles missing indexes gracefully.
-        let options = parquet_page_index_options(&runtime).await;
+        let options = parquet_page_index_options(&app);
         assert!(options.enable_page_index);
     }
 
@@ -3157,52 +3151,48 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_parquet_page_index_options_skip() {
+    #[test]
+    fn test_parquet_page_index_options_skip() {
         let mut params = std::collections::HashMap::new();
         params.insert("parquet_page_index".to_string(), "skip".to_string());
-        let app = app::AppBuilder::new("test")
-            .with_runtime_params(params)
-            .build();
-        let runtime = crate::Runtime::builder()
-            .with_app_opt(Some(Arc::new(app)))
-            .build()
-            .await;
+        let app = Arc::new(
+            app::AppBuilder::new("test")
+                .with_runtime_params(params)
+                .build(),
+        );
 
-        let options = parquet_page_index_options(&runtime).await;
+        let options = parquet_page_index_options(&app);
         assert!(!options.enable_page_index);
     }
 
-    #[tokio::test]
-    async fn test_parquet_page_index_options_required() {
+    #[test]
+    fn test_parquet_page_index_options_required() {
         let mut params = std::collections::HashMap::new();
         params.insert("parquet_page_index".to_string(), "required".to_string());
-        let app = app::AppBuilder::new("test")
-            .with_runtime_params(params)
-            .build();
-        let runtime = crate::Runtime::builder()
-            .with_app_opt(Some(Arc::new(app)))
-            .build()
-            .await;
+        let app = Arc::new(
+            app::AppBuilder::new("test")
+                .with_runtime_params(params)
+                .build(),
+        );
 
-        let options = parquet_page_index_options(&runtime).await;
+        let options = parquet_page_index_options(&app);
         assert!(options.enable_page_index);
     }
 
-    #[tokio::test]
-    async fn test_parquet_page_index_options_invalid() {
+    #[test]
+    fn test_parquet_page_index_options_invalid() {
         let mut params = std::collections::HashMap::new();
         params.insert("parquet_page_index".to_string(), "invalid".to_string());
-        let app = app::AppBuilder::new("test")
-            .with_runtime_params(params)
-            .build();
-        let runtime = crate::Runtime::builder()
-            .with_app_opt(Some(Arc::new(app)))
-            .build()
-            .await;
+        let app = Arc::new(
+            app::AppBuilder::new("test")
+                .with_runtime_params(params)
+                .build(),
+        );
 
-        let options = parquet_page_index_options(&runtime).await;
-        // Should fall back to default
-        assert!(options.enable_page_index);
+        let options = parquet_page_index_options(&app);
+        assert!(
+            options.enable_page_index,
+            "an invalid value falls back to the default"
+        );
     }
 }

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -1002,7 +1002,7 @@ pub trait ListingTableConnector: DataConnector {
     where
         Self: Display,
     {
-        build_table_parquet_options(self.get_app()).map_err(|e| {
+        build_table_parquet_options(self.get_app().as_ref()).map_err(|e| {
             crate::dataconnector::DataConnectorError::UnableToConnectInternal {
                 dataconnector: format!("{self}"),
                 connector_component: ConnectorComponent::from(dataset),
@@ -1820,13 +1820,13 @@ impl SensitiveListingTableUrl {
 /// sets `enable_page_index` accordingly. When no runtime is available,
 /// `enable_page_index` retains the `DataFusion` default (`true`).
 pub fn build_table_parquet_options(
-    app: Option<Arc<App>>,
+    app: Option<&Arc<App>>,
 ) -> std::result::Result<TableParquetOptions, DataFusionError> {
     let mut opts = TableParquetOptions::new();
     opts.set("pushdown_filters", "true")?;
 
-    if app.is_some() {
-        let page_index_options = parquet_page_index_options(&app);
+    if let Some(app) = app {
+        let page_index_options = parquet_page_index_options(app);
         opts.set(
             "enable_page_index",
             &page_index_options.enable_page_index.to_string(),
@@ -1857,9 +1857,11 @@ impl Default for ParquetPageIndexOptions {
 ///   params:
 ///     parquet_page_index: required # skip, auto
 /// ```
-fn parquet_page_index_options(app: &Option<Arc<App>>) -> ParquetPageIndexOptions {
+fn parquet_page_index_options(app: &Arc<App>) -> ParquetPageIndexOptions {
+    // `App::get_runtime_param` reads the `Option<Arc<App>>` the runtime stores.
+    let app = Some(Arc::clone(app));
     let parquet_page_index_param =
-        App::get_runtime_param(app, "parquet_page_index", "required".to_string());
+        App::get_runtime_param(&app, "parquet_page_index", "required".to_string());
 
     match parquet_page_index_param.as_str() {
         // Note: "auto" and "required" both enable page index now. The difference was that "auto"

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -53,13 +53,13 @@ use {
     datafusion_datasource::file_format::FileFormatFactory, vortex_datafusion::VortexFormatFactory,
 };
 
-use crate::Runtime;
 use crate::component::dataset::Dataset;
 use crate::dataconnector::{
     ConnectorComponent, DataConnector, DataConnectorError, DataConnectorResult,
     listing::infer::{infer_partitions_with_types_from_files, infer_partitions_with_types_prefix},
 };
 use crate::parameters::{ExposedParamLookup, Parameters};
+use app::App;
 use data_components::object::{
     metadata::{MetadataColumn, ObjectStoreMetadataTable},
     text::ObjectStoreTextTable,
@@ -547,7 +547,12 @@ pub trait ListingTableConnector: DataConnector {
             })
     }
 
-    fn get_runtime(&self) -> Option<Runtime> {
+    /// The loaded app, for the runtime-level configuration this connector's
+    /// reads consult (currently `runtime.params.parquet_page_index`).
+    ///
+    /// `None` where no runtime is attached — connector unit tests that build the
+    /// connector directly.
+    fn get_app(&self) -> Option<Arc<App>> {
         None
     }
 
@@ -997,16 +1002,13 @@ pub trait ListingTableConnector: DataConnector {
     where
         Self: Display,
     {
-        let runtime = self.get_runtime();
-        build_table_parquet_options(runtime.as_ref())
-            .await
-            .map_err(
-                |e| crate::dataconnector::DataConnectorError::UnableToConnectInternal {
-                    dataconnector: format!("{self}"),
-                    connector_component: ConnectorComponent::from(dataset),
-                    source: Box::new(e),
-                },
-            )
+        build_table_parquet_options(self.get_app()).map_err(|e| {
+            crate::dataconnector::DataConnectorError::UnableToConnectInternal {
+                dataconnector: format!("{self}"),
+                connector_component: ConnectorComponent::from(dataset),
+                source: Box::new(e),
+            }
+        })
     }
 
     /// A hook that is called when an accelerated table is registered to the
@@ -1817,14 +1819,14 @@ impl SensitiveListingTableUrl {
 /// `runtime.params.parquet_page_index` (`required` | `auto` | `skip`) and
 /// sets `enable_page_index` accordingly. When no runtime is available,
 /// `enable_page_index` retains the `DataFusion` default (`true`).
-pub async fn build_table_parquet_options(
-    runtime: Option<&Runtime>,
+pub fn build_table_parquet_options(
+    app: Option<Arc<App>>,
 ) -> std::result::Result<TableParquetOptions, DataFusionError> {
     let mut opts = TableParquetOptions::new();
     opts.set("pushdown_filters", "true")?;
 
-    if let Some(rt) = runtime {
-        let page_index_options = parquet_page_index_options(rt).await;
+    if app.is_some() {
+        let page_index_options = parquet_page_index_options(&app);
         opts.set(
             "enable_page_index",
             &page_index_options.enable_page_index.to_string(),
@@ -1855,11 +1857,9 @@ impl Default for ParquetPageIndexOptions {
 ///   params:
 ///     parquet_page_index: required # skip, auto
 /// ```
-async fn parquet_page_index_options(runtime: &Runtime) -> ParquetPageIndexOptions {
-    let runtime_app = runtime.app();
-    let app = runtime_app.read().await;
+fn parquet_page_index_options(app: &Option<Arc<App>>) -> ParquetPageIndexOptions {
     let parquet_page_index_param =
-        app::App::get_runtime_param(&app, "parquet_page_index", "required".to_string());
+        App::get_runtime_param(app, "parquet_page_index", "required".to_string());
 
     match parquet_page_index_param.as_str() {
         // Note: "auto" and "required" both enable page index now. The difference was that "auto"

--- a/crates/runtime/src/dataconnector/listing/connector.rs
+++ b/crates/runtime/src/dataconnector/listing/connector.rs
@@ -54,7 +54,6 @@ use {
 };
 
 use crate::Runtime;
-use crate::accelerated::AcceleratedTable;
 use crate::component::dataset::Dataset;
 use crate::dataconnector::{
     ConnectorComponent, DataConnector, DataConnectorError, DataConnectorResult,
@@ -65,6 +64,7 @@ use data_components::object::{
     metadata::{MetadataColumn, ObjectStoreMetadataTable},
     text::ObjectStoreTextTable,
 };
+use data_connector_api::accelerated::RegisteredAcceleratedTable;
 
 use super::{
     DelimitedFormat, ParsedFileExtension, detect_file_extension_from_path,
@@ -1018,7 +1018,7 @@ pub trait ListingTableConnector: DataConnector {
     async fn on_accelerated_table_registration(
         &self,
         _dataset: &Dataset,
-        _accelerated_table: &mut AcceleratedTable,
+        _accelerated_table: &mut dyn RegisteredAcceleratedTable,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
@@ -1436,7 +1436,7 @@ impl<T: ListingTableConnector + Display> DataConnector for T {
     async fn on_accelerated_table_registration(
         &self,
         dataset: &Dataset,
-        accelerated_table: &mut AcceleratedTable,
+        accelerated_table: &mut dyn RegisteredAcceleratedTable,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         ListingTableConnector::on_accelerated_table_registration(self, dataset, accelerated_table)
             .await

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -18,7 +18,6 @@ use crate::component::ComponentInitialization;
 use crate::component::catalog::Catalog;
 use crate::component::dataset::Dataset;
 use crate::component::dataset::acceleration::RefreshMode;
-use crate::federated::FederatedTable;
 // A second alias for the `runtime-parameters` types, kept crate-visible for the
 // same reason as the `parameters` alias itself: it would otherwise be a way for
 // a connector to name them without depending on the crate that owns them.
@@ -28,6 +27,7 @@ use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
 use data_connector_api::accelerated::{AcceleratorSetup, RegisteredAcceleratedTable};
+use data_connector_api::federated::FederatedTableProvider;
 use datafusion::datasource::TableProvider;
 use linkme::distributed_slice;
 pub use parameters::ConnectorParams;
@@ -383,7 +383,7 @@ pub trait DataConnector: Debug + Send + Sync + 'static {
 
     fn changes_stream(
         &self,
-        _federated_table: Arc<FederatedTable>,
+        _federated_table: Arc<dyn FederatedTableProvider>,
         _dataset: &Dataset,
     ) -> Option<ChangesStream> {
         None
@@ -393,7 +393,10 @@ pub trait DataConnector: Debug + Send + Sync + 'static {
         false
     }
 
-    fn append_stream(&self, _federated_table: Arc<FederatedTable>) -> Option<ChangesStream> {
+    fn append_stream(
+        &self,
+        _federated_table: Arc<dyn FederatedTableProvider>,
+    ) -> Option<ChangesStream> {
         None
     }
 

--- a/crates/runtime/src/dataconnector/mod.rs
+++ b/crates/runtime/src/dataconnector/mod.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use crate::accelerated::{self, AcceleratedTable};
 use crate::component::ComponentInitialization;
 use crate::component::catalog::Catalog;
 use crate::component::dataset::Dataset;
@@ -28,6 +27,7 @@ pub(crate) use crate::parameters::Parameters;
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use data_components::cdc::ChangesStream;
+use data_connector_api::accelerated::{AcceleratorSetup, RegisteredAcceleratedTable};
 use datafusion::datasource::TableProvider;
 use linkme::distributed_slice;
 pub use parameters::ConnectorParams;
@@ -453,18 +453,17 @@ pub trait DataConnector: Debug + Send + Sync + 'static {
     }
 
     /// A hook called **before** the accelerated table is built, giving the
-    /// connector a chance to wrap or replace the accelerator provider on the
-    /// [`Builder`](crate::accelerated::Builder).
+    /// connector a chance to wrap or replace the accelerator's provider.
     ///
-    /// Any provider set here will be shared with the [`Refresher`] that is
-    /// created during [`Builder::build`]. Use this hook instead of
+    /// Any provider set here will be shared with the [`Refresher`] created when
+    /// the table is built. Use this hook instead of
     /// [`on_accelerated_table_registration`](Self::on_accelerated_table_registration)
     /// when the wrapped provider must be visible to the refresh pipeline
     /// (e.g. to recreate indexes after a data refresh).
     async fn on_accelerator_setup(
         &self,
         _dataset: &Dataset,
-        _builder: &mut accelerated::Builder,
+        _accelerator: &mut dyn AcceleratorSetup,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }
@@ -478,7 +477,7 @@ pub trait DataConnector: Debug + Send + Sync + 'static {
     async fn on_accelerated_table_registration(
         &self,
         _dataset: &Dataset,
-        _accelerated_table: &mut AcceleratedTable,
+        _accelerated_table: &mut dyn RegisteredAcceleratedTable,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Ok(())
     }

--- a/crates/runtime/src/dataconnector/parameters.rs
+++ b/crates/runtime/src/dataconnector/parameters.rs
@@ -58,8 +58,8 @@ pub trait Validator {
 /// [`ConnectorComponent`] spec.
 ///
 /// Each method is a single capability rather than a handle to the orchestrator,
-/// so the contract names only types that live below `runtime`. A connector that
-/// needed `Arc<Runtime>` was really after one of these.
+/// so the contract names only types that live below `runtime`: a registry, a
+/// session, the loaded app, or an already-resolved answer.
 #[async_trait]
 pub trait ConnectorContext: Send + Sync {
     /// The loaded app, for the runtime-level configuration a connector consults

--- a/crates/runtime/src/dataconnector/parameters.rs
+++ b/crates/runtime/src/dataconnector/parameters.rs
@@ -17,8 +17,13 @@ limitations under the License.
 use std::sync::Arc;
 
 use app::App;
+use arrow_schema::SchemaRef;
 use async_trait::async_trait;
+use data_http_rate_control::HttpRateControlRegistry;
+use datafusion::execution::context::SessionContext;
 use datafusion_table_providers::UnsupportedTypeAction;
+use runtime_component::dataset::DatasetSpec;
+use token_provider::registry::TokenProviderRegistry;
 use tokio::{runtime::Handle, sync::RwLock};
 
 use crate::{
@@ -51,14 +56,35 @@ pub trait Validator {
 /// built, behind a handle so [`ConnectorParams`] does not name them directly.
 /// A connector's *configuration* travels separately, as the
 /// [`ConnectorComponent`] spec.
+///
+/// Each method is a single capability rather than a handle to the orchestrator,
+/// so the contract names only types that live below `runtime`. A connector that
+/// needed `Arc<Runtime>` was really after one of these.
+#[async_trait]
 pub trait ConnectorContext: Send + Sync {
     /// The loaded app, for the runtime-level configuration a connector consults
-    /// (e.g. `runtime.params`).
+    /// (e.g. `runtime.params`, `runtime.flight`).
     fn app(&self) -> Arc<App>;
 
-    /// The live runtime, for connectors that register object stores or reach
-    /// runtime-wide registries during construction.
-    fn runtime(&self) -> Arc<Runtime>;
+    /// The process-wide per-origin HTTP rate-control registry, so connectors
+    /// sharing an origin share one limiter.
+    fn http_rate_control_registry(&self) -> Arc<HttpRateControlRegistry>;
+
+    /// The registry of token providers a connector authenticates through.
+    fn token_provider_registry(&self) -> Arc<TokenProviderRegistry>;
+
+    /// The runtime's own `DataFusion` session, for a connector that registers an
+    /// object store the main session must resolve at scan time.
+    fn datafusion_session_context(&self) -> Arc<SessionContext>;
+
+    /// The accelerated schema recorded in this dataset's acceleration
+    /// checkpoint, so a connector can re-advertise the schema a previous run
+    /// stored rather than re-deriving it.
+    ///
+    /// `None` when there is nothing to inherit: the dataset is not
+    /// file-accelerated, no checkpoint has been written yet, or the stored
+    /// checkpoint cannot be read.
+    async fn accelerated_checkpoint_schema(&self, dataset: &DatasetSpec) -> Option<SchemaRef>;
 }
 
 /// [`ConnectorContext`] over the app + runtime handles a component carries.
@@ -74,13 +100,34 @@ impl RuntimeConnectorContext {
     }
 }
 
+#[async_trait]
 impl ConnectorContext for RuntimeConnectorContext {
     fn app(&self) -> Arc<App> {
         Arc::clone(&self.app)
     }
 
-    fn runtime(&self) -> Arc<Runtime> {
-        Arc::clone(&self.runtime)
+    fn http_rate_control_registry(&self) -> Arc<HttpRateControlRegistry> {
+        self.runtime.http_rate_control_registry()
+    }
+
+    fn token_provider_registry(&self) -> Arc<TokenProviderRegistry> {
+        self.runtime.token_provider_registry()
+    }
+
+    fn datafusion_session_context(&self) -> Arc<SessionContext> {
+        Arc::clone(&self.runtime.datafusion().ctx)
+    }
+
+    async fn accelerated_checkpoint_schema(&self, dataset: &DatasetSpec) -> Option<SchemaRef> {
+        // Reading the checkpoint needs the accelerator engine registry and the
+        // secrets, which hang off the runtime — so the spec is rebound to the
+        // handles held here rather than handed across the connector boundary.
+        let dataset = Dataset {
+            spec: dataset.clone(),
+            app: Arc::clone(&self.app),
+            runtime: Arc::clone(&self.runtime),
+        };
+        super::sink::accelerated_checkpoint_schema(&dataset).await
     }
 }
 
@@ -102,10 +149,37 @@ impl ConnectorParams {
         self.context.as_ref().map(|ctx| ctx.app())
     }
 
-    /// The live runtime, if one is attached.
+    /// The HTTP rate-control registry, if a runtime is attached.
     #[must_use]
-    pub fn runtime(&self) -> Option<Arc<Runtime>> {
-        self.context.as_ref().map(|ctx| ctx.runtime())
+    pub fn http_rate_control_registry(&self) -> Option<Arc<HttpRateControlRegistry>> {
+        self.context
+            .as_ref()
+            .map(|ctx| ctx.http_rate_control_registry())
+    }
+
+    /// The token-provider registry, if a runtime is attached.
+    #[must_use]
+    pub fn token_provider_registry(&self) -> Option<Arc<TokenProviderRegistry>> {
+        self.context
+            .as_ref()
+            .map(|ctx| ctx.token_provider_registry())
+    }
+
+    /// The runtime's own `DataFusion` session, if a runtime is attached.
+    #[must_use]
+    pub fn datafusion_session_context(&self) -> Option<Arc<SessionContext>> {
+        self.context
+            .as_ref()
+            .map(|ctx| ctx.datafusion_session_context())
+    }
+
+    /// The accelerated schema stored for `dataset`, if a runtime is attached and
+    /// a checkpoint holds one.
+    pub async fn accelerated_checkpoint_schema(&self, dataset: &DatasetSpec) -> Option<SchemaRef> {
+        self.context
+            .as_ref()?
+            .accelerated_checkpoint_schema(dataset)
+            .await
     }
 }
 

--- a/crates/runtime/src/dataconnector/s3.rs
+++ b/crates/runtime/src/dataconnector/s3.rs
@@ -24,8 +24,9 @@ use super::{
     },
 };
 
+use app::App;
+
 use crate::{
-    Runtime,
     component::dataset::Dataset,
     dataconnector::listing::{LISTING_TABLE_PARAMETERS, ObjectVersionType},
 };
@@ -103,21 +104,21 @@ pub enum Error {
 
 pub struct S3 {
     pub(crate) params: Parameters,
-    pub(crate) runtime: Option<Runtime>,
+    pub(crate) app: Option<Arc<App>>,
     pub(crate) tokio_io_runtime: tokio::runtime::Handle,
 }
 
 impl S3 {
-    /// Creates a new `S3` connector with the given parameters, runtime, and I/O runtime handle.
+    /// Creates a new `S3` connector with the given parameters, app, and I/O runtime handle.
     #[must_use]
     pub fn new(
         params: Parameters,
-        runtime: Option<Runtime>,
+        app: Option<Arc<App>>,
         tokio_io_runtime: tokio::runtime::Handle,
     ) -> Self {
         Self {
             params,
-            runtime,
+            app,
             tokio_io_runtime,
         }
     }
@@ -281,10 +282,10 @@ impl DataConnectorFactory for S3Factory {
                 }
             }
 
-            let runtime = params.runtime().map(Arc::unwrap_or_clone);
+            let app = params.app();
             let s3 = S3 {
                 params: params.parameters,
-                runtime,
+                app,
                 tokio_io_runtime: params.io_runtime,
             };
             Ok(Arc::new(s3) as Arc<dyn DataConnector>)
@@ -361,8 +362,8 @@ impl ListingTableConnector for S3 {
         Ok(s3_url)
     }
 
-    fn get_runtime(&self) -> Option<Runtime> {
-        self.runtime.clone()
+    fn get_app(&self) -> Option<Arc<App>> {
+        self.app.clone()
     }
 
     fn handle_object_store_error(
@@ -431,7 +432,7 @@ mod tests {
     fn create_test_connector(params: Parameters) -> S3 {
         S3 {
             params,
-            runtime: None,
+            app: None,
             tokio_io_runtime: tokio::runtime::Handle::current(),
         }
     }

--- a/crates/runtime/src/dataconnector/sink.rs
+++ b/crates/runtime/src/dataconnector/sink.rs
@@ -140,16 +140,11 @@ impl DataConnectorFactory for SinkConnectorFactory {
             // Reading the checkpoint needs the accelerator engine registry and the secrets, so
             // the spec is rebound to the runtime handles from the connector context; without a
             // context (connector unit tests) there is no accelerator to inherit from.
-            let schema = match (&params.component, params.app(), params.runtime()) {
-                (ConnectorComponent::Dataset(spec), Some(app), Some(runtime)) => {
-                    let dataset = Dataset {
-                        spec: spec.as_ref().clone(),
-                        app,
-                        runtime,
-                    };
-                    accelerated_checkpoint_schema(&dataset).await
+            let schema = match &params.component {
+                ConnectorComponent::Dataset(spec) => {
+                    params.accelerated_checkpoint_schema(spec).await
                 }
-                _ => None,
+                ConnectorComponent::Catalog(_) => None,
             }
             .unwrap_or_else(placeholder_schema);
 

--- a/crates/runtime/src/dataconnector/spiceai.rs
+++ b/crates/runtime/src/dataconnector/spiceai.rs
@@ -50,12 +50,13 @@ use super::{
     ConnectorComponent, ConnectorParams, DataConnector, DataConnectorError, DataConnectorFactory,
     ParameterSpec,
 };
-use crate::{component::dataset::Dataset, federated::FederatedTable};
+use crate::component::dataset::Dataset;
 use data_components::cdc::{
     self, ChangeBatch, ChangeEnvelope, ChangesStream, CommitChange, CommitError,
 };
 use data_components::flight::{FlightFactory, FlightTable};
 use data_components::{Read, ReadWrite};
+use data_connector_api::federated::FederatedTableProvider;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -568,13 +569,16 @@ impl DataConnector for SpiceAI {
 
     fn changes_stream(
         &self,
-        federated_table: Arc<FederatedTable>,
+        federated_table: Arc<dyn FederatedTableProvider>,
         _dataset: &Dataset,
     ) -> Option<ChangesStream> {
         self.append_stream(federated_table)
     }
 
-    fn append_stream(&self, federated_table: Arc<FederatedTable>) -> Option<ChangesStream> {
+    fn append_stream(
+        &self,
+        federated_table: Arc<dyn FederatedTableProvider>,
+    ) -> Option<ChangesStream> {
         Some(Box::pin(stream! {
             let table_provider = federated_table.table_provider().await;
             let Some(federated_table_provider_adaptor) = table_provider

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -57,6 +57,7 @@ use crate::secrets::Secrets;
 use crate::tracing_util::view_registered_trace;
 use crate::view::prepare_view;
 use crate::{status, view};
+use data_connector_api::federated::FederatedTableProvider;
 use runtime_search::udtf::TEXT_SEARCH_UDTF_NAME;
 
 use snafu::ResultExt;
@@ -3095,7 +3096,10 @@ impl DataFusion {
                 },
             );
 
-            let changes_stream = source.changes_stream(Arc::clone(&source_table_provider), dataset);
+            let changes_stream = source.changes_stream(
+                Arc::clone(&source_table_provider) as Arc<dyn FederatedTableProvider>,
+                dataset,
+            );
 
             if let Some(changes_stream) = changes_stream {
                 accelerated_table_builder.changes_stream(changes_stream);

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -33,6 +33,7 @@ use crate::secrets::Secrets;
 use async_trait::async_trait;
 use data_components::cdc::{ChangeEnvelope, ChangesStream, StreamError, replace_change_batch_data};
 use data_connector_api::accelerated::{AcceleratorSetup, RegisteredAcceleratedTable};
+use data_connector_api::federated::FederatedTableProvider;
 use datafusion::datasource::TableProvider;
 use futures::StreamExt;
 use itertools::Itertools;
@@ -345,7 +346,7 @@ impl DataConnector for EmbeddingConnector {
 
     fn changes_stream(
         &self,
-        federated_table: Arc<FederatedTable>,
+        federated_table: Arc<dyn FederatedTableProvider>,
         dataset: &Dataset,
     ) -> Option<ChangesStream> {
         let table_provider = federated_table.try_table_provider_sync()?;
@@ -422,7 +423,10 @@ impl DataConnector for EmbeddingConnector {
         self.inner_connector.supports_append_stream()
     }
 
-    fn append_stream(&self, federated_table: Arc<FederatedTable>) -> Option<ChangesStream> {
+    fn append_stream(
+        &self,
+        federated_table: Arc<dyn FederatedTableProvider>,
+    ) -> Option<ChangesStream> {
         let table_provider = federated_table.try_table_provider_sync()?;
 
         if let Some(indexed_table) =
@@ -727,7 +731,7 @@ pub(crate) async fn try_wrap_view_accelerator_with_hnsw(
 /// drop the changes stream and leave the index stale.
 fn underlying_federated_table_for_indexed_table(
     src_table_provider: &Arc<dyn TableProvider>,
-) -> Arc<FederatedTable> {
+) -> Arc<dyn FederatedTableProvider> {
     let source = peel_to(src_table_provider, LayerWalk::Source);
     Arc::new(FederatedTable::Immediate(Arc::clone(source)))
 }
@@ -763,7 +767,7 @@ mod tests {
 
         fn changes_stream(
             &self,
-            _federated_table: Arc<FederatedTable>,
+            _federated_table: Arc<dyn FederatedTableProvider>,
             _dataset: &Dataset,
         ) -> Option<ChangesStream> {
             Some(futures::stream::empty().boxed())
@@ -773,7 +777,10 @@ mod tests {
             true
         }
 
-        fn append_stream(&self, _federated_table: Arc<FederatedTable>) -> Option<ChangesStream> {
+        fn append_stream(
+            &self,
+            _federated_table: Arc<dyn FederatedTableProvider>,
+        ) -> Option<ChangesStream> {
             Some(futures::stream::empty().boxed())
         }
     }
@@ -790,7 +797,7 @@ mod tests {
     /// The provider stack an `EmbeddingConnector` is handed when the dataset also has
     /// full-text search: the outer `FullTextConnector` peels its own `IndexLayer`
     /// off before delegating, leaving the vector scan on top.
-    fn vector_scan_over_memtable() -> Arc<FederatedTable> {
+    fn vector_scan_over_memtable() -> Arc<dyn FederatedTableProvider> {
         let vector_scan = VectorScanTableProvider {
             table_provider: memtable(),
             vector_index_list: Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-use crate::accelerated::{self, AcceleratedTable};
 use crate::changes::Indexes;
 use crate::changes::index_change_envelope;
 use crate::component::ComponentInitialization;
@@ -33,6 +32,7 @@ use crate::model::EmbeddingModelStore;
 use crate::secrets::Secrets;
 use async_trait::async_trait;
 use data_components::cdc::{ChangeEnvelope, ChangesStream, StreamError, replace_change_batch_data};
+use data_connector_api::accelerated::{AcceleratorSetup, RegisteredAcceleratedTable};
 use datafusion::datasource::TableProvider;
 use futures::StreamExt;
 use itertools::Itertools;
@@ -289,10 +289,10 @@ impl DataConnector for EmbeddingConnector {
     async fn on_accelerator_setup(
         &self,
         dataset: &Dataset,
-        builder: &mut accelerated::Builder,
+        accelerator: &mut dyn AcceleratorSetup,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.inner_connector
-            .on_accelerator_setup(dataset, builder)
+            .on_accelerator_setup(dataset, accelerator)
             .await?;
 
         #[cfg(feature = "duckdb")]
@@ -308,18 +308,17 @@ impl DataConnector for EmbeddingConnector {
                 "Wrapping accelerator with DuckDB HNSW vector indexes"
             );
 
-            let accelerator = builder.get_accelerator();
             let indexed_accelerator =
                 crate::embeddings::index::duckdb::wrap_accelerator_with_duckdb_vector_indexes(
                     &dataset.name,
                     embedding_columns,
                     &vector_engine,
-                    accelerator,
+                    accelerator.accelerator(),
                     Arc::clone(&self.embedding_models),
                     Arc::clone(&self.secrets),
                 )
                 .await?;
-            builder.set_accelerator(indexed_accelerator);
+            accelerator.set_accelerator(indexed_accelerator);
             return Ok(());
         }
 
@@ -329,7 +328,7 @@ impl DataConnector for EmbeddingConnector {
     async fn on_accelerated_table_registration(
         &self,
         dataset: &Dataset,
-        accelerated_table: &mut AcceleratedTable,
+        accelerated_table: &mut dyn RegisteredAcceleratedTable,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.inner_connector
             .on_accelerated_table_registration(dataset, accelerated_table)

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -31,6 +31,7 @@ use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResul
 use crate::federated::FederatedTable;
 use crate::search::full_text::table::add_full_text_search_to_table;
 use data_connector_api::accelerated::{AcceleratorSetup, RegisteredAcceleratedTable};
+use data_connector_api::federated::FederatedTableProvider;
 use futures::StreamExt;
 use runtime_metrics::component::MetricsProvider;
 use spice_table::LayerWalk;
@@ -49,11 +50,11 @@ impl FullTextConnector {
     #[expect(clippy::needless_pass_by_value)]
     fn with_indexed_stream<F>(
         &self,
-        federated_table: Arc<FederatedTable>,
+        federated_table: Arc<dyn FederatedTableProvider>,
         f: F,
     ) -> Option<ChangesStream>
     where
-        F: Fn(&Arc<dyn DataConnector>, Arc<FederatedTable>) -> Option<ChangesStream>,
+        F: Fn(&Arc<dyn DataConnector>, Arc<dyn FederatedTableProvider>) -> Option<ChangesStream>,
     {
         let table_provider = federated_table.try_table_provider_sync()?;
         let indexed_table = spice_table::nodes(table_provider.as_ref(), LayerWalk::Index)
@@ -207,7 +208,7 @@ impl DataConnector for FullTextConnector {
 
     fn changes_stream(
         &self,
-        federated_table: Arc<FederatedTable>,
+        federated_table: Arc<dyn FederatedTableProvider>,
         dataset: &Dataset,
     ) -> Option<ChangesStream> {
         self.with_indexed_stream(federated_table, |inner, ft| {
@@ -219,7 +220,10 @@ impl DataConnector for FullTextConnector {
         self.inner_connector.supports_append_stream()
     }
 
-    fn append_stream(&self, federated_table: Arc<FederatedTable>) -> Option<ChangesStream> {
+    fn append_stream(
+        &self,
+        federated_table: Arc<dyn FederatedTableProvider>,
+    ) -> Option<ChangesStream> {
         self.with_indexed_stream(federated_table, |inner, ft| inner.append_stream(ft))
     }
 

--- a/crates/runtime/src/search/full_text/connector.rs
+++ b/crates/runtime/src/search/full_text/connector.rs
@@ -22,7 +22,6 @@ use search::index::compound::CompoundSearchIndex;
 use std::any::Any;
 use std::sync::Arc;
 
-use crate::accelerated::{self, AcceleratedTable};
 use crate::changes::{Indexes, index_change_envelope};
 use crate::component::{
     ComponentInitialization,
@@ -31,6 +30,7 @@ use crate::component::{
 use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResult};
 use crate::federated::FederatedTable;
 use crate::search::full_text::table::add_full_text_search_to_table;
+use data_connector_api::accelerated::{AcceleratorSetup, RegisteredAcceleratedTable};
 use futures::StreamExt;
 use runtime_metrics::component::MetricsProvider;
 use spice_table::LayerWalk;
@@ -176,17 +176,17 @@ impl DataConnector for FullTextConnector {
     async fn on_accelerator_setup(
         &self,
         dataset: &Dataset,
-        builder: &mut accelerated::Builder,
+        accelerator: &mut dyn AcceleratorSetup,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.inner_connector
-            .on_accelerator_setup(dataset, builder)
+            .on_accelerator_setup(dataset, accelerator)
             .await
     }
 
     async fn on_accelerated_table_registration(
         &self,
         dataset: &Dataset,
-        accelerated_table: &mut AcceleratedTable,
+        accelerated_table: &mut dyn RegisteredAcceleratedTable,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.inner_connector
             .on_accelerated_table_registration(dataset, accelerated_table)

--- a/crates/runtime/src/search/full_text/elasticsearch.rs
+++ b/crates/runtime/src/search/full_text/elasticsearch.rs
@@ -39,6 +39,7 @@ use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResul
 use crate::federated::FederatedTable;
 use crate::search::full_text::table::add_compound_fts_to_table;
 use data_connector_api::accelerated::{AcceleratorSetup, RegisteredAcceleratedTable};
+use data_connector_api::federated::FederatedTableProvider;
 use runtime_metrics::component::MetricsProvider;
 use runtime_parameters_typed::TypedParams as _;
 use runtime_search::store_params::elasticsearch::{
@@ -121,11 +122,11 @@ impl ElasticsearchFullTextConnector {
     #[expect(clippy::needless_pass_by_value)]
     fn with_indexed_stream<F>(
         &self,
-        federated_table: Arc<FederatedTable>,
+        federated_table: Arc<dyn FederatedTableProvider>,
         f: F,
     ) -> Option<ChangesStream>
     where
-        F: Fn(&Arc<dyn DataConnector>, Arc<FederatedTable>) -> Option<ChangesStream>,
+        F: Fn(&Arc<dyn DataConnector>, Arc<dyn FederatedTableProvider>) -> Option<ChangesStream>,
     {
         let table_provider = federated_table.try_table_provider_sync()?;
         let indexed_table =
@@ -263,7 +264,7 @@ impl DataConnector for ElasticsearchFullTextConnector {
 
     fn changes_stream(
         &self,
-        federated_table: Arc<FederatedTable>,
+        federated_table: Arc<dyn FederatedTableProvider>,
         dataset: &Dataset,
     ) -> Option<ChangesStream> {
         self.with_indexed_stream(federated_table, |inner, table| {
@@ -275,7 +276,10 @@ impl DataConnector for ElasticsearchFullTextConnector {
         self.inner_connector.supports_append_stream()
     }
 
-    fn append_stream(&self, federated_table: Arc<FederatedTable>) -> Option<ChangesStream> {
+    fn append_stream(
+        &self,
+        federated_table: Arc<dyn FederatedTableProvider>,
+    ) -> Option<ChangesStream> {
         self.with_indexed_stream(federated_table, |inner, table| inner.append_stream(table))
     }
 

--- a/crates/runtime/src/search/full_text/elasticsearch.rs
+++ b/crates/runtime/src/search/full_text/elasticsearch.rs
@@ -27,7 +27,6 @@ use datafusion::datasource::TableProvider;
 use futures::StreamExt;
 use tokio::sync::RwLock;
 
-use crate::accelerated::{self, AcceleratedTable};
 use crate::changes::{Indexes, index_change_envelope};
 use crate::component::{
     ComponentInitialization,
@@ -39,6 +38,7 @@ use crate::component::{
 use crate::dataconnector::{DataConnector, DataConnectorError, DataConnectorResult};
 use crate::federated::FederatedTable;
 use crate::search::full_text::table::add_compound_fts_to_table;
+use data_connector_api::accelerated::{AcceleratorSetup, RegisteredAcceleratedTable};
 use runtime_metrics::component::MetricsProvider;
 use runtime_parameters_typed::TypedParams as _;
 use runtime_search::store_params::elasticsearch::{
@@ -230,10 +230,10 @@ impl DataConnector for ElasticsearchFullTextConnector {
     async fn on_accelerator_setup(
         &self,
         dataset: &Dataset,
-        builder: &mut accelerated::Builder,
+        accelerator: &mut dyn AcceleratorSetup,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.inner_connector
-            .on_accelerator_setup(dataset, builder)
+            .on_accelerator_setup(dataset, accelerator)
             .await?;
 
         Ok(())
@@ -242,7 +242,7 @@ impl DataConnector for ElasticsearchFullTextConnector {
     async fn on_accelerated_table_registration(
         &self,
         dataset: &Dataset,
-        accelerated_table: &mut AcceleratedTable,
+        accelerated_table: &mut dyn RegisteredAcceleratedTable,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.inner_connector
             .on_accelerated_table_registration(dataset, accelerated_table)


### PR DESCRIPTION
Narrows the `DataConnector` trait so its signatures name fewer types that live at or above the `runtime` crate. Everything stays inside its current crate — no crate moves, no tier changes — so the layering graph is untouched and this is reviewable on correctness alone.

Three couplings are removed.

**Accelerated-table hooks.** `on_accelerator_setup` and `on_accelerated_table_registration` took the accelerated-table types themselves (`accelerated::Builder`, `AcceleratedTable`). Those live beside the runtime that orchestrates them, so a connector naming either depended on the orchestrator for the sake of two getters and a `Vec::push`. Each hook now takes a capability trait holding the slice its implementations actually reach for — `AcceleratorSetup` (read the accelerator's provider, replace it with a wrapper) and `RegisteredAcceleratedTable` (request a refresh, attach a task whose lifetime follows the table). Only two of the eleven implementations do real work: the embedding connector's DuckDB HNSW wrapping and the file connector's watcher. A refresh request goes through `RefreshRequester::request_refresh` rather than a send on the raw trigger channel, which keeps `RefreshOverrides` off the contract, and attaching a task goes through `attach_task` rather than pushing onto the public `handlers` field.

**Change streams.** `changes_stream` and `append_stream` took an `Arc<FederatedTable>`. All eleven implementations want the same thing of it — the `TableProvider`, so they can recover their own concrete provider type and start reading. Both now take `Arc<dyn FederatedTableProvider>`, a two-method trait that `FederatedTable` implements: `table_provider` resolves asynchronously, because a deferred dataset registers before its source is contacted, and `try_table_provider_sync` covers the synchronous peek the embedding and full-text wrappers make before delegating inward.

**The runtime handle.** `ConnectorContext::runtime() -> Arc<Runtime>` handed connectors the whole orchestrator. Six connector call sites used it, and between them they wanted three things: the HTTP rate-control registry, the token-provider registry, and the runtime's own DataFusion session. Each is now its own method over a type below `runtime`. The sink connector was the only caller that wanted a real `Arc<Runtime>` — it rebuilt a whole `Dataset` from the context to read the accelerator's checkpoint schema — so the capability is now the result, `accelerated_checkpoint_schema(&DatasetSpec) -> Option<SchemaRef>`, and the rebinding happens inside `RuntimeConnectorContext` where those handles belong.

`ConnectorContext::app()` is unchanged: the `app` crate already sits below `runtime`, so `Arc<App>` was never part of the problem. All four `.app()` callers read the spicepod `runtime:` block, one of them through the typed `runtime.flight` config rather than a named param.

`ListingTableConnector::get_runtime() -> Option<Runtime>` goes with the handle, as `get_app()`. Its one consumer chain resolved an entire `Arc<Runtime>` down to a single spicepod string — `runtime.params.parquet_page_index` — which four connector structs were carrying a runtime handle to reach.

### What is deliberately not here

Retyping the trait's `&Dataset` parameters to `&DatasetSpec` was expected to be mechanical, on the theory that existing callers keep compiling through deref coercion. That holds for the configuration-only methods, but not for the three that hand back a provider: `read_provider`, `read_write_provider` and `changes_stream` reach the accelerator's `spice_sys` state — the CDC checkpoint stores in kafka, mysql, postgres and mongodb — which needs the runtime-bound `Dataset`. Narrowing those means giving those stores a below-runtime interface, the way `runtime-checkpoint-api` already does for DynamoDB's blob checkpoints. That is its own change with CDC-state correctness implications, so the retype waits for it; the module docs on `RefreshSource` now record this as the remaining blocker rather than predicting an easier path.

### Verification

Behavior-preserving throughout. Full-workspace `cargo check` green under the release feature set; the crate-layering guard passes (142 crates, no upward edges); `Cargo.lock` regenerated and committed.
