### PR TITLE
fix(cayenne): hold primary keys committed while the existence index is checked out

### DIFF
--- a/crates/cayenne/src/provider/on_conflict.rs
+++ b/crates/cayenne/src/provider/on_conflict.rs
@@ -22,7 +22,9 @@ limitations under the License.
 //! scan/update plumbing. The provider drives these from its insert/delete path.
 
 use super::delete::CayenneDeletionSink;
-use super::pk_index::{CachedPkIndex, PkDigestSet, PkExistenceRef, ShardedPkIndex};
+use super::pk_index::{
+    CachedPkIndex, PendingPkExistence, PkDigestSet, PkExistenceRef, ShardedPkIndex,
+};
 use crate::metadata::InlinedData;
 
 use arrow::record_batch::RecordBatch;
@@ -1081,6 +1083,13 @@ pub(crate) struct OnConflictContext<'a> {
     pub(crate) on_conflict: &'a OnConflict,
     pub(crate) upsert_options: &'a UpsertOptions,
     pub(crate) existing: PkExistenceRef<'a>,
+    /// Keys committed by other writers since `existing` was checked out of its
+    /// cache, which `existing` therefore cannot know about (see
+    /// [`PendingPkKeys`](super::pk_index::PendingPkKeys)).
+    /// Consulted on an `existing` miss so a key committed mid-validation is not
+    /// classified as a new primary key. `None` when nothing was committed during
+    /// this checkout — the common case.
+    pub(crate) pending: Option<&'a PendingPkExistence>,
     pub(crate) incoming_keys: &'a PkDigestSet,
 }
 
@@ -1171,12 +1180,24 @@ impl OnConflictValidationStream {
             CachedPkIndex::Bloom(bloom) => PkExistenceRef::Bloom(bloom),
         };
 
+        // Snapshot per batch, not per stream: `existing` was checked out before the
+        // first batch, and this stream is consumed lazily as the encode runs, so a
+        // concurrent writer can commit a key between two batches of it.
+        let pending = if self.store_back {
+            self.table.pending_pk_existence()
+        } else {
+            // Off-lock staging validates against a private keyset it just built —
+            // it holds no checkout, so the log is another writer's business.
+            None
+        };
+
         let mut ctx = OnConflictContext {
             pk_indices: &self.pk_indices,
             converter: &self.converter,
             on_conflict: &self.on_conflict,
             upsert_options: &self.upsert_options,
             existing,
+            pending: pending.as_ref(),
             incoming_keys: &self.incoming_keys,
         };
 

--- a/crates/cayenne/src/provider/pk_index.rs
+++ b/crates/cayenne/src/provider/pk_index.rs
@@ -732,6 +732,235 @@ impl CachedPkIndex {
     }
 }
 
+/// One committed key batch held while a PK existence index was checked out of
+/// its cache. Carries the recorded [`RowLocation`] and commit sequence verbatim
+/// so replaying it into the restored index is byte-identical to having recorded
+/// it directly.
+struct PendingPkKeyBatch {
+    keys: PkDigestSet,
+    location: RowLocation,
+    sequence: i64,
+}
+
+/// Divisor applied to a PK cache's byte budget to bound its pending-key log.
+/// The log is transient (it lives only while an index is checked out) and holds
+/// the same per-key payload as the cache, so a quarter keeps the worst case a
+/// fraction of the index it protects.
+const PENDING_PK_KEYS_BUDGET_DIVISOR: usize = 4;
+
+/// Keys committed by other writers while a PK existence index was checked out
+/// of its cache for validation.
+///
+/// A validation stream takes the shared index out of its cache cell and holds it
+/// for the whole lazily-consumed stream, so a writer that commits during that
+/// window finds the cell empty. Recording its keys there is a no-op, and an
+/// existence entry that never lands leaves the index a strict UNDER-approximation
+/// of the live rows — a later upsert probes the restored index, misses, and
+/// classifies the key as new, so it emits no supersede and the table ends up with
+/// two live rows for one primary key. (Over-approximation is the safe direction:
+/// a stale-present entry only costs a redundant tombstone.)
+///
+/// The keys are therefore held here instead, and are both:
+/// - merged into the index when it is restored, so the cache regains every key, and
+/// - probed by the in-flight validation that holds the checked-out index, so a key
+///   committed mid-stream is not read as a new primary key by the writer whose
+///   snapshot predates it.
+///
+/// Bounded by a byte cap. Past it the log stops recording, its snapshot reports
+/// [`PendingPkExistence::is_incomplete`], and the restore discards the index
+/// (forcing an authoritative rebuild) rather than caching one that is silently
+/// missing keys.
+#[derive(Default)]
+pub(crate) struct PendingPkKeys {
+    /// How many indexes are currently checked out over this cache. Distinguishes
+    /// "checked out" from "no cache at all": a cold cache needs no log, because the
+    /// next validation rebuilds the index from the table and sees every committed
+    /// key. Normally 0 or 1 (writers are serialized by the table write lock); see
+    /// [`Self::begin_checkout`] for what a second one means.
+    outstanding: usize,
+    batches: Vec<PendingPkKeyBatch>,
+    approx_bytes: usize,
+    /// The log hit its byte cap and stopped recording, so it no longer holds every
+    /// key committed during the checkout.
+    overflowed: bool,
+    /// The cache was invalidated while the index was checked out, so the index
+    /// describes a table state that has since been superseded (a DELETE, a
+    /// compaction, a recovery) and must not be cached when it comes back.
+    invalidated: bool,
+}
+
+impl PendingPkKeys {
+    /// Byte cap for a log protecting a cache with `cache_budget` bytes.
+    pub(crate) fn budget_from_cache_budget(cache_budget: usize) -> usize {
+        cache_budget / PENDING_PK_KEYS_BUDGET_DIVISOR
+    }
+
+    /// Open a checkout window: keys committed from here until [`Self::end_checkout`]
+    /// are recorded. Any residue from an abandoned checkout is dropped — that index
+    /// was never stored back, so the next validation rebuilds from the table and
+    /// already sees those keys.
+    ///
+    /// Opening a SECOND window while one is outstanding puts two independently-aged
+    /// indexes over one cache: each was read at a different point, so whichever is
+    /// stored last silently reverts the other's keys. Neither is trustworthy, so both
+    /// are marked for discard and the cache goes cold — one rebuild instead of a
+    /// cache that answers "absent" for a live key. Writers are serialized by the
+    /// table write lock, so this is a backstop, not a routine path.
+    pub(crate) fn begin_checkout(&mut self) {
+        if self.outstanding == 0 {
+            self.overflowed = false;
+            self.invalidated = false;
+        } else {
+            self.invalidated = true;
+        }
+        self.batches.clear();
+        self.approx_bytes = 0;
+        self.outstanding = self.outstanding.saturating_add(1);
+    }
+
+    /// Report that the cache was invalidated while an index was checked out, so the
+    /// restore drops that index instead of resurrecting a superseded one. A no-op
+    /// when nothing is checked out — there is then no index in flight, and the flag
+    /// would otherwise leak into the next checkout.
+    pub(crate) fn invalidate(&mut self) {
+        if self.outstanding == 0 {
+            return;
+        }
+        self.invalidated = true;
+        self.batches.clear();
+        self.approx_bytes = 0;
+    }
+
+    /// Hold one committed key batch. A no-op when no index is checked out, or once
+    /// the log has stopped recording. Callers read [`Self::approx_bytes`] around the
+    /// call to account the change.
+    pub(crate) fn record(
+        &mut self,
+        keys: &PkDigestSet,
+        location: &RowLocation,
+        sequence: i64,
+        max_bytes: usize,
+    ) {
+        if self.outstanding == 0 || self.overflowed || self.invalidated {
+            return;
+        }
+        let batch_bytes = keys
+            .iter()
+            .map(approx_pk_keyset_entry_bytes)
+            .fold(0, usize::saturating_add);
+        if self.approx_bytes.saturating_add(batch_bytes) > max_bytes {
+            // Stop holding keys rather than grow without bound, and release the ones
+            // already held: the index this log protects is now unrecoverable either
+            // way, and `end_checkout` reports that so it is discarded instead of
+            // being stored back missing entries.
+            self.overflowed = true;
+            self.batches.clear();
+            self.approx_bytes = 0;
+            return;
+        }
+        self.approx_bytes = self.approx_bytes.saturating_add(batch_bytes);
+        self.batches.push(PendingPkKeyBatch {
+            keys: keys.clone(),
+            location: location.clone(),
+            sequence,
+        });
+    }
+
+    /// Close the checkout window and hand back everything committed during it. With
+    /// several windows outstanding every one of them reports a discard, and the flags
+    /// only reset once the last closes.
+    pub(crate) fn end_checkout(&mut self) -> RestoredPkKeys {
+        let restored = RestoredPkKeys {
+            batches: std::mem::take(&mut self.batches),
+            discard_index: self.overflowed || self.invalidated,
+        };
+        self.approx_bytes = 0;
+        self.outstanding = self.outstanding.saturating_sub(1);
+        if self.outstanding == 0 {
+            self.overflowed = false;
+            self.invalidated = false;
+        }
+        restored
+    }
+
+    /// Existence view over the keys held so far, for the validation that holds the
+    /// checked-out index. `None` when nothing was committed during this checkout —
+    /// the overwhelmingly common case, which costs one uncontended lock.
+    pub(crate) fn existence(&self) -> Option<PendingPkExistence> {
+        if self.batches.is_empty() && !self.overflowed {
+            return None;
+        }
+        let capacity = self
+            .batches
+            .iter()
+            .map(|batch| batch.keys.len())
+            .fold(0, usize::saturating_add);
+        let mut locations: HashMap<u128, RowLocation, PrehashedBuildHasher> =
+            HashMap::with_capacity_and_hasher(capacity, PrehashedBuildHasher);
+        // Later batches win: a key committed twice during the checkout lives where
+        // its most recent commit put it.
+        for batch in &self.batches {
+            for (digest, _) in batch.keys.iter_with_digest() {
+                locations.insert(digest, batch.location.clone());
+            }
+        }
+        Some(PendingPkExistence {
+            locations,
+            incomplete: self.overflowed,
+        })
+    }
+
+    /// Bytes currently held, for memory accounting.
+    pub(crate) fn approx_bytes(&self) -> usize {
+        self.approx_bytes
+    }
+}
+
+/// Keys committed while an index was checked out, handed to the restore.
+pub(crate) struct RestoredPkKeys {
+    batches: Vec<PendingPkKeyBatch>,
+    discard_index: bool,
+}
+
+impl RestoredPkKeys {
+    /// Whether the index that was checked out must be dropped rather than cached:
+    /// keys committed during the checkout went unheld (the log hit its cap), or the
+    /// cache was invalidated while the index was out. Caching it either way would
+    /// answer "absent" for a live key, which reads as a new primary key.
+    pub(crate) fn index_must_be_discarded(&self) -> bool {
+        self.discard_index
+    }
+
+    /// Replay every held batch, oldest first, so a key committed twice ends on its
+    /// most recent location and sequence.
+    pub(crate) fn batches(&self) -> impl Iterator<Item = (&PkDigestSet, &RowLocation, i64)> {
+        self.batches
+            .iter()
+            .map(|batch| (&batch.keys, &batch.location, batch.sequence))
+    }
+}
+
+/// Snapshot of a [`PendingPkKeys`] log handed to per-batch validation alongside
+/// the checked-out index, so an index miss can still see a concurrent commit.
+pub(crate) struct PendingPkExistence {
+    locations: HashMap<u128, RowLocation, PrehashedBuildHasher>,
+    incomplete: bool,
+}
+
+impl PendingPkExistence {
+    /// Where a key committed during this checkout lives, or `None` if no such key
+    /// was recorded.
+    pub(crate) fn location_by_digest(&self, digest: u128) -> Option<&RowLocation> {
+        self.locations.get(&digest)
+    }
+
+    /// Whether keys committed during this checkout went unrecorded, so a miss here
+    /// does not prove the key is absent from the table.
+    pub(crate) fn is_incomplete(&self) -> bool {
+        self.incomplete
+    }
+}
+
 /// Streaming, budget-bounded builder for the cold PK-index rebuild
 /// (`load_existing_pk_index`). Routes every scanned key to its shard
 /// (`shard_of_pk`) as it arrives and, when a byte budget is set (upsert tables,

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -57,9 +57,10 @@ use super::on_conflict::{
 };
 use super::pk_index::{
     BoundedShardedPkIndexBuilder, COLD_PK_BLOOM_PER_FILE_MAX_BYTES, CachedPkIndex, CachedPkKeyset,
-    ColdPkExistence, PK_INDEX_PERSIST_MAX_BYTES, PkBloom, PkDigestSet, PkExistenceRef,
-    PkKeysetInsertOutcome, RowLocation, ShardedPkIndex, approx_captured_file_bytes,
-    deserialize_pk_bloom_sidecar, pk_digest, serialize_pk_bloom_sidecar, shard_of_pk,
+    ColdPkExistence, PK_INDEX_PERSIST_MAX_BYTES, PendingPkExistence, PendingPkKeys, PkBloom,
+    PkDigestSet, PkExistenceRef, PkKeysetInsertOutcome, RowLocation, ShardedPkIndex,
+    approx_captured_file_bytes, deserialize_pk_bloom_sidecar, pk_digest,
+    serialize_pk_bloom_sidecar, shard_of_pk,
 };
 use super::streaming::StreamingExec;
 use crate::bounded_fifo::BoundedFifoSet;
@@ -1653,6 +1654,16 @@ pub struct CayenneTableProvider {
     /// `build_sharded_pk_index` / the sharded validate path; routed by
     /// `shard_of_pk` so a key co-locates with its tier segments + tombstones.
     sharded_pk_keyset_cache: Arc<ParkingMutex<Option<ShardedPkIndex>>>,
+    /// Keys committed by other writers while `pk_keyset_cache` was checked out for
+    /// validation, and its `sharded_pk_keyset_cache` twin (see [`PendingPkKeys`]).
+    /// Without them a concurrent commit's existence entries are dropped and the
+    /// restored index answers "absent" for a live key, which reads as a new primary
+    /// key and duplicates the row.
+    ///
+    /// Lock order: each log is taken WHILE its cache's mutex is held (or on its own
+    /// for the read-only validation probe) — never the other way round.
+    pk_keyset_pending: Arc<ParkingMutex<PendingPkKeys>>,
+    sharded_pk_keyset_pending: Arc<ParkingMutex<PendingPkKeys>>,
     /// One-shot latch for the write-path warm-cache probe
     /// (`maybe_install_warm_pk_caches`): probe once per cache lifetime,
     /// re-armed by `clear_cached_pk_keyset`. Shared across clones so every
@@ -6088,6 +6099,8 @@ impl CayenneTableProvider {
             )),
             pk_keyset_cache: Arc::new(ParkingMutex::new(None)),
             sharded_pk_keyset_cache: Arc::new(ParkingMutex::new(None)),
+            pk_keyset_pending: Arc::new(ParkingMutex::new(PendingPkKeys::default())),
+            sharded_pk_keyset_pending: Arc::new(ParkingMutex::new(PendingPkKeys::default())),
             pk_warm_probe_done: Arc::new(AtomicBool::new(false)),
             pk_keyset_bytes_single: Arc::new(AtomicUsize::new(0)),
             pk_keyset_bytes_sharded: Arc::new(AtomicUsize::new(0)),
@@ -7282,6 +7295,8 @@ impl CayenneTableProvider {
             ),
             pk_keyset_cache: Arc::clone(&self.pk_keyset_cache),
             sharded_pk_keyset_cache: Arc::clone(&self.sharded_pk_keyset_cache),
+            pk_keyset_pending: Arc::clone(&self.pk_keyset_pending),
+            sharded_pk_keyset_pending: Arc::clone(&self.sharded_pk_keyset_pending),
             pk_warm_probe_done: Arc::clone(&self.pk_warm_probe_done),
             pk_keyset_bytes_single: Arc::clone(&self.pk_keyset_bytes_single),
             pk_keyset_bytes_sharded: Arc::clone(&self.pk_keyset_bytes_sharded),
@@ -7678,8 +7693,40 @@ impl CayenneTableProvider {
         self.scan_file_statistics.clear();
     }
 
+    /// Check the table-wide PK index out for validation. The cell is left empty for
+    /// the whole (lazily consumed) validation stream, so open a
+    /// [`PendingPkKeys`] window over that gap: keys committed meanwhile are held
+    /// there and merged back by [`Self::store_cached_pk_index`].
+    ///
+    /// Returns `None` when no index is cached — the caller then rebuilds one from
+    /// the table, which is equally a checkout: the rebuild reads a snapshot of the
+    /// table and every key committed after it must still reach the restored index.
     fn take_cached_pk_index(&self) -> Option<CachedPkIndex> {
-        self.pk_keyset_cache.lock().take()
+        let mut guard = self.pk_keyset_cache.lock();
+        self.pk_keyset_pending.lock().begin_checkout();
+        guard.take()
+    }
+
+    /// Close a checkout opened by [`Self::take_cached_pk_index`] without restoring
+    /// an index (the validation never got one — it failed while rebuilding). The
+    /// cache stays empty, so the next validation rebuilds and sees every committed
+    /// key; holding the log open past that point would only accumulate keys nothing
+    /// will replay.
+    fn abandon_cached_pk_index_checkout(&self) {
+        let _guard = self.pk_keyset_cache.lock();
+        let _ = self.pk_keyset_pending.lock().end_checkout();
+    }
+
+    /// Existence view over the keys committed while the table-wide index has been
+    /// checked out, for the validation holding that index. `None` when there are
+    /// none (the common case).
+    pub(crate) fn pending_pk_existence(&self) -> Option<PendingPkExistence> {
+        self.pk_keyset_pending.lock().existence()
+    }
+
+    /// [`Self::pending_pk_existence`] for the per-shard index.
+    pub(crate) fn pending_sharded_pk_existence(&self) -> Option<PendingPkExistence> {
+        self.sharded_pk_keyset_pending.lock().existence()
     }
 
     /// Whether this table may fall back to a bounded bloom existence filter when
@@ -7778,8 +7825,84 @@ impl CayenneTableProvider {
         bloom
     }
 
+    /// Restore the table-wide PK index to its cache, closing the checkout window
+    /// [`Self::take_cached_pk_index`] opened: the keys committed while the index was
+    /// out are replayed into it first, so the cache regains every key it would have
+    /// recorded had nothing been checked out. When the pending log overflowed those
+    /// keys are gone, and the index is dropped instead of cached — an index missing
+    /// a live key answers "absent" for it, which reads as a new primary key and
+    /// duplicates the row.
     pub(crate) fn store_cached_pk_index(&self, index: CachedPkIndex) {
         let max_bytes = self.effective_single_keyset_budget();
+        // Held from closing the checkout window through the store, so no writer can
+        // slip a key in between: it would find the cell empty, see no checkout, and
+        // drop the key.
+        let mut guard = self.pk_keyset_cache.lock();
+        let restored = self.pk_keyset_pending.lock().end_checkout();
+        if restored.index_must_be_discarded() {
+            drop(guard);
+            tracing::debug!(
+                table = self.table_metadata.table_name.as_str(),
+                key_count = index.len(),
+                "Dropping the primary-key index instead of caching it: it no longer describes the \
+                 table's live keys (the cache was invalidated, or concurrent commits during \
+                 validation exceeded the pending-key budget)"
+            );
+            self.clear_cached_pk_keyset();
+            return;
+        }
+        let mut index = index;
+        let mut replayed_keys = 0_usize;
+        let mut replay_over_budget = false;
+        for (keys, location, sequence) in restored.batches() {
+            replayed_keys = replayed_keys.saturating_add(keys.len());
+            if !Self::apply_keys_to_index(&mut index, keys, location, sequence, max_bytes) {
+                // Replaying pushed the exact keyset over budget. Convert exactly as
+                // `record_pk_keys_with_location` would have at commit time, feeding
+                // the WHOLE batch into the bloom: the conversion only carries the
+                // keys already inserted, so the ones the insert stopped short of
+                // would be false negatives. `DoNothing` needs exactness and instead
+                // drops the keyset below.
+                if !self.upsert_bloom_eligible() {
+                    replay_over_budget = true;
+                    break;
+                }
+                let mut bloom = match &index {
+                    CachedPkIndex::Exact(keyset) => Self::bloom_from_keyset(keyset, max_bytes),
+                    CachedPkIndex::Bloom(_) => PkBloom::with_byte_budget(max_bytes),
+                };
+                for key in keys.iter() {
+                    bloom.insert(key.as_ref());
+                }
+                index = CachedPkIndex::Bloom(bloom);
+            }
+        }
+        if replayed_keys > 0 {
+            tracing::debug!(
+                table = self.table_metadata.table_name.as_str(),
+                replayed_keys,
+                replay_over_budget,
+                "Replayed primary keys committed while the existence index was checked out"
+            );
+        }
+
+        if replay_over_budget {
+            // A `DoNothing` table cannot fall back to a bloom, so a replay that ran
+            // past the budget leaves the keyset unusable — drop it and let the next
+            // validation rebuild, exactly as the over-budget arm below does.
+            tracing::debug!(
+                table = self.table_metadata.table_name.as_str(),
+                max_bytes,
+                "Clearing the primary-key keyset cache: replaying the keys committed while it \
+                 was checked out would exceed the byte budget"
+            );
+            *guard = None;
+            drop(guard);
+            self.pk_keyset_occ_degraded.store(false, Ordering::Release);
+            self.publish_single_keyset_bytes(0);
+            return;
+        }
+
         let to_store = match index {
             CachedPkIndex::Exact(keyset) if keyset.approx_bytes > max_bytes => {
                 if self.upsert_bloom_eligible() {
@@ -7803,7 +7926,8 @@ impl CayenneTableProvider {
                         max_bytes,
                         "Skipping primary-key keyset cache because it exceeds the configured byte budget"
                     );
-                    *self.pk_keyset_cache.lock() = None;
+                    *guard = None;
+                    drop(guard);
                     // Full invalidation: the next access rebuilds a trustworthy
                     // keyset (floor-stamped, or a Bloom that takes the per-table
                     // fallback), so clear any degraded flag or it would stay stuck
@@ -7818,7 +7942,8 @@ impl CayenneTableProvider {
         };
 
         let bytes = to_store.approx_bytes();
-        *self.pk_keyset_cache.lock() = Some(to_store);
+        *guard = Some(to_store);
+        drop(guard);
         self.publish_single_keyset_bytes(bytes);
     }
 
@@ -7921,7 +8046,14 @@ impl CayenneTableProvider {
     }
 
     pub(crate) fn clear_cached_pk_keyset(&self) {
-        *self.pk_keyset_cache.lock() = None;
+        {
+            let mut guard = self.pk_keyset_cache.lock();
+            // An index checked out for validation is not in the cell, so emptying it
+            // would not reach that index — and its restore would put a superseded
+            // one straight back. Tell the checkout to drop it instead.
+            self.pk_keyset_pending.lock().invalidate();
+            *guard = None;
+        }
         // The keyset is gone: while it is `None`, `transaction_has_conflict`
         // already takes the per-table fallback, and the next rebuild floor-stamps
         // every key to the current high-water (`load_existing_pk_index`) or returns
@@ -7933,7 +8065,11 @@ impl CayenneTableProvider {
         // invalidates the single keyset (delete, compaction, snapshot rewrite,
         // recovery) equally invalidates the sharded view. At N=1 the sharded cache
         // is never populated, so this is a no-op there.
-        *self.sharded_pk_keyset_cache.lock() = None;
+        {
+            let mut sharded = self.sharded_pk_keyset_cache.lock();
+            self.sharded_pk_keyset_pending.lock().invalidate();
+            *sharded = None;
+        }
         // The cold-tier PK existence view is tied to the same keyset generation
         // (a promotion that changes the cold manifest calls this on commit), so
         // drop it too; the next apply's cache miss rebuilds it from the current
@@ -7969,6 +8105,13 @@ impl CayenneTableProvider {
                     *location = RowLocation::FileUnlocated;
                 }
             }
+        } else {
+            // An index checked out for validation is not in the cell, so its entries
+            // keep saying `Inlined` for rows this checkpoint just moved into files.
+            // An upsert of such a key would tombstone the inline copy only and leave
+            // the file copy live, so drop that index at its restore instead — the
+            // rebuild reads the post-checkpoint locations.
+            self.pk_keyset_pending.lock().invalidate();
         }
         drop(guard);
         // The N>1 sharded cache carries the same per-key `RowLocation`s; flip them
@@ -7983,7 +8126,93 @@ impl CayenneTableProvider {
                     }
                 }
             }
+        } else if sharded.is_none() {
+            // Checked out for validation (or cold, where this is a no-op) — see the
+            // single-index arm above.
+            self.sharded_pk_keyset_pending.lock().invalidate();
         }
+    }
+
+    /// Record one committed key batch into an owned PK existence index. Returns
+    /// `false` when an `Exact` keyset hit `max_bytes` mid-batch, leaving the rest of
+    /// the batch unrecorded — the caller then converts to a bloom (upsert) or drops
+    /// the index (`DoNothing`), and MUST re-record the whole batch into whatever it
+    /// builds: a key the insert stopped short of would be a false negative, which
+    /// under upsert reads as a new primary key and writes a duplicate live row.
+    ///
+    /// Shared by the commit path ([`Self::record_pk_keys_with_location`]) and the
+    /// checkout replay ([`Self::store_cached_pk_index`]) so a key recorded while the
+    /// index was checked out lands exactly as it would have at commit time.
+    fn apply_keys_to_index(
+        index: &mut CachedPkIndex,
+        keys: &PkDigestSet,
+        location: &RowLocation,
+        sequence: i64,
+        max_bytes: usize,
+    ) -> bool {
+        match index {
+            CachedPkIndex::Bloom(bloom) => {
+                for key in keys.iter() {
+                    bloom.insert(key.as_ref());
+                }
+                true
+            }
+            CachedPkIndex::Exact(keyset) => {
+                // Existence-only insert. Under `deletion_mode: position`, real
+                // `(file, position)` for File rows is captured separately by the
+                // row_idx() read-back, which upgrades these to `FilePositioned`.
+                // Reuse each key's stored digest (the keyset is digest-keyed) and
+                // fold the presence check and the insert into a single hash
+                // lookup — the common case on re-touched PKs (e.g. CDC updates)
+                // is "present", where this clones neither the key nor re-hashes.
+                for (digest, key) in keys.iter_with_digest() {
+                    match keyset.try_insert_with_digest(digest, key, location.clone(), max_bytes) {
+                        PkKeysetInsertOutcome::OverBudget => return false,
+                        PkKeysetInsertOutcome::Updated | PkKeysetInsertOutcome::Inserted => {
+                            // Stamp the key's last-commit sequence for per-key OCC.
+                            keyset.record_sequence(digest, sequence);
+                        }
+                    }
+                }
+                true
+            }
+        }
+    }
+
+    /// Hold a committed key batch for the index checked out of `pending`'s cache,
+    /// and account the bytes it adds against that cache's share of the memory pool —
+    /// the keys are resident until the checkout replays them.
+    ///
+    /// A no-op when nothing is checked out: the cache is then simply cold, and the
+    /// next validation rebuilds an index that already reads this commit from the
+    /// table. Callers hold the corresponding cache lock (see `pk_keyset_pending`).
+    fn record_pending_pk_keys(
+        &self,
+        pending: &ParkingMutex<PendingPkKeys>,
+        accounted_bytes: &AtomicUsize,
+        keys: &PkDigestSet,
+        location: &RowLocation,
+        sequence: i64,
+        cache_budget: usize,
+    ) {
+        let max_bytes = PendingPkKeys::budget_from_cache_budget(cache_budget);
+        let (before, after) = {
+            let mut log = pending.lock();
+            let before = log.approx_bytes();
+            log.record(keys, location, sequence, max_bytes);
+            (before, log.approx_bytes())
+        };
+        if after == before {
+            return;
+        }
+        let _ = accounted_bytes.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |held| {
+            Some(if after > before {
+                held.saturating_add(after - before)
+            } else {
+                held.saturating_sub(before - after)
+            })
+        });
+        self.publish_keyset_bytes_total();
     }
 
     fn record_pk_keys_with_location(
@@ -8005,6 +8234,21 @@ impl CayenneTableProvider {
         {
             let mut sharded = self.sharded_pk_keyset_cache.lock();
             let mut drop_index = false;
+            if sharded.is_none() {
+                // Either the sharded index is checked out for validation
+                // (`build_sharded_pk_index`) or the table has no sharded cache at
+                // all (N=1, or a cold cache). Hold the keys for the checkout to
+                // replay; with nothing checked out this is a no-op, because the next
+                // validation rebuilds the index and reads this commit from the table.
+                self.record_pending_pk_keys(
+                    &self.sharded_pk_keyset_pending,
+                    &self.pk_keyset_bytes_sharded,
+                    keys,
+                    location,
+                    sequence,
+                    self.effective_sharded_keyset_budget(),
+                );
+            }
             if let Some(index) = sharded.as_mut() {
                 // Budget enforced DURING the insert, not after it. Recording the
                 // whole batch first and reconciling afterwards made the budget a
@@ -8046,46 +8290,32 @@ impl CayenneTableProvider {
         // Take ownership so an over-budget Exact keyset can be replaced by a
         // bloom without a borrow conflict; the index is restored before return.
         let Some(mut index) = guard.take() else {
-            // The shared keyset is checked out by a concurrent writer, so this
-            // committed write's key stamps (and existence entries) are dropped on
-            // the floor. A later per-key OCC check against the eventually
-            // stored-back keyset would then miss this write (it is floor-stamped
-            // to the CONCURRENT writer's begin high-water, which is below this
-            // write's sequence) — a silent lost update. Degrade to the per-table
-            // fallback until the next rebuild floor-stamps past this sequence.
+            // The shared keyset is checked out by a concurrent writer (or absent).
+            // Hold this commit's keys for the checkout to replay: dropping them
+            // would leave the restored keyset missing an existence entry for a live
+            // row, and a later upsert probing that keyset would miss, classify the
+            // key as new, emit no supersede, and leave two live rows for one primary
+            // key. `PendingPkKeys` also serves them to the in-flight validation, so
+            // the writer holding the checked-out keyset does not read this key as
+            // new either.
+            self.record_pending_pk_keys(
+                &self.pk_keyset_pending,
+                &self.pk_keyset_bytes_single,
+                keys,
+                location,
+                sequence,
+                max_bytes,
+            );
+            // The replay restores the entries but stamps them with this write's
+            // sequence AFTER the checked-out keyset's own floor-stamp, so per-key
+            // OCC stays on the conservative per-table fallback until the next
+            // rebuild (over-abort, never a missed conflict).
             self.mark_pk_keyset_occ_degraded();
             return;
         };
 
-        let mut convert_to_bloom = false;
-        match &mut index {
-            CachedPkIndex::Bloom(bloom) => {
-                for key in keys.iter() {
-                    bloom.insert(key.as_ref());
-                }
-            }
-            CachedPkIndex::Exact(keyset) => {
-                // Existence-only insert. Under `deletion_mode: position`, real
-                // `(file, position)` for File rows is captured separately by the
-                // row_idx() read-back, which upgrades these to `FilePositioned`.
-                // Reuse each key's stored digest (the keyset is digest-keyed) and
-                // fold the presence check and the insert into a single hash
-                // lookup — the common case on re-touched PKs (e.g. CDC updates)
-                // is "present", where this clones neither the key nor re-hashes.
-                for (digest, key) in keys.iter_with_digest() {
-                    match keyset.try_insert_with_digest(digest, key, location.clone(), max_bytes) {
-                        PkKeysetInsertOutcome::OverBudget => {
-                            convert_to_bloom = true;
-                            break;
-                        }
-                        PkKeysetInsertOutcome::Updated | PkKeysetInsertOutcome::Inserted => {
-                            // Stamp the key's last-commit sequence for per-key OCC.
-                            keyset.record_sequence(digest, sequence);
-                        }
-                    }
-                }
-            }
-        }
+        let convert_to_bloom =
+            !Self::apply_keys_to_index(&mut index, keys, location, sequence, max_bytes);
 
         if convert_to_bloom {
             if self.upsert_bloom_eligible() {
@@ -8137,9 +8367,59 @@ impl CayenneTableProvider {
     /// it (step 6 of `validate_and_append_sharded`). Restored BEFORE the appends so each
     /// `append_to_shard` can grow its shard's existence view UNDER `locks[s]` for
     /// the just-validated/MISS keys (§5 Phase 6).
+    ///
+    /// Closes the checkout window `build_sharded_pk_index` opened, replaying the
+    /// keys committed while the index was out (the sharded twin of
+    /// `store_cached_pk_index` — see there for why an index that is missing a live
+    /// key must be dropped rather than cached).
     fn store_sharded_pk_index(&self, index: ShardedPkIndex) {
+        let max_bytes = self.effective_sharded_keyset_budget();
+        // Held from closing the checkout window through the store — see
+        // `store_cached_pk_index`.
+        let mut guard = self.sharded_pk_keyset_cache.lock();
+        let restored = self.sharded_pk_keyset_pending.lock().end_checkout();
+        if restored.index_must_be_discarded() {
+            drop(guard);
+            tracing::debug!(
+                table = self.table_metadata.table_name.as_str(),
+                "Dropping the per-shard primary-key index instead of caching it: it no longer \
+                 describes the table's live keys"
+            );
+            self.clear_cached_pk_keyset();
+            return;
+        }
+        let mut index = index;
+        let mut drop_index = false;
+        // The per-shard index carries existence and location only — per-key OCC
+        // stamps live on the table-wide keyset — so the recorded sequence has no
+        // slot here.
+        for (keys, location, _sequence) in restored.batches() {
+            if !index.record_keys_bounded(keys, location, max_bytes) {
+                // Over budget: upsert degrades to per-shard blooms, `DoNothing` needs
+                // exactness and drops the index — the same policy the commit path
+                // applies in `record_pk_keys_with_location`.
+                if !self.upsert_bloom_eligible() {
+                    drop_index = true;
+                    break;
+                }
+                let per_shard = max_bytes / index.shard_count().max(1);
+                index.degrade_to_blooms(per_shard);
+                // The bounded insert stopped at the budget, so the keys after the
+                // stop are absent from the blooms it converted — backfill the whole
+                // batch (see `record_keys_after_degrade`).
+                index.record_keys_after_degrade(keys);
+            }
+        }
+
+        if drop_index {
+            *guard = None;
+            drop(guard);
+            self.publish_sharded_keyset_bytes(0);
+            return;
+        }
         let bytes = index.approx_bytes();
-        *self.sharded_pk_keyset_cache.lock() = Some(index);
+        *guard = Some(index);
+        drop(guard);
         self.publish_sharded_keyset_bytes(bytes);
     }
 
@@ -9516,8 +9796,19 @@ impl CayenneTableProvider {
             );
             existing_keys
         } else {
-            self.load_pk_index_for_validation(&pk_indices, &converter)
-                .await?
+            // `take_cached_pk_index` already opened the checkout window, so close it
+            // if the rebuild fails: nothing will restore an index, and the keys it
+            // would hold are read from the table by the next validation's rebuild.
+            match self
+                .load_pk_index_for_validation(&pk_indices, &converter)
+                .await
+            {
+                Ok(existing_keys) => existing_keys,
+                Err(error) => {
+                    self.abandon_cached_pk_index_checkout();
+                    return Err(error);
+                }
+            }
         };
 
         let on_conflict = self
@@ -9738,7 +10029,17 @@ impl CayenneTableProvider {
         // the single source of truth restored after validation by
         // `store_sharded_pk_index` (before the appends), then grown per shard UNDER
         // `locks[s]` by the kept-key insert inside `append_to_shard` (§5 Phase 6).
-        if let Some(cached) = self.sharded_pk_keyset_cache.lock().take() {
+        let cached = {
+            let mut guard = self.sharded_pk_keyset_cache.lock();
+            // Open the checkout window over the gap this leaves in the cache, so a
+            // key committed before the index is restored is held rather than dropped
+            // (see `take_cached_pk_index`). Opened for the rebuild below too: it
+            // reads a snapshot of the table, and a key committed after that snapshot
+            // must still reach the restored index.
+            self.sharded_pk_keyset_pending.lock().begin_checkout();
+            guard.take()
+        };
+        if let Some(cached) = cached {
             // The stored shard count is fixed at the table's `cdc_mem_tier_shards`
             // and never changes for the table's lifetime, so it always matches `n`.
             if cached.shard_count() == n {
@@ -10044,7 +10345,16 @@ impl CayenneTableProvider {
 
             let keep_row = match ctx.existing {
                 PkExistenceRef::Exact(existing_keys) => {
-                    if let Some(existing) = existing_keys.location_by_digest(digest) {
+                    // A key committed by another writer since this keyset was checked
+                    // out is absent from it, so fall through to the pending log
+                    // before concluding the key is new (see `PendingPkKeys`). The
+                    // log carries the location the commit recorded, so the supersede
+                    // below masks the row where it actually lives.
+                    let existing = existing_keys.location_by_digest(digest).or_else(|| {
+                        ctx.pending
+                            .and_then(|pending| pending.location_by_digest(digest))
+                    });
+                    if let Some(existing) = existing {
                         match ctx.on_conflict {
                             OnConflict::DoNothingAll | OnConflict::DoNothing(_) => false,
                             OnConflict::Upsert(_) => {
@@ -10104,12 +10414,23 @@ impl CayenneTableProvider {
                     } else if cold_existence
                         .as_ref()
                         .is_some_and(|c| c.maybe_contains(key.as_ref()))
+                        || (matches!(ctx.on_conflict, OnConflict::Upsert(_))
+                            && ctx.pending.is_some_and(PendingPkExistence::is_incomplete))
                     {
                         // Not in the warm/mem keyset, but a datalake (cold) file
                         // MAY hold this key — record a key-based supersede so the
                         // cold copy is masked (the exact analog of a warm `Bloom`
                         // HIT). A bloom false positive masks nothing and is a
                         // harmless no-op under upsert.
+                        //
+                        // The same shape covers an overflowed pending log: keys
+                        // committed during this checkout went unrecorded, so a miss
+                        // no longer proves the key is absent and the supersede is
+                        // what keeps a concurrent commit from surviving as a second
+                        // live row. Upsert only — `DoNothing` must not emit deletes,
+                        // and keeps the row rather than risk dropping a genuinely
+                        // new one (its restored index is discarded and rebuilt, so
+                        // the uncertainty ends with this batch).
                         push_key_supersede(
                             row_idx,
                             &key,
@@ -10149,7 +10470,14 @@ impl CayenneTableProvider {
                     // delete to BOTH the file and inline lists, so the prior version
                     // is masked wherever it lives. A false positive matches nothing
                     // and is a no-op. No `delete_specs` — we have no row location.
-                    if bloom.maybe_contains(key.as_ref()) {
+                    //
+                    // A key committed since this bloom was checked out cannot be in
+                    // it, so the pending log is consulted alongside it; an overflowed
+                    // log means no miss proves absence (see the `Exact` arm).
+                    let pending_hit = ctx.pending.is_some_and(|pending| {
+                        pending.is_incomplete() || pending.location_by_digest(digest).is_some()
+                    });
+                    if bloom.maybe_contains(key.as_ref()) || pending_hit {
                         match &self.pk_deletion_strategy {
                             PkDeletionStrategyWithCache::Int64Pk { .. } => {
                                 if let Some(arr) = int64_pk_array {
@@ -10252,6 +10580,7 @@ impl CayenneTableProvider {
         batch: &RecordBatch,
         bloom: &PkBloom,
         cold_existence: Option<&ColdPkExistence>,
+        pending_existence: Option<&PendingPkExistence>,
         pk_indices: &[usize],
         converter: &RowConverter,
         incoming_keys: &PkDigestSet,
@@ -10282,8 +10611,17 @@ impl CayenneTableProvider {
             let cold_hit = cold_existence.is_some_and(|c| c.maybe_contains(key.as_ref()));
             // One hash per row, reused for both existence-set probes below.
             let digest = pk_digest(&key);
+            // A concurrent writer committed this key after the index was checked
+            // out, so the bloom cannot hold it — route it to the HIT path, which
+            // supersedes the row it committed. Fast-pathing it as brand-new would
+            // leave two live rows for one primary key. `is_incomplete` means keys
+            // went unrecorded, so no MISS here proves absence.
+            let pending_hit = pending_existence.is_some_and(|pending| {
+                pending.is_incomplete() || pending.location_by_digest(digest).is_some()
+            });
             let is_miss = !null_pk
                 && !cold_hit
+                && !pending_hit
                 && !bloom.maybe_contains(key.as_ref())
                 && !incoming_keys.contains_digest(digest)
                 && !miss_keys.contains_digest(digest);
@@ -10354,6 +10692,11 @@ impl CayenneTableProvider {
         // Table-global (not sharded): every shard consults the same view for its
         // own keys so a cold-resident key never fast-paths as brand-new.
         let cold_existence = self.cold_pk_existence.lock().clone();
+        // Keys committed since this apply's index was checked out
+        // (`build_sharded_pk_index`), which the index itself cannot know about.
+        // Table-global like the cold view: a key routes to exactly one shard, so a
+        // shard only ever matches its own keys here.
+        let pending_existence = self.pending_sharded_pk_existence();
         let mut incoming_keys: PkDigestSet = PkDigestSet::default();
         let mut delete_specs: HashMap<Arc<str>, Vec<u64>> = HashMap::new();
         let mut deleted_pk_i64: Vec<i64> = Vec::new();
@@ -10395,6 +10738,7 @@ impl CayenneTableProvider {
                         &batch,
                         bloom,
                         cold_existence.as_deref(),
+                        pending_existence.as_ref(),
                         pk_indices,
                         converter,
                         &incoming_keys,
@@ -10426,6 +10770,7 @@ impl CayenneTableProvider {
                 on_conflict,
                 upsert_options: &upsert_options,
                 existing: index.existence_ref(s),
+                pending: pending_existence.as_ref(),
                 incoming_keys: &incoming_keys,
             };
             let result = self.apply_on_conflict_to_batch(hit_batch, &mut ctx)?;
@@ -48676,5 +49021,263 @@ mod tests {
             "a floor-stamped rebuild (the production clear->load_existing_pk_index \
              path) must still conflict the stage_seq=5 txn against high-water 7"
         );
+    }
+
+    /// Primary keys for `ids`, encoded the way the write path encodes them, so a
+    /// keyset entry recorded from this set matches what validation probes for.
+    fn pk_digest_set_for_ids(converter: &RowConverter, ids: &[i64]) -> PkDigestSet {
+        use arrow::array::{ArrayRef, Int64Array};
+
+        let column: ArrayRef = Arc::new(Int64Array::from(ids.to_vec()));
+        let rows = converter
+            .convert_columns(&[column])
+            .expect("convert the pk column");
+        let mut keys = PkDigestSet::with_capacity(ids.len());
+        for row_idx in 0..ids.len() {
+            let key = rows.row(row_idx).owned();
+            keys.insert_with_digest(pk_digest(&key), key);
+        }
+        keys
+    }
+
+    /// Regression for #12956: a write that commits while the shared PK keyset is
+    /// checked out for validation must not lose its existence entries.
+    ///
+    /// The cross-partition append coordinator publishes its validated keys with no
+    /// checkout of its own (`PreparedStagedAppend::publish_validated_file_keys` →
+    /// `record_file_pk_keys`) and holds only each participant's listing fence, so it
+    /// runs concurrently with a mainline write holding the table write lock — and
+    /// lands here while that write has the keyset out. Dropping the entry leaves the
+    /// restored keyset a strict under-approximation of the live rows, and the next
+    /// upsert of that key misses, treats it as new, emits no supersede, and leaves
+    /// two live rows for one declared primary key.
+    #[tokio::test]
+    async fn keys_committed_while_the_keyset_is_checked_out_survive_the_restore() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) = create_cdc_upsert_table_with_vortex_config(
+            "pk_checkout_replay",
+            ctx.runtime_env(),
+            VortexConfig::default(),
+        )
+        .await;
+        let schema = provider.table_schema();
+        let pk_indices = provider
+            .primary_key_indices()
+            .expect("primary key indices resolve")
+            .expect("the table declares a primary key");
+        let converter = provider
+            .build_pk_converter(&pk_indices)
+            .expect("primary key converter");
+
+        // Seed one row so the table has a live keyset to check out.
+        insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[1], &[10])).await;
+        let checked_out = provider
+            .take_cached_pk_index()
+            .expect("the seed insert leaves a cached keyset");
+
+        // The concurrent writer commits id=7 while the keyset is out.
+        let committed = pk_digest_set_for_ids(&converter, &[7]);
+        let committed_digest = committed
+            .iter_with_digest()
+            .next()
+            .expect("one committed key")
+            .0;
+        provider.record_file_pk_keys(&committed, 11);
+
+        // The validation holding the keyset must see the commit too — its snapshot
+        // predates it, and without this the SAME writer classifies id=7 as new.
+        let pending = provider.pending_pk_existence();
+        assert!(
+            pending
+                .as_ref()
+                .is_some_and(|pending| pending.location_by_digest(committed_digest).is_some()),
+            "in-flight validation must see a key committed while it holds the keyset"
+        );
+
+        // The writer finishes and returns the keyset.
+        provider.store_cached_pk_index(checked_out);
+
+        let guard = provider.pk_keyset_cache.lock();
+        match guard.as_ref() {
+            Some(CachedPkIndex::Exact(keyset)) => match keyset.location_by_digest(committed_digest)
+            {
+                Some(RowLocation::FileUnlocated) => {}
+                Some(other) => panic!("id=7 must be replayed at the location it was committed at, got {other:?}"),
+                None => panic!(
+                    "the restored keyset must know id=7: a concurrent commit's existence entry \
+                     was dropped, so the next upsert would keep both rows"
+                ),
+            },
+            other => panic!(
+                "expected the restored keyset to be exact, present={}",
+                other.is_some()
+            ),
+        }
+    }
+
+    /// The in-flight half of #12956: the writer holding the checked-out keyset must
+    /// supersede a key another writer committed mid-validation, rather than keep it
+    /// as a new primary key.
+    #[tokio::test]
+    async fn validation_supersedes_a_key_committed_while_it_holds_the_keyset() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) = create_cdc_upsert_table_with_vortex_config(
+            "pk_checkout_inflight",
+            ctx.runtime_env(),
+            VortexConfig::default(),
+        )
+        .await;
+        let schema = provider.table_schema();
+        let pk_indices = provider
+            .primary_key_indices()
+            .expect("primary key indices resolve")
+            .expect("the table declares a primary key");
+        let converter = provider
+            .build_pk_converter(&pk_indices)
+            .expect("primary key converter");
+
+        insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[1], &[10])).await;
+        let checked_out = provider
+            .take_cached_pk_index()
+            .expect("the seed insert leaves a cached keyset");
+        provider.record_file_pk_keys(&pk_digest_set_for_ids(&converter, &[7]), 11);
+
+        let pending = provider.pending_pk_existence();
+        let existing = match &checked_out {
+            CachedPkIndex::Exact(keyset) => PkExistenceRef::Exact(keyset),
+            CachedPkIndex::Bloom(bloom) => PkExistenceRef::Bloom(bloom),
+        };
+        let on_conflict = OnConflict::Upsert(
+            datafusion_table_providers::util::column_reference::ColumnReference::new(vec![
+                "id".to_string(),
+            ]),
+        );
+        let upsert_options = on_conflict.get_upsert_options();
+        let incoming_keys = PkDigestSet::default();
+        let mut validation_ctx = OnConflictContext {
+            pk_indices: &pk_indices,
+            converter: &converter,
+            on_conflict: &on_conflict,
+            upsert_options: &upsert_options,
+            existing,
+            pending: pending.as_ref(),
+            incoming_keys: &incoming_keys,
+        };
+
+        let result = provider
+            .apply_on_conflict_to_batch(
+                id_value_batch(Arc::clone(&schema), &[7], &[71]),
+                &mut validation_ctx,
+            )
+            .expect("validating an upsert of the concurrently committed key");
+
+        assert_eq!(
+            result.deleted_pk_i64,
+            vec![7],
+            "the upsert must supersede the row the concurrent writer committed, not \
+             add a second live row for id=7"
+        );
+        assert_eq!(
+            result.filtered_batch.map(|batch| batch.num_rows()),
+            Some(1),
+            "the upserted row is still written; only the prior version is tombstoned"
+        );
+    }
+
+    /// End-to-end shape of #12956, driven entirely through the insert path: a write
+    /// that commits while another holds the keyset must leave ONE live row per
+    /// primary key.
+    ///
+    /// The concurrent writer restores a keyset it rebuilt BEFORE its own commit, so
+    /// the two indexes are differently aged and the last store silently reverts the
+    /// other's keys. Neither is trustworthy, so both are dropped and the next write
+    /// rebuilds from the table.
+    #[tokio::test]
+    async fn a_concurrent_commit_during_validation_leaves_one_live_row_per_key() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) = create_cdc_upsert_table_with_vortex_config(
+            "pk_checkout_duplicate",
+            ctx.runtime_env(),
+            VortexConfig::default(),
+        )
+        .await;
+        let schema = provider.table_schema();
+
+        insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[1], &[10])).await;
+
+        // A mainline write starts validating: it holds the keyset for its whole
+        // lazily-consumed stream.
+        let checked_out = provider
+            .take_cached_pk_index()
+            .expect("the seed insert leaves a cached keyset");
+
+        // Another writer commits id=7 in that window.
+        insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[7], &[70])).await;
+
+        // The first write finishes and returns its keyset.
+        provider.store_cached_pk_index(checked_out);
+
+        // A later upsert of the same key must replace the committed row.
+        insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[7], &[71])).await;
+
+        assert_eq!(
+            collect_id_value_pairs(&ctx, &provider, "pk_checkout_duplicate").await,
+            vec![(1, 10), (7, 71)],
+            "id=7 must have exactly one live row, carrying the upserted value"
+        );
+    }
+
+    /// The per-shard index has the same checkout gap as the table-wide keyset
+    /// (`build_sharded_pk_index` takes it, the appends restore it), so a commit
+    /// landing in that window must survive the restore there too.
+    #[tokio::test]
+    async fn keys_committed_while_the_sharded_index_is_checked_out_survive_the_restore() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) = create_sharded_cdc_upsert_table_with_cap(
+            "pk_sharded_checkout_replay",
+            ctx.runtime_env(),
+            4,
+            0,
+        )
+        .await;
+        let pk_indices = provider
+            .primary_key_indices()
+            .expect("primary key indices resolve")
+            .expect("the table declares a primary key");
+        let converter = provider
+            .build_pk_converter(&pk_indices)
+            .expect("primary key converter");
+        provider.maybe_install_warm_pk_caches().await;
+
+        let checked_out = provider
+            .build_sharded_pk_index(&pk_indices, &converter, 4)
+            .await
+            .expect("the warm per-shard index is checked out");
+
+        let committed = pk_digest_set_for_ids(&converter, &[7]);
+        let committed_digest = committed
+            .iter_with_digest()
+            .next()
+            .expect("one committed key")
+            .0;
+        provider.record_file_pk_keys(&committed, 11);
+
+        provider.store_sharded_pk_index(checked_out);
+
+        match provider.sharded_pk_keyset_cache.lock().as_ref() {
+            Some(ShardedPkIndex::Exact(keysets)) => {
+                assert!(
+                    keysets
+                        .iter()
+                        .any(|keyset| keyset.location_by_digest(committed_digest).is_some()),
+                    "the restored per-shard index must know id=7: dropping a concurrent \
+                     commit's entry duplicates the row on the next upsert"
+                );
+            }
+            other => panic!(
+                "expected exact per-shard keysets, present={}",
+                other.is_some()
+            ),
+        }
     }
 }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -49102,7 +49102,9 @@ mod tests {
             Some(CachedPkIndex::Exact(keyset)) => match keyset.location_by_digest(committed_digest)
             {
                 Some(RowLocation::FileUnlocated) => {}
-                Some(other) => panic!("id=7 must be replayed at the location it was committed at, got {other:?}"),
+                Some(other) => panic!(
+                    "id=7 must be replayed at the location it was committed at, got {other:?}"
+                ),
                 None => panic!(
                     "the restored keyset must know id=7: a concurrent commit's existence entry \
                      was dropped, so the next upsert would keep both rows"


### PR DESCRIPTION
Fixes #12956

## The bug

A validation stream takes the shared PK existence index out of its cache cell and holds it for the whole lazily-consumed stream — as long as the Vortex encode. A writer that committed during that window found the cell empty and dropped its keys:

```rust
let Some(mut index) = guard.take() else {
    // ... this committed write's key stamps (and existence entries) are dropped ...
    self.mark_pk_keyset_occ_degraded();
    return;
};
```

`pk_keyset_occ_degraded` covered the transaction surface (per-key OCC falls back to the conservative per-table check), but nothing covered the **existence** half. The restored index was then a strict UNDER-approximation of the live rows, and mainline upsert validation reads an `Exact` miss as "this primary key is new" — so a later upsert of that key emitted no supersede and the table kept **two live rows for one declared primary key**.

The two writers hold disjoint locks by construction, so they run concurrently: the mainline write holds the table `write_lock`, while the cross-partition append coordinator publishes its validated keys (`publish_validated_file_keys` → `record_file_pk_keys`) holding only each participant's listing fence.

## The fix

`PendingPkKeys` spans the checkout gap. Keys committed while an index is out are held, then:

- **replayed into the index when it is restored**, so the cache regains every key it would have recorded had nothing been checked out (replay is byte-identical to the commit-time record — both now go through one `apply_keys_to_index`); and
- **probed by the in-flight validation**, so the writer whose snapshot predates the commit supersedes that row instead of adding a second one — and at the exact location the commit recorded, so the prior version is masked wherever it lives.

The log is bounded by a quarter of the cache's byte budget. Past it the index is dropped rather than cached missing entries, and validation stops treating a miss as proof of absence (upsert emits a key supersede — the shape the bloom path already uses; `DoNothing` keeps the row rather than risk dropping a genuinely new one, and its index is rebuilt).

Rather than gate on `pk_keyset_occ_degraded` as the issue suggested, the fix carries the precise signal. That flag is also set for stale-**present** keys (an upsert filter-DELETE keeps the superset keyset and stays degraded until the next rebuild, which upsert tables deliberately avoid), so gating existence on it would emit a redundant supersede for every genuinely new key indefinitely — unbounded tombstone growth and inflated `total_superseded`. The pending log answers the question exactly instead of conservatively.

### Same window, three more ways in

Closing the gap surfaced sibling paths that also let an index come back describing a table state that has moved on. Each now marks the checkout for discard instead of silently missing it:

- **Invalidation during a checkout** (`clear_cached_pk_keyset` — a DELETE, compaction, recovery): emptying a cell the index is not in did nothing, and the restore put the superseded index straight back.
- **The inline-checkpoint location flip**: entries kept saying `Inlined` for rows just moved into files, so an upsert would tombstone the inline copy only and leave the file copy live.
- **Two overlapping checkouts**: differently-aged indexes over one cache, where the last store silently reverts the other's keys. Both are discarded and the cache goes cold — one rebuild.

The report covered the table-wide keyset; the **per-shard** index has the identical checkout gap (`build_sharded_pk_index` takes it, the appends restore it) and its mirror silently no-opped while it was out, so both caches are covered.

## Verification

Four regression tests, each confirmed to **fail** with the fix neutralized and pass with it:

| Test | Without the fix |
|---|---|
| `a_concurrent_commit_during_validation_leaves_one_live_row_per_key` (end-to-end, real insert path) | `[(1, 10), (7, 70), (7, 71)]` — two live rows for `id=7` |
| `keys_committed_while_the_keyset_is_checked_out_survive_the_restore` | the restored keyset has no entry for `id=7` |
| `validation_supersedes_a_key_committed_while_it_holds_the_keyset` | no supersede emitted (`[]` vs `[7]`) |
| `keys_committed_while_the_sharded_index_is_checked_out_survive_the_restore` | the restored per-shard index has no entry for `id=7` |

Full crate suite green: 1479 tests run, 1479 passed (unit + integration, including the concurrent mutation property tests). `cargo clippy -p cayenne --lib --tests` clean.
