### PR TITLE
fix(graphql): keep the configured schema when a page has no rows (fixes #13004)

### DIFF
--- a/crates/data-connectors/connector-graphql/src/graphql/client.rs
+++ b/crates/data-connectors/connector-graphql/src/graphql/client.rs
@@ -956,7 +956,6 @@ impl GraphQLClient {
         .await
     }
 
-    #[expect(clippy::too_many_lines)]
     #[expect(clippy::too_many_arguments)]
     async fn execute_inner(
         &self,

--- a/crates/data-connectors/connector-graphql/src/graphql/client.rs
+++ b/crates/data-connectors/connector-graphql/src/graphql/client.rs
@@ -1119,6 +1119,39 @@ impl GraphQLClient {
             .map(|p| p(&response_headers, &response))
             .transpose()?;
 
+        self.process_response(query, schema.as_ref(), limit, cursor.as_deref(), &response)
+    }
+
+    /// The result for a page that yielded no rows, keeping whichever schema the table is
+    /// configured with so an empty page cannot narrow it.
+    ///
+    /// Every early exit out of [`Self::process_response`] goes through here: the schema a rowless
+    /// page reports is the one rule they must agree on, so it lives in one place.
+    fn empty_page(
+        &self,
+        schema: Option<&SchemaRef>,
+        cursor: Option<String>,
+    ) -> Result<GraphQLQueryResult> {
+        Ok(GraphQLQueryResult {
+            records: vec![],
+            limit_reached: false,
+            // No rows to infer from, so this resolves to the override or the configured schema.
+            schema: get_json_schema(self.schema.as_ref(), schema, &[])?,
+            cursor,
+        })
+    }
+
+    /// Turn a decoded GraphQL response body into record batches, resolving the schema each page is
+    /// parsed with. Split out from `execute_inner` so the page-shape handling — null payload, empty
+    /// page, repeated cursor — is reachable without an HTTP round trip.
+    fn process_response(
+        &self,
+        query: &GraphQLQuery,
+        schema: Option<&SchemaRef>,
+        limit: Option<usize>,
+        cursor: Option<&str>,
+        response: &serde_json::Value,
+    ) -> Result<GraphQLQueryResult> {
         let json_pointer = query
             .json_pointer
             .as_ref()
@@ -1141,7 +1174,7 @@ impl GraphQLClient {
                 } else {
                     format!("Invalid JSON pointer: '{json_pointer}'. The expected data path was not found in the response.")
                 };
-                tracing::error!("Failed to extract data from response. Full response: {}", serde_json::to_string_pretty(&response).unwrap_or_else(|_| format!("{response:?}")));
+                tracing::error!("Failed to extract data from response. Full response: {}", serde_json::to_string_pretty(response).unwrap_or_else(|_| format!("{response:?}")));
                 Error::InvalidJsonPointer {
                     pointer: error_msg,
                 }
@@ -1151,18 +1184,13 @@ impl GraphQLClient {
         // Handle null data explicitly
         if extracted_data.is_null() {
             tracing::debug!("Extracted data at pointer '{json_pointer}' is null");
-            return Ok(GraphQLQueryResult {
-                records: vec![],
-                limit_reached: false,
-                schema: schema.unwrap_or_else(|| Arc::new(arrow::datatypes::Schema::empty())),
-                cursor: None,
-            });
+            return self.empty_page(schema, None);
         }
 
         let next_cursor = query
             .pagination_parameters
             .as_ref()
-            .and_then(|x| x.get_next_cursor_from_response(&response));
+            .and_then(|x| x.get_next_cursor_from_response(response));
 
         // Validate next cursor if present
         if let Some(ref next_cursor_val) = next_cursor {
@@ -1170,17 +1198,12 @@ impl GraphQLClient {
                 tracing::warn!("Empty cursor returned from pagination, stopping pagination");
             }
             // Detect potential infinite loop - same cursor returned
-            if cursor.as_ref() == Some(next_cursor_val) {
+            if cursor == Some(next_cursor_val.as_str()) {
                 tracing::warn!(
                     "Same cursor returned from pagination, stopping to prevent infinite loop"
                 );
                 // Use limit_reached: false for loop protection exits, not data limit exhaustion
-                return Ok(GraphQLQueryResult {
-                    records: vec![],
-                    limit_reached: false,
-                    schema: schema.unwrap_or_else(|| Arc::new(arrow::datatypes::Schema::empty())),
-                    cursor: None,
-                });
+                return self.empty_page(schema, None);
             }
         }
 
@@ -1195,12 +1218,7 @@ impl GraphQLClient {
         // Validate we have data to process
         if unwrapped.is_empty() {
             tracing::debug!("No data to process after extraction");
-            return Ok(GraphQLQueryResult {
-                records: vec![],
-                limit_reached: false,
-                schema: schema.unwrap_or_else(|| Arc::new(arrow::datatypes::Schema::empty())),
-                cursor: next_cursor,
-            });
+            return self.empty_page(schema, next_cursor);
         }
 
         unwrapped = match self.unnest_parameters.behavior {
@@ -1210,7 +1228,7 @@ impl GraphQLClient {
             }
         };
 
-        let schema = get_json_schema(self.schema.as_ref(), schema.as_ref(), &unwrapped)?;
+        let schema = get_json_schema(self.schema.as_ref(), schema, &unwrapped)?;
 
         let mut res = vec![];
         for v in unwrapped {
@@ -1470,6 +1488,11 @@ impl GraphQLClient {
     }
 }
 
+/// Resolve the schema a page's rows are parsed with: per-query override, then the schema
+/// configured on the client, then inference from the rows themselves.
+///
+/// An empty `json_iter` means there are no rows to infer from, so the last step yields an empty
+/// schema rather than guessing one.
 fn get_json_schema(
     client_schema: Option<&SchemaRef>,
     schema_override: Option<&SchemaRef>,
@@ -1718,6 +1741,191 @@ mod tests {
     use crate::graphql::client::GraphQLQuery;
 
     use super::{DuplicateBehavior, PaginationParameters, UnnestBehavior, handle_http_error};
+
+    mod empty_page_schema {
+        use std::sync::Arc;
+
+        use arrow::array::RecordBatch;
+        use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+        use serde_json::json;
+        use url::Url;
+
+        use crate::graphql::builder::GraphQLClientBuilder;
+        use crate::graphql::client::{
+            GraphQLClient, GraphQLQuery, GraphQLQueryResult, UnnestBehavior,
+        };
+
+        const UNPAGINATED_QUERY: &str = "query { view { nodes { id } } }";
+        const PAGINATED_QUERY: &str =
+            "query { view(first: 10) { nodes { id } pageInfo { hasNextPage endCursor } } }";
+
+        fn configured_schema() -> SchemaRef {
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Utf8, true),
+                Field::new("title", DataType::Utf8, true),
+            ]))
+        }
+
+        fn client_with_schema(schema: Option<SchemaRef>) -> GraphQLClient {
+            GraphQLClientBuilder::new(
+                Url::parse("https://example.com/graphql").expect("valid URL"),
+                UnnestBehavior::Depth(0),
+            )
+            .with_json_pointer(Some("/data/view/nodes"))
+            .with_schema(schema)
+            .build(reqwest::Client::new())
+            .expect("client to build")
+        }
+
+        fn process(
+            client: &GraphQLClient,
+            query_str: &str,
+            schema_override: Option<&SchemaRef>,
+            cursor: Option<&str>,
+            response: &serde_json::Value,
+        ) -> GraphQLQueryResult {
+            let query =
+                GraphQLQuery::try_from(Arc::<str>::from(query_str)).expect("query to parse");
+
+            client
+                .process_response(&query, schema_override, None, cursor, response)
+                .expect("an empty page is a valid response, not an error")
+        }
+
+        /// Regression test for #13004: a first page with no rows must not discard the configured
+        /// schema, or preflight builds the table from `Schema::empty()` and the dataset fails to
+        /// connect.
+        #[test]
+        fn empty_page_keeps_the_configured_schema() {
+            let schema = configured_schema();
+            let client = client_with_schema(Some(Arc::clone(&schema)));
+
+            let result = process(
+                &client,
+                UNPAGINATED_QUERY,
+                None,
+                None,
+                &json!({"data": {"view": {"nodes": []}}}),
+            );
+
+            assert!(result.records.is_empty(), "an empty page yields no rows");
+            assert_eq!(result.schema, schema);
+        }
+
+        /// A null payload is the same shape as an empty page: GitHub returns `nodes: null` rather
+        /// than `[]` for some resources.
+        #[test]
+        fn null_payload_keeps_the_configured_schema() {
+            let schema = configured_schema();
+            let client = client_with_schema(Some(Arc::clone(&schema)));
+
+            let result = process(
+                &client,
+                UNPAGINATED_QUERY,
+                None,
+                None,
+                &json!({"data": {"view": {"nodes": null}}}),
+            );
+
+            assert!(result.records.is_empty());
+            assert_eq!(result.schema, schema);
+        }
+
+        /// The pagination loop-guard exit is the third early return out of the page handler, and it
+        /// dropped the configured schema the same way the other two did.
+        #[test]
+        fn repeated_cursor_keeps_the_configured_schema() {
+            let schema = configured_schema();
+            let client = client_with_schema(Some(Arc::clone(&schema)));
+
+            let result = process(
+                &client,
+                PAGINATED_QUERY,
+                None,
+                Some("cursor-1"),
+                &json!({
+                    "data": {
+                        "view": {
+                            "nodes": [{"id": "1", "title": "a"}],
+                            "pageInfo": {"hasNextPage": true, "endCursor": "cursor-1"}
+                        }
+                    }
+                }),
+            );
+
+            assert!(
+                result.records.is_empty(),
+                "the loop guard stops before parsing rows"
+            );
+            assert!(result.cursor.is_none(), "the loop guard clears the cursor");
+            assert_eq!(result.schema, schema);
+        }
+
+        /// A per-query schema override outranks the client's configured schema on an empty page,
+        /// matching the precedence a non-empty page already used.
+        #[test]
+        fn schema_override_outranks_the_configured_schema_on_an_empty_page() {
+            let override_schema: SchemaRef = Arc::new(Schema::new(vec![Field::new(
+                "only_field",
+                DataType::Int64,
+                true,
+            )]));
+            let client = client_with_schema(Some(configured_schema()));
+
+            let result = process(
+                &client,
+                UNPAGINATED_QUERY,
+                Some(&override_schema),
+                None,
+                &json!({"data": {"view": {"nodes": []}}}),
+            );
+
+            assert_eq!(result.schema, override_schema);
+        }
+
+        /// With nothing configured there is still nothing to infer from, so an empty page keeps
+        /// reporting an empty schema.
+        #[test]
+        fn empty_page_without_a_configured_schema_stays_empty() {
+            let client = client_with_schema(None);
+
+            let result = process(
+                &client,
+                UNPAGINATED_QUERY,
+                None,
+                None,
+                &json!({"data": {"view": {"nodes": []}}}),
+            );
+
+            assert_eq!(result.schema.fields().len(), 0);
+        }
+
+        /// A page that does have rows is unaffected: the configured schema is what its batches are
+        /// parsed with.
+        #[test]
+        fn non_empty_page_still_parses_with_the_configured_schema() {
+            let schema = configured_schema();
+            let client = client_with_schema(Some(Arc::clone(&schema)));
+
+            let result = process(
+                &client,
+                UNPAGINATED_QUERY,
+                None,
+                None,
+                &json!({"data": {"view": {"nodes": [{"id": "1", "title": "a"}]}}}),
+            );
+
+            assert_eq!(result.schema, schema);
+            assert_eq!(
+                result
+                    .records
+                    .iter()
+                    .map(RecordBatch::num_rows)
+                    .sum::<usize>(),
+                1
+            );
+        }
+    }
 
     struct TestPaginationParseCase {
         name: &'static str,

--- a/crates/data-connectors/connector-graphql/src/graphql/provider.rs
+++ b/crates/data-connectors/connector-graphql/src/graphql/provider.rs
@@ -14,10 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use arrow::{
-    array::{RecordBatch, new_empty_array},
-    datatypes::SchemaRef,
-};
+use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use async_trait::async_trait;
 use datafusion::{
     catalog::Session,
@@ -38,9 +35,7 @@ use futures::StreamExt;
 use snafu::ResultExt;
 use std::{fmt, sync::Arc};
 
-use super::{
-    ArrowInternalSnafu, ErrorChecker, GraphQLContext, ResultTransformSnafu, client::GraphQLClient,
-};
+use super::{ErrorChecker, GraphQLContext, ResultTransformSnafu, client::GraphQLClient};
 use super::{Result, client::GraphQLQuery};
 
 pub type TransformFn =
@@ -52,13 +47,9 @@ fn derive_table_schema(
 ) -> Result<SchemaRef> {
     match transform_fn {
         Some(transform_fn) => {
-            let empty_columns = gql_schema
-                .fields()
-                .iter()
-                .map(|field| new_empty_array(field.data_type()))
-                .collect();
-            let empty_batch = RecordBatch::try_new(Arc::clone(gql_schema), empty_columns)
-                .context(ArrowInternalSnafu)?;
+            // `new_empty` rather than `try_new`, which cannot build a batch from a fieldless
+            // schema — see `derive_table_schema_handles_a_fieldless_schema`.
+            let empty_batch = RecordBatch::new_empty(Arc::clone(gql_schema));
 
             Ok(transform_fn(&empty_batch)
                 .context(ResultTransformSnafu)?
@@ -458,6 +449,45 @@ mod tests {
         )]));
 
         RecordBatch::try_new(schema, vec![Arc::clone(batch.column(0))]).map_err(Into::into)
+    }
+
+    fn fixed_output_schema(
+        _batch: &RecordBatch,
+    ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "cast_id",
+            DataType::Utf8,
+            true,
+        )]));
+
+        Ok(RecordBatch::new_empty(schema))
+    }
+
+    /// Regression test for #13004: with nothing configured to fall back to, an empty first page
+    /// leaves a fieldless schema, and building the transform's probe batch out of it used to fail
+    /// with "must either specify a row count or at least one column" — failing the whole dataset.
+    #[test]
+    fn derive_table_schema_handles_a_fieldless_schema() {
+        let empty: SchemaRef = Arc::new(Schema::empty());
+
+        let derived = derive_table_schema(&empty, Some(fixed_output_schema))
+            .expect("a fieldless schema is not a reason to fail the dataset");
+
+        assert_eq!(derived.field(0).name(), "cast_id");
+    }
+
+    /// The probe batch a transform sees still carries every configured field, so a transform that
+    /// inspects its input keeps working.
+    #[test]
+    fn derive_table_schema_passes_configured_fields_to_the_transform() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, true)]));
+
+        let derived = derive_table_schema(&schema, Some(rename_first_column))
+            .expect("transform to run over the configured fields");
+
+        assert_eq!(derived.field(0).name(), "renamed_id");
+        assert_eq!(derived.field(0).data_type(), &DataType::Int64);
     }
 
     #[test]

--- a/crates/data-connectors/connector-graphql/src/graphql/provider.rs
+++ b/crates/data-connectors/connector-graphql/src/graphql/provider.rs
@@ -451,6 +451,10 @@ mod tests {
         RecordBatch::try_new(schema, vec![Arc::clone(batch.column(0))]).map_err(Into::into)
     }
 
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "signature is fixed by TransformFn, which fallible transforms also implement"
+    )]
     fn fixed_output_schema(
         _batch: &RecordBatch,
     ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {


### PR DESCRIPTION
## Summary

A GraphQL dataset whose first page came back with **no rows** failed to connect, even when the table had a configured schema:

```
WARN runtime::init::dataset: Failed to connect to the source for dataset <name> (github).
Failed to process GraphQL response: Invalid argument error: must either specify a row count or at least one column
```

Root cause is two defects on the same path.

**1. The empty-page early returns discarded the configured schema.** `GraphQLClient`'s page handler has three early exits — a null payload, a page with no rows, and the pagination loop-guard — and each built its result as `schema.unwrap_or_else(|| Schema::empty())`. That consults only the per-query override, so a client *configured* with a schema (every GitHub table: `issues`, `pulls`, …) reported `Schema::empty()` for an empty page. The non-empty path never had this bug: it goes through `get_json_schema`, which walks override → configured → inference. The three early returns simply never called it. This is what makes the reported dataset fail.

**2. A fieldless schema cannot build a transform's probe batch.** With the empty schema in hand, preflight then calls `derive_table_schema`, which built a zero-row probe batch with `RecordBatch::try_new`. A schema with no fields has no column to carry the row count, so Arrow rejects it — `must either specify a row count or at least one column`. That surfaces as `Error::ArrowInternal`, which is neither retriable nor `RateLimited`, so the GitHub connector's existing configured-schema fallback (`build_without_validation`) never ran and the dataset failed outright.

A repo with no issues, or any page that simply happens to be empty, is a valid result — it should register as a ready table with zero rows.

## Changes

- `client.rs`: added `GraphQLClient::empty_page`, and routed all three early exits through it. The schema a rowless page reports is the one rule those exits must agree on, so it now lives in exactly one place — a fourth early exit added later cannot reintroduce this bug. It resolves the schema with `get_json_schema`, the same function and precedence the non-empty path uses; an empty row slice skips inference, giving override → configured → empty.
- `client.rs`: split the response handling out of `execute_inner` into `process_response`. This is what makes the fix testable — the crate has no HTTP mock and the defect lives entirely past the request.
- `provider.rs`: `derive_table_schema` builds its probe batch with `RecordBatch::new_empty`, which is infallible and identical for a schema that does have fields (it maps `new_empty_array` over them exactly as the removed code did).

On scope, two deliberate calls:

- Change 3 is **defense in depth, not the load-bearing fix**. Once the client keeps the configured schema, the fieldless-schema path is not reachable for any connector that installs a transform — `with_schema_transform` has exactly one production caller (`connector-github`), and every GitHub table passes `Some(gql_schema())`. It is still worth making `derive_table_schema` total rather than partial, which is what the issue asked for.
- The issue also proposed widening the GitHub connector's error-recovery fallback to treat this failure class as recoverable. Deliberately **not** included: with the two defects above fixed, preflight succeeds on an empty page rather than needing to be recovered from, and widening the fallback would change error handling for failures unrelated to this bug.

## Test plan

- `make lint`
- `make nextest`

New unit tests, all against the production functions. Each regression test was verified by reverting its fix and confirming it fails — and with the client fix reverted, exactly the three empty-page tests fail while the three back-compat/precedence pins keep passing:

- `empty_page_keeps_the_configured_schema` — the reported failure: an empty first page keeps the configured schema instead of `Schema::empty()`.
- `null_payload_keeps_the_configured_schema` — `nodes: null`, the other empty-page shape GitHub returns.
- `repeated_cursor_keeps_the_configured_schema` — the pagination loop-guard exit, the third site.
- `schema_override_outranks_the_configured_schema_on_an_empty_page` — precedence now matches the non-empty path.
- `empty_page_without_a_configured_schema_stays_empty` — back-compat: with nothing configured there is still nothing to infer, so the schema stays empty.
- `non_empty_page_still_parses_with_the_configured_schema` — the unchanged path, pinned.
- `derive_table_schema_handles_a_fieldless_schema` — reproduces the exact Arrow error from the report when the fix is reverted.
- `derive_table_schema_passes_configured_fields_to_the_transform` — the probe batch still carries every configured field.

## Review gate

- Adversarial review: `codex` — job `review-msru04s5-i75xz8`, verdict `needs-attention`, 1 finding. **Valid, fixed:** `process_response` took `schema`, `cursor`, and `response` by value while only borrowing them, which `clippy::pedantic`'s `needless_pass_by_value` would have failed the lint gate on. Signature now takes `Option<&SchemaRef>`, `Option<&str>`, `&serde_json::Value`.
- `/security-review`: no findings. The diff adds no log lines, no error strings carrying response content, no new dependencies, no `unsafe`, and no new network-reachable surface; the schema values it newly propagates come from spicepod config, not from the remote response.
- `/simplify`: applied — collapsed the three duplicated empty-result literals into `empty_page` (the altitude fix above), corrected a doc paragraph on `get_json_schema` that claimed emptiness is what preserves the configured schema when the configured schema in fact wins regardless, de-duplicated a rationale comment against its test, and made the test helper borrow rather than take ownership. Skipped: converting four of the tests to a table (distinct named tests are what made the revert-verification legible, and four cases do not warrant it) and sharing a test client-builder with `provider.rs`'s existing tests (would rewrite three tests outside this diff).

Its altitude pass also found the same defect shape in code this diff does not touch — the ClickHouse connector discards its `projected_schema` and returns `Schema::empty()` for a zero-row result. Filed as #13015.

Fixes #13004

## Checklist

- [ ] Tests pass locally (`make signoff`)
- [ ] Lint is green
- [ ] Issue linked
