### PR TITLE
Harden persisted Cloud Connect state handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17184,6 +17184,7 @@ dependencies = [
  "fs4",
  "gethostname",
  "getrandom 0.3.4",
+ "http 1.4.1",
  "libc",
  "pem",
  "prost",

--- a/bin/spice/src/commands/connect/mod.rs
+++ b/bin/spice/src/commands/connect/mod.rs
@@ -245,7 +245,7 @@ fn reject_cloud_region(cloud_region: Option<&str>) -> Result<()> {
             "--cloud-region {region} does not apply to `spice connect`. Spice Cloud selects this \
              instance's gateway from the location supplied to `spiced --region` during \
              `spiced --token` enrollment and returns it in the enroll response, falling back \
-             to the home stamp for a location it does not recognise. Use --endpoint <url> \
+             to the home stamp for a location it does not recognize. Use --endpoint <url> \
              here only to inspect or release state through another Spice Cloud control plane. \
              See: https://spiceai.org/docs"
         ),
@@ -293,7 +293,15 @@ async fn connect_existing(
 /// unreadable identity would report success, but every `spiced` restart would
 /// reject that identity and run without Cloud Connect.
 fn has_enrolled_identity(config_dir: &Path) -> Result<bool> {
-    runtime_cloud_connect::identity::IdentityStore::load_optional(&config_dir.join(IDENTITY_FILE))
+    let mut config = runtime_cloud_connect::CloudConnectConfig::from_env_at(
+        env!("CARGO_PKG_VERSION"),
+        config_dir.to_path_buf(),
+    );
+    // An installed service carries only SPICE_CONFIG_DIR. A gateway override
+    // inherited from the invoking shell is transient and cannot make an
+    // otherwise unusable durable identity safe to install.
+    config.gateway_endpoint = None;
+    runtime_cloud_connect::load_reconnectable_identity(&config)
         .map(|identity| identity.is_some())
         .map_err(|e| Error::CloudConnectIo {
             message: format!("load identity: {e}"),
@@ -367,10 +375,16 @@ fn instance_dir_for(config_dir: &Path) -> PathBuf {
 async fn print_status(config_dir: &Path, endpoint: Option<&str>) -> Result<()> {
     let identity_path = config_dir.join(IDENTITY_FILE);
 
-    let identity = runtime_cloud_connect::identity::IdentityStore::load_optional(&identity_path)
-        .map_err(|e| Error::CloudConnectIo {
+    let mut config = runtime_cloud_connect::CloudConnectConfig::from_env_at(
+        env!("CARGO_PKG_VERSION"),
+        config_dir.to_path_buf(),
+    );
+    config.gateway_endpoint = None;
+    let identity = runtime_cloud_connect::load_reconnectable_identity(&config).map_err(|e| {
+        Error::CloudConnectIo {
             message: format!("load identity: {e}"),
-        })?;
+        }
+    })?;
 
     if let Some(id) = identity {
         let expiry = id.not_after_unix.map_or_else(
@@ -628,10 +642,12 @@ async fn remove_identity(
 
     if had_identity {
         // Clearing this also destroys the cache key, which is only in this file.
-        runtime_cloud_connect::identity::IdentityStore::clear(&identity_path).map_err(|e| {
-            Error::CloudConnectIo {
-                message: format!("clear identity: {e}"),
-            }
+        runtime_cloud_connect::identity::IdentityStore::clear_with_transaction(
+            &identity_path,
+            &enrollment_transaction,
+        )
+        .map_err(|e| Error::CloudConnectIo {
+            message: format!("clear identity: {e}"),
         })?;
     }
 
@@ -799,6 +815,32 @@ mod tests {
         let error = has_enrolled_identity(dir.path())
             .expect_err("a malformed identity must not enable service installation");
         assert!(error.to_string().contains("load identity"), "{error}");
+    }
+
+    #[test]
+    fn a_parseable_but_unusable_identity_is_not_accepted_as_enrolled_state() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join(IDENTITY_FILE);
+        std::fs::write(
+            path,
+            serde_json::json!({
+                "identifier": "",
+                "identity_cert_pem": "credential-that-must-not-be-printed",
+                "private_key_pem": "private-key-that-must-not-be-printed",
+                "public_key_pem": "public-key",
+                "gateway_addr": "gateway.example:443"
+            })
+            .to_string(),
+        )
+        .expect("write unusable identity");
+
+        let error = has_enrolled_identity(dir.path())
+            .expect_err("an unusable identity must not enable service installation");
+        let rendered = error.to_string();
+        assert!(rendered.contains("cannot be used"), "{rendered}");
+        assert!(rendered.contains("identifier is empty"), "{rendered}");
+        assert!(!rendered.contains("credential-that-must-not-be-printed"));
+        assert!(!rendered.contains("private-key-that-must-not-be-printed"));
     }
 
     #[test]

--- a/bin/spice/src/commands/connect/mod.rs
+++ b/bin/spice/src/commands/connect/mod.rs
@@ -47,7 +47,7 @@ use crate::output::OutputFormat;
 use clap::{Args, Subcommand};
 use runtime_cloud_connect::config::{CloudConnectConfig, IDENTITY_FILE};
 
-use status::ConnectStatus;
+use status::{ConnectStatus, ConnectionState};
 
 /// File (relative to the config dir) holding a `--endpoint` override so later
 /// `spiced` starts reach the same control plane the enroll did.
@@ -330,10 +330,13 @@ fn reject_cloud_region(cloud_region: Option<&str>) -> Result<()> {
 /// enrollment belongs to the runtime — so it errors with the exact command that
 /// does enroll.
 async fn connect_existing(config_dir: &Path, endpoint: Option<&str>) -> Result<()> {
-    if has_enrolled_identity(config_dir)? {
-        println!("This host is already enrolled with Spice Cloud.");
-        println!();
-        return print_status(config_dir, endpoint, OutputFormat::Table).await;
+    let status = collect_status(config_dir, endpoint).await;
+    if status.connection.state != ConnectionState::NotConnected {
+        if status.connection.state == ConnectionState::Enrolled {
+            println!("This host is already enrolled with Spice Cloud.");
+            println!();
+        }
+        return render_status(&status, OutputFormat::Table);
     }
 
     Err(Error::InvalidArgument {
@@ -347,17 +350,26 @@ async fn connect_existing(config_dir: &Path, endpoint: Option<&str>) -> Result<(
     })
 }
 
-/// Whether this directory holds a usable enrolled identity.
-///
-/// Existence alone is not enough: an unreadable identity would be reported as
-/// enrolled, but every `spiced` restart would reject it and run without Cloud
-/// Connect.
-fn has_enrolled_identity(config_dir: &Path) -> Result<bool> {
-    runtime_cloud_connect::identity::IdentityStore::load_optional(&config_dir.join(IDENTITY_FILE))
-        .map(|identity| identity.is_some())
-        .map_err(|e| Error::CloudConnectIo {
-            message: format!("load identity: {e}"),
-        })
+/// Collect the one status snapshot used by the bare and explicit status forms.
+async fn collect_status(config_dir: &Path, endpoint: Option<&str>) -> ConnectStatus {
+    ConnectStatus::collect(
+        service::backend(),
+        &instance_dir_for(config_dir),
+        config_dir,
+        &resolved_endpoint(config_dir, endpoint),
+    )
+    .await
+}
+
+/// Render an already-collected snapshot and preserve its degraded exit status.
+fn render_status(status: &ConnectStatus, output: OutputFormat) -> Result<()> {
+    status::render(status, output)?;
+    // The report is already on stdout; the diagnosis travels as the command's
+    // error so a `--output json` run stays parseable.
+    match status.degradation() {
+        Some(message) => Err(Error::ServiceUnavailable { message }),
+        None => Ok(()),
+    }
 }
 
 /// The canonical instance directory a config dir belongs to: `<dir>/.spice` →
@@ -419,20 +431,8 @@ async fn print_status(
     endpoint: Option<&str>,
     output: OutputFormat,
 ) -> Result<()> {
-    let status = ConnectStatus::collect(
-        service::backend(),
-        &instance_dir_for(config_dir),
-        config_dir,
-        &resolved_endpoint(config_dir, endpoint),
-    )
-    .await;
-    status::render(&status, output)?;
-    // The report is already on stdout; the diagnosis travels as the command's
-    // error so a `--output json` run stays parseable.
-    match status.degradation() {
-        Some(message) => Err(Error::ServiceUnavailable { message }),
-        None => Ok(()),
-    }
+    let status = collect_status(config_dir, endpoint).await;
+    render_status(&status, output)
 }
 
 /// What Spice Cloud said about the release, reduced to the only question that
@@ -552,10 +552,12 @@ async fn remove_identity(
     let instance_dir = instance_dir_for(config_dir);
     let backend = service::backend();
 
-    let identity = runtime_cloud_connect::identity::IdentityStore::load_optional(&identity_path)
-        .map_err(|e| Error::CloudConnectIo {
-            message: format!("load identity: {e}"),
-        })?;
+    let identity =
+        runtime_cloud_connect::identity::IdentityStore::load_optional_async(identity_path.clone())
+            .await
+            .map_err(|e| Error::CloudConnectIo {
+                message: format!("load identity: {e}"),
+            })?;
     let installed = service::resolve(backend, &instance_dir, config_dir)?;
 
     let had_identity = identity.is_some();
@@ -657,10 +659,13 @@ async fn remove_identity(
 
     if had_identity {
         // Clearing this also destroys the cache key, which is only in this file.
-        runtime_cloud_connect::identity::IdentityStore::clear(&identity_path).map_err(|e| {
-            Error::CloudConnectIo {
-                message: format!("clear identity: {e}"),
-            }
+        runtime_cloud_connect::identity::IdentityStore::clear_with_transaction_async(
+            identity_path.clone(),
+            Arc::clone(&enrollment_transaction),
+        )
+        .await
+        .map_err(|e| Error::CloudConnectIo {
+            message: format!("clear identity: {e}"),
         })?;
     }
 
@@ -1061,17 +1066,6 @@ mod tests {
             canonicalize_instance_dir(Path::new("../unresolvable/edge")),
             PathBuf::from("../unresolvable/edge")
         );
-    }
-
-    #[test]
-    fn a_malformed_identity_is_not_reported_as_enrolled() {
-        let dir = tempfile::tempdir().expect("create tempdir");
-        std::fs::write(dir.path().join(IDENTITY_FILE), "not valid JSON")
-            .expect("write malformed identity");
-
-        let error = has_enrolled_identity(dir.path())
-            .expect_err("a malformed identity must not read as enrolled");
-        assert!(error.to_string().contains("load identity"), "{error}");
     }
 
     #[test]

--- a/bin/spice/src/commands/connect/mod.rs
+++ b/bin/spice/src/commands/connect/mod.rs
@@ -245,12 +245,13 @@ pub async fn execute(ctx: &RuntimeContext, args: ConnectArgs) -> Result<()> {
                 remove_identity(&config_dir, args.endpoint.as_deref(), args.yes, args.force).await
             }
             ConnectCommand::Service(service_args) => {
+                let endpoint = resolved_endpoint(&config_dir, args.endpoint.as_deref())?;
                 service::cli::execute(
                     ctx,
                     service_args,
                     &instance_dir_for(&config_dir),
                     &config_dir,
-                    &resolved_endpoint(&config_dir, args.endpoint.as_deref()),
+                    &endpoint,
                 )
                 .await
             }
@@ -330,7 +331,7 @@ fn reject_cloud_region(cloud_region: Option<&str>) -> Result<()> {
 /// enrollment belongs to the runtime — so it errors with the exact command that
 /// does enroll.
 async fn connect_existing(config_dir: &Path, endpoint: Option<&str>) -> Result<()> {
-    let status = collect_status(config_dir, endpoint).await;
+    let status = collect_status(config_dir, endpoint).await?;
     if status.connection.state != ConnectionState::NotConnected {
         if status.connection.state == ConnectionState::Enrolled {
             println!("This host is already enrolled with Spice Cloud.");
@@ -351,14 +352,15 @@ async fn connect_existing(config_dir: &Path, endpoint: Option<&str>) -> Result<(
 }
 
 /// Collect the one status snapshot used by the bare and explicit status forms.
-async fn collect_status(config_dir: &Path, endpoint: Option<&str>) -> ConnectStatus {
-    ConnectStatus::collect(
+async fn collect_status(config_dir: &Path, endpoint: Option<&str>) -> Result<ConnectStatus> {
+    let endpoint = resolved_endpoint(config_dir, endpoint)?;
+    Ok(ConnectStatus::collect(
         service::backend(),
         &instance_dir_for(config_dir),
         config_dir,
-        &resolved_endpoint(config_dir, endpoint),
+        &endpoint,
     )
-    .await
+    .await)
 }
 
 /// Render an already-collected snapshot and preserve its degraded exit status.
@@ -431,7 +433,7 @@ async fn print_status(
     endpoint: Option<&str>,
     output: OutputFormat,
 ) -> Result<()> {
-    let status = collect_status(config_dir, endpoint).await;
+    let status = collect_status(config_dir, endpoint).await?;
     render_status(&status, output)
 }
 
@@ -474,14 +476,14 @@ async fn release_instance(
     config_dir: &Path,
     endpoint: Option<&str>,
     identity: &runtime_cloud_connect::Identity,
-) -> ReleaseVerdict {
-    let endpoint = resolved_endpoint(config_dir, endpoint);
+) -> Result<ReleaseVerdict> {
+    let endpoint = resolved_endpoint(config_dir, endpoint)?;
     let ca = (!identity.ca_bundle_pem.is_empty()).then_some(identity.ca_bundle_pem.as_str());
 
-    classify_release(
+    Ok(classify_release(
         runtime_cloud_connect::release::release(&endpoint, identity, ca).await,
         &endpoint,
-    )
+    ))
 }
 
 /// [`release_instance`] without the request: the classification of what the
@@ -599,7 +601,7 @@ async fn remove_identity(
     // Reported before anything is cleared: the identity leaf is the credential
     // that authorises the release, so it has to still exist.
     if let Some(ref identity) = identity {
-        match release_instance(config_dir, endpoint, identity).await {
+        match release_instance(config_dir, endpoint, identity).await? {
             ReleaseVerdict::Confirmed { outcome } => {
                 println!("Released this instance in Spice Cloud.");
                 if !outcome.status.is_empty() {
@@ -748,21 +750,25 @@ fn confirm(prompt: &str) -> Result<bool> {
 /// precedence used at runtime: an explicit `--endpoint` first, then the
 /// `SPICE_CLOUD_ENDPOINT` env var, then the on-disk `cloud-endpoint` override
 /// in the config dir, then the built-in default.
-fn resolved_endpoint(config_dir: &Path, explicit: Option<&str>) -> String {
+fn resolved_endpoint(config_dir: &Path, explicit: Option<&str>) -> Result<String> {
     if let Some(endpoint) = explicit.filter(|e| !e.is_empty()) {
-        return endpoint.to_string();
+        return Ok(endpoint.to_string());
     }
     if let Ok(env) = std::env::var("SPICE_CLOUD_ENDPOINT")
         && !env.is_empty()
     {
-        return env;
+        return Ok(env);
     }
-    if let Ok(Some(endpoint)) =
-        runtime_cloud_connect::CloudConnectConfig::read_enroll_endpoint_override(config_dir)
-    {
-        return endpoint;
+    match runtime_cloud_connect::CloudConnectConfig::read_enroll_endpoint_override(config_dir) {
+        Ok(Some(endpoint)) => Ok(endpoint),
+        Ok(None) => Ok(runtime_cloud_connect::config::DEFAULT_ENDPOINT.to_string()),
+        Err(source) => Err(Error::CloudConnectIo {
+            message: format!(
+                "read the Cloud Connect endpoint override at {}: {source}",
+                config_dir.join(CLOUD_ENDPOINT_FILE).display()
+            ),
+        }),
     }
-    runtime_cloud_connect::config::DEFAULT_ENDPOINT.to_string()
 }
 
 #[cfg(test)]
@@ -1071,7 +1077,8 @@ mod tests {
     fn resolved_endpoint_prefers_the_explicit_flag() {
         let dir = tempfile::tempdir().expect("create tempdir");
         assert_eq!(
-            resolved_endpoint(dir.path(), Some("https://explicit.example")),
+            resolved_endpoint(dir.path(), Some("https://explicit.example"))
+                .expect("explicit endpoint"),
             "https://explicit.example"
         );
     }
@@ -1082,7 +1089,7 @@ mod tests {
 
         // Nothing on disk: the built-in default.
         assert_eq!(
-            resolved_endpoint(dir.path(), None),
+            resolved_endpoint(dir.path(), None).expect("default endpoint"),
             runtime_cloud_connect::config::DEFAULT_ENDPOINT
         );
 
@@ -1093,16 +1100,40 @@ mod tests {
         )
         .expect("write override");
         assert_eq!(
-            resolved_endpoint(dir.path(), None),
+            resolved_endpoint(dir.path(), None).expect("persisted endpoint"),
             "https://override.example"
         );
 
         // A blank override is not an endpoint.
         std::fs::write(dir.path().join(CLOUD_ENDPOINT_FILE), "  \n").expect("write blank override");
         assert_eq!(
-            resolved_endpoint(dir.path(), None),
+            resolved_endpoint(dir.path(), None).expect("blank override uses the default"),
             runtime_cloud_connect::config::DEFAULT_ENDPOINT
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolved_endpoint_fails_closed_on_an_unreadable_override() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let target = dir.path().join("redirected-endpoint");
+        std::fs::write(&target, "https://wrong-control-plane.example")
+            .expect("write target endpoint");
+        symlink(&target, dir.path().join(CLOUD_ENDPOINT_FILE)).expect("create endpoint symlink");
+
+        let error = resolved_endpoint(dir.path(), None)
+            .expect_err("an unsafe override must not fall back to the production endpoint");
+
+        assert!(
+            error.to_string().contains("could not be read safely")
+                || error
+                    .to_string()
+                    .contains("read the Cloud Connect endpoint override"),
+            "{error}"
+        );
+        assert!(!error.to_string().contains("wrong-control-plane"));
     }
 
     #[tokio::test]

--- a/bin/spice/src/commands/connect/service/cli.rs
+++ b/bin/spice/src/commands/connect/service/cli.rs
@@ -222,6 +222,8 @@ async fn install(
     config_dir: &Path,
     endpoint: &str,
 ) -> Result<()> {
+    validate_service_identity(config_dir).await?;
+
     // Resolved, not derived from `$HOME`: `sudo` rewrites `HOME` to `/root`, and
     // the runtime the operator installed is normally under their own home.
     let spiced_path = ctx.resolve_spiced_path().ok_or_else(|| Error::InvalidArgument {
@@ -272,6 +274,37 @@ async fn install(
     println!("  spice connect service logs -f");
     println!("  spice connect service uninstall");
     Ok(())
+}
+
+/// Require the exact durable identity the installed service can use.
+///
+/// The unit persists only `SPICE_CONFIG_DIR`, so an override inherited from
+/// the installing shell cannot make an otherwise unusable identity safe to
+/// install. The runtime will make the same decision after the first restart.
+async fn validate_service_identity(config_dir: &Path) -> Result<()> {
+    let mut config = runtime_cloud_connect::CloudConnectConfig::from_env_at(
+        env!("CARGO_PKG_VERSION"),
+        config_dir.to_path_buf(),
+    );
+    config.gateway_endpoint = None;
+
+    match runtime_cloud_connect::load_reconnectable_identity_async(&config).await {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err(Error::InvalidArgument {
+            message: format!(
+                "Failed to install the Spice Cloud Connect service: {} has no enrolled identity. \
+                 Mint an enrollment key in the Spice Cloud portal and start the runtime with \
+                 `spiced --token <enrollment-key>` before installing the service. \
+                 See: https://spiceai.org/docs",
+                config.identity_path.display()
+            ),
+        }),
+        Err(error) => Err(Error::CloudConnectIo {
+            message: format!(
+                "validate the durable Cloud Connect identity before installing the service: {error}"
+            ),
+        }),
+    }
 }
 
 /// Uninstall and say exactly what was and was not removed.
@@ -345,7 +378,7 @@ fn resolve_or_report(
 /// The report is already on stdout by the time this runs: the diagnosis travels
 /// as the process's error on stderr, so a `--output json` run stays parseable.
 fn degraded_error(status: &ConnectStatus) -> Result<()> {
-    match status.degradation() {
+    match status.service_degradation() {
         Some(message) => Err(Error::ServiceUnavailable { message }),
         None => Ok(()),
     }

--- a/bin/spice/src/commands/connect/service/mod.rs
+++ b/bin/spice/src/commands/connect/service/mod.rs
@@ -89,6 +89,7 @@ const NAME_DIGEST_HEX: usize = 16;
 
 /// Marks a booted systemd system. Present only when systemd is PID 1 and
 /// running, which is exactly the condition `systemctl` needs.
+#[cfg(target_os = "linux")]
 const SYSTEMD_RUNTIME_MARKER: &str = "/run/systemd/system";
 
 /// Root-owned directory the installed service's `spiced` is staged into.
@@ -301,6 +302,7 @@ pub(crate) enum PreflightFailure {
     /// Neither Linux nor macOS — there is no supervisor to install into.
     UnsupportedPlatform,
     /// Linux, but systemd is not the running init.
+    #[cfg(target_os = "linux")]
     SystemdUnavailable,
     /// A user-scope service was asked for, and the back end does not install
     /// one yet.
@@ -319,6 +321,7 @@ impl PreflightFailure {
                  See: https://spiceai.org/docs",
                 std::env::consts::OS
             ),
+            #[cfg(target_os = "linux")]
             Self::SystemdUnavailable => format!(
                 "Failed to install the Spice Cloud Connect service: systemd is not running on \
                  this host ({SYSTEMD_RUNTIME_MARKER} is absent). This is normal inside a \
@@ -1275,18 +1278,21 @@ mod tests {
                 .contains("sudo"),
             "the deferred user-scope failure must name the path that does work"
         );
-        assert!(
-            PreflightFailure::SystemdUnavailable
-                .message()
-                .contains("restart policy"),
-            "the no-systemd failure must point containers at the --token flow"
-        );
-        assert!(
-            PreflightFailure::SystemdUnavailable
-                .message()
-                .contains("spiced --token"),
-            "containers enroll directly with the runtime, not this installer"
-        );
+        #[cfg(target_os = "linux")]
+        {
+            assert!(
+                PreflightFailure::SystemdUnavailable
+                    .message()
+                    .contains("restart policy"),
+                "the no-systemd failure must point containers at the --token flow"
+            );
+            assert!(
+                PreflightFailure::SystemdUnavailable
+                    .message()
+                    .contains("spiced --token"),
+                "containers enroll directly with the runtime, not this installer"
+            );
+        }
         assert!(
             PreflightFailure::UnsupportedPlatform
                 .message()

--- a/bin/spice/src/commands/connect/snapshots/spice__commands__connect__status__tests__connect_service_status_schema.snap
+++ b/bin/spice/src/commands/connect/snapshots/spice__commands__connect__status__tests__connect_service_status_schema.snap
@@ -3,7 +3,7 @@ source: bin/spice/src/commands/connect/status.rs
 expression: json
 ---
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "service": {
     "installed": true,
     "state": "running",

--- a/bin/spice/src/commands/connect/snapshots/spice__commands__connect__status__tests__connect_status_schema.snap
+++ b/bin/spice/src/commands/connect/snapshots/spice__commands__connect__status__tests__connect_status_schema.snap
@@ -3,7 +3,7 @@ source: bin/spice/src/commands/connect/status.rs
 expression: json
 ---
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "connection": {
     "state": "enrolled",
     "directory": "/srv/edge-analytics",

--- a/bin/spice/src/commands/connect/status.rs
+++ b/bin/spice/src/commands/connect/status.rs
@@ -30,7 +30,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
-use runtime_cloud_connect::config::IDENTITY_FILE;
+use runtime_cloud_connect::config::{CloudConnectConfig, IDENTITY_FILE};
 
 use super::service::{self, ServiceBackend, ServiceStatus};
 use crate::error::Result;
@@ -41,7 +41,7 @@ use crate::output::{OutputFormat, write_json};
 /// This is a public automation surface. Bump it when a field is renamed or
 /// removed, or when an enum grows a variant consumers must branch on, and
 /// update the golden fixtures in the same change.
-pub(crate) const STATUS_SCHEMA_VERSION: u32 = 1;
+pub(crate) const STATUS_SCHEMA_VERSION: u32 = 2;
 
 /// Whether this directory is connected to Spice Cloud.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -54,6 +54,9 @@ pub(crate) enum ConnectionState {
     EnrollmentIncomplete,
     /// An enrolled identity is present.
     Enrolled,
+    /// An identity is readable but its durable credential or endpoint state
+    /// cannot activate Cloud Connect.
+    Unusable,
     /// An identity file is present and could not be read. Reported rather than
     /// folded into `not_connected`: every `spiced` start in this directory will
     /// reject the same file and run unmanaged, which is a failure to fix, not
@@ -116,7 +119,8 @@ pub(crate) struct ConnectionStatus {
     /// states a wrong clock explains. `null` when it was not measured or was
     /// insignificant.
     pub(crate) clock: Option<String>,
-    /// Why the state is `unreadable`, when it is. `null` otherwise.
+    /// Why the state is `unreadable` or `unusable`, when it is. `null`
+    /// otherwise.
     pub(crate) diagnostic: Option<String>,
 }
 
@@ -174,8 +178,10 @@ impl ConnectStatus {
         // An identity that is present but unreadable is its own state. Reading
         // the error as "nothing here" would report a directory as unconnected
         // while every `spiced` start in it keeps rejecting the same file.
-        let identity =
-            runtime_cloud_connect::identity::IdentityStore::load_optional(&identity_path);
+        let identity = runtime_cloud_connect::identity::IdentityStore::load_optional_async(
+            identity_path.clone(),
+        )
+        .await;
 
         let mut connection = ConnectionStatus {
             state: ConnectionState::NotConnected,
@@ -208,16 +214,29 @@ impl ConnectStatus {
             }
         };
 
+        let mut clock_relevant = false;
         if let Some(id) = identity {
-            connection.state = ConnectionState::Enrolled;
             connection.expired = id.is_expired();
-            connection.expires_at_unix = id.not_after_unix;
+            clock_relevant = connection.expired || id.is_not_yet_valid();
+            connection.expires_at_unix = id.effective_not_after_unix();
             connection.gateway_addr =
                 (!id.gateway_addr.is_empty()).then(|| id.gateway_addr.clone());
-            connection.identifier = Some(id.identifier);
-            connection.org_name = id.org_name;
-            connection.app_name = id.app_name;
-            connection.monitor_url = id.monitor_url;
+            connection.identifier = Some(id.identifier.clone());
+            connection.org_name.clone_from(&id.org_name);
+            connection.app_name.clone_from(&id.app_name);
+            connection.monitor_url.clone_from(&id.monitor_url);
+
+            let config = CloudConnectConfig::from_env_at(
+                env!("CARGO_PKG_VERSION"),
+                config_dir.to_path_buf(),
+            );
+            match runtime_cloud_connect::validate_reconnectable_identity_async(&config, id).await {
+                Ok(_) => connection.state = ConnectionState::Enrolled,
+                Err(error) => {
+                    connection.state = ConnectionState::Unusable;
+                    connection.diagnostic = Some(error.to_string());
+                }
+            }
         } else if connection.draft_path.is_some() {
             connection.state = ConnectionState::EnrollmentIncomplete;
         }
@@ -226,7 +245,7 @@ impl ConnectStatus {
         // not actually expired, and a stuck enrollment is a state a wrong clock
         // explains — the enroll keeps failing on certificate validity. Measure
         // only there, so the common `status` stays offline and instant.
-        if connection.expired || connection.state == ConnectionState::EnrollmentIncomplete {
+        if clock_relevant || connection.state == ConnectionState::EnrollmentIncomplete {
             connection.clock = clock_advice(endpoint).await;
         }
 
@@ -259,16 +278,27 @@ impl ConnectStatus {
     /// what travels as the command's error — which keeps a `--output json` run
     /// parseable and still exits non-zero.
     pub(crate) fn degradation(&self) -> Option<String> {
-        if self.connection.state == ConnectionState::Unreadable {
+        if matches!(
+            self.connection.state,
+            ConnectionState::Unreadable | ConnectionState::Unusable
+        ) {
             return Some(self.connection.diagnostic.clone().unwrap_or_else(|| {
                 format!(
-                    "The Spice Cloud Connect identity at {} could not be read.",
+                    "The Spice Cloud Connect identity at {} cannot activate Cloud Connect.",
                     self.connection.identity_path.display()
                 )
             }));
         }
+        self.service_degradation()
+    }
+
+    /// The service-only diagnosis used by the filtered status command.
+    ///
+    /// Its JSON document contains only the service object, so its exit status
+    /// must never depend on a connection condition the document cannot explain.
+    pub(crate) fn service_degradation(&self) -> Option<String> {
         if self.service.state.is_degraded() {
-            return Some(format!(
+            Some(format!(
                 "The Spice Cloud Connect service for {} is {}{}",
                 self.connection.directory.display(),
                 self.service.state,
@@ -276,9 +306,10 @@ impl ConnectStatus {
                     Some(diagnostic) => format!(": {diagnostic}"),
                     None => ".".to_string(),
                 }
-            ));
+            ))
+        } else {
+            None
         }
-        None
     }
 }
 
@@ -413,6 +444,17 @@ fn render_connection(connection: &ConnectionStatus) {
         ConnectionState::Unreadable => {
             println!("Spice Cloud Connect: identity unreadable");
             println!("  identity:    {}", connection.identity_path.display());
+        }
+        ConnectionState::Unusable => {
+            println!("Spice Cloud Connect: identity unusable");
+            println!("  identity:    {}", connection.identity_path.display());
+            println!(
+                "  expiry:      {}",
+                match connection.expires_at_unix {
+                    Some(secs) => format!("unix={secs} (expired={})", connection.expired),
+                    None => "unbounded".to_string(),
+                }
+            );
         }
     }
     if let Some(diagnostic) = &connection.diagnostic {
@@ -625,6 +667,52 @@ mod tests {
             .degradation()
             .expect("an unreadable identity must not exit zero");
         assert!(degradation.contains("identity"), "{degradation}");
+    }
+
+    #[tokio::test]
+    async fn a_parseable_but_unusable_identity_is_not_reported_as_connected() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join(IDENTITY_FILE),
+            serde_json::json!({
+                "identifier": "",
+                "identity_cert_pem": "credential-that-must-not-be-printed",
+                "private_key_pem": "private-key-that-must-not-be-printed",
+                "public_key_pem": "public-key",
+                "gateway_addr": "gateway.example:443"
+            })
+            .to_string(),
+        )
+        .expect("write unusable identity");
+
+        let status = snapshot(dir.path(), &instance_dir, &config_dir).await;
+        assert_eq!(status.connection.state, ConnectionState::Unusable);
+        let diagnostic = status
+            .connection
+            .diagnostic
+            .as_deref()
+            .expect("an unusable identity must say why");
+        assert!(diagnostic.contains("identifier is empty"), "{diagnostic}");
+        assert!(!diagnostic.contains("credential-that-must-not-be-printed"));
+        assert!(!diagnostic.contains("private-key-that-must-not-be-printed"));
+        assert!(status.degradation().is_some());
+    }
+
+    #[test]
+    fn the_filtered_service_status_is_not_degraded_by_hidden_connection_state() {
+        let mut status = golden_status();
+        status.connection.state = ConnectionState::Unusable;
+        status.connection.diagnostic = Some("identity needs repair".to_string());
+
+        assert!(status.degradation().is_some());
+        assert_eq!(
+            status.service_degradation(),
+            None,
+            "the service-only document reports a healthy running service"
+        );
     }
 
     #[tokio::test]

--- a/bin/spice/tests/cli_integration.rs
+++ b/bin/spice/tests/cli_integration.rs
@@ -790,7 +790,8 @@ mod connect {
             .stdout(predicate::str::contains("spiced --token <enrollment-key>"))
             .stdout(predicate::str::contains("status"))
             .stdout(predicate::str::contains("remove"))
-            .stdout(predicate::str::contains("--install"))
+            .stdout(predicate::str::contains("service install"))
+            .stdout(predicate::str::contains("--install").not())
             .stdout(predicate::str::contains("SPICE-ADOPT").not())
             .stdout(predicate::str::contains("pending-adopt-code").not())
             .stdout(predicate::str::contains("--app-name").not())
@@ -843,12 +844,102 @@ mod connect {
 
         spice_cmd()
             .env("SPICE_CONFIG_DIR", config_dir.path())
-            .arg("connect")
-            .arg("--install")
+            .args(["connect", "service", "install"])
             .assert()
             .failure()
-            .stdout(predicate::str::contains("load identity"))
+            .stdout(predicate::str::contains("validate the durable"))
             .stdout(predicate::str::contains("not valid JSON").not());
+    }
+
+    #[test]
+    fn install_rejects_a_missing_identity_before_service_setup() {
+        let config_dir = TempDir::new().expect("create config directory");
+
+        spice_cmd()
+            .env("SPICE_CONFIG_DIR", config_dir.path())
+            .args(["connect", "service", "install"])
+            .assert()
+            .failure()
+            .stdout(predicate::str::contains("has no enrolled identity"))
+            .stdout(predicate::str::contains("spiced --token"));
+    }
+
+    #[test]
+    fn install_rejects_a_parseable_but_unusable_identity_before_service_setup() {
+        let config_dir = TempDir::new().expect("create config directory");
+        fs::write(
+            config_dir.path().join("identity.json"),
+            serde_json::json!({
+                "identifier": "",
+                "identity_cert_pem": "credential-that-must-not-be-printed",
+                "private_key_pem": "private-key-that-must-not-be-printed",
+                "public_key_pem": "public-key",
+                "gateway_addr": "gateway.example:443"
+            })
+            .to_string(),
+        )
+        .expect("write unusable identity");
+
+        spice_cmd()
+            .env("SPICE_CONFIG_DIR", config_dir.path())
+            .args(["connect", "service", "install"])
+            .assert()
+            .failure()
+            .stdout(predicate::str::contains("cannot be used"))
+            .stdout(predicate::str::contains("identifier is empty"))
+            .stdout(predicate::str::contains("credential-that-must-not-be-printed").not())
+            .stdout(predicate::str::contains("private-key-that-must-not-be-printed").not());
+    }
+
+    #[test]
+    fn status_uses_signed_expiry_without_treating_the_host_clock_as_credential_authority() {
+        use rcgen::{CertificateParams, KeyPair};
+
+        let config_dir = TempDir::new().expect("create config directory");
+        let material = runtime_cloud_connect::identity::IdentityStore::generate_enrollment()
+            .expect("generate identity material");
+        let keypair = KeyPair::from_pem(&material.private_key_pem).expect("parse identity key");
+        let mut params =
+            CertificateParams::new(Vec::<String>::new()).expect("certificate parameters");
+        params.not_before = rcgen::date_time_ymd(2019, 1, 1);
+        params.not_after = rcgen::date_time_ymd(2020, 1, 1);
+        let certificate = params.self_signed(&keypair).expect("sign certificate");
+        let identity = runtime_cloud_connect::Identity {
+            identifier: "inst_expired".to_string(),
+            identity_cert_pem: certificate.pem(),
+            private_key_pem: material.private_key_pem,
+            public_key_pem: material.public_key_pem,
+            ca_bundle_pem: String::new(),
+            gateway_addr: "gateway.example:443".to_string(),
+            // Deliberately inconsistent: status and activation must trust the
+            // signed certificate rather than this unsigned cache field.
+            not_after_unix: Some(4_102_444_800),
+            enc_private_key_pem: material.enc_private_key_pem,
+            enc_public_key_pem: material.enc_public_key_pem,
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+            app_id: None,
+            org_name: None,
+            app_name: None,
+            monitor_url: None,
+        };
+        runtime_cloud_connect::identity::IdentityStore::store(
+            &config_dir.path().join("identity.json"),
+            &identity,
+        )
+        .expect("store expired identity");
+
+        spice_cmd()
+            .env("SPICE_CONFIG_DIR", config_dir.path())
+            .args(["connect", "--endpoint", "http://127.0.0.1:9", "status"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Spice Cloud Connect: connected"))
+            .stdout(predicate::str::contains(
+                "expiry:      unix=1577836800 (expired=true)",
+            ))
+            .stdout(predicate::str::contains("4102444800").not())
+            .stdout(predicate::str::contains("identity unusable").not());
     }
 }
 

--- a/bin/spice/tests/cli_integration.rs
+++ b/bin/spice/tests/cli_integration.rs
@@ -941,6 +941,29 @@ mod connect {
             .stdout(predicate::str::contains("4102444800").not())
             .stdout(predicate::str::contains("identity unusable").not());
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn status_fails_closed_when_the_persisted_endpoint_is_a_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let config_dir = TempDir::new().expect("create config directory");
+        let target = config_dir.path().join("redirected-endpoint");
+        fs::write(&target, "https://wrong-control-plane.example").expect("write target endpoint");
+        symlink(&target, config_dir.path().join("cloud-endpoint"))
+            .expect("create endpoint symlink");
+
+        spice_cmd()
+            .env("SPICE_CONFIG_DIR", config_dir.path())
+            .env_remove("SPICE_CLOUD_ENDPOINT")
+            .args(["connect", "status"])
+            .assert()
+            .failure()
+            .stdout(predicate::str::contains(
+                "read the Cloud Connect endpoint override",
+            ))
+            .stdout(predicate::str::contains("wrong-control-plane").not());
+    }
 }
 
 // ============================================================================

--- a/bin/spice/tests/cli_integration.rs
+++ b/bin/spice/tests/cli_integration.rs
@@ -850,6 +850,34 @@ mod connect {
             .stdout(predicate::str::contains("load identity"))
             .stdout(predicate::str::contains("not valid JSON").not());
     }
+
+    #[test]
+    fn install_rejects_a_parseable_but_unusable_identity_before_service_setup() {
+        let config_dir = TempDir::new().expect("create config directory");
+        fs::write(
+            config_dir.path().join("identity.json"),
+            serde_json::json!({
+                "identifier": "",
+                "identity_cert_pem": "credential-that-must-not-be-printed",
+                "private_key_pem": "private-key-that-must-not-be-printed",
+                "public_key_pem": "public-key",
+                "gateway_addr": "gateway.example:443"
+            })
+            .to_string(),
+        )
+        .expect("write unusable identity");
+
+        spice_cmd()
+            .env("SPICE_CONFIG_DIR", config_dir.path())
+            .arg("connect")
+            .arg("--install")
+            .assert()
+            .failure()
+            .stdout(predicate::str::contains("cannot be used"))
+            .stdout(predicate::str::contains("identifier is empty"))
+            .stdout(predicate::str::contains("credential-that-must-not-be-printed").not())
+            .stdout(predicate::str::contains("private-key-that-must-not-be-printed").not());
+    }
 }
 
 // ============================================================================

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -29,8 +29,8 @@ limitations under the License.
 //!    then enrolls this instance *before the runtime is built or any
 //!    listener binds*, so the durable identity exists by the time anything
 //!    else here runs.
-//! 2. `$SPICE_CONFIG_DIR/identity.json` exists (a previously enrolled
-//!    instance) — reconnection is automatic, with no flag.
+//! 2. `$SPICE_CONFIG_DIR/identity.json` contains a usable previously-enrolled
+//!    identity — reconnection is automatic, with no flag.
 //!
 //! If neither is true, this module never opens a connection. An existing
 //! identity always wins over a supplied `--token`: the key is not redeemed
@@ -78,9 +78,9 @@ use runtime::Runtime;
 use runtime::datafusion::query::Error as QueryError;
 use runtime::metrics_reader::MetricsReader;
 use runtime::status::ComponentStatus;
-use runtime_cloud_connect::config::{
-    CLOUD_MANAGED_SPICEPOD_FILE, CloudConnectConfig, IDENTITY_FILE,
-};
+#[cfg(test)]
+use runtime_cloud_connect::config::IDENTITY_FILE;
+use runtime_cloud_connect::config::{CLOUD_MANAGED_SPICEPOD_FILE, CloudConnectConfig};
 use runtime_cloud_connect::handlers::{
     ApplyOutcome, Capability, CommandError, MAX_QUERY_RESULT_BYTES, QueryOutcome, RuntimeHandle,
     RuntimePhase, SpicepodDeployment, StatusReport, effective_max_rows,
@@ -111,22 +111,17 @@ const DEFAULT_LOG_TAIL_LINES: usize = 500;
 /// one that holds even if that budget is raised or a phase hangs.
 const DEPLOYMENT_DRAIN_BUDGET: Duration = Duration::from_mins(2);
 
-/// Cheap probe for whether Spice Cloud Connect is configured for this
-/// instance, using the same signals as [`maybe_start`]: a `--token`
-/// enrollment bootstrap in progress, or an on-disk identity.
+/// Whether this instance has durable state that can activate Cloud Connect.
 ///
-/// Called from `init_tracing` (before [`maybe_start`]) to decide whether to
-/// install the log-capture layer. It runs in the same process — hence the
-/// same working directory — as [`maybe_start`], so both resolve the config
-/// directory identically. This is a lightweight existence check; it does not
-/// read or validate the file (that happens in `maybe_start`).
-pub(crate) fn is_configured(token_supplied: bool) -> bool {
-    if token_supplied {
-        return true;
-    }
-    CloudConnectConfig::default_config_dir()
-        .join(IDENTITY_FILE)
-        .exists()
+/// The one-time `--token` is consumed before this runs, so it is never an
+/// activation signal. A usable identity is the only signal shared by early
+/// metrics/log/deployment setup and the control client itself.
+pub(crate) async fn is_configured() -> runtime_cloud_connect::Result<bool> {
+    runtime_cloud_connect::load_reconnectable_identity_async(&build_config(env!(
+        "CARGO_PKG_VERSION"
+    )))
+    .await
+    .map(|identity| identity.is_some())
 }
 
 /// Read the optional instance-local `cloud-endpoint` override file. This
@@ -292,9 +287,9 @@ pub struct CloudManagedSpicepodReadError {
 /// Reads files only — no control-plane round trip — so an instance whose
 /// gateway is unreachable still comes up on its deployed configuration.
 pub async fn cloud_managed_spicepod(
-    token_supplied: bool,
+    configured: bool,
 ) -> std::result::Result<Option<CloudManagedSpicepod>, CloudManagedSpicepodReadError> {
-    if !is_configured(token_supplied) {
+    if !configured {
         return Ok(None);
     }
     let config_dir = CloudConnectConfig::default_config_dir();
@@ -339,9 +334,9 @@ pub struct DeliveredSecretsState {
 pub async fn restore_delivered_secrets(
     runtime_version: &str,
     runtime: &Arc<Runtime>,
-    token_supplied: bool,
+    configured: bool,
 ) -> Option<DeliveredSecretsState> {
-    if !is_configured(token_supplied) {
+    if !configured {
         return None;
     }
     let config = build_config(runtime_version);
@@ -392,7 +387,8 @@ pub async fn maybe_start(
     // treating it as "not enrolled", so a broken identity file is visible
     // to the operator instead of quietly disabling Cloud Connect.
     let mut persisted_app_id = None;
-    let has_identity = match IdentityStore::load_optional(&config.identity_path) {
+    let has_identity = match runtime_cloud_connect::load_reconnectable_identity_async(&config).await
+    {
         Ok(opt) => {
             // Restores the metrics attribution across a restart. Without it the
             // instance exports nothing until its next deploy, which may be days.

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -29,8 +29,8 @@ limitations under the License.
 //!    then enrolls this instance *before the runtime is built or any
 //!    listener binds*, so the durable identity exists by the time anything
 //!    else here runs.
-//! 2. `$SPICE_CONFIG_DIR/identity.json` exists (a previously enrolled
-//!    instance) — reconnection is automatic, with no flag.
+//! 2. `$SPICE_CONFIG_DIR/identity.json` contains a usable previously-enrolled
+//!    identity — reconnection is automatic, with no flag.
 //!
 //! If neither is true, this module never opens a connection. An existing
 //! identity always wins over a supplied `--token`: the key is not redeemed
@@ -80,9 +80,9 @@ use runtime::Runtime;
 use runtime::datafusion::query::Error as QueryError;
 use runtime::metrics_reader::MetricsReader;
 use runtime::status::ComponentStatus;
-use runtime_cloud_connect::config::{
-    CLOUD_MANAGED_SPICEPOD_FILE, CloudConnectConfig, IDENTITY_FILE,
-};
+#[cfg(test)]
+use runtime_cloud_connect::config::IDENTITY_FILE;
+use runtime_cloud_connect::config::{CLOUD_MANAGED_SPICEPOD_FILE, CloudConnectConfig};
 use runtime_cloud_connect::handlers::{
     Capability, CommandError, MAX_QUERY_RESULT_BYTES, QueryOutcome, RuntimeHandle, RuntimePhase,
     SpicepodDeployment, StatusReport, effective_max_rows,
@@ -126,22 +126,68 @@ const DEFAULT_LOG_TAIL_LINES: usize = 500;
 /// itself is bounded, this wait always settles.
 const INITIAL_LOAD_BUDGET: Duration = Duration::from_mins(2);
 
-/// Cheap probe for whether Spice Cloud Connect is configured for this
-/// instance, using the same signals as [`maybe_start`]: a `--token`
-/// enrollment bootstrap in progress, or an on-disk identity.
+/// The one durable-state decision made before the runtime is built.
 ///
-/// Called from `init_tracing` (before [`maybe_start`]) to decide whether to
-/// install the log-capture layer. It runs in the same process — hence the
-/// same working directory — as [`maybe_start`], so both resolve the config
-/// directory identically. This is a lightweight existence check; it does not
-/// read or validate the file (that happens in `maybe_start`).
-pub(crate) fn is_configured(token_supplied: bool) -> bool {
-    if token_supplied {
-        return true;
+/// The one-time `--token` is consumed before this runs, so it is never an
+/// activation signal. A usable identity exclusively activates credentialed
+/// facilities; observing an unusable identity only preserves the instance's
+/// cloud-managed configuration provenance.
+pub(crate) struct StartupState {
+    config_dir: PathBuf,
+    identity_observed: bool,
+    reconnectable_identity: Option<runtime_cloud_connect::ReconnectableIdentity>,
+}
+
+impl StartupState {
+    #[must_use]
+    pub(crate) fn config_dir(&self) -> &Path {
+        &self.config_dir
     }
-    CloudConnectConfig::default_config_dir()
-        .join(IDENTITY_FILE)
-        .exists()
+
+    #[must_use]
+    pub(crate) fn identity_observed(&self) -> bool {
+        self.identity_observed
+    }
+
+    #[must_use]
+    pub(crate) fn into_identity(self) -> Option<runtime_cloud_connect::ReconnectableIdentity> {
+        self.reconnectable_identity
+    }
+}
+
+pub(crate) async fn load_startup_state() -> StartupState {
+    load_startup_state_from_config(&build_config(env!("CARGO_PKG_VERSION"))).await
+}
+
+/// Load the durable activation snapshot without making an optional Cloud
+/// Connect configuration failure fatal to the rest of the runtime.
+///
+/// The error is still surfaced at ERROR through the temporary startup
+/// subscriber installed by `main`; the absent activation token makes every
+/// credentialed Cloud Connect facility fail closed while configuration
+/// provenance remains available so the runtime can keep serving.
+async fn load_startup_state_from_config(config: &CloudConnectConfig) -> StartupState {
+    match runtime_cloud_connect::load_reconnectable_identity_async(config).await {
+        Ok(reconnectable_identity) => StartupState {
+            config_dir: config.config_dir.clone(),
+            identity_observed: reconnectable_identity.is_some(),
+            reconnectable_identity,
+        },
+        Err(error) => {
+            tracing::error!(
+                "Spice Cloud Connect is disabled for this start because its durable identity could not be activated: {error}"
+            );
+            StartupState {
+                config_dir: config.config_dir.clone(),
+                // A failed load still proves that this instance had durable
+                // enrollment state. Keep using its deployed configuration,
+                // while the absent activation token disables every credentialed
+                // Cloud Connect facility.
+                identity_observed: true,
+                reconnectable_identity: None,
+            }
+        }
+    }
 }
 
 /// Read the optional instance-local `cloud-endpoint` override file. This
@@ -301,18 +347,19 @@ pub struct CloudManagedSpicepodReadError {
     pub source: std::io::Error,
 }
 
-/// The cloud-managed spicepod this instance starts on, or `None` when Cloud
-/// Connect is not configured or no deployment has ever landed here.
+/// The cloud-managed spicepod this instance starts on, or `None` when no
+/// durable identity state was observed or no deployment has ever landed here.
 ///
 /// Reads files only — no control-plane round trip — so an instance whose
-/// gateway is unreachable still comes up on its deployed configuration.
+/// credentials are expired, corrupt, or otherwise unusable still comes up on
+/// its deployed configuration without activating Cloud Connect.
 pub async fn cloud_managed_spicepod(
-    token_supplied: bool,
+    config_dir: &Path,
+    identity_observed: bool,
 ) -> std::result::Result<Option<CloudManagedSpicepod>, CloudManagedSpicepodReadError> {
-    if !is_configured(token_supplied) {
+    if !identity_observed {
         return Ok(None);
     }
-    let config_dir = CloudConnectConfig::default_config_dir();
     let path = config_dir.join(CLOUD_MANAGED_SPICEPOD_FILE);
     read_cloud_managed_spicepod(path).await
 }
@@ -352,14 +399,11 @@ pub struct DeliveredSecretsState {
 /// the config dir, so a restart restores its secrets with the gateway
 /// unreachable. That is the property the local cache key buys.
 pub async fn restore_delivered_secrets(
-    runtime_version: &str,
     runtime: &Arc<Runtime>,
-    token_supplied: bool,
+    identity: Option<&runtime_cloud_connect::ReconnectableIdentity>,
 ) -> Option<DeliveredSecretsState> {
-    if !is_configured(token_supplied) {
-        return None;
-    }
-    let config = build_config(runtime_version);
+    let identity = identity?;
+    let config = identity.config();
 
     // Registered as a built-in so `${ secrets:NAME }` reaches it with nothing
     // declared in the spicepod, it sits below every user-declared store, and a
@@ -370,7 +414,7 @@ pub async fn restore_delivered_secrets(
         Arc::clone(&store) as Arc<dyn runtime::secrets::SecretStore>,
     );
 
-    load_cached_secrets(&config, &store);
+    load_cached_secrets(config, &store, identity.as_identity());
     Some(DeliveredSecretsState { store })
 }
 
@@ -393,43 +437,21 @@ pub async fn restore_delivered_secrets(
 /// `runtime_overrides` are the process's `--set-runtime` values, which a
 /// deployment has to carry the same way a start onto the same file would.
 pub async fn maybe_start(
-    runtime_version: &str,
     runtime: Arc<Runtime>,
+    identity: Option<runtime_cloud_connect::ReconnectableIdentity>,
     delivered_secrets: Option<DeliveredSecretsState>,
     running_deployment: Option<CloudManagedSpicepod>,
     metrics: Option<MetricsReader>,
     runtime_overrides: Vec<(String, String)>,
 ) -> Option<CloudConnect> {
-    let config = build_config(runtime_version);
-
-    // Quick sanity probe — no identity means disabled. Surface a load/parse
-    // error (corrupt or unreadable identity.json) rather than silently
-    // treating it as "not enrolled", so a broken identity file is visible
-    // to the operator instead of quietly disabling Cloud Connect.
-    let mut persisted_app_id = None;
-    let has_identity = match IdentityStore::load_optional(&config.identity_path) {
-        Ok(opt) => {
-            // Restores the metrics attribution across a restart. Without it the
-            // instance exports nothing until its next deploy, which may be days.
-            persisted_app_id = opt.as_ref().and_then(|i| i.app_id.clone());
-            opt.is_some()
-        }
-        Err(err) => {
-            tracing::warn!(
-                "Spice Cloud Connect: could not read identity at {}: {err}; \
-                 treating as not-enrolled — fix or remove the file to re-enroll",
-                config.identity_path.display()
-            );
-            false
-        }
-    };
-    if !has_identity {
-        tracing::debug!(
-            "Spice Cloud Connect: disabled (no identity at {})",
-            config.identity_path.display()
-        );
+    let Some(identity) = identity else {
+        tracing::debug!("Spice Cloud Connect: disabled (no usable persisted identity)");
         return None;
-    }
+    };
+    let config = identity.config();
+    // Restores metrics attribution across a restart. Without it the instance
+    // exports nothing until its next deploy, which may be days.
+    let persisted_app_id = identity.app_id.clone();
 
     tracing::info!(
         "Spice Cloud Connect: enabled, enroll_endpoint={}",
@@ -469,7 +491,7 @@ pub async fn maybe_start(
             CLOUD_DELIVERED_STORE,
             Arc::clone(&store) as Arc<dyn runtime::secrets::SecretStore>,
         );
-        load_cached_secrets(&config, &store);
+        load_cached_secrets(config, &store, identity.as_identity());
         store
     };
 
@@ -489,16 +511,7 @@ pub async fn maybe_start(
             initial_load_budget: INITIAL_LOAD_BUDGET,
         }));
 
-    match CloudConnect::start(config, handle).await {
-        Ok(Some(client)) => Some(client),
-        Ok(None) => None,
-        Err(err) => {
-            tracing::warn!(
-                "Spice Cloud Connect: failed to start (continuing without cloud management): {err}"
-            );
-            None
-        }
-    }
+    Some(CloudConnect::start_reconnectable(handle, identity))
 }
 
 /// Load the delivered-secrets cache into `store`.
@@ -511,12 +524,12 @@ pub async fn maybe_start(
 /// wrong-key, or unknown-version cache is discarded with an actionable warning
 /// and the instance comes up with no delivered secrets, which one deployment
 /// restores. Crashing here would make a corrupt file unbootable.
-fn load_cached_secrets(config: &CloudConnectConfig, store: &CloudDeliveredSecretStore) {
-    let Some(key) = IdentityStore::load_optional(&config.identity_path)
-        .ok()
-        .flatten()
-        .and_then(|identity| identity.cache_key())
-    else {
+fn load_cached_secrets(
+    config: &CloudConnectConfig,
+    store: &CloudDeliveredSecretStore,
+    identity: &runtime_cloud_connect::Identity,
+) {
+    let Some(key) = identity.cache_key() else {
         // No identity yet (a first boot that will enroll below), or one that
         // predates the cache key. Either way there is nothing to restore.
         return;
@@ -1908,6 +1921,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn an_unusable_identity_disables_cloud_connect_without_aborting_startup() {
+        let dir = scratch_dir("unusable-startup-identity");
+        let identity_path = dir.join(IDENTITY_FILE);
+        std::fs::write(&identity_path, "not valid identity JSON")
+            .expect("write malformed identity");
+        let mut config = CloudConnectConfig::from_env("test-runtime");
+        config.config_dir.clone_from(&dir);
+        config.identity_path = identity_path;
+
+        let state = load_startup_state_from_config(&config).await;
+        assert!(
+            state.reconnectable_identity.is_none(),
+            "an optional integration's unusable identity must fail Cloud Connect closed without failing spiced"
+        );
+        assert!(
+            state.identity_observed,
+            "invalid credentials must not erase cloud-managed configuration provenance"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn an_unusable_identity_still_restores_its_managed_spicepod() {
+        let dir = scratch_dir("unusable-identity-managed-spicepod");
+        let identity_path = dir.join(IDENTITY_FILE);
+        std::fs::write(&identity_path, "not valid identity JSON")
+            .expect("write malformed identity");
+        std::fs::write(dir.join(CLOUD_MANAGED_SPICEPOD_FILE), VALID_SPICEPOD)
+            .expect("write managed spicepod");
+        let mut config = CloudConnectConfig::from_env("test-runtime");
+        config.config_dir.clone_from(&dir);
+        config.identity_path = identity_path;
+
+        let state = load_startup_state_from_config(&config).await;
+        let deployed = cloud_managed_spicepod(state.config_dir(), state.identity_observed())
+            .await
+            .expect("read managed spicepod")
+            .expect("managed spicepod remains selected");
+        assert_eq!(deployed.spicepod_yaml, VALID_SPICEPOD);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn a_removed_identity_does_not_restore_a_stale_managed_spicepod() {
+        let dir = scratch_dir("removed-identity-stale-managed-spicepod");
+        std::fs::write(dir.join(CLOUD_MANAGED_SPICEPOD_FILE), VALID_SPICEPOD)
+            .expect("write stale managed spicepod");
+        let mut config = CloudConnectConfig::from_env("test-runtime");
+        config.config_dir.clone_from(&dir);
+        config.identity_path = dir.join(IDENTITY_FILE);
+
+        let state = load_startup_state_from_config(&config).await;
+        assert!(!state.identity_observed());
+        assert!(
+            cloud_managed_spicepod(state.config_dir(), state.identity_observed())
+                .await
+                .expect("check managed spicepod")
+                .is_none(),
+            "release removes the identity marker, so stale deployment state must stay inactive"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
     async fn a_missing_managed_deployment_is_an_ordinary_absence() {
         let dir = scratch_dir("managed-missing");
         let path = dir.join(CLOUD_MANAGED_SPICEPOD_FILE);
@@ -2306,7 +2386,7 @@ datasets:
             "views:\n  - name: v\n    sql: SELECT 1\n",
             "catalogs:\n  - from: spice.ai\n    name: c\n",
             "models:\n  - from: openai\n    name: m\n",
-            "functions:\n  - name: f\n    from: https://example.com\n",
+            "functions:\n  - name: f\n    from: https://example.com\n    signature:\n      args: []\n      returns: int64\n",
         ];
         for change in changes {
             // Appending to `ACTIVE` would leave two `datasets:` keys, so the
@@ -2341,13 +2421,19 @@ datasets:
                 "extensions",
                 "extensions:\n  spice_cloud:\n    enabled: true\n",
             ),
-            ("management", "management:\n  enabled: true\n"),
+            (
+                "management",
+                "management:\n  enabled: true\n  api_key: test-api-key\n",
+            ),
             ("rerankers", "rerankers:\n  - name: r\n    from: openai\n"),
             ("runtime", "runtime:\n  dataset_load_parallelism: 2\n"),
             ("secrets", "secrets:\n  - from: env\n    name: env\n"),
             ("snapshots", "snapshots:\n  enabled: true\n"),
-            ("tools", "tools:\n  - name: t\n    from: builtin\n"),
-            ("workers", "workers:\n  - name: w\n    from: builtin\n"),
+            (
+                "tools",
+                "tools:\n  - name: t\n    from: builtin:list_datasets\n",
+            ),
+            ("workers", "workers:\n  - name: w\n    sql: SELECT 1\n"),
         ];
         for (section, change) in changes {
             let deployed = with_sections(change);
@@ -2410,7 +2496,7 @@ datasets:
     async fn a_mixed_deployment_serves_its_components_and_names_the_rest() {
         let dir = scratch_dir("split-mixed");
         let deployed = with_sections(
-            "runtime:\n  dataset_load_parallelism: 2\ntools:\n  - name: t\n    from: builtin\nviews:\n  - name: v\n    sql: SELECT 1\n",
+            "runtime:\n  dataset_load_parallelism: 2\ntools:\n  - name: t\n    from: builtin:list_datasets\nviews:\n  - name: v\n    sql: SELECT 1\n",
         );
         let split = split(&dir, ACTIVE, &deployed).await;
 
@@ -2815,7 +2901,7 @@ views:
     sql: SELECT 1 AS n
 tools:
   - name: local_tool
-    from: builtin
+    from: builtin:list_datasets
 ";
         let handle = handle_serving_locally(&dir, local).await;
 
@@ -2830,7 +2916,7 @@ views:
     sql: SELECT 2 AS n
 tools:
   - name: local_tool
-    from: builtin
+    from: builtin:list_datasets
 ";
         let document = handle
             .apply_spicepod(deployment(&dir, deployed))
@@ -2852,7 +2938,8 @@ tools:
 
         // And a start-time section it does change is reported against that same
         // baseline rather than being lost with it.
-        let changes_tools = deployed.replace("from: builtin", "from: https://example.com");
+        let changes_tools =
+            deployed.replace("from: builtin:list_datasets", "from: https://example.com");
         let document = handle
             .apply_spicepod(deployment(&dir, &changes_tools))
             .await
@@ -2860,7 +2947,7 @@ tools:
         assert_eq!(document["restart_required"], serde_json::json!(["tools"]));
         assert_eq!(
             active_app(&handle).await.tools[0].from,
-            "builtin",
+            "builtin:list_datasets",
             "the tool this instance started with is the one it keeps"
         );
 

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -156,7 +156,19 @@ impl StartupState {
 }
 
 pub(crate) async fn load_startup_state() -> StartupState {
-    load_startup_state_from_config(&build_config(env!("CARGO_PKG_VERSION"))).await
+    let mut config = CloudConnectConfig::from_env(env!("CARGO_PKG_VERSION"));
+    if std::env::var_os("SPICE_CLOUD_ENDPOINT").is_none()
+        && let Err(error) = apply_endpoint_override(&mut config)
+    {
+        tracing::error!(
+            "Spice Cloud Connect is disabled for this start because the enrollment endpoint override at {} could not be read safely: {error}",
+            config.config_dir.join("cloud-endpoint").display()
+        );
+        let mut state = load_startup_state_from_config(&config).await;
+        state.reconnectable_identity = None;
+        return state;
+    }
+    load_startup_state_from_config(&config).await
 }
 
 /// Load the durable activation snapshot without making an optional Cloud
@@ -202,31 +214,17 @@ fn identity_contents_were_observed(error: &runtime_cloud_connect::Error) -> bool
     )
 }
 
-/// Read the optional instance-local `cloud-endpoint` override file. This
-/// overrides the cloud **enroll** endpoint (state plane); the gateway (stream)
-/// address comes from the enroll response.
-fn read_endpoint_override(config_dir: &Path) -> Option<String> {
-    match CloudConnectConfig::read_enroll_endpoint_override(config_dir) {
-        Ok(endpoint) => endpoint,
-        Err(error) => {
-            tracing::warn!(
-                "Spice Cloud Connect ignored the enrollment endpoint override in {}: {error}",
-                config_dir.display()
-            );
-            None
-        }
-    }
-}
-
-/// Build a [`CloudConnectConfig`] from env + on-disk state.
-fn build_config(runtime_version: &str) -> CloudConnectConfig {
-    let mut config = CloudConnectConfig::from_env(runtime_version);
-    if std::env::var_os("SPICE_CLOUD_ENDPOINT").is_none()
-        && let Some(override_endpoint) = read_endpoint_override(&config.config_dir)
+/// Apply the optional instance-local `cloud-endpoint` override. This overrides
+/// the cloud **enroll** endpoint (state plane); the gateway (stream) address
+/// comes from the enroll response. An unsafe or unreadable file is an error so
+/// the caller cannot silently renew against another control plane.
+fn apply_endpoint_override(config: &mut CloudConnectConfig) -> std::io::Result<()> {
+    if let Some(override_endpoint) =
+        CloudConnectConfig::read_enroll_endpoint_override(&config.config_dir)?
     {
         config.enroll_endpoint = override_endpoint;
     }
-    config
+    Ok(())
 }
 
 /// Why a `--token` bootstrap could not produce a durable identity. Every
@@ -247,6 +245,15 @@ pub enum BootstrapEnrollmentError {
          'us-west-2' or 'on-prem-syd'). See: https://spiceai.org/docs"
     ))]
     InvalidRegion { region: String },
+
+    #[snafu(display(
+        "Failed to enroll this instance with Spice Cloud: the enrollment endpoint override at {} could not be read safely: {source}",
+        path.display()
+    ))]
+    EndpointOverride {
+        path: PathBuf,
+        source: std::io::Error,
+    },
 
     #[snafu(display("Failed to enroll this instance with Spice Cloud ({endpoint}): {source}"))]
     Enroll {
@@ -272,8 +279,8 @@ pub enum BootstrapEnrollmentError {
 /// # Errors
 ///
 /// Returns [`BootstrapEnrollmentError`] when the key or region is malformed
-/// (checked locally, never echoed) or when [`enroll_now`] fails terminally
-/// or exhausts its retry budget.
+/// (checked locally, never echoed), the endpoint override cannot be read
+/// safely, or [`enroll_now`] fails terminally or exhausts its retry budget.
 pub async fn bootstrap_enrollment(args: &mut crate::Args) -> Result<(), BootstrapEnrollmentError> {
     use runtime_cloud_connect::{
         EnrollNowOutcome, EnrollmentAuthority, EnrollmentKey, RetryPolicy,
@@ -300,7 +307,12 @@ pub async fn bootstrap_enrollment(args: &mut crate::Args) -> Result<(), Bootstra
         });
     }
 
-    let mut config = build_config(env!("CARGO_PKG_VERSION"));
+    let mut config = CloudConnectConfig::from_env(env!("CARGO_PKG_VERSION"));
+    if std::env::var_os("SPICE_CLOUD_ENDPOINT").is_none() {
+        let path = config.config_dir.join("cloud-endpoint");
+        apply_endpoint_override(&mut config)
+            .map_err(|source| BootstrapEnrollmentError::EndpointOverride { path, source })?;
+    }
     config.instance_region = args.region.clone();
 
     let authority = EnrollmentAuthority::Token {
@@ -1956,6 +1968,25 @@ mod tests {
             state.identity_observed,
             "invalid credentials must not erase cloud-managed configuration provenance"
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_unsafe_endpoint_override_is_a_configuration_error() {
+        use std::os::unix::fs::symlink;
+
+        let dir = scratch_dir("unsafe-endpoint-override");
+        let target = dir.join("redirected-endpoint");
+        std::fs::write(&target, "https://wrong-control-plane.example")
+            .expect("write target endpoint");
+        symlink(&target, dir.join("cloud-endpoint")).expect("create endpoint symlink");
+        let mut config = CloudConnectConfig::from_env("test-runtime");
+        config.config_dir.clone_from(&dir);
+
+        apply_endpoint_override(&mut config)
+            .expect_err("an unsafe override must disable enrollment and renewal");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -557,6 +557,9 @@ pub struct AppBundle {
     running_deployment: Option<cloud_connect::CloudManagedSpicepod>,
     /// Deferred because `build_app` runs before tracing is initialized.
     deployment_note: Option<DeploymentNote>,
+    /// The validated durable identity snapshot loaded before the runtime is
+    /// built. Every Cloud Connect facility consumes this exact decision.
+    cloud_connect_identity: Option<runtime_cloud_connect::ReconnectableIdentity>,
 }
 
 /// Resolve the CPU entitlement from all three configuration surfaces plus host
@@ -613,7 +616,9 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
         spicepod_load_error,
         running_deployment,
         deployment_note,
+        cloud_connect_identity,
     } = app_bundle;
+    let cloud_connect_configured = cloud_connect_identity.is_some();
     // Deferred until tracing exists, and appended to below — everything about
     // which configuration this start is serving belongs in one place in the log.
     let mut deployment_notes: Vec<DeploymentNote> = deployment_note.into_iter().collect();
@@ -721,9 +726,10 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
     // them under delta temporality.
     //
     // Created here because readers are fixed when the meter provider is built,
-    // which happens well before Cloud Connect starts — so the decision is made
-    // from the same cheap on-disk/flag probe that gates log capture.
-    let cloud_connect_metrics = if cloud_connect::is_configured(args.token.is_some()) {
+    // which happens well before Cloud Connect starts. The durable identity was
+    // already loaded and validated while building the app, and that same
+    // decision gates log capture.
+    let cloud_connect_metrics = if cloud_connect_configured {
         Some(runtime::metrics_reader::MetricsReader::new_cumulative())
     } else {
         None
@@ -792,7 +798,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
             "SPICED_LOG",
             app.as_ref().and_then(|a| a.runtime.output_level),
         ),
-        args.token.is_some(),
+        cloud_connect_configured,
     )
     .await
     .context(UnableToInitializeTracingSnafu)?;
@@ -1110,11 +1116,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
     }
     let endpoint_auth = endpoint_auth.with_identity_source(identity_source);
 
-    // Captured before `args` is moved into the server task below. The
-    // `--token` bootstrap already enrolled (in `load_and_run`, before the
-    // runtime was built), so by now the signal it leaves behind is the
-    // durable identity — this is only the belt-and-braces activation hint.
-    let cloud_connect_token_supplied = args.token.is_some();
+    // Captured before `args` is moved into the server task below.
     let runtime_overrides = args.set_runtime.clone();
 
     let server_thread = tokio::spawn(async move {
@@ -1129,16 +1131,13 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
     // loading them again, which is this path. Local files only, no
     // control-plane round trip, so this neither blocks nor fails when the
     // gateway is unreachable.
-    let delivered_secrets = cloud_connect::restore_delivered_secrets(
-        env!("CARGO_PKG_VERSION"),
-        &rt,
-        cloud_connect_token_supplied,
-    )
-    .await;
+    let delivered_secrets =
+        cloud_connect::restore_delivered_secrets(&rt, cloud_connect_identity.as_ref()).await;
 
-    // Spice Cloud Connect. Default off — activates only when an enrolled
-    // identity is on disk (which a `--token` bootstrap guarantees by this
-    // point). Failures here are non-fatal: spiced keeps running.
+    // Spice Cloud Connect. Default off — activates only from the validated
+    // durable identity snapshot loaded before the runtime was built (which a
+    // successful `--token` bootstrap creates). Failures here are non-fatal:
+    // spiced keeps running.
     //
     // Started BEFORE `load_components()` so the control plane holds a session
     // while components initialize. The load has no deadline — a dataset whose
@@ -1150,8 +1149,8 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
     // it finishes; an `ApplySpicepod` waits for the load, under a bound of its
     // own, so it reconciles against a fully-registered app.
     let cloud_connect_handle = cloud_connect::maybe_start(
-        env!("CARGO_PKG_VERSION"),
         Arc::clone(&rt),
+        cloud_connect_identity,
         delivered_secrets,
         running_deployment,
         cloud_connect_metrics,
@@ -1187,23 +1186,20 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
 
 /// Whether a failed local spicepod load should be tolerated by starting on an
 /// empty spicepod instead of exiting.
-fn tolerates_missing_spicepod(args: &Args, error: &app::Error) -> bool {
-    tolerates_missing_spicepod_when_configured(
-        args,
-        error,
-        cloud_connect::is_configured(args.token.is_some()),
-    )
+fn tolerates_missing_spicepod(args: &Args, error: &app::Error, cloud_managed_state: bool) -> bool {
+    tolerates_missing_spicepod_when_cloud_managed(args, error, cloud_managed_state)
 }
 
-/// Pure policy behind [`tolerates_missing_spicepod`]. Keeping the configuration
-/// signal separate makes the implicit activation path (an enrolled identity)
-/// testable without mutating process-global environment state.
-fn tolerates_missing_spicepod_when_configured(
+/// Pure policy behind [`tolerates_missing_spicepod`]. Configuration provenance
+/// is deliberately separate from credential activation: an unusable identity
+/// still means the instance has no local Spicepod, while it enables no Cloud
+/// Connect facility.
+fn tolerates_missing_spicepod_when_cloud_managed(
     args: &Args,
     error: &app::Error,
-    cloud_connect_configured: bool,
+    cloud_managed_state: bool,
 ) -> bool {
-    cloud_connect_configured && args.spicepod.is_none() && error.is_spicepod_missing()
+    cloud_managed_state && args.spicepod.is_none() && error.is_spicepod_missing()
 }
 
 /// What `build_app` decided about which spicepod this start serves, logged once
@@ -1269,6 +1265,10 @@ impl DeploymentNote {
 /// persisted rather than the instance directory's `spicepod.yaml` — see the
 /// cloud-managed branch below.
 pub async fn build_app(args: &Args) -> Result<AppBundle> {
+    let cloud_connect_startup = cloud_connect::load_startup_state().await;
+    let cloud_connect_config_dir = cloud_connect_startup.config_dir().to_path_buf();
+    let cloud_managed_state = cloud_connect_startup.identity_observed();
+    let cloud_connect_identity = cloud_connect_startup.into_identity();
     // Check for explicit executor role OR implicit executor role (scheduler_address set without explicit role)
     let is_executor = matches!(args.runtime.cluster.role, Some(ClusterRole::Executor))
         || (args.runtime.cluster.role.is_none()
@@ -1296,6 +1296,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
                 spicepod_load_error: None,
                 running_deployment: None,
                 deployment_note: None,
+                cloud_connect_identity,
             });
         }
         tracing::info!(
@@ -1306,6 +1307,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
             spicepod_load_error: None,
             running_deployment: None,
             deployment_note: None,
+            cloud_connect_identity,
         });
     }
 
@@ -1314,13 +1316,14 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
     // file, so reading anything else here would drop every deployment on the
     // floor at the moment it was meant to take effect.
     let mut deployment_note = None;
-    let cloud_managed_spicepod = cloud_connect::cloud_managed_spicepod(args.token.is_some())
-        .await
-        .map_err(
-            |cloud_connect::CloudManagedSpicepodReadError { path, source }| {
-                Error::UnableToReadCloudManagedSpicepod { path, source }
-            },
-        )?;
+    let cloud_managed_spicepod =
+        cloud_connect::cloud_managed_spicepod(&cloud_connect_config_dir, cloud_managed_state)
+            .await
+            .map_err(
+                |cloud_connect::CloudManagedSpicepodReadError { path, source }| {
+                    Error::UnableToReadCloudManagedSpicepod { path, source }
+                },
+            )?;
     if let Some(deployed) = cloud_managed_spicepod {
         match AppBuilder::build_from_path(deployed.path.clone()).await {
             Ok(mut app) => {
@@ -1332,6 +1335,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
                         path: deployed.path.clone(),
                     }),
                     running_deployment: Some(deployed),
+                    cloud_connect_identity,
                 });
             }
             Err(e) => {
@@ -1382,7 +1386,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
                     local_error: e.to_string(),
                 });
                 None
-            } else if tolerates_missing_spicepod(args, &e) {
+            } else if tolerates_missing_spicepod(args, &e, cloud_managed_state) {
                 // A cloud-managed instance that has connected but not yet
                 // received a deployment has no spicepod anywhere: none was
                 // deployed, and `spice connect` writes nothing to the instance
@@ -1407,6 +1411,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
         spicepod_load_error,
         running_deployment: None,
         deployment_note,
+        cloud_connect_identity,
     })
 }
 
@@ -1832,7 +1837,7 @@ mod tests {
         let error = missing_spicepod_error(dir.path()).await;
 
         let args = Args::parse_from(["spiced", "--token", TEST_ENROLLMENT_KEY]);
-        assert!(tolerates_missing_spicepod(&args, &error));
+        assert!(tolerates_missing_spicepod(&args, &error, true));
     }
 
     #[tokio::test]
@@ -1841,7 +1846,7 @@ mod tests {
         let error = missing_spicepod_error(dir.path()).await;
 
         let args = Args::parse_from(["spiced"]);
-        assert!(tolerates_missing_spicepod_when_configured(
+        assert!(tolerates_missing_spicepod_when_cloud_managed(
             &args, &error, true
         ));
     }
@@ -1852,7 +1857,7 @@ mod tests {
         let error = missing_spicepod_error(dir.path()).await;
 
         let args = Args::parse_from(["spiced"]);
-        assert!(!tolerates_missing_spicepod(&args, &error));
+        assert!(!tolerates_missing_spicepod(&args, &error, false));
     }
 
     #[tokio::test]
@@ -1870,7 +1875,7 @@ mod tests {
             path.as_os_str(),
         ]);
         assert_eq!(args.spicepod.as_deref(), Some(path.as_path()));
-        assert!(!tolerates_missing_spicepod(&args, &error));
+        assert!(!tolerates_missing_spicepod(&args, &error, true));
     }
 
     /// A spicepod that exists but does not parse must not be swallowed as
@@ -1888,7 +1893,7 @@ mod tests {
             .expect_err("a malformed spicepod.yaml must fail to load");
 
         let args = Args::parse_from(["spiced", "--token", TEST_ENROLLMENT_KEY]);
-        assert!(!tolerates_missing_spicepod(&args, &error));
+        assert!(!tolerates_missing_spicepod(&args, &error, true));
     }
 
     /// `Debug` over the parsed arguments must never reproduce the `--token`
@@ -1953,8 +1958,9 @@ mod tests {
         assert_eq!(args.region.as_deref(), Some("us-west-2"));
     }
 
-    /// The deleted `--cloud-connect` flag must not parse: identity presence
-    /// (or `--token`) is the only activation signal.
+    /// The deleted `--cloud-connect` flag must not parse: a usable persisted
+    /// identity is the only activation signal. `--token` only creates that
+    /// durable identity during pre-runtime bootstrap.
     #[test]
     fn the_cloud_connect_flag_no_longer_exists() {
         Args::try_parse_from(["spiced", "--cloud-connect"])

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -172,6 +172,11 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    #[snafu(display("Failed to load the durable Spice Cloud Connect identity: {source}"))]
+    UnableToLoadCloudConnectIdentity {
+        source: runtime_cloud_connect::Error,
+    },
+
     #[snafu(display("Unable to start Spice Runtime servers: {source}"))]
     UnableToStartServers { source: Box<runtime::Error> },
 
@@ -557,6 +562,9 @@ pub struct AppBundle {
     running_deployment: Option<cloud_connect::CloudManagedSpicepod>,
     /// Deferred because `build_app` runs before tracing is initialized.
     deployment_note: Option<DeploymentNote>,
+    /// The validated durable-state activation decision made before the runtime
+    /// is built. Every early Cloud Connect facility consumes this same value.
+    cloud_connect_configured: bool,
 }
 
 /// Resolve the CPU entitlement from all three configuration surfaces plus host
@@ -613,6 +621,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
         spicepod_load_error,
         running_deployment,
         deployment_note,
+        cloud_connect_configured,
     } = app_bundle;
     // Deferred until tracing exists, and appended to below — everything about
     // which configuration this start is serving belongs in one place in the log.
@@ -721,9 +730,10 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
     // them under delta temporality.
     //
     // Created here because readers are fixed when the meter provider is built,
-    // which happens well before Cloud Connect starts — so the decision is made
-    // from the same cheap on-disk/flag probe that gates log capture.
-    let cloud_connect_metrics = if cloud_connect::is_configured(args.token.is_some()) {
+    // which happens well before Cloud Connect starts. The durable identity was
+    // already loaded and validated while building the app, and that same
+    // decision gates log capture.
+    let cloud_connect_metrics = if cloud_connect_configured {
         Some(runtime::metrics_reader::MetricsReader::new_cumulative())
     } else {
         None
@@ -792,7 +802,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
             "SPICED_LOG",
             app.as_ref().and_then(|a| a.runtime.output_level),
         ),
-        args.token.is_some(),
+        cloud_connect_configured,
     )
     .await
     .context(UnableToInitializeTracingSnafu)?;
@@ -1110,11 +1120,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
     }
     let endpoint_auth = endpoint_auth.with_identity_source(identity_source);
 
-    // Captured before `args` is moved into the server task below. The
-    // `--token` bootstrap already enrolled (in `load_and_run`, before the
-    // runtime was built), so by now the signal it leaves behind is the
-    // durable identity — this is only the belt-and-braces activation hint.
-    let cloud_connect_token_supplied = args.token.is_some();
+    // Captured before `args` is moved into the server task below.
     let runtime_overrides = args.set_runtime.clone();
 
     let server_thread = tokio::spawn(async move {
@@ -1131,7 +1137,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
     let delivered_secrets = cloud_connect::restore_delivered_secrets(
         env!("CARGO_PKG_VERSION"),
         &rt,
-        cloud_connect_token_supplied,
+        cloud_connect_configured,
     )
     .await;
 
@@ -1186,12 +1192,12 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
 
 /// Whether a failed local spicepod load should be tolerated by starting on an
 /// empty spicepod instead of exiting.
-fn tolerates_missing_spicepod(args: &Args, error: &app::Error) -> bool {
-    tolerates_missing_spicepod_when_configured(
-        args,
-        error,
-        cloud_connect::is_configured(args.token.is_some()),
-    )
+fn tolerates_missing_spicepod(
+    args: &Args,
+    error: &app::Error,
+    cloud_connect_configured: bool,
+) -> bool {
+    tolerates_missing_spicepod_when_configured(args, error, cloud_connect_configured)
 }
 
 /// Pure policy behind [`tolerates_missing_spicepod`]. Keeping the configuration
@@ -1268,6 +1274,9 @@ impl DeploymentNote {
 /// persisted rather than the instance directory's `spicepod.yaml` — see the
 /// cloud-managed branch below.
 pub async fn build_app(args: &Args) -> Result<AppBundle> {
+    let cloud_connect_configured = cloud_connect::is_configured()
+        .await
+        .map_err(|source| Error::UnableToLoadCloudConnectIdentity { source })?;
     // Check for explicit executor role OR implicit executor role (scheduler_address set without explicit role)
     let is_executor = matches!(args.runtime.cluster.role, Some(ClusterRole::Executor))
         || (args.runtime.cluster.role.is_none()
@@ -1295,6 +1304,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
                 spicepod_load_error: None,
                 running_deployment: None,
                 deployment_note: None,
+                cloud_connect_configured,
             });
         }
         tracing::info!(
@@ -1305,6 +1315,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
             spicepod_load_error: None,
             running_deployment: None,
             deployment_note: None,
+            cloud_connect_configured,
         });
     }
 
@@ -1313,7 +1324,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
     // file, so reading anything else here would drop every deployment on the
     // floor at the moment it was meant to take effect.
     let mut deployment_note = None;
-    let cloud_managed_spicepod = cloud_connect::cloud_managed_spicepod(args.token.is_some())
+    let cloud_managed_spicepod = cloud_connect::cloud_managed_spicepod(cloud_connect_configured)
         .await
         .map_err(
             |cloud_connect::CloudManagedSpicepodReadError { path, source }| {
@@ -1331,6 +1342,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
                         path: deployed.path.clone(),
                     }),
                     running_deployment: Some(deployed),
+                    cloud_connect_configured,
                 });
             }
             Err(e) => {
@@ -1381,7 +1393,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
                     local_error: e.to_string(),
                 });
                 None
-            } else if tolerates_missing_spicepod(args, &e) {
+            } else if tolerates_missing_spicepod(args, &e, cloud_connect_configured) {
                 // A cloud-managed instance that has connected but not yet
                 // received a deployment has no spicepod anywhere: none was
                 // deployed, and `spice connect` writes nothing to the instance
@@ -1406,6 +1418,7 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
         spicepod_load_error,
         running_deployment: None,
         deployment_note,
+        cloud_connect_configured,
     })
 }
 
@@ -1831,7 +1844,7 @@ mod tests {
         let error = missing_spicepod_error(dir.path()).await;
 
         let args = Args::parse_from(["spiced", "--token", TEST_ENROLLMENT_KEY]);
-        assert!(tolerates_missing_spicepod(&args, &error));
+        assert!(tolerates_missing_spicepod(&args, &error, true));
     }
 
     #[tokio::test]
@@ -1851,7 +1864,7 @@ mod tests {
         let error = missing_spicepod_error(dir.path()).await;
 
         let args = Args::parse_from(["spiced"]);
-        assert!(!tolerates_missing_spicepod(&args, &error));
+        assert!(!tolerates_missing_spicepod(&args, &error, false));
     }
 
     #[tokio::test]
@@ -1869,7 +1882,7 @@ mod tests {
             path.as_os_str(),
         ]);
         assert_eq!(args.spicepod.as_deref(), Some(path.as_path()));
-        assert!(!tolerates_missing_spicepod(&args, &error));
+        assert!(!tolerates_missing_spicepod(&args, &error, true));
     }
 
     /// A spicepod that exists but does not parse must not be swallowed as
@@ -1887,7 +1900,7 @@ mod tests {
             .expect_err("a malformed spicepod.yaml must fail to load");
 
         let args = Args::parse_from(["spiced", "--token", TEST_ENROLLMENT_KEY]);
-        assert!(!tolerates_missing_spicepod(&args, &error));
+        assert!(!tolerates_missing_spicepod(&args, &error, true));
     }
 
     /// `Debug` over the parsed arguments must never reproduce the `--token`

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -166,12 +166,12 @@ fn should_include_otel_location(is_release_build: bool, verbosity: &LogVerbosity
 /// unchanged. The same `task_history` exclusion as the console layer is
 /// applied so span-only records don't pollute the log tail.
 fn cloud_connect_log_capture_layer<S>(
-    token_supplied: bool,
+    cloud_connect_configured: bool,
 ) -> Option<Box<dyn Layer<S> + Send + Sync>>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    if !crate::cloud_connect::is_configured(token_supplied) {
+    if !cloud_connect_configured {
         return None;
     }
     let ring = crate::log_capture::install(crate::log_capture::DEFAULT_CAPACITY);
@@ -241,7 +241,7 @@ pub(crate) async fn init_tracing(
     config: Option<&TracingConfig>,
     df: Arc<DataFusion>,
     verbosity: LogVerbosity,
-    token_supplied: bool,
+    cloud_connect_configured: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let include_otel_location = should_include_otel_location(!cfg!(debug_assertions), &verbosity);
     let filter: EnvFilter = verbosity.into();
@@ -267,7 +267,7 @@ pub(crate) async fn init_tracing(
         .with(task_history_layer)
         .with(progress_layer())
         .with(console_layer(ansi, std::io::stdout))
-        .with(cloud_connect_log_capture_layer(token_supplied));
+        .with(cloud_connect_log_capture_layer(cloud_connect_configured));
 
     tracing::subscriber::set_global_default(subscriber)?;
     // Routes `log` records — which most of the dependency graph, DataFusion

--- a/crates/runtime-cloud-connect/Cargo.toml
+++ b/crates/runtime-cloud-connect/Cargo.toml
@@ -44,7 +44,7 @@ rand = { workspace = true }
 # Pin the aws_lc_rs backend (matching `crates/runtime`, which forces it via
 # feature unification in the spiced build) so key generation uses the same
 # backend in every build target.
-rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs"] }
+rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs", "x509-parser"] }
 # Out-of-band HTTPS enroll/renew against the cloud control plane.
 reqwest = { workspace = true }
 spice-cloud-client = { workspace = true }

--- a/crates/runtime-cloud-connect/Cargo.toml
+++ b/crates/runtime-cloud-connect/Cargo.toml
@@ -30,6 +30,7 @@ chrono = { workspace = true }
 getrandom = { version = "0.3", features = ["std"] }
 dirs = "6"
 gethostname = { workspace = true }
+http = { workspace = true }
 # Advisory locks distinguish abandoned secret-bearing atomic-write temp files
 # from live concurrent writers before reclamation.
 fs4 = { workspace = true }
@@ -44,7 +45,7 @@ rand = { workspace = true }
 # Pin the aws_lc_rs backend (matching `crates/runtime`, which forces it via
 # feature unification in the spiced build) so key generation uses the same
 # backend in every build target.
-rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs"] }
+rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs", "x509-parser"] }
 # Out-of-band HTTPS enroll/renew against the cloud control plane.
 reqwest = { workspace = true }
 spice-cloud-client = { workspace = true }

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -311,19 +311,7 @@ impl ClientDriver {
     /// `None` when the identity carries no gateway address (a pre-split
     /// identity file) — non-recoverable without re-enrolling.
     fn stream_endpoint(&self) -> Option<String> {
-        if let Some(ref endpoint) = self.config.gateway_endpoint {
-            return Some(endpoint.clone());
-        }
-        let identity = self.identity.as_ref()?;
-        if identity.gateway_addr.is_empty() {
-            return None;
-        }
-        let scheme = if self.config.insecure {
-            "http"
-        } else {
-            "https"
-        };
-        Some(format!("{scheme}://{}", identity.gateway_addr))
+        self.config.stream_endpoint(self.identity.as_ref()?)
     }
 
     /// Renew the identity against the cloud `/renew` endpoint with a fresh

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -235,6 +235,12 @@ impl ClientDriver {
             .is_some_and(|id| renewal_due(id, self.config.renewal_lead))
         {
             match self.renew_once(enroll_client).await {
+                Ok(()) if self.identity.is_none() => {
+                    tracing::info!(
+                        "Cloud Connect: the durable identity was removed while renewal was in flight; exiting cloud-connect without replaying the stale credential"
+                    );
+                    return CredentialStep::Exit;
+                }
                 Ok(()) => {}
                 Err(err) if renewal_rejection_revokes_identity(&err) => {
                     // A 401 is the cloud's credential revocation signal. It
@@ -307,6 +313,8 @@ impl ClientDriver {
                 reason: format!("failed to generate renewal key material: {source}"),
             }
         })?;
+        let expected_identifier = current.identifier.clone();
+        let expected_public_key_pem = current.public_key_pem.clone();
         let outcome = client.renew(&current, &material).await?;
 
         let mut rotated = Identity {
@@ -317,7 +325,10 @@ impl ClientDriver {
             // The CA bundle and gateway address are not re-sent on renewal.
             ca_bundle_pem: current.ca_bundle_pem,
             gateway_addr: current.gateway_addr,
-            not_after_unix: Some(outcome.not_after_unix),
+            // The response's unsigned `not_after` hint is deliberately
+            // ignored. Validation below derives this cache exclusively from
+            // the signed leaf the cloud has already committed.
+            not_after_unix: None,
             // The attachment tuple is not part of the credential and /renew
             // does not re-send it, so it rides across the rotation unchanged
             // (and is re-merged from disk by the persist below, in case a
@@ -362,9 +373,18 @@ impl ClientDriver {
         // persistence fails, the rotated identity must be used in memory
         // (the old key can no longer renew). Persistence logs the failure;
         // the next successful renewal re-attempts the write.
-        rotated = self
-            .persist_identity_preserving_attachment(rotated, "renewed identity")
-            .await;
+        let Some(rotated) = self
+            .persist_identity_preserving_attachment(
+                &expected_identifier,
+                &expected_public_key_pem,
+                rotated,
+                "renewed identity",
+            )
+            .await
+        else {
+            self.identity = None;
+            return Ok(());
+        };
         tracing::info!(
             "Cloud Connect: identity renewed for {} (identity and encryption keypairs rotated, valid until {})",
             rotated.identifier,
@@ -386,37 +406,53 @@ impl ClientDriver {
     /// recently written by a command handler.
     async fn persist_identity_preserving_attachment(
         &self,
+        expected_identifier: &str,
+        expected_public_key_pem: &str,
         identity: Identity,
         update: &'static str,
-    ) -> Identity {
+    ) -> Option<Identity> {
         let path = self.config.identity_path.clone();
         let fallback = identity.clone();
+        let expected_identifier = expected_identifier.to_string();
+        let expected_public_key_pem = expected_public_key_pem.to_string();
         let result = tokio::task::spawn_blocking(move || {
-            IdentityStore::store_credential_update(&path, &identity)
+            IdentityStore::store_credential_update(
+                &path,
+                &expected_identifier,
+                &expected_public_key_pem,
+                &identity,
+            )
         })
         .await;
         match result {
-            Ok(Ok(Some(merged))) => merged,
-            Ok(Ok(None)) => {
-                tracing::error!(
-                    "Cloud Connect: identity disappeared while the {update} was being persisted at {}; continuing with the updated in-memory identity",
+            Ok(Ok(crate::identity::CredentialUpdateOutcome::Stored(merged))) => Some(merged),
+            Ok(Ok(crate::identity::CredentialUpdateOutcome::Superseded(current))) => {
+                tracing::warn!(
+                    "Cloud Connect: skipped the stale {update} at {} because another enrollment or renewal published a newer credential generation; continuing with that durable identity",
                     self.config.identity_path.display()
                 );
-                fallback
+                Some(current)
+            }
+            Ok(Ok(crate::identity::CredentialUpdateOutcome::Missing)) => {
+                tracing::error!(
+                    "Cloud Connect: identity disappeared while the {update} was being persisted at {}; dropping the stale in-memory identity",
+                    self.config.identity_path.display()
+                );
+                None
             }
             Ok(Err(error)) => {
                 tracing::error!(
                     "Cloud Connect: failed to persist the {update} at {}: {error}; continuing with the updated in-memory identity (it will be lost on restart)",
                     self.config.identity_path.display()
                 );
-                fallback
+                Some(fallback)
             }
             Err(error) => {
                 tracing::error!(
                     "Cloud Connect: {update} persistence task failed at {}: {error}; continuing with the updated in-memory identity (it will be lost on restart)",
                     self.config.identity_path.display()
                 );
-                fallback
+                Some(fallback)
             }
         }
     }
@@ -1165,13 +1201,16 @@ impl ClientDriver {
         if crate::sealed_secrets::opened_with_current(&opened.inner_key_id, &keyring) {
             let mut updated = identity;
             if updated.retire_previous_enc_key() {
-                self.identity = Some(
-                    self.persist_identity_preserving_attachment(
+                let expected_identifier = updated.identifier.clone();
+                let expected_public_key_pem = updated.public_key_pem.clone();
+                self.identity = self
+                    .persist_identity_preserving_attachment(
+                        &expected_identifier,
+                        &expected_public_key_pem,
                         updated,
                         "previous encryption-key retirement",
                     )
-                    .await,
-                );
+                    .await;
             }
         }
 

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -211,24 +211,13 @@ impl ClientDriver {
         }
     }
 
-    /// Pre-connect credential phase: drop an unrenewable identity and renew
-    /// a due one. Returns what the connect loop should do next.
+    /// Pre-connect credential phase: renew a due identity. Returns what the
+    /// connect loop should do next.
     ///
     /// The driver never enrolls — enrollment is an explicit pre-runtime
     /// step ([`crate::enroll::enroll_now`]) — so running out of usable
     /// credentials exits the task with re-enrollment guidance.
     async fn ensure_credentials(&mut self, enroll_client: &EnrollClient) -> CredentialStep {
-        // An identity past the renewal grace window can no longer be
-        // renewed by the cloud — only a fresh enrollment key helps.
-        if let Some(ref id) = self.identity
-            && enroll::past_renewal_grace(id)
-        {
-            tracing::warn!(
-                "Cloud Connect: the stored identity expired past the renewal grace window and can no longer be renewed"
-            );
-            self.identity = None;
-        }
-
         if self.identity.is_none() {
             tracing::error!(
                 "Cloud Connect: cannot connect (no usable identity); exiting cloud-connect. Mint a new enrollment key in the Spice Cloud portal and restart spiced with `--token <enrollment-key>` to re-enroll. See: https://spiceai.org/docs"
@@ -236,9 +225,10 @@ impl ClientDriver {
             return CredentialStep::Exit;
         }
 
-        // Renew before connecting when due — this covers the
-        // expired-within-grace startup case, where the gateway would
-        // reject the old leaf but /renew still accepts it.
+        // Renew before connecting when due. The control plane, not the host
+        // clock, decides whether the credential remains renewable: dropping it
+        // locally on a calculated grace deadline could destroy a valid identity
+        // on a fast-clock host.
         if self
             .identity
             .as_ref()
@@ -302,19 +292,7 @@ impl ClientDriver {
     /// `None` when the identity carries no gateway address (a pre-split
     /// identity file) — non-recoverable without re-enrolling.
     fn stream_endpoint(&self) -> Option<String> {
-        if let Some(ref endpoint) = self.config.gateway_endpoint {
-            return Some(endpoint.clone());
-        }
-        let identity = self.identity.as_ref()?;
-        if identity.gateway_addr.is_empty() {
-            return None;
-        }
-        let scheme = if self.config.insecure {
-            "http"
-        } else {
-            "https"
-        };
-        Some(format!("{scheme}://{}", identity.gateway_addr))
+        self.config.stream_endpoint(self.identity.as_ref()?)
     }
 
     /// Renew the identity against the cloud `/renew` endpoint with a fresh
@@ -368,11 +346,18 @@ impl ClientDriver {
         // a payload sealed moments before this point is still addressed to it and
         // cannot be re-sealed in flight.
         rotated.rotate_encryption_key(material.enc_private_key_pem, material.enc_public_key_pem);
-        if let Some(reason) =
-            rotated.reconnect_validation_error(self.config.gateway_endpoint.as_deref())
-        {
-            return Err(client.invalid_renew_response(reason));
-        }
+        // The signed leaf, not the response's unsigned `not_after`, is the
+        // authority for both acceptance and the next renewal deadline. The
+        // shared reconnectability gate also normalizes the cached field to the
+        // signed value before this identity reaches persistence or scheduling.
+        let (validated, _endpoint) =
+            crate::validate_reconnectable_credential_async(&self.config, rotated)
+                .await
+                .map_err(|error| client.invalid_renew_response(error.to_string()))?;
+        rotated = validated;
+        // Channel construction happens in the reconnect loop. It must remain
+        // retryable host state rather than deciding whether the cloud-committed
+        // credential is adopted here.
         // The cloud has already pinned the new public key: even if
         // persistence fails, the rotated identity must be used in memory
         // (the old key can no longer renew). Persistence logs the failure;
@@ -452,7 +437,7 @@ impl ClientDriver {
     /// Delay until the next renewal attempt, or `None` when the identity
     /// carries no expiry and renewal is moot.
     fn next_renewal_delay(&self) -> Option<Duration> {
-        let not_after = self.identity.as_ref()?.not_after_unix?;
+        let not_after = self.identity.as_ref()?.effective_not_after_unix()?;
         let due_at = not_after.saturating_sub(self.config.renewal_lead.as_secs());
         let due_in = Duration::from_secs(due_at.saturating_sub(now_unix()));
         // After a transient failure, pace retries instead of spinning on a
@@ -1368,7 +1353,7 @@ async fn sleep_or_never(delay: Option<Duration>) {
 /// `true` when the identity should be renewed now: within `lead` of its
 /// `not_after` (or already past it). An identity with no expiry never renews.
 fn renewal_due(identity: &Identity, lead: Duration) -> bool {
-    let Some(not_after) = identity.not_after_unix else {
+    let Some(not_after) = identity.effective_not_after_unix() else {
         return false;
     };
     now_unix().saturating_add(lead.as_secs()) >= not_after
@@ -1412,11 +1397,11 @@ fn server_trust<'a>(ca_bundle_pem: &'a str, dev_ca_pem: Option<&'a str>) -> Serv
     }
 }
 
-fn build_channel(
+fn build_endpoint(
     config: &CloudConnectConfig,
     endpoint_url: &str,
     identity: &Identity,
-) -> Result<Channel> {
+) -> Result<Endpoint> {
     let mut endpoint = Endpoint::from_shared(endpoint_url.to_string())
         .map_err(|source| Error::InvalidEndpoint {
             endpoint: endpoint_url.to_string(),
@@ -1455,7 +1440,15 @@ fn build_channel(
         endpoint = endpoint.tls_config(tls).context(TransportSnafu)?;
     }
 
-    Ok(endpoint.connect_lazy())
+    Ok(endpoint)
+}
+
+fn build_channel(
+    config: &CloudConnectConfig,
+    endpoint_url: &str,
+    identity: &Identity,
+) -> Result<Channel> {
+    build_endpoint(config, endpoint_url, identity).map(|endpoint| endpoint.connect_lazy())
 }
 
 fn build_hello(
@@ -1714,7 +1707,6 @@ fn renewal_rejection_revokes_identity(error: &enroll::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::enroll::past_renewal_grace;
 
     #[test]
     fn backoff_doubles_until_cap() {
@@ -1881,11 +1873,26 @@ mod tests {
         }
     }
 
+    fn identity_with_signed_expiry(
+        signed_validity: Duration,
+        cached_not_after_unix: u64,
+    ) -> Identity {
+        let key = rcgen::KeyPair::generate().expect("generate identity key");
+        let now = std::time::SystemTime::now();
+        let mut params = rcgen::CertificateParams::new(Vec::<String>::new())
+            .expect("build identity certificate parameters");
+        params.not_before = (now - Duration::from_mins(1)).into();
+        params.not_after = (now + signed_validity).into();
+        let certificate = params.self_signed(&key).expect("sign identity certificate");
+        let mut identity = identity_with_not_after(Some(cached_not_after_unix));
+        identity.identity_cert_pem = certificate.pem();
+        identity
+    }
+
     #[test]
     fn renewal_never_due_for_unbounded_identity() {
         let id = identity_with_not_after(None);
         assert!(!renewal_due(&id, Duration::from_hours(12)));
-        assert!(!past_renewal_grace(&id));
     }
 
     #[test]
@@ -1897,18 +1904,37 @@ mod tests {
         // Expires in 24h with a 12h lead: not yet due.
         let later = identity_with_not_after(Some(now_unix() + 24 * 60 * 60));
         assert!(!renewal_due(&later, lead));
-        // Already expired: due (renewable within the grace window).
+        // Already expired: due; the control plane decides whether it remains
+        // renewable.
         let expired = identity_with_not_after(Some(now_unix().saturating_sub(60)));
         assert!(renewal_due(&expired, lead));
-        assert!(!past_renewal_grace(&expired));
     }
 
     #[test]
-    fn identity_past_grace_cannot_renew() {
-        let long_dead = identity_with_not_after(Some(
-            now_unix().saturating_sub(crate::enroll::RENEWAL_GRACE.as_secs() + 60),
-        ));
-        assert!(past_renewal_grace(&long_dead));
+    fn renewal_scheduling_uses_the_signed_expiry_over_the_unsigned_cache() {
+        let identity = identity_with_signed_expiry(
+            Duration::from_mins(1),
+            now_unix().saturating_add(Duration::from_hours(24).as_secs()),
+        );
+        let lead = Duration::from_hours(12);
+
+        assert!(
+            renewal_due(&identity, lead),
+            "the signed leaf is due even though the response cache claims another day"
+        );
+
+        let runtime: Arc<dyn RuntimeHandle> = Arc::new(crate::handlers::NoopRuntimeHandle);
+        let driver = ClientDriver::new(
+            CloudConnectConfig::from_env("test-runtime"),
+            runtime,
+            crate::shutdown::Shutdown::new(),
+            Some(identity),
+        );
+        assert_eq!(
+            driver.next_renewal_delay(),
+            Some(Duration::ZERO),
+            "the live-stream timer must also use the signed leaf deadline"
+        );
     }
 
     #[test]

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -140,6 +140,58 @@ pub struct CloudConnectConfig {
 }
 
 impl CloudConnectConfig {
+    /// Resolve the control-stream endpoint for a persisted identity.
+    ///
+    /// A configured override is already a complete URL. Otherwise the enroll
+    /// response supplies `host:port`, and transport mode supplies the scheme.
+    #[must_use]
+    pub fn stream_endpoint(&self, identity: &crate::identity::Identity) -> Option<String> {
+        if let Some(ref endpoint) = self.gateway_endpoint {
+            return Some(endpoint.clone());
+        }
+        if identity.gateway_addr.trim().is_empty() {
+            return None;
+        }
+        let scheme = if self.insecure { "http" } else { "https" };
+        Some(format!("{scheme}://{}", identity.gateway_addr))
+    }
+
+    /// Resolve and validate the exact control-stream endpoint shape accepted
+    /// by the client transport.
+    ///
+    /// Both persisted gateway addresses and explicit overrides identify one
+    /// network authority, not a URL subtree or alternate transport. Requiring
+    /// an explicit port also keeps a persisted `host:port` from being
+    /// reinterpreted through a scheme or path embedded in untrusted state.
+    pub(crate) fn validated_stream_endpoint(
+        &self,
+        identity: &crate::identity::Identity,
+    ) -> Result<String, &'static str> {
+        let endpoint = self
+            .stream_endpoint(identity)
+            .ok_or("the gateway address is empty")?;
+        let uri = endpoint
+            .parse::<http::Uri>()
+            .map_err(|_| "the gateway endpoint is invalid")?;
+        let expected_scheme = if self.insecure { "http" } else { "https" };
+        if uri.scheme_str() != Some(expected_scheme) {
+            return Err("the gateway endpoint uses the wrong transport scheme");
+        }
+        if uri.host().is_none() {
+            return Err("the gateway endpoint has no host");
+        }
+        if uri.port_u16().is_none() {
+            return Err("the gateway endpoint has no explicit port");
+        }
+        if uri
+            .path_and_query()
+            .is_some_and(|path_and_query| path_and_query.as_str() != "/")
+        {
+            return Err("the gateway endpoint must not contain a path or query");
+        }
+        Ok(endpoint)
+    }
+
     /// Resolve the Cloud Connect config directory to its canonical location.
     ///
     /// Precedence:

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -140,6 +140,22 @@ pub struct CloudConnectConfig {
 }
 
 impl CloudConnectConfig {
+    /// Resolve the control-stream endpoint for a persisted identity.
+    ///
+    /// A configured override is already a complete URL. Otherwise the enroll
+    /// response supplies `host:port`, and transport mode supplies the scheme.
+    #[must_use]
+    pub fn stream_endpoint(&self, identity: &crate::identity::Identity) -> Option<String> {
+        if let Some(ref endpoint) = self.gateway_endpoint {
+            return Some(endpoint.clone());
+        }
+        if identity.gateway_addr.trim().is_empty() {
+            return None;
+        }
+        let scheme = if self.insecure { "http" } else { "https" };
+        Some(format!("{scheme}://{}", identity.gateway_addr))
+    }
+
     /// Resolve the Cloud Connect config directory to its canonical location.
     ///
     /// Precedence:

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -180,8 +180,10 @@ impl CloudConnectConfig {
         if uri.host().is_none() {
             return Err("the gateway endpoint has no host");
         }
-        if uri.port_u16().is_none() {
-            return Err("the gateway endpoint has no explicit port");
+        match uri.port_u16() {
+            None => return Err("the gateway endpoint has no explicit port"),
+            Some(0) => return Err("the gateway endpoint port must be greater than zero"),
+            Some(_) => {}
         }
         if uri
             .path_and_query()
@@ -445,6 +447,38 @@ mod tests {
         assert!(
             config.instance_region.is_none(),
             "the region is an explicit argument, never read from the environment"
+        );
+    }
+
+    #[test]
+    fn persisted_gateway_rejects_port_zero() {
+        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+        unsafe {
+            std::env::remove_var("SPICE_CLOUD_ENDPOINT");
+            std::env::remove_var("SPICE_CLOUD_GATEWAY_ENDPOINT");
+        }
+        let config = CloudConnectConfig::from_env("v0.0.0-test");
+        let identity = crate::identity::Identity {
+            identifier: "inst_test".to_string(),
+            identity_cert_pem: String::new(),
+            private_key_pem: String::new(),
+            public_key_pem: String::new(),
+            ca_bundle_pem: String::new(),
+            gateway_addr: "gateway.example.test:0".to_string(),
+            not_after_unix: None,
+            app_id: None,
+            org_name: None,
+            app_name: None,
+            monitor_url: None,
+            enc_private_key_pem: String::new(),
+            enc_public_key_pem: String::new(),
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+        };
+
+        assert_eq!(
+            config.validated_persisted_gateway_endpoint(&identity),
+            Err("the gateway endpoint port must be greater than zero")
         );
     }
 

--- a/crates/runtime-cloud-connect/src/draft.rs
+++ b/crates/runtime-cloud-connect/src/draft.rs
@@ -64,6 +64,10 @@ const LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30)
 #[cfg(test)]
 const LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_millis(250);
 const LOCK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+#[cfg(not(test))]
+const REMOVAL_LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(test)]
+const REMOVAL_LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Current schema of the draft file.
 const DRAFT_SCHEMA_VERSION: u32 = 2;
@@ -90,6 +94,12 @@ pub enum Error {
         path: PathBuf,
         source: serde_json::Error,
     },
+
+    #[snafu(display(
+        "The enrollment draft at {} cannot be replayed safely: {reason}. Preserve the draft and contact Spice Cloud support before removing it or starting a new enrollment",
+        path.display()
+    ))]
+    Invalid { path: PathBuf, reason: &'static str },
 
     #[snafu(display(
         "The enrollment draft at {} uses unsupported schema {found} (this runtime requires \
@@ -139,6 +149,10 @@ impl EnrollmentTransactionLock {
         Self::acquire_with_budget(config_dir, std::time::Duration::ZERO)
     }
 
+    pub(crate) fn acquire_for_removal(config_dir: &Path) -> Result<Self> {
+        Self::acquire_with_budget(config_dir, REMOVAL_LOCK_WAIT_BUDGET)
+    }
+
     fn acquire_with_budget(config_dir: &Path, wait_budget: std::time::Duration) -> Result<Self> {
         let draft_path = EnrollmentDraft::path_in(config_dir);
         if let Some(parent) = draft_path.parent() {
@@ -169,14 +183,18 @@ impl EnrollmentTransactionLock {
             .map_err(|source| Error::AcquireTaskPanicked { source })?
     }
 
+    pub(crate) fn protects(&self, path: &Path) -> bool {
+        self.draft_path.parent() == path.parent()
+    }
+
     pub(crate) fn load_or_create(
         &self,
         instance: &InstanceFacts,
         region: Option<&str>,
     ) -> Result<EnrollmentDraft> {
-        match std::fs::read_to_string(&self.draft_path) {
-            Ok(contents) => EnrollmentDraft::load_published(&self.draft_path, &contents),
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+        match crate::identity::read_regular_file_optional(&self.draft_path) {
+            Ok(Some(contents)) => EnrollmentDraft::load_published(&self.draft_path, &contents),
+            Ok(None) => {
                 EnrollmentDraft::publish_locked(&self.draft_path, &self.file, instance, region)
             }
             Err(source) => Err(Error::Io {
@@ -301,9 +319,16 @@ impl EnrollmentDraft {
                 found: header.schema_version,
             });
         }
-        serde_json::from_str::<Self>(contents).context(ParseSnafu {
+        let draft = serde_json::from_str::<Self>(contents).context(ParseSnafu {
             path: path.to_path_buf(),
-        })
+        })?;
+        if let Some(reason) = draft.material().validation_error() {
+            return Err(Error::Invalid {
+                path: path.to_path_buf(),
+                reason,
+            });
+        }
+        Ok(draft)
     }
 
     fn load_published(path: &Path, contents: &str) -> Result<Self> {
@@ -402,9 +427,9 @@ impl EnrollmentDraft {
         // another process can publish before this process owns it. Re-read
         // while locked so a delayed creator cannot replace the durable winner
         // through the atomic rename below.
-        match std::fs::read_to_string(path) {
-            Ok(contents) => return Self::parse_at(path, &contents),
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+        match crate::identity::read_regular_file_optional(path) {
+            Ok(Some(contents)) => return Self::parse_at(path, &contents),
+            Ok(None) => {}
             Err(source) => {
                 return Err(Error::Io {
                     path: path.to_path_buf(),
@@ -574,6 +599,27 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(path).expect("corrupt draft remains"),
             "{not json",
+            "ambiguous enrollment state must not be silently replaced"
+        );
+    }
+
+    #[test]
+    fn cryptographically_inconsistent_draft_is_never_replayed_or_replaced() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = EnrollmentDraft::path_in(dir.path());
+        let mut corrupted = load_or_create(dir.path()).expect("create draft");
+        corrupted.enc_public_key_pem = IdentityStore::generate_enrollment()
+            .expect("generate mismatched material")
+            .enc_public_key_pem;
+        let serialized = serde_json::to_string_pretty(&corrupted).expect("serialize draft");
+        std::fs::write(&path, &serialized).expect("write corrupt draft");
+
+        let error = load_or_create(dir.path()).expect_err("must refuse unsafe replay");
+        assert!(matches!(error, Error::Invalid { .. }), "{error}");
+        assert!(error.to_string().contains("do not match"), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(path).expect("corrupt draft remains"),
+            serialized,
             "ambiguous enrollment state must not be silently replaced"
         );
     }
@@ -812,6 +858,55 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o600, "the draft holds private key material");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn draft_reads_reject_symlinks_without_reading_the_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("outside.json");
+        let path = EnrollmentDraft::path_in(dir.path());
+        std::fs::write(&target, "sensitive target").expect("write target");
+        symlink(&target, &path).expect("create draft symlink");
+
+        let error = load_or_create(dir.path()).expect_err("symlink must be rejected");
+        assert!(matches!(error, Error::Io { .. }), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(target).expect("target remains readable"),
+            "sensitive target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn draft_reads_reject_fifos_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt as _;
+        use std::os::unix::fs::FileTypeExt as _;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = EnrollmentDraft::path_in(dir.path());
+        let path_c = CString::new(path.as_os_str().as_bytes()).expect("FIFO path has no NUL");
+        // SAFETY: `path_c` is a valid NUL-terminated path and `0o600` is a
+        // valid mode. `mkfifo` retains neither argument.
+        let result = unsafe { libc::mkfifo(path_c.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "create FIFO: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let error = load_or_create(dir.path()).expect_err("FIFO must be rejected");
+        assert!(matches!(error, Error::Io { .. }), "{error}");
+        assert!(
+            std::fs::metadata(path)
+                .expect("FIFO metadata")
+                .file_type()
+                .is_fifo()
+        );
     }
 
     #[cfg(unix)]

--- a/crates/runtime-cloud-connect/src/draft.rs
+++ b/crates/runtime-cloud-connect/src/draft.rs
@@ -64,6 +64,10 @@ const LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30)
 #[cfg(test)]
 const LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_millis(250);
 const LOCK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+#[cfg(not(test))]
+const REMOVAL_LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(test)]
+const REMOVAL_LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Current schema of the draft file.
 const DRAFT_SCHEMA_VERSION: u32 = 2;
@@ -85,11 +89,22 @@ pub enum Error {
     #[snafu(display("Failed to serialize the enrollment draft: {source}"))]
     Serialize { source: serde_json::Error },
 
-    #[snafu(display("Failed to parse the enrollment draft at {}: {source}", path.display()))]
+    #[snafu(display(
+        "Failed to parse the enrollment draft at {} (line {}, column {})",
+        path.display(),
+        source.line(),
+        source.column()
+    ))]
     Parse {
         path: PathBuf,
         source: serde_json::Error,
     },
+
+    #[snafu(display(
+        "The enrollment draft at {} cannot be replayed safely: {reason}. Preserve the draft and contact Spice Cloud support before removing it or starting a new enrollment",
+        path.display()
+    ))]
+    Invalid { path: PathBuf, reason: &'static str },
 
     #[snafu(display(
         "The enrollment draft at {} uses unsupported schema {found} (this runtime requires \
@@ -139,6 +154,10 @@ impl EnrollmentTransactionLock {
         Self::acquire_with_budget(config_dir, std::time::Duration::ZERO)
     }
 
+    pub(crate) fn acquire_for_removal(config_dir: &Path) -> Result<Self> {
+        Self::acquire_with_budget(config_dir, REMOVAL_LOCK_WAIT_BUDGET)
+    }
+
     fn acquire_with_budget(config_dir: &Path, wait_budget: std::time::Duration) -> Result<Self> {
         let draft_path = EnrollmentDraft::path_in(config_dir);
         if let Some(parent) = draft_path.parent() {
@@ -169,14 +188,18 @@ impl EnrollmentTransactionLock {
             .map_err(|source| Error::AcquireTaskPanicked { source })?
     }
 
+    pub(crate) fn protects(&self, path: &Path) -> bool {
+        self.draft_path.parent() == path.parent()
+    }
+
     pub(crate) fn load_or_create(
         &self,
         instance: &InstanceFacts,
         region: Option<&str>,
     ) -> Result<EnrollmentDraft> {
-        match std::fs::read_to_string(&self.draft_path) {
-            Ok(contents) => EnrollmentDraft::load_published(&self.draft_path, &contents),
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+        match crate::identity::read_regular_file_optional(&self.draft_path) {
+            Ok(Some(contents)) => EnrollmentDraft::load_published(&self.draft_path, &contents),
+            Ok(None) => {
                 EnrollmentDraft::publish_locked(&self.draft_path, &self.file, instance, region)
             }
             Err(source) => Err(Error::Io {
@@ -301,9 +324,16 @@ impl EnrollmentDraft {
                 found: header.schema_version,
             });
         }
-        serde_json::from_str::<Self>(contents).context(ParseSnafu {
+        let draft = serde_json::from_str::<Self>(contents).context(ParseSnafu {
             path: path.to_path_buf(),
-        })
+        })?;
+        if let Some(reason) = draft.material().validation_error() {
+            return Err(Error::Invalid {
+                path: path.to_path_buf(),
+                reason,
+            });
+        }
+        Ok(draft)
     }
 
     fn load_published(path: &Path, contents: &str) -> Result<Self> {
@@ -402,9 +432,9 @@ impl EnrollmentDraft {
         // another process can publish before this process owns it. Re-read
         // while locked so a delayed creator cannot replace the durable winner
         // through the atomic rename below.
-        match std::fs::read_to_string(path) {
-            Ok(contents) => return Self::parse_at(path, &contents),
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+        match crate::identity::read_regular_file_optional(path) {
+            Ok(Some(contents)) => return Self::parse_at(path, &contents),
+            Ok(None) => {}
             Err(source) => {
                 return Err(Error::Io {
                     path: path.to_path_buf(),
@@ -574,6 +604,41 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(path).expect("corrupt draft remains"),
             "{not json",
+            "ambiguous enrollment state must not be silently replaced"
+        );
+    }
+
+    #[test]
+    fn draft_parse_errors_never_echo_persisted_values() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = EnrollmentDraft::path_in(dir.path());
+        let sensitive = "private-key-material-that-must-not-be-printed";
+        std::fs::write(&path, format!(r#"{{"schema_version":"{sensitive}"}}"#))
+            .expect("write malformed draft");
+
+        let error = load_or_create(dir.path()).expect_err("must refuse malformed draft");
+        let rendered = error.to_string();
+        assert!(rendered.contains("line"), "{rendered}");
+        assert!(!rendered.contains(sensitive), "{rendered}");
+    }
+
+    #[test]
+    fn cryptographically_inconsistent_draft_is_never_replayed_or_replaced() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = EnrollmentDraft::path_in(dir.path());
+        let mut corrupted = load_or_create(dir.path()).expect("create draft");
+        corrupted.enc_public_key_pem = IdentityStore::generate_enrollment()
+            .expect("generate mismatched material")
+            .enc_public_key_pem;
+        let serialized = serde_json::to_string_pretty(&corrupted).expect("serialize draft");
+        std::fs::write(&path, &serialized).expect("write corrupt draft");
+
+        let error = load_or_create(dir.path()).expect_err("must refuse unsafe replay");
+        assert!(matches!(error, Error::Invalid { .. }), "{error}");
+        assert!(error.to_string().contains("do not match"), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(path).expect("corrupt draft remains"),
+            serialized,
             "ambiguous enrollment state must not be silently replaced"
         );
     }
@@ -812,6 +877,55 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o600, "the draft holds private key material");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn draft_reads_reject_symlinks_without_reading_the_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("outside.json");
+        let path = EnrollmentDraft::path_in(dir.path());
+        std::fs::write(&target, "sensitive target").expect("write target");
+        symlink(&target, &path).expect("create draft symlink");
+
+        let error = load_or_create(dir.path()).expect_err("symlink must be rejected");
+        assert!(matches!(error, Error::Io { .. }), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(target).expect("target remains readable"),
+            "sensitive target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn draft_reads_reject_fifos_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt as _;
+        use std::os::unix::fs::FileTypeExt as _;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = EnrollmentDraft::path_in(dir.path());
+        let path_c = CString::new(path.as_os_str().as_bytes()).expect("FIFO path has no NUL");
+        // SAFETY: `path_c` is a valid NUL-terminated path and `0o600` is a
+        // valid mode. `mkfifo` retains neither argument.
+        let result = unsafe { libc::mkfifo(path_c.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "create FIFO: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let error = load_or_create(dir.path()).expect_err("FIFO must be rejected");
+        assert!(matches!(error, Error::Io { .. }), "{error}");
+        assert!(
+            std::fs::metadata(path)
+                .expect("FIFO metadata")
+                .file_type()
+                .is_fifo()
+        );
     }
 
     #[cfg(unix)]

--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -223,6 +223,11 @@ pub enum Error {
     #[snafu(display("Failed to reach the Spice Cloud endpoint {url}: {source}"))]
     Http { url: String, source: reqwest::Error },
 
+    #[snafu(display(
+        "Failed to construct the Spice Cloud request for {url}: the endpoint URL or request headers are invalid"
+    ))]
+    InvalidRequest { url: String },
+
     #[snafu(display("Failed to read the Spice Cloud response from {url}: {source}"))]
     ResponseBody { url: String, source: reqwest::Error },
 
@@ -269,25 +274,26 @@ impl Error {
     /// `true` only when the cloud *authoritatively rejected* the request
     /// ([`Error::Denied`]): retrying the same request cannot succeed.
     ///
-    /// Everything else is retryable: transport failures and 408/429/5xx are
-    /// transient, [`Error::CertificateValidity`] (a skewed host clock) is
-    /// fixable and the request never reached the cloud, and a local
-    /// proof-of-possession failure never left this host.
+    /// Every other variant is a local failure, a transient response, or an
+    /// unusable response rather than an authoritative cloud rejection.
     #[must_use]
     pub fn is_authoritative_rejection(&self) -> bool {
         matches!(self, Error::Denied { .. })
     }
 
     /// `true` when retrying the same enrollment operation cannot produce a
-    /// different outcome. A denied request is authoritative, while a malformed
-    /// decoded successful response with invalid required fields is committed
-    /// under the operation's idempotency key and will therefore replay the same
-    /// unusable semantics. Body transport and JSON decode failures remain
-    /// retryable because an unframed partial body is indistinguishable from
-    /// response loss.
+    /// different outcome. A locally invalid request was never sent, a denied
+    /// request is authoritative, and a decoded successful response with
+    /// invalid required fields is committed under the operation's idempotency
+    /// key and will therefore replay the same unusable semantics. Body
+    /// transport and JSON decode failures remain retryable because an unframed
+    /// partial body is indistinguishable from response loss.
     #[must_use]
     pub fn is_terminal_enrollment_failure(&self) -> bool {
-        matches!(self, Error::Denied { .. } | Error::InvalidResponse { .. })
+        matches!(
+            self,
+            Error::Denied { .. } | Error::InvalidRequest { .. } | Error::InvalidResponse { .. }
+        )
     }
 
     /// `true` only when the *credential itself* was rejected (HTTP 401).
@@ -671,6 +677,11 @@ impl EnrollClient {
         let response = match builder.send().await {
             Ok(response) => response,
             Err(source) => {
+                if source.is_builder() {
+                    return Err(Error::InvalidRequest {
+                        url: url.to_string(),
+                    });
+                }
                 // A TLS validity rejection is the shape a wrong host clock
                 // produces at every layer of this flow. Diagnose it here
                 // rather than handing the operator a bare certificate error.
@@ -965,6 +976,9 @@ fn denial_remediation(source: &Error) -> &'static str {
         Error::Denied { code, .. } => code.remediation(),
         Error::InvalidResponse { .. } => {
             "Spice Cloud returned unusable data for this pending operation. Preserve enrollment-draft.json and contact Spice Cloud support before removing it or starting a new enrollment"
+        }
+        Error::InvalidRequest { .. } => {
+            "Fix the configured Spice Cloud endpoint or organization name and retry"
         }
         _ => "Fix the reported problem and retry",
     }
@@ -1444,6 +1458,15 @@ mod tests {
             "an invalid response is not a credential revocation signal"
         );
 
+        let invalid_request = Error::InvalidRequest {
+            url: "not a URL".to_string(),
+        };
+        assert!(
+            invalid_request.is_terminal_enrollment_failure(),
+            "a locally invalid request cannot improve on retry"
+        );
+        assert!(!invalid_request.is_authoritative_rejection());
+
         let pop = Error::ProofOfPossession {
             reason: "key material generation failed".to_string(),
         };
@@ -1460,6 +1483,42 @@ mod tests {
             skew.to_string().contains("clock"),
             "the message must name the clock: {skew}"
         );
+    }
+
+    #[tokio::test]
+    async fn invalid_request_construction_is_terminal_without_network_retry() {
+        let client = EnrollClient::new(&test_config("http://127.0.0.1:9")).expect("client");
+        let invalid_url = "://not-a-url";
+        let request = client.http.get(invalid_url);
+        let Err(error) = client
+            .send::<EnrollResponseWire>(invalid_url, request, None)
+            .await
+        else {
+            panic!("an invalid URL must fail locally");
+        };
+
+        assert!(matches!(error, Error::InvalidRequest { .. }), "{error}");
+        assert!(error.is_terminal_enrollment_failure());
+    }
+
+    #[tokio::test]
+    async fn invalid_organization_header_is_terminal_and_redacted() {
+        let client = EnrollClient::new(&test_config("http://127.0.0.1:9")).expect("client");
+        let authority = EnrollmentAuthority::AuthenticatedSession {
+            access_token: SessionToken::new("session-secret-never-printed".to_string()),
+            org: "invalid\norganization".to_string(),
+        };
+        let material = IdentityStore::generate_enrollment().expect("enrollment material");
+        let error = client
+            .enroll(&authority, "test-operation", &material, &test_facts(), None)
+            .await
+            .expect_err("an invalid header must fail locally");
+
+        assert!(matches!(error, Error::InvalidRequest { .. }), "{error}");
+        assert!(error.is_terminal_enrollment_failure());
+        let rendered = error.to_string();
+        assert!(!rendered.contains("session-secret-never-printed"));
+        assert!(!rendered.contains("invalid\norganization"));
     }
 
     #[tokio::test]

--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -83,15 +83,6 @@ const RETRY_BACKOFF_BASE: Duration = Duration::from_secs(1);
 /// Full-jitter backoff ceiling: no retry window grows past this.
 const RETRY_BACKOFF_CAP: Duration = Duration::from_secs(30);
 
-/// `true` when the identity expired longer than [`RENEWAL_GRACE`] ago —
-/// the cloud refuses to renew it, so only a fresh enrollment helps.
-#[must_use]
-pub fn past_renewal_grace(identity: &Identity) -> bool {
-    identity.not_after_unix.is_some_and(|not_after| {
-        crate::heartbeat::now_unix() >= not_after.saturating_add(RENEWAL_GRACE.as_secs())
-    })
-}
-
 /// A logged-in Spice Cloud session's bearer token, wrapped so it cannot
 /// leak through `Debug` and is wiped on drop. Constructed by callers that
 /// own a login session; this crate only ever places it in the one
@@ -223,6 +214,11 @@ pub enum Error {
     #[snafu(display("Failed to reach the Spice Cloud endpoint {url}: {source}"))]
     Http { url: String, source: reqwest::Error },
 
+    #[snafu(display(
+        "Failed to construct the Spice Cloud request for {url}: the endpoint URL or request headers are invalid"
+    ))]
+    InvalidRequest { url: String },
+
     #[snafu(display("Failed to read the Spice Cloud response from {url}: {source}"))]
     ResponseBody { url: String, source: reqwest::Error },
 
@@ -269,25 +265,26 @@ impl Error {
     /// `true` only when the cloud *authoritatively rejected* the request
     /// ([`Error::Denied`]): retrying the same request cannot succeed.
     ///
-    /// Everything else is retryable: transport failures and 408/429/5xx are
-    /// transient, [`Error::CertificateValidity`] (a skewed host clock) is
-    /// fixable and the request never reached the cloud, and a local
-    /// proof-of-possession failure never left this host.
+    /// Every other variant is a local failure, a transient response, or an
+    /// unusable response rather than an authoritative cloud rejection.
     #[must_use]
     pub fn is_authoritative_rejection(&self) -> bool {
         matches!(self, Error::Denied { .. })
     }
 
     /// `true` when retrying the same enrollment operation cannot produce a
-    /// different outcome. A denied request is authoritative, while a malformed
-    /// decoded successful response with invalid required fields is committed
-    /// under the operation's idempotency key and will therefore replay the same
-    /// unusable semantics. Body transport and JSON decode failures remain
-    /// retryable because an unframed partial body is indistinguishable from
-    /// response loss.
+    /// different outcome. A locally invalid request was never sent, a denied
+    /// request is authoritative, and a decoded successful response with
+    /// invalid required fields is committed under the operation's idempotency
+    /// key and will therefore replay the same unusable semantics. Body
+    /// transport and JSON decode failures remain retryable because an unframed
+    /// partial body is indistinguishable from response loss.
     #[must_use]
     pub fn is_terminal_enrollment_failure(&self) -> bool {
-        matches!(self, Error::Denied { .. } | Error::InvalidResponse { .. })
+        matches!(
+            self,
+            Error::Denied { .. } | Error::InvalidRequest { .. } | Error::InvalidResponse { .. }
+        )
     }
 
     /// `true` only when the *credential itself* was rejected (HTTP 401).
@@ -654,10 +651,10 @@ impl EnrollClient {
 
     /// Classify a syntactically successful renewal response whose issued
     /// credential cannot be used with the key material sent in the request.
-    pub(crate) fn invalid_renew_response(&self, reason: &'static str) -> Error {
+    pub(crate) fn invalid_renew_response(&self, reason: impl Into<String>) -> Error {
         Error::InvalidResponse {
             url: self.renew_url.clone(),
-            reason: format!("issued identity cannot reconnect: {reason}"),
+            reason: format!("issued identity cannot reconnect: {}", reason.into()),
         }
     }
 
@@ -671,6 +668,11 @@ impl EnrollClient {
         let response = match builder.send().await {
             Ok(response) => response,
             Err(source) => {
+                if source.is_builder() {
+                    return Err(Error::InvalidRequest {
+                        url: url.to_string(),
+                    });
+                }
                 // A TLS validity rejection is the shape a wrong host clock
                 // produces at every layer of this flow. Diagnose it here
                 // rather than handing the operator a bare certificate error.
@@ -942,7 +944,16 @@ pub enum EnrollNowError {
     ))]
     IdentityUnusable {
         path: std::path::PathBuf,
-        reason: &'static str,
+        reason: String,
+    },
+
+    #[snafu(display(
+        "The existing Cloud Connect identity at {} could not be activated because the local gateway environment is unavailable: {source}. The supplied enrollment authority was not redeemed. Fix the host trust or transport configuration and retry. See: https://spiceai.org/docs",
+        path.display()
+    ))]
+    IdentityEnvironment {
+        path: std::path::PathBuf,
+        source: crate::Error,
     },
 
     #[snafu(display(
@@ -965,6 +976,9 @@ fn denial_remediation(source: &Error) -> &'static str {
         Error::Denied { code, .. } => code.remediation(),
         Error::InvalidResponse { .. } => {
             "Spice Cloud returned unusable data for this pending operation. Preserve enrollment-draft.json and contact Spice Cloud support before removing it or starting a new enrollment"
+        }
+        Error::InvalidRequest { .. } => {
+            "Fix the configured Spice Cloud endpoint or organization name and retry"
         }
         _ => "Fix the reported problem and retry",
     }
@@ -1003,12 +1017,12 @@ pub enum EnrollNowOutcome {
 /// Operation-aware one-shot enrollment: the typed entry point `spiced
 /// --token` uses directly.
 ///
-/// 1. **Existing identity wins.** A readable identity that is not past the
-///    renewal grace window short-circuits to
-///    [`EnrollNowOutcome::AlreadyEnrolled`]; the supplied authority is not
-///    redeemed and not persisted. (An expired-but-in-grace identity still
-///    wins — the driver renews it.) A readable but unusable identity fails
-///    closed with removal guidance; it never causes implicit re-enrollment.
+/// 1. **Existing identity wins.** A readable, structurally valid identity
+///    short-circuits to [`EnrollNowOutcome::AlreadyEnrolled`]; the supplied
+///    authority is not redeemed and not persisted. The driver asks the control
+///    plane to renew an expired identity, so a skewed host clock can never
+///    trigger implicit re-enrollment. A malformed identity fails closed with
+///    removal guidance.
 /// 2. The per-directory [`EnrollmentDraft`] is loaded or created: the same
 ///    operation ID and key material back every retry, so a lost response —
 ///    or a fresh key presented after the first one expired — recovers the
@@ -1033,8 +1047,9 @@ pub enum EnrollNowOutcome {
 /// - [`EnrollNowError::InvalidRegion`] — the declared region label is
 ///   malformed (checked before any request).
 /// - [`EnrollNowError::IdentityUnreadable`] / [`EnrollNowError::IdentityUnusable`]
-///   — an identity file exists but cannot be safely reused; refusing to guess
-///   beats silently re-enrolling over a live instance.
+///   / [`EnrollNowError::IdentityEnvironment`] — an identity file exists but
+///   cannot be safely reused; refusing to guess beats silently re-enrolling
+///   over a live instance.
 /// - [`EnrollNowError::Draft`] / [`EnrollNowError::Client`] /
 ///   [`EnrollNowError::Persist`] — local state or client construction
 ///   failures.
@@ -1082,24 +1097,24 @@ pub async fn enroll_now(
         source,
     })?;
     if let Some(identity) = existing {
-        if past_renewal_grace(&identity) {
-            tracing::warn!(
-                "Cloud Connect: the stored identity at {} expired past the renewal grace window; enrolling this instance again",
-                identity_path.display()
-            );
-        } else {
-            if let Some(reason) =
-                identity.reconnect_validation_error(config.gateway_endpoint.as_deref())
-            {
-                return Err(EnrollNowError::IdentityUnusable {
-                    path: identity_path,
-                    reason,
-                });
-            }
-            cleanup_enrollment_draft(&enrollment_transaction).await;
-            drop(enrollment_transaction);
-            return Ok(EnrollNowOutcome::AlreadyEnrolled { identity });
-        }
+        let (identity, _endpoint) =
+            crate::validate_reconnectable_credential_async(config, identity)
+                .await
+                .map_err(|error| match error {
+                    crate::Error::IdentityUnusable { reason, .. } => {
+                        EnrollNowError::IdentityUnusable {
+                            path: identity_path.clone(),
+                            reason: reason.to_string(),
+                        }
+                    }
+                    source => EnrollNowError::IdentityEnvironment {
+                        path: identity_path.clone(),
+                        source,
+                    },
+                })?;
+        cleanup_enrollment_draft(&enrollment_transaction).await;
+        drop(enrollment_transaction);
+        return Ok(EnrollNowOutcome::AlreadyEnrolled { identity });
     }
 
     if let Some(ref region) = config.instance_region
@@ -1181,15 +1196,14 @@ pub async fn enroll_now(
     // retryable draft. The operation is already committed under its
     // idempotency key, making this a terminal response error with support
     // guidance rather than an instruction to discard the draft.
-    if let Some(reason) = identity.reconnect_validation_error(config.gateway_endpoint.as_deref()) {
-        return Err(EnrollNowError::Rejected {
+    let (identity, _endpoint) = crate::validate_reconnectable_credential_async(config, identity)
+        .await
+        .map_err(|error| EnrollNowError::Rejected {
             source: Error::InvalidResponse {
                 url: client.enroll_url.clone(),
-                reason: format!("issued identity cannot reconnect: {reason}"),
+                reason: format!("issued identity cannot reconnect: {error}"),
             },
-        });
-    }
-
+        })?;
     let to_store = identity.clone();
     let store_path = config.identity_path.clone();
     let stored = tokio::task::spawn_blocking(move || IdentityStore::store(&store_path, &to_store))
@@ -1444,6 +1458,15 @@ mod tests {
             "an invalid response is not a credential revocation signal"
         );
 
+        let invalid_request = Error::InvalidRequest {
+            url: "not a URL".to_string(),
+        };
+        assert!(
+            invalid_request.is_terminal_enrollment_failure(),
+            "a locally invalid request cannot improve on retry"
+        );
+        assert!(!invalid_request.is_authoritative_rejection());
+
         let pop = Error::ProofOfPossession {
             reason: "key material generation failed".to_string(),
         };
@@ -1460,6 +1483,42 @@ mod tests {
             skew.to_string().contains("clock"),
             "the message must name the clock: {skew}"
         );
+    }
+
+    #[tokio::test]
+    async fn invalid_request_construction_is_terminal_without_network_retry() {
+        let client = EnrollClient::new(&test_config("http://127.0.0.1:9")).expect("client");
+        let invalid_url = "://not-a-url";
+        let request = client.http.get(invalid_url);
+        let Err(error) = client
+            .send::<EnrollResponseWire>(invalid_url, request, None)
+            .await
+        else {
+            panic!("an invalid URL must fail locally");
+        };
+
+        assert!(matches!(error, Error::InvalidRequest { .. }), "{error}");
+        assert!(error.is_terminal_enrollment_failure());
+    }
+
+    #[tokio::test]
+    async fn invalid_organization_header_is_terminal_and_redacted() {
+        let client = EnrollClient::new(&test_config("http://127.0.0.1:9")).expect("client");
+        let authority = EnrollmentAuthority::AuthenticatedSession {
+            access_token: SessionToken::new("session-secret-never-printed".to_string()),
+            org: "invalid\norganization".to_string(),
+        };
+        let material = IdentityStore::generate_enrollment().expect("enrollment material");
+        let error = client
+            .enroll(&authority, "test-operation", &material, &test_facts(), None)
+            .await
+            .expect_err("an invalid header must fail locally");
+
+        assert!(matches!(error, Error::InvalidRequest { .. }), "{error}");
+        assert!(error.is_terminal_enrollment_failure());
+        let rendered = error.to_string();
+        assert!(!rendered.contains("session-secret-never-printed"));
+        assert!(!rendered.contains("invalid\norganization"));
     }
 
     #[tokio::test]

--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -446,7 +446,6 @@ struct RenewRequest<'a> {
 #[derive(Deserialize)]
 struct RenewResponseWire {
     identity_cert_pem: String,
-    not_after: String,
 }
 
 /// Parsed result of a successful renewal (the CA bundle and gateway address
@@ -454,8 +453,6 @@ struct RenewResponseWire {
 #[derive(Debug)]
 pub struct RenewOutcome {
     pub identity_cert_pem: String,
-    /// New leaf expiry, Unix seconds.
-    pub not_after_unix: u64,
 }
 
 /// Error body shape the cloud endpoints return:
@@ -632,7 +629,6 @@ impl EnrollClient {
         };
         let builder = self.http.post(&self.renew_url).json(&request);
         let wire: RenewResponseWire = self.send(&self.renew_url, builder, None).await?;
-        let not_after_unix = parse_not_after(&self.renew_url, &wire.not_after)?;
         ensure_response_field(
             &self.renew_url,
             "identity_cert_pem",
@@ -640,7 +636,6 @@ impl EnrollClient {
         )?;
         Ok(RenewOutcome {
             identity_cert_pem: wire.identity_cert_pem,
-            not_after_unix,
         })
     }
 
@@ -1284,8 +1279,8 @@ pub(crate) fn sign_pop_payload(
     Ok(base64::engine::general_purpose::STANDARD.encode(signature.as_ref()))
 }
 
-/// Parse an RFC 3339 `not_after` timestamp from an enroll/renew response
-/// into Unix seconds.
+/// Parse an RFC 3339 `not_after` timestamp from an enroll response into Unix
+/// seconds. Renewal derives this value from the signed leaf instead.
 pub(crate) fn parse_not_after(url: &str, value: &str) -> Result<u64> {
     let parsed =
         chrono::DateTime::parse_from_rfc3339(value).map_err(|source| Error::InvalidResponse {
@@ -1402,6 +1397,17 @@ mod tests {
     fn parse_not_after_rejects_pre_epoch() {
         parse_not_after("http://test", "1899-01-01T00:00:00Z")
             .expect_err("pre-epoch timestamps cannot be a cert expiry");
+    }
+
+    #[test]
+    fn renewal_response_does_not_trust_the_unsigned_expiry_hint() {
+        let response: RenewResponseWire = serde_json::from_value(serde_json::json!({
+            "identity_cert_pem": "signed-leaf",
+            "not_after": "not-a-timestamp"
+        }))
+        .expect("the unsigned hint cannot reject a committed renewal");
+
+        assert_eq!(response.identity_cert_pem, "signed-leaf");
     }
 
     #[test]

--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -37,7 +37,10 @@ limitations under the License.
 use std::path::{Path, PathBuf};
 
 use base64::Engine as _;
-use rcgen::{CertificateParams, DnType, ExtendedKeyUsagePurpose, KeyPair, PublicKeyData};
+use rcgen::{
+    CertificateParams, CertificateSigningRequestParams, DnType, ExtendedKeyUsagePurpose, KeyPair,
+    PublicKeyData,
+};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use zeroize::Zeroizing;
@@ -323,6 +326,37 @@ impl Identity {
         {
             return Some("the gateway address is empty");
         }
+        match (
+            self.enc_private_key_pem.trim().is_empty(),
+            self.enc_public_key_pem.trim().is_empty(),
+        ) {
+            // Identities written before encrypted secret delivery carry
+            // neither field. They remain reconnectable and gain a keypair on
+            // their next scheduled renewal.
+            (true, true) => {}
+            (false, false) => {
+                let Ok(keypair) = cloud_connect_crypto::EncryptionKeypair::from_pkcs8_pem(
+                    &self.enc_private_key_pem,
+                ) else {
+                    return Some(
+                        "the secret-delivery private key is not valid X25519 key material",
+                    );
+                };
+                let Ok(public_key) = pem::parse(&self.enc_public_key_pem) else {
+                    return Some("the secret-delivery public key is not valid PEM");
+                };
+                if public_key.tag() != "PUBLIC KEY" {
+                    return Some("the secret-delivery public key has an invalid PEM label");
+                }
+                let Ok(expected_public_key) = pem::parse(keypair.public_key_spki_pem()) else {
+                    return Some("the secret-delivery public key could not be derived");
+                };
+                if public_key.contents() != expected_public_key.contents() {
+                    return Some("the secret-delivery public and private keys do not match");
+                }
+            }
+            _ => return Some("the secret-delivery keypair is incomplete"),
+        }
         None
     }
 
@@ -542,6 +576,68 @@ fn acquire_update_transaction(path: &Path) -> Result<crate::draft::EnrollmentTra
     })
 }
 
+fn acquire_removal_transaction(path: &Path) -> Result<crate::draft::EnrollmentTransactionLock> {
+    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    crate::draft::EnrollmentTransactionLock::acquire_for_removal(config_dir).map_err(|source| {
+        Error::UpdateTransaction {
+            path: path.to_path_buf(),
+            reason: source.to_string(),
+        }
+    })
+}
+
+/// Read a security-sensitive state file without following symlinks or opening
+/// a FIFO/device in blocking mode.
+///
+/// A missing path is the only absence case. Every other file-system object is
+/// rejected so a privileged bootstrap cannot be redirected outside its config
+/// directory or held indefinitely by a special file.
+pub(crate) fn read_regular_file_optional(path: &Path) -> std::io::Result<Option<String>> {
+    use std::io::Read as _;
+
+    #[cfg(unix)]
+    let mut file = {
+        use std::os::unix::fs::OpenOptionsExt as _;
+
+        let mut options = std::fs::OpenOptions::new();
+        options
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        match options.open(path) {
+            Ok(file) => file,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(source),
+        }
+    };
+
+    #[cfg(not(unix))]
+    let mut file = {
+        let metadata = match std::fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(source),
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "the state path must be a regular file",
+            ));
+        }
+        std::fs::OpenOptions::new().read(true).open(path)?
+    };
+
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the state path must be a regular file",
+        ));
+    }
+
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    Ok(Some(contents))
+}
+
 impl IdentityStore {
     /// Read an identity file, returning `Ok(None)` if it does not exist.
     ///
@@ -554,14 +650,14 @@ impl IdentityStore {
         cleanup_stale_identity_backups(path).context(IoSnafu {
             path: path.to_path_buf(),
         })?;
-        match std::fs::read_to_string(path) {
-            Ok(s) => {
+        match read_regular_file_optional(path) {
+            Ok(Some(s)) => {
                 let identity: Identity = serde_json::from_str(&s).context(ParseSnafu {
                     path: path.to_path_buf(),
                 })?;
                 Ok(Some(identity))
             }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Ok(None) => Ok(None),
             Err(err) => Err(Error::Io {
                 path: path.to_path_buf(),
                 source: err,
@@ -776,15 +872,42 @@ impl IdentityStore {
 
     /// Remove the identity file. No-op if it doesn't exist.
     ///
-    /// Takes [`write_lock`] to serialize with updates in this process. The
-    /// caller performing `spice connect remove` owns the config directory's
-    /// enrollment transaction before calling this method, which serializes the
-    /// removal with updates from another process.
+    /// Acquires the config directory's persistent enrollment transaction before
+    /// [`write_lock`], the same order used by every read-modify-write. This
+    /// serializes runtime revocation and remote removal with writers in another
+    /// process, preventing a stale writer from resurrecting the identity.
     ///
     /// # Errors
     ///
     /// Returns an error if the file exists but cannot be removed.
     pub fn clear(path: &Path) -> Result<()> {
+        let transaction = acquire_removal_transaction(path)?;
+        Self::clear_with_transaction(path, &transaction)
+    }
+
+    /// Remove the identity while the caller retains ownership of the config
+    /// directory's enrollment transaction.
+    ///
+    /// This is the non-recursive removal path for `spice connect remove`, which
+    /// owns one transaction across the identity, draft, endpoint, cached
+    /// secrets, and installed service. The transaction must protect the same
+    /// config directory as `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the transaction belongs to another directory or
+    /// when the identity file exists but cannot be removed.
+    pub fn clear_with_transaction(
+        path: &Path,
+        transaction: &crate::draft::EnrollmentTransactionLock,
+    ) -> Result<()> {
+        if !transaction.protects(path) {
+            return Err(Error::UpdateTransaction {
+                path: path.to_path_buf(),
+                reason: "the held enrollment transaction belongs to another config directory"
+                    .to_string(),
+            });
+        }
         let _guard = write_lock();
         Self::clear_locked(path)
     }
@@ -905,6 +1028,53 @@ pub struct EnrollmentMaterial {
     /// X25519 encryption public key (RFC 8410 SPKI PEM); sent as the
     /// enroll request's `enc_pubkey_pem`.
     pub enc_public_key_pem: String,
+}
+
+impl EnrollmentMaterial {
+    /// Why persisted enrollment material is not safe to replay, if any.
+    ///
+    /// Every reason is deliberately independent of the key bytes so a corrupt
+    /// draft can be diagnosed without reproducing credential material.
+    pub(crate) fn validation_error(&self) -> Option<&'static str> {
+        let Ok(private_key) = KeyPair::from_pem(&self.private_key_pem) else {
+            return Some("the identity private key is not valid PKCS key material");
+        };
+        let Ok(public_key) = pem::parse(&self.public_key_pem) else {
+            return Some("the identity public key is not valid PEM");
+        };
+        if public_key.tag() != "PUBLIC KEY" {
+            return Some("the identity public key has an invalid PEM label");
+        }
+        if public_key.contents() != private_key.subject_public_key_info().as_slice() {
+            return Some("the identity public and private keys do not match");
+        }
+
+        let Ok(csr) = CertificateSigningRequestParams::from_pem(&self.csr_pem) else {
+            return Some("the certificate request is invalid or has a bad self-signature");
+        };
+        if csr.public_key.der_bytes() != private_key.der_bytes() {
+            return Some("the certificate request and identity private key do not match");
+        }
+
+        let Ok(enc_keypair) =
+            cloud_connect_crypto::EncryptionKeypair::from_pkcs8_pem(&self.enc_private_key_pem)
+        else {
+            return Some("the secret-delivery private key is not valid X25519 key material");
+        };
+        let Ok(enc_public_key) = pem::parse(&self.enc_public_key_pem) else {
+            return Some("the secret-delivery public key is not valid PEM");
+        };
+        if enc_public_key.tag() != "PUBLIC KEY" {
+            return Some("the secret-delivery public key has an invalid PEM label");
+        }
+        let Ok(expected_enc_public_key) = pem::parse(enc_keypair.public_key_spki_pem()) else {
+            return Some("the secret-delivery public key could not be derived");
+        };
+        if enc_public_key.contents() != expected_enc_public_key.contents() {
+            return Some("the secret-delivery public and private keys do not match");
+        }
+        None
+    }
 }
 
 impl std::fmt::Debug for EnrollmentMaterial {
@@ -1213,6 +1383,8 @@ mod tests {
             .expect("build sample identity certificate parameters")
             .self_signed(&key_pair)
             .expect("sign sample identity certificate");
+        let encryption_keypair = cloud_connect_crypto::EncryptionKeypair::generate()
+            .expect("generate sample encryption key");
         Identity {
             identifier: "inst_test".to_string(),
             identity_cert_pem: certificate.pem(),
@@ -1226,10 +1398,8 @@ mod tests {
             org_name: None,
             app_name: None,
             monitor_url: None,
-            enc_private_key_pem:
-                "-----BEGIN PRIVATE KEY-----\nMOCKENC\n-----END PRIVATE KEY-----\n".to_string(),
-            enc_public_key_pem: "-----BEGIN PUBLIC KEY-----\nMOCKENC\n-----END PUBLIC KEY-----\n"
-                .to_string(),
+            enc_private_key_pem: encryption_keypair.to_pkcs8_pem().to_string(),
+            enc_public_key_pem: encryption_keypair.public_key_spki_pem(),
             enc_previous_private_key_pem: String::new(),
             cache_key_b64: String::new(),
         }
@@ -1297,6 +1467,43 @@ mod tests {
         assert_eq!(
             identity.reconnect_validation_error(None),
             Some("the client identity public and private keys do not match")
+        );
+    }
+
+    #[test]
+    fn reconnect_validation_rejects_a_mismatched_encryption_keypair() {
+        let mut identity = sample_identity();
+        identity.enc_public_key_pem = cloud_connect_crypto::EncryptionKeypair::generate()
+            .expect("generate mismatched encryption key")
+            .public_key_spki_pem();
+
+        assert_eq!(
+            identity.reconnect_validation_error(None),
+            Some("the secret-delivery public and private keys do not match")
+        );
+    }
+
+    #[test]
+    fn enrollment_material_validation_binds_both_keypairs_and_the_csr() {
+        let material = IdentityStore::generate_enrollment().expect("generate material");
+        assert_eq!(material.validation_error(), None);
+
+        let mut mismatched_csr = material.clone();
+        mismatched_csr.csr_pem = IdentityStore::generate_enrollment()
+            .expect("generate mismatched CSR")
+            .csr_pem;
+        assert_eq!(
+            mismatched_csr.validation_error(),
+            Some("the certificate request and identity private key do not match")
+        );
+
+        let mut mismatched_encryption_key = material;
+        mismatched_encryption_key.enc_public_key_pem = IdentityStore::generate_enrollment()
+            .expect("generate mismatched encryption key")
+            .enc_public_key_pem;
+        assert_eq!(
+            mismatched_encryption_key.validation_error(),
+            Some("the secret-delivery public and private keys do not match")
         );
     }
 
@@ -1809,9 +2016,9 @@ mod tests {
     }
 
     /// A release racing attachment updates must win, exactly as it does for
-    /// app-id updates: both writers take the same lock, so the file is either
-    /// removed before the read (nothing to update) or after the write (removed
-    /// again).
+    /// app-id updates: both mutations take the same persistent transaction, so
+    /// an update either lands before removal, observes the removed file after
+    /// it, or is explicitly rejected while removal owns the directory.
     #[test]
     fn a_release_wins_over_concurrent_attachment_updates() {
         let dir = tempfile::tempdir().expect("create tempdir");
@@ -1825,7 +2032,13 @@ mod tests {
                         app_id: format!("400{i}"),
                         ..sample_attachment()
                     };
-                    IdentityStore::set_attachment(&path, Some(&attachment)).expect("attach");
+                    if let Err(error) = IdentityStore::set_attachment(&path, Some(&attachment)) {
+                        assert!(
+                            error.to_string().contains("Another live process"),
+                            "{error}"
+                        );
+                        break;
+                    }
                 }
             });
             IdentityStore::clear(&path).expect("clear");
@@ -1922,8 +2135,8 @@ mod tests {
     /// A release racing app-id updates must win: `store_app_id` reads the file
     /// and writes it back, so a removal landing between the two would be undone
     /// and the instance would keep talking to a control plane that released it.
-    /// Both sides take the same writer lock, which leaves only the two orderings
-    /// where the file ends up gone.
+    /// Both sides take the same persistent transaction, so a racing update may
+    /// be rejected, but no ordering can recreate the file after removal.
     #[test]
     fn a_release_wins_over_concurrent_app_id_updates() {
         let dir = tempfile::tempdir().expect("create tempdir");
@@ -1933,7 +2146,13 @@ mod tests {
         std::thread::scope(|scope| {
             let updater = scope.spawn(|| {
                 for i in 0..200 {
-                    IdentityStore::store_app_id(&path, &format!("400{i}")).expect("store app id");
+                    if let Err(error) = IdentityStore::store_app_id(&path, &format!("400{i}")) {
+                        assert!(
+                            error.to_string().contains("Another live process"),
+                            "{error}"
+                        );
+                        break;
+                    }
                 }
             });
             IdentityStore::clear(&path).expect("clear");
@@ -2080,6 +2299,8 @@ mod tests {
             .expect("store after removal transaction")
             .expect("identity remains");
         assert_eq!(merged.private_key_pem, "ROTATED-KEY");
+        IdentityStore::clear(&path).expect("clear after transaction ownership is released");
+        assert!(IdentityStore::load_optional(&path).expect("load").is_none());
     }
 
     #[test]
@@ -2133,6 +2354,55 @@ mod tests {
         let path = dir.path().join("does-not-exist.json");
         let loaded = IdentityStore::load_optional(&path).expect("load");
         assert!(loaded.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_reads_reject_symlinks_without_reading_the_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let target = dir.path().join("outside.json");
+        let path = dir.path().join("identity.json");
+        std::fs::write(&target, "sensitive target").expect("write target");
+        symlink(&target, &path).expect("create identity symlink");
+
+        let error = IdentityStore::load_optional(&path).expect_err("symlink must be rejected");
+        assert!(matches!(error, Error::Io { .. }), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(target).expect("target remains readable"),
+            "sensitive target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_reads_reject_fifos_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt as _;
+        use std::os::unix::fs::FileTypeExt as _;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        let path_c = CString::new(path.as_os_str().as_bytes()).expect("FIFO path has no NUL");
+        // SAFETY: `path_c` is a valid NUL-terminated path and `0o600` is a
+        // valid mode. `mkfifo` retains neither argument.
+        let result = unsafe { libc::mkfifo(path_c.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "create FIFO: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let error = IdentityStore::load_optional(&path).expect_err("FIFO must be rejected");
+        assert!(matches!(error, Error::Io { .. }), "{error}");
+        assert!(
+            std::fs::metadata(path)
+                .expect("FIFO metadata")
+                .file_type()
+                .is_fifo()
+        );
     }
 
     /// An identity file written before the encryption keyring and cache key

--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -90,6 +90,18 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Result of a credential read-modify-write under the enrollment transaction.
+#[derive(Debug)]
+pub enum CredentialUpdateOutcome {
+    /// The update matched the durable generation and was stored.
+    Stored(Identity),
+    /// A newer enrollment or renewal was already durable, so the stale update
+    /// was rejected and the durable winner is returned to the caller.
+    Superseded(Identity),
+    /// Removal won the transaction and no identity remains.
+    Missing,
+}
+
 /// Persisted runtime identity. Treat as opaque outside this crate.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Identity {
@@ -637,6 +649,12 @@ fn acquire_removal_transaction(path: &Path) -> Result<crate::draft::EnrollmentTr
 pub(crate) fn read_regular_file_optional(path: &Path) -> std::io::Result<Option<String>> {
     use std::io::Read as _;
 
+    match validate_state_path_ancestors(path) {
+        Ok(()) => {}
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(source),
+    }
+
     #[cfg(unix)]
     let mut file = {
         use std::os::unix::fs::OpenOptionsExt as _;
@@ -695,6 +713,90 @@ pub(crate) fn read_regular_file_optional(path: &Path) -> std::io::Result<Option<
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
     Ok(Some(contents))
+}
+
+/// Reject a state path whose parent traversal can be redirected by an
+/// untrusted symlink or reparse point.
+///
+/// Unix has a small set of root-owned compatibility links in otherwise
+/// immutable directories (`/var` and `/tmp` on macOS are common examples).
+/// Those links cannot be replaced by the process running Spice and are safe to
+/// traverse. Every other symlink is rejected, including a root-owned link in a
+/// user-writable directory. The final component is still opened with
+/// `O_NOFOLLOW`, closing the leaf race after this full-path validation.
+#[cfg(unix)]
+fn validate_state_path_ancestors(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let Some(parent) = absolute.parent() else {
+        return Ok(());
+    };
+    let mut current = PathBuf::new();
+    for component in parent.components() {
+        current.push(component.as_os_str());
+        let metadata = std::fs::symlink_metadata(&current)?;
+        if !metadata.file_type().is_symlink() {
+            continue;
+        }
+        let containing = current.parent().unwrap_or_else(|| Path::new("/"));
+        let containing_metadata = std::fs::metadata(containing)?;
+        let trusted_system_link = metadata.uid() == 0
+            && containing_metadata.uid() == 0
+            && containing_metadata.permissions().mode() & 0o022 == 0;
+        if !trusted_system_link {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "the state path has an untrusted symlink ancestor: {}",
+                    current.display()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn validate_state_path_ancestors(path: &Path) -> std::io::Result<()> {
+    use std::os::windows::fs::MetadataExt as _;
+
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let Some(parent) = absolute.parent() else {
+        return Ok(());
+    };
+    let mut current = PathBuf::new();
+    for component in parent.components() {
+        current.push(component.as_os_str());
+        let metadata = std::fs::symlink_metadata(&current)?;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "the state path has a reparse-point ancestor: {}",
+                    current.display()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn validate_state_path_ancestors(_path: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "secure state-file reads are unsupported on this platform",
+    ))
 }
 
 impl IdentityStore {
@@ -922,8 +1024,11 @@ impl IdentityStore {
     /// is owned by control commands and can be newer on disk, so every such
     /// full identity update must merge it while holding [`write_lock`].
     ///
-    /// Returns `Ok(None)` when the identity was removed before the write and
-    /// does not recreate it.
+    /// `expected_identifier` and `expected_public_key_pem` fence the durable
+    /// credential generation the caller cloned before a long-running request.
+    /// A removal followed by re-enrollment can therefore win the transaction
+    /// without a queued stale update overwriting the replacement. Missing and
+    /// superseded generations are reported without writing.
     ///
     /// # Errors
     ///
@@ -931,13 +1036,20 @@ impl IdentityStore {
     /// merged identity cannot be written.
     pub fn store_credential_update(
         path: &Path,
+        expected_identifier: &str,
+        expected_public_key_pem: &str,
         credential_update: &Identity,
-    ) -> Result<Option<Identity>> {
+    ) -> Result<CredentialUpdateOutcome> {
         let _transaction = acquire_update_transaction(path)?;
         let _guard = write_lock();
         let Some(current) = Self::load_optional(path)? else {
-            return Ok(None);
+            return Ok(CredentialUpdateOutcome::Missing);
         };
+        if current.identifier != expected_identifier
+            || current.public_key_pem != expected_public_key_pem
+        {
+            return Ok(CredentialUpdateOutcome::Superseded(current));
+        }
         let mut merged = credential_update.clone();
         // The whole attachment tuple, not just the app id: a command handler
         // may have written any of these after the caller cloned its identity,
@@ -947,7 +1059,7 @@ impl IdentityStore {
         merged.app_name = current.app_name;
         merged.monitor_url = current.monitor_url;
         Self::store_locked(path, &merged)?;
-        Ok(Some(merged))
+        Ok(CredentialUpdateOutcome::Stored(merged))
     }
 
     /// The write itself, with the caller already holding [`write_lock`].
@@ -1041,7 +1153,9 @@ impl IdentityStore {
     /// The removal itself, with the caller already holding [`write_lock`].
     fn clear_locked(path: &Path) -> Result<()> {
         match std::fs::remove_file(path) {
-            Ok(()) => Ok(()),
+            Ok(()) => sync_parent_directory(path).context(IoSnafu {
+                path: path.to_path_buf(),
+            }),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(err) => Err(Error::Io {
                 path: path.to_path_buf(),
@@ -2309,9 +2423,15 @@ mod tests {
             rotated.app_id, None,
             "the renewal clone is stale by construction"
         );
-        let merged = IdentityStore::store_credential_update(&path, &rotated)
-            .expect("store rotated")
-            .expect("identity still present");
+        let CredentialUpdateOutcome::Stored(merged) = IdentityStore::store_credential_update(
+            &path,
+            &identity.identifier,
+            &identity.public_key_pem,
+            &rotated,
+        )
+        .expect("store rotated") else {
+            panic!("the expected credential generation must still be present");
+        };
 
         let loaded = IdentityStore::load_optional(&path)
             .expect("load")
@@ -2335,11 +2455,17 @@ mod tests {
             .expect("present");
         IdentityStore::set_attachment(&path, Some(&sample_attachment())).expect("attach");
 
-        let mut rotated = stale;
+        let mut rotated = stale.clone();
         rotated.private_key_pem = "ROTATED-KEY".to_string();
-        let merged = IdentityStore::store_credential_update(&path, &rotated)
-            .expect("store rotated")
-            .expect("identity still present");
+        let CredentialUpdateOutcome::Stored(merged) = IdentityStore::store_credential_update(
+            &path,
+            &stale.identifier,
+            &stale.public_key_pem,
+            &rotated,
+        )
+        .expect("store rotated") else {
+            panic!("the expected credential generation must still be present");
+        };
 
         let loaded = IdentityStore::load_optional(&path)
             .expect("load")
@@ -2363,11 +2489,47 @@ mod tests {
         IdentityStore::store(&path, &identity).expect("store");
         IdentityStore::clear(&path).expect("remove");
 
-        let stored = IdentityStore::store_credential_update(&path, &identity)
-            .expect("credential update is a no-op");
+        let stored = IdentityStore::store_credential_update(
+            &path,
+            &identity.identifier,
+            &identity.public_key_pem,
+            &identity,
+        )
+        .expect("credential update is a no-op");
 
-        assert!(stored.is_none());
+        assert!(matches!(stored, CredentialUpdateOutcome::Missing));
         assert!(IdentityStore::load_optional(&path).expect("load").is_none());
+    }
+
+    #[test]
+    fn credential_update_cannot_overwrite_a_replacement_identity() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        let stale = sample_identity();
+        IdentityStore::store(&path, &stale).expect("store original identity");
+
+        let mut stale_update = stale.clone();
+        stale_update.private_key_pem = "STALE-ROTATED-KEY".to_string();
+        let replacement = sample_identity();
+        IdentityStore::store(&path, &replacement).expect("publish replacement identity");
+
+        let outcome = IdentityStore::store_credential_update(
+            &path,
+            &stale.identifier,
+            &stale.public_key_pem,
+            &stale_update,
+        )
+        .expect("reject stale update without losing the replacement");
+        let CredentialUpdateOutcome::Superseded(winner) = outcome else {
+            panic!("a new credential generation must supersede the stale update");
+        };
+
+        assert_eq!(winner.public_key_pem, replacement.public_key_pem);
+        let durable = IdentityStore::load_optional(&path)
+            .expect("load replacement")
+            .expect("replacement remains present");
+        assert_eq!(durable.public_key_pem, replacement.public_key_pem);
+        assert_eq!(durable.private_key_pem, replacement.private_key_pem);
     }
 
     #[test]
@@ -2382,8 +2544,13 @@ mod tests {
 
         let mut rotated = identity.clone();
         rotated.private_key_pem = "ROTATED-KEY".to_string();
-        let credential_error = IdentityStore::store_credential_update(&path, &rotated)
-            .expect_err("credential update must not overlap removal");
+        let credential_error = IdentityStore::store_credential_update(
+            &path,
+            &identity.identifier,
+            &identity.public_key_pem,
+            &rotated,
+        )
+        .expect_err("credential update must not overlap removal");
         let app_id_error = IdentityStore::set_app_id(&path, Some("4002"))
             .expect_err("app id update must not overlap removal");
         let attachment = AppAttachment {
@@ -2418,9 +2585,15 @@ mod tests {
         assert_eq!(stored.app_id, None);
 
         drop(removal);
-        let merged = IdentityStore::store_credential_update(&path, &rotated)
-            .expect("store after removal transaction")
-            .expect("identity remains");
+        let CredentialUpdateOutcome::Stored(merged) = IdentityStore::store_credential_update(
+            &path,
+            &identity.identifier,
+            &identity.public_key_pem,
+            &rotated,
+        )
+        .expect("store after removal transaction") else {
+            panic!("the original credential generation remains");
+        };
         assert_eq!(merged.private_key_pem, "ROTATED-KEY");
         IdentityStore::clear(&path).expect("clear after transaction ownership is released");
         assert!(IdentityStore::load_optional(&path).expect("load").is_none());
@@ -2512,6 +2685,29 @@ mod tests {
         symlink(&target, &path).expect("create identity symlink");
 
         let error = IdentityStore::load_optional(&path).expect_err("symlink must be rejected");
+        assert!(matches!(error, Error::Io { .. }), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(target).expect("target remains readable"),
+            "sensitive target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_reads_reject_an_untrusted_symlink_ancestor() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir(&outside).expect("create target directory");
+        let target = outside.join("identity.json");
+        std::fs::write(&target, "sensitive target").expect("write target");
+        let redirected_parent = dir.path().join("redirected-config");
+        symlink(&outside, &redirected_parent).expect("create parent symlink");
+
+        let error = IdentityStore::load_optional(&redirected_parent.join("identity.json"))
+            .expect_err("a state path with an untrusted symlink ancestor must be rejected");
+
         assert!(matches!(error, Error::Io { .. }), "{error}");
         assert_eq!(
             std::fs::read_to_string(target).expect("target remains readable"),

--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -34,10 +34,16 @@ limitations under the License.
 //! between the runtime and the local filesystem. Other Spice tooling
 //! should treat it as opaque.
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use base64::Engine as _;
-use rcgen::{CertificateParams, DnType, ExtendedKeyUsagePurpose, KeyPair, PublicKeyData};
+use rcgen::{
+    CertificateParams, CertificateSigningRequestParams, DnType, ExtendedKeyUsagePurpose, KeyPair,
+    PublicKeyData,
+};
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use zeroize::Zeroizing;
@@ -52,7 +58,12 @@ pub enum Error {
         source: std::io::Error,
     },
 
-    #[snafu(display("Failed to parse identity JSON at {}: {source}", path.display()))]
+    #[snafu(display(
+        "Failed to parse identity JSON at {} (line {}, column {})",
+        path.display(),
+        source.line(),
+        source.column()
+    ))]
     Parse {
         path: PathBuf,
         source: serde_json::Error,
@@ -270,6 +281,24 @@ where
 }
 
 impl Identity {
+    pub(crate) fn certificate_validity_unix(&self) -> Result<(i64, i64), &'static str> {
+        let certificate_pem = pem::parse(&self.identity_cert_pem)
+            .map_err(|_| "the client identity certificate is not valid PEM")?;
+        if certificate_pem.tag() != "CERTIFICATE" {
+            return Err("the client identity certificate has an invalid PEM label");
+        }
+        let (remaining, certificate) =
+            x509_parser::prelude::parse_x509_certificate(certificate_pem.contents())
+                .map_err(|_| "the client identity certificate is not valid X.509")?;
+        if !remaining.is_empty() {
+            return Err("the client identity certificate has trailing DER data");
+        }
+        Ok((
+            certificate.validity().not_before.timestamp(),
+            certificate.validity().not_after.timestamp(),
+        ))
+    }
+
     /// Why this identity cannot establish a control stream, if any.
     ///
     /// Enrollment uses this as a fail-closed gate before honoring the
@@ -323,24 +352,76 @@ impl Identity {
         {
             return Some("the gateway address is empty");
         }
+        match (
+            self.enc_private_key_pem.trim().is_empty(),
+            self.enc_public_key_pem.trim().is_empty(),
+        ) {
+            // Identities written before encrypted secret delivery carry
+            // neither field. They remain reconnectable and gain a keypair on
+            // their next scheduled renewal.
+            (true, true) => {}
+            (false, false) => {
+                let Ok(keypair) = cloud_connect_crypto::EncryptionKeypair::from_pkcs8_pem(
+                    &self.enc_private_key_pem,
+                ) else {
+                    return Some(
+                        "the secret-delivery private key is not valid X25519 key material",
+                    );
+                };
+                let Ok(public_key) = pem::parse(&self.enc_public_key_pem) else {
+                    return Some("the secret-delivery public key is not valid PEM");
+                };
+                if public_key.tag() != "PUBLIC KEY" {
+                    return Some("the secret-delivery public key has an invalid PEM label");
+                }
+                let Ok(expected_public_key) = pem::parse(keypair.public_key_spki_pem()) else {
+                    return Some("the secret-delivery public key could not be derived");
+                };
+                if public_key.contents() != expected_public_key.contents() {
+                    return Some("the secret-delivery public and private keys do not match");
+                }
+            }
+            _ => return Some("the secret-delivery keypair is incomplete"),
+        }
         None
+    }
+
+    /// The signed certificate expiry, falling back to the cached response value
+    /// only when a legacy certificate cannot be parsed.
+    #[must_use]
+    pub fn effective_not_after_unix(&self) -> Option<u64> {
+        self.certificate_validity_unix()
+            .ok()
+            .and_then(|(_, not_after)| u64::try_from(not_after).ok())
+            .or(self.not_after_unix)
     }
 
     /// Returns `true` if the identity has an expiry that is in the past
     /// relative to the system clock. An identity with no expiry never expires.
     #[must_use]
     pub fn is_expired(&self) -> bool {
-        let Some(not_after) = self.not_after_unix else {
-            return false;
-        };
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| d.as_secs());
+        let not_after = self.effective_not_after_unix().map(i128::from);
+        let Some(not_after) = not_after else {
+            return false;
+        };
         // Treat the cert as expired *at* `not_after`, not only strictly after
         // it: the field is defined as the timestamp after which the server no
         // longer accepts the credential, so the boundary second should
         // already be considered past the NotAfter limit.
-        now >= not_after
+        i128::from(now) >= not_after
+    }
+
+    /// Returns `true` when the signed certificate validity interval starts in
+    /// the future relative to the system clock.
+    #[must_use]
+    pub fn is_not_yet_valid(&self) -> bool {
+        self.certificate_validity_unix()
+            .is_ok_and(|(not_before, _)| {
+                i128::from(crate::heartbeat::now_unix()) < i128::from(not_before)
+            })
     }
 
     /// The encryption keys a sealed payload may be addressed to: the current
@@ -542,6 +623,85 @@ fn acquire_update_transaction(path: &Path) -> Result<crate::draft::EnrollmentTra
     })
 }
 
+fn acquire_removal_transaction(path: &Path) -> Result<crate::draft::EnrollmentTransactionLock> {
+    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    crate::draft::EnrollmentTransactionLock::acquire_for_removal(config_dir).map_err(|source| {
+        Error::UpdateTransaction {
+            path: path.to_path_buf(),
+            reason: source.to_string(),
+        }
+    })
+}
+
+/// Read a security-sensitive state file without following symlinks or opening
+/// a FIFO/device in blocking mode.
+///
+/// A missing path is the only absence case. Every other file-system object is
+/// rejected so a privileged bootstrap cannot be redirected outside its config
+/// directory or held indefinitely by a special file.
+pub(crate) fn read_regular_file_optional(path: &Path) -> std::io::Result<Option<String>> {
+    use std::io::Read as _;
+
+    #[cfg(unix)]
+    let mut file = {
+        use std::os::unix::fs::OpenOptionsExt as _;
+
+        let mut options = std::fs::OpenOptions::new();
+        options
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        match options.open(path) {
+            Ok(file) => file,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(source),
+        }
+    };
+
+    #[cfg(windows)]
+    let mut file = {
+        use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
+
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        let file = match std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)
+        {
+            Ok(file) => file,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(source),
+        };
+        let metadata = file.metadata()?;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 || !metadata.is_file() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "the state path must be a regular file",
+            ));
+        }
+        file
+    };
+
+    #[cfg(not(any(unix, windows)))]
+    let mut file = {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "secure state-file reads are unsupported on this platform",
+        ));
+    };
+
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the state path must be a regular file",
+        ));
+    }
+
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    Ok(Some(contents))
+}
+
 impl IdentityStore {
     /// Read an identity file, returning `Ok(None)` if it does not exist.
     ///
@@ -554,19 +714,37 @@ impl IdentityStore {
         cleanup_stale_identity_backups(path).context(IoSnafu {
             path: path.to_path_buf(),
         })?;
-        match std::fs::read_to_string(path) {
-            Ok(s) => {
+        match read_regular_file_optional(path) {
+            Ok(Some(s)) => {
                 let identity: Identity = serde_json::from_str(&s).context(ParseSnafu {
                     path: path.to_path_buf(),
                 })?;
                 Ok(Some(identity))
             }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Ok(None) => Ok(None),
             Err(err) => Err(Error::Io {
                 path: path.to_path_buf(),
                 source: err,
             }),
         }
+    }
+
+    /// Async wrapper around [`Self::load_optional`] for Tokio call sites.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::load_optional`]. A failed blocking
+    /// task is reported as an I/O error without exposing identity contents.
+    pub async fn load_optional_async(path: PathBuf) -> Result<Option<Identity>> {
+        let task_path = path.clone();
+        tokio::task::spawn_blocking(move || Self::load_optional(&task_path))
+            .await
+            .unwrap_or_else(|join| {
+                Err(Error::Io {
+                    path,
+                    source: std::io::Error::other(format!("identity load task panicked: {join}")),
+                })
+            })
     }
 
     /// Persist an identity to disk atomically with `0600` perms on Unix.
@@ -776,17 +954,60 @@ impl IdentityStore {
 
     /// Remove the identity file. No-op if it doesn't exist.
     ///
-    /// Takes [`write_lock`] to serialize with updates in this process. The
-    /// caller performing `spice connect remove` owns the config directory's
-    /// enrollment transaction before calling this method, which serializes the
-    /// removal with updates from another process.
+    /// Acquires the config directory's persistent enrollment transaction before
+    /// [`write_lock`], the same order used by every read-modify-write. This
+    /// serializes runtime revocation and remote removal with writers in another
+    /// process, preventing a stale writer from resurrecting the identity.
     ///
     /// # Errors
     ///
     /// Returns an error if the file exists but cannot be removed.
     pub fn clear(path: &Path) -> Result<()> {
+        let transaction = acquire_removal_transaction(path)?;
+        Self::clear_with_transaction(path, &transaction)
+    }
+
+    /// Remove the identity while the caller retains ownership of the config
+    /// directory's enrollment transaction.
+    ///
+    /// This is the non-recursive removal path for `spice connect remove`, which
+    /// owns one transaction across the identity, draft, endpoint, cached
+    /// secrets, and installed service. The transaction must protect the same
+    /// config directory as `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the transaction belongs to another directory or
+    /// when the identity file exists but cannot be removed.
+    pub fn clear_with_transaction(
+        path: &Path,
+        transaction: &crate::draft::EnrollmentTransactionLock,
+    ) -> Result<()> {
+        if !transaction.protects(path) {
+            return Err(Error::UpdateTransaction {
+                path: path.to_path_buf(),
+                reason: "the held enrollment transaction belongs to another config directory"
+                    .to_string(),
+            });
+        }
         let _guard = write_lock();
         Self::clear_locked(path)
+    }
+
+    /// Async variant of [`Self::clear_with_transaction`] for a caller that
+    /// already owns the config directory's enrollment transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::clear_with_transaction`], or an error
+    /// when the blocking task carrying the removal panics.
+    pub async fn clear_with_transaction_async(
+        path: PathBuf,
+        transaction: Arc<crate::draft::EnrollmentTransactionLock>,
+    ) -> Result<()> {
+        tokio::task::spawn_blocking(move || Self::clear_with_transaction(&path, &transaction))
+            .await
+            .map_err(|source| Error::ClearTaskPanicked { source })?
     }
 
     /// Async variant of [`IdentityStore::clear`] for use on the Tokio driver
@@ -905,6 +1126,53 @@ pub struct EnrollmentMaterial {
     /// X25519 encryption public key (RFC 8410 SPKI PEM); sent as the
     /// enroll request's `enc_pubkey_pem`.
     pub enc_public_key_pem: String,
+}
+
+impl EnrollmentMaterial {
+    /// Why persisted enrollment material is not safe to replay, if any.
+    ///
+    /// Every reason is deliberately independent of the key bytes so a corrupt
+    /// draft can be diagnosed without reproducing credential material.
+    pub(crate) fn validation_error(&self) -> Option<&'static str> {
+        let Ok(private_key) = KeyPair::from_pem(&self.private_key_pem) else {
+            return Some("the identity private key is not valid PKCS key material");
+        };
+        let Ok(public_key) = pem::parse(&self.public_key_pem) else {
+            return Some("the identity public key is not valid PEM");
+        };
+        if public_key.tag() != "PUBLIC KEY" {
+            return Some("the identity public key has an invalid PEM label");
+        }
+        if public_key.contents() != private_key.subject_public_key_info().as_slice() {
+            return Some("the identity public and private keys do not match");
+        }
+
+        let Ok(csr) = CertificateSigningRequestParams::from_pem(&self.csr_pem) else {
+            return Some("the certificate request is invalid or has a bad self-signature");
+        };
+        if csr.public_key.der_bytes() != private_key.der_bytes() {
+            return Some("the certificate request and identity private key do not match");
+        }
+
+        let Ok(enc_keypair) =
+            cloud_connect_crypto::EncryptionKeypair::from_pkcs8_pem(&self.enc_private_key_pem)
+        else {
+            return Some("the secret-delivery private key is not valid X25519 key material");
+        };
+        let Ok(enc_public_key) = pem::parse(&self.enc_public_key_pem) else {
+            return Some("the secret-delivery public key is not valid PEM");
+        };
+        if enc_public_key.tag() != "PUBLIC KEY" {
+            return Some("the secret-delivery public key has an invalid PEM label");
+        }
+        let Ok(expected_enc_public_key) = pem::parse(enc_keypair.public_key_spki_pem()) else {
+            return Some("the secret-delivery public key could not be derived");
+        };
+        if enc_public_key.contents() != expected_enc_public_key.contents() {
+            return Some("the secret-delivery public and private keys do not match");
+        }
+        None
+    }
 }
 
 impl std::fmt::Debug for EnrollmentMaterial {
@@ -1213,6 +1481,8 @@ mod tests {
             .expect("build sample identity certificate parameters")
             .self_signed(&key_pair)
             .expect("sign sample identity certificate");
+        let encryption_keypair = cloud_connect_crypto::EncryptionKeypair::generate()
+            .expect("generate sample encryption key");
         Identity {
             identifier: "inst_test".to_string(),
             identity_cert_pem: certificate.pem(),
@@ -1226,13 +1496,27 @@ mod tests {
             org_name: None,
             app_name: None,
             monitor_url: None,
-            enc_private_key_pem:
-                "-----BEGIN PRIVATE KEY-----\nMOCKENC\n-----END PRIVATE KEY-----\n".to_string(),
-            enc_public_key_pem: "-----BEGIN PUBLIC KEY-----\nMOCKENC\n-----END PUBLIC KEY-----\n"
-                .to_string(),
+            enc_private_key_pem: encryption_keypair.to_pkcs8_pem().to_string(),
+            enc_public_key_pem: encryption_keypair.public_key_spki_pem(),
             enc_previous_private_key_pem: String::new(),
             cache_key_b64: String::new(),
         }
+    }
+
+    fn set_sample_certificate_validity(
+        identity: &mut Identity,
+        not_before: (i32, u8, u8),
+        not_after: (i32, u8, u8),
+    ) {
+        let key_pair = KeyPair::from_pem(&identity.private_key_pem).expect("parse identity key");
+        let mut params = CertificateParams::new(Vec::<String>::new())
+            .expect("build sample identity certificate parameters");
+        params.not_before = rcgen::date_time_ymd(not_before.0, not_before.1, not_before.2);
+        params.not_after = rcgen::date_time_ymd(not_after.0, not_after.1, not_after.2);
+        identity.identity_cert_pem = params
+            .self_signed(&key_pair)
+            .expect("sign sample identity certificate")
+            .pem();
     }
 
     #[test]
@@ -1297,6 +1581,43 @@ mod tests {
         assert_eq!(
             identity.reconnect_validation_error(None),
             Some("the client identity public and private keys do not match")
+        );
+    }
+
+    #[test]
+    fn reconnect_validation_rejects_a_mismatched_encryption_keypair() {
+        let mut identity = sample_identity();
+        identity.enc_public_key_pem = cloud_connect_crypto::EncryptionKeypair::generate()
+            .expect("generate mismatched encryption key")
+            .public_key_spki_pem();
+
+        assert_eq!(
+            identity.reconnect_validation_error(None),
+            Some("the secret-delivery public and private keys do not match")
+        );
+    }
+
+    #[test]
+    fn enrollment_material_validation_binds_both_keypairs_and_the_csr() {
+        let material = IdentityStore::generate_enrollment().expect("generate material");
+        assert_eq!(material.validation_error(), None);
+
+        let mut mismatched_csr = material.clone();
+        mismatched_csr.csr_pem = IdentityStore::generate_enrollment()
+            .expect("generate mismatched CSR")
+            .csr_pem;
+        assert_eq!(
+            mismatched_csr.validation_error(),
+            Some("the certificate request and identity private key do not match")
+        );
+
+        let mut mismatched_encryption_key = material;
+        mismatched_encryption_key.enc_public_key_pem = IdentityStore::generate_enrollment()
+            .expect("generate mismatched encryption key")
+            .enc_public_key_pem;
+        assert_eq!(
+            mismatched_encryption_key.validation_error(),
+            Some("the secret-delivery public and private keys do not match")
         );
     }
 
@@ -1809,9 +2130,9 @@ mod tests {
     }
 
     /// A release racing attachment updates must win, exactly as it does for
-    /// app-id updates: both writers take the same lock, so the file is either
-    /// removed before the read (nothing to update) or after the write (removed
-    /// again).
+    /// app-id updates: both mutations take the same persistent transaction, so
+    /// an update either lands before removal, observes the removed file after
+    /// it, or is explicitly rejected while removal owns the directory.
     #[test]
     fn a_release_wins_over_concurrent_attachment_updates() {
         let dir = tempfile::tempdir().expect("create tempdir");
@@ -1825,7 +2146,13 @@ mod tests {
                         app_id: format!("400{i}"),
                         ..sample_attachment()
                     };
-                    IdentityStore::set_attachment(&path, Some(&attachment)).expect("attach");
+                    if let Err(error) = IdentityStore::set_attachment(&path, Some(&attachment)) {
+                        assert!(
+                            error.to_string().contains("Another live process"),
+                            "{error}"
+                        );
+                        break;
+                    }
                 }
             });
             IdentityStore::clear(&path).expect("clear");
@@ -1922,8 +2249,8 @@ mod tests {
     /// A release racing app-id updates must win: `store_app_id` reads the file
     /// and writes it back, so a removal landing between the two would be undone
     /// and the instance would keep talking to a control plane that released it.
-    /// Both sides take the same writer lock, which leaves only the two orderings
-    /// where the file ends up gone.
+    /// Both sides take the same persistent transaction, so a racing update may
+    /// be rejected, but no ordering can recreate the file after removal.
     #[test]
     fn a_release_wins_over_concurrent_app_id_updates() {
         let dir = tempfile::tempdir().expect("create tempdir");
@@ -1933,7 +2260,13 @@ mod tests {
         std::thread::scope(|scope| {
             let updater = scope.spawn(|| {
                 for i in 0..200 {
-                    IdentityStore::store_app_id(&path, &format!("400{i}")).expect("store app id");
+                    if let Err(error) = IdentityStore::store_app_id(&path, &format!("400{i}")) {
+                        assert!(
+                            error.to_string().contains("Another live process"),
+                            "{error}"
+                        );
+                        break;
+                    }
                 }
             });
             IdentityStore::clear(&path).expect("clear");
@@ -2080,6 +2413,8 @@ mod tests {
             .expect("store after removal transaction")
             .expect("identity remains");
         assert_eq!(merged.private_key_pem, "ROTATED-KEY");
+        IdentityStore::clear(&path).expect("clear after transaction ownership is released");
+        assert!(IdentityStore::load_optional(&path).expect("load").is_none());
     }
 
     #[test]
@@ -2133,6 +2468,76 @@ mod tests {
         let path = dir.path().join("does-not-exist.json");
         let loaded = IdentityStore::load_optional(&path).expect("load");
         assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn identity_parse_errors_never_echo_persisted_values() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        let secret = "credential-value-that-must-stay-redacted";
+        std::fs::write(
+            &path,
+            format!(r#"{{"identifier":["{secret}"],"identity_cert_pem":"CERT","private_key_pem":"KEY","public_key_pem":"PUB"}}"#),
+        )
+        .expect("write malformed identity");
+
+        let error = IdentityStore::load_optional(&path)
+            .expect_err("the wrong identifier type must fail parsing");
+        let rendered = error.to_string();
+        assert!(rendered.contains("Failed to parse identity JSON"));
+        assert!(
+            !rendered.contains(secret),
+            "parse error leaked persisted data"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_reads_reject_symlinks_without_reading_the_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let target = dir.path().join("outside.json");
+        let path = dir.path().join("identity.json");
+        std::fs::write(&target, "sensitive target").expect("write target");
+        symlink(&target, &path).expect("create identity symlink");
+
+        let error = IdentityStore::load_optional(&path).expect_err("symlink must be rejected");
+        assert!(matches!(error, Error::Io { .. }), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(target).expect("target remains readable"),
+            "sensitive target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_reads_reject_fifos_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt as _;
+        use std::os::unix::fs::FileTypeExt as _;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        let path_c = CString::new(path.as_os_str().as_bytes()).expect("FIFO path has no NUL");
+        // SAFETY: `path_c` is a valid NUL-terminated path and `0o600` is a
+        // valid mode. `mkfifo` retains neither argument.
+        let result = unsafe { libc::mkfifo(path_c.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "create FIFO: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let error = IdentityStore::load_optional(&path).expect_err("FIFO must be rejected");
+        assert!(matches!(error, Error::Io { .. }), "{error}");
+        assert!(
+            std::fs::metadata(path)
+                .expect("FIFO metadata")
+                .file_type()
+                .is_fifo()
+        );
     }
 
     /// An identity file written before the encryption keyring and cache key
@@ -2379,33 +2784,30 @@ mod tests {
     }
 
     #[test]
-    fn is_expired_detects_past_timestamp() {
+    fn is_expired_uses_the_signed_certificate_over_a_future_cached_timestamp() {
         let mut identity = sample_identity();
-        identity.not_after_unix = Some(1);
+        set_sample_certificate_validity(&mut identity, (2019, 1, 1), (2020, 1, 1));
+        identity.not_after_unix = Some(4_102_444_800);
         assert!(identity.is_expired());
     }
 
     #[test]
-    fn is_expired_treats_boundary_second_as_expired() {
-        // A cert whose `not_after_unix` equals the current second is past the
-        // NotAfter boundary and must be considered expired.
+    fn is_expired_falls_back_to_the_cached_timestamp_for_an_unparseable_certificate() {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
             .expect("system clock after unix epoch");
         let mut identity = sample_identity();
+        identity.identity_cert_pem = "not a certificate".to_string();
         identity.not_after_unix = Some(now);
         assert!(identity.is_expired());
     }
 
     #[test]
-    fn is_expired_accepts_future_timestamp() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .expect("system clock after unix epoch");
+    fn is_expired_uses_the_signed_certificate_over_a_past_cached_timestamp() {
         let mut identity = sample_identity();
-        identity.not_after_unix = Some(now + 3600);
+        set_sample_certificate_validity(&mut identity, (2025, 1, 1), (2099, 1, 1));
+        identity.not_after_unix = Some(1);
         assert!(!identity.is_expired());
     }
 }

--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -649,30 +649,20 @@ fn acquire_removal_transaction(path: &Path) -> Result<crate::draft::EnrollmentTr
 pub(crate) fn read_regular_file_optional(path: &Path) -> std::io::Result<Option<String>> {
     use std::io::Read as _;
 
-    match validate_state_path_ancestors(path) {
-        Ok(()) => {}
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(source) => return Err(source),
-    }
-
     #[cfg(unix)]
-    let mut file = {
-        use std::os::unix::fs::OpenOptionsExt as _;
-
-        let mut options = std::fs::OpenOptions::new();
-        options
-            .read(true)
-            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
-        match options.open(path) {
-            Ok(file) => file,
-            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(source) => return Err(source),
-        }
+    let Some(mut file) = open_regular_file_optional_unix(path)? else {
+        return Ok(None);
     };
 
     #[cfg(windows)]
     let mut file = {
         use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
+
+        match validate_state_path_ancestors(path) {
+            Ok(()) => {}
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(source),
+        }
 
         const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
         const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
@@ -715,35 +705,161 @@ pub(crate) fn read_regular_file_optional(path: &Path) -> std::io::Result<Option<
     Ok(Some(contents))
 }
 
-/// Reject a state path whose parent traversal can be redirected by an
-/// untrusted symlink or reparse point.
+/// Open a state file relative to verified directory descriptors, refusing a
+/// symlink or non-directory at every component.
 ///
 /// Unix has a small set of root-owned compatibility links in otherwise
 /// immutable directories (`/var` and `/tmp` on macOS are common examples).
 /// Those links cannot be replaced by the process running Spice and are safe to
-/// traverse. Every other symlink is rejected, including a root-owned link in a
-/// user-writable directory. The final component is still opened with
-/// `O_NOFOLLOW`, closing the leaf race after this full-path validation.
+/// resolve before descriptor traversal. Every other symlink is rejected,
+/// including a root-owned link in a user-writable directory. `openat` with
+/// `O_NOFOLLOW` then closes the rename race between inspecting and opening
+/// every ordinary component.
 #[cfg(unix)]
-fn validate_state_path_ancestors(path: &Path) -> std::io::Result<()> {
-    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+fn open_regular_file_optional_unix(path: &Path) -> std::io::Result<Option<std::fs::File>> {
+    open_regular_file_optional_unix_with(path, || {})
+}
 
+#[cfg(unix)]
+fn open_regular_file_optional_unix_with(
+    path: &Path,
+    before_descriptor_traversal: impl FnOnce(),
+) -> std::io::Result<Option<std::fs::File>> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd as _, FromRawFd as _};
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let absolute = normalize_absolute_state_path(path)?;
+    let file_name = absolute.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "the state path has no file name",
+        )
+    })?;
+    let parent = absolute.parent().unwrap_or_else(|| Path::new("/"));
+    let parent = resolve_trusted_system_links(parent)?;
+    before_descriptor_traversal();
+    let mut directory = std::fs::File::open("/")?;
+
+    for component in parent.components() {
+        let std::path::Component::Normal(component) = component else {
+            continue;
+        };
+        let component = CString::new(component.as_bytes()).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "the state path contains a NUL byte",
+            )
+        })?;
+        // SAFETY: `component` is NUL-terminated, the directory descriptor is
+        // live for this call, and no pointer is retained. `O_NOFOLLOW` and
+        // `O_DIRECTORY` make a raced symlink/non-directory fail this step.
+        let descriptor = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                component.as_ptr(),
+                libc::O_RDONLY
+                    | libc::O_DIRECTORY
+                    | libc::O_NOFOLLOW
+                    | libc::O_NONBLOCK
+                    | libc::O_CLOEXEC,
+            )
+        };
+        if descriptor < 0 {
+            let source = std::io::Error::last_os_error();
+            if source.kind() == std::io::ErrorKind::NotFound {
+                return Ok(None);
+            }
+            return Err(source);
+        }
+        // SAFETY: `openat` returned a new owned descriptor on success.
+        directory = unsafe { std::fs::File::from_raw_fd(descriptor) };
+    }
+
+    let file_name = CString::new(file_name.as_bytes()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "the state path contains a NUL byte",
+        )
+    })?;
+    // SAFETY: `file_name` is NUL-terminated, the directory descriptor is live
+    // for this call, and no pointer is retained. The leaf cannot be followed.
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            file_name.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        let source = std::io::Error::last_os_error();
+        if source.kind() == std::io::ErrorKind::NotFound {
+            return Ok(None);
+        }
+        return Err(source);
+    }
+    // SAFETY: `openat` returned a new owned descriptor on success.
+    Ok(Some(unsafe { std::fs::File::from_raw_fd(descriptor) }))
+}
+
+#[cfg(unix)]
+fn normalize_absolute_state_path(path: &Path) -> std::io::Result<PathBuf> {
     let absolute = if path.is_absolute() {
         path.to_path_buf()
     } else {
         std::env::current_dir()?.join(path)
     };
-    let Some(parent) = absolute.parent() else {
-        return Ok(());
-    };
-    let mut current = PathBuf::new();
-    for component in parent.components() {
-        current.push(component.as_os_str());
-        let metadata = std::fs::symlink_metadata(&current)?;
+    let mut normalized = PathBuf::from("/");
+    for component in absolute.components() {
+        match component {
+            std::path::Component::RootDir | std::path::Component::CurDir => {}
+            std::path::Component::Normal(component) => normalized.push(component),
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "the state path escapes the filesystem root",
+                    ));
+                }
+            }
+            std::path::Component::Prefix(_) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "the state path has a non-Unix prefix",
+                ));
+            }
+        }
+    }
+    Ok(normalized)
+}
+
+#[cfg(unix)]
+fn resolve_trusted_system_links(path: &Path) -> std::io::Result<PathBuf> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let mut resolved = PathBuf::from("/");
+    let mut components = path.components().filter_map(|component| match component {
+        std::path::Component::Normal(component) => Some(component),
+        _ => None,
+    });
+    while let Some(component) = components.next() {
+        let candidate = resolved.join(component);
+        let metadata = match std::fs::symlink_metadata(&candidate) {
+            Ok(metadata) => metadata,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                resolved.push(component);
+                for remaining in components {
+                    resolved.push(remaining);
+                }
+                return Ok(resolved);
+            }
+            Err(source) => return Err(source),
+        };
         if !metadata.file_type().is_symlink() {
+            resolved.push(component);
             continue;
         }
-        let containing = current.parent().unwrap_or_else(|| Path::new("/"));
+        let containing = candidate.parent().unwrap_or_else(|| Path::new("/"));
         let containing_metadata = std::fs::metadata(containing)?;
         let trusted_system_link = metadata.uid() == 0
             && containing_metadata.uid() == 0
@@ -753,12 +869,13 @@ fn validate_state_path_ancestors(path: &Path) -> std::io::Result<()> {
                 std::io::ErrorKind::InvalidInput,
                 format!(
                     "the state path has an untrusted symlink ancestor: {}",
-                    current.display()
+                    candidate.display()
                 ),
             ));
         }
+        resolved = std::fs::canonicalize(candidate)?;
     }
-    Ok(())
+    Ok(resolved)
 }
 
 #[cfg(windows)]
@@ -2712,6 +2829,35 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(target).expect("target remains readable"),
             "sensitive target"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn descriptor_traversal_rejects_a_parent_swapped_to_a_symlink_after_validation() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let config = dir.path().join("config");
+        std::fs::create_dir(&config).expect("create config directory");
+        std::fs::write(config.join("identity.json"), "safe identity").expect("write safe file");
+        let outside = dir.path().join("outside");
+        std::fs::create_dir(&outside).expect("create target directory");
+        std::fs::write(outside.join("identity.json"), "redirected identity")
+            .expect("write redirected file");
+        let checked_config = dir.path().join("checked-config");
+        let identity_path = config.join("identity.json");
+
+        open_regular_file_optional_unix_with(&identity_path, || {
+            std::fs::rename(&config, &checked_config).expect("move checked directory");
+            symlink(&outside, &config).expect("replace parent with symlink");
+        })
+        .expect_err("descriptor-relative traversal must reject the raced parent symlink");
+
+        assert_eq!(
+            std::fs::read_to_string(outside.join("identity.json"))
+                .expect("redirected target remains readable"),
+            "redirected identity"
         );
     }
 

--- a/crates/runtime-cloud-connect/src/lib.rs
+++ b/crates/runtime-cloud-connect/src/lib.rs
@@ -53,10 +53,12 @@ limitations under the License.
 //! ## Public entry points
 //!
 //! Call [`enroll::enroll_now`] before runtime construction to redeem an
-//! enrollment authority, then [`CloudConnect::start`] from the runtime
-//! bootstrap. `start` returns a handle whose tokio task
-//! crashes/disconnects are isolated from the rest of the process; the
-//! runtime stays up.
+//! enrollment authority, load one startup snapshot with
+//! [`load_reconnectable_identity_async`], and pass it to
+//! [`CloudConnect::start_reconnectable`] after every optional facility has
+//! followed that same decision. The returned handle owns a tokio task whose
+//! crashes/disconnects are isolated from the rest of the process; the runtime
+//! stays up.
 
 pub mod clock_skew;
 pub mod config;
@@ -131,6 +133,18 @@ pub enum Error {
         source: identity::Error,
     },
 
+    #[snafu(display("Identity load task failed for {}: {source}", path.display()))]
+    IdentityLoadTaskPanicked {
+        path: std::path::PathBuf,
+        source: tokio::task::JoinError,
+    },
+
+    #[snafu(display("Identity validation task failed for {}: {source}", path.display()))]
+    IdentityValidationTaskPanicked {
+        path: std::path::PathBuf,
+        source: tokio::task::JoinError,
+    },
+
     #[snafu(display(
         "The Cloud Connect identity at {} cannot be used: {reason}. Stop spiced, run `spice connect remove --yes` from this instance directory, mint a new enrollment key in the Spice Cloud portal, and restart with `spiced --token <enrollment-key>`. See: https://spiceai.org/docs",
         path.display()
@@ -157,6 +171,181 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// A persisted identity that passed the complete local reconnectability gate.
+///
+/// The inner value is intentionally not constructible by callers. Carrying
+/// this token from early bootstrap into [`CloudConnect`] prevents later startup
+/// phases from making a second, potentially different activation decision.
+#[derive(Clone, Debug)]
+pub struct ReconnectableIdentity {
+    identity: Identity,
+    config: CloudConnectConfig,
+}
+
+impl ReconnectableIdentity {
+    #[must_use]
+    pub fn as_identity(&self) -> &Identity {
+        &self.identity
+    }
+
+    /// The exact configuration used to validate this startup snapshot.
+    #[must_use]
+    pub fn config(&self) -> &CloudConnectConfig {
+        &self.config
+    }
+}
+
+impl std::ops::Deref for ReconnectableIdentity {
+    type Target = Identity;
+
+    fn deref(&self) -> &Self::Target {
+        &self.identity
+    }
+}
+
+/// Load the durable identity that may activate Cloud Connect.
+///
+/// This is the shared activation boundary for the runtime, early bootstrap
+/// facilities, and service installation. A file being present or parseable is
+/// insufficient: the credential, key relationships, renewal window, and exact
+/// endpoint shape used by the control client must all be usable.
+///
+/// # Errors
+///
+/// Returns [`Error::IdentityLoad`] when the state path is unreadable, unsafe, or
+/// malformed, and [`Error::IdentityUnusable`] when its durable contents cannot
+/// establish or renew a control stream.
+pub fn load_reconnectable_identity(
+    config: &CloudConnectConfig,
+) -> Result<Option<ReconnectableIdentity>> {
+    let identity_path = config.identity_path.clone();
+    let Some(identity) =
+        IdentityStore::load_optional(&identity_path).map_err(|source| Error::IdentityLoad {
+            path: identity_path.clone(),
+            source,
+        })?
+    else {
+        return Ok(None);
+    };
+    validate_reconnectable_identity(config, identity).map(Some)
+}
+
+/// Validate an already-loaded identity against the complete reconnectability
+/// boundary.
+///
+/// # Errors
+///
+/// Returns [`Error::IdentityUnusable`] when the durable credential, signed
+/// validity interval, or endpoint shape cannot establish or renew a control
+/// stream. Host-local channel setup is retried by the driver and is not part of
+/// this durable-state decision.
+pub fn validate_reconnectable_identity(
+    config: &CloudConnectConfig,
+    identity: Identity,
+) -> Result<ReconnectableIdentity> {
+    let (identity, _endpoint) = validate_reconnectable_credential(config, identity)?;
+
+    Ok(ReconnectableIdentity {
+        identity,
+        config: config.clone(),
+    })
+}
+
+/// Validate the durable credential independently of the current host's clock
+/// and transport environment, returning its normalized identity and endpoint.
+///
+/// The control plane is authoritative for whether the signed interval includes
+/// its current time. A host clock can schedule an early or late renewal, but it
+/// must not reject a credential the cloud has already committed. Channel setup
+/// is likewise retried by the driver, so a temporarily unavailable native trust
+/// store cannot turn valid durable state into a process-lifetime disablement.
+pub(crate) fn validate_reconnectable_credential(
+    config: &CloudConnectConfig,
+    mut identity: Identity,
+) -> Result<(Identity, String)> {
+    let identity_path = config.identity_path.clone();
+
+    if let Some(reason) = identity.reconnect_validation_error(config.gateway_endpoint.as_deref()) {
+        return Err(Error::IdentityUnusable {
+            path: identity_path,
+            reason,
+        });
+    }
+    let (not_before, not_after) =
+        identity
+            .certificate_validity_unix()
+            .map_err(|reason| Error::IdentityUnusable {
+                path: identity_path.clone(),
+                reason,
+            })?;
+    let signed_not_after = u64::try_from(not_after).map_err(|_| Error::IdentityUnusable {
+        path: identity_path.clone(),
+        reason: "the certificate expiration precedes the Unix epoch",
+    })?;
+    if not_after <= not_before {
+        return Err(Error::IdentityUnusable {
+            path: identity_path,
+            reason: "the certificate validity interval is empty or inverted",
+        });
+    }
+    // The signed certificate is authoritative. Normalize the unsigned cache
+    // field before the driver uses it to schedule renewal.
+    identity.not_after_unix = Some(signed_not_after);
+    let endpoint = config
+        .validated_stream_endpoint(&identity)
+        .map_err(|reason| Error::IdentityUnusable {
+            path: identity_path,
+            reason,
+        })?;
+    Ok((identity, endpoint))
+}
+
+/// Async variant of [`validate_reconnectable_identity`] for CLI and runtime
+/// paths already executing on Tokio.
+///
+/// # Errors
+///
+/// Returns the same validation errors as [`validate_reconnectable_identity`],
+/// or [`Error::IdentityValidationTaskPanicked`] if the blocking task fails.
+pub async fn validate_reconnectable_identity_async(
+    config: &CloudConnectConfig,
+    identity: Identity,
+) -> Result<ReconnectableIdentity> {
+    let config = config.clone();
+    let path = config.identity_path.clone();
+    tokio::task::spawn_blocking(move || validate_reconnectable_identity(&config, identity))
+        .await
+        .map_err(|source| Error::IdentityValidationTaskPanicked { path, source })?
+}
+
+pub(crate) async fn validate_reconnectable_credential_async(
+    config: &CloudConnectConfig,
+    identity: Identity,
+) -> Result<(Identity, String)> {
+    let config = config.clone();
+    let path = config.identity_path.clone();
+    tokio::task::spawn_blocking(move || validate_reconnectable_credential(&config, identity))
+        .await
+        .map_err(|source| Error::IdentityValidationTaskPanicked { path, source })?
+}
+
+/// Async variant of [`load_reconnectable_identity`] for startup paths running
+/// on Tokio. File and certificate parsing stay on the blocking pool.
+///
+/// # Errors
+///
+/// Returns the same errors as [`load_reconnectable_identity`], plus
+/// [`Error::IdentityLoadTaskPanicked`] if the blocking task fails.
+pub async fn load_reconnectable_identity_async(
+    config: &CloudConnectConfig,
+) -> Result<Option<ReconnectableIdentity>> {
+    let config = config.clone();
+    let path = config.identity_path.clone();
+    tokio::task::spawn_blocking(move || load_reconnectable_identity(&config))
+        .await
+        .map_err(|source| Error::IdentityLoadTaskPanicked { path, source })?
+}
 
 /// Handle for a running `CloudConnect` client.
 ///
@@ -186,24 +375,12 @@ impl CloudConnect {
     /// `config.identity_path` but cannot be read or parsed, or
     /// [`Error::IdentityUnusable`] if its reconnect credentials are
     /// internally inconsistent.
-    #[expect(
-        clippy::unused_async,
-        reason = "spawns a background tokio task, so it must be called from within a tokio runtime context"
-    )]
     pub async fn start(
         config: CloudConnectConfig,
         runtime: Arc<dyn RuntimeHandle>,
     ) -> Result<Option<Self>> {
         let identity_path = config.identity_path.clone();
-        let identity = match IdentityStore::load_optional(&identity_path) {
-            Ok(identity) => identity,
-            Err(source) => {
-                return Err(Error::IdentityLoad {
-                    path: identity_path,
-                    source,
-                });
-            }
-        };
+        let identity = load_reconnectable_identity_async(&config).await?;
 
         let Some(identity) = identity else {
             tracing::debug!(
@@ -212,20 +389,26 @@ impl CloudConnect {
             );
             return Ok(None);
         };
-        if let Some(reason) =
-            identity.reconnect_validation_error(config.gateway_endpoint.as_deref())
-        {
-            return Err(Error::IdentityUnusable {
-                path: identity_path,
-                reason,
-            });
-        }
+        Ok(Some(Self::start_reconnectable(runtime, identity)))
+    }
+
+    /// Start from the exact identity snapshot validated during early startup.
+    ///
+    /// This does not reload on-disk state: metrics, logging, managed
+    /// configuration, cached secrets, and the control client must all follow
+    /// one activation decision for this process.
+    #[must_use]
+    pub fn start_reconnectable(
+        runtime: Arc<dyn RuntimeHandle>,
+        identity: ReconnectableIdentity,
+    ) -> Self {
+        let ReconnectableIdentity { identity, config } = identity;
         let identity = Some(identity);
 
         let shutdown = Shutdown::new();
         let shutdown_for_task = Arc::clone(&shutdown);
 
-        let runtime_for_task = Arc::clone(&runtime);
+        let runtime_for_task = runtime;
         let task = tokio::spawn(async move {
             let driver =
                 client::ClientDriver::new(config, runtime_for_task, shutdown_for_task, identity);
@@ -234,10 +417,10 @@ impl CloudConnect {
             }
         });
 
-        Ok(Some(Self {
+        Self {
             task: Mutex::new(Some(task)),
             shutdown,
-        }))
+        }
     }
 
     /// Request graceful shutdown of the Cloud Connect task.
@@ -268,7 +451,7 @@ impl CloudConnect {
 /// than any catalog the CLI shipped with, or in no cloud region at all
 /// (`on-prem-syd`), and both must enroll. The catalog is used cloud-side for
 /// display and gateway-stamp selection, which fall back to the home stamp for
-/// a label it does not recognise.
+/// a label it does not recognize.
 ///
 /// The rule mirrors the cloud's own enroll validation (2–64 lowercase letters,
 /// digits, and hyphens, starting and ending alphanumeric) so the CLI never
@@ -288,6 +471,191 @@ pub fn is_valid_instance_region(region: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_config(config_dir: &std::path::Path) -> CloudConnectConfig {
+        CloudConnectConfig {
+            enroll_endpoint: "https://api.spice.ai".to_string(),
+            gateway_endpoint: None,
+            ca_cert_pem: None,
+            insecure: false,
+            identity_path: config_dir.join(config::IDENTITY_FILE),
+            config_dir: config_dir.to_path_buf(),
+            instance_region: None,
+            runtime_version: "v0-test".to_string(),
+            heartbeat_interval: std::time::Duration::from_secs(30),
+            telemetry_interval: std::time::Duration::from_mins(1),
+            metrics_interval: std::time::Duration::from_secs(30),
+            renewal_lead: std::time::Duration::from_hours(12),
+            query_deadline: std::time::Duration::from_secs(25),
+        }
+    }
+
+    fn test_identity() -> Identity {
+        use rcgen::{CertificateParams, KeyPair};
+
+        let material = IdentityStore::generate_enrollment().expect("generate enrollment material");
+        let keypair = KeyPair::from_pem(&material.private_key_pem).expect("parse identity key");
+        let certificate = CertificateParams::new(Vec::<String>::new())
+            .expect("certificate parameters")
+            .self_signed(&keypair)
+            .expect("sign certificate");
+        Identity {
+            identifier: "inst_test".to_string(),
+            identity_cert_pem: certificate.pem(),
+            private_key_pem: material.private_key_pem,
+            public_key_pem: material.public_key_pem,
+            ca_bundle_pem: String::new(),
+            gateway_addr: "gateway.example:443".to_string(),
+            not_after_unix: None,
+            enc_private_key_pem: material.enc_private_key_pem,
+            enc_public_key_pem: material.enc_public_key_pem,
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+            app_id: None,
+            org_name: None,
+            app_name: None,
+            monitor_url: None,
+        }
+    }
+
+    fn set_certificate_validity(
+        identity: &mut Identity,
+        not_before: (i32, u8, u8),
+        not_after: (i32, u8, u8),
+    ) {
+        use rcgen::{CertificateParams, KeyPair};
+
+        let keypair = KeyPair::from_pem(&identity.private_key_pem).expect("parse identity key");
+        let mut params =
+            CertificateParams::new(Vec::<String>::new()).expect("certificate parameters");
+        params.not_before = rcgen::date_time_ymd(not_before.0, not_before.1, not_before.2);
+        params.not_after = rcgen::date_time_ymd(not_after.0, not_after.1, not_after.2);
+        identity.identity_cert_pem = params
+            .self_signed(&keypair)
+            .expect("sign certificate")
+            .pem();
+    }
+
+    fn set_certificate_validity_from_now(
+        identity: &mut Identity,
+        not_before: std::time::Duration,
+        not_after: std::time::Duration,
+    ) {
+        use rcgen::{CertificateParams, KeyPair};
+
+        let keypair = KeyPair::from_pem(&identity.private_key_pem).expect("parse identity key");
+        let now = std::time::SystemTime::now();
+        let mut params =
+            CertificateParams::new(Vec::<String>::new()).expect("certificate parameters");
+        params.not_before = (now + not_before).into();
+        params.not_after = (now + not_after).into();
+        identity.identity_cert_pem = params
+            .self_signed(&keypair)
+            .expect("sign certificate")
+            .pem();
+    }
+
+    #[test]
+    fn durable_activation_requires_a_reconnectable_identity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = test_config(dir.path());
+        let identity = test_identity();
+        IdentityStore::store(&config.identity_path, &identity).expect("store identity");
+
+        let loaded = load_reconnectable_identity(&config)
+            .expect("validate identity")
+            .expect("identity is present");
+        assert_eq!(loaded.identifier, identity.identifier);
+    }
+
+    #[test]
+    fn durable_activation_uses_signed_expiry_and_rejects_invalid_endpoints() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = test_config(dir.path());
+        let mut identity = test_identity();
+        set_certificate_validity(&mut identity, (2019, 1, 1), (2020, 1, 1));
+        identity.not_after_unix = Some(4_102_444_800);
+        IdentityStore::store(&config.identity_path, &identity).expect("store expired identity");
+        let expired = load_reconnectable_identity(&config)
+            .expect("the control plane decides whether the identity remains renewable")
+            .expect("identity is present");
+        assert_eq!(expired.not_after_unix, Some(1_577_836_800));
+
+        set_certificate_validity(&mut identity, (2025, 1, 1), (2099, 1, 1));
+        identity.gateway_addr = "not a valid gateway".to_string();
+        IdentityStore::store(&config.identity_path, &identity).expect("store invalid endpoint");
+        let invalid = load_reconnectable_identity(&config).expect_err("endpoint must fail");
+        assert!(
+            invalid.to_string().contains("endpoint is invalid"),
+            "{invalid}"
+        );
+    }
+
+    #[test]
+    fn durable_activation_uses_signed_validity_and_exact_gateway_shape() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut config = test_config(dir.path());
+        let mut identity = test_identity();
+        set_certificate_validity(&mut identity, (2025, 1, 1), (2099, 1, 1));
+        for gateway in [
+            "gateway.example",
+            "http://gateway.example:80",
+            "gateway.example:443/path",
+        ] {
+            identity.gateway_addr = gateway.to_string();
+            let error = validate_reconnectable_identity(&config, identity.clone())
+                .expect_err("persisted gateway must be exactly host:port");
+            assert!(error.to_string().contains("gateway endpoint"), "{error}");
+        }
+
+        identity.gateway_addr = "gateway.example:443".to_string();
+        for override_endpoint in [
+            "unix:///tmp/cloud-connect.sock",
+            "http://gateway.example:443",
+            "https://gateway.example:443/path",
+        ] {
+            config.gateway_endpoint = Some(override_endpoint.to_string());
+            let error = validate_reconnectable_identity(&config, identity.clone())
+                .expect_err("gateway override must match the channel transport shape");
+            assert!(error.to_string().contains("gateway endpoint"), "{error}");
+        }
+    }
+
+    #[test]
+    fn durable_activation_does_not_use_the_host_clock_as_credential_authority() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = test_config(dir.path());
+        let mut identity = test_identity();
+        set_certificate_validity_from_now(
+            &mut identity,
+            std::time::Duration::from_hours(24),
+            std::time::Duration::from_hours(48),
+        );
+
+        validate_reconnectable_credential(&config, identity)
+            .expect("the cloud-committed credential must survive a slow host clock");
+    }
+
+    #[test]
+    fn reconnectable_identity_is_a_stable_startup_snapshot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut config = test_config(dir.path());
+        let identity = test_identity();
+        IdentityStore::store(&config.identity_path, &identity).expect("store identity");
+        let snapshot = load_reconnectable_identity(&config)
+            .expect("validate identity")
+            .expect("identity present");
+
+        let mut replacement = identity;
+        replacement.identifier = "inst_replaced_after_bootstrap".to_string();
+        IdentityStore::store(&config.identity_path, &replacement).expect("replace identity");
+        config.gateway_endpoint = Some("https://other.example:443".to_string());
+
+        assert_eq!(snapshot.identifier, "inst_test");
+        assert_ne!(snapshot.identifier, replacement.identifier);
+        assert!(snapshot.config().gateway_endpoint.is_none());
+        assert_ne!(snapshot.config().gateway_endpoint, config.gateway_endpoint);
+    }
 
     #[test]
     fn accepts_catalog_and_non_catalog_regions() {

--- a/crates/runtime-cloud-connect/src/lib.rs
+++ b/crates/runtime-cloud-connect/src/lib.rs
@@ -134,6 +134,12 @@ pub enum Error {
         source: identity::Error,
     },
 
+    #[snafu(display("Identity load task failed for {}: {source}", path.display()))]
+    IdentityLoadTaskPanicked {
+        path: std::path::PathBuf,
+        source: tokio::task::JoinError,
+    },
+
     #[snafu(display(
         "The Cloud Connect identity at {} cannot be used: {reason}. Stop spiced, run `spice connect remove --yes` from this instance directory, mint a new enrollment key in the Spice Cloud portal, and restart with `spiced --token <enrollment-key>`. See: https://spiceai.org/docs",
         path.display()
@@ -160,6 +166,74 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Load the durable identity that may activate Cloud Connect.
+///
+/// This is the shared activation boundary for the runtime, early bootstrap
+/// facilities, and service installation. A file being present or parseable is
+/// insufficient: the credential, key relationships, renewal window, and exact
+/// endpoint shape used by the control client must all be usable.
+///
+/// # Errors
+///
+/// Returns [`Error::IdentityLoad`] when the state path is unreadable, unsafe, or
+/// malformed, and [`Error::IdentityUnusable`] when its durable contents cannot
+/// establish or renew a control stream.
+pub fn load_reconnectable_identity(config: &CloudConnectConfig) -> Result<Option<Identity>> {
+    let identity_path = config.identity_path.clone();
+    let Some(identity) =
+        IdentityStore::load_optional(&identity_path).map_err(|source| Error::IdentityLoad {
+            path: identity_path.clone(),
+            source,
+        })?
+    else {
+        return Ok(None);
+    };
+
+    if enroll::past_renewal_grace(&identity) {
+        return Err(Error::IdentityUnusable {
+            path: identity_path,
+            reason: "the certificate expired past the renewal grace window",
+        });
+    }
+    if let Some(reason) = identity.reconnect_validation_error(config.gateway_endpoint.as_deref()) {
+        return Err(Error::IdentityUnusable {
+            path: identity_path,
+            reason,
+        });
+    }
+    let endpoint = config
+        .stream_endpoint(&identity)
+        .ok_or_else(|| Error::IdentityUnusable {
+            path: identity_path.clone(),
+            reason: "the gateway address is empty",
+        })?;
+    if tonic::transport::Endpoint::from_shared(endpoint).is_err() {
+        return Err(Error::IdentityUnusable {
+            path: identity_path,
+            reason: "the gateway endpoint is invalid",
+        });
+    }
+
+    Ok(Some(identity))
+}
+
+/// Async variant of [`load_reconnectable_identity`] for startup paths running
+/// on Tokio. File and certificate parsing stay on the blocking pool.
+///
+/// # Errors
+///
+/// Returns the same errors as [`load_reconnectable_identity`], plus
+/// [`Error::IdentityLoadTaskPanicked`] if the blocking task fails.
+pub async fn load_reconnectable_identity_async(
+    config: &CloudConnectConfig,
+) -> Result<Option<Identity>> {
+    let config = config.clone();
+    let path = config.identity_path.clone();
+    tokio::task::spawn_blocking(move || load_reconnectable_identity(&config))
+        .await
+        .map_err(|source| Error::IdentityLoadTaskPanicked { path, source })?
+}
 
 /// Handle for a running `CloudConnect` client.
 ///
@@ -189,24 +263,12 @@ impl CloudConnect {
     /// `config.identity_path` but cannot be read or parsed, or
     /// [`Error::IdentityUnusable`] if its reconnect credentials are
     /// internally inconsistent.
-    #[expect(
-        clippy::unused_async,
-        reason = "spawns a background tokio task, so it must be called from within a tokio runtime context"
-    )]
     pub async fn start(
         config: CloudConnectConfig,
         runtime: Arc<dyn RuntimeHandle>,
     ) -> Result<Option<Self>> {
         let identity_path = config.identity_path.clone();
-        let identity = match IdentityStore::load_optional(&identity_path) {
-            Ok(identity) => identity,
-            Err(source) => {
-                return Err(Error::IdentityLoad {
-                    path: identity_path,
-                    source,
-                });
-            }
-        };
+        let identity = load_reconnectable_identity_async(&config).await?;
 
         let Some(identity) = identity else {
             tracing::debug!(
@@ -215,14 +277,6 @@ impl CloudConnect {
             );
             return Ok(None);
         };
-        if let Some(reason) =
-            identity.reconnect_validation_error(config.gateway_endpoint.as_deref())
-        {
-            return Err(Error::IdentityUnusable {
-                path: identity_path,
-                reason,
-            });
-        }
         let identity = Some(identity);
 
         let shutdown = Shutdown::new();
@@ -271,7 +325,7 @@ impl CloudConnect {
 /// than any catalog the CLI shipped with, or in no cloud region at all
 /// (`on-prem-syd`), and both must enroll. The catalog is used cloud-side for
 /// display and gateway-stamp selection, which fall back to the home stamp for
-/// a label it does not recognise.
+/// a label it does not recognize.
 ///
 /// The rule mirrors the cloud's own enroll validation (2–64 lowercase letters,
 /// digits, and hyphens, starting and ending alphanumeric) so the CLI never
@@ -291,6 +345,85 @@ pub fn is_valid_instance_region(region: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_config(config_dir: &std::path::Path) -> CloudConnectConfig {
+        CloudConnectConfig {
+            enroll_endpoint: "https://api.spice.ai".to_string(),
+            gateway_endpoint: None,
+            ca_cert_pem: None,
+            insecure: false,
+            identity_path: config_dir.join(config::IDENTITY_FILE),
+            config_dir: config_dir.to_path_buf(),
+            instance_region: None,
+            runtime_version: "v0-test".to_string(),
+            heartbeat_interval: std::time::Duration::from_secs(30),
+            telemetry_interval: std::time::Duration::from_mins(1),
+            metrics_interval: std::time::Duration::from_secs(30),
+            renewal_lead: std::time::Duration::from_hours(12),
+            query_deadline: std::time::Duration::from_secs(25),
+        }
+    }
+
+    fn test_identity() -> Identity {
+        use rcgen::{CertificateParams, KeyPair};
+
+        let material = IdentityStore::generate_enrollment().expect("generate enrollment material");
+        let keypair = KeyPair::from_pem(&material.private_key_pem).expect("parse identity key");
+        let certificate = CertificateParams::new(Vec::<String>::new())
+            .expect("certificate parameters")
+            .self_signed(&keypair)
+            .expect("sign certificate");
+        Identity {
+            identifier: "inst_test".to_string(),
+            identity_cert_pem: certificate.pem(),
+            private_key_pem: material.private_key_pem,
+            public_key_pem: material.public_key_pem,
+            ca_bundle_pem: String::new(),
+            gateway_addr: "gateway.example:443".to_string(),
+            not_after_unix: None,
+            enc_private_key_pem: material.enc_private_key_pem,
+            enc_public_key_pem: material.enc_public_key_pem,
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+            app_id: None,
+            org_name: None,
+            app_name: None,
+            monitor_url: None,
+        }
+    }
+
+    #[test]
+    fn durable_activation_requires_a_reconnectable_identity() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = test_config(dir.path());
+        let identity = test_identity();
+        IdentityStore::store(&config.identity_path, &identity).expect("store identity");
+
+        let loaded = load_reconnectable_identity(&config)
+            .expect("validate identity")
+            .expect("identity is present");
+        assert_eq!(loaded.identifier, identity.identifier);
+    }
+
+    #[test]
+    fn durable_activation_rejects_past_grace_and_invalid_endpoints() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = test_config(dir.path());
+        let mut identity = test_identity();
+        identity.not_after_unix = Some(1);
+        IdentityStore::store(&config.identity_path, &identity).expect("store expired identity");
+        let expired = load_reconnectable_identity(&config).expect_err("past grace must fail");
+        assert!(expired.to_string().contains("renewal grace"), "{expired}");
+
+        identity.not_after_unix = None;
+        identity.gateway_addr = "not a valid gateway".to_string();
+        IdentityStore::store(&config.identity_path, &identity).expect("store invalid endpoint");
+        let invalid = load_reconnectable_identity(&config).expect_err("endpoint must fail");
+        assert!(
+            invalid.to_string().contains("endpoint is invalid"),
+            "{invalid}"
+        );
+    }
 
     #[test]
     fn accepts_catalog_and_non_catalog_regions() {

--- a/crates/runtime-cloud-connect/tests/enrollment_flow.rs
+++ b/crates/runtime-cloud-connect/tests/enrollment_flow.rs
@@ -306,6 +306,7 @@ struct EnrollMockState {
     /// When set, every request is rejected with this (status, code, error).
     reject: Option<(u16, &'static str, &'static str)>,
     ca: Arc<EnrollCa>,
+    reported_not_after: Arc<Mutex<Vec<String>>>,
 }
 
 struct EnrollCa {
@@ -334,17 +335,21 @@ impl EnrollCa {
         }
     }
 
-    fn sign_csr(&self, csr_pem: &str) -> String {
-        CertificateSigningRequestParams::from_pem(csr_pem)
-            .expect("parse enrollment CSR")
+    fn sign_csr(&self, csr_pem: &str, validity: Duration) -> (String, String) {
+        let now = std::time::SystemTime::now();
+        let not_after = now + validity;
+        let mut request =
+            CertificateSigningRequestParams::from_pem(csr_pem).expect("parse enrollment CSR");
+        request.params.not_before = (now - Duration::from_mins(1)).into();
+        request.params.not_after = not_after.into();
+        let certificate = request
             .signed_by(&self.issuer)
             .expect("sign enrollment CSR")
-            .pem()
+            .pem();
+        let reported_not_after = chrono::DateTime::<chrono::Utc>::from(not_after)
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        (certificate, reported_not_after)
     }
-}
-
-fn not_after_in(hours: i64) -> String {
-    (chrono::Utc::now() + chrono::Duration::hours(hours)).to_rfc3339()
 }
 
 async fn enroll_handler(
@@ -358,9 +363,15 @@ async fn enroll_handler(
             Json(serde_json::json!({ "code": code, "error": error, "retryable": false })),
         );
     }
-    let identity_certificate = state
-        .ca
-        .sign_csr(body["csr_pem"].as_str().expect("CSR is a string"));
+    let (identity_certificate, not_after) = state.ca.sign_csr(
+        body["csr_pem"].as_str().expect("CSR is a string"),
+        Duration::from_hours(24),
+    );
+    state
+        .reported_not_after
+        .lock()
+        .await
+        .push(not_after.clone());
     (
         StatusCode::OK,
         Json(serde_json::json!({
@@ -368,7 +379,7 @@ async fn enroll_handler(
             "identity_cert_pem": identity_certificate,
             "ca_bundle_pem": state.ca.certificate_pem.clone(),
             "gateway_addr": state.gateway_addr,
-            "not_after": not_after_in(24),
+            "not_after": not_after,
             "organization": {"id": 7, "name": "unit-org"},
             "portal": {"new_project_url": "https://cloud.test/unit-org/new?instance=inst_unit_test"},
             "attachment": null,
@@ -381,13 +392,15 @@ async fn enroll_handler(
 async fn spawn_enroll_server(
     gateway_addr: String,
     reject: Option<(u16, &'static str, &'static str)>,
-) -> (SocketAddr, Arc<Mutex<Vec<Value>>>) {
+) -> (SocketAddr, Arc<Mutex<Vec<Value>>>, Arc<Mutex<Vec<String>>>) {
     let requests = Arc::new(Mutex::new(Vec::new()));
+    let reported_not_after = Arc::new(Mutex::new(Vec::new()));
     let state = EnrollMockState {
         requests: Arc::clone(&requests),
         gateway_addr,
         reject,
         ca: Arc::new(EnrollCa::new()),
+        reported_not_after: Arc::clone(&reported_not_after),
     };
     let app = Router::new()
         .route("/v1/cloud-connect/enroll", post(enroll_handler))
@@ -397,7 +410,7 @@ async fn spawn_enroll_server(
     tokio::spawn(async move {
         let _ = axum::serve(listener, app).await;
     });
-    (addr, requests)
+    (addr, requests, reported_not_after)
 }
 
 fn enroll_config(enroll_addr: SocketAddr, dir: &std::path::Path) -> CloudConnectConfig {
@@ -452,7 +465,8 @@ async fn pre_runtime_enroll_persists_identity_and_connects() {
     let mock_state = Arc::clone(&mock.state);
     let gateway_addr = spawn_server(mock).await;
 
-    let (enroll_addr, enroll_requests) = spawn_enroll_server(gateway_addr.to_string(), None).await;
+    let (enroll_addr, enroll_requests, reported_not_after) =
+        spawn_enroll_server(gateway_addr.to_string(), None).await;
 
     let config = enroll_config(enroll_addr, dir.path());
 
@@ -487,9 +501,18 @@ async fn pre_runtime_enroll_persists_identity_and_connects() {
         1,
         "enroll ca_bundle_pem should be persisted into identity.json"
     );
-    assert!(
-        identity.not_after_unix.is_some_and(|secs| secs > 0),
-        "not_after must be parsed"
+    let reported_not_after = reported_not_after.lock().await;
+    let reported_not_after = chrono::DateTime::parse_from_rfc3339(
+        reported_not_after
+            .first()
+            .expect("the mock records its response expiry"),
+    )
+    .expect("parse the reported response expiry")
+    .timestamp();
+    assert_eq!(
+        identity.not_after_unix,
+        Some(u64::try_from(reported_not_after).expect("reported expiry is after the Unix epoch")),
+        "the signed durable renewal deadline must match the independently captured response expiry"
     );
 
     // The enroll request carried the canonical contract shape: kind + token
@@ -567,7 +590,7 @@ async fn a_terminal_rejection_creates_no_identity_and_stops_immediately() {
 
     // The cloud terminally rejects the key (unknown/consumed). No gateway
     // is involved.
-    let (enroll_addr, enroll_requests) = spawn_enroll_server(
+    let (enroll_addr, enroll_requests, _reported_not_after) = spawn_enroll_server(
         String::new(),
         Some((401, "invalid_token", "unknown enrollment key")),
     )

--- a/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
@@ -59,7 +59,7 @@ limitations under the License.
 use std::collections::{HashMap, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -190,9 +190,25 @@ impl TestCa {
     /// requester's P-256 public key point (for later PoP verification).
     /// `from_pem` verifies the CSR's self-signature, so this only succeeds
     /// if the client genuinely holds the private key it enrolled with.
-    fn sign_csr(&self, csr_pem: &str) -> Result<(String, Vec<u8>), rcgen::Error> {
-        let csr = CertificateSigningRequestParams::from_pem(csr_pem)?;
+    fn sign_csr(
+        &self,
+        csr_pem: &str,
+        validity: Duration,
+        not_before_offset_secs: i64,
+    ) -> Result<(String, Vec<u8>), rcgen::Error> {
+        let mut csr = CertificateSigningRequestParams::from_pem(csr_pem)?;
         let point = p256_point(csr.public_key.der_bytes());
+        // The signed interval is the credential's authority. Keep it aligned
+        // with the response timestamp so renewal tests exercise real mTLS
+        // validity rather than an unsigned scheduling hint.
+        let now = std::time::SystemTime::now();
+        csr.params.not_before = if not_before_offset_secs < 0 {
+            now - Duration::from_secs(not_before_offset_secs.unsigned_abs())
+        } else {
+            now + Duration::from_secs(not_before_offset_secs.unsigned_abs())
+        }
+        .into();
+        csr.params.not_after = (now + validity).into();
         let leaf = csr.signed_by(&self.issuer)?;
         Ok((leaf.pem(), point))
     }
@@ -262,6 +278,9 @@ struct CloudMock {
     /// When set, enrollment returns a valid X.509 leaf for a different key
     /// than the submitted CSR, modeling an unusable committed response.
     issue_mismatched_enroll_certificate: Arc<AtomicBool>,
+    /// Offset from the mock host's current time for a renewed leaf's
+    /// `not_before`. A positive value models the client clock trailing the CA.
+    renew_not_before_offset_secs: Arc<AtomicI64>,
     /// The public key pinned at the last enroll/renew — the only key whose
     /// PoP signature authorizes a rotation (mirrors the cloud's pinning).
     pinned_point: Arc<Mutex<Option<Vec<u8>>>>,
@@ -308,6 +327,7 @@ impl CloudMock {
             enroll_paused: Arc::new(Notify::new()),
             resume_enroll: Arc::new(Notify::new()),
             issue_mismatched_enroll_certificate: Arc::new(AtomicBool::new(false)),
+            renew_not_before_offset_secs: Arc::new(AtomicI64::new(-60)),
             pinned_point: Arc::new(Mutex::new(None)),
             stored_region: Arc::new(Mutex::new(None)),
             enroll_requests: Arc::new(Mutex::new(Vec::new())),
@@ -531,7 +551,11 @@ async fn mock_enroll(
         };
         org
     };
-    let Ok((mut leaf_pem, point)) = mock.ca.sign_csr(csr_pem) else {
+    let Ok((mut leaf_pem, point)) = mock.ca.sign_csr(
+        csr_pem,
+        Duration::from_secs(u64::try_from(mock.leaf_validity_secs).unwrap_or_default()),
+        -60,
+    ) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid_request", "Malformed CSR");
     };
     if mock
@@ -669,7 +693,11 @@ async fn mock_renew(
     }
 
     // Re-issue over the CSR's NEW key and pin it (the rotation).
-    let Ok((leaf_pem, point)) = mock.ca.sign_csr(csr_pem) else {
+    let Ok((leaf_pem, point)) = mock.ca.sign_csr(
+        csr_pem,
+        Duration::from_hours(24),
+        mock.renew_not_before_offset_secs.load(Ordering::SeqCst),
+    ) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid_request", "Malformed CSR");
     };
     *mock.pinned_point.lock().await = Some(point);
@@ -3300,10 +3328,9 @@ async fn reconnects_over_mtls_after_disconnect() {
 
 #[tokio::test]
 async fn renewal_rotates_keypair_and_persists() {
-    // Issue a leaf that "expires" in 5s with a 2s renewal lead: renewal
+    // Issue a leaf that expires in 5s with a 2s renewal lead: renewal
     // becomes due ~3s after enrollment, exercising the ~12h loop at test
-    // speed. (The rcgen-signed cert itself is valid longer — the client
-    // schedules from the reported not_after, which is what's under test.)
+    // speed. The signed certificate and response report the same interval.
     let harness = Harness::new(5).await;
     let dir = tempfile::tempdir().unwrap();
     let identity_path = dir.path().join("identity.json");
@@ -3323,6 +3350,13 @@ async fn renewal_rotates_keypair_and_persists() {
         .expect("load identity")
         .expect("identity present");
     assert_eq!(enrolled_identity.identifier, ASSIGNED_ID);
+    // Model a CA whose clock is one hour ahead of this host. The cloud commits
+    // the new public key before returning the renewed leaf, so local clock
+    // validation must not discard the only matching private key.
+    harness
+        .cloud
+        .renew_not_before_offset_secs
+        .store(60 * 60, Ordering::SeqCst);
     let handle = runtime_cloud_connect::CloudConnect::start(config, runtime)
         .await
         .expect("start")


### PR DESCRIPTION
## Summary

- make usable persisted identity—not `--token`, mode, or file existence—the single Cloud Connect activation signal
- carry one validated identity-and-configuration snapshot through metrics, log capture, managed Spicepod and secret restore, and control-client startup
- validate signed certificate intervals, key relationships, gateway shape, enrollment drafts, and installed-service state before use while leaving host-clock and channel-environment failures to retry against the cloud
- serialize every identity writer with enrollment/removal, fence stale credential generations, and harden state-file reads against symlinked leaves, ancestors, and special files
- preserve cloud-committed key rotations even when unsigned response hints are malformed, fail closed on unreadable persisted control-plane overrides, and keep filtered service status exit semantics scoped to the service document
- preserve active-configuration reconciliation from #12975 and report signed expiry diagnostics consistently

This is an additive hardening follow-up to #12915. It relates to spicehq/spiceai#1400.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runtime-cloud-connect` (218 unit, 9 contract, 6 enrollment-flow, 36 standalone E2E)
- `cargo test -p spiced --lib cloud_connect` (45)
- `cargo test -p spiced --test cloud_connect_bootstrap` (2)
- `cargo test -p spice --lib commands::connect` (110)
- `cargo test -p spice --test cli_integration connect::` (8)
- deterministic descriptor-race regression plus focused `spiced` and real CLI endpoint-symlink regressions
- warnings-denied Clippy for `runtime-cloud-connect --all-targets`, `spiced --lib`, and `spice --all-targets`
- independent Claude Opus review: READY (0 critical, 0 high); its actionable durable-activation findings were addressed and the focused gates above rerun
