### PR TITLE
feat(cli): manage systemd user and system services end to end

### DIFF
--- a/bin/spice/src/commands/connect/service/backend.rs
+++ b/bin/spice/src/commands/connect/service/backend.rs
@@ -29,7 +29,7 @@ use std::path::{Path, PathBuf};
 
 use super::model::{LogSource, ServiceScope, ServiceStarts, ServiceState, Supervisor};
 use super::{InstalledService, PreflightFailure, manifest::ServiceManifest};
-use crate::error::{Error, Result};
+use crate::error::Result;
 
 /// What an install needs to know, resolved by the caller so the back end
 /// never derives a path from the environment.
@@ -44,6 +44,9 @@ pub(crate) struct InstallRequest<'a> {
     pub(crate) spiced_path: &'a Path,
     /// The service domain to install into.
     pub(crate) scope: ServiceScope,
+    /// Where this instance answers a health probe, so an install can prove the
+    /// service it just started is actually serving before it reports success.
+    pub(crate) health_url: &'a str,
 }
 
 /// One fresh reading of what the supervisor says about a service.
@@ -183,15 +186,15 @@ pub(crate) trait ServiceBackend {
 ///
 /// A typed error rather than a panic: the CLI has to exit with a diagnosis and
 /// a non-zero status, and a caller that reaches an unfinished path should
-/// degrade rather than abort. The grammar, manifest, and status model land
-/// first so the systemd and launchd lifecycle work has one interface to fill
-/// in.
+/// degrade rather than abort. Compiled only where a back end still has
+/// operations to fill in, so the day none does the compiler says so.
+#[cfg(target_os = "macos")]
 pub(crate) fn lifecycle_pending(
     backend: &dyn ServiceBackend,
     action: &str,
     manifest: &ServiceManifest,
-) -> Error {
-    Error::NotImplemented {
+) -> crate::error::Error {
+    crate::error::Error::NotImplemented {
         message: format!(
             "Failed to {action} the Spice Cloud Connect service {name} ({supervisor}): \
              {supervisor} lifecycle control is not available in this release. \

--- a/bin/spice/src/commands/connect/service/cli.rs
+++ b/bin/spice/src/commands/connect/service/cli.rs
@@ -182,32 +182,28 @@ pub async fn execute(
             status::render_service(&status, args.output)?;
             degraded_error(&status)
         }
-        ServiceCommand::Start => backend.start(&require_installed(
-            backend,
-            instance_dir,
-            config_dir,
-            action,
-        )?),
+        ServiceCommand::Start => {
+            let manifest = require_installed(backend, instance_dir, config_dir, action)?;
+            with_recovery_detail(backend, &manifest, backend.start(&manifest))
+        }
         ServiceCommand::Stop => match resolve_or_report(backend, instance_dir, config_dir, action)?
         {
-            Some(manifest) => backend.stop(&manifest),
+            Some(manifest) => with_recovery_detail(backend, &manifest, backend.stop(&manifest)),
             None => Ok(()),
         },
-        ServiceCommand::Restart => backend.restart(&require_installed(
-            backend,
-            instance_dir,
-            config_dir,
-            action,
-        )?),
+        ServiceCommand::Restart => {
+            let manifest = require_installed(backend, instance_dir, config_dir, action)?;
+            with_recovery_detail(backend, &manifest, backend.restart(&manifest))
+        }
         ServiceCommand::Logs(args) => {
             match resolve_or_report(backend, instance_dir, config_dir, action)? {
-                Some(manifest) => backend.logs(
-                    &manifest,
-                    super::LogRequest {
+                Some(manifest) => {
+                    let request = super::LogRequest {
                         number: args.number,
                         follow: args.follow,
-                    },
-                ),
+                    };
+                    with_recovery_detail(backend, &manifest, backend.logs(&manifest, request))
+                }
                 None => Ok(()),
             }
         }
@@ -338,6 +334,33 @@ fn resolve_or_report(
         );
     }
     Ok(resolved)
+}
+
+/// Name the supervisor's own commands for this service when a Spice command
+/// could not complete.
+///
+/// Recovery detail, never the primary interface: the hints are printed only on
+/// a failure, on stderr so a `--output json` run stays parseable, and ahead of
+/// the diagnosis the process exits with. An interruption is not a failure —
+/// the viewer stopped and the service is unchanged — so it gets none.
+fn with_recovery_detail(
+    backend: &dyn ServiceBackend,
+    manifest: &ServiceManifest,
+    result: Result<()>,
+) -> Result<()> {
+    if matches!(result, Err(ref err) if !matches!(err, Error::Interrupted)) {
+        let hints = backend.recovery_hints(manifest);
+        if !hints.is_empty() {
+            eprintln!(
+                "If you need to drive {} directly, its supervisor's own commands are:",
+                manifest.name
+            );
+            for hint in hints {
+                eprintln!("  {hint}");
+            }
+        }
+    }
+    result
 }
 
 /// Turn a degraded snapshot into the non-zero exit automation needs.

--- a/bin/spice/src/commands/connect/service/launchd.rs
+++ b/bin/spice/src/commands/connect/service/launchd.rs
@@ -250,6 +250,9 @@ fn install(request: &InstallRequest<'_>) -> Result<InstalledService> {
         config_dir,
         spiced_path,
         scope,
+        // The launchd install gates on the job staying up rather than on the
+        // instance answering; the health gate arrives with its lifecycle.
+        health_url: _,
     } = *request;
 
     let account = super::service_account(instance_dir)?;

--- a/bin/spice/src/commands/connect/service/mod.rs
+++ b/bin/spice/src/commands/connect/service/mod.rs
@@ -19,10 +19,12 @@ limitations under the License.
 //!
 //! A deployment applies to the running instance and never ends its process, so
 //! the supervisor is what keeps the instance up across the things that do end
-//! it — a host reboot, an OOM kill, an unhandled failure. Both back ends
-//! therefore bring a failed runtime back — systemd with `Restart=on-failure`,
-//! launchd with `KeepAlive` — while leaving a clean exit alone, because a clean
-//! exit is what an operator's `stop` produces.
+//! it — a host reboot, an OOM kill, an unhandled failure.
+//!
+//! The two back ends do not promise the same thing about a *clean* exit, so
+//! neither does this. systemd uses `Restart=on-failure`: a failure comes back,
+//! and an exit an operator asked for stays down. launchd uses `KeepAlive`,
+//! which brings the job back from any exit at all, including a clean one.
 //!
 //! ## Support matrix
 //!

--- a/bin/spice/src/commands/connect/service/mod.rs
+++ b/bin/spice/src/commands/connect/service/mod.rs
@@ -19,9 +19,10 @@ limitations under the License.
 //!
 //! A deployment applies to the running instance and never ends its process, so
 //! the supervisor is what keeps the instance up across the things that do end
-//! it — a host reboot, an OOM kill, an operator's `systemctl restart`. Both
-//! back ends therefore restart the runtime unconditionally — systemd with
-//! `Restart=always`, launchd with `KeepAlive`.
+//! it — a host reboot, an OOM kill, an unhandled failure. Both back ends
+//! therefore bring a failed runtime back — systemd with `Restart=on-failure`,
+//! launchd with `KeepAlive` — while leaving a clean exit alone, because a clean
+//! exit is what an operator's `stop` produces.
 //!
 //! ## Support matrix
 //!
@@ -101,7 +102,8 @@ const SYSTEMD_RUNTIME_MARKER: &str = "/run/systemd/system";
 #[cfg(target_os = "macos")]
 const RUNTIME_STAGE_DIR: &str = "/Library/Spice";
 
-/// Root-owned directory the installed service's `spiced` is staged into.
+/// Root-owned directory holding the per-service directories a system service's
+/// `spiced` is staged into.
 #[cfg(not(target_os = "macos"))]
 const RUNTIME_STAGE_DIR: &str = "/usr/local/lib/spice";
 
@@ -213,7 +215,9 @@ fn provision_config_ownership(path: &Path, account: ServiceAccount) -> Result<()
     })
 }
 
-/// The `spiced` the installed service runs.
+/// The `spiced` an installed service runs, for a back end that stages one copy
+/// per host rather than one per instance.
+#[cfg(target_os = "macos")]
 fn staged_runtime_path() -> PathBuf {
     Path::new(RUNTIME_STAGE_DIR).join(STAGED_RUNTIME_FILE)
 }
@@ -296,14 +300,24 @@ fn sanitize_fragment(name: &str) -> String {
 ///
 /// Distinguished from a generic error so the caller can run the check before
 /// touching any state: a failed preflight must change nothing.
+///
+/// Each supervisor's own reasons are compiled only where that supervisor is, so
+/// a message can name a concrete fix without hedging about the host it is
+/// printed on.
 #[derive(Debug)]
 pub(crate) enum PreflightFailure {
     /// Neither Linux nor macOS — there is no supervisor to install into.
     UnsupportedPlatform,
     /// Linux, but systemd is not the running init.
+    #[cfg(target_os = "linux")]
     SystemdUnavailable,
+    /// Linux with systemd, but the account has no user manager for a user
+    /// service to live in.
+    #[cfg(target_os = "linux")]
+    SystemdUserManagerUnavailable,
     /// A user-scope service was asked for, and the back end does not install
     /// one yet.
+    #[cfg(target_os = "macos")]
     UserScopePending,
 }
 
@@ -319,6 +333,7 @@ impl PreflightFailure {
                  See: https://spiceai.org/docs",
                 std::env::consts::OS
             ),
+            #[cfg(target_os = "linux")]
             Self::SystemdUnavailable => format!(
                 "Failed to install the Spice Cloud Connect service: systemd is not running on \
                  this host ({SYSTEMD_RUNTIME_MARKER} is absent). This is normal inside a \
@@ -326,17 +341,20 @@ impl PreflightFailure {
                  runtime's restart policy (`docker run --restart unless-stopped`) \
                  instead. See: https://spiceai.org/docs"
             ),
-            Self::UserScopePending => format!(
-                "Failed to install the Spice Cloud Connect service: a {} is not available in \
-                 this release. Install a system service instead: \
-                 `sudo spice connect service install`. \
-                 See: https://spiceai.org/docs",
-                if cfg!(target_os = "macos") {
-                    "user LaunchAgent"
-                } else {
-                    "systemd user service"
-                }
+            #[cfg(target_os = "linux")]
+            Self::SystemdUserManagerUnavailable => format!(
+                "Failed to install the Spice Cloud Connect service: this account has no systemd \
+                 user manager to install a user service into (no {}). Log in as the account that \
+                 will run the instance and re-run `spice connect service install`, enable one for \
+                 it (`sudo loginctl enable-linger <user>`), or install a host-wide service with \
+                 `sudo spice connect service install`. See: https://spiceai.org/docs",
+                std::env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| "/run/user/<uid>".to_string())
             ),
+            #[cfg(target_os = "macos")]
+            Self::UserScopePending => "Failed to install the Spice Cloud Connect service: a user \
+                 LaunchAgent is not available in this release. Install a system service instead: \
+                 `sudo spice connect service install`. See: https://spiceai.org/docs"
+                .to_string(),
         }
     }
 }
@@ -413,12 +431,18 @@ pub(crate) fn resolve(
 /// reportable and removable instead of invisible. It is not a fallback search:
 /// the name is still derived from the canonical directory, and the definition
 /// is accepted only if it names that same directory as its working directory.
+///
+/// Both domains are asked, because either can hold this directory's service.
+/// The least-privileged one is asked first: an operator's own user service is
+/// the common case, and a host-wide definition under the same derived name is
+/// the one that needs elevation to act on.
 fn adopt_installed_definition(
     backend: &dyn ServiceBackend,
     instance_dir: &Path,
 ) -> Option<ServiceManifest> {
-    let scope = ServiceScope::System;
-    let installed = backend.find_installed(instance_dir, scope)?;
+    let (scope, installed) = [ServiceScope::User, ServiceScope::System]
+        .into_iter()
+        .find_map(|scope| Some((scope, backend.find_installed(instance_dir, scope)?)))?;
     let owner = installed_owner(instance_dir);
     Some(ServiceManifest {
         schema_version: manifest::MANIFEST_SCHEMA_VERSION,
@@ -529,8 +553,9 @@ pub(crate) fn install(
     // directory's derived name that belongs to somewhere else, has to fail
     // before anything is written.
     let existing = resolve(backend, instance_dir, config_dir)?;
-    if existing.is_none() {
-        ensure_name_unclaimed(backend, instance_dir, scope)?;
+    match &existing {
+        Some(existing) => ensure_same_domain(existing, scope, instance_dir)?,
+        None => ensure_name_unclaimed(backend, instance_dir, scope)?,
     }
 
     let installed = backend.install(&InstallRequest {
@@ -538,6 +563,7 @@ pub(crate) fn install(
         config_dir,
         spiced_path,
         scope,
+        health_url,
     })?;
 
     let owner = install_owner(instance_dir)?;
@@ -573,6 +599,43 @@ fn install_owner(instance_dir: &Path) -> Result<ServiceOwner> {
 #[cfg(not(unix))]
 fn install_owner(instance_dir: &Path) -> Result<ServiceOwner> {
     Ok(installed_owner(instance_dir))
+}
+
+/// Refuse to install a service into a different domain from the one this
+/// directory already has a service in.
+///
+/// The domain follows the privilege of the invocation, so an unprivileged
+/// re-install of a host-wide service would otherwise install a *second*
+/// service — a user one — for the same directory, leave the system one running,
+/// and rewrite the manifest to describe only the new one. The elevation is the
+/// operator's to give, so this names it instead.
+fn ensure_same_domain(
+    existing: &ServiceManifest,
+    scope: ServiceScope,
+    instance_dir: &Path,
+) -> Result<()> {
+    if existing.scope == scope {
+        return Ok(());
+    }
+    let retry = match existing.scope {
+        ServiceScope::System => format!(
+            "Re-run it as `sudo spice connect service install --dir {}`",
+            instance_dir.display()
+        ),
+        ServiceScope::User => format!("Run it as {} without sudo", existing.owner.describe()),
+    };
+    Err(Error::InvalidArgument {
+        message: format!(
+            "Failed to install the Spice Cloud Connect service for {instance}: a {existing_scope} \
+             service ({name}) is already installed for this directory, and this invocation would \
+             install a {scope} one alongside it. {retry}, or remove the installed service first \
+             with `spice connect service uninstall`. Nothing was changed. \
+             See: https://spiceai.org/docs",
+            instance = instance_dir.display(),
+            existing_scope = existing.scope,
+            name = existing.name,
+        ),
+    })
 }
 
 /// Refuse to install over a definition that already carries this directory's
@@ -725,6 +788,7 @@ fn is_root() -> bool {
 /// already executes, so a runtime that turns out to be unusable must never
 /// reach it: publishing first and checking afterwards would take out the
 /// instances that were working.
+#[cfg(target_os = "macos")]
 fn stage_runtime<F>(source: &Path, verify_staged: F) -> Result<PathBuf>
 where
     F: Fn(&Path, &Path) -> Result<()> + Copy,
@@ -1055,26 +1119,27 @@ mod tests {
     }
 
     #[test]
-    fn staged_runtime_is_not_under_a_user_home() {
-        // The service runs it as root, so it must never be a path its operator
-        // could later replace.
-        let staged = staged_runtime_path();
-        let staged = staged.to_string_lossy();
-        assert!(!staged.contains("/home/"), "{staged}");
-        assert!(!staged.contains("/Users/"), "{staged}");
+    fn the_root_owned_staging_directory_is_not_under_a_user_home() {
+        // A system service runs its staged runtime as root, so the directory it
+        // is staged into must never be a path its operator could later replace.
+        assert!(!RUNTIME_STAGE_DIR.contains("/home/"), "{RUNTIME_STAGE_DIR}");
+        assert!(
+            !RUNTIME_STAGE_DIR.contains("/Users/"),
+            "{RUNTIME_STAGE_DIR}"
+        );
     }
 
     #[test]
-    fn staged_runtime_path_has_no_whitespace() {
+    fn the_staging_paths_have_no_whitespace() {
         // Every remedy this module prints names this path, and a
         // `sudo chown root <path>` with a space in it is two arguments and the
         // wrong instruction. systemd's `ExecStart` splits on it too.
-        let staged = staged_runtime_path();
-        let staged = staged.to_string_lossy();
-        assert!(
-            !staged.contains(char::is_whitespace),
-            "the staged runtime path must be usable verbatim in a command: {staged}"
-        );
+        for path in [RUNTIME_STAGE_DIR, STAGED_RUNTIME_FILE] {
+            assert!(
+                !path.contains(char::is_whitespace),
+                "a staging path must be usable verbatim in a command: {path}"
+            );
+        }
     }
 
     #[test]
@@ -1267,14 +1332,20 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
-    fn preflight_failures_name_the_fix() {
+    fn a_deferred_user_scope_failure_names_the_path_that_works() {
         assert!(
             PreflightFailure::UserScopePending
                 .message()
                 .contains("sudo"),
             "the deferred user-scope failure must name the path that does work"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_systemd_preflight_failures_name_their_fixes() {
         assert!(
             PreflightFailure::SystemdUnavailable
                 .message()
@@ -1287,6 +1358,17 @@ mod tests {
                 .contains("spiced --token"),
             "containers enroll directly with the runtime, not this installer"
         );
+        // A host with no user manager still has a way to install: say which.
+        let no_manager = PreflightFailure::SystemdUserManagerUnavailable.message();
+        assert!(
+            no_manager.contains("sudo spice connect service install"),
+            "{no_manager}"
+        );
+        assert!(no_manager.contains("enable-linger"), "{no_manager}");
+    }
+
+    #[test]
+    fn preflight_failures_name_the_fix() {
         assert!(
             PreflightFailure::UnsupportedPlatform
                 .message()
@@ -1398,6 +1480,69 @@ mod tests {
     }
 
     #[test]
+    fn install_refuses_to_add_a_second_service_in_the_other_domain() {
+        // The domain follows the privilege of the invocation, so without this
+        // an unprivileged re-install of a host-wide service would install a
+        // user service beside it, leave the system one running, and rewrite the
+        // manifest to describe only the new one.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let fake = FakeBackend::new(dir.path());
+        let mut installed = manifest_for(&fake, &instance_dir);
+
+        for (existing, invoked) in [
+            (ServiceScope::System, ServiceScope::User),
+            (ServiceScope::User, ServiceScope::System),
+        ] {
+            installed.scope = existing;
+            let error = ensure_same_domain(&installed, invoked, &instance_dir)
+                .expect_err("a domain switch must be refused");
+            assert!(error.to_string().contains("already installed"), "{error}");
+            assert!(
+                error
+                    .to_string()
+                    .contains("spice connect service uninstall"),
+                "{error}"
+            );
+            // The retry is the operator's to run, never an elevation Spice
+            // performs for them.
+            let expected_retry = match existing {
+                ServiceScope::System => "sudo spice connect service install",
+                ServiceScope::User => "without sudo",
+            };
+            assert!(error.to_string().contains(expected_retry), "{error}");
+        }
+
+        installed.scope = ServiceScope::User;
+        ensure_same_domain(&installed, ServiceScope::User, &instance_dir)
+            .expect("re-installing in the same domain is the upgrade path");
+    }
+
+    /// The manifest a fake back end would write for `instance_dir`.
+    fn manifest_for(backend: &FakeBackend, instance_dir: &Path) -> ServiceManifest {
+        let scope = ServiceScope::System;
+        let name = backend.name_for_dir(instance_dir);
+        ServiceManifest {
+            schema_version: manifest::MANIFEST_SCHEMA_VERSION,
+            directory: instance_dir.to_path_buf(),
+            name: name.clone(),
+            scope,
+            supervisor: backend.supervisor(),
+            owner: ServiceOwner {
+                uid: 1000,
+                gid: 1000,
+                name: Some("alice".to_string()),
+            },
+            definition_path: backend.definition_path(&name, scope),
+            runtime_path: PathBuf::from("/usr/local/lib/spice/edge-1/spiced"),
+            log_source: backend.log_source(&name, scope),
+            runtime_digest: "0".repeat(64),
+            runtime_version: "v2.2.0".to_string(),
+            health_url: "http://127.0.0.1:8090/health".to_string(),
+        }
+    }
+
+    #[test]
     fn a_service_installed_without_a_manifest_is_still_resolved() {
         // A directory that lost its manifest must not lose the service it
         // still has installed — resolution is still by canonical directory,
@@ -1412,6 +1557,7 @@ mod tests {
             config_dir: &config_dir,
             spiced_path: Path::new("/usr/bin/spiced"),
             scope: ServiceScope::System,
+            health_url: "http://127.0.0.1:8090/health",
         })
         .expect("install without writing a manifest");
 
@@ -1542,28 +1688,9 @@ mod tests {
     /// manifest write, the owner, the log source — is exercised without a
     /// supervisor.
     fn write_manifest_for(backend: &FakeBackend, instance_dir: &Path, config_dir: &Path) {
-        let name = backend.name_for_dir(instance_dir);
-        let scope = ServiceScope::System;
-        ServiceManifest {
-            schema_version: manifest::MANIFEST_SCHEMA_VERSION,
-            directory: instance_dir.to_path_buf(),
-            name: name.clone(),
-            scope,
-            supervisor: backend.supervisor(),
-            owner: ServiceOwner {
-                uid: 1000,
-                gid: 1000,
-                name: Some("alice".to_string()),
-            },
-            definition_path: backend.definition_path(&name, scope),
-            runtime_path: PathBuf::from("/usr/local/lib/spice/spiced"),
-            log_source: backend.log_source(&name, scope),
-            runtime_digest: "0".repeat(64),
-            runtime_version: "v2.2.0".to_string(),
-            health_url: "http://127.0.0.1:8090/health".to_string(),
-        }
-        .write(config_dir)
-        .expect("write manifest");
+        manifest_for(backend, instance_dir)
+            .write(config_dir)
+            .expect("write manifest");
     }
 
     #[test]

--- a/bin/spice/src/commands/connect/service/systemd.rs
+++ b/bin/spice/src/commands/connect/service/systemd.rs
@@ -15,12 +15,37 @@ limitations under the License.
 */
 
 //! The Linux back end: one systemd unit per instance directory.
+//!
+//! ## Two domains, one code path
+//!
+//! An unprivileged install writes a user unit under the account's own
+//! configuration directory and drives it with `systemctl --user`; a root
+//! install writes a system unit under `/etc/systemd/system` and runs the
+//! runtime as the invoking operator rather than as root. The user unit is the
+//! least-privileged normal case, so it is what an ordinary invocation gets.
+//!
+//! ## One runtime per service
+//!
+//! Each unit executes a copy of `spiced` staged for that one instance. A single
+//! host-wide copy would make an upgrade in one instance directory silently
+//! change what every other instance runs at its next restart, and would leave
+//! an uninstall unable to say whether the binary it is deleting is still in
+//! use.
+//!
+//! ## An install is not finished when systemd accepts the unit
+//!
+//! `systemctl restart` returning zero means the service was started, not that
+//! it works. So an install or upgrade gives the service [`HEALTH_GATE`] to
+//! reach `active` and answer its health URL, and anything else puts the
+//! previous unit and the previous runtime back before failing — an upgrade must
+//! never leave an instance worse off than the one it replaced.
 
+use std::io::{Read as _, Write as _};
+use std::net::{TcpStream, ToSocketAddrs as _};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-use super::backend::{
-    InstallRequest, LogRequest, ServiceBackend, ServiceObservation, lifecycle_pending,
-};
+use super::backend::{InstallRequest, LogRequest, ServiceBackend, ServiceObservation};
 use super::manifest::ServiceManifest;
 use super::model::{LogSource, ServiceScope, ServiceStarts, ServiceState, Supervisor};
 use super::{InstalledService, PreflightFailure, SYSTEMD_RUNTIME_MARKER, ServiceAccount};
@@ -40,6 +65,60 @@ const UNIT_PREFIX: &str = "spiced-cloud-connect";
 /// Suffix of every unit this command installs.
 const UNIT_SUFFIX: &str = ".service";
 
+/// The target a system unit is wanted by: reached during boot with nobody
+/// logged in.
+const SYSTEM_WANTED_BY: &str = "multi-user.target";
+
+/// The target a user unit is wanted by: reached when the account's own manager
+/// starts, which is at login, or at boot for an account that lingers.
+const USER_WANTED_BY: &str = "default.target";
+
+/// Directory a user service's own runtime is staged into, relative to the
+/// account's XDG data directory.
+const USER_RUNTIME_SUBDIR: &str = "spice/services";
+
+/// Mode a unit file is written with: readable by the supervisor and by the
+/// operator reading it back, writable only by whoever installed it.
+const UNIT_MODE: u32 = 0o644;
+
+const SYSTEMCTL: &str = "systemctl";
+const JOURNALCTL: &str = "journalctl";
+const LOGINCTL: &str = "loginctl";
+
+/// How long an install or upgrade has to prove the service healthy before it is
+/// rolled back.
+const HEALTH_GATE: Duration = Duration::from_secs(30);
+
+/// How often the health gate asks. Bounded by attempts rather than by a clock
+/// so the whole gate is exercised deterministically in tests.
+const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const HEALTH_ATTEMPTS: u32 = 60;
+
+/// How long a `start`, `stop`, or `restart` has to reach the state it asked
+/// for. systemd returns from these once the job is *done*, so this only covers
+/// a unit that is still settling.
+const LIFECYCLE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const LIFECYCLE_ATTEMPTS: u32 = 40;
+
+/// How long the health probe waits for the instance to accept a connection and
+/// answer. Short: it is retried for the whole of the gate.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Bytes of a health response read before giving up on finding a status line.
+const PROBE_READ_LIMIT: usize = 512;
+
+/// Consecutive `active` readings that stand in for an unanswered health probe:
+/// a runtime that has served uninterrupted for this long is up, whatever the
+/// recorded health URL points at.
+const SETTLE_ATTEMPTS: u32 = 20;
+
+/// Consecutive `failed` readings that end the health gate early.
+///
+/// One is not enough: a unit that is being restarted reports its state through
+/// several words on the way, and calling the first `failed` terminal would roll
+/// back an install that was about to succeed.
+const FAILED_READINGS_BEFORE_GIVING_UP: u32 = 2;
+
 /// Derive this instance directory's unit name.
 pub(super) fn unit_name_for_dir(dir: &Path) -> String {
     format!(
@@ -48,23 +127,202 @@ pub(super) fn unit_name_for_dir(dir: &Path) -> String {
     )
 }
 
+/// One completed supervisor command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CommandOutput {
+    /// Whether the command reported success.
+    pub(super) success: bool,
+    /// The exit code, when the command exited on its own.
+    pub(super) code: Option<i32>,
+    pub(super) stdout: String,
+    pub(super) stderr: String,
+}
+
+impl CommandOutput {
+    /// How a failure is named in an error message: the supervisor's own words
+    /// when it said any, because they diagnose the problem far better than an
+    /// exit code.
+    fn describe_failure(&self) -> String {
+        let stderr = folded(self.stderr.trim());
+        if !stderr.is_empty() {
+            return stderr;
+        }
+        match self.code {
+            Some(code) => format!("exit status {code}"),
+            None => "terminated by a signal".to_string(),
+        }
+    }
+}
+
+/// Everything this back end does outside its own process.
+///
+/// Every supervisor call, the health probe, and the waiting between polls go
+/// through here, so the whole lifecycle — including the states a test host
+/// cannot be put into on demand, like a service that never becomes healthy —
+/// is exercised deterministically against a scripted host.
+pub(super) trait SystemdHost {
+    /// Run a command to completion and capture what it said.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the command could not be run at all, which is a
+    /// different answer from a command that ran and reported a failure.
+    fn output(&self, program: &str, args: &[&str]) -> std::io::Result<CommandOutput>;
+
+    /// Run a command with this process's own stdout and stderr attached, for
+    /// output that is streamed rather than captured.
+    ///
+    /// Returns the exit code, or `None` when the command was ended by a signal
+    /// — which is how an interrupted `logs --follow` ends.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the command could not be run at all.
+    fn stream(&self, program: &str, args: &[&str]) -> std::io::Result<Option<i32>>;
+
+    /// Whether the instance answers `url` right now.
+    fn probe_health(&self, url: &str) -> bool;
+
+    /// Wait before polling again.
+    fn sleep(&self, duration: Duration);
+}
+
+/// The host as it really is.
+pub(super) struct ProcessHost;
+
+impl SystemdHost for ProcessHost {
+    fn output(&self, program: &str, args: &[&str]) -> std::io::Result<CommandOutput> {
+        let output = std::process::Command::new(program).args(args).output()?;
+        Ok(CommandOutput {
+            success: output.status.success(),
+            code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
+    }
+
+    fn stream(&self, program: &str, args: &[&str]) -> std::io::Result<Option<i32>> {
+        let status = std::process::Command::new(program).args(args).status()?;
+        Ok(status.code())
+    }
+
+    fn probe_health(&self, url: &str) -> bool {
+        probe_http_health(url)
+    }
+
+    fn sleep(&self, duration: Duration) {
+        std::thread::sleep(duration);
+    }
+}
+
+/// Whether a health URL is one this back end can probe.
+///
+/// Only plain HTTP is: the recorded URL is the loopback endpoint the runtime
+/// serves, and a gate that cannot reach an unusual one must not fail an install
+/// that is fine — it gates on what systemd reports instead.
+fn is_probeable(url: &str) -> bool {
+    url.strip_prefix("http://")
+        .is_some_and(|rest| !rest.is_empty() && !rest.starts_with('/'))
+}
+
+/// `GET` the health URL and report whether it answered `2xx`.
+///
+/// Blocking and dependency-free on purpose: this runs inside the installer's
+/// own thread, between two filesystem operations, and answers one question
+/// about one loopback address.
+fn probe_http_health(url: &str) -> bool {
+    let Some(rest) = url.strip_prefix("http://") else {
+        return false;
+    };
+    let (authority, path) = match rest.find('/') {
+        Some(index) => (&rest[..index], &rest[index..]),
+        None => (rest, "/"),
+    };
+    let authority = if authority.contains(':') {
+        authority.to_string()
+    } else {
+        format!("{authority}:80")
+    };
+
+    let Ok(mut addrs) = authority.to_socket_addrs() else {
+        return false;
+    };
+    let Some(addr) = addrs.next() else {
+        return false;
+    };
+    let Ok(mut stream) = TcpStream::connect_timeout(&addr, PROBE_TIMEOUT) else {
+        return false;
+    };
+    if stream.set_read_timeout(Some(PROBE_TIMEOUT)).is_err()
+        || stream.set_write_timeout(Some(PROBE_TIMEOUT)).is_err()
+    {
+        return false;
+    }
+
+    let request = format!(
+        "GET {path} HTTP/1.1\r\nHost: {authority}\r\nUser-Agent: spice\r\nConnection: close\r\n\r\n"
+    );
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+
+    let mut response = Vec::with_capacity(PROBE_READ_LIMIT);
+    let mut chunk = [0_u8; 128];
+    while response.len() < PROBE_READ_LIMIT {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => response.extend_from_slice(&chunk[..read]),
+            Err(_) => return false,
+        }
+        if response.contains(&b'\n') {
+            break;
+        }
+    }
+    status_line_is_success(&String::from_utf8_lossy(&response))
+}
+
+/// Whether an HTTP response begins with a `2xx` status line.
+fn status_line_is_success(response: &str) -> bool {
+    let Some(line) = response.lines().next() else {
+        return false;
+    };
+    let mut fields = line.split_whitespace();
+    let Some(version) = fields.next() else {
+        return false;
+    };
+    if !version.starts_with("HTTP/") {
+        return false;
+    }
+    fields
+        .next()
+        .and_then(|code| code.parse::<u16>().ok())
+        .is_some_and(|code| (200..300).contains(&code))
+}
+
 /// Render the unit file for an instance.
 ///
 /// `instance_dir` is baked in as `WorkingDirectory` so the service resolves its
-/// spicepod from the directory the operator enrolled, not from wherever
-/// systemd happens to start it. `config_dir` preserves the resolved Spice state
+/// spicepod from the directory the operator enrolled, not from wherever systemd
+/// happens to start it. `config_dir` preserves the resolved Spice state
 /// directory and `spiced_path` is the absolute binary path resolved at install
 /// time.
+///
+/// `account` is `Some` only for a system unit: a user unit is already running
+/// as its owner, and systemd refuses `User=` in one.
 fn render_unit(
     instance_dir: &Path,
     config_dir: &Path,
     spiced_path: &Path,
-    account: ServiceAccount,
+    account: Option<ServiceAccount>,
+    scope: ServiceScope,
 ) -> Result<String> {
+    use std::fmt::Write as _;
+
     let instance_dir = escape_systemd_path(instance_dir)?;
     let config_dir = escape_systemd_path(config_dir)?;
     let spiced = escape_systemd_path(spiced_path)?;
-    Ok(format!(
+
+    let mut unit = String::from(
         "[Unit]\n\
          Description=Spice runtime connected to Spice Cloud\n\
          Documentation=https://spiceai.org/docs\n\
@@ -72,16 +330,24 @@ fn render_unit(
          Wants=network-online.target\n\
          \n\
          [Service]\n\
-         Type=simple\n\
-         User={uid}\n\
-         Group={gid}\n\
-         WorkingDirectory=\"{instance_dir}\"\n\
+         Type=simple\n",
+    );
+    // Writing into a String is infallible; the Result exists only to satisfy
+    // the `Write` trait.
+    if let Some(account) = account {
+        let _ = writeln!(unit, "User={}", account.uid);
+        let _ = writeln!(unit, "Group={}", account.gid);
+    }
+    let _ = write!(
+        unit,
+        "WorkingDirectory=\"{instance_dir}\"\n\
          Environment=\"SPICE_CONFIG_DIR={config_dir}\"\n\
          ExecStart=\"{spiced}\"\n\
-         # A deployment applies to the running instance, so this is not what\n\
-         # makes one land: it is what brings the instance back from the things\n\
-         # that do end it — a reboot, an OOM kill, an unhandled failure.\n\
-         Restart=always\n\
+         # A deployment applies to the running instance and never ends its\n\
+         # process, so this is what brings the instance back from the things\n\
+         # that do end it — an OOM kill, an unhandled failure. A clean exit is\n\
+         # left alone: it is what an operator's `stop` produces.\n\
+         Restart=on-failure\n\
          RestartSec=5\n\
          # A crash loop must not be given up on: an instance that lost its\n\
          # network for an hour has to come back on its own.\n\
@@ -90,10 +356,13 @@ fn render_unit(
          TimeoutStopSec=30\n\
          \n\
          [Install]\n\
-         WantedBy=multi-user.target\n",
-        uid = account.uid,
-        gid = account.gid,
-    ))
+         WantedBy={wanted_by}\n",
+        wanted_by = match scope {
+            ServiceScope::System => SYSTEM_WANTED_BY,
+            ServiceScope::User => USER_WANTED_BY,
+        }
+    );
+    Ok(unit)
 }
 
 /// Escape a path for a double-quoted systemd directive value.
@@ -150,72 +419,469 @@ fn normalize_systemd_state(reported: &str) -> ServiceState {
     }
 }
 
+/// Whether this host can host a service in `scope`.
+///
+/// A user service needs the account's own manager, which is not running for an
+/// account with no session — a `su` shell, or a container that never logged
+/// anyone in. Detected here so the refusal comes before anything is written
+/// rather than as a `systemctl --user` failure halfway through an install.
 fn preflight(scope: ServiceScope) -> std::result::Result<(), PreflightFailure> {
     if !Path::new(SYSTEMD_RUNTIME_MARKER).is_dir() {
         return Err(PreflightFailure::SystemdUnavailable);
     }
-    if scope == ServiceScope::User {
-        return Err(PreflightFailure::UserScopePending);
+    if scope == ServiceScope::User && !user_runtime_dir().is_dir() {
+        return Err(PreflightFailure::SystemdUserManagerUnavailable);
     }
     Ok(())
 }
 
-fn install(request: &InstallRequest<'_>) -> Result<InstalledService> {
-    let InstallRequest {
-        instance_dir,
-        config_dir,
-        spiced_path,
-        scope,
-    } = *request;
+/// The runtime directory the account's own systemd manager lives in, which is
+/// also the one `systemctl --user` needs to reach it.
+fn user_runtime_dir() -> PathBuf {
+    std::env::var_os("XDG_RUNTIME_DIR").map_or_else(
+        || {
+            PathBuf::from(format!(
+                "/run/user/{}",
+                nix::unistd::Uid::effective().as_raw()
+            ))
+        },
+        PathBuf::from,
+    )
+}
 
-    let account = super::service_account(instance_dir)?;
-    super::provision_config_ownership(config_dir, account)?;
+/// Where units of `scope` live. `None` when the account has no discoverable
+/// configuration directory, which is the one case a user unit path cannot be
+/// derived from.
+fn unit_dir(scope: ServiceScope) -> Option<PathBuf> {
+    match scope {
+        ServiceScope::System => Some(PathBuf::from(SYSTEMD_UNIT_DIR)),
+        ServiceScope::User => Some(dirs::config_dir()?.join(SYSTEMD_USER_UNIT_SUBDIR)),
+    }
+}
 
-    // systemd reports a unit whose `ExecStart` will not run, so the staged copy
-    // needs no separate check.
-    let staged_runtime = super::stage_runtime(spiced_path, |_, _| Ok(()))?;
+/// The directory holding the `spiced` copy this instance's service runs.
+///
+/// Per instance, and inside the domain that owns the service: a system service
+/// runs a root-owned copy no operator can replace behind the supervisor's back,
+/// and a user service runs one out of the account's own data directory. `None`
+/// when a user account has no discoverable data directory.
+fn runtime_dir(instance_dir: &Path, scope: ServiceScope) -> Option<PathBuf> {
+    let stem = super::name_stem_for_dir(instance_dir);
+    match scope {
+        ServiceScope::System => Some(Path::new(super::RUNTIME_STAGE_DIR).join(stem)),
+        ServiceScope::User => Some(dirs::data_local_dir()?.join(USER_RUNTIME_SUBDIR).join(stem)),
+    }
+}
 
-    let name = unit_name_for_dir(instance_dir);
-    let dir = unit_dir(scope).ok_or_else(|| Error::CloudConnectIo {
-        message: "locate the systemd unit directory for this account".to_string(),
-    })?;
-    let path = dir.join(&name);
-    let unit = render_unit(instance_dir, config_dir, &staged_runtime, account)?;
+/// The `spiced` copy this instance's service runs.
+fn runtime_path(instance_dir: &Path, scope: ServiceScope) -> Option<PathBuf> {
+    Some(runtime_dir(instance_dir, scope)?.join(super::STAGED_RUNTIME_FILE))
+}
 
-    std::fs::write(&path, unit).map_err(|e| Error::CloudConnectIo {
+/// Everything an install writes, resolved before it writes any of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InstallPaths {
+    unit: PathBuf,
+    runtime_dir: PathBuf,
+    runtime: PathBuf,
+}
+
+/// Resolve where this install will write, or say which directory could not be
+/// derived.
+fn install_paths(name: &str, instance_dir: &Path, scope: ServiceScope) -> Result<InstallPaths> {
+    let missing = |what: &str| Error::CloudConnectIo {
         message: format!(
-            "write systemd unit {}: {e}. The identity is staged at {} — fix the problem \
-             and re-run `spice connect service install` to finish.",
-            path.display(),
-            config_dir.display()
+            "locate the {what} a {scope} service needs: this account has no such directory. Set \
+             XDG_CONFIG_HOME and XDG_DATA_HOME, or install a system service with \
+             `sudo spice connect service install`."
         ),
-    })?;
-
-    systemctl(scope, &["daemon-reload"])?;
-    // `enable --now` starts the service and persists the boot-time link in one
-    // step. On a reinstall the unit is already enabled and already running, so
-    // follow with an explicit restart to pick up the rewritten unit and the
-    // upgraded binary — `enable --now` alone would leave the old process up.
-    systemctl(scope, &["enable", "--now", &name])?;
-    systemctl(scope, &["restart", &name])?;
-
-    Ok(InstalledService {
-        name,
-        path,
-        working_dir: instance_dir.to_path_buf(),
-        runtime: staged_runtime,
+    };
+    let unit = unit_dir(scope).ok_or_else(|| missing("systemd unit directory"))?;
+    let runtime_dir =
+        runtime_dir(instance_dir, scope).ok_or_else(|| missing("Spice runtime directory"))?;
+    Ok(InstallPaths {
+        unit: unit.join(name),
+        runtime: runtime_dir.join(super::STAGED_RUNTIME_FILE),
+        runtime_dir,
     })
 }
 
-/// Stop, disable, and delete the unit the manifest describes.
+/// Prepare the account the service will run as, and give it access to the
+/// enrolled identity.
+///
+/// `None` for a user service: it already runs as the account that owns the
+/// state, so there is nothing to resolve and nothing to chown.
+fn prepare_account(request: &InstallRequest<'_>) -> Result<Option<ServiceAccount>> {
+    if request.scope == ServiceScope::User {
+        return Ok(None);
+    }
+    let account = super::service_account(request.instance_dir)?;
+    super::provision_config_ownership(request.config_dir, account)?;
+    Ok(Some(account))
+}
+
+fn install(host: &dyn SystemdHost, request: &InstallRequest<'_>) -> Result<InstalledService> {
+    let name = unit_name_for_dir(request.instance_dir);
+    let paths = install_paths(&name, request.instance_dir, request.scope)?;
+    let account = prepare_account(request)?;
+    install_at(host, request, &name, &paths, account)
+}
+
+/// Install into explicitly resolved paths, and leave the previous installation
+/// in force if the new one does not come up healthy.
+fn install_at(
+    host: &dyn SystemdHost,
+    request: &InstallRequest<'_>,
+    name: &str,
+    paths: &InstallPaths,
+    account: Option<ServiceAccount>,
+) -> Result<InstalledService> {
+    ensure_stage_dir(&paths.runtime_dir, request.scope)?;
+
+    // Captured before anything is overwritten: an upgrade that does not come up
+    // has to be able to put back exactly what was serving before it.
+    let rollback = Rollback::capture(paths)?;
+
+    let applied = apply(host, request, name, paths, account);
+    let verdict = match applied {
+        Ok(()) => health_gate(host, name, request.scope, request.health_url),
+        Err(err) => Err(folded(&err.to_string())),
+    };
+
+    match verdict {
+        Ok(()) => {
+            rollback.discard();
+            Ok(InstalledService {
+                name: name.to_string(),
+                path: paths.unit.clone(),
+                working_dir: request.instance_dir.to_path_buf(),
+                runtime: paths.runtime.clone(),
+            })
+        }
+        Err(why) => {
+            let restored = rollback.restore(host, name, request.scope);
+            Err(Error::CloudConnectIo {
+                message: format!(
+                    "install the Spice Cloud Connect service {name} (systemd): {why}. {restored} \
+                     Read what the runtime said with `spice connect service logs -n 200 --dir {dir}`.",
+                    dir = request.instance_dir.display(),
+                ),
+            })
+        }
+    }
+}
+
+/// Stage the runtime, write the unit, and hand the service to systemd.
+fn apply(
+    host: &dyn SystemdHost,
+    request: &InstallRequest<'_>,
+    name: &str,
+    paths: &InstallPaths,
+    account: Option<ServiceAccount>,
+) -> Result<()> {
+    // systemd reports a unit whose `ExecStart` will not run, and the health
+    // gate below is what proves the staged binary actually serves, so the copy
+    // needs no separate check.
+    super::stage_runtime_at(request.spiced_path, &paths.runtime, |_, _| Ok(()))?;
+
+    let unit = render_unit(
+        request.instance_dir,
+        request.config_dir,
+        &paths.runtime,
+        account,
+        request.scope,
+    )?;
+    write_unit(&paths.unit, &unit)?;
+
+    systemctl(host, request.scope, &["daemon-reload"])?;
+    // `enable` writes the persistent boot-time link; `restart` is what picks up
+    // a rewritten unit and an upgraded binary, and starts a service that was
+    // not running. `enable --now` alone would leave the old process up.
+    systemctl(host, request.scope, &["enable", name])?;
+    systemctl(host, request.scope, &["restart", name])?;
+
+    if request.scope == ServiceScope::User {
+        // Best effort: a policy that refuses lingering is reported by `status`
+        // as `login_only` with the command to run, not as a failed install.
+        let _ = enable_linger(host);
+    }
+    Ok(())
+}
+
+/// Wait for the service to prove it is serving, or say what it is doing
+/// instead.
+///
+/// Two things count as proof, and both have to be here. Answering the health
+/// URL is the strongest, and ends the gate as soon as it happens. Staying
+/// `active` without interruption for [`SETTLE_ATTEMPTS`] polls is the other,
+/// and it is what a healthy instance whose endpoint this CLI cannot reach
+/// looks like: the recorded health URL is the address the *CLI* was pointed at,
+/// while the service serves whatever its spicepod configures, so refusing an
+/// install because a probe went unanswered would fail an instance that is
+/// working. What neither accepts is the failure this gate exists for — a
+/// runtime that exits and is restarted, which never accumulates an
+/// uninterrupted run and never answers.
+fn health_gate(
+    host: &dyn SystemdHost,
+    name: &str,
+    scope: ServiceScope,
+    health_url: &str,
+) -> std::result::Result<(), String> {
+    let probeable = is_probeable(health_url);
+    let mut failures = 0;
+    let mut settled = 0;
+    let mut last = format!(
+        "systemd did not report {name} as running within {}s",
+        HEALTH_GATE.as_secs()
+    );
+
+    for attempt in 0..HEALTH_ATTEMPTS {
+        if attempt > 0 {
+            host.sleep(HEALTH_POLL_INTERVAL);
+        }
+        let reported = is_active(host, name, scope).unwrap_or_default();
+        match normalize_systemd_state(&reported) {
+            ServiceState::Running => {
+                failures = 0;
+                settled += 1;
+                if probeable && host.probe_health(health_url) {
+                    return Ok(());
+                }
+                if settled >= SETTLE_ATTEMPTS {
+                    return Ok(());
+                }
+                last = format!(
+                    "{name} did not stay running for {}s, and did not answer {health_url}",
+                    settle_window().as_secs()
+                );
+            }
+            ServiceState::Failed => {
+                settled = 0;
+                failures += 1;
+                last = format!("systemd reports {name} as failed");
+                if failures >= FAILED_READINGS_BEFORE_GIVING_UP {
+                    return Err(last);
+                }
+            }
+            other => {
+                settled = 0;
+                failures = 0;
+                last = format!(
+                    "systemd reports {name} as {other} rather than running, {}s after it was \
+                     started",
+                    HEALTH_GATE.as_secs()
+                );
+            }
+        }
+    }
+    Err(last)
+}
+
+/// How long a service has to run without interruption to count as up.
+fn settle_window() -> Duration {
+    SETTLE_ATTEMPTS * HEALTH_POLL_INTERVAL
+}
+
+/// What an install has to be able to put back.
+///
+/// The unit and the runtime together decide what the host runs, so both are
+/// captured: restoring one without the other would leave a unit pointing at a
+/// binary that is no longer the one it was written for.
+struct Rollback {
+    unit: PathBuf,
+    /// The unit file that was in force, or `None` when nothing was installed.
+    previous_unit: Option<Vec<u8>>,
+    runtime: PathBuf,
+    /// A second name for the runtime that was in force, or `None` when there
+    /// was none.
+    previous_runtime: Option<PathBuf>,
+}
+
+impl Rollback {
+    /// The name the previous runtime is held under while the new one is
+    /// installed.
+    fn backup_name(runtime: &Path) -> PathBuf {
+        runtime.with_extension("previous")
+    }
+
+    /// Capture what is in force now.
+    ///
+    /// The runtime is captured by hard link where the filesystem allows one —
+    /// the publish that follows replaces the directory entry rather than the
+    /// bytes, so a second name preserves the old binary for nothing — and by
+    /// copy where it does not. A capture that cannot be made fails the install
+    /// rather than proceeding: an upgrade nobody can undo is exactly the one
+    /// that must not start.
+    fn capture(paths: &InstallPaths) -> Result<Self> {
+        let previous_unit = std::fs::read(&paths.unit).ok();
+        let previous_runtime = if paths.runtime.is_file() {
+            let backup = Self::backup_name(&paths.runtime);
+            let _ = std::fs::remove_file(&backup);
+            if std::fs::hard_link(&paths.runtime, &backup).is_err() {
+                std::fs::copy(&paths.runtime, &backup).map_err(|e| Error::CloudConnectIo {
+                    message: format!(
+                        "keep a copy of the Spice runtime {} before upgrading it: {e}. The \
+                         upgrade was not started, so the installed service is untouched.",
+                        paths.runtime.display()
+                    ),
+                })?;
+            }
+            Some(backup)
+        } else {
+            None
+        };
+        Ok(Self {
+            unit: paths.unit.clone(),
+            previous_unit,
+            runtime: paths.runtime.clone(),
+            previous_runtime,
+        })
+    }
+
+    /// Let go of the captured runtime, after the new one proved healthy.
+    fn discard(&self) {
+        if let Some(backup) = &self.previous_runtime {
+            let _ = std::fs::remove_file(backup);
+        }
+    }
+
+    /// Put back what was in force, and describe what an operator is left with.
+    ///
+    /// Best effort by design: this already runs on a failure path, and a
+    /// restoration step that also fails must not replace the diagnosis of the
+    /// original failure with its own.
+    fn restore(&self, host: &dyn SystemdHost, name: &str, scope: ServiceScope) -> String {
+        match &self.previous_unit {
+            Some(unit) => {
+                let _ = write_unit_bytes(&self.unit, unit);
+            }
+            None => {
+                let _ = std::fs::remove_file(&self.unit);
+            }
+        }
+        match &self.previous_runtime {
+            Some(backup) => {
+                let _ = std::fs::rename(backup, &self.runtime);
+            }
+            None => {
+                let _ = std::fs::remove_file(&self.runtime);
+            }
+        }
+        // The stamp describes the source the staged runtime was copied from,
+        // and the restored binary did not come from it. Dropping it is what
+        // makes the next install copy again instead of trusting a stamp that
+        // now describes the runtime this rollback just removed.
+        let _ = std::fs::remove_file(self.runtime.with_extension("stamp"));
+
+        let _ = systemctl(host, scope, &["daemon-reload"]);
+        if self.previous_unit.is_some() {
+            let _ = systemctl(host, scope, &["restart", name]);
+            "The service and runtime that were installed before have been put back.".to_string()
+        } else {
+            let _ = systemctl(host, scope, &["disable", "--now", name]);
+            "Nothing was left installed for this directory.".to_string()
+        }
+    }
+}
+
+/// Create the directory a service's runtime is staged into, and refuse it
+/// unless only the domain that owns the service can change what it holds.
+fn ensure_stage_dir(dir: &Path, scope: ServiceScope) -> Result<()> {
+    match scope {
+        ServiceScope::System => super::ensure_root_only_dir(dir),
+        ServiceScope::User => ensure_account_only_dir(dir),
+    }
+}
+
+/// Create `dir` if absent and refuse it unless this account alone can change
+/// what it holds.
+///
+/// The leaf is what is checked, not the whole path to it: everything above a
+/// user's data directory is the account's own home, and anyone who can write
+/// that can already replace the `spiced` on the operator's `PATH`. What this
+/// rules out is the thing that is not implied — a staging directory shared with
+/// another account, or a symlink pointing the service's binary somewhere this
+/// check cannot vouch for.
+fn ensure_account_only_dir(dir: &Path) -> Result<()> {
+    use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _, PermissionsExt as _};
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o755)
+        .create(dir)
+        .map_err(|e| Error::CloudConnectIo {
+            message: format!("create {}: {e}", dir.display()),
+        })?;
+
+    let meta = std::fs::symlink_metadata(dir).map_err(|e| Error::CloudConnectIo {
+        message: format!("inspect {}: {e}", dir.display()),
+    })?;
+    let uid = nix::unistd::Uid::effective().as_raw();
+    let mode = meta.permissions().mode() & 0o7777;
+    if meta.file_type().is_symlink() || meta.uid() != uid || mode & 0o022 != 0 {
+        return Err(Error::InvalidArgument {
+            message: format!(
+                "Failed to install the Spice Cloud Connect service: {dir} must be a real \
+                 directory owned by this account (uid {uid}) that no other account can write, so \
+                 the runtime the service executes cannot be replaced behind it. Fix it \
+                 (`chown {uid} {dir}` and `chmod go-w {dir}`) and re-run \
+                 `spice connect service install`.",
+                dir = dir.display(),
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Write a unit file, creating its directory and replacing it atomically.
+fn write_unit(path: &Path, unit: &str) -> Result<()> {
+    write_unit_bytes(path, unit.as_bytes())
+}
+
+fn write_unit_bytes(path: &Path, unit: &[u8]) -> Result<()> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let io_error = |e: std::io::Error| Error::CloudConnectIo {
+        message: format!("write systemd unit {}: {e}", path.display()),
+    };
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(io_error)?;
+    }
+
+    // A sibling that is renamed into place, so systemd never reads half a unit,
+    // and an explicit mode, so the file does not inherit whatever the process
+    // umask happens to be.
+    let staging = path.with_extension("service.incoming");
+    let _ = std::fs::remove_file(&staging);
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(UNIT_MODE)
+        .open(&staging)
+        .map_err(io_error)?;
+    file.write_all(unit).map_err(io_error)?;
+    file.sync_all().map_err(io_error)?;
+    drop(file);
+
+    std::fs::rename(&staging, path).map_err(|e| {
+        let _ = std::fs::remove_file(&staging);
+        io_error(e)
+    })
+}
+
+/// Stop, disable, and delete the unit the manifest describes, together with the
+/// runtime staged for it.
 ///
 /// Stop/disable failures are tolerated — a unit file left on disk would restart
 /// a service against a released identity forever, so the deletion is what must
-/// happen.
-fn uninstall(manifest: &ServiceManifest) -> Result<()> {
+/// happen. The journal is left to systemd's own retention.
+fn uninstall(host: &dyn SystemdHost, manifest: &ServiceManifest) -> Result<()> {
+    ensure_authorized(manifest, "uninstall")?;
+
     // Best-effort: a unit that is already stopped, already disabled, or whose
     // systemd is not running must not block removing the file.
-    if let Err(err) = systemctl(manifest.scope, &["disable", "--now", &manifest.name]) {
+    if let Err(err) = systemctl(host, manifest.scope, &["disable", "--now", &manifest.name]) {
         tracing::debug!("systemctl disable --now {}: {err}", manifest.name);
     }
 
@@ -226,21 +892,245 @@ fn uninstall(manifest: &ServiceManifest) -> Result<()> {
             return Err(Error::CloudConnectIo {
                 message: format!(
                     "remove systemd unit {}: {e}. The service would keep restarting against a \
-                     released identity — delete the file and run `sudo systemctl daemon-reload`.",
-                    manifest.definition_path.display()
+                     released identity — delete the file and run `{}`.",
+                    manifest.definition_path.display(),
+                    systemctl_command(manifest.scope, &["daemon-reload"]),
                 ),
             });
         }
     }
 
-    if let Err(err) = systemctl(manifest.scope, &["daemon-reload"]) {
+    remove_staged_runtime(manifest);
+
+    if let Err(err) = systemctl(host, manifest.scope, &["daemon-reload"]) {
         tracing::debug!("systemctl daemon-reload: {err}");
     }
 
     Ok(())
 }
 
-/// The unit installed for `instance_dir` in `scope`, if the definition under
+/// The staging directory holding the runtime this service — and only this
+/// service — executes.
+///
+/// `None` when the manifest records a runtime somewhere else, which describes a
+/// binary this command cannot prove is unshared: one uninstall must never take
+/// out another service's runtime.
+fn owned_runtime_dir(manifest: &ServiceManifest) -> Option<PathBuf> {
+    let expected = runtime_dir(&manifest.directory, manifest.scope)?;
+    (manifest.runtime_path.parent() == Some(expected.as_path())).then_some(expected)
+}
+
+/// Delete the runtime staged for this service, and nothing else.
+fn remove_staged_runtime(manifest: &ServiceManifest) {
+    let Some(owned) = owned_runtime_dir(manifest) else {
+        tracing::debug!(
+            "leaving {} in place: it is not this service's own staged runtime",
+            manifest.runtime_path.display()
+        );
+        return;
+    };
+    if let Err(e) = std::fs::remove_dir_all(&owned)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::debug!("remove staged runtime {}: {e}", owned.display());
+    }
+}
+
+/// Start an installed service and confirm it came up.
+fn start(host: &dyn SystemdHost, manifest: &ServiceManifest) -> Result<()> {
+    ensure_authorized(manifest, "start")?;
+    systemctl_action(host, manifest, "start", &["start", &manifest.name])?;
+    await_state(host, manifest, "start", ServiceState::Running)
+}
+
+/// Stop a running service and confirm it went down, leaving it installed.
+fn stop(host: &dyn SystemdHost, manifest: &ServiceManifest) -> Result<()> {
+    ensure_authorized(manifest, "stop")?;
+    systemctl_action(host, manifest, "stop", &["stop", &manifest.name])?;
+    await_state(host, manifest, "stop", ServiceState::Stopped)
+}
+
+/// Restart through the supervisor and wait for the service to come back.
+///
+/// Never asks `spiced` to exit itself: the supervisor owns the stop and the
+/// start, so a restart that fails is systemd's failure to report rather than a
+/// runtime that quietly went away.
+fn restart(host: &dyn SystemdHost, manifest: &ServiceManifest) -> Result<()> {
+    ensure_authorized(manifest, "restart")?;
+    systemctl_action(host, manifest, "restart", &["restart", &manifest.name])?;
+    await_state(host, manifest, "restart", ServiceState::Running)
+}
+
+/// Wait for the unit to reach `wanted`, or report what it is doing instead.
+///
+/// `systemctl` returns once its job is done, so this only covers a unit that is
+/// still settling — and it is what turns "the command exited zero" into "the
+/// service is in the state you asked for".
+fn await_state(
+    host: &dyn SystemdHost,
+    manifest: &ServiceManifest,
+    action: &str,
+    wanted: ServiceState,
+) -> Result<()> {
+    let mut observed = ServiceState::Unavailable;
+    for attempt in 0..LIFECYCLE_ATTEMPTS {
+        if attempt > 0 {
+            host.sleep(LIFECYCLE_POLL_INTERVAL);
+        }
+        let reported = is_active(host, &manifest.name, manifest.scope).unwrap_or_default();
+        observed = normalize_systemd_state(&reported);
+        if observed == wanted {
+            return Ok(());
+        }
+        // A unit stopped after a failure stays `failed`, which is systemd's
+        // word for "not running, and it did not end cleanly". The service is
+        // down, which is what a stop asked for.
+        if wanted == ServiceState::Stopped && observed == ServiceState::Failed {
+            return Ok(());
+        }
+    }
+
+    Err(Error::CloudConnectIo {
+        message: format!(
+            "{action} the Spice Cloud Connect service {name} (systemd): systemd reports it as \
+             {observed} rather than {wanted}. Inspect it with `{status}` and \
+             `spice connect service logs -n 200 --dir {dir}`.",
+            name = manifest.name,
+            status = systemctl_command(manifest.scope, &["status", &manifest.name]),
+            dir = manifest.directory.display(),
+        ),
+    })
+}
+
+/// Print the service's output from the journal, bounded and without a pager.
+fn logs(host: &dyn SystemdHost, manifest: &ServiceManifest, request: LogRequest) -> Result<()> {
+    let args = journal_args(&manifest.name, manifest.scope, request);
+    let args: Vec<&str> = args.iter().map(String::as_str).collect();
+
+    if request.follow {
+        // Streamed rather than captured: the snapshot systemd prints first and
+        // everything after it has to reach the terminal as it arrives, and it
+        // does not end until the viewer is interrupted.
+        return match host.stream(JOURNALCTL, &args) {
+            // Ended by a signal, or by the SIGINT that also reached this
+            // process: the viewer stopped, the service did not change.
+            Ok(None | Some(130)) => Err(Error::Interrupted),
+            Ok(Some(0)) => Ok(()),
+            Ok(Some(code)) => Err(journal_failure(
+                manifest,
+                &format!("`journalctl` exited with status {code}"),
+            )),
+            Err(e) => Err(journal_failure(manifest, &format!("run `journalctl`: {e}"))),
+        };
+    }
+
+    let output = host
+        .output(JOURNALCTL, &args)
+        .map_err(|e| journal_failure(manifest, &format!("run `journalctl`: {e}")))?;
+    if !output.success {
+        return Err(journal_failure(manifest, &output.describe_failure()));
+    }
+
+    if output.stdout.trim().is_empty() {
+        println!("No logs yet for {}.", manifest.name);
+        if manifest.scope == ServiceScope::System && !super::is_root() {
+            println!(
+                "If this account cannot read the system journal, retry with \
+                 `sudo spice connect service logs --dir {}`.",
+                manifest.directory.display()
+            );
+        }
+        return Ok(());
+    }
+
+    print!("{}", output.stdout);
+    if !output.stdout.ends_with('\n') {
+        println!();
+    }
+    Ok(())
+}
+
+/// The exact `journalctl` invocation for one service.
+///
+/// Scoped to the unit by exact name, bounded by `-n`, and never paged: a log
+/// command that opens a pager cannot be used from a script, and one that is
+/// unbounded prints whatever the host has kept.
+fn journal_args(name: &str, scope: ServiceScope, request: LogRequest) -> Vec<String> {
+    let mut args: Vec<String> = Vec::with_capacity(9);
+    if scope == ServiceScope::User {
+        args.push("--user".to_string());
+    }
+    args.extend([
+        "-u".to_string(),
+        name.to_string(),
+        "--no-pager".to_string(),
+        "-q".to_string(),
+        "-o".to_string(),
+        "cat".to_string(),
+        "-n".to_string(),
+        request.number.to_string(),
+    ]);
+    if request.follow {
+        args.push("-f".to_string());
+    }
+    args
+}
+
+/// The error a journal read fails with, naming the elevation it may need
+/// rather than performing it.
+fn journal_failure(manifest: &ServiceManifest, reason: &str) -> Error {
+    let retry = match manifest.scope {
+        ServiceScope::System if !super::is_root() => format!(
+            " If this account cannot read the system journal, retry with \
+             `sudo spice connect service logs --dir {}`.",
+            manifest.directory.display()
+        ),
+        _ => String::new(),
+    };
+    Error::CloudConnectIo {
+        message: format!(
+            "read the logs of the Spice Cloud Connect service {name} (systemd): {reason}.{retry}",
+            name = manifest.name,
+        ),
+    }
+}
+
+/// Refuse an action this invocation cannot perform, naming the exact retry.
+///
+/// Spice never elevates on its own, and never drives a user service through
+/// `sudo`: root's user manager is a different manager from the operator's, so a
+/// `sudo systemctl --user` would report on a service that is not the installed
+/// one.
+fn ensure_authorized(manifest: &ServiceManifest, action: &str) -> Result<()> {
+    let effective = nix::unistd::Uid::effective().as_raw();
+    match manifest.scope {
+        ServiceScope::System if effective != 0 => Err(Error::InvalidArgument {
+            message: format!(
+                "Failed to {action} the Spice Cloud Connect service {name} (systemd): a system \
+                 service is managed with root privileges, and Spice never elevates on its own. \
+                 Retry with `sudo spice connect service {action} --dir {dir}`. Nothing was \
+                 changed. See: https://spiceai.org/docs",
+                name = manifest.name,
+                dir = manifest.directory.display(),
+            ),
+        }),
+        ServiceScope::User if effective != manifest.owner.uid => Err(Error::InvalidArgument {
+            message: format!(
+                "Failed to {action} the Spice Cloud Connect service {name} (systemd): a user \
+                 service is managed by the account that owns it ({owner}), and running this \
+                 through sudo would target root's user manager instead of that account's. Run \
+                 `spice connect service {action} --dir {dir}` as {owner}. Nothing was changed. \
+                 See: https://spiceai.org/docs",
+                name = manifest.name,
+                owner = manifest.owner.describe(),
+                dir = manifest.directory.display(),
+            ),
+        }),
+        _ => Ok(()),
+    }
+}
+
+/// The service installed for `instance_dir` in `scope`, if the definition under
 /// this directory's derived name names this directory as its working directory.
 ///
 /// The working-directory check is what makes this a verification rather than a
@@ -257,23 +1147,15 @@ pub(super) fn find_for_dir(instance_dir: &Path, scope: ServiceScope) -> Option<I
     if parse_working_dir(&unit)? != instance_dir {
         return None;
     }
-    let runtime = parse_exec_runtime(&unit).unwrap_or_else(super::staged_runtime_path);
+    let runtime = parse_exec_runtime(&unit)
+        .or_else(|| runtime_path(instance_dir, scope))
+        .unwrap_or_default();
     Some(InstalledService {
         name,
         path,
         working_dir: instance_dir.to_path_buf(),
         runtime,
     })
-}
-
-/// Where units of `scope` live. `None` when the account has no discoverable
-/// configuration directory, which is the one case a user unit path cannot be
-/// derived from.
-fn unit_dir(scope: ServiceScope) -> Option<PathBuf> {
-    match scope {
-        ServiceScope::System => Some(PathBuf::from(SYSTEMD_UNIT_DIR)),
-        ServiceScope::User => Some(dirs::config_dir()?.join(SYSTEMD_USER_UNIT_SUBDIR)),
-    }
 }
 
 /// Parse the `WorkingDirectory=` value out of a rendered unit.
@@ -348,17 +1230,17 @@ fn unit_directive<'a>(unit: &'a str, key: &str) -> Option<&'a str> {
 
 /// The service's current state as `systemctl is-active` reports it
 /// (`active`, `inactive`, `failed`, …), or `None` when it cannot be determined.
-fn is_active(unit_name: &str, scope: ServiceScope) -> Option<String> {
+fn is_active(host: &dyn SystemdHost, unit_name: &str, scope: ServiceScope) -> Option<String> {
     // `is-active` exits non-zero for anything but `active`, and prints the
     // state either way — so read stdout regardless of the exit status.
-    let state = systemctl_query(scope, &["is-active", unit_name])?;
+    let state = systemctl_query(host, scope, &["is-active", unit_name])?;
     (!state.is_empty()).then_some(state)
 }
 
 /// Observe the unit: the state systemd reports plus whether it will come back
 /// on its own.
-fn observe(manifest: &ServiceManifest) -> ServiceObservation {
-    let Some(reported) = is_active(&manifest.name, manifest.scope) else {
+fn observe(host: &dyn SystemdHost, manifest: &ServiceManifest) -> ServiceObservation {
+    let Some(reported) = is_active(host, &manifest.name, manifest.scope) else {
         return ServiceObservation::unavailable(format!(
             "systemctl could not be asked about {}. Check that systemd is running and that this \
              account may query it ({}).",
@@ -366,7 +1248,7 @@ fn observe(manifest: &ServiceManifest) -> ServiceObservation {
             systemctl_command(manifest.scope, &["is-active", &manifest.name])
         ));
     };
-    let (starts, starts_action) = observe_persistence(manifest);
+    let (starts, starts_action) = observe_persistence(host, manifest);
     let state = normalize_systemd_state(&reported);
     ServiceObservation {
         state,
@@ -392,7 +1274,26 @@ fn unrecognized_state_diagnostic(reported: &str, manifest: &ServiceManifest) -> 
     )
 }
 
-/// Whether the unit is enabled, translated into the operator outcome.
+/// Whether the unit is enabled — and, for a user unit, whether its account
+/// lingers — translated into the operator outcome.
+fn observe_persistence(
+    host: &dyn SystemdHost,
+    manifest: &ServiceManifest,
+) -> (ServiceStarts, Option<String>) {
+    let Some(reported) = systemctl_query(host, manifest.scope, &["is-enabled", &manifest.name])
+    else {
+        return (ServiceStarts::Unavailable, None);
+    };
+    let lingers = match manifest.scope {
+        ServiceScope::System => None,
+        ServiceScope::User => account_lingers(host, &manifest.owner.describe()),
+    };
+    classify_persistence(&reported, lingers, manifest)
+}
+
+/// [`observe_persistence`] without the process: the classification of what
+/// `systemctl is-enabled` and `loginctl` answered, so every branch is testable
+/// on a host that has no systemd.
 ///
 /// Only a plain `enabled` establishes persistence. `enabled-runtime` is
 /// deliberately not enough: its link lives under `/run` and is gone after a
@@ -405,29 +1306,22 @@ fn unrecognized_state_diagnostic(reported: &str, manifest: &ServiceManifest) -> 
 /// A *masked* unit cannot be enabled until it is unmasked, so its remediation
 /// says so rather than printing an `enable` that is guaranteed to fail.
 ///
-/// A system unit that is enabled comes up at boot with nobody logged in. A
-/// *user* unit that is enabled comes up when its owner logs in and no earlier
-/// unless that account lingers, so the conservative answer is `login_only`
-/// plus the command that changes it — claiming boot persistence that is not
-/// there is the failure this avoids.
-fn observe_persistence(manifest: &ServiceManifest) -> (ServiceStarts, Option<String>) {
-    let Some(reported) = systemctl_query(manifest.scope, &["is-enabled", &manifest.name]) else {
-        return (ServiceStarts::Unavailable, None);
-    };
-    classify_persistence(&reported, manifest)
-}
-
-/// [`observe_persistence`] without the process: the classification of what
-/// `systemctl is-enabled` answered, so every branch is testable on a host that
-/// has no systemd.
+/// An enabled system unit comes up at boot with nobody logged in. An enabled
+/// *user* unit comes up when its owner's manager starts, which is at login and
+/// no earlier unless that account lingers — so `lingers` decides between the
+/// two operator outcomes, and an account whose lingering could not be read is
+/// reported as `login_only` with the command that settles it rather than as a
+/// boot-persistence claim that may not hold.
 fn classify_persistence(
     reported: &str,
+    lingers: Option<bool>,
     manifest: &ServiceManifest,
 ) -> (ServiceStarts, Option<String>) {
     let enable = || systemctl_command(manifest.scope, &["enable", &manifest.name]);
     match reported.trim() {
         "enabled" => match manifest.scope {
             ServiceScope::System => (ServiceStarts::BootWithoutLogin, None),
+            ServiceScope::User if lingers == Some(true) => (ServiceStarts::BootWithoutLogin, None),
             ServiceScope::User => (
                 ServiceStarts::LoginOnly,
                 Some(format!(
@@ -448,6 +1342,37 @@ fn classify_persistence(
         // is not a state to invent an outcome for.
         "" => (ServiceStarts::Unavailable, None),
         _ => (ServiceStarts::Disabled, Some(enable())),
+    }
+}
+
+/// Ask logind to keep this account's manager running with nobody logged in,
+/// and report what it did.
+///
+/// The verification is the point: `enable-linger` can be refused by policy, and
+/// an install that assumed it worked would promise boot persistence the host
+/// will not deliver.
+fn enable_linger(host: &dyn SystemdHost) -> Option<bool> {
+    let account = super::account_name(nix::unistd::Uid::effective().as_raw())?;
+    let _ = host.output(LOGINCTL, &["enable-linger", &account]);
+    account_lingers(host, &account)
+}
+
+/// Whether logind reports `account` as lingering. `None` when it could not be
+/// asked, which is not the same as an account that does not linger.
+fn account_lingers(host: &dyn SystemdHost, account: &str) -> Option<bool> {
+    let output = host
+        .output(
+            LOGINCTL,
+            &["show-user", account, "--property=Linger", "--value"],
+        )
+        .ok()?;
+    if !output.success {
+        return None;
+    }
+    match output.stdout.trim() {
+        "yes" => Some(true),
+        "no" => Some(false),
+        _ => None,
     }
 }
 
@@ -478,7 +1403,7 @@ fn systemctl_command(scope: ServiceScope, args: &[&str]) -> String {
     if scope == ServiceScope::System && !super::is_root() {
         parts.push("sudo");
     }
-    parts.push("systemctl");
+    parts.push(SYSTEMCTL);
     parts.extend(scope_args(scope));
     parts.extend(args);
     parts.join(" ")
@@ -489,43 +1414,78 @@ fn systemctl_command(scope: ServiceScope, args: &[&str]) -> String {
 /// The exit status is ignored on purpose: the query commands report their
 /// answer on stdout and use the exit status to encode that answer. `None`
 /// means `systemctl` could not be run at all.
-fn systemctl_query(scope: ServiceScope, args: &[&str]) -> Option<String> {
-    let output = std::process::Command::new("systemctl")
-        .args(scope_args(scope))
-        .args(args)
-        .output()
-        .ok()?;
-    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+fn systemctl_query(host: &dyn SystemdHost, scope: ServiceScope, args: &[&str]) -> Option<String> {
+    let mut all = scope_args(scope).to_vec();
+    all.extend_from_slice(args);
+    let output = host.output(SYSTEMCTL, &all).ok()?;
+    Some(output.stdout.trim().to_string())
 }
 
 /// Run `systemctl <args>`, turning a non-zero exit into an error carrying
 /// systemd's own stderr — which names the actual problem far better than an
 /// exit code.
-fn systemctl(scope: ServiceScope, args: &[&str]) -> Result<()> {
-    let output = std::process::Command::new("systemctl")
-        .args(scope_args(scope))
-        .args(args)
-        .output()
+fn systemctl(host: &dyn SystemdHost, scope: ServiceScope, args: &[&str]) -> Result<()> {
+    let mut all = scope_args(scope).to_vec();
+    all.extend_from_slice(args);
+    let output = host
+        .output(SYSTEMCTL, &all)
         .map_err(|e| Error::CloudConnectIo {
             message: format!("run `{}`: {e}", systemctl_command(scope, args)),
         })?;
 
-    if output.status.success() {
+    if output.success {
         return Ok(());
     }
 
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     Err(Error::CloudConnectIo {
         message: format!(
             "`{}` failed: {}",
             systemctl_command(scope, args),
-            if stderr.is_empty() {
-                format!("exit status {}", output.status)
-            } else {
-                stderr
-            }
+            output.describe_failure()
         ),
     })
+}
+
+/// [`systemctl`] for a lifecycle action, adding the retry an authorization
+/// refusal needs.
+///
+/// The pre-flight authorization check catches the usual case, but polkit can
+/// refuse a root-equivalent invocation too — and the answer is still a command
+/// the operator runs, never an elevation this CLI performs.
+fn systemctl_action(
+    host: &dyn SystemdHost,
+    manifest: &ServiceManifest,
+    action: &str,
+    args: &[&str],
+) -> Result<()> {
+    systemctl(host, manifest.scope, args).map_err(|err| {
+        let denied = ["denied", "not authorized", "authentication", "permitted"]
+            .iter()
+            .any(|word| err.to_string().to_ascii_lowercase().contains(word));
+        let retry = if denied && manifest.scope == ServiceScope::System {
+            format!(
+                " Retry with `sudo spice connect service {action} --dir {}`.",
+                manifest.directory.display()
+            )
+        } else {
+            String::new()
+        };
+        Error::CloudConnectIo {
+            message: format!(
+                "{action} the Spice Cloud Connect service {name} (systemd): {reason}.{retry}",
+                name = manifest.name,
+                reason = folded(&err.to_string()),
+            ),
+        }
+    })
+}
+
+/// One line, whatever the source said.
+///
+/// Supervisor output arrives with newlines in it, and a log line that carries
+/// them is two records that only one of which can be searched for.
+fn folded(message: &str) -> String {
+    message.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// The Linux back end.
@@ -562,31 +1522,31 @@ impl ServiceBackend for SystemdBackend {
     }
 
     fn install(&self, request: &InstallRequest<'_>) -> Result<InstalledService> {
-        install(request)
+        install(&ProcessHost, request)
     }
 
     fn uninstall(&self, manifest: &ServiceManifest) -> Result<()> {
-        uninstall(manifest)
+        uninstall(&ProcessHost, manifest)
     }
 
     fn start(&self, manifest: &ServiceManifest) -> Result<()> {
-        Err(lifecycle_pending(self, "start", manifest))
+        start(&ProcessHost, manifest)
     }
 
     fn stop(&self, manifest: &ServiceManifest) -> Result<()> {
-        Err(lifecycle_pending(self, "stop", manifest))
+        stop(&ProcessHost, manifest)
     }
 
     fn restart(&self, manifest: &ServiceManifest) -> Result<()> {
-        Err(lifecycle_pending(self, "restart", manifest))
+        restart(&ProcessHost, manifest)
     }
 
     fn observe(&self, manifest: &ServiceManifest) -> ServiceObservation {
-        observe(manifest)
+        observe(&ProcessHost, manifest)
     }
 
-    fn logs(&self, manifest: &ServiceManifest, _request: LogRequest) -> Result<()> {
-        Err(lifecycle_pending(self, "read the logs of", manifest))
+    fn logs(&self, manifest: &ServiceManifest, request: LogRequest) -> Result<()> {
+        logs(&ProcessHost, manifest, request)
     }
 
     fn recovery_hints(&self, manifest: &ServiceManifest) -> Vec<String> {
@@ -596,7 +1556,185 @@ impl ServiceBackend for SystemdBackend {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::collections::{HashMap, VecDeque};
+
     use super::*;
+
+    /// A host whose every answer is scripted, so the lifecycle can be exercised
+    /// against states no test machine can be put into on demand — a service
+    /// that never becomes healthy, a `loginctl` that refuses to linger, a
+    /// journal that cannot be read.
+    struct ScriptedHost {
+        answers: RefCell<HashMap<String, VecDeque<CommandOutput>>>,
+        health: RefCell<VecDeque<bool>>,
+        calls: RefCell<Vec<String>>,
+        streamed: RefCell<Vec<String>>,
+        stream_code: Option<i32>,
+        slept: RefCell<Duration>,
+    }
+
+    impl ScriptedHost {
+        fn new() -> Self {
+            Self {
+                answers: RefCell::new(HashMap::new()),
+                health: RefCell::new(VecDeque::new()),
+                calls: RefCell::new(Vec::new()),
+                streamed: RefCell::new(Vec::new()),
+                stream_code: Some(0),
+                slept: RefCell::new(Duration::ZERO),
+            }
+        }
+
+        /// The command line as this host keys its answers by.
+        fn key(program: &str, args: &[&str]) -> String {
+            if args.is_empty() {
+                program.to_string()
+            } else {
+                format!("{program} {}", args.join(" "))
+            }
+        }
+
+        /// Answer `command` with `stdout`, repeating the last answer once the
+        /// scripted ones run out.
+        fn says(self, command: &str, stdout: &str) -> Self {
+            self.sequence(command, &[stdout])
+        }
+
+        fn sequence(self, command: &str, stdouts: &[&str]) -> Self {
+            let answers = stdouts
+                .iter()
+                .map(|stdout| CommandOutput {
+                    success: true,
+                    code: Some(0),
+                    stdout: (*stdout).to_string(),
+                    stderr: String::new(),
+                })
+                .collect();
+            self.answers
+                .borrow_mut()
+                .insert(command.to_string(), answers);
+            self
+        }
+
+        fn fails(self, command: &str, stderr: &str) -> Self {
+            self.answers.borrow_mut().insert(
+                command.to_string(),
+                VecDeque::from(vec![CommandOutput {
+                    success: false,
+                    code: Some(1),
+                    stdout: String::new(),
+                    stderr: stderr.to_string(),
+                }]),
+            );
+            self
+        }
+
+        fn health(self, verdicts: &[bool]) -> Self {
+            *self.health.borrow_mut() = verdicts.iter().copied().collect();
+            self
+        }
+
+        fn streaming(mut self, code: Option<i32>) -> Self {
+            self.stream_code = code;
+            self
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.borrow().clone()
+        }
+
+        fn ran(&self, command: &str) -> bool {
+            self.calls.borrow().iter().any(|call| call == command)
+        }
+    }
+
+    impl SystemdHost for ScriptedHost {
+        fn output(&self, program: &str, args: &[&str]) -> std::io::Result<CommandOutput> {
+            let key = Self::key(program, args);
+            self.calls.borrow_mut().push(key.clone());
+            let mut answers = self.answers.borrow_mut();
+            let Some(queued) = answers.get_mut(&key) else {
+                return Ok(CommandOutput {
+                    success: true,
+                    code: Some(0),
+                    stdout: String::new(),
+                    stderr: String::new(),
+                });
+            };
+            // The last scripted answer stands for every later ask, so a poll
+            // that settles does not need one answer per attempt.
+            let answer = if queued.len() > 1 {
+                queued.pop_front()
+            } else {
+                queued.front().cloned()
+            };
+            Ok(answer.expect("a scripted command always has an answer"))
+        }
+
+        fn stream(&self, program: &str, args: &[&str]) -> std::io::Result<Option<i32>> {
+            self.streamed.borrow_mut().push(Self::key(program, args));
+            Ok(self.stream_code)
+        }
+
+        fn probe_health(&self, _url: &str) -> bool {
+            let mut health = self.health.borrow_mut();
+            if health.len() > 1 {
+                health.pop_front().unwrap_or(false)
+            } else {
+                health.front().copied().unwrap_or(false)
+            }
+        }
+
+        fn sleep(&self, duration: Duration) {
+            *self.slept.borrow_mut() += duration;
+        }
+    }
+
+    const TEST_ACCOUNT: ServiceAccount = ServiceAccount {
+        uid: 1000,
+        gid: 1001,
+    };
+
+    const HEALTH_URL: &str = "http://127.0.0.1:8090/health";
+
+    fn rendered(instance_dir: &str, config_dir: &str, spiced_path: &str) -> String {
+        render_unit(
+            Path::new(instance_dir),
+            Path::new(config_dir),
+            Path::new(spiced_path),
+            Some(TEST_ACCOUNT),
+            ServiceScope::System,
+        )
+        .expect("test paths are safe systemd values")
+    }
+
+    /// A manifest for the unit under test, without touching the filesystem.
+    ///
+    /// The owner is this account, so the authorization check lets a user-scope
+    /// lifecycle action through; the tests that exercise a refusal say so.
+    fn manifest(scope: ServiceScope) -> ServiceManifest {
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        let uid = nix::unistd::Uid::effective().as_raw();
+        ServiceManifest {
+            schema_version: super::super::manifest::MANIFEST_SCHEMA_VERSION,
+            directory: PathBuf::from("/opt/edge-1"),
+            name: name.clone(),
+            scope,
+            supervisor: Supervisor::Systemd,
+            owner: super::super::ServiceOwner {
+                uid,
+                gid: uid,
+                name: Some("alice".to_string()),
+            },
+            definition_path: SystemdBackend.definition_path(&name, scope),
+            runtime_path: runtime_path(Path::new("/opt/edge-1"), scope).unwrap_or_default(),
+            log_source: SystemdBackend.log_source(&name, scope),
+            runtime_digest: String::new(),
+            runtime_version: "v2.2.0".to_string(),
+            health_url: HEALTH_URL.to_string(),
+        }
+    }
 
     #[test]
     fn every_systemd_state_normalizes() {
@@ -620,21 +1758,6 @@ mod tests {
         }
         // `is-active` output arrives with a trailing newline.
         assert_eq!(normalize_systemd_state("active\n"), ServiceState::Running);
-    }
-
-    const TEST_ACCOUNT: ServiceAccount = ServiceAccount {
-        uid: 1000,
-        gid: 1001,
-    };
-
-    fn rendered(instance_dir: &str, config_dir: &str, spiced_path: &str) -> String {
-        render_unit(
-            Path::new(instance_dir),
-            Path::new(config_dir),
-            Path::new(spiced_path),
-            TEST_ACCOUNT,
-        )
-        .expect("test paths are safe systemd values")
     }
 
     #[test]
@@ -663,7 +1786,7 @@ mod tests {
         let unit = rendered(
             "/opt/edge-1",
             "/opt/edge-1/.spice",
-            "/root/.spice/bin/spiced",
+            "/usr/local/lib/spice/edge-1/spiced",
         );
         assert!(unit.contains("WorkingDirectory=\"/opt/edge-1\"\n"));
         assert_eq!(
@@ -678,46 +1801,59 @@ mod tests {
         let unit = rendered(
             "/opt/edge-1",
             "/opt/edge-1/.spice",
-            "/root/.spice/bin/spiced",
+            "/usr/local/lib/spice/edge-1/spiced",
         );
         // No flag: the enrolled identity under SPICE_CONFIG_DIR is what
         // activates Cloud Connect on every start.
-        assert!(unit.contains("ExecStart=\"/root/.spice/bin/spiced\"\n"));
+        assert!(unit.contains("ExecStart=\"/usr/local/lib/spice/edge-1/spiced\"\n"));
         assert!(!unit.contains("--cloud-connect"));
     }
 
     #[test]
-    fn rendered_unit_always_restarts() {
-        // `Restart=always` is what keeps an enrolled instance reachable: a
-        // deployment applies without ending the process, but a reboot or an
-        // unhandled failure does end it, and the instance has to come back.
-        let unit = rendered("/opt/edge-1", "/opt/edge-1/.spice", "/usr/bin/spiced");
-        assert!(unit.contains("\nRestart=always\n"));
-        // A rate limit would let a crash loop give up permanently.
-        assert!(unit.contains("StartLimitIntervalSec=0"));
-        assert!(unit.contains("WantedBy=multi-user.target"));
+    fn rendered_unit_restarts_a_failure_and_leaves_a_clean_exit_alone() {
+        // A deployment applies to the running instance without ending it, so
+        // the restart policy is there for the things that do end it. A clean
+        // exit is what an operator's `stop` produces and must stay stopped.
+        for scope in [ServiceScope::System, ServiceScope::User] {
+            let unit = render_unit(
+                Path::new("/opt/edge-1"),
+                Path::new("/opt/edge-1/.spice"),
+                Path::new("/usr/bin/spiced"),
+                None,
+                scope,
+            )
+            .expect("render unit");
+            assert!(unit.contains("\nRestart=on-failure\n"), "{scope}");
+            assert!(unit.contains("\nRestartSec=5\n"), "{scope}");
+            // A rate limit would let a crash loop give up permanently.
+            assert!(unit.contains("\nStartLimitIntervalSec=0\n"), "{scope}");
+        }
     }
 
     #[test]
-    fn rendered_unit_runs_the_root_owned_staged_runtime() {
-        // ExecStart stays the staged root-owned copy — never the operator's
-        // replaceable `~/.spice/bin/spiced`.
-        let staged = super::super::staged_runtime_path();
-        let unit = render_unit(
-            Path::new("/opt/edge-1"),
-            Path::new("/opt/edge-1/.spice"),
-            &staged,
-            TEST_ACCOUNT,
-        )
-        .expect("render unit");
-        assert_eq!(parse_exec_runtime(&unit), Some(staged));
-    }
-
-    #[test]
-    fn rendered_unit_runs_as_the_non_root_operator() {
+    fn a_system_unit_runs_as_the_operator_and_starts_before_anyone_logs_in() {
         let unit = rendered("/opt/edge-1", "/opt/edge-1/.spice", "/usr/bin/spiced");
         assert!(unit.contains("User=1000\n"));
         assert!(unit.contains("Group=1001\n"));
+        assert!(unit.contains("WantedBy=multi-user.target\n"));
+    }
+
+    #[test]
+    fn a_user_unit_names_no_account_and_is_wanted_by_the_default_target() {
+        // systemd refuses `User=` in a user unit — the manager is already
+        // running as that account — and `multi-user.target` is not a target a
+        // user manager reaches.
+        let unit = render_unit(
+            Path::new("/opt/edge-1"),
+            Path::new("/opt/edge-1/.spice"),
+            Path::new("/home/alice/.local/share/spice/services/edge-1/spiced"),
+            None,
+            ServiceScope::User,
+        )
+        .expect("render unit");
+        assert!(!unit.contains("User="), "{unit}");
+        assert!(!unit.contains("Group="), "{unit}");
+        assert!(unit.contains("WantedBy=default.target\n"), "{unit}");
     }
 
     #[test]
@@ -737,7 +1873,8 @@ mod tests {
             dir,
             &dir.join(".spice"),
             Path::new("/usr/local/lib/spice/spiced"),
-            TEST_ACCOUNT,
+            Some(TEST_ACCOUNT),
+            ServiceScope::System,
         )
         .expect("hostile but valid path is escaped");
         assert!(unit.contains("WorkingDirectory=\"/opt/edge %%i/quoted\\\"dir\""));
@@ -750,7 +1887,8 @@ mod tests {
             Path::new("/opt/edge\nExecStart=/bin/sh"),
             Path::new("/opt/edge/.spice"),
             Path::new("/usr/bin/spiced"),
-            TEST_ACCOUNT,
+            Some(TEST_ACCOUNT),
+            ServiceScope::System,
         )
         .expect_err("newlines must not enter unit syntax");
         assert!(matches!(err, Error::InvalidArgument { .. }));
@@ -784,27 +1922,36 @@ mod tests {
         );
     }
 
-    /// A manifest for the unit under test, without touching the filesystem.
-    fn manifest(scope: ServiceScope) -> ServiceManifest {
-        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
-        ServiceManifest {
-            schema_version: super::super::manifest::MANIFEST_SCHEMA_VERSION,
-            directory: PathBuf::from("/opt/edge-1"),
-            name: name.clone(),
-            scope,
-            supervisor: Supervisor::Systemd,
-            owner: super::super::ServiceOwner {
-                uid: 1000,
-                gid: 1000,
-                name: Some("alice".to_string()),
-            },
-            definition_path: SystemdBackend.definition_path(&name, scope),
-            runtime_path: super::super::staged_runtime_path(),
-            log_source: SystemdBackend.log_source(&name, scope),
-            runtime_digest: String::new(),
-            runtime_version: "v2.2.0".to_string(),
-            health_url: "http://127.0.0.1:8090/health".to_string(),
-        }
+    #[test]
+    fn each_instance_directory_stages_its_own_runtime() {
+        // A shared binary would make an upgrade in one directory change what
+        // every other instance runs at its next restart.
+        let one = runtime_path(Path::new("/opt/edge-1"), ServiceScope::System)
+            .expect("a system runtime path is always derivable");
+        let two = runtime_path(Path::new("/opt/edge-2"), ServiceScope::System)
+            .expect("a system runtime path is always derivable");
+        assert_ne!(one, two);
+        assert!(one.starts_with(super::super::RUNTIME_STAGE_DIR), "{one:?}");
+        assert!(one.ends_with("spiced"), "{one:?}");
+        assert_ne!(
+            one,
+            Path::new(super::super::RUNTIME_STAGE_DIR).join("spiced"),
+            "the runtime must not be the host-wide shared copy"
+        );
+    }
+
+    #[test]
+    fn a_user_service_stages_its_runtime_under_the_accounts_own_data_directory() {
+        let Some(user) = runtime_path(Path::new("/opt/edge-1"), ServiceScope::User) else {
+            // No discoverable data directory on this host; the installer
+            // refuses rather than guessing, which `install_paths` covers.
+            return;
+        };
+        assert!(
+            !user.starts_with(super::super::RUNTIME_STAGE_DIR),
+            "{user:?}"
+        );
+        assert!(user.ends_with("spiced"), "{user:?}");
     }
 
     #[test]
@@ -837,6 +1984,10 @@ mod tests {
         let user = SystemdBackend.definition_path(&name, ServiceScope::User);
         assert!(system.starts_with(SYSTEMD_UNIT_DIR), "{system:?}");
         assert_ne!(system, user);
+        assert!(
+            user.to_string_lossy().contains(SYSTEMD_USER_UNIT_SUBDIR),
+            "{user:?}"
+        );
     }
 
     #[test]
@@ -874,7 +2025,8 @@ mod tests {
             "generated",
             "transient",
         ] {
-            let (starts, action) = classify_persistence(reported, &manifest(ServiceScope::System));
+            let (starts, action) =
+                classify_persistence(reported, None, &manifest(ServiceScope::System));
             assert_eq!(starts, ServiceStarts::Disabled, "{reported}");
             let action = action.unwrap_or_else(|| panic!("{reported} needs a remediation"));
             assert!(action.contains("systemctl"), "{reported}: {action}");
@@ -887,7 +2039,8 @@ mod tests {
         // `systemctl enable` on a masked unit fails, so printing it alone would
         // hand the operator a command that cannot work.
         for reported in ["masked", "masked-runtime"] {
-            let (starts, action) = classify_persistence(reported, &manifest(ServiceScope::System));
+            let (starts, action) =
+                classify_persistence(reported, None, &manifest(ServiceScope::System));
             assert_eq!(starts, ServiceStarts::Disabled, "{reported}");
             let action = action.unwrap_or_else(|| panic!("{reported} needs a remediation"));
             assert!(action.contains("unmask"), "{reported}: {action}");
@@ -897,22 +2050,67 @@ mod tests {
 
     #[test]
     fn an_unanswerable_enablement_query_is_not_an_outcome() {
-        let (starts, action) = classify_persistence("", &manifest(ServiceScope::System));
+        let (starts, action) = classify_persistence("", None, &manifest(ServiceScope::System));
         assert_eq!(starts, ServiceStarts::Unavailable);
         assert_eq!(action, None, "there is nothing to advise yet");
     }
 
     #[test]
-    fn a_user_service_is_login_only_until_its_account_lingers() {
-        let (starts, action) = classify_persistence("enabled", &manifest(ServiceScope::User));
-        assert_eq!(starts, ServiceStarts::LoginOnly);
-        let action = action.expect("a user service needs a remediation");
-        assert!(action.contains("enable-linger"), "{action}");
+    fn a_user_service_starts_at_boot_only_once_its_account_lingers() {
+        // Denied, and not asked, are both `login_only` with the command that
+        // changes it: claiming boot persistence that is not there is the
+        // failure this avoids.
+        for lingers in [Some(false), None] {
+            let (starts, action) =
+                classify_persistence("enabled", lingers, &manifest(ServiceScope::User));
+            assert_eq!(starts, ServiceStarts::LoginOnly, "{lingers:?}");
+            let action = action.unwrap_or_else(|| panic!("{lingers:?} needs a remediation"));
+            assert!(action.contains("enable-linger"), "{action}");
+        }
 
-        // Trailing newline from `systemctl` output, and the system answer.
-        let (starts, action) = classify_persistence("enabled\n", &manifest(ServiceScope::System));
+        // Lingering verified: the account's manager runs with nobody logged in,
+        // so the service really does come up at boot.
+        let (starts, action) =
+            classify_persistence("enabled", Some(true), &manifest(ServiceScope::User));
         assert_eq!(starts, ServiceStarts::BootWithoutLogin);
         assert_eq!(action, None, "nothing to fix");
+
+        // Trailing newline from `systemctl` output, and the system answer.
+        let (starts, action) =
+            classify_persistence("enabled\n", None, &manifest(ServiceScope::System));
+        assert_eq!(starts, ServiceStarts::BootWithoutLogin);
+        assert_eq!(action, None, "nothing to fix");
+    }
+
+    #[test]
+    fn lingering_is_verified_rather_than_assumed() {
+        let account = super::super::account_name(nix::unistd::Uid::effective().as_raw());
+        let Some(account) = account else {
+            // No account name on this host, so there is nobody to ask about.
+            return;
+        };
+        let query = format!("loginctl show-user {account} --property=Linger --value");
+
+        let granted = ScriptedHost::new().says(&query, "yes");
+        assert_eq!(enable_linger(&granted), Some(true));
+        assert!(
+            granted.ran(&format!("loginctl enable-linger {account}")),
+            "{:?}",
+            granted.calls()
+        );
+
+        // A policy that refuses lingering is reported, not assumed away.
+        let denied = ScriptedHost::new()
+            .fails(
+                &format!("loginctl enable-linger {account}"),
+                "Access denied",
+            )
+            .says(&query, "no");
+        assert_eq!(enable_linger(&denied), Some(false));
+
+        // A logind that cannot be asked is not an answer.
+        let silent = ScriptedHost::new().fails(&query, "Failed to get user: no such user");
+        assert_eq!(enable_linger(&silent), None);
     }
 
     #[test]
@@ -925,34 +2123,640 @@ mod tests {
     }
 
     #[test]
-    fn a_user_scope_install_is_refused_rather_than_half_performed() {
-        // The systemd user lifecycle is separate work; asking for it must name
-        // the path that does work instead of writing a unit nothing manages.
-        assert!(matches!(
-            preflight(ServiceScope::User),
-            Err(PreflightFailure::UserScopePending | PreflightFailure::SystemdUnavailable)
-        ));
+    fn observing_a_user_service_asks_that_accounts_own_manager() {
+        let manifest = manifest(ServiceScope::User);
+        let host = ScriptedHost::new()
+            .says(
+                &format!("systemctl --user is-active {}", manifest.name),
+                "active",
+            )
+            .says(
+                &format!("systemctl --user is-enabled {}", manifest.name),
+                "enabled",
+            );
+
+        let observed = observe(&host, &manifest);
+        assert_eq!(observed.state, ServiceState::Running);
+        assert_eq!(observed.starts, ServiceStarts::LoginOnly);
+        assert!(
+            host.calls()
+                .iter()
+                .all(|call| !call.starts_with("systemctl is-")),
+            "a user service must never be queried through the system manager: {:?}",
+            host.calls()
+        );
     }
 
     #[test]
-    fn every_lifecycle_action_reports_itself_as_pending_rather_than_panicking() {
-        let manifest = manifest(ServiceScope::System);
-        for result in [
-            SystemdBackend.start(&manifest),
-            SystemdBackend.stop(&manifest),
-            SystemdBackend.restart(&manifest),
-            SystemdBackend.logs(
-                &manifest,
-                super::super::LogRequest {
-                    number: 100,
-                    follow: false,
-                },
-            ),
-        ] {
-            let error = result.expect_err("the lifecycle is not implemented yet");
-            assert!(matches!(error, Error::NotImplemented { .. }), "{error}");
-            // The refusal has to leave the operator with something they can run.
-            assert!(error.to_string().contains("systemctl"), "{error}");
+    fn starting_waits_for_the_service_to_be_running() {
+        let manifest = manifest(ServiceScope::User);
+        let is_active = format!("systemctl --user is-active {}", manifest.name);
+        // systemd returns from `start` while the unit is still activating.
+        let host =
+            ScriptedHost::new().sequence(&is_active, &["activating", "activating", "active"]);
+
+        start(&host, &manifest).expect("the service reaches running");
+        assert!(
+            host.ran(&format!("systemctl --user start {}", manifest.name)),
+            "{:?}",
+            host.calls()
+        );
+        assert!(*host.slept.borrow() > Duration::ZERO, "it polled");
+    }
+
+    #[test]
+    fn starting_is_idempotent_for_a_running_service() {
+        let manifest = manifest(ServiceScope::User);
+        let host = ScriptedHost::new().says(
+            &format!("systemctl --user is-active {}", manifest.name),
+            "active",
+        );
+        start(&host, &manifest).expect("an already-running service succeeds");
+    }
+
+    #[test]
+    fn stopping_waits_for_the_service_to_be_down_and_leaves_it_installed() {
+        let manifest = manifest(ServiceScope::User);
+        let host = ScriptedHost::new().sequence(
+            &format!("systemctl --user is-active {}", manifest.name),
+            &["deactivating", "inactive"],
+        );
+
+        stop(&host, &manifest).expect("the service reaches stopped");
+        assert!(host.ran(&format!("systemctl --user stop {}", manifest.name)));
+        assert!(
+            !host
+                .calls()
+                .iter()
+                .any(|call| call.contains("disable") || call.contains("remove")),
+            "a stop must leave the service installed and enabled: {:?}",
+            host.calls()
+        );
+    }
+
+    #[test]
+    fn restarting_is_owned_by_the_supervisor() {
+        let manifest = manifest(ServiceScope::User);
+        let host = ScriptedHost::new().sequence(
+            &format!("systemctl --user is-active {}", manifest.name),
+            &["activating", "active"],
+        );
+
+        restart(&host, &manifest).expect("the service comes back");
+        assert!(host.ran(&format!("systemctl --user restart {}", manifest.name)));
+    }
+
+    #[test]
+    fn a_service_that_does_not_reach_its_state_is_reported_rather_than_assumed() {
+        let manifest = manifest(ServiceScope::User);
+        let host = ScriptedHost::new().says(
+            &format!("systemctl --user is-active {}", manifest.name),
+            "failed",
+        );
+
+        let error = restart(&host, &manifest).expect_err("a failed unit must fail the restart");
+        assert!(error.to_string().contains("failed"), "{error}");
+        assert!(error.to_string().contains("logs"), "{error}");
+    }
+
+    #[test]
+    fn a_system_service_never_self_elevates_and_names_the_retry() {
+        // Root can drive a system service; everyone else is told exactly what
+        // to run instead of having it run for them.
+        if nix::unistd::Uid::effective().is_root() {
+            return;
         }
+        let manifest = manifest(ServiceScope::System);
+        let host = ScriptedHost::new();
+        for (action, result) in [
+            ("start", start(&host, &manifest)),
+            ("stop", stop(&host, &manifest)),
+            ("restart", restart(&host, &manifest)),
+            ("uninstall", uninstall(&host, &manifest)),
+        ] {
+            let error = result.expect_err("a non-root system-service mutation must be refused");
+            assert!(
+                error.to_string().contains(&format!(
+                    "sudo spice connect service {action} --dir /opt/edge-1"
+                )),
+                "{action}: {error}"
+            );
+        }
+        assert!(
+            host.calls().is_empty(),
+            "a refusal must not touch the supervisor: {:?}",
+            host.calls()
+        );
+    }
+
+    #[test]
+    fn a_user_service_is_never_driven_through_another_accounts_manager() {
+        // What `sudo spice connect service restart` on a user service would
+        // otherwise do: talk to root's user manager, which holds no such unit.
+        let mut manifest = manifest(ServiceScope::User);
+        manifest.owner.uid = nix::unistd::Uid::effective().as_raw() + 1;
+        manifest.owner.name = Some("alice".to_string());
+
+        let host = ScriptedHost::new();
+        let error = restart(&host, &manifest).expect_err("another account's service is refused");
+        assert!(error.to_string().contains("alice"), "{error}");
+        assert!(
+            error
+                .to_string()
+                .contains("spice connect service restart --dir /opt/edge-1"),
+            "{error}"
+        );
+        assert!(!error.to_string().contains("sudo spice"), "{error}");
+        assert!(host.calls().is_empty(), "{:?}", host.calls());
+    }
+
+    #[test]
+    fn the_journal_is_read_by_exact_unit_bounded_and_unpaged() {
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        let args = journal_args(
+            &name,
+            ServiceScope::System,
+            LogRequest {
+                number: 100,
+                follow: false,
+            },
+        );
+        assert_eq!(
+            args,
+            vec!["-u", &name, "--no-pager", "-q", "-o", "cat", "-n", "100"]
+        );
+
+        // A user service's output lives in that account's own journal.
+        let user = journal_args(
+            &name,
+            ServiceScope::User,
+            LogRequest {
+                number: 0,
+                follow: true,
+            },
+        );
+        assert_eq!(user.first().map(String::as_str), Some("--user"));
+        assert_eq!(user.last().map(String::as_str), Some("-f"));
+        // `-n 0 -f` follows without printing any history.
+        assert!(user.windows(2).any(|pair| pair == ["-n", "0"]), "{user:?}");
+    }
+
+    #[test]
+    fn following_logs_streams_and_reports_an_interruption_without_changing_the_service() {
+        let manifest = manifest(ServiceScope::User);
+        let host = ScriptedHost::new().streaming(None);
+        let error = logs(
+            &host,
+            &manifest,
+            LogRequest {
+                number: 100,
+                follow: true,
+            },
+        )
+        .expect_err("an interrupted viewer exits as interrupted");
+        assert!(matches!(error, Error::Interrupted), "{error}");
+        assert_eq!(
+            host.streamed.borrow().len(),
+            1,
+            "the snapshot and the follow are one bounded journalctl"
+        );
+        assert!(
+            host.calls().is_empty(),
+            "reading logs must not touch the service: {:?}",
+            host.calls()
+        );
+    }
+
+    #[test]
+    fn an_empty_journal_is_a_successful_answer() {
+        let manifest = manifest(ServiceScope::User);
+        let host = ScriptedHost::new();
+        logs(
+            &host,
+            &manifest,
+            LogRequest {
+                number: 100,
+                follow: false,
+            },
+        )
+        .expect("an empty history is not a failure");
+    }
+
+    #[test]
+    fn a_journal_that_cannot_be_read_says_so() {
+        let manifest = manifest(ServiceScope::User);
+        let host = ScriptedHost::new().fails(
+            &format!(
+                "journalctl --user -u {} --no-pager -q -o cat -n 100",
+                manifest.name
+            ),
+            "Failed to add match: Invalid argument",
+        );
+        let error = logs(
+            &host,
+            &manifest,
+            LogRequest {
+                number: 100,
+                follow: false,
+            },
+        )
+        .expect_err("a journal failure is reported");
+        assert!(error.to_string().contains("Invalid argument"), "{error}");
+    }
+
+    #[test]
+    fn the_health_gate_accepts_a_service_that_comes_up_and_answers() {
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        let host = ScriptedHost::new()
+            .sequence(
+                &format!("systemctl --user is-active {name}"),
+                &["activating", "active"],
+            )
+            .health(&[false, true]);
+
+        health_gate(&host, &name, ServiceScope::User, HEALTH_URL).expect("a healthy install");
+    }
+
+    #[test]
+    fn a_service_that_stays_up_without_answering_is_accepted_once_it_settles() {
+        // The health URL is the address the CLI was pointed at, while the
+        // service serves whatever its spicepod configures. An unanswered probe
+        // is therefore not proof of a broken install — an uninterrupted run is
+        // what stands in for it.
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        let host = ScriptedHost::new()
+            .says(&format!("systemctl --user is-active {name}"), "active")
+            .health(&[false]);
+
+        health_gate(&host, &name, ServiceScope::User, HEALTH_URL)
+            .expect("a service that stays up is up");
+        assert!(
+            *host.slept.borrow() >= settle_window(),
+            "it may only be accepted after it has stayed up: {:?}",
+            host.slept
+        );
+    }
+
+    #[test]
+    fn the_health_gate_rejects_a_service_that_never_comes_up() {
+        // The failure an install has to catch: systemd accepted the unit and
+        // the runtime never started serving.
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        let host = ScriptedHost::new()
+            .says(&format!("systemctl --user is-active {name}"), "activating")
+            .health(&[false]);
+
+        let why = health_gate(&host, &name, ServiceScope::User, HEALTH_URL)
+            .expect_err("a runtime that never comes up must not pass");
+        assert!(why.contains("rather than running"), "{why}");
+    }
+
+    #[test]
+    fn the_health_gate_rejects_a_runtime_that_keeps_being_restarted() {
+        // A crash loop never accumulates an uninterrupted run and never
+        // answers, which is exactly what the gate has to refuse.
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        let flapping: Vec<&str> = (0..HEALTH_ATTEMPTS)
+            .map(|attempt| {
+                if attempt % 2 == 0 {
+                    "active"
+                } else {
+                    "activating"
+                }
+            })
+            .collect();
+        let host = ScriptedHost::new()
+            .sequence(&format!("systemctl --user is-active {name}"), &flapping)
+            .health(&[false]);
+
+        let why = health_gate(&host, &name, ServiceScope::User, HEALTH_URL)
+            .expect_err("a restarting runtime must not pass");
+        assert!(!why.is_empty(), "the refusal has to say what it saw");
+    }
+
+    #[test]
+    fn the_health_gate_gives_up_on_a_unit_systemd_calls_failed() {
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        let host = ScriptedHost::new().says(&format!("systemctl is-active {name}"), "failed");
+
+        let why = health_gate(&host, &name, ServiceScope::System, HEALTH_URL)
+            .expect_err("a failed unit must not pass");
+        assert!(why.contains("failed"), "{why}");
+        // Given up on early rather than after the whole gate, but not on the
+        // first reading — a restarting unit passes through several words.
+        assert!(*host.slept.borrow() < HEALTH_GATE, "{:?}", host.slept);
+    }
+
+    #[test]
+    fn an_unprobeable_health_url_gates_on_what_systemd_reports() {
+        // A health URL this back end cannot reach must not fail an install that
+        // is fine.
+        assert!(is_probeable(HEALTH_URL));
+        assert!(!is_probeable("https://127.0.0.1:8090/health"));
+
+        let name = unit_name_for_dir(Path::new("/opt/edge-1"));
+        let host = ScriptedHost::new()
+            .says(&format!("systemctl is-active {name}"), "active")
+            .health(&[false]);
+        health_gate(
+            &host,
+            &name,
+            ServiceScope::System,
+            "https://127.0.0.1:8090/health",
+        )
+        .expect("systemd's own report is the answer here");
+    }
+
+    #[test]
+    fn only_a_success_status_line_counts_as_healthy() {
+        assert!(status_line_is_success("HTTP/1.1 200 OK\r\nDate: now\r\n"));
+        assert!(status_line_is_success("HTTP/1.0 204 No Content\r\n"));
+        assert!(!status_line_is_success("HTTP/1.1 503 Service Unavailable"));
+        assert!(!status_line_is_success("HTTP/1.1 200"), "no reason phrase");
+        assert!(!status_line_is_success(""));
+        assert!(!status_line_is_success("garbage"));
+    }
+
+    /// An install request pointing at a runtime and directories under `root`.
+    fn install_request<'a>(
+        instance_dir: &'a Path,
+        config_dir: &'a Path,
+        spiced: &'a Path,
+    ) -> InstallRequest<'a> {
+        InstallRequest {
+            instance_dir,
+            config_dir,
+            spiced_path: spiced,
+            scope: ServiceScope::User,
+            health_url: HEALTH_URL,
+        }
+    }
+
+    /// The paths an install under `root` writes, so the whole install can run
+    /// without touching a real systemd directory.
+    fn install_paths_under(root: &Path, name: &str) -> InstallPaths {
+        let runtime_dir = root.join("runtime");
+        InstallPaths {
+            unit: root.join("units").join(name),
+            runtime: runtime_dir.join("spiced"),
+            runtime_dir,
+        }
+    }
+
+    #[test]
+    fn an_install_that_comes_up_healthy_records_what_it_installed() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let spiced = dir.path().join("spiced");
+        std::fs::create_dir_all(&instance_dir).expect("create instance dir");
+        std::fs::write(&spiced, b"runtime-v1").expect("write runtime");
+
+        let name = unit_name_for_dir(&instance_dir);
+        let paths = install_paths_under(dir.path(), &name);
+        let host = ScriptedHost::new()
+            .says(&format!("systemctl --user is-active {name}"), "active")
+            .health(&[true]);
+
+        let installed = install_at(
+            &host,
+            &install_request(&instance_dir, &config_dir, &spiced),
+            &name,
+            &paths,
+            None,
+        )
+        .expect("install");
+
+        assert_eq!(installed.runtime, paths.runtime);
+        assert_eq!(installed.path, paths.unit);
+        assert_eq!(
+            std::fs::read(&paths.runtime).expect("read staged runtime"),
+            b"runtime-v1",
+            "the service runs its own staged copy"
+        );
+        let unit = std::fs::read_to_string(&paths.unit).expect("read unit");
+        assert_eq!(
+            parse_working_dir(&unit).as_deref(),
+            Some(instance_dir.as_path())
+        );
+        assert_eq!(
+            parse_exec_runtime(&unit).as_deref(),
+            Some(paths.runtime.as_path())
+        );
+        // Enabled for boot, then restarted so the new unit and binary are what
+        // is actually running.
+        assert!(host.ran(&format!("systemctl --user enable {name}")));
+        assert!(host.ran(&format!("systemctl --user restart {name}")));
+        assert!(
+            !paths.runtime.with_extension("previous").exists(),
+            "a successful install keeps no rollback copy"
+        );
+    }
+
+    #[test]
+    fn an_upgrade_that_does_not_come_up_puts_the_previous_one_back() {
+        // The acceptance criterion an upgrade lives or dies by: a runtime that
+        // does not serve must leave the instance running exactly what it was
+        // running before.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let spiced = dir.path().join("spiced");
+        std::fs::create_dir_all(&instance_dir).expect("create instance dir");
+        std::fs::write(&spiced, b"runtime-v1").expect("write runtime");
+
+        let name = unit_name_for_dir(&instance_dir);
+        let paths = install_paths_under(dir.path(), &name);
+        let healthy = ScriptedHost::new()
+            .says(&format!("systemctl --user is-active {name}"), "active")
+            .health(&[true]);
+        install_at(
+            &healthy,
+            &install_request(&instance_dir, &config_dir, &spiced),
+            &name,
+            &paths,
+            None,
+        )
+        .expect("the first install");
+        let installed_unit = std::fs::read(&paths.unit).expect("read unit");
+
+        // The upgrade: a new binary systemd cannot keep running.
+        std::fs::write(&spiced, b"runtime-v2-broken").expect("write the upgrade");
+        let broken = ScriptedHost::new()
+            .says(&format!("systemctl --user is-active {name}"), "failed")
+            .health(&[false]);
+        let error = install_at(
+            &broken,
+            &install_request(&instance_dir, &config_dir, &spiced),
+            &name,
+            &paths,
+            None,
+        )
+        .expect_err("an upgrade that does not serve must fail");
+
+        assert!(error.to_string().contains("put back"), "{error}");
+        assert_eq!(
+            std::fs::read(&paths.runtime).expect("read staged runtime"),
+            b"runtime-v1",
+            "the runtime that was serving must be back"
+        );
+        assert_eq!(
+            std::fs::read(&paths.unit).expect("read unit"),
+            installed_unit,
+            "the unit that was in force must be back"
+        );
+        assert!(
+            !paths.runtime.with_extension("previous").exists(),
+            "the rollback copy is consumed"
+        );
+        assert!(
+            broken.ran(&format!("systemctl --user restart {name}")),
+            "the restored service is started again: {:?}",
+            broken.calls()
+        );
+    }
+
+    #[test]
+    fn a_first_install_that_does_not_come_up_leaves_nothing_behind() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let spiced = dir.path().join("spiced");
+        std::fs::create_dir_all(&instance_dir).expect("create instance dir");
+        std::fs::write(&spiced, b"runtime-v1").expect("write runtime");
+
+        let name = unit_name_for_dir(&instance_dir);
+        let paths = install_paths_under(dir.path(), &name);
+        let host = ScriptedHost::new()
+            .says(&format!("systemctl --user is-active {name}"), "inactive")
+            .health(&[false]);
+
+        let error = install_at(
+            &host,
+            &install_request(&instance_dir, &config_dir, &spiced),
+            &name,
+            &paths,
+            None,
+        )
+        .expect_err("a service that never comes up must fail the install");
+        assert!(
+            error.to_string().contains("Nothing was left installed"),
+            "{error}"
+        );
+        assert!(!paths.unit.exists(), "the unit must be gone");
+        assert!(!paths.runtime.exists(), "the staged runtime must be gone");
+        assert!(
+            host.ran(&format!("systemctl --user disable --now {name}")),
+            "{:?}",
+            host.calls()
+        );
+    }
+
+    #[test]
+    fn an_uninstall_removes_only_this_services_own_runtime() {
+        let mut manifest = manifest(ServiceScope::System);
+
+        // Its own staging directory goes with it.
+        let own = runtime_dir(&manifest.directory, ServiceScope::System)
+            .expect("a system staging directory is always derivable");
+        manifest.runtime_path = own.join("spiced");
+        assert_eq!(owned_runtime_dir(&manifest).as_ref(), Some(&own));
+
+        // A runtime recorded anywhere else — a host-wide copy another service
+        // may still execute, another instance's staged copy, or an edited
+        // manifest — is not this uninstall's to delete.
+        for elsewhere in [
+            PathBuf::from(super::super::RUNTIME_STAGE_DIR).join("spiced"),
+            runtime_dir(Path::new("/opt/edge-2"), ServiceScope::System)
+                .expect("a system staging directory is always derivable")
+                .join("spiced"),
+            PathBuf::from("/usr/bin/spiced"),
+        ] {
+            manifest.runtime_path.clone_from(&elsewhere);
+            assert_eq!(owned_runtime_dir(&manifest), None, "{elsewhere:?}");
+        }
+    }
+
+    #[test]
+    fn uninstalling_deletes_the_definition_and_leaves_the_journal_to_systemd() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let mut manifest = manifest(ServiceScope::User);
+        manifest.definition_path = dir.path().join("unit.service");
+        // Recorded elsewhere, so the runtime removal is out of the way of what
+        // this test is about; its own guard is covered separately.
+        manifest.runtime_path = dir.path().join("spiced");
+        std::fs::write(&manifest.definition_path, "[Unit]\n").expect("write unit");
+        std::fs::write(&manifest.runtime_path, b"runtime").expect("write runtime");
+
+        let host = ScriptedHost::new();
+        uninstall(&host, &manifest).expect("uninstall");
+
+        assert!(!manifest.definition_path.exists(), "the unit must be gone");
+        assert!(host.ran(&format!("systemctl --user disable --now {}", manifest.name)));
+        assert!(host.ran("systemctl --user daemon-reload"));
+        assert!(
+            !host.calls().iter().any(|call| call.contains("journal")),
+            "log history is systemd's to retain: {:?}",
+            host.calls()
+        );
+
+        // Idempotent: a second uninstall has nothing left to remove and still
+        // succeeds.
+        uninstall(&host, &manifest).expect("second uninstall");
+    }
+
+    #[test]
+    fn a_user_scope_stage_directory_must_be_this_accounts_own() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let stage = dir.path().join("runtime");
+        ensure_account_only_dir(&stage).expect("a fresh directory is this account's");
+
+        // A symlink points the runtime somewhere this check cannot vouch for.
+        let linked = dir.path().join("linked");
+        std::os::unix::fs::symlink(&stage, &linked).expect("symlink");
+        let error = ensure_account_only_dir(&linked).expect_err("a symlinked stage is refused");
+        assert!(error.to_string().contains("real directory"), "{error}");
+
+        // So does a directory anyone else can write.
+        std::fs::set_permissions(&stage, std::fs::Permissions::from_mode(0o777))
+            .expect("widen the mode");
+        let error = ensure_account_only_dir(&stage).expect_err("a world-writable stage is refused");
+        assert!(error.to_string().contains("chmod go-w"), "{error}");
+    }
+
+    #[test]
+    fn a_user_install_needs_the_accounts_own_manager() {
+        // Asking for a user service on a host with no user manager has to fail
+        // before anything is written, naming the path that does work.
+        let failure = preflight(ServiceScope::User);
+        if let Err(failure) = failure {
+            let message = Error::from(failure).to_string();
+            assert!(
+                message.contains("spice connect service install"),
+                "{message}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_gates_poll_for_exactly_as_long_as_they_promise() {
+        // The messages both gates print name a duration, and the loops are
+        // bounded by attempts — so the two have to be kept in step here rather
+        // than in a comment.
+        assert_eq!(HEALTH_POLL_INTERVAL * HEALTH_ATTEMPTS, HEALTH_GATE);
+        assert_eq!(
+            LIFECYCLE_POLL_INTERVAL * LIFECYCLE_ATTEMPTS,
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn a_folded_message_stays_on_one_line() {
+        assert_eq!(
+            folded("Failed to start.\nSee `systemctl status`.\n"),
+            "Failed to start. See `systemctl status`."
+        );
     }
 }

--- a/bin/spice/src/commands/connect/service/systemd.rs
+++ b/bin/spice/src/commands/connect/service/systemd.rs
@@ -43,12 +43,14 @@ limitations under the License.
 use std::io::{Read as _, Write as _};
 use std::net::{TcpStream, ToSocketAddrs as _};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use super::backend::{InstallRequest, LogRequest, ServiceBackend, ServiceObservation};
 use super::manifest::ServiceManifest;
 use super::model::{LogSource, ServiceScope, ServiceStarts, ServiceState, Supervisor};
-use super::{InstalledService, PreflightFailure, SYSTEMD_RUNTIME_MARKER, ServiceAccount};
+use super::{
+    InstalledService, PreflightFailure, SYSTEMD_RUNTIME_MARKER, ServiceAccount, ServiceOwner,
+};
 use crate::error::{Error, Result};
 
 /// Directory systemd reads administrator-provided unit files from.
@@ -89,10 +91,8 @@ const LOGINCTL: &str = "loginctl";
 /// rolled back.
 const HEALTH_GATE: Duration = Duration::from_secs(30);
 
-/// How often the health gate asks. Bounded by attempts rather than by a clock
-/// so the whole gate is exercised deterministically in tests.
+/// How often the health gate asks.
 const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(500);
-const HEALTH_ATTEMPTS: u32 = 60;
 
 /// How long a `start`, `stop`, or `restart` has to reach the state it asked
 /// for. systemd returns from these once the job is *done*, so this only covers
@@ -107,10 +107,11 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Bytes of a health response read before giving up on finding a status line.
 const PROBE_READ_LIMIT: usize = 512;
 
-/// Consecutive `active` readings that stand in for an unanswered health probe:
-/// a runtime that has served uninterrupted for this long is up, whatever the
-/// recorded health URL points at.
-const SETTLE_ATTEMPTS: u32 = 20;
+/// How long one uninterrupted run stands in for an unanswered health probe: a
+/// runtime that has served this long on the same start is up, whatever the
+/// recorded health URL points at. Measured on the clock and against systemd's
+/// own restart count, not by counting polls.
+const SETTLE_WINDOW: Duration = Duration::from_secs(10);
 
 /// Consecutive `failed` readings that end the health gate early.
 ///
@@ -183,6 +184,13 @@ pub(super) trait SystemdHost {
     /// Whether the instance answers `url` right now.
     fn probe_health(&self, url: &str) -> bool;
 
+    /// Now, on a clock that only moves forward.
+    ///
+    /// The gates are bounded by this rather than by a count of polls: a health
+    /// probe can block for seconds, so counting attempts would promise a
+    /// 30-second gate and take minutes.
+    fn now(&self) -> Instant;
+
     /// Wait before polling again.
     fn sleep(&self, duration: Duration);
 }
@@ -208,6 +216,10 @@ impl SystemdHost for ProcessHost {
 
     fn probe_health(&self, url: &str) -> bool {
         probe_http_health(url)
+    }
+
+    fn now(&self) -> Instant {
+        Instant::now()
     }
 
     fn sleep(&self, duration: Duration) {
@@ -281,9 +293,13 @@ fn probe_http_health(url: &str) -> bool {
     status_line_is_success(&String::from_utf8_lossy(&response))
 }
 
-/// Whether an HTTP response begins with a `2xx` status line.
+/// Whether an HTTP response begins with a complete `2xx` status line.
+///
+/// The terminator is required: a response that ended before one arrived is a
+/// connection that was cut mid-answer, and reading `HTTP/1.1 20` as a success
+/// would report an instance healthy on the strength of a truncated read.
 fn status_line_is_success(response: &str) -> bool {
-    let Some(line) = response.lines().next() else {
+    let Some((line, _)) = response.split_once('\n') else {
         return false;
     };
     let mut fields = line.split_whitespace();
@@ -328,6 +344,11 @@ fn render_unit(
          Documentation=https://spiceai.org/docs\n\
          After=network-online.target\n\
          Wants=network-online.target\n\
+         # A crash loop must not be given up on: an instance that lost its\n\
+         # network for an hour has to come back on its own. This is a [Unit]\n\
+         # directive — systemd ignores it under [Service], which would leave\n\
+         # the default rate limit in force and stop the service for good.\n\
+         StartLimitIntervalSec=0\n\
          \n\
          [Service]\n\
          Type=simple\n",
@@ -349,9 +370,6 @@ fn render_unit(
          # left alone: it is what an operator's `stop` produces.\n\
          Restart=on-failure\n\
          RestartSec=5\n\
-         # A crash loop must not be given up on: an instance that lost its\n\
-         # network for an hour has to come back on its own.\n\
-         StartLimitIntervalSec=0\n\
          KillSignal=SIGTERM\n\
          TimeoutStopSec=30\n\
          \n\
@@ -540,7 +558,7 @@ fn install_at(
 
     // Captured before anything is overwritten: an upgrade that does not come up
     // has to be able to put back exactly what was serving before it.
-    let rollback = Rollback::capture(paths)?;
+    let rollback = Rollback::capture(host, paths, name, request.scope)?;
 
     let applied = apply(host, request, name, paths, account);
     let verdict = match applied {
@@ -551,6 +569,15 @@ fn install_at(
     match verdict {
         Ok(()) => {
             rollback.discard();
+            if request.scope == ServiceScope::User {
+                // After the gate, not before: lingering is an account-wide
+                // setting that outlives this service, and an install that is
+                // about to be rolled back must not leave it behind. Best effort
+                // either way — a policy that refuses it is reported by `status`
+                // as `login_only` with the command to run, not as a failed
+                // install.
+                let _ = enable_linger(host);
+            }
             Ok(InstalledService {
                 name: name.to_string(),
                 path: paths.unit.clone(),
@@ -598,29 +625,25 @@ fn apply(
     // a rewritten unit and an upgraded binary, and starts a service that was
     // not running. `enable --now` alone would leave the old process up.
     systemctl(host, request.scope, &["enable", name])?;
-    systemctl(host, request.scope, &["restart", name])?;
-
-    if request.scope == ServiceScope::User {
-        // Best effort: a policy that refuses lingering is reported by `status`
-        // as `login_only` with the command to run, not as a failed install.
-        let _ = enable_linger(host);
-    }
-    Ok(())
+    systemctl(host, request.scope, &["restart", name])
 }
 
 /// Wait for the service to prove it is serving, or say what it is doing
 /// instead.
 ///
 /// Two things count as proof, and both have to be here. Answering the health
-/// URL is the strongest, and ends the gate as soon as it happens. Staying
-/// `active` without interruption for [`SETTLE_ATTEMPTS`] polls is the other,
-/// and it is what a healthy instance whose endpoint this CLI cannot reach
-/// looks like: the recorded health URL is the address the *CLI* was pointed at,
-/// while the service serves whatever its spicepod configures, so refusing an
-/// install because a probe went unanswered would fail an instance that is
-/// working. What neither accepts is the failure this gate exists for — a
-/// runtime that exits and is restarted, which never accumulates an
-/// uninterrupted run and never answers.
+/// URL is the strongest, and ends the gate as soon as it happens. One
+/// uninterrupted run of [`SETTLE_WINDOW`] is the other, and it is what a
+/// healthy instance whose endpoint this CLI cannot reach looks like: the
+/// recorded health URL is the address the *CLI* was pointed at, while the
+/// service serves whatever its spicepod configures, so refusing an install
+/// because a probe went unanswered would fail an instance that is working.
+///
+/// What neither accepts is the failure this gate exists for — a runtime that
+/// exits and is restarted. Sampling `is-active` cannot see that on its own,
+/// because systemd may well be back to `active` by the next poll, so the run is
+/// identified by systemd's restart count and the start time of the current run:
+/// a restart between two samples changes it, and the window starts again.
 fn health_gate(
     host: &dyn SystemdHost,
     name: &str,
@@ -628,35 +651,44 @@ fn health_gate(
     health_url: &str,
 ) -> std::result::Result<(), String> {
     let probeable = is_probeable(health_url);
+    let deadline = host.now() + HEALTH_GATE;
     let mut failures = 0;
-    let mut settled = 0;
+    // When the run that is up now began, and which run it is.
+    let mut running_since: Option<(Instant, Option<String>)> = None;
     let mut last = format!(
         "systemd did not report {name} as running within {}s",
         HEALTH_GATE.as_secs()
     );
 
-    for attempt in 0..HEALTH_ATTEMPTS {
-        if attempt > 0 {
-            host.sleep(HEALTH_POLL_INTERVAL);
-        }
+    loop {
+        let sampled_at = host.now();
         let reported = is_active(host, name, scope).unwrap_or_default();
         match normalize_systemd_state(&reported) {
             ServiceState::Running => {
                 failures = 0;
-                settled += 1;
+                let identity = run_identity(host, name, scope);
+                if running_since
+                    .as_ref()
+                    .is_none_or(|(_, running)| *running != identity)
+                {
+                    running_since = Some((sampled_at, identity));
+                }
                 if probeable && host.probe_health(health_url) {
                     return Ok(());
                 }
-                if settled >= SETTLE_ATTEMPTS {
+                let uninterrupted = running_since.as_ref().map_or(Duration::ZERO, |(since, _)| {
+                    host.now().saturating_duration_since(*since)
+                });
+                if uninterrupted >= SETTLE_WINDOW {
                     return Ok(());
                 }
                 last = format!(
-                    "{name} did not stay running for {}s, and did not answer {health_url}",
-                    settle_window().as_secs()
+                    "{name} has not stayed running for {}s, and has not answered {health_url}",
+                    SETTLE_WINDOW.as_secs()
                 );
             }
             ServiceState::Failed => {
-                settled = 0;
+                running_since = None;
                 failures += 1;
                 last = format!("systemd reports {name} as failed");
                 if failures >= FAILED_READINGS_BEFORE_GIVING_UP {
@@ -664,29 +696,51 @@ fn health_gate(
                 }
             }
             other => {
-                settled = 0;
+                running_since = None;
                 failures = 0;
-                last = format!(
-                    "systemd reports {name} as {other} rather than running, {}s after it was \
-                     started",
-                    HEALTH_GATE.as_secs()
-                );
+                last = format!("systemd reports {name} as {other} rather than running");
             }
         }
+
+        // Checked after the sample, so a probe that blocked past the deadline
+        // still ends the gate rather than buying another round.
+        if host.now() >= deadline {
+            return Err(format!(
+                "{last}, {}s after it was started",
+                HEALTH_GATE.as_secs()
+            ));
+        }
+        host.sleep(HEALTH_POLL_INTERVAL);
     }
-    Err(last)
 }
 
-/// How long a service has to run without interruption to count as up.
-fn settle_window() -> Duration {
-    SETTLE_ATTEMPTS * HEALTH_POLL_INTERVAL
+/// Which run of the unit is up: how many times systemd has restarted it, and
+/// when the current run began.
+///
+/// `None` when systemd could not be asked, in which case the gate falls back to
+/// what sampling alone can see.
+fn run_identity(host: &dyn SystemdHost, name: &str, scope: ServiceScope) -> Option<String> {
+    let identity = systemctl_query(
+        host,
+        scope,
+        &[
+            "show",
+            name,
+            "--property=NRestarts",
+            "--property=ActiveEnterTimestampMonotonic",
+            "--value",
+        ],
+    )?;
+    (!identity.is_empty()).then_some(identity)
 }
 
 /// What an install has to be able to put back.
 ///
-/// The unit and the runtime together decide what the host runs, so both are
-/// captured: restoring one without the other would leave a unit pointing at a
-/// binary that is no longer the one it was written for.
+/// The unit and the runtime together decide what the host *runs*, and the
+/// enablement and the running state decide *whether* it runs — so all four are
+/// captured. Restoring the files alone would leave a service that was
+/// deliberately stopped, or deliberately not enabled, started and enabled by a
+/// rolled-back upgrade.
 struct Rollback {
     unit: PathBuf,
     /// The unit file that was in force, or `None` when nothing was installed.
@@ -695,6 +749,11 @@ struct Rollback {
     /// A second name for the runtime that was in force, or `None` when there
     /// was none.
     previous_runtime: Option<PathBuf>,
+    /// Whether the service was enabled for boot, and whether it was running.
+    /// `None` for either means systemd could not be asked, and that part of the
+    /// state is left as the install found it rather than guessed at.
+    was_enabled: Option<bool>,
+    was_running: Option<bool>,
 }
 
 impl Rollback {
@@ -712,30 +771,92 @@ impl Rollback {
     /// copy where it does not. A capture that cannot be made fails the install
     /// rather than proceeding: an upgrade nobody can undo is exactly the one
     /// that must not start.
-    fn capture(paths: &InstallPaths) -> Result<Self> {
-        let previous_unit = std::fs::read(&paths.unit).ok();
-        let previous_runtime = if paths.runtime.is_file() {
-            let backup = Self::backup_name(&paths.runtime);
-            let _ = std::fs::remove_file(&backup);
-            if std::fs::hard_link(&paths.runtime, &backup).is_err() {
-                std::fs::copy(&paths.runtime, &backup).map_err(|e| Error::CloudConnectIo {
+    ///
+    /// Only a genuinely absent file reads as "nothing was installed". A unit or
+    /// runtime that exists but cannot be read is reported, because taking it for
+    /// an empty slot would have the rollback *delete* the installation it was
+    /// supposed to protect.
+    fn capture(
+        host: &dyn SystemdHost,
+        paths: &InstallPaths,
+        name: &str,
+        scope: ServiceScope,
+    ) -> Result<Self> {
+        let previous_unit = match std::fs::read(&paths.unit) {
+            Ok(unit) => Some(unit),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            Err(e) => {
+                return Err(Error::CloudConnectIo {
                     message: format!(
-                        "keep a copy of the Spice runtime {} before upgrading it: {e}. The \
-                         upgrade was not started, so the installed service is untouched.",
-                        paths.runtime.display()
+                        "read the installed systemd unit {} before replacing it: {e}. The upgrade \
+                         was not started, so the installed service is untouched.",
+                        paths.unit.display()
                     ),
-                })?;
+                });
             }
-            Some(backup)
-        } else {
-            None
         };
+        let previous_runtime = Self::capture_runtime(paths)?;
+        // Only meaningful when there is something to restore, and asking about a
+        // unit that does not exist yet would record systemd's answer for a unit
+        // it has no record of.
+        let (was_enabled, was_running) = if previous_unit.is_some() {
+            (
+                systemctl_query(host, scope, &["is-enabled", name])
+                    .filter(|reported| !reported.is_empty())
+                    .map(|reported| reported.trim().starts_with("enabled")),
+                is_active(host, name, scope)
+                    .map(|reported| normalize_systemd_state(&reported) == ServiceState::Running),
+            )
+        } else {
+            (None, None)
+        };
+
         Ok(Self {
             unit: paths.unit.clone(),
             previous_unit,
             runtime: paths.runtime.clone(),
             previous_runtime,
+            was_enabled,
+            was_running,
         })
+    }
+
+    /// Hold on to the runtime that is in force, so an upgrade can be undone.
+    fn capture_runtime(paths: &InstallPaths) -> Result<Option<PathBuf>> {
+        let io_error = |e: std::io::Error| Error::CloudConnectIo {
+            message: format!(
+                "keep a copy of the Spice runtime {} before upgrading it: {e}. The upgrade was \
+                 not started, so the installed service is untouched.",
+                paths.runtime.display()
+            ),
+        };
+
+        match std::fs::symlink_metadata(&paths.runtime) {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(io_error(e)),
+            Ok(metadata) if !metadata.is_file() => {
+                return Err(Error::InvalidArgument {
+                    message: format!(
+                        "Failed to install the Spice Cloud Connect service: {} is not a regular \
+                         file, so the runtime it stands for cannot be preserved across the \
+                         upgrade. Remove it and re-run `spice connect service install`.",
+                        paths.runtime.display()
+                    ),
+                });
+            }
+            Ok(_) => {}
+        }
+
+        let backup = Self::backup_name(&paths.runtime);
+        match std::fs::remove_file(&backup) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(io_error(e)),
+        }
+        if std::fs::hard_link(&paths.runtime, &backup).is_err() {
+            std::fs::copy(&paths.runtime, &backup).map_err(io_error)?;
+        }
+        Ok(Some(backup))
     }
 
     /// Let go of the captured runtime, after the new one proved healthy.
@@ -745,42 +866,120 @@ impl Rollback {
         }
     }
 
-    /// Put back what was in force, and describe what an operator is left with.
+    /// Put back what was in force, and say exactly what an operator is left
+    /// with.
     ///
-    /// Best effort by design: this already runs on a failure path, and a
-    /// restoration step that also fails must not replace the diagnosis of the
-    /// original failure with its own.
+    /// Every step is attempted even after an earlier one fails — a unit that
+    /// could not be rewritten must not stop the runtime from being put back —
+    /// but nothing is *claimed*: a restoration that did not fully succeed
+    /// reports which steps failed and the commands that finish the job by hand,
+    /// because an operator told recovery worked will not go looking.
     fn restore(&self, host: &dyn SystemdHost, name: &str, scope: ServiceScope) -> String {
+        let mut failed: Vec<String> = Vec::new();
+        let mut manual: Vec<String> = Vec::new();
+
         match &self.previous_unit {
             Some(unit) => {
-                let _ = write_unit_bytes(&self.unit, unit);
+                if let Err(err) = write_unit_bytes(&self.unit, unit) {
+                    failed.push(format!("rewrite the unit {}", self.unit.display()));
+                    tracing::debug!("restore {}: {err}", self.unit.display());
+                }
             }
-            None => {
-                let _ = std::fs::remove_file(&self.unit);
-            }
+            None => Self::remove_file(&self.unit, "remove the unit", &mut failed),
         }
+
         match &self.previous_runtime {
             Some(backup) => {
-                let _ = std::fs::rename(backup, &self.runtime);
+                if let Err(err) = std::fs::rename(backup, &self.runtime) {
+                    failed.push(format!(
+                        "put the previous runtime back as {} (it is at {})",
+                        self.runtime.display(),
+                        backup.display()
+                    ));
+                    tracing::debug!("restore {}: {err}", self.runtime.display());
+                }
             }
-            None => {
-                let _ = std::fs::remove_file(&self.runtime);
-            }
+            None => Self::remove_file(&self.runtime, "remove the staged runtime", &mut failed),
         }
         // The stamp describes the source the staged runtime was copied from,
         // and the restored binary did not come from it. Dropping it is what
         // makes the next install copy again instead of trusting a stamp that
         // now describes the runtime this rollback just removed.
-        let _ = std::fs::remove_file(self.runtime.with_extension("stamp"));
+        Self::remove_file(
+            &self.runtime.with_extension("stamp"),
+            "remove the staging stamp",
+            &mut failed,
+        );
 
-        let _ = systemctl(host, scope, &["daemon-reload"]);
-        if self.previous_unit.is_some() {
-            let _ = systemctl(host, scope, &["restart", name]);
-            "The service and runtime that were installed before have been put back.".to_string()
+        // The service is put back the way it was found, not the way an install
+        // leaves one: a service that was deliberately stopped, or deliberately
+        // not enabled for boot, must not come back started and enabled.
+        let mut supervisor_steps: Vec<Vec<&str>> = vec![vec!["daemon-reload"]];
+        if self.previous_unit.is_none() {
+            supervisor_steps.push(vec!["disable", "--now", name]);
         } else {
-            let _ = systemctl(host, scope, &["disable", "--now", name]);
-            "Nothing was left installed for this directory.".to_string()
+            if self.was_enabled == Some(false) {
+                supervisor_steps.push(vec!["disable", name]);
+            }
+            supervisor_steps.push(if self.was_running == Some(false) {
+                vec!["stop", name]
+            } else {
+                vec!["restart", name]
+            });
         }
+        for step in supervisor_steps {
+            if let Err(err) = systemctl(host, scope, &step) {
+                failed.push(format!("run `{}`", systemctl_command(scope, &step)));
+                manual.push(systemctl_command(scope, &step));
+                tracing::debug!("restore: {err}");
+            }
+        }
+
+        Self::describe(
+            if self.previous_unit.is_none() {
+                "Nothing was left installed for this directory."
+            } else {
+                "The service and runtime that were installed before have been put back."
+            },
+            &failed,
+            &manual,
+        )
+    }
+
+    /// Delete a file this rollback owns, recording the failure rather than
+    /// swallowing it.
+    fn remove_file(path: &Path, what: &str, failed: &mut Vec<String>) {
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                failed.push(format!("{what} {}", path.display()));
+                tracing::debug!("restore {}: {e}", path.display());
+            }
+        }
+    }
+
+    /// The sentence the install failure carries: what the rollback achieved,
+    /// and what it could not.
+    fn describe(succeeded: &str, failed: &[String], manual: &[String]) -> String {
+        if failed.is_empty() {
+            return succeeded.to_string();
+        }
+        let mut message = format!(
+            "The previous installation could not be fully restored: this could not {}.",
+            failed.join("; ")
+        );
+        if !manual.is_empty() {
+            use std::fmt::Write as _;
+            // Writing into a String is infallible; the Result exists only to
+            // satisfy the `Write` trait.
+            let _ = write!(
+                message,
+                " Finish it by hand with `{}`.",
+                manual.join("` and `")
+            );
+        }
+        message
     }
 }
 
@@ -900,13 +1099,11 @@ fn uninstall(host: &dyn SystemdHost, manifest: &ServiceManifest) -> Result<()> {
         }
     }
 
-    remove_staged_runtime(manifest);
-
     if let Err(err) = systemctl(host, manifest.scope, &["daemon-reload"]) {
         tracing::debug!("systemctl daemon-reload: {err}");
     }
 
-    Ok(())
+    remove_staged_runtime(manifest)
 }
 
 /// The staging directory holding the runtime this service — and only this
@@ -921,18 +1118,30 @@ fn owned_runtime_dir(manifest: &ServiceManifest) -> Option<PathBuf> {
 }
 
 /// Delete the runtime staged for this service, and nothing else.
-fn remove_staged_runtime(manifest: &ServiceManifest) {
+///
+/// A failure is reported rather than logged: the caller deletes the manifest
+/// once this returns, and a manifest that is gone while the staged runtime is
+/// still on disk leaves nobody who knows what the orphan belongs to.
+fn remove_staged_runtime(manifest: &ServiceManifest) -> Result<()> {
     let Some(owned) = owned_runtime_dir(manifest) else {
         tracing::debug!(
             "leaving {} in place: it is not this service's own staged runtime",
             manifest.runtime_path.display()
         );
-        return;
+        return Ok(());
     };
-    if let Err(e) = std::fs::remove_dir_all(&owned)
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        tracing::debug!("remove staged runtime {}: {e}", owned.display());
+    match std::fs::remove_dir_all(&owned) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(Error::CloudConnectIo {
+            message: format!(
+                "remove the runtime staged for the Spice Cloud Connect service {name} at {}: {e}. \
+                 The service definition is already gone, so nothing runs it — remove the \
+                 directory and re-run `spice connect service uninstall`.",
+                owned.display(),
+                name = manifest.name,
+            ),
+        }),
     }
 }
 
@@ -1286,9 +1495,19 @@ fn observe_persistence(
     };
     let lingers = match manifest.scope {
         ServiceScope::System => None,
-        ServiceScope::User => account_lingers(host, &manifest.owner.describe()),
+        ServiceScope::User => account_lingers(host, &linger_account(&manifest.owner)),
     };
     classify_persistence(&reported, lingers, manifest)
+}
+
+/// How this owner is named to `loginctl`.
+///
+/// The account name when the host has one, and the bare uid otherwise — which
+/// logind accepts just as well. Not [`ServiceOwner::describe`]: that produces
+/// `uid 1000` for human output, which is two arguments and not a user logind
+/// can be asked about.
+fn linger_account(owner: &ServiceOwner) -> String {
+    owner.name.clone().unwrap_or_else(|| owner.uid.to_string())
 }
 
 /// [`observe_persistence`] without the process: the classification of what
@@ -1326,7 +1545,7 @@ fn classify_persistence(
                 ServiceStarts::LoginOnly,
                 Some(format!(
                     "loginctl enable-linger {}",
-                    manifest.owner.describe()
+                    linger_account(&manifest.owner)
                 )),
             ),
         },
@@ -1352,7 +1571,10 @@ fn classify_persistence(
 /// an install that assumed it worked would promise boot persistence the host
 /// will not deliver.
 fn enable_linger(host: &dyn SystemdHost) -> Option<bool> {
-    let account = super::account_name(nix::unistd::Uid::effective().as_raw())?;
+    let uid = nix::unistd::Uid::effective().as_raw();
+    // The uid is a name logind accepts, so an account NSS cannot resolve is
+    // still asked about rather than skipped.
+    let account = super::account_name(uid).unwrap_or_else(|| uid.to_string());
     let _ = host.output(LOGINCTL, &["enable-linger", &account]);
     account_lingers(host, &account)
 }
@@ -1571,6 +1793,10 @@ mod tests {
         calls: RefCell<Vec<String>>,
         streamed: RefCell<Vec<String>>,
         stream_code: Option<i32>,
+        /// The scripted clock: it starts here and only what this host is asked
+        /// to wait for moves it, so a gate bounded by a deadline runs in the
+        /// time a test takes rather than in the time it measures.
+        started: Instant,
         slept: RefCell<Duration>,
     }
 
@@ -1582,6 +1808,7 @@ mod tests {
                 calls: RefCell::new(Vec::new()),
                 streamed: RefCell::new(Vec::new()),
                 stream_code: Some(0),
+                started: Instant::now(),
                 slept: RefCell::new(Duration::ZERO),
             }
         }
@@ -1686,6 +1913,10 @@ mod tests {
             }
         }
 
+        fn now(&self) -> Instant {
+            self.started + *self.slept.borrow()
+        }
+
         fn sleep(&self, duration: Duration) {
             *self.slept.borrow_mut() += duration;
         }
@@ -1697,6 +1928,11 @@ mod tests {
     };
 
     const HEALTH_URL: &str = "http://127.0.0.1:8090/health";
+
+    /// How many times a gate samples before its deadline, for the scripted
+    /// answers a whole-gate test has to supply. Pinned against the constants it
+    /// is derived from by [`the_gates_are_bounded_by_the_windows_they_promise`].
+    const SAMPLES_IN_A_GATE: u32 = 61;
 
     fn rendered(instance_dir: &str, config_dir: &str, spiced_path: &str) -> String {
         render_unit(
@@ -1825,8 +2061,16 @@ mod tests {
             .expect("render unit");
             assert!(unit.contains("\nRestart=on-failure\n"), "{scope}");
             assert!(unit.contains("\nRestartSec=5\n"), "{scope}");
-            // A rate limit would let a crash loop give up permanently.
-            assert!(unit.contains("\nStartLimitIntervalSec=0\n"), "{scope}");
+            // A rate limit would let a crash loop give up permanently — and
+            // systemd only honours this directive under [Unit], so a copy that
+            // drifted into [Service] would be silently ignored.
+            let limit = unit
+                .find("\nStartLimitIntervalSec=0\n")
+                .unwrap_or_else(|| panic!("{scope}: no start-rate limit override"));
+            let service_section = unit
+                .find("\n[Service]\n")
+                .unwrap_or_else(|| panic!("{scope}: no [Service] section"));
+            assert!(limit < service_section, "{scope}: {unit}");
         }
     }
 
@@ -2391,7 +2635,7 @@ mod tests {
         health_gate(&host, &name, ServiceScope::User, HEALTH_URL)
             .expect("a service that stays up is up");
         assert!(
-            *host.slept.borrow() >= settle_window(),
+            *host.slept.borrow() >= SETTLE_WINDOW,
             "it may only be accepted after it has stayed up: {:?}",
             host.slept
         );
@@ -2413,25 +2657,33 @@ mod tests {
 
     #[test]
     fn the_health_gate_rejects_a_runtime_that_keeps_being_restarted() {
-        // A crash loop never accumulates an uninterrupted run and never
-        // answers, which is exactly what the gate has to refuse.
+        // The failure sampling alone cannot see: every poll finds the unit
+        // `active`, because systemd has already restarted it by the time the
+        // next sample lands. systemd's own restart count is what gives it away.
         let name = unit_name_for_dir(Path::new("/opt/edge-1"));
-        let flapping: Vec<&str> = (0..HEALTH_ATTEMPTS)
-            .map(|attempt| {
-                if attempt % 2 == 0 {
-                    "active"
-                } else {
-                    "activating"
-                }
-            })
+        let restarts: Vec<String> = (0..SAMPLES_IN_A_GATE)
+            .map(|restart| format!("{restart}\n{restart}00"))
             .collect();
+        let restarts: Vec<&str> = restarts.iter().map(String::as_str).collect();
         let host = ScriptedHost::new()
-            .sequence(&format!("systemctl --user is-active {name}"), &flapping)
+            .says(&format!("systemctl --user is-active {name}"), "active")
+            .sequence(
+                &format!(
+                    "systemctl --user show {name} --property=NRestarts \
+                     --property=ActiveEnterTimestampMonotonic --value"
+                ),
+                &restarts,
+            )
             .health(&[false]);
 
         let why = health_gate(&host, &name, ServiceScope::User, HEALTH_URL)
-            .expect_err("a restarting runtime must not pass");
-        assert!(!why.is_empty(), "the refusal has to say what it saw");
+            .expect_err("a runtime that is restarted between samples must not pass");
+        assert!(why.contains("has not stayed running"), "{why}");
+        assert!(
+            *host.slept.borrow() >= HEALTH_GATE,
+            "the gate runs to its deadline before giving up: {:?}",
+            host.slept
+        );
     }
 
     #[test]
@@ -2471,10 +2723,14 @@ mod tests {
     fn only_a_success_status_line_counts_as_healthy() {
         assert!(status_line_is_success("HTTP/1.1 200 OK\r\nDate: now\r\n"));
         assert!(status_line_is_success("HTTP/1.0 204 No Content\r\n"));
-        assert!(!status_line_is_success("HTTP/1.1 503 Service Unavailable"));
-        assert!(!status_line_is_success("HTTP/1.1 200"), "no reason phrase");
+        assert!(!status_line_is_success(
+            "HTTP/1.1 503 Service Unavailable\r\n"
+        ));
+        // A response that ended before the status line did is a cut
+        // connection, not a healthy instance.
+        assert!(!status_line_is_success("HTTP/1.1 200"), "no terminator");
         assert!(!status_line_is_success(""));
-        assert!(!status_line_is_success("garbage"));
+        assert!(!status_line_is_success("garbage\r\n"));
     }
 
     /// An install request pointing at a runtime and directories under `root`.
@@ -2580,10 +2836,18 @@ mod tests {
         .expect("the first install");
         let installed_unit = std::fs::read(&paths.unit).expect("read unit");
 
-        // The upgrade: a new binary systemd cannot keep running.
+        // The upgrade: a new binary systemd cannot keep running. The first
+        // answer is what the rollback captures — a service that was running and
+        // has to be running again afterwards — and the rest is the upgrade
+        // failing.
         std::fs::write(&spiced, b"runtime-v2-broken").expect("write the upgrade");
+        let restart = format!("systemctl --user restart {name}");
         let broken = ScriptedHost::new()
-            .says(&format!("systemctl --user is-active {name}"), "failed")
+            .sequence(
+                &format!("systemctl --user is-active {name}"),
+                &["active", "failed"],
+            )
+            .says(&format!("systemctl --user is-enabled {name}"), "enabled")
             .health(&[false]);
         let error = install_at(
             &broken,
@@ -2609,10 +2873,136 @@ mod tests {
             !paths.runtime.with_extension("previous").exists(),
             "the rollback copy is consumed"
         );
-        assert!(
-            broken.ran(&format!("systemctl --user restart {name}")),
-            "the restored service is started again: {:?}",
+        // Twice: the upgrade's own restart, and the one that brings the
+        // restored service back — it was running before, so it has to be
+        // running after.
+        assert_eq!(
+            broken
+                .calls()
+                .iter()
+                .filter(|call| **call == restart)
+                .count(),
+            2,
+            "{:?}",
             broken.calls()
+        );
+        assert!(
+            !broken
+                .calls()
+                .iter()
+                .any(|call| call.contains(&format!("stop {name}"))),
+            "a service that was running must not be left stopped: {:?}",
+            broken.calls()
+        );
+    }
+
+    #[test]
+    fn a_rolled_back_upgrade_leaves_a_stopped_service_stopped() {
+        // The state an install would otherwise impose on a service that was
+        // deliberately down: `apply` always enables and restarts, so a rollback
+        // that only put the files back would leave it running and enabled.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let spiced = dir.path().join("spiced");
+        std::fs::create_dir_all(&instance_dir).expect("create instance dir");
+        std::fs::write(&spiced, b"runtime-v1").expect("write runtime");
+
+        let name = unit_name_for_dir(&instance_dir);
+        let paths = install_paths_under(dir.path(), &name);
+        install_at(
+            &ScriptedHost::new()
+                .says(&format!("systemctl --user is-active {name}"), "active")
+                .health(&[true]),
+            &install_request(&instance_dir, &config_dir, &spiced),
+            &name,
+            &paths,
+            None,
+        )
+        .expect("the first install");
+
+        std::fs::write(&spiced, b"runtime-v2-broken").expect("write the upgrade");
+        let broken = ScriptedHost::new()
+            // Stopped and not enabled when the upgrade found it, then failing.
+            .sequence(
+                &format!("systemctl --user is-active {name}"),
+                &["inactive", "failed"],
+            )
+            .says(&format!("systemctl --user is-enabled {name}"), "disabled")
+            .health(&[false]);
+        install_at(
+            &broken,
+            &install_request(&instance_dir, &config_dir, &spiced),
+            &name,
+            &paths,
+            None,
+        )
+        .expect_err("an upgrade that does not serve must fail");
+
+        assert!(
+            broken.ran(&format!("systemctl --user stop {name}")),
+            "a service that was stopped must be stopped again: {:?}",
+            broken.calls()
+        );
+        assert!(
+            broken.ran(&format!("systemctl --user disable {name}")),
+            "a service that was not enabled must not be left enabled: {:?}",
+            broken.calls()
+        );
+    }
+
+    #[test]
+    fn a_rollback_that_could_not_finish_says_so_rather_than_claiming_recovery() {
+        // An operator told that recovery worked will not go looking, so a
+        // restoration step that failed has to be named along with the command
+        // that finishes it by hand.
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        let spiced = dir.path().join("spiced");
+        std::fs::create_dir_all(&instance_dir).expect("create instance dir");
+        std::fs::write(&spiced, b"runtime-v1").expect("write runtime");
+
+        let name = unit_name_for_dir(&instance_dir);
+        let paths = install_paths_under(dir.path(), &name);
+        install_at(
+            &ScriptedHost::new()
+                .says(&format!("systemctl --user is-active {name}"), "active")
+                .health(&[true]),
+            &install_request(&instance_dir, &config_dir, &spiced),
+            &name,
+            &paths,
+            None,
+        )
+        .expect("the first install");
+
+        std::fs::write(&spiced, b"runtime-v2-broken").expect("write the upgrade");
+        let restart = format!("systemctl --user restart {name}");
+        let broken = ScriptedHost::new()
+            .says(&format!("systemctl --user is-active {name}"), "active")
+            .says(&format!("systemctl --user is-enabled {name}"), "enabled")
+            .fails(&restart, "Failed to restart: Unit not found.")
+            .health(&[false]);
+
+        let error = install_at(
+            &broken,
+            &install_request(&instance_dir, &config_dir, &spiced),
+            &name,
+            &paths,
+            None,
+        )
+        .expect_err("an upgrade whose service will not restart must fail");
+
+        assert!(
+            error.to_string().contains("could not be fully restored"),
+            "{error}"
+        );
+        assert!(error.to_string().contains(&restart), "{error}");
+        assert!(!error.to_string().contains("put back"), "{error}");
+        // The files are still restored, even though the supervisor step failed.
+        assert_eq!(
+            std::fs::read(&paths.runtime).expect("read staged runtime"),
+            b"runtime-v1"
         );
     }
 
@@ -2741,15 +3131,21 @@ mod tests {
     }
 
     #[test]
-    fn the_gates_poll_for_exactly_as_long_as_they_promise() {
-        // The messages both gates print name a duration, and the loops are
-        // bounded by attempts — so the two have to be kept in step here rather
-        // than in a comment.
-        assert_eq!(HEALTH_POLL_INTERVAL * HEALTH_ATTEMPTS, HEALTH_GATE);
+    fn the_gates_are_bounded_by_the_windows_they_promise() {
+        assert!(
+            SETTLE_WINDOW < HEALTH_GATE,
+            "an install cannot wait longer for a settled run than its whole gate lasts"
+        );
         assert_eq!(
             LIFECYCLE_POLL_INTERVAL * LIFECYCLE_ATTEMPTS,
-            Duration::from_secs(10)
+            Duration::from_secs(10),
+            "the lifecycle wait names this duration in its failure"
         );
+        // What the whole-gate tests script answers for.
+        let samples = u32::try_from(HEALTH_GATE.as_millis() / HEALTH_POLL_INTERVAL.as_millis())
+            .expect("a gate is a small number of polls")
+            + 1;
+        assert_eq!(samples, SAMPLES_IN_A_GATE);
     }
 
     #[test]


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

## What

- Install a systemd **user** unit (`${XDG_CONFIG_HOME:-~/.config}/systemd/user/`, `WantedBy=default.target`) when unprivileged, and a **system** unit (`/etc/systemd/system/`, verified `User`/`Group`, `WantedBy=multi-user.target`) as root. Both use `Restart=on-failure`, `RestartSec=5`, `StartLimitIntervalSec=0`.
- Stage a **per-instance** `spiced` copy recorded in `service.json` (`/usr/local/lib/spice/<stem>/` for system, `$XDG_DATA_HOME/spice/services/<stem>/` for user) instead of one host-wide binary.
- Gate install/upgrade for 30 seconds — the service must answer its health URL or stay uninterrupted-running — and roll the previous unit *and* runtime back when it does not.
- Implement `start`, `stop`, `restart` (supervisor-owned, waiting for the state asked for) and `logs` (`journalctl [--user] -u <unit> --no-pager -q -o cat -n <N> [-f]`, "No logs yet" on empty history, exit 130 on interrupt).
- Attempt and then **verify** `loginctl enable-linger` on a user install, so `starts` reports `boot_without_login` or `login_only` plus the command that changes it.
- Refuse mutations this invocation cannot perform, naming the exact retry: `sudo spice connect service <action> --dir <path>` for a system service, the owning account for a user one. Never self-elevates, never drives a user service through root's manager.
- Refuse an install that would add a service in the other domain for a directory that already has one.
- Uninstall removes only this service's unit and its own staged runtime; journal history is left to systemd retention.
- Route every supervisor call, the health probe, and poll waits through one host abstraction; failed lifecycle commands print native `systemctl`/`journalctl` commands on stderr as recovery detail.

## Why

- Requiring root forced host-wide installation on machines where the runtime belongs to one operator; user systemd is the least-privilege normal case.
- A shared staged runtime made an upgrade in one instance directory silently change what every other instance runs at its next restart, and left uninstall unable to tell whether a binary was still in use.
- `systemctl restart` exiting zero means started, not serving — without a health gate a failed upgrade replaced a working instance and reported success.
- `start`/`stop`/`restart`/`logs` were unimplemented, so routine operations had to go through `systemctl` and `journalctl` directly.
- Claiming boot persistence without checking lingering promised exactly the thing that would not happen after a reboot.
- Domain follows invocation privilege, so an unprivileged re-install over a system service would have left two services running with a manifest describing only one.

## 🔗 Related

<!-- Link to relevant issues, discussions, or other PRs. Use "Closes #123" to auto-close issues. Omit if none. -->

* Part of #12905