### PR TITLE
fix(testoperator benchmarks): benchmark fixes

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -336,16 +336,9 @@ jobs:
           fi
           echo "Seed complete: $DB_NAME on $PGHOST."
 
-      # Postgres-accelerator spicepods (file[parquet]-postgres, s3[parquet]-postgres,
-      # ...) write into a dedicated database on POSTGRES_RW_HOST (pg_db:
-      # *_accelerated). The accelerator creates its own tables but not the database
-      # itself, and the local postgres:16 service container starts empty - so every
-      # *_accelerated database the spicepod names must be created before spiced
-      # starts, or dataset acceleration fails with "database ... does not exist".
-      # Idempotent, and no schema is loaded: the accelerator manages its own tables.
-      # PGHOST must resolve identically to the POSTGRES_RW_HOST the benchmark step
-      # hands the spicepod (local container for SF1/SF10 and the clickbench
-      # acceleration run; the hosted cluster otherwise).
+      # Postgres-accelerator spicepods need a *_accelerated database that the
+      # empty postgres:16 container doesn't have yet - create it before spiced
+      # starts (idempotent), matching the PGHOST the spicepod will connect to.
       - name: Create postgres acceleration databases
         if: ${{ contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') }}
         env:

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -303,29 +303,24 @@ jobs:
           if [ "$PGHOST" != "127.0.0.1" ]; then
             echo "::error::$DB_NAME is missing or empty on the hosted $PGHOST cluster. Scale factor $SCALE_FACTOR is too large to safely generate and load inline from a CI runner. Pre-provision it first, e.g.:"
             echo "  cd test/tpc-bench && DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME DBGEN_SCALE=$SCALE_FACTOR make tpch-clone tpch-fleet-gen pg-init && DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME TPCH_DATA_DIR=./tmp/fleet make pg-load && DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-create-index"
-            echo "(substitute the tpcds-* targets for a tpcds run)"
+            echo "(for a tpcds run: make tpcds-clone tpcds-fleet-gen pg-tpcds-init, then TPCDS_DATA_DIR=./tmp/tpcds-fleet make pg-tpcds-load, then make pg-tpcds-create-index)"
             exit 1
           fi
 
           echo "$DB_NAME is missing or empty on $PGHOST - seeding it now."
           sudo apt-get install -y git
-          if [ "$QUERY_SET" = "tpcds" ]; then
-            # tpcds-kit's tools/Makefile hardcodes CC=gcc-9 on Linux; ubuntu-24.04's
-            # default gcc isn't named gcc-9, so install it explicitly via the PPA.
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa -y
-            sudo apt-get update -y
-            sudo apt-get install -y flex bison byacc gcc-9 g++-9
-          else
-            # TPC-H data comes from the pinned DuckDB CLI (see tpch-fleet-gen), so
-            # nothing is compiled here - tpch-kit is only cloned for dss.ddl.
-            sudo apt-get install -y unzip
-          fi
+          # Both query sets seed from the pinned DuckDB CLI (tpch-fleet-gen /
+          # tpcds-fleet-gen), so nothing is compiled here - the kits are only
+          # cloned for their DDL (dss.ddl / tpcds.sql, tpcds_ri.sql). Seeding
+          # from any other generator produces data the recorded expected
+          # answers don't match (see the fleet-gen comments in the Makefile).
+          sudo apt-get install -y unzip
 
           if [ "$QUERY_SET" = "tpcds" ]; then
-            make tpcds-init
-            DBGEN_SCALE=$SCALE_FACTOR make tpcds-gen
+            make tpcds-clone
+            DBGEN_SCALE=$SCALE_FACTOR make tpcds-fleet-gen
             DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-tpcds-init
-            DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-tpcds-load
+            DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME TPCDS_DATA_DIR=./tmp/tpcds-fleet make pg-tpcds-load
             DB_HOST=$PGHOST DB_PORT=5432 DB_USER=postgres DB_NAME=$DB_NAME make pg-tpcds-create-index
           else
             make tpch-clone

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -119,11 +119,16 @@ jobs:
       # factors (SF100+) target benchmarking-postgres directly instead. Either
       # way the target starts empty and is seeded by the "Seed postgres..."
       # step below (a plain postgres image with no pre-baked data, unlike the
-      # earlier iteration of this fix). Excludes ducklake[postgres+s3], which
-      # provisions its own local postgres catalog DB on the same port, and
-      # clickbench, whose postgres source uses a different (unseeded) database.
+      # earlier iteration of this fix). Also serves clickbench's
+      # s3[parquet]-postgres run, whose postgres is purely an acceleration
+      # target (source data comes from s3) and so needs only the empty
+      # *_accelerated database the "Create postgres acceleration databases"
+      # step provides. Excludes ducklake[postgres+s3], which provisions its own
+      # local postgres catalog DB on the same port, and clickbench's
+      # postgres-source configs, which read the pre-loaded hits data on the
+      # hosted cluster (too large to seed inline).
       postgres_tpch:
-        image: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') && (startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) && 'postgres:16' || '' }}
+        image: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') && (((startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) || (github.event.inputs.query_set == 'clickbench' && contains(github.event.inputs.spicepod_path, 's3[parquet]-postgres')))) && 'postgres:16' || '' }}
         ports:
           - 5432:5432
         env:
@@ -331,6 +336,41 @@ jobs:
           fi
           echo "Seed complete: $DB_NAME on $PGHOST."
 
+      # Postgres-accelerator spicepods (file[parquet]-postgres, s3[parquet]-postgres,
+      # ...) write into a dedicated database on POSTGRES_RW_HOST (pg_db:
+      # *_accelerated). The accelerator creates its own tables but not the database
+      # itself, and the local postgres:16 service container starts empty - so every
+      # *_accelerated database the spicepod names must be created before spiced
+      # starts, or dataset acceleration fails with "database ... does not exist".
+      # Idempotent, and no schema is loaded: the accelerator manages its own tables.
+      # PGHOST must resolve identically to the POSTGRES_RW_HOST the benchmark step
+      # hands the spicepod (local container for SF1/SF10 and the clickbench
+      # acceleration run; the hosted cluster otherwise).
+      - name: Create postgres acceleration databases
+        if: ${{ contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') }}
+        env:
+          PGHOST: ${{ (((startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) || (github.event.inputs.query_set == 'clickbench' && contains(github.event.inputs.spicepod_path, 's3[parquet]-postgres'))) && '127.0.0.1' || vars.TEST_POSTGRES_HOST }}
+          PGPASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
+        run: |
+          set -e
+          SPICEPOD="${{ steps.set_spicepod_path.outputs.SPICEPOD_PATH }}"
+          ACCEL_DBS="$(grep -oE 'pg_db: *[A-Za-z0-9_]+_accelerated' "$SPICEPOD" | awk '{print $2}' | sort -u)"
+          if [ -z "$ACCEL_DBS" ]; then
+            echo "No *_accelerated pg_db in $SPICEPOD - nothing to create."
+            exit 0
+          fi
+          if ! command -v psql >/dev/null; then
+            sudo apt-get update -y && sudo apt-get install -y postgresql-client
+          fi
+          for db in $ACCEL_DBS; do
+            if psql -U postgres -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$db'" | grep -q 1; then
+              echo "$db already exists on $PGHOST."
+            else
+              createdb -U postgres "$db"
+              echo "Created $db on $PGHOST."
+            fi
+          done
+
       - name: Setup ODBC
         if: ${{ contains(github.event.inputs.spicepod_path, 'odbc') }}
         uses: ./.github/actions/setup-odbc
@@ -505,7 +545,7 @@ jobs:
           MONGODB_HOST: ${{ vars.TEST_MONGODB_HOST }}
           MONGODB_PASSWORD: ${{ secrets.TEST_MONGODB_PASSWORD }}
           POSTGRES_HOST: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') && (startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) && '127.0.0.1' || vars.TEST_POSTGRES_HOST }}
-          POSTGRES_RW_HOST: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') && (startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) && '127.0.0.1' || vars.TEST_POSTGRES_HOST }}
+          POSTGRES_RW_HOST: ${{ (contains(github.event.inputs.spicepod_path, 'postgres') && !contains(github.event.inputs.spicepod_path, 'ducklake') && (((startsWith(github.event.inputs.query_set, 'tpch') || github.event.inputs.query_set == 'tpcds') && (github.event.inputs.scale_factor == '1' || github.event.inputs.scale_factor == '10')) || (github.event.inputs.query_set == 'clickbench' && contains(github.event.inputs.spicepod_path, 's3[parquet]-postgres')))) && '127.0.0.1' || vars.TEST_POSTGRES_HOST }}
           POSTGRES_PASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
           SPICEAI_TEST_ENDPOINT: ${{ vars.SPICE_SECRET_SPICEAI_TEST_ENDPOINT }}
           SPICEAI_TEST_TPCH_API_KEY: ${{ secrets.SPICE_SECRET_SPICEAI_TEST_TPCH_BENCHMARK_KEY }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
  "regex",
  "toml 1.1.2+spec-1.1.0",
  "windows-registry",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -339,7 +339,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2675,7 +2675,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -4122,7 +4122,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6211,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6259,7 +6259,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "futures",
  "log",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-compression",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6376,7 +6376,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6398,7 +6398,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6447,12 +6447,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6473,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6696,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "chrono",
@@ -6747,7 +6747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6782,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "chrono",
@@ -6798,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6818,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "chrono",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6947,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6965,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -7404,7 +7404,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7902,7 +7902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8895,8 +8895,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -10029,7 +10029,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -10064,7 +10064,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -10715,7 +10715,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10729,15 +10729,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -12990,7 +12981,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15234,8 +15225,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.12.1",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -15256,7 +15247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15584,7 +15575,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -15623,7 +15614,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -17955,7 +17946,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18023,7 +18014,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19155,7 +19146,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -19246,7 +19237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19763,7 +19754,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20490,7 +20481,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20552,7 +20543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20766,7 +20757,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark 0.12.2",
@@ -23900,7 +23891,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6211,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6259,7 +6259,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "futures",
  "log",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "async-compression",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6376,7 +6376,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6398,7 +6398,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6447,12 +6447,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6473,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6696,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "chrono",
@@ -6747,7 +6747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6782,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "chrono",
@@ -6798,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6818,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "chrono",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6947,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6965,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
+source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6211,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6259,7 +6259,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "futures",
  "log",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-compression",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6376,7 +6376,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6398,7 +6398,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6447,12 +6447,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6473,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6696,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "chrono",
@@ -6747,7 +6747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6782,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "chrono",
@@ -6798,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6818,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "chrono",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6947,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6965,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=583fa0d159dd77ea8766d9cba1304a6f1152e76a#583fa0d159dd77ea8766d9cba1304a6f1152e76a"
+source = "git+https://github.com/spiceai/datafusion.git?rev=1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593#1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6211,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6259,7 +6259,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6284,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "futures",
  "log",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-compression",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6376,7 +6376,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6398,7 +6398,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6447,12 +6447,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6473,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6622,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6696,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "chrono",
@@ -6747,7 +6747,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6782,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "chrono",
@@ -6798,7 +6798,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6818,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "chrono",
@@ -6879,7 +6879,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6919,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6947,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6965,7 +6965,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=ac8d583646129b2f0869c595c4045cab5ebaa89d#ac8d583646129b2f0869c595c4045cab5ebaa89d"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -486,41 +486,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -486,41 +486,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "ac8d583646129b2f0869c595c4045cab5ebaa89d" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -486,41 +486,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" } # branch: spiceai-54 + PR #190 test-merge (refs/pull/190/merge); repin to the real spiceai-54 SHA once #190 merges
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -486,41 +486,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" } # branch: spiceai-54 + PR #190 test-merge (refs/pull/190/merge); repin to the real spiceai-54 SHA once #190 merges
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "583fa0d159dd77ea8766d9cba1304a6f1152e76a" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -1292,7 +1292,7 @@ pub fn get_tpcds_test_queries(
         {
             remove_tpcds_query!(
                 queries,
-                78 // SF100 Resources exhausted error https://github.com/spiceai/spiceai/issues/10965
+                78, 97 // SF100 Resources exhausted error https://github.com/spiceai/spiceai/issues/10965
             )
         }
         Some(_) | None => queries,

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -1291,8 +1291,8 @@ pub fn get_tpcds_test_queries(
             if scale_factor.is_some_and(|sf| (sf - 100.0).abs() < f64::EPSILON) =>
         {
             remove_tpcds_query!(
-                queries,
-                78, 97 // SF100 Resources exhausted error https://github.com/spiceai/spiceai/issues/10965
+                queries, 78,
+                97 // SF100 Resources exhausted error https://github.com/spiceai/spiceai/issues/10965
             )
         }
         Some(_) | None => queries,

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -572,8 +572,7 @@ mod tests {
 
         // Different file counts must redact to the identical token.
         let input = "|               |   CayenneAccelerationExec: snapshots_scanned=1, files_scanned=30   |";
-        let expected =
-            "|               |   CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>   |";
+        let expected = "|               |   CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>   |";
         assert_eq!(regex.replace_all(input, replacement), expected);
 
         let input = "|               |   CayenneAccelerationExec: snapshots_scanned=1, files_scanned=35   |";
@@ -589,7 +588,8 @@ mod tests {
         assert_eq!(regex.replace_all(input, replacement), input);
 
         // Other operators' counters are not this filter's job.
-        let input = "DataSourceExec: file_groups={16 groups: [<redacted>]}, projection=[o_orderkey]";
+        let input =
+            "DataSourceExec: file_groups={16 groups: [<redacted>]}, projection=[o_orderkey]";
         assert_eq!(regex.replace_all(input, replacement), input);
 
         Ok(())

--- a/crates/test-framework/src/snapshot/mod.rs
+++ b/crates/test-framework/src/snapshot/mod.rs
@@ -59,6 +59,17 @@ const CONNECTION_CONTEXT_FILTER_REPLACEMENT: &str = "compute_context=<CONNECTION
 const ENDPOINT_CONTEXT_FILTER_PATTERN: &str = r"compute_context=(?:url=|sc://)\S+";
 const ENDPOINT_CONTEXT_FILTER_REPLACEMENT: &str = CONNECTION_CONTEXT_FILTER_REPLACEMENT;
 
+/// Redact the scan counters `CayenneAccelerationExec` surfaces in its plan display.
+/// `snapshots_scanned`/`files_scanned` report read amplification, which depends on
+/// ingestion batching and how far compaction has progressed when the query runs —
+/// state that varies run to run, not plan structure. Left in the snapshot, the
+/// explain check fails whenever the accelerator happens to hold a different file
+/// count (e.g. `files_scanned=30` vs `=35`) even though the plan is identical.
+const CAYENNE_SCAN_COUNTERS_FILTER_PATTERN: &str =
+    r"CayenneAccelerationExec: snapshots_scanned=\d+, files_scanned=\d+";
+const CAYENNE_SCAN_COUNTERS_FILTER_REPLACEMENT: &str =
+    "CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>";
+
 /// Queries temporarily excluded from explain-plan snapshot validation because their
 /// plans are not yet stable enough to snapshot deterministically.
 const EXPLAIN_SNAPSHOT_SKIP_LIST: &[&str] = &["chbench_q5"];
@@ -85,6 +96,10 @@ fn build_explain_filters(temp_dir: &std::path::Path) -> Vec<(String, &'static st
         (
             ENDPOINT_CONTEXT_FILTER_PATTERN.to_string(),
             ENDPOINT_CONTEXT_FILTER_REPLACEMENT,
+        ),
+        (
+            CAYENNE_SCAN_COUNTERS_FILTER_PATTERN.to_string(),
+            CAYENNE_SCAN_COUNTERS_FILTER_REPLACEMENT,
         ),
         (r"required_guarantees=\[[^\]]*\]".to_string(), "required_guarantees=[N]"),
         (r"partition_sizes=\[[^\]]*\]".to_string(), "partition_sizes=[<redacted>]"),
@@ -544,6 +559,37 @@ mod tests {
         // The `host=` form stays the other pattern's job; this one must not half-match
         // it and leave a partially-redacted context behind.
         let input = "VirtualExecutionPlan name=mysql compute_context=host=db,port=3306,db=tpch,user=root base_sql=SELECT 1";
+        assert_eq!(regex.replace_all(input, replacement), input);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cayenne_scan_counters_filter() -> Result<(), String> {
+        let regex = regex::Regex::new(super::CAYENNE_SCAN_COUNTERS_FILTER_PATTERN)
+            .map_err(|e| format!("{e}"))?;
+        let replacement = super::CAYENNE_SCAN_COUNTERS_FILTER_REPLACEMENT;
+
+        // Different file counts must redact to the identical token.
+        let input = "|               |   CayenneAccelerationExec: snapshots_scanned=1, files_scanned=30   |";
+        let expected =
+            "|               |   CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>   |";
+        assert_eq!(regex.replace_all(input, replacement), expected);
+
+        let input = "|               |   CayenneAccelerationExec: snapshots_scanned=1, files_scanned=35   |";
+        assert_eq!(regex.replace_all(input, replacement), expected);
+
+        // A not-yet-refreshed accelerator reports zero for both counters.
+        let input = "CayenneAccelerationExec: snapshots_scanned=0, files_scanned=0";
+        let expected = "CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>";
+        assert_eq!(regex.replace_all(input, replacement), expected);
+
+        // Idempotent: an already-redacted snapshot is left unchanged.
+        let input = "CayenneAccelerationExec: snapshots_scanned=<N>, files_scanned=<N>";
+        assert_eq!(regex.replace_all(input, replacement), input);
+
+        // Other operators' counters are not this filter's job.
+        let input = "DataSourceExec: file_groups={16 groups: [<redacted>]}, projection=[o_orderkey]";
         assert_eq!(regex.replace_all(input, replacement), input);
 
         Ok(())

--- a/test/tpc-bench/Makefile
+++ b/test/tpc-bench/Makefile
@@ -9,6 +9,12 @@ all: tpch-gen pg-load
 # $(TPCH_FLEET_DIR) instead, so a caller using it must pass TPCH_DATA_DIR to match.
 TPCH_DATA_DIR ?= tpch-kit/dbgen
 
+# Directory the *-tpcds-load targets read TPC-DS .dat files from. dsdgen writes to
+# tpcds-kit/tools/tmp/data (see tpcds-gen), so that is the default; tpcds-fleet-gen
+# writes to $(TPCDS_FLEET_DIR) instead, so a caller using it must pass
+# TPCDS_DATA_DIR to match.
+TPCDS_DATA_DIR ?= tpcds-kit/tools/tmp/data
+
 tpch-clone:
 	@if [ ! -d "tpch-kit" ]; then \
 		git clone https://github.com/spiceai/tpch-kit.git; \
@@ -31,11 +37,13 @@ tpch-init: tpch-clone
 
 	@echo "Initialized successfully."
 
-tpcds-init:
+tpcds-clone:
 	@if [ ! -d "tpcds-kit" ]; then \
 		git clone https://github.com/spiceai/tpcds-kit.git; \
 		cd tpcds-kit && git checkout dd01f906992e1e39837526bffb3f5b759e83b3a8; \
 	fi
+
+tpcds-init: tpcds-clone
 	@OS=`uname`; \
 	if [ -z "$(OS)" ]; then \
 		if [ "$$OS" = "Linux" ]; then \
@@ -146,6 +154,52 @@ tpch-fleet-gen: $(DUCKDB)
 	done
 	@rm -f "$(TPCH_FLEET_DIR)/gen.duckdb" "$(TPCH_FLEET_DIR)/gen.duckdb.wal"
 	@echo "Test data generated successfully in $(TPCH_FLEET_DIR) - pass TPCH_DATA_DIR=$(TPCH_FLEET_DIR) to the load targets."
+
+# tpcds-fleet-gen is the TPC-DS analog of tpch-fleet-gen above: it generates the
+# same TPC-DS dataset the rest of the benchmark fleet runs on - the s3/file
+# parquet copies and the hosted MySQL and Spice Cloud databases - which is what
+# crates/test-framework/src/queries/validation/tpcds/*.csv holds the expected
+# answers for. That dataset comes from DuckDB's tpcds extension, a
+# reimplementation whose RNG diverges from tpcds-kit's C dsdgen: schemas and row
+# counts are identical, but which customer bought which item on which ticket
+# differs, so cross-fact-table join incidence differs. Queries whose canonical
+# SF1 answers hold only 1-2 rows (q17, q25, q85 - store/catalog/web sales
+# joined to their returns) come back genuinely empty from a tpcds-kit-seeded
+# database no matter how correct the engine under test is, and value-level
+# result snapshots differ broadly. Seeding from the same generator the expected
+# answers were produced with is what makes a result mismatch mean a real bug.
+#
+# Data only - the DDL (tpcds.sql) and foreign keys (tpcds_ri.sql) still come
+# from tpcds-kit, which tpcds-clone fetches without compiling the C tools.
+# Example: DBGEN_SCALE=1 make tpcds-fleet-gen
+TPCDS_FLEET_DIR ?= ./tmp/tpcds-fleet
+
+TPCDS_TABLES = call_center catalog_page catalog_returns catalog_sales customer \
+	customer_address customer_demographics date_dim household_demographics \
+	income_band inventory item promotion reason ship_mode store store_returns \
+	store_sales time_dim warehouse web_page web_returns web_sales web_site
+
+tpcds-fleet-gen: $(DUCKDB)
+	@# Check if DBGEN_SCALE is set, else default to 1
+	$(eval DBGEN_SCALE ?= 1)
+	@mkdir -p "$(TPCDS_FLEET_DIR)"
+	@rm -f "$(TPCDS_FLEET_DIR)"/*.dat "$(TPCDS_FLEET_DIR)/gen.duckdb" "$(TPCDS_FLEET_DIR)/gen.duckdb.wal"
+	@echo "Generating TPC-DS scale factor $(DBGEN_SCALE)..."
+	@"$(DUCKDB)" "$(TPCDS_FLEET_DIR)/gen.duckdb" -c "INSTALL tpcds; LOAD tpcds; CALL dsdgen(sf=$(DBGEN_SCALE));" > /dev/null
+	@# QUOTE '' disables CSV quoting so no field is ever wrapped, and the trailing
+	@# empty column reproduces dsdgen's trailing '|'; NULLs export as empty fields,
+	@# exactly as dsdgen writes them. The result is byte-compatible with dsdgen's
+	@# .dat format, so every *-tpcds-load target reads it unchanged. Tables are
+	@# dropped as they are written to bound peak disk at the larger scales.
+	@for table in $(TPCDS_TABLES); do \
+		echo "Writing $$table.dat..."; \
+		"$(DUCKDB)" "$(TPCDS_FLEET_DIR)/gen.duckdb" -c "\
+			COPY (SELECT *, '' FROM $$table) TO '$(TPCDS_FLEET_DIR)/$$table.dat' (FORMAT CSV, DELIMITER '|', HEADER false, QUOTE ''); \
+			DROP TABLE $$table; \
+			CHECKPOINT;" > /dev/null || exit 1; \
+	done
+	@rm -f "$(TPCDS_FLEET_DIR)/gen.duckdb" "$(TPCDS_FLEET_DIR)/gen.duckdb.wal"
+	@echo "Test data generated successfully in $(TPCDS_FLEET_DIR) - pass TPCDS_DATA_DIR=$(TPCDS_FLEET_DIR) to the load targets."
 
 # Default value for DB_NAME
 DB_NAME ?= tpch
@@ -298,7 +352,7 @@ mysql-tpcds-load:
 	@mkdir -p ./tmp
 	@for table in call_center catalog_page catalog_returns catalog_sales customer customer_address customer_demographics date_dim household_demographics income_band inventory item promotion reason ship_mode store store_returns store_sales time_dim warehouse web_page web_returns web_sales web_site; do \
 		echo "Loading $$table..."; \
-		sed 's/|$$//' tpcds-kit/tools/tmp/data/$$table.dat > ./tmp/$$table.dat; \
+		sed 's/|$$//' "$(TPCDS_DATA_DIR)/$$table.dat" > ./tmp/$$table.dat; \
 		mysql -h$(DB_HOST) -u$(DB_USER) -p$(DB_PASS) -P$(DB_PORT) --local-infile=1 $(DB_NAME) -e "LOAD DATA LOCAL INFILE './tmp/$$table.dat' INTO TABLE $$table FIELDS TERMINATED BY '|' LINES TERMINATED BY '\n';"; \
 	done
 	@echo "Benchmark dataset has been successfully loaded to '$(DB_NAME)' database."
@@ -340,7 +394,7 @@ pg-tpcds-load:
 	@mkdir -p ./tmp
 	@for table in call_center catalog_page catalog_returns catalog_sales customer customer_address customer_demographics date_dim household_demographics income_band inventory item promotion reason ship_mode store store_returns store_sales time_dim warehouse web_page web_returns web_sales web_site; do \
 		echo "Loading $$table..."; \
-		sed 's/|$$//' tpcds-kit/tools/tmp/data/$$table.dat > ./tmp/$$table.dat; \
+		sed 's/|$$//' "$(TPCDS_DATA_DIR)/$$table.dat" > ./tmp/$$table.dat; \
 		psql -h $(DB_HOST) -p $(DB_PORT) -U $(DB_USER) $(DB_NAME) -c "\\copy $$table FROM './tmp/$$table.dat' CSV DELIMITER '|';"; \
 	done
 	@echo "Applying foreign keys from tpcds_ri.sql..."


### PR DESCRIPTION
- Bumps the pinned `spiceai/datafusion` fork to https://github.com/spiceai/datafusion/commit/1c43ad804bbf3f2e9c22e9b5700bdf8ebd957593
- TPC-DS Postgres seeding now uses the DuckDB-based fleet generator instead of tpcds-kit's `dsdgen`, whose RNG diverges from the generator that produced the recorded expected answers.
- Self-healing benchmark data: the workflow now creates any missing `*_accelerated` Postgres databases it finds in the dispatched spicepod before `spiced` starts, and Clickbench's `s3[parquet]-postgres` run gets its own local Postgres service container instead of the shared hosted cluster (it only needs an empty acceleration target, not pre-loaded source data).
- Snapshot hygiene: `CayenneAccelerationExec`'s `snapshots_scanned=`/`files_scanned=` counters are redacted (`<N>`) in explain-plan snapshots — they reflect compaction/ingestion state, not plan structure, and were breaking snapshots on every file-count drift.