### PR TITLE
fix(mysql): rebuild a purged-position acceleration atomically instead of emptying it (fixes #12967)

### DIFF
--- a/crates/data_components/src/cdc.rs
+++ b/crates/data_components/src/cdc.rs
@@ -617,6 +617,16 @@ impl ChangeEnvelope {
     /// Carried as its own zero-row envelope (see
     /// [`build_history_unavailable_envelope`]) so it is ordered in the stream
     /// rather than racing it.
+    ///
+    /// A source may raise it mid-stream, not only at the head. The consumer
+    /// treats it as a **barrier**: it coalesces envelopes into runs and performs
+    /// one rebuild per run, so everything the run carried ahead of the signal is
+    /// discarded rather than applied on top of the replacement — applying it
+    /// would write values the re-read has already moved past. Two obligations
+    /// follow for a source that raises this: the committers it emitted before
+    /// the signal must be safely droppable (they are dropped unacked), and the
+    /// position it resumes from afterwards must be at or after them, so the
+    /// re-read genuinely subsumes what was discarded.
     #[must_use]
     pub fn history_unavailable(&self) -> bool {
         self.history_unavailable
@@ -847,6 +857,15 @@ pub fn build_ready_signal_envelope(schema: &SchemaRef) -> Result<ChangeEnvelope,
 /// *before* the changes it precedes, so the rebuild is ordered ahead of them
 /// rather than racing them, and `is_dataset_ready` is false because a dataset
 /// whose accelerator is about to be replaced is not ready to serve.
+///
+/// **The no-op committer is the catch**, and why neither shipped source uses
+/// this: a rebuild that acknowledges no position leaves nothing behind saying it
+/// happened, so the next start finds the same unusable position and re-reads the
+/// whole table again — on every restart of a dataset whose source is quiet. A
+/// source with a position to record should build the envelope itself around its
+/// own committer (`ChangeEnvelope::from_parts(committer, batch, false, true)`),
+/// which also keeps it out of the consumer's zero-row heartbeat stripping. Use
+/// this only when there is genuinely no position to persist.
 pub fn build_history_unavailable_envelope(
     schema: &SchemaRef,
 ) -> Result<ChangeEnvelope, ChangeBatchError> {

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -940,11 +940,6 @@ async fn attach_member(
             // contents until it swaps. Clearing the table here and letting the
             // snapshot refill it — what a `truncate` prelude does — is
             // observable to queries as an empty, then partially filled, table.
-            //
-            // The boundary committer rides this envelope rather than following
-            // it: it must persist the head only once the replacement is durably
-            // applied, and being a real committer it also keeps the envelope out
-            // of the consumer's zero-row heartbeat stripping.
             let signal = snapshot_boundary_envelope(
                 source,
                 &member_key,
@@ -964,24 +959,14 @@ async fn attach_member(
             Box::pin(stream::once(async move { Ok(signal) }))
         }
         MemberStart::Snapshot => {
-            let dataset_for_boundary = dataset_name.clone();
             // Clear whatever a crashed earlier load left behind, so the snapshot
             // is a full replace rather than an upsert over rows the source no
             // longer has. Reached only when nothing was ever persisted for this
             // member, so there is no completed load to preserve; an acceleration
             // that has one takes the `Rebuild` arm above.
             let truncate = super::truncate_envelope(&schema, &primary_keys, &column_map)?;
-            let snapshot = super::bootstrap::snapshot_stream(super::bootstrap::SnapshotInput {
-                params: params.clone(),
-                layout,
-                schema: Arc::clone(&schema),
-                primary_keys,
-                column_map,
-                database,
-                table,
-                dataset_name,
-                metrics: Arc::clone(&metrics),
-            });
+            // Built before the snapshot input takes ownership of `dataset_name`.
+            //
             // Snapshot completion is signalled by a real boundary committer, NOT
             // a stream-drain hook: the committer's `commit()` runs on the apply
             // loop only after every prior (snapshot) envelope is durably applied,
@@ -996,9 +981,20 @@ async fn attach_member(
                 source,
                 &member_key,
                 &schema,
-                dataset_for_boundary,
+                dataset_name.clone(),
                 false,
             )?;
+            let snapshot = super::bootstrap::snapshot_stream(super::bootstrap::SnapshotInput {
+                params: params.clone(),
+                layout,
+                schema: Arc::clone(&schema),
+                primary_keys,
+                column_map,
+                database,
+                table,
+                dataset_name,
+                metrics: Arc::clone(&metrics),
+            });
             Box::pin(
                 stream::once(async move { Ok(truncate) })
                     .chain(snapshot)
@@ -1115,12 +1111,18 @@ async fn resolve_start_position(
             message: e.to_string(),
         })?;
 
-    // A recorded position proves two things the emptiness question turns on:
-    // the store is durable (an accelerator that does not survive restarts is
-    // wired to `NoopPositionStore`, which records nothing), and a load once ran
-    // far enough to record progress. So an acceleration that reaches the
-    // loading path with one behind it is holding rows, and must be replaced
-    // rather than emptied and refilled.
+    // A recorded position proves the acceleration is holding rows: the store is
+    // durable (an accelerator that does not survive restarts is wired to
+    // `NoopPositionStore`, which records nothing) and a load once ran far enough
+    // to record progress. Such an acceleration must be replaced, not emptied and
+    // refilled.
+    //
+    // The converse does not hold, and this deliberately under-claims rather than
+    // guessing: a durable acceleration whose sidecar failed to open also records
+    // nothing, and reads here as a first load. Closing that needs the store to
+    // say whether it can record at all, and the params to say whether the
+    // acceleration survives restarts — the shape `postgres_replication` uses.
+    // Tracked in #13021.
     let has_recorded_position = persisted.is_some();
 
     // `Some((position, gtid_seed))` to resume, `None` to (re)snapshot.
@@ -1134,13 +1136,7 @@ async fn resolve_start_position(
             )
             .is_err()
             {
-                apply_invalid_checkpoint(
-                    params,
-                    position_store,
-                    dataset_name,
-                    "layout/schema drift",
-                )
-                .await?;
+                apply_invalid_checkpoint(params, dataset_name, "layout/schema drift")?;
                 None
             } else {
                 match persisted.cursor_type {
@@ -1181,25 +1177,13 @@ async fn resolve_start_position(
                                 match gtid_checkpoint_verdict(&set, &source_executed) {
                                     CheckpointVerdict::Resume => Some((persisted.position, set)),
                                     CheckpointVerdict::Unresumable(reason) => {
-                                        apply_invalid_checkpoint(
-                                            params,
-                                            position_store,
-                                            dataset_name,
-                                            reason,
-                                        )
-                                        .await?;
+                                        apply_invalid_checkpoint(params, dataset_name, reason)?;
                                         None
                                     }
                                 }
                             }
                             Err(reason) => {
-                                apply_invalid_checkpoint(
-                                    params,
-                                    position_store,
-                                    dataset_name,
-                                    reason,
-                                )
-                                .await?;
+                                apply_invalid_checkpoint(params, dataset_name, reason)?;
                                 None
                             }
                         }
@@ -1211,13 +1195,7 @@ async fn resolve_start_position(
                         match file_checkpoint_verdict(present) {
                             CheckpointVerdict::Resume => Some((persisted.position, GtidSet::new())),
                             CheckpointVerdict::Unresumable(reason) => {
-                                apply_invalid_checkpoint(
-                                    params,
-                                    position_store,
-                                    dataset_name,
-                                    reason,
-                                )
-                                .await?;
+                                apply_invalid_checkpoint(params, dataset_name, reason)?;
                                 None
                             }
                         }
@@ -1278,9 +1256,8 @@ async fn resolve_start_position(
 
 /// Apply `invalid_checkpoint_behavior` for one member: `Error` fails the
 /// member's stream; `Restart` clears its saved position so it re-snapshots.
-async fn apply_invalid_checkpoint(
+fn apply_invalid_checkpoint(
     params: &ReplicationParams,
-    position_store: &Arc<dyn PositionStore>,
     dataset_name: &str,
     reason: &str,
 ) -> Result<()> {
@@ -1298,10 +1275,10 @@ async fn apply_invalid_checkpoint(
         }
         .fail(),
         InvalidCheckpointBehavior::Restart => {
-            tracing::warn!(dataset = %dataset_name, reason, "persisted mysql binlog checkpoint unusable; rebootstrapping");
-            if let Err(e) = position_store.clear().await {
-                tracing::warn!(dataset = %dataset_name, error = %e, "failed to clear unusable binlog position");
-            }
+            tracing::warn!(dataset = %dataset_name, reason, "persisted mysql binlog checkpoint unusable; rebuilding");
+            // Deliberately left in place until the rebuild's boundary committer
+            // replaces it with the new head — same invariant, and same reasoning,
+            // as `rebootstrap_member`.
             Ok(())
         }
     }
@@ -2445,7 +2422,6 @@ async fn poll_head_and_heartbeat(
 mod tests {
     use crate::mysql_replication::metrics::Metrics;
 
-    use arrow::array::Array;
     use arrow::datatypes::{DataType, Field, Schema};
 
     use super::*;
@@ -2513,14 +2489,15 @@ mod tests {
 
     /// A source with one live member whose channel the test owns, built without
     /// touching `MySQL`: everything `rebootstrap_member` reads is local state.
-    fn source_with_member(
-        member_key: &MemberKey,
-    ) -> (
-        Arc<SharedSource>,
-        Arc<MemberHandle>,
-        Arc<MemoryPositionStore>,
-        mpsc::Receiver<std::result::Result<ChangeEnvelope, StreamError>>,
-    ) {
+    /// One live member and everything a test needs to observe what it emitted.
+    struct TestMember {
+        source: Arc<SharedSource>,
+        member: Arc<MemberHandle>,
+        position_store: Arc<MemoryPositionStore>,
+        receiver: mpsc::Receiver<std::result::Result<ChangeEnvelope, StreamError>>,
+    }
+
+    fn source_with_member(member_key: &MemberKey) -> TestMember {
         let params = test_params();
         let source = Arc::new(SharedSource {
             key: SourceKey {
@@ -2585,22 +2562,12 @@ mod tests {
             .ack
             .register(member_key, pos("binlog.000001", 100), false);
         source.ack.promote_ready_members();
-        (source, member, position_store, receiver)
-    }
-
-    /// Every row's `op` in an envelope's built batch. `"t"` is the truncate that
-    /// empties the acceleration.
-    fn envelope_ops(envelope: ChangeEnvelope) -> Vec<String> {
-        let (_, batch, _, _) = envelope.into_parts().expect("build change batch");
-        let ops = batch
-            .record
-            .column_by_name("op")
-            .expect("op column")
-            .as_any()
-            .downcast_ref::<arrow::array::StringArray>()
-            .expect("op is a string column")
-            .clone();
-        (0..ops.len()).map(|i| ops.value(i).to_string()).collect()
+        TestMember {
+            source,
+            member,
+            position_store,
+            receiver,
+        }
     }
 
     #[tokio::test]
@@ -2612,7 +2579,12 @@ mod tests {
         // the contents atomically instead, so a query issued mid-rebuild returns
         // either the pre-rebuild rows or the completed ones.
         let member_key = key("db", "orders");
-        let (source, member, position_store, mut receiver) = source_with_member(&member_key);
+        let TestMember {
+            source,
+            member,
+            position_store,
+            mut receiver,
+        } = source_with_member(&member_key);
         // The purged checkpoint this member is recovering from.
         let purged = PersistedPosition {
             position: pos("binlog.000001", 100),
@@ -2648,9 +2620,8 @@ mod tests {
             "the signal carries the boundary committer, so the consumer's heartbeat \
              stripping cannot drop it and leave the new head unpersisted"
         );
-        assert_eq!(
-            envelope_ops(envelope),
-            Vec::<String>::new(),
+        assert!(
+            envelope.is_empty(),
             "the rebuild is a zero-row signal: no truncate, and no snapshot rows \
              for the consumer to apply on top of a table it is about to replace"
         );
@@ -2667,11 +2638,7 @@ mod tests {
         assert_eq!(slot.committed(), pos("binlog.000004", 4));
 
         // The unusable checkpoint stays until the signal's committer replaces it
-        // with the new head. It is the only durable evidence that this
-        // acceleration holds rows no position explains — clearing it up front and
-        // then crashing mid-rebuild would leave the next start reading a
-        // populated acceleration as a first load, and a first load empties it and
-        // refills it from a snapshot: the window this whole change closes.
+        // with the new head — see `rebootstrap_member` for why.
         let still_there = position_store
             .load()
             .await
@@ -2686,7 +2653,7 @@ mod tests {
         // to preserve and must NOT trigger a rebuild — that would re-read the
         // source table on every cold start.
         let member_key = key("db", "orders");
-        let (source, member, _position_store, _receiver) = source_with_member(&member_key);
+        let TestMember { source, member, .. } = source_with_member(&member_key);
 
         for (history_unavailable, expected) in [(false, false), (true, true)] {
             let envelope = snapshot_boundary_envelope(

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -553,6 +553,46 @@ impl CommitChange for SnapshotBoundaryCommitter {
     }
 }
 
+/// The zero-row boundary envelope carrying a [`SnapshotBoundaryCommitter`]:
+/// promotes the member out of `SNAPSHOTTING`, persists the captured head, and
+/// requests the reconnect — once the consumer has durably applied everything
+/// before it.
+///
+/// `history_unavailable` additionally asks the consumer to replace the
+/// acceleration's contents from the source before applying anything further
+/// (see [`crate::cdc::ChangeEnvelope::history_unavailable`]). The committer
+/// rides that same envelope rather than following it, for two reasons: the head
+/// must not be persisted until the replacement is durably applied, and a real
+/// committer keeps the envelope out of the consumer's zero-row heartbeat
+/// stripping — which a no-op one would not survive, leaving the rebuild
+/// unrequested.
+fn snapshot_boundary_envelope(
+    source: &Arc<SharedSource>,
+    key: &MemberKey,
+    schema: &SchemaRef,
+    dataset: String,
+    history_unavailable: bool,
+) -> Result<ChangeEnvelope> {
+    let schema_mismatch = |e: crate::cdc::ChangeBatchError| Error::SchemaMismatch {
+        message: e.to_string(),
+    };
+    let (_, batch, _, _) = crate::cdc::build_heartbeat_envelope(schema, None, false)
+        .map_err(schema_mismatch)?
+        .into_parts()
+        .map_err(schema_mismatch)?;
+    Ok(ChangeEnvelope::from_parts(
+        Box::new(SnapshotBoundaryCommitter {
+            source: Arc::clone(source),
+            key: key.clone(),
+            dataset,
+        }),
+        batch,
+        // Readiness stays lag-based: a member still loading is not ready.
+        false,
+        history_unavailable,
+    ))
+}
+
 struct MemberHandle {
     dataset_name: String,
     schema: SchemaRef,
@@ -822,7 +862,7 @@ async fn attach_member(
         );
     }
     let rejoining = lock(&source.detached).remove(&member_key);
-    let (floor, gtid_seed, snapshotting): (BinlogPosition, GtidSet, bool) = resolve_start_position(
+    let (floor, gtid_seed, start): (BinlogPosition, GtidSet, MemberStart) = resolve_start_position(
         &mut conn,
         &params,
         &position_store,
@@ -839,6 +879,10 @@ async fn attach_member(
         tracing::debug!(dataset = %dataset_name, error = %e, "setup disconnect");
     }
 
+    // Both loading starts hold the member SNAPSHOTTING until its boundary
+    // envelope lands, so neither can advance the shared floor on rows the
+    // consumer has not applied yet.
+    let snapshotting = start.is_loading();
     let (sender, receiver) = mpsc::channel(DEFAULT_MEMBER_CHANNEL_CAPACITY);
     source
         .ack
@@ -885,65 +929,88 @@ async fn attach_member(
     }
 
     // Head of the member's stream: initial snapshot (whose completion hook
-    // promotes it and reconnects), or an immediate empty head on resume.
-    let head: ChangesStream = if snapshotting {
-        let dataset_for_boundary = dataset_name.clone();
-        // Clear stale accelerator state before the snapshot so a cold or
-        // re-bootstrap (`invalid_checkpoint_behavior: restart`) load is a full
-        // replace, not an upsert over rows the source no longer has — mirrors
-        // the per-dataset `start_inner` truncate prelude.
-        let truncate = super::truncate_envelope(&schema, &primary_keys, &column_map)?;
-        let snapshot = super::bootstrap::snapshot_stream(super::bootstrap::SnapshotInput {
-            params: params.clone(),
-            layout,
-            schema: Arc::clone(&schema),
-            primary_keys,
-            column_map,
-            database,
-            table,
-            dataset_name,
-            metrics: Arc::clone(&metrics),
-        });
-        // Snapshot completion is signalled by a real boundary committer, NOT a
-        // stream-drain hook: the committer's `commit()` runs on the apply loop
-        // only after every prior (snapshot) envelope is durably applied, whereas
-        // a drain hook fires when the reader pulls it — up to a prefetch-channel
-        // ahead of durable apply. Promoting + persisting this member's head
-        // before its snapshot is durably applied would lose base rows on a
-        // crash. On a snapshot error the stream ends before this envelope, so
-        // the member stays SNAPSHOTTING and re-snapshots on rejoin (see
-        // `detach_member`). `persist_all` also skips SNAPSHOTTING members until
-        // this fires.
-        let schema_mismatch = |e: crate::cdc::ChangeBatchError| Error::SchemaMismatch {
-            message: e.to_string(),
-        };
-        let (_, boundary_batch, _, _) = crate::cdc::build_heartbeat_envelope(&schema, None, false)
-            .map_err(schema_mismatch)?
-            .into_parts()
-            .map_err(schema_mismatch)?;
-        let boundary = ChangeEnvelope::from_parts(
-            Box::new(SnapshotBoundaryCommitter {
-                source: Arc::clone(source),
-                key: member_key.clone(),
-                dataset: dataset_for_boundary,
-            }),
-            boundary_batch,
-            false,
-            // Not a history-unavailable signal: this boundary envelope exists to
-            // persist the snapshot head, and MySQL's own purged-binlog case is
-            // not wired to this mechanism.
-            false,
-        );
-        Box::pin(
-            stream::once(async move { Ok(truncate) })
-                .chain(snapshot)
-                .chain(stream::once(async move { Ok(boundary) })),
-        )
-    } else {
-        metrics.mark_bootstrap_complete();
-        Box::pin(stream::empty::<
-            std::result::Result<ChangeEnvelope, StreamError>,
-        >())
+    // promotes it and reconnects), the consumer-side rebuild that replaces it
+    // when the acceleration already holds rows, or an immediate empty head on
+    // resume.
+    let head: ChangesStream = match start {
+        MemberStart::Rebuild => {
+            // One zero-row envelope asking the consumer to replace the
+            // acceleration's contents from the source, and nothing else: the
+            // replacement is atomic, so queries keep seeing the pre-rebuild
+            // contents until it swaps. Clearing the table here and letting the
+            // snapshot refill it — what a `truncate` prelude does — is
+            // observable to queries as an empty, then partially filled, table.
+            //
+            // The boundary committer rides this envelope rather than following
+            // it: it must persist the head only once the replacement is durably
+            // applied, and being a real committer it also keeps the envelope out
+            // of the consumer's zero-row heartbeat stripping.
+            let signal = snapshot_boundary_envelope(
+                source,
+                &member_key,
+                &schema,
+                dataset_name.clone(),
+                true,
+            )?;
+            tracing::warn!(
+                dataset = %dataset_name,
+                connection = %source.key.label(),
+                "the persisted binlog position for this dataset is unusable and its acceleration survives restarts, so it will be rebuilt from the source before changes are applied"
+            );
+            // No snapshot runs on this path — the consumer's rebuild replaces it
+            // — so the gauge's "finished, or skipped" state is reached here.
+            // Leaving it at 0 would strand every readiness probe reading it.
+            metrics.mark_bootstrap_complete();
+            Box::pin(stream::once(async move { Ok(signal) }))
+        }
+        MemberStart::Snapshot => {
+            let dataset_for_boundary = dataset_name.clone();
+            // Clear whatever a crashed earlier load left behind, so the snapshot
+            // is a full replace rather than an upsert over rows the source no
+            // longer has. Reached only when nothing was ever persisted for this
+            // member, so there is no completed load to preserve; an acceleration
+            // that has one takes the `Rebuild` arm above.
+            let truncate = super::truncate_envelope(&schema, &primary_keys, &column_map)?;
+            let snapshot = super::bootstrap::snapshot_stream(super::bootstrap::SnapshotInput {
+                params: params.clone(),
+                layout,
+                schema: Arc::clone(&schema),
+                primary_keys,
+                column_map,
+                database,
+                table,
+                dataset_name,
+                metrics: Arc::clone(&metrics),
+            });
+            // Snapshot completion is signalled by a real boundary committer, NOT
+            // a stream-drain hook: the committer's `commit()` runs on the apply
+            // loop only after every prior (snapshot) envelope is durably applied,
+            // whereas a drain hook fires when the reader pulls it — up to a
+            // prefetch-channel ahead of durable apply. Promoting + persisting
+            // this member's head before its snapshot is durably applied would
+            // lose base rows on a crash. On a snapshot error the stream ends
+            // before this envelope, so the member stays SNAPSHOTTING and
+            // re-snapshots on rejoin (see `detach_member`). `persist_all` also
+            // skips SNAPSHOTTING members until this fires.
+            let boundary = snapshot_boundary_envelope(
+                source,
+                &member_key,
+                &schema,
+                dataset_for_boundary,
+                false,
+            )?;
+            Box::pin(
+                stream::once(async move { Ok(truncate) })
+                    .chain(snapshot)
+                    .chain(stream::once(async move { Ok(boundary) })),
+            )
+        }
+        MemberStart::Stream => {
+            metrics.mark_bootstrap_complete();
+            Box::pin(stream::empty::<
+                std::result::Result<ChangeEnvelope, StreamError>,
+            >())
+        }
     };
 
     Ok(Box::pin(head.chain(ReceiverStream::new(receiver))))
@@ -991,9 +1058,37 @@ fn file_checkpoint_verdict(persisted_file_present: bool) -> CheckpointVerdict {
     }
 }
 
+/// How a member's stream starts once its position has been resolved.
+///
+/// The distinction that matters is between the two loading starts: a snapshot
+/// refills an acceleration that holds nothing worth keeping, while a rebuild
+/// replaces one that is already serving rows and must never be emptied first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MemberStart {
+    /// Resume from the persisted position; nothing to load.
+    Stream,
+    /// Snapshot into an acceleration with no completed load behind it: no
+    /// position was ever persisted for this member.
+    Snapshot,
+    /// A position was persisted but cannot be resumed from, so the acceleration
+    /// holds rows whose explanation is gone from the source's binary log. Only
+    /// re-reading the table can correct them, and the consumer owns the
+    /// accelerator so it can do that as one atomic replacement — see
+    /// [`crate::cdc::ChangeEnvelope::history_unavailable`].
+    Rebuild,
+}
+
+impl MemberStart {
+    /// Whether the member is loading its acceleration, by either route. Held
+    /// `SNAPSHOTTING` in the ack until its boundary envelope lands.
+    const fn is_loading(self) -> bool {
+        matches!(self, Self::Snapshot | Self::Rebuild)
+    }
+}
+
 /// Resolve a fresh (non-rejoin) member's start position, applying
 /// `invalid_checkpoint_behavior` per member. Returns
-/// `(floor, gtid_seed, snapshotting)`. `gtid_seed` is the executed GTID set to
+/// `(floor, gtid_seed, start)`. `gtid_seed` is the executed GTID set to
 /// seed the member's ack from (empty when the dump is file-positioning);
 /// `use_gtid` is the source's current mode (all members share it).
 #[expect(
@@ -1012,13 +1107,21 @@ async fn resolve_start_position(
     database: &str,
     table: &str,
     use_gtid: bool,
-) -> Result<(BinlogPosition, GtidSet, bool)> {
+) -> Result<(BinlogPosition, GtidSet, MemberStart)> {
     let persisted = position_store
         .load()
         .await
         .map_err(|e| Error::PositionStoreAccess {
             message: e.to_string(),
         })?;
+
+    // A recorded position proves two things the emptiness question turns on:
+    // the store is durable (an accelerator that does not survive restarts is
+    // wired to `NoopPositionStore`, which records nothing), and a load once ran
+    // far enough to record progress. So an acceleration that reaches the
+    // loading path with one behind it is holding rows, and must be replaced
+    // rather than emptied and refilled.
+    let has_recorded_position = persisted.is_some();
 
     // `Some((position, gtid_seed))` to resume, `None` to (re)snapshot.
     let resume: Option<(BinlogPosition, GtidSet)> = match persisted {
@@ -1136,7 +1239,7 @@ async fn resolve_start_position(
         } else {
             tracing::info!(dataset = %dataset_name, position = %position, "shared mysql binlog: resuming from persisted file+offset position");
         }
-        return Ok((position, gtid_seed, false));
+        return Ok((position, gtid_seed, MemberStart::Stream));
     }
 
     // No usable position: capture the head (and its executed GTID set, when
@@ -1165,9 +1268,11 @@ async fn resolve_start_position(
         if let Err(e) = position_store.save(&initial).await {
             tracing::warn!(dataset = %dataset_name, error = %e, "failed to persist initial binlog head");
         }
-        Ok((head, head_gtid, false))
+        Ok((head, head_gtid, MemberStart::Stream))
+    } else if has_recorded_position {
+        Ok((head, head_gtid, MemberStart::Rebuild))
     } else {
-        Ok((head, head_gtid, true))
+        Ok((head, head_gtid, MemberStart::Snapshot))
     }
 }
 
@@ -2175,90 +2280,55 @@ async fn rebootstrap_all_for_restart(
         if member.sender.is_closed() {
             continue;
         }
-        rebootstrap_member(source, params, &key, &member, &head, &head_gtid).await?;
+        rebootstrap_member(source, &key, &member, &head, &head_gtid).await?;
     }
     Ok(())
 }
 
-/// Re-snapshot one member in place after its resume position was purged and
+/// Rebuild one member in place after its resume position was purged and
 /// `invalid_position_behavior = Restart`. Drops the purged checkpoint first (a
-/// crash mid-rebootstrap must cold-start, never resume a half-applied snapshot),
-/// resets the slot to `head` held `SNAPSHOTTING`, then pushes a fresh
-/// truncate → snapshot → boundary through the member's LIVE channel — the same
-/// bootstrap it received at cold start, delivered mid-stream because the runtime
-/// holds a single `ChangesStream` and never re-subscribes. The boundary's
-/// [`SnapshotBoundaryCommitter`] clears `SNAPSHOTTING`, persists the new head,
-/// and requests the reconnect that promotes the member back to streaming.
+/// crash mid-rebuild must reload from scratch, never resume on a position whose
+/// rows were never applied), resets the slot to `head` held `SNAPSHOTTING`, then
+/// pushes one rebuild signal through the member's LIVE channel — delivered
+/// mid-stream because the runtime holds a single `ChangesStream` and never
+/// re-subscribes.
+///
+/// The member is serving rows here, so the acceleration is replaced rather than
+/// refilled: the consumer answers
+/// [`crate::cdc::ChangeEnvelope::history_unavailable`] with one atomic overwrite
+/// and queries keep seeing the pre-rebuild contents until it swaps. Clearing the
+/// table and streaming a fresh snapshot into it — the shape this replaced —
+/// is observable to every query for the length of the re-read as an empty, then
+/// partially filled, table.
+///
+/// The signal's [`SnapshotBoundaryCommitter`] clears `SNAPSHOTTING`, persists the
+/// new head, and requests the reconnect that promotes the member back to
+/// streaming, all after the consumer has durably applied the replacement.
 async fn rebootstrap_member(
     source: &Arc<SharedSource>,
-    params: &ReplicationParams,
     key: &MemberKey,
     member: &Arc<MemberHandle>,
     head: &BinlogPosition,
     head_gtid: &GtidSet,
 ) -> Result<()> {
     if let Err(e) = member.position_store.clear().await {
-        tracing::warn!(dataset = %member.dataset_name, error = %e, "failed to clear purged mysql binlog checkpoint before re-snapshot");
+        tracing::warn!(dataset = %member.dataset_name, error = %e, "failed to clear purged mysql binlog checkpoint before rebuild");
     }
     // Reset to head, held SNAPSHOTTING so `persist_all`/promotion skip it until
-    // the boundary lands — identical to a cold-start member.
+    // the boundary lands — identical to a loading member.
     source
         .ack
         .register_with_gtid(key, head.clone(), head_gtid.clone(), true);
 
-    let ml = lock(&member.layout).clone();
-    let dropped = "changes stream receiver dropped during re-snapshot";
-    let truncate = super::truncate_envelope(&member.schema, &member.primary_keys, &ml.column_map)?;
-    if member.sender.send(Ok(truncate)).await.is_err() {
-        source.detach_member(key, dropped, true);
-        return Ok(());
-    }
-
-    let mut snapshot = super::bootstrap::snapshot_stream(super::bootstrap::SnapshotInput {
-        params: params.clone(),
-        layout: ml.layout.clone(),
-        schema: Arc::clone(&member.schema),
-        primary_keys: member.primary_keys.clone(),
-        column_map: ml.column_map.clone(),
-        database: key.0.clone(),
-        table: key.1.clone(),
-        dataset_name: member.dataset_name.clone(),
-        metrics: Arc::clone(&member.metrics),
-    });
-    while let Some(item) = snapshot.next().await {
-        let failed = item.is_err();
-        if member.sender.send(item).await.is_err() {
-            source.detach_member(key, dropped, true);
-            return Ok(());
-        }
-        if failed {
-            // Snapshot errored; leave the member SNAPSHOTTING with no boundary so
-            // it cannot falsely advance. The error is now visible downstream.
-            return Ok(());
-        }
-    }
-
-    let schema_mismatch = |e: crate::cdc::ChangeBatchError| Error::SchemaMismatch {
-        message: e.to_string(),
-    };
-    let (_, boundary_batch, _, _) =
-        crate::cdc::build_heartbeat_envelope(&member.schema, None, false)
-            .map_err(schema_mismatch)?
-            .into_parts()
-            .map_err(schema_mismatch)?;
-    let boundary = ChangeEnvelope::from_parts(
-        Box::new(SnapshotBoundaryCommitter {
-            source: Arc::clone(source),
-            key: key.clone(),
-            dataset: member.dataset_name.clone(),
-        }),
-        boundary_batch,
-        false,
-        // See the sibling boundary envelope: not a history-unavailable signal.
-        false,
-    );
-    if member.sender.send(Ok(boundary)).await.is_err() {
-        source.detach_member(key, dropped, true);
+    let signal = snapshot_boundary_envelope(
+        source,
+        key,
+        &member.schema,
+        member.dataset_name.clone(),
+        true,
+    )?;
+    if member.sender.send(Ok(signal)).await.is_err() {
+        source.detach_member(key, "changes stream receiver dropped during rebuild", true);
     }
     Ok(())
 }
@@ -2371,6 +2441,9 @@ async fn poll_head_and_heartbeat(
 mod tests {
     use crate::mysql_replication::metrics::Metrics;
 
+    use arrow::array::Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+
     use super::*;
 
     fn key(db: &str, t: &str) -> MemberKey {
@@ -2385,6 +2458,204 @@ mod tests {
 
     fn gtids(raw: &str) -> GtidSet {
         GtidSet::parse(raw).expect("parse gtid set")
+    }
+
+    fn test_params() -> ReplicationParams {
+        ReplicationParams {
+            opts: mysql_async::Opts::from_url("mysql://user:pass@localhost:3306/db")
+                .expect("parse test connection url"),
+            server_id: 1,
+            snapshot_mode: InitialSnapshotMode::default(),
+            bootstrap_batch_size: 1,
+            checkpoint_interval: Duration::from_secs(1),
+            invalid_position_behavior: InvalidCheckpointBehavior::Restart,
+            ready_lag: Duration::from_secs(2),
+        }
+    }
+
+    fn test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]))
+    }
+
+    /// A source with one live member whose channel the test owns, built without
+    /// touching `MySQL`: everything `rebootstrap_member` reads is local state.
+    fn source_with_member(
+        member_key: &MemberKey,
+    ) -> (
+        Arc<SharedSource>,
+        Arc<MemberHandle>,
+        mpsc::Receiver<std::result::Result<ChangeEnvelope, StreamError>>,
+    ) {
+        let params = test_params();
+        let source = Arc::new(SharedSource {
+            key: SourceKey {
+                host: "localhost".to_string(),
+                port: 3306,
+                user: "user".to_string(),
+                pass: None,
+                ssl: None,
+                server_id: params.server_id,
+            },
+            params: params.clone(),
+            setup_lock: tokio::sync::Mutex::new(()),
+            members: Mutex::new(HashMap::new()),
+            ack: Arc::new(AckTable::default()),
+            pump_started: AtomicBool::new(true),
+            restart_requested: AtomicBool::new(false),
+            dead: AtomicBool::new(false),
+            detached: Mutex::new(HashSet::new()),
+        });
+        let (sender, receiver) = mpsc::channel(8);
+        let member = Arc::new(MemberHandle {
+            dataset_name: "orders".to_string(),
+            schema: test_schema(),
+            primary_keys: vec!["id".to_string()],
+            layout: Mutex::new(Arc::new(MemberLayout {
+                // Covers every column of `test_schema`, so anything the member
+                // builds from the layout (a truncate row included) is buildable
+                // — an under-covered fixture would fail a test for its own
+                // reasons rather than the asserted one.
+                layout: super::super::setup::TableLayout {
+                    columns: vec![
+                        super::super::setup::SourceColumn {
+                            name: "id".to_string(),
+                            column_type: "bigint".to_string(),
+                            enum_variants: None,
+                            set_variants: None,
+                            is_primary_key: true,
+                        },
+                        super::super::setup::SourceColumn {
+                            name: "name".to_string(),
+                            column_type: "varchar(64)".to_string(),
+                            enum_variants: None,
+                            set_variants: None,
+                            is_primary_key: false,
+                        },
+                    ],
+                },
+                column_map: vec![0, 1],
+                pk_source_indexes: vec![0],
+            })),
+            sender,
+            metrics: MetricsCollector::new(),
+            ready_lag: params.ready_lag,
+            position_store: Arc::new(super::super::NoopPositionStore),
+            checkpoint_schema_json: None,
+            cursor_type: CursorType::File,
+        });
+        lock(&source.members).insert(member_key.clone(), Arc::clone(&member));
+        // A streaming member: the rebuild is what puts it back into SNAPSHOTTING.
+        source
+            .ack
+            .register(member_key, pos("binlog.000001", 100), false);
+        source.ack.promote_ready_members();
+        (source, member, receiver)
+    }
+
+    /// Every row's `op` in an envelope's built batch. `"t"` is the truncate that
+    /// empties the acceleration.
+    fn envelope_ops(envelope: ChangeEnvelope) -> Vec<String> {
+        let (_, batch, _, _) = envelope.into_parts().expect("build change batch");
+        let ops = batch
+            .record
+            .column_by_name("op")
+            .expect("op column")
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("op is a string column")
+            .clone();
+        (0..ops.len()).map(|i| ops.value(i).to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn rebuild_replaces_the_acceleration_instead_of_emptying_it() {
+        // A purged binlog position under `invalid_checkpoint_behavior: restart`
+        // must not clear the acceleration and refill it through the change
+        // stream: for the whole re-read, queries would be answered from an empty,
+        // then partially filled, table. The member asks the consumer to replace
+        // the contents atomically instead, so a query issued mid-rebuild returns
+        // either the pre-rebuild rows or the completed ones.
+        let member_key = key("db", "orders");
+        let (source, member, mut receiver) = source_with_member(&member_key);
+
+        rebootstrap_member(
+            &source,
+            &member_key,
+            &member,
+            &pos("binlog.000004", 4),
+            &GtidSet::new(),
+        )
+        .await
+        .expect("rebootstrap the member");
+
+        let envelope = receiver
+            .try_recv()
+            .expect("the rebuild signal is sent")
+            .expect("the rebuild signal is not a stream error");
+        assert!(
+            envelope.history_unavailable(),
+            "the member must ask the consumer to rebuild from the source"
+        );
+        assert!(
+            !envelope.is_no_op_heartbeat(),
+            "the signal carries the boundary committer, so the consumer's heartbeat \
+             stripping cannot drop it and leave the new head unpersisted"
+        );
+        assert_eq!(
+            envelope_ops(envelope),
+            Vec::<String>::new(),
+            "the rebuild is a zero-row signal: no truncate, and no snapshot rows \
+             for the consumer to apply on top of a table it is about to replace"
+        );
+        assert!(
+            receiver.try_recv().is_err(),
+            "the rebuild signal is the whole prelude — nothing follows it on the \
+             member's channel"
+        );
+
+        // Held SNAPSHOTTING until the signal's committer runs, so the shared floor
+        // cannot advance onto rows the consumer has not applied.
+        let slot = source.ack.slot(&member_key).expect("member slot");
+        assert!(slot.has(SNAPSHOTTING));
+        assert_eq!(slot.committed(), pos("binlog.000004", 4));
+    }
+
+    #[tokio::test]
+    async fn only_the_rebuild_boundary_asks_for_a_replacement() {
+        // The same envelope serves both loading starts; a first load has nothing
+        // to preserve and must NOT trigger a rebuild — that would re-read the
+        // source table on every cold start.
+        let member_key = key("db", "orders");
+        let (source, member, _receiver) = source_with_member(&member_key);
+
+        for (history_unavailable, expected) in [(false, false), (true, true)] {
+            let envelope = snapshot_boundary_envelope(
+                &source,
+                &member_key,
+                &member.schema,
+                member.dataset_name.clone(),
+                history_unavailable,
+            )
+            .expect("build the boundary envelope");
+            assert_eq!(envelope.history_unavailable(), expected);
+            // Both carry the boundary committer: a snapshot's head must survive
+            // the consumer's heartbeat stripping too.
+            assert!(!envelope.is_no_op_heartbeat());
+            assert!(!envelope.is_dataset_ready());
+        }
+    }
+
+    #[test]
+    fn both_loading_starts_hold_the_member_snapshotting() {
+        // The ack floor is held for whichever way the acceleration is loaded. A
+        // rebuild that reported itself as not-loading would let the shared floor
+        // advance past rows the consumer has not applied yet.
+        assert!(MemberStart::Snapshot.is_loading());
+        assert!(MemberStart::Rebuild.is_loading());
+        assert!(!MemberStart::Stream.is_loading());
     }
 
     #[test]

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -2286,12 +2286,19 @@ async fn rebootstrap_all_for_restart(
 }
 
 /// Rebuild one member in place after its resume position was purged and
-/// `invalid_position_behavior = Restart`. Drops the purged checkpoint first (a
-/// crash mid-rebuild must reload from scratch, never resume on a position whose
-/// rows were never applied), resets the slot to `head` held `SNAPSHOTTING`, then
-/// pushes one rebuild signal through the member's LIVE channel — delivered
-/// mid-stream because the runtime holds a single `ChangesStream` and never
-/// re-subscribes.
+/// `invalid_position_behavior = Restart`. Resets the slot to `head` held
+/// `SNAPSHOTTING`, then pushes one rebuild signal through the member's LIVE
+/// channel — delivered mid-stream because the runtime holds a single
+/// `ChangesStream` and never re-subscribes.
+///
+/// The purged checkpoint is deliberately left in place until the boundary
+/// committer replaces it with the new head. It is the only durable evidence that
+/// this acceleration holds rows no position explains: clearing it up front and
+/// then crashing mid-rebuild would leave a populated acceleration with no
+/// checkpoint, which the next start reads as a first load — and a first load
+/// empties the table and refills it from a snapshot, which is the very window
+/// this exists to close. Leaving it costs at most one repeated rebuild after a
+/// crash, since the next start re-detects it as unusable and lands here again.
 ///
 /// The member is serving rows here, so the acceleration is replaced rather than
 /// refilled: the consumer answers
@@ -2311,9 +2318,6 @@ async fn rebootstrap_member(
     head: &BinlogPosition,
     head_gtid: &GtidSet,
 ) -> Result<()> {
-    if let Err(e) = member.position_store.clear().await {
-        tracing::warn!(dataset = %member.dataset_name, error = %e, "failed to clear purged mysql binlog checkpoint before rebuild");
-    }
     // Reset to head, held SNAPSHOTTING so `persist_all`/promotion skip it until
     // the boundary lands — identical to a loading member.
     source
@@ -2473,6 +2477,33 @@ mod tests {
         }
     }
 
+    /// Stands in for a member's durable accelerator sidecar, so a test can read
+    /// back what the rebuild did (or did not) do to the persisted checkpoint.
+    #[derive(Default)]
+    struct MemoryPositionStore {
+        inner: Mutex<Option<PersistedPosition>>,
+    }
+
+    #[async_trait]
+    impl super::super::PositionStore for MemoryPositionStore {
+        async fn load(
+            &self,
+        ) -> std::result::Result<Option<PersistedPosition>, super::super::StoreError> {
+            Ok(lock(&self.inner).clone())
+        }
+        async fn save(
+            &self,
+            position: &PersistedPosition,
+        ) -> std::result::Result<(), super::super::StoreError> {
+            *lock(&self.inner) = Some(position.clone());
+            Ok(())
+        }
+        async fn clear(&self) -> std::result::Result<(), super::super::StoreError> {
+            *lock(&self.inner) = None;
+            Ok(())
+        }
+    }
+
     fn test_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),
@@ -2487,6 +2518,7 @@ mod tests {
     ) -> (
         Arc<SharedSource>,
         Arc<MemberHandle>,
+        Arc<MemoryPositionStore>,
         mpsc::Receiver<std::result::Result<ChangeEnvelope, StreamError>>,
     ) {
         let params = test_params();
@@ -2509,6 +2541,7 @@ mod tests {
             detached: Mutex::new(HashSet::new()),
         });
         let (sender, receiver) = mpsc::channel(8);
+        let position_store: Arc<MemoryPositionStore> = Arc::new(MemoryPositionStore::default());
         let member = Arc::new(MemberHandle {
             dataset_name: "orders".to_string(),
             schema: test_schema(),
@@ -2542,7 +2575,7 @@ mod tests {
             sender,
             metrics: MetricsCollector::new(),
             ready_lag: params.ready_lag,
-            position_store: Arc::new(super::super::NoopPositionStore),
+            position_store: Arc::clone(&position_store) as Arc<dyn PositionStore>,
             checkpoint_schema_json: None,
             cursor_type: CursorType::File,
         });
@@ -2552,7 +2585,7 @@ mod tests {
             .ack
             .register(member_key, pos("binlog.000001", 100), false);
         source.ack.promote_ready_members();
-        (source, member, receiver)
+        (source, member, position_store, receiver)
     }
 
     /// Every row's `op` in an envelope's built batch. `"t"` is the truncate that
@@ -2579,7 +2612,18 @@ mod tests {
         // the contents atomically instead, so a query issued mid-rebuild returns
         // either the pre-rebuild rows or the completed ones.
         let member_key = key("db", "orders");
-        let (source, member, mut receiver) = source_with_member(&member_key);
+        let (source, member, position_store, mut receiver) = source_with_member(&member_key);
+        // The purged checkpoint this member is recovering from.
+        let purged = PersistedPosition {
+            position: pos("binlog.000001", 100),
+            schema_json: None,
+            gtid_set: None,
+            cursor_type: CursorType::File,
+        };
+        position_store
+            .save(&purged)
+            .await
+            .expect("seed the purged checkpoint");
 
         rebootstrap_member(
             &source,
@@ -2621,6 +2665,19 @@ mod tests {
         let slot = source.ack.slot(&member_key).expect("member slot");
         assert!(slot.has(SNAPSHOTTING));
         assert_eq!(slot.committed(), pos("binlog.000004", 4));
+
+        // The unusable checkpoint stays until the signal's committer replaces it
+        // with the new head. It is the only durable evidence that this
+        // acceleration holds rows no position explains — clearing it up front and
+        // then crashing mid-rebuild would leave the next start reading a
+        // populated acceleration as a first load, and a first load empties it and
+        // refills it from a snapshot: the window this whole change closes.
+        let still_there = position_store
+            .load()
+            .await
+            .expect("store readable")
+            .expect("the purged checkpoint survives until the rebuild commits");
+        assert_eq!(still_there.position, purged.position);
     }
 
     #[tokio::test]
@@ -2629,7 +2686,7 @@ mod tests {
         // to preserve and must NOT trigger a rebuild — that would re-read the
         // source table on every cold start.
         let member_key = key("db", "orders");
-        let (source, member, _receiver) = source_with_member(&member_key);
+        let (source, member, _position_store, _receiver) = source_with_member(&member_key);
 
         for (history_unavailable, expected) in [(false, false), (true, true)] {
             let envelope = snapshot_boundary_envelope(

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -1270,7 +1270,8 @@ fn apply_invalid_checkpoint(
             message: format!(
                 "cannot resume mysql binlog for {dataset_name}: {reason}. Resuming could serve \
                  incorrect data. Set `mysql_replication_invalid_checkpoint_behavior: restart` to \
-                 drop the saved position and re-snapshot the table."
+                 rebuild the acceleration from the source instead. See: \
+                 https://spiceai.org/docs/components/data-connectors/mysql"
             ),
         }
         .fail(),

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -1951,18 +1951,26 @@ impl RefreshTask {
             "run must contain at least one envelope"
         );
 
+        // Runs before the heartbeat retain below: a signal may ride a zero-row
+        // envelope, which the retain would otherwise strip — and the rebuild
+        // would never happen. See `trim_to_rebuild_signal` for why the prefix
+        // goes with it.
+        let history_unavailable = trim_to_rebuild_signal(&mut envelopes);
+
+        // Read after the trim and before the retain. After, because a readiness
+        // flag from a discarded envelope must not survive it: the rebuild signal
+        // is deliberately not-ready, and honoring a stale flag would mark the
+        // dataset Ready the moment the replacement lands — before the source has
+        // reconnected at the captured head and caught up, which is exactly the
+        // stale-serving window lag-based readiness exists to prevent. Before,
+        // because the retain drops heartbeats whose ready flag IS meant to count.
+        //
         // Split envelopes into (committers, batches, ready_flags) preserving
         // arrival order. Committers will be drained sequentially in the
         // background commit task; per-source semantics (e.g., PG `Standby
         // Status Update` carrying the latest LSN, Kafka per-partition
         // offsets) require this ordering.
         let any_ready = envelopes.iter().any(cdc::ChangeEnvelope::is_dataset_ready);
-
-        // Read before the heartbeat retain below, for the same reason `any_ready`
-        // is: a signal may ride a zero-row envelope, which the retain would
-        // otherwise strip — and the rebuild would never happen. See
-        // `trim_to_rebuild_signal` for why the prefix goes with it.
-        let history_unavailable = trim_to_rebuild_signal(&mut envelopes);
 
         // Strip zero-row readiness heartbeats from the write/durability path
         // (#12007). Lag-based readiness (#11777) makes CDC connectors emit a
@@ -6855,7 +6863,11 @@ mod tests {
         // everything after it (post-capture changes, which DO replay) survive.
         let mut run = vec![
             make_tracked_envelope(1, Arc::clone(&log), false),
-            make_tracked_envelope(2, Arc::clone(&log), false),
+            // Ready, and discarded: `apply_envelope_run` reads `any_ready` from
+            // the TRIMMED run, so this flag must not survive to mark the dataset
+            // Ready the moment the replacement lands — before the source has
+            // reconnected at the captured head and caught up.
+            make_tracked_envelope(2, Arc::clone(&log), true),
             signal(),
             make_tracked_envelope(3, Arc::clone(&log), false),
         ];
@@ -6863,6 +6875,10 @@ mod tests {
         assert_eq!(run.len(), 2, "only the signal and its suffix survive");
         assert!(run[0].history_unavailable(), "the signal leads the run");
         assert!(!run[1].history_unavailable());
+        assert!(
+            !run.iter().any(cdc::ChangeEnvelope::is_dataset_ready),
+            "a readiness flag from a discarded envelope must not survive the trim"
+        );
 
         // Two signals in one coalesced run still get exactly one rebuild, so the
         // envelopes BETWEEN them are subsumed by it too and must not survive.

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -1959,32 +1959,10 @@ impl RefreshTask {
         let any_ready = envelopes.iter().any(cdc::ChangeEnvelope::is_dataset_ready);
 
         // Read before the heartbeat retain below, for the same reason `any_ready`
-        // is: the signal rides a zero-row, no-op-committer envelope (see
-        // `cdc::build_history_unavailable_envelope`), so the retain would
-        // otherwise strip it and the rebuild would never happen.
-        let history_unavailable = envelopes
-            .iter()
-            .any(cdc::ChangeEnvelope::history_unavailable);
-
-        // Runs BEFORE the heartbeat retain, so the signal is still findable
-        // whichever committer it rides: a source that raises it on a no-op
-        // envelope (`cdc::build_history_unavailable_envelope`) would otherwise
-        // have it stripped here and the prefix below would survive.
-        //
-        // The rebuild runs before the whole run, so anything the run carries
-        // AHEAD of the signal would be applied on top of a table that was
-        // re-read after it — writing a value the source has already moved past.
-        // Streaming resumes at the position the source captured when it raised
-        // the signal, which is at or after those envelopes, so nothing replays
-        // over the regression and it is durable.
-        //
-        // Discarding them is exact rather than lossy: the signal means the
-        // source can no longer explain what changed, and the re-read observes
-        // the source at a point at or after every envelope that preceded the
-        // signal, so the re-read already reflects them. Their committers are
-        // dropped unacked, which only holds a source position back — the
-        // rebuild's own boundary commit carries the new one.
-        discard_pre_rebuild_envelopes(&mut envelopes);
+        // is: a signal may ride a zero-row envelope, which the retain would
+        // otherwise strip — and the rebuild would never happen. See
+        // `trim_to_rebuild_signal` for why the prefix goes with it.
+        let history_unavailable = trim_to_rebuild_signal(&mut envelopes);
 
         // Strip zero-row readiness heartbeats from the write/durability path
         // (#12007). Lag-based readiness (#11777) makes CDC connectors emit a
@@ -3892,19 +3870,37 @@ fn encode_array_value(array: &dyn Array, row_id: usize, key: &mut Vec<u8>) {
     }
 }
 
-/// Drop everything a run carries ahead of a [`cdc::ChangeEnvelope::history_unavailable`]
-/// signal, so the rebuild is an ordering barrier rather than a jump ahead of the
-/// changes it was queued behind.
+/// Trim a run to start at its [`cdc::ChangeEnvelope::history_unavailable`]
+/// signal, reporting whether it had one.
 ///
-/// A no-op when the run carries no signal, which is every ordinary run.
-fn discard_pre_rebuild_envelopes(envelopes: &mut Vec<cdc::ChangeEnvelope>) {
-    if let Some(signal) = envelopes
+/// The rebuild runs before the whole run, so anything the run carries AHEAD of
+/// the signal would be applied on top of a table that was re-read past it —
+/// writing a value the source has already moved on from. Streaming resumes at
+/// the position the source captured when it raised the signal, which is at or
+/// after those envelopes, so nothing replays over the regression and it is
+/// durable.
+///
+/// Discarding them is exact rather than lossy: the signal means the source can
+/// no longer explain what changed, and the re-read observes the source at a
+/// point at or after every envelope that preceded the signal, so the re-read
+/// already reflects them. Their committers are dropped unacked, which only holds
+/// a source position back — the rebuild's own boundary commit carries the new
+/// one.
+///
+/// The LAST signal is the barrier, not the first: one rebuild answers every
+/// signal in the run (the caller performs exactly one), so envelopes between two
+/// signals are subsumed by it just as the leading ones are.
+///
+/// A no-op on every ordinary run, which carries no signal at all.
+fn trim_to_rebuild_signal(envelopes: &mut Vec<cdc::ChangeEnvelope>) -> bool {
+    let Some(signal) = envelopes
         .iter()
-        .position(cdc::ChangeEnvelope::history_unavailable)
-        && signal > 0
-    {
-        envelopes.drain(..signal);
-    }
+        .rposition(cdc::ChangeEnvelope::history_unavailable)
+    else {
+        return false;
+    };
+    envelopes.drain(..signal);
+    true
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6839,14 +6835,17 @@ mod tests {
     /// Build a zero-row readiness heartbeat envelope over the unit-test data
     /// schema, as CDC connectors emit (#11777) roughly once a second on a
     /// caught-up source.
+    fn make_heartbeat_envelope(is_ready: bool) -> ChangeEnvelope {
+        let schema = Arc::new(create_test_data_schema());
+        cdc::build_heartbeat_envelope(&schema, cdc::now_unix_ms(), is_ready)
+            .expect("heartbeat envelope builds")
+    }
+
     /// A rebuild signal is an ordering barrier, not a jump to the front of the
-    /// run. Anything the run carries ahead of the signal is subsumed by the
-    /// re-read that follows and must be discarded: applying it afterwards writes
-    /// a value the source has already moved past, and because streaming resumes
-    /// at the position captured when the signal was raised, nothing replays over
-    /// the regression.
+    /// run: what the run carries ahead of it is subsumed by the re-read and must
+    /// go with it. See `trim_to_rebuild_signal`.
     #[test]
-    fn a_rebuild_signal_discards_only_what_precedes_it() {
+    fn a_run_is_trimmed_to_its_last_rebuild_signal() {
         let log = Arc::new(CommitLog::default());
         let schema = Arc::new(create_test_data_schema());
         let signal =
@@ -6860,30 +6859,37 @@ mod tests {
             signal(),
             make_tracked_envelope(3, Arc::clone(&log), false),
         ];
-        discard_pre_rebuild_envelopes(&mut run);
+        assert!(trim_to_rebuild_signal(&mut run));
         assert_eq!(run.len(), 2, "only the signal and its suffix survive");
         assert!(run[0].history_unavailable(), "the signal leads the run");
         assert!(!run[1].history_unavailable());
 
-        // A signal already at the front loses nothing — the stream-head case
-        // every source takes when it raises the signal at subscribe time.
-        let mut run = vec![signal(), make_tracked_envelope(4, Arc::clone(&log), false)];
-        discard_pre_rebuild_envelopes(&mut run);
-        assert_eq!(run.len(), 2);
-
-        // An ordinary run is untouched.
+        // Two signals in one coalesced run still get exactly one rebuild, so the
+        // envelopes BETWEEN them are subsumed by it too and must not survive.
         let mut run = vec![
+            make_tracked_envelope(4, Arc::clone(&log), false),
+            signal(),
             make_tracked_envelope(5, Arc::clone(&log), false),
+            signal(),
             make_tracked_envelope(6, Arc::clone(&log), false),
         ];
-        discard_pre_rebuild_envelopes(&mut run);
-        assert_eq!(run.len(), 2);
-    }
+        assert!(trim_to_rebuild_signal(&mut run));
+        assert_eq!(run.len(), 2, "the run is trimmed to the LAST signal");
+        assert!(run[0].history_unavailable());
 
-    fn make_heartbeat_envelope(is_ready: bool) -> ChangeEnvelope {
-        let schema = Arc::new(create_test_data_schema());
-        cdc::build_heartbeat_envelope(&schema, cdc::now_unix_ms(), is_ready)
-            .expect("heartbeat envelope builds")
+        // A signal already at the front loses nothing — the stream-head case
+        // every source takes when it raises the signal at subscribe time.
+        let mut run = vec![signal(), make_tracked_envelope(7, Arc::clone(&log), false)];
+        assert!(trim_to_rebuild_signal(&mut run));
+        assert_eq!(run.len(), 2);
+
+        // An ordinary run is untouched, and reports no rebuild.
+        let mut run = vec![
+            make_tracked_envelope(8, Arc::clone(&log), false),
+            make_tracked_envelope(9, Arc::clone(&log), false),
+        ];
+        assert!(!trim_to_rebuild_signal(&mut run));
+        assert_eq!(run.len(), 2);
     }
 
     /// A run of pure readiness heartbeats must flip the dataset Ready without

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -1958,12 +1958,17 @@ impl RefreshTask {
         let history_unavailable = trim_to_rebuild_signal(&mut envelopes);
 
         // Read after the trim and before the retain. After, because a readiness
-        // flag from a discarded envelope must not survive it: the rebuild signal
-        // is deliberately not-ready, and honoring a stale flag would mark the
-        // dataset Ready the moment the replacement lands — before the source has
-        // reconnected at the captured head and caught up, which is exactly the
-        // stale-serving window lag-based readiness exists to prevent. Before,
-        // because the retain drops heartbeats whose ready flag IS meant to count.
+        // flag from a discarded envelope must not reach `signal_dataset_ready`,
+        // which wakes everything blocked on initial load using a flag describing
+        // a source state the rebuild is about to replace. That narrows, but does
+        // not close, the stale-serving window: on the `history_unavailable` path
+        // the dataset becomes Ready regardless, because `rebuild_from_source` is
+        // the ordinary full refresh and `RefreshTask::run` sets `Ready` (and with
+        // it `initial_load_completed`) on success, before the source has
+        // reconnected at the captured head and confirmed catch-up by lag. Closing
+        // the window needs the rebuild to run without that terminal Ready
+        // transition, tracked in #13028. Before the retain, because it drops
+        // heartbeats whose ready flag IS meant to count.
         //
         // Split envelopes into (committers, batches, ready_flags) preserving
         // arrival order. Committers will be drained sequentially in the

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -1966,6 +1966,26 @@ impl RefreshTask {
             .iter()
             .any(cdc::ChangeEnvelope::history_unavailable);
 
+        // Runs BEFORE the heartbeat retain, so the signal is still findable
+        // whichever committer it rides: a source that raises it on a no-op
+        // envelope (`cdc::build_history_unavailable_envelope`) would otherwise
+        // have it stripped here and the prefix below would survive.
+        //
+        // The rebuild runs before the whole run, so anything the run carries
+        // AHEAD of the signal would be applied on top of a table that was
+        // re-read after it — writing a value the source has already moved past.
+        // Streaming resumes at the position the source captured when it raised
+        // the signal, which is at or after those envelopes, so nothing replays
+        // over the regression and it is durable.
+        //
+        // Discarding them is exact rather than lossy: the signal means the
+        // source can no longer explain what changed, and the re-read observes
+        // the source at a point at or after every envelope that preceded the
+        // signal, so the re-read already reflects them. Their committers are
+        // dropped unacked, which only holds a source position back — the
+        // rebuild's own boundary commit carries the new one.
+        discard_pre_rebuild_envelopes(&mut envelopes);
+
         // Strip zero-row readiness heartbeats from the write/durability path
         // (#12007). Lag-based readiness (#11777) makes CDC connectors emit a
         // heartbeat roughly every second on a caught-up source; the heartbeat's
@@ -3869,6 +3889,21 @@ fn encode_array_value(array: &dyn Array, row_id: usize, key: &mut Vec<u8>) {
         encode_bytes(value.as_bytes(), key);
     } else {
         key.push(0xff);
+    }
+}
+
+/// Drop everything a run carries ahead of a [`cdc::ChangeEnvelope::history_unavailable`]
+/// signal, so the rebuild is an ordering barrier rather than a jump ahead of the
+/// changes it was queued behind.
+///
+/// A no-op when the run carries no signal, which is every ordinary run.
+fn discard_pre_rebuild_envelopes(envelopes: &mut Vec<cdc::ChangeEnvelope>) {
+    if let Some(signal) = envelopes
+        .iter()
+        .position(cdc::ChangeEnvelope::history_unavailable)
+        && signal > 0
+    {
+        envelopes.drain(..signal);
     }
 }
 
@@ -6804,6 +6839,47 @@ mod tests {
     /// Build a zero-row readiness heartbeat envelope over the unit-test data
     /// schema, as CDC connectors emit (#11777) roughly once a second on a
     /// caught-up source.
+    /// A rebuild signal is an ordering barrier, not a jump to the front of the
+    /// run. Anything the run carries ahead of the signal is subsumed by the
+    /// re-read that follows and must be discarded: applying it afterwards writes
+    /// a value the source has already moved past, and because streaming resumes
+    /// at the position captured when the signal was raised, nothing replays over
+    /// the regression.
+    #[test]
+    fn a_rebuild_signal_discards_only_what_precedes_it() {
+        let log = Arc::new(CommitLog::default());
+        let schema = Arc::new(create_test_data_schema());
+        let signal =
+            || cdc::build_history_unavailable_envelope(&schema).expect("rebuild signal builds");
+
+        // Stale changes queued behind the signal are dropped; the signal and
+        // everything after it (post-capture changes, which DO replay) survive.
+        let mut run = vec![
+            make_tracked_envelope(1, Arc::clone(&log), false),
+            make_tracked_envelope(2, Arc::clone(&log), false),
+            signal(),
+            make_tracked_envelope(3, Arc::clone(&log), false),
+        ];
+        discard_pre_rebuild_envelopes(&mut run);
+        assert_eq!(run.len(), 2, "only the signal and its suffix survive");
+        assert!(run[0].history_unavailable(), "the signal leads the run");
+        assert!(!run[1].history_unavailable());
+
+        // A signal already at the front loses nothing — the stream-head case
+        // every source takes when it raises the signal at subscribe time.
+        let mut run = vec![signal(), make_tracked_envelope(4, Arc::clone(&log), false)];
+        discard_pre_rebuild_envelopes(&mut run);
+        assert_eq!(run.len(), 2);
+
+        // An ordinary run is untouched.
+        let mut run = vec![
+            make_tracked_envelope(5, Arc::clone(&log), false),
+            make_tracked_envelope(6, Arc::clone(&log), false),
+        ];
+        discard_pre_rebuild_envelopes(&mut run);
+        assert_eq!(run.len(), 2);
+    }
+
     fn make_heartbeat_envelope(is_ready: bool) -> ChangeEnvelope {
         let schema = Arc::new(create_test_data_schema());
         cdc::build_heartbeat_envelope(&schema, cdc::now_unix_ms(), is_ready)

--- a/crates/runtime/tests/mysql/replication.rs
+++ b/crates/runtime/tests/mysql/replication.rs
@@ -466,31 +466,44 @@ async fn purged_position_behavior() -> Result<(), anyhow::Error> {
     );
     drop(stream);
 
-    // `restart`: the stale position is dropped and a fresh snapshot runs.
+    // `restart`: the stale position is dropped and the acceleration is rebuilt.
+    //
+    // A position was persisted, so the acceleration this member is attached to
+    // already holds rows. It must NOT be emptied and refilled through the change
+    // stream — for the length of the re-read every query would be answered from
+    // an empty, then partially filled, table. The member hands the replacement to
+    // the consumer instead, which performs it as one atomic overwrite.
     let store: Arc<MemoryPositionStore> = Arc::new(MemoryPositionStore::default());
     store.save(&stale).await.expect("save stale position");
     let mut input = stream_input(port, 200_202, Arc::clone(&store) as Arc<dyn PositionStore>);
     input.params.invalid_position_behavior = InvalidCheckpointBehavior::Restart;
     let mut stream = start_replication_stream(input);
 
-    let envelope = next_envelope(&mut stream, "restart truncate barrier").await?;
-    assert_eq!(ops_of(&envelope), vec!["t"]);
-    let envelope = next_envelope(&mut stream, "restart snapshot").await?;
-    assert_eq!(ops_of(&envelope), vec!["c", "c"]);
-    // Post-snapshot boundary is a zero-row not-ready marker; it persists the
-    // fresh position. Readiness then follows from the live stream once caught up.
-    let envelope = next_envelope(&mut stream, "restart boundary").await?;
+    let envelope = next_envelope(&mut stream, "restart rebuild signal").await?;
+    assert!(
+        envelope.history_unavailable(),
+        "the purged position must ask the consumer to rebuild from the source"
+    );
+    // Zero rows: no truncate to empty the table, and no snapshot rows to apply
+    // on top of a table the consumer is about to replace wholesale.
     assert_eq!(num_rows(&envelope), 0);
     assert!(
-        !envelope.is_dataset_ready(),
-        "restart boundary must not signal ready; readiness is lag-based"
+        ops_of(&envelope).is_empty(),
+        "the rebuild signal carries no change rows, least of all a truncate"
     );
+    assert!(
+        !envelope.is_dataset_ready(),
+        "rebuild signal must not signal ready; readiness is lag-based"
+    );
+    // It carries the boundary committer, so committing it persists the fresh
+    // position — a no-op committer would be stripped by the consumer's heartbeat
+    // filter and leave the next start rebuilding all over again.
     envelope.commit().await?;
     let repersisted = store
         .load()
         .await
         .expect("store readable")
-        .expect("rebootstrap persists a fresh position")
+        .expect("rebuild persists a fresh position")
         .position;
     assert_ne!(repersisted.file, "binlog.999999");
 

--- a/crates/runtime/tests/mysql/replication_shared.rs
+++ b/crates/runtime/tests/mysql/replication_shared.rs
@@ -298,12 +298,13 @@ async fn drain_bootstrap(
 /// re-read moves to the consumer's atomic overwrite
 /// (`ChangeEnvelope::history_unavailable`), so the resulting contents are
 /// asserted where that path is covered, not here.
+///
 /// The idle heartbeats a caught-up GTID stream interleaves are zero-row too, so
 /// the signal is found by its flag rather than by position. Any envelope
 /// carrying rows before it is the failure this guards: that is a truncate or a
 /// snapshot batch, i.e. the acceleration being emptied and refilled.
 async fn drain_rebuild(stream: &mut ChangesStream, what: &str) -> Result<(), anyhow::Error> {
-    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    let deadline = std::time::Instant::now() + Duration::from_mins(1);
     loop {
         let env = next_envelope(stream, &format!("{what} rebuild signal")).await?;
         anyhow::ensure!(
@@ -312,15 +313,17 @@ async fn drain_rebuild(stream: &mut ChangesStream, what: &str) -> Result<(), any
              member's channel before any rebuild signal (ops: {:?})",
             ops_of(&env)
         );
-        if env.history_unavailable() {
+        let is_signal = env.history_unavailable();
+        if is_signal {
             assert!(
                 !env.is_dataset_ready(),
                 "{what}: the rebuild signal is not ready; readiness is lag-based"
             );
-            env.commit().await?;
-            return Ok(());
         }
         env.commit().await?;
+        if is_signal {
+            return Ok(());
+        }
         anyhow::ensure!(
             std::time::Instant::now() < deadline,
             "{what}: never received a rebuild signal"

--- a/crates/runtime/tests/mysql/replication_shared.rs
+++ b/crates/runtime/tests/mysql/replication_shared.rs
@@ -288,6 +288,46 @@ async fn drain_bootstrap(
     Ok(())
 }
 
+/// Drain one member's rebuild head: the single zero-row signal that asks the
+/// consumer to replace the acceleration's contents from the source.
+///
+/// Unlike [`drain_bootstrap`] there are no rows to assert here, and that is the
+/// point — a member whose acceleration already holds rows must not empty it and
+/// stream a fresh snapshot into it, because every query for the length of that
+/// re-read would be answered from an empty, then partially filled, table. The
+/// re-read moves to the consumer's atomic overwrite
+/// (`ChangeEnvelope::history_unavailable`), so the resulting contents are
+/// asserted where that path is covered, not here.
+/// The idle heartbeats a caught-up GTID stream interleaves are zero-row too, so
+/// the signal is found by its flag rather than by position. Any envelope
+/// carrying rows before it is the failure this guards: that is a truncate or a
+/// snapshot batch, i.e. the acceleration being emptied and refilled.
+async fn drain_rebuild(stream: &mut ChangesStream, what: &str) -> Result<(), anyhow::Error> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        let env = next_envelope(stream, &format!("{what} rebuild signal")).await?;
+        anyhow::ensure!(
+            num_rows(&env) == 0,
+            "{what}: the acceleration must be replaced atomically, but rows arrived on the \
+             member's channel before any rebuild signal (ops: {:?})",
+            ops_of(&env)
+        );
+        if env.history_unavailable() {
+            assert!(
+                !env.is_dataset_ready(),
+                "{what}: the rebuild signal is not ready; readiness is lag-based"
+            );
+            env.commit().await?;
+            return Ok(());
+        }
+        env.commit().await?;
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "{what}: never received a rebuild signal"
+        );
+    }
+}
+
 /// Read the next change on `stream`, asserting it is a single row with `op`/`id`,
 /// then commit it.
 async fn expect_single_change(
@@ -731,19 +771,25 @@ async fn shared_group_single_dataset_streams_snapshot_and_changes() -> Result<()
 }
 
 /// A purged resume position with `invalid_checkpoint_behavior: restart` must
-/// re-snapshot the member in place instead of fatally erroring — for BOTH the
+/// rebuild the member in place instead of fatally erroring — for BOTH the
 /// file+offset and GTID positioning paths (a purge surfaces as `MySQL` error 1236
 /// in both, and recovery captures the head differently per mode). Regression
 /// test for issue #11968 (restart was a no-op): the running pump's purge handler
 /// now honors `invalid_position_behavior` rather than always broadcasting the
 /// fatal purge error and stopping.
+///
+/// The two modes reach the rebuild by different routes, which is why both are
+/// covered: file mode detects the purge when resolving the start position, so
+/// the signal is the member's stream head; GTID mode resumes and is rejected by
+/// the running pump's `COM_BINLOG_DUMP_GTID`, so the signal is delivered
+/// mid-stream through the member's live channel.
 #[tokio::test(flavor = "multi_thread")]
-async fn shared_group_purged_position_restart_re_snapshots_file() -> Result<(), anyhow::Error> {
+async fn shared_group_purged_position_restart_rebuilds_file() -> Result<(), anyhow::Error> {
     run_purged_position_restart(MYSQL_SHARED_PORT + 6, 210_601, false).await
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn shared_group_purged_position_restart_re_snapshots_gtid() -> Result<(), anyhow::Error> {
+async fn shared_group_purged_position_restart_rebuilds_gtid() -> Result<(), anyhow::Error> {
     run_purged_position_restart(MYSQL_SHARED_PORT + 7, 210_701, true).await
 }
 
@@ -753,8 +799,8 @@ async fn shared_group_purged_position_restart_re_snapshots_gtid() -> Result<(), 
 /// Structure: subscription 1 bootstraps and persists a resume checkpoint, then
 /// is dropped; we purge that checkpoint's binlogs from the source; subscription
 /// 2 (a distinct `server_id`, so a fully independent source with no teardown
-/// race) resumes from the shared store and must re-snapshot the current state
-/// rather than fatally erroring. A purge surfaces as `MySQL` error 1236 in both
+/// race) resumes from the shared store and must rebuild the acceleration rather
+/// than fatally erroring. A purge surfaces as `MySQL` error 1236 in both
 /// modes — file mode via the resolve-time file check, GTID mode via the running
 /// pump's `COM_BINLOG_DUMP_GTID` rejection (the path issue #11968 fixed).
 async fn run_purged_position_restart(
@@ -810,10 +856,11 @@ async fn run_purged_position_restart(
     exec(&pool, &format!("PURGE BINARY LOGS TO '{current_file}'")).await?;
 
     // Subscription 2: resume from the purged checkpoint. With restart, the
-    // member must re-snapshot the current source state ([1..=5]) — a truncate
-    // barrier, the full snapshot, then the boundary — instead of fataling.
+    // member must hand the consumer an atomic rebuild instead of fataling — and
+    // instead of emptying the acceleration and streaming a fresh snapshot into
+    // it, which every query would observe as an empty, then partial, table.
     let mut stream = subscribe(server_id + 1);
-    drain_bootstrap(&mut stream, "re-snapshot after purge", &[1, 2, 3, 4, 5]).await?;
+    drain_rebuild(&mut stream, "rebuild after purge").await?;
 
     drop(stream);
     pool.disconnect().await?;

--- a/docs/features/mysql-binlog-replication.md
+++ b/docs/features/mysql-binlog-replication.md
@@ -106,7 +106,7 @@ as the Postgres connector's snapshot/WAL boundary.
 | `mysql_replication_initial_snapshot` | `auto` | When existing rows load: `auto` snapshots when no resumable position exists; `disabled` streams changes only; `always` re-snapshots on every start. |
 | `mysql_replication_checkpoint_interval` | `10s` | How often the committed position persists to the sidecar. Bounds crash-replay volume. |
 | `mysql_replication_bootstrap_batch_size` | `8192` | Rows per emitted snapshot batch (max `1048576`). |
-| `mysql_replication_invalid_checkpoint_behavior` | `error` | What to do when the persisted position was purged from the source: `error` or `restart` (drop the position and re-snapshot). |
+| `mysql_replication_invalid_checkpoint_behavior` | `error` | What to do when the persisted position was purged from the source: `error` or `restart` (drop the position and rebuild the acceleration from the source). |
 | `mysql_replication_ready_lag` | `2s` | For `refresh_mode: changes`, the dataset is marked Ready once its replication lag (now minus the newest applied change's source-commit time) falls below this — it stays not-ready while snapshotting or draining a backlog, so it never serves stale or incomplete data. Accepts any [fundu](https://docs.rs/fundu) duration string. |
 
 The runtime-level CDC apply tunables (`cdc_prefetch_buffer`,
@@ -126,8 +126,14 @@ params:
   mysql_replication_invalid_checkpoint_behavior: restart
 ```
 
-to instead drop the stale position, truncate the accelerator, and re-snapshot
-the table automatically.
+to instead drop the stale position and rebuild the acceleration from the
+source automatically.
+
+The rebuild replaces the acceleration's contents in one atomic swap, so
+queries issued while it runs are answered from the pre-rebuild contents until
+the replacement completes — never from an empty or partially loaded table.
+Change streaming resumes on top of the replacement; the overlap between the
+captured position and the re-read replays idempotently.
 
 ## Semantics and type notes
 


### PR DESCRIPTION
## Summary

A MySQL CDC acceleration whose persisted binlog position has been purged from the source (`mysql_replication_invalid_checkpoint_behavior: restart`) was rebuilt by **clearing it and refilling it through the change stream**. For the whole duration of that re-read, queries against the accelerated table were answered from an empty — then partially filled — table, with no error and no indication the answer was incomplete. On a large table that window is as long as the full re-read takes.

The data does converge, so this is not silent divergence; it is a read-correctness window, and a dashboard or query issued during the rebuild gets a confidently wrong answer.

**Root cause.** `rebootstrap_member` pushed a `truncate → snapshot → boundary` sequence through the member's live channel. The truncate committed immediately and the snapshot batches then arrived incrementally, so every query in between saw the intermediate state.

The consumer-side machinery for this already exists and is source-agnostic: a source reports `ChangeEnvelope::history_unavailable`, and the apply loop (`rebuild_from_source`) replaces the acceleration's contents through the ordinary `refresh_mode: full` write path — an `InsertOp::Overwrite`, so readers keep seeing the pre-rebuild contents until the replacement swaps in. This is what #12922 wired up for PostgreSQL after rejecting clear-then-refill for exactly this reason. MySQL now emits that signal instead of reimplementing the replacement.

## Changes

**MySQL — emit the signal instead of emptying the table**

- `rebootstrap_member` (mid-stream purge) emits one zero-row envelope flagged `history_unavailable` in place of the truncate + snapshot. It carries the existing `SnapshotBoundaryCommitter`, so the new head is persisted only once the consumer has durably applied the replacement, and — being a real committer — the envelope survives the consumer's zero-row heartbeat stripping. A no-op committer would leave the head unpersisted and rebuild again on the very next start.
- **The join-time path (`attach_member`) is the same defect reached the other way, and the more common one.** When spiced is *down* while the position is purged, the rebuild happens at subscribe time, not mid-stream. `resolve_start_position` now reports a `MemberStart` rather than a bare `snapshotting` bool, distinguishing a **first load** (nothing was ever persisted → nothing to preserve → keep the snapshot path) from a **rebuild** (a position *was* persisted → the store is durable and a load once completed → hand the atomic replacement to the consumer). `initial_snapshot: always` on a durable acceleration takes the rebuild arm for the same reason.
- The unusable checkpoint is now left in place until the rebuild's boundary committer replaces it with the new head, on both paths. It is the only durable evidence that the acceleration holds rows no position explains: clearing it up front and then crashing mid-rebuild left the next start reading a populated acceleration as a first load — and a first load empties it and refills it from a snapshot, which is the window this closes. The cost is at most one repeated rebuild after a crash.
- Both loading starts still hold the member `SNAPSHOTTING` until their boundary envelope lands, so neither can advance the shared ack floor over rows the consumer has not applied.

**Consumer — make the signal an ordering barrier**

The rebuild runs before the whole coalesced run, so envelopes the run carried *ahead* of the signal were applied on top of a table that had just been re-read past them — writing values the source has already moved on from. Streaming then resumes at the position captured when the signal was raised, which is at or after those envelopes, so nothing replays over the regression and it is durable. `trim_to_rebuild_signal` now trims the run to its signal: the re-read observes the source at a point at or after every discarded envelope, so it already reflects them. It trims to the **last** signal, since one rebuild answers every signal in the run.

`ChangeEnvelope::history_unavailable`'s contract now states this, because it is an obligation on sources: committers emitted before the signal must be safely droppable, and the resume position must be at or after them.

**Cold start is unchanged**, as the issue asks: a first load keeps the snapshot path. Routing it through the consumer would re-read the source table on every cold start.

**The issue also asks whether the per-dataset (non-shared) MySQL path has the same window. It does not exist any more** — `mysql_replication::start` routes everything through `shared::subscribe`, and both `truncate_envelope` call sites were in `shared.rs`. The `start_inner` comment referencing a per-dataset prelude was stale and is gone.

## Test plan

- `make lint`
- `make test`

Unit tests (`crates/data_components/src/mysql_replication/shared.rs`, `crates/runtime-table/src/accelerated/refresh_task/changes.rs`):

- `rebuild_replaces_the_acceleration_instead_of_emptying_it` — drives `rebootstrap_member` and asserts the member emits **exactly one** envelope, flagged `history_unavailable`, not a no-op heartbeat, carrying **no rows at all** (so no `op="t"` truncate and no snapshot rows), that the member is held `SNAPSHOTTING` at the new head, and that the purged checkpoint is still readable.
- `only_the_rebuild_boundary_asks_for_a_replacement` — a first load's boundary must **not** request a rebuild; both boundaries carry a real committer and neither reports the dataset ready.
- `both_loading_starts_hold_the_member_snapshotting` — pins the ack-floor hold across the new `MemberStart` variants.
- `a_run_is_trimmed_to_its_last_rebuild_signal` — the barrier, including the two-signals-in-one-run case.

Integration suites updated to assert the new sequence (they asserted the truncate barrier + snapshot rows): `replication.rs::purged_position_behavior`, and both `replication_shared.rs` purge tests. The GTID variant finds the signal by its flag rather than by position — idle heartbeats are zero-row too — and fails if **any** row-carrying envelope precedes it, which is a stronger statement of the invariant than the old positional assert.

**The regression tests were neutered, not assumed.** Six arms, each run against the final code and fixtures:

| Neuter arm | Result |
| --- | --- |
| Restore the truncate prelude before the rebuild signal | **FAILS** — `the member must ask the consumer to rebuild from the source` |
| `history_unavailable: false` on the signal | **FAILS** — same assertion |
| Swap the boundary committer for a no-op | **FAILS** — `the signal carries the boundary committer, so the consumer's heartbeat stripping cannot drop it and leave the new head unpersisted` |
| Restore the pre-rebuild `position_store.clear()` | **FAILS** — `the purged checkpoint survives until the rebuild commits` |
| Make the ordering barrier a no-op | **FAILS** — `only the signal and its suffix survive` (left: 4, right: 2) |
| Trim to the *first* signal (`position`) rather than the last | **FAILS** — `the run is trimmed to the LAST signal` |

The first arm initially failed inside its own fixture rather than on the assertion — the test layout covered one column of a two-column schema, so building a truncate row panicked. The fixture was widened to cover the full schema and the arm re-run, so all six now fail on the asserted message.

## Review gate

- Adversarial review: `codex` — job `review-msrv8hun-c8kp9k` (`exit=0`, verdict `needs-attention`, base `origin/trunk`). Three findings, all real; two fixed here, one filed.
  - **[critical] the rebuild signal is not an ordering barrier** — confirmed against `apply_envelope_run`. **Fixed** (`trim_to_rebuild_signal`, with its own neuter arm). The `/simplify` altitude pass then found the fix was still partial — it trimmed to the *first* signal while the flag hoist collapsed *every* signal into one rebuild, so envelopes between two signals survived. Now `rposition`, with a test for that shape.
  - **[high] a crash after checkpoint deletion falls back to the destructive snapshot path** — confirmed. **Fixed** on both call sites (`rebootstrap_member` and `apply_invalid_checkpoint`'s `Restart` arm). One sub-claim was **wrong** and not acted on: sidecar read failures are not "converted to `None`" — `position_store.load()` errors become `Error::PositionStoreAccess` and propagate.
  - **[high] the rebuild leaves stale documents in a CDC-attached search index** — confirmed at `crates/search/src/generation/text_search/index.rs:304-314`, where a `cdc_attached` index deliberately skips the `ReplaceAll` clear because "a CDC-fed index is told about deletions explicitly by its change stream" — which is exactly what `history_unavailable` means is impossible. **Filed as #13020**, not fixed here: it is a property of the shared recovery mechanism and is equally true for PostgreSQL today, and the Elasticsearch half already has #12413. Worth knowing before merge: for a MySQL CDC dataset with an attached index, this trades a stale search document for the whole-table empty-read window, which is the much broader defect.
- `/security-review`: **no findings.** Verified concretely that the one new log line cannot leak credentials — `SourceKey::label()` formats only `host:port`, and `SourceKey`'s hand-written `Debug` redacts `pass`/`ssl`. No new route, deserialization, or authz surface; the change strictly reduces the rows pushed through the change stream.
- `/simplify`: ran four parallel passes (reuse, simplification, efficiency, altitude). Applied: one scan of the run instead of two on the CDC apply hot path (all three passes flagged it independently); `rposition` per the altitude finding above; dropped a dead `signal > 0` guard (`drain(..0)` is already a no-op); replaced a hand-rolled `op`-column downcast with `ChangeEnvelope::is_empty()`; dropped a `dataset_for_boundary` binding that only existed because of statement order; fixed a doc comment that my own edit had orphaned onto the wrong function; de-duplicated three near-verbatim comment blocks; gave the test fixture a named struct instead of a 4-tuple.
  Skipped, with reasons: a shared `cdc::build_boundary_envelope` collapsing the `build_heartbeat_envelope → into_parts → from_parts` round trip across MySQL, PostgreSQL and `build_history_unavailable_envelope` (real duplication, but it edits another connector — a refactor, not this fix; the trap is documented on the helper instead), and exporting an `InMemoryPositionStore` to dedupe three identical test stores (adds public library API for test convenience; the duplication predates this branch).
  The altitude pass also found that `MemberStart::Rebuild` keying off "a position was persisted" under-claims: a file-accelerated dataset whose sidecar fails to open gets a `NoopPositionStore`, so a durable acceleration reads as a first load. Pre-existing, not a regression from this change, and closing it needs a `records_positions()`-style method plus accelerator durability in `ReplicationParams` — **filed as #13021** and referenced from the comment that states the limitation.

Fixes #12967

## Checklist

- [x] Root cause identified and stated
- [x] Regression tests that fail without the fix (six neuter arms)
- [x] Bug class swept: both MySQL rebuild paths, both checkpoint-clearing sites, and the per-dataset path confirmed gone
- [x] Docs updated
- [x] No behavior change on cold start