### PR TITLE
fix(runtime): stop query_active_count drifting up when queries share a request (fixes #12883)

### DIFF
--- a/crates/runtime-request-context/src/context.rs
+++ b/crates/runtime-request-context/src/context.rs
@@ -439,10 +439,22 @@ impl RequestContext {
         }
     }
 
+    /// Enters a query on this request, reporting whether it is the only one
+    /// running — the transition from no queries to some.
+    ///
+    /// Independent queries can share one request context and overlap, so this
+    /// means "the request went from idle to busy", not "this query encloses the
+    /// others". A caller pairing an acquire with a release must take the
+    /// release from [`Self::exited_top_level_query`] rather than remembering
+    /// this answer, because the query that opened the request is not
+    /// guaranteed to be the one that closes it.
     pub fn entered_top_level_query(&self) -> bool {
         self.nested_query_level.fetch_add(1, Ordering::Relaxed) == 0
     }
 
+    /// Leaves a query on this request, reporting whether it was the last one
+    /// running — the transition back to idle, and the release that pairs with
+    /// [`Self::entered_top_level_query`]'s acquire.
     pub fn exited_top_level_query(&self) -> bool {
         self.nested_query_level.fetch_add(-1, Ordering::Relaxed) == 1
     }

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1925,9 +1925,10 @@ fn attach_query_tracker_to_stream(
 /// query per table and per embedding column; NSQL samples datasets with
 /// `buffer_unordered`, which yields in completion order), so the guard that
 /// opened the request is not guaranteed to be the one that closes it. Anchoring
-/// the release on the guard instead of the edge either strands the decrement
-/// when that guard finishes last, or fires it early while siblings are still
-/// running.
+/// the release on that guard instead of on the edge fails whichever way it is
+/// written: releasing only when it is *also* the last one out strands the
+/// decrement every time it is not, and releasing unconditionally fires it while
+/// siblings are still running.
 ///
 /// Each guard keeps the dimensions it was built with, which pins the pair for
 /// a request that runs one query at a time. Across overlapping queries the two

--- a/crates/runtime/src/datafusion/query.rs
+++ b/crates/runtime/src/datafusion/query.rs
@@ -1914,35 +1914,50 @@ fn attach_query_tracker_to_stream(
 
 /// This guard guarantees:
 ///  * If we incremented nested query count, we will decrement. And vice versa.
-///  * If we incremented active query count, we will decrement. And vice versa.
+///  * A request that goes from idle to busy increments the active query count
+///    exactly once, and decrements it exactly once when it goes back to idle.
 ///  * Active query count decrement will be called with the same dimensions as increment.
+///
+/// The increment and the decrement are taken from the two *edges* of the
+/// request's query count — idle to busy, and busy back to idle — rather than
+/// from a flag remembered on the guard that saw the first edge. Independent
+/// queries can share one request context and overlap (a search fans out one
+/// query per table and per embedding column; NSQL samples datasets with
+/// `buffer_unordered`, which yields in completion order), so the guard that
+/// opened the request is not guaranteed to be the one that closes it. Anchoring
+/// the release on the guard instead of the edge either strands the decrement
+/// when that guard finishes last, or fires it early while siblings are still
+/// running.
+///
+/// Each guard keeps the dimensions it was built with, which pins the pair for
+/// a request that runs one query at a time. Across overlapping queries the two
+/// edges can land on different guards, and those agree because
+/// `to_protocol_dimensions` interns one `'static` slice per `Protocol` and the
+/// only writer of a context's protocol is `set_flightsql_protocol`, which every
+/// `FlightSQL` handler calls before it runs a query.
 pub struct QueryActiveGuard {
     request_context: Arc<RequestContext>,
     dimensions: &'static [KeyValue],
-    active: bool,
 }
 
 impl QueryActiveGuard {
     pub fn new(request_context: Arc<RequestContext>) -> Self {
         let dimensions = request_context.to_protocol_dimensions();
 
-        let active = request_context.entered_top_level_query();
-        if active {
+        if request_context.entered_top_level_query() {
             runtime_metrics::telemetry::inc_query_active_count(dimensions);
         }
 
         Self {
             request_context,
             dimensions,
-            active,
         }
     }
 }
 
 impl Drop for QueryActiveGuard {
     fn drop(&mut self) {
-        let exited = self.request_context.exited_top_level_query();
-        if self.active && exited {
+        if self.request_context.exited_top_level_query() {
             runtime_metrics::telemetry::dec_query_active_count(self.dimensions);
         }
     }

--- a/crates/runtime/tests/query_active_count.rs
+++ b/crates/runtime/tests/query_active_count.rs
@@ -45,9 +45,10 @@ use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
 use runtime::datafusion::query::QueryActiveGuard;
 use runtime_request_context::{Protocol, RequestContext};
 
-/// How wide a fan-out to exercise beyond the two-query minimum. Every guard
-/// after the first is a nested one, so the count must stay at exactly one
-/// however many there are.
+/// How wide a fan-out to exercise beyond the two-query minimum. These are
+/// concurrent siblings rather than nested queries — the distinction this test
+/// exists to keep — and only the first of them finds the request idle, so the
+/// count must stay at exactly one however many overlap.
 const FAN_OUT: usize = 8;
 
 /// The one `MeterProvider` for this binary, installed before any instrument

--- a/crates/runtime/tests/query_active_count.rs
+++ b/crates/runtime/tests/query_active_count.rs
@@ -1,0 +1,172 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! `query_active_count` must stay raised for exactly as long as a request has a
+//! query running, in whatever order those queries finish.
+//!
+//! Several independent top-level queries can share one `RequestContext` — a
+//! search fans out one query per table and per embedding column, and NSQL
+//! samples up to ten datasets with `buffer_unordered`, which yields in
+//! completion order by construction. Those siblings are not dropped
+//! last-in-first-out, which breaks both ways of anchoring the release on a
+//! single guard: the guard that raised the count can strand its decrement when
+//! it is not the last one out, leaving the series permanently high (the
+//! instrument is a cumulative up/down counter, so the drift never recovers), or
+//! it can release as soon as it finishes, reporting an idle runtime while its
+//! siblings are still running.
+//!
+//! So the assertions below check the reading *between* drops, not only after
+//! the last one — a test that looks only at the end passes under both failures.
+//!
+//! Regression test for <https://github.com/spiceai/spiceai/issues/12883>.
+//!
+//! This lives in its own test binary because the meter install is global: the
+//! instrument is a `LazyLock` over `global::meter(..)`, so it binds to whichever
+//! provider is installed when it is first touched, and a count assertion is only
+//! stable when no other test is recording on the same series.
+
+use std::sync::{Arc, LazyLock};
+
+use opentelemetry::global;
+use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
+use runtime::datafusion::query::QueryActiveGuard;
+use runtime_request_context::{Protocol, RequestContext};
+
+/// How wide a fan-out to exercise beyond the two-query minimum. Every guard
+/// after the first is a nested one, so the count must stay at exactly one
+/// however many there are.
+const FAN_OUT: usize = 8;
+
+/// The one `MeterProvider` for this binary, installed before any instrument
+/// exists.
+static PROMETHEUS: LazyLock<prometheus::Registry> =
+    LazyLock::new(install_prometheus_meter_provider);
+
+/// Installs a `MeterProvider` backed by a scrapable Prometheus registry, as
+/// `spiced` does for the `--metrics` endpoint.
+fn install_prometheus_meter_provider() -> prometheus::Registry {
+    let registry = prometheus::Registry::new();
+
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .without_scope_info()
+        .without_units()
+        .without_counter_suffixes()
+        .without_target_info()
+        .build()
+        .expect("to build the prometheus exporter");
+
+    let provider = SdkMeterProvider::builder()
+        .with_resource(Resource::builder().build())
+        .with_reader(exporter)
+        .build();
+    global::set_meter_provider(provider);
+
+    registry
+}
+
+/// Asserts `query_active_count` sits exactly `expected` above `baseline`.
+///
+/// `#[track_caller]` so a failure names the drop it followed. Every assertion
+/// here reads the same instrument, and several of them expect the same value,
+/// so without it a panic points at this line and leaves the reader to guess
+/// which of a dozen call sites produced it.
+#[track_caller]
+fn assert_raised_by(registry: &prometheus::Registry, baseline: f64, expected: f64) {
+    let observed = query_active_count(registry) - baseline;
+    assert!(
+        (observed - expected).abs() < f64::EPSILON,
+        "query_active_count is {observed} above baseline, expected {expected}"
+    );
+}
+
+/// The value on `query_active_count`, summed over every label set.
+///
+/// An up/down counter is not monotonic, so it exports as a Prometheus gauge.
+fn query_active_count(registry: &prometheus::Registry) -> f64 {
+    registry
+        .gather()
+        .iter()
+        .filter(|family| family.name() == "query_active_count")
+        .flat_map(prometheus::proto::MetricFamily::get_metric)
+        .map(|metric| metric.get_gauge().value())
+        .sum()
+}
+
+#[test]
+fn query_active_count_returns_to_baseline_whatever_order_queries_finish_in() {
+    let registry = &*PROMETHEUS;
+    let context = Arc::new(RequestContext::builder(Protocol::Http).build());
+
+    // Assertions are deltas rather than absolute values, so reading the
+    // instrument before it has been touched (which reports 0.0, since an
+    // unrecorded family is absent rather than zero) is the right baseline.
+    let baseline = query_active_count(registry);
+
+    // Two sibling top-level queries sharing one request context, finishing in
+    // the order they started. This is the case that leaked.
+    let first = QueryActiveGuard::new(Arc::clone(&context));
+    let second = QueryActiveGuard::new(Arc::clone(&context));
+    assert_raised_by(registry, baseline, 1.0);
+    drop(first);
+    // The reading between the two drops is the half of this that a
+    // "returns to baseline" assertion cannot see: the request is still busy,
+    // so releasing here would report an idle runtime while a query runs.
+    assert_raised_by(registry, baseline, 1.0);
+    drop(second);
+    assert_raised_by(registry, baseline, 0.0);
+
+    // The count unwound with them, so the query after them is recognised as
+    // the start of a new busy period and is counted again.
+    let next = QueryActiveGuard::new(Arc::clone(&context));
+    assert_raised_by(registry, baseline, 1.0);
+    drop(next);
+    assert_raised_by(registry, baseline, 0.0);
+
+    // A genuinely nested query is the last-in-first-out case, and must keep
+    // being counted once for the request as a whole.
+    let outer = QueryActiveGuard::new(Arc::clone(&context));
+    let inner = QueryActiveGuard::new(Arc::clone(&context));
+    assert_raised_by(registry, baseline, 1.0);
+    drop(inner);
+    assert_raised_by(registry, baseline, 1.0);
+    drop(outer);
+    assert_raised_by(registry, baseline, 0.0);
+
+    // A wider fan-out, again finishing oldest first. Checking before every
+    // drop covers the same ground as checking after: the request stays busy
+    // until the last one leaves, and the check after the last drop is the one
+    // below the loop.
+    let fan_out: Vec<QueryActiveGuard> = (0..FAN_OUT)
+        .map(|_| QueryActiveGuard::new(Arc::clone(&context)))
+        .collect();
+    for guard in fan_out {
+        assert_raised_by(registry, baseline, 1.0);
+        drop(guard);
+    }
+    assert_raised_by(registry, baseline, 0.0);
+
+    // Two requests are counted independently, and one finishing does not
+    // release the other's count.
+    let other = Arc::new(RequestContext::builder(Protocol::Http).build());
+    let held = QueryActiveGuard::new(Arc::clone(&context));
+    let elsewhere = QueryActiveGuard::new(Arc::clone(&other));
+    assert_raised_by(registry, baseline, 2.0);
+    drop(held);
+    assert_raised_by(registry, baseline, 1.0);
+    drop(elsewhere);
+    assert_raised_by(registry, baseline, 0.0);
+}


### PR DESCRIPTION
## Summary

`query_active_count` climbs permanently whenever two independent top-level queries share one `RequestContext`.

`QueryActiveGuard` incremented when `entered_top_level_query()` observed the request's query count go `0 -> 1`, then decremented only if *that same guard* also observed `1 -> 0` on the way out. Those two conditions coincide only under LIFO drop order. That holds for a genuinely nested query, but not for concurrent siblings. With A and B under one context: A drops first, sees the count fall only to 1, concludes it was not the last one out, and skips the decrement it owes; B, which never incremented, sees `1 -> 0` but has nothing of its own to release. The count still unwinds to zero, and the metric is stuck at `+1`.

It is an OpenTelemetry cumulative up/down counter, so every skipped decrement is permanent for the life of the process. The series only ever climbs, an "active queries above N" alert eventually fires and stays fired, and the gauge cannot be used to detect real query-concurrency saturation.

Siblings under one request context are the normal path rather than an edge case: a search fans out one query per table and per embedding column, and NSQL/chat context sampling drives up to ten dataset samples with `buffer_unordered`, which yields in completion order by construction. If the incrementing guard happens to be dropped last the pair balances, so the leak rate is proportional to fan-out traffic rather than being deterministic.

## Changes

The increment and the decrement now come from the two *edges* of the request's query count — idle to busy, and busy back to idle — instead of from a flag remembered on whichever guard saw the first edge. `entered_top_level_query` already reported the opening edge; `exited_top_level_query` reports the closing one, and `Drop` releases on that. Since neither edge is tied to a particular guard, drop order stops mattering.

`QueryActiveGuard` loses its `active` field as a result: nothing is decided at drop time from information captured at construction, so there is nothing left to remember.

**This is deliberately not the patch suggested on the issue.** That patch keeps the release on the guard that incremented and drops the `&& exited` condition. It does fix the permanent drift, but it introduces a new inaccuracy in the other direction, which the adversarial review pass caught: with A and B overlapping and A finishing first, A's decrement fires immediately and `query_active_count` reads `0` while B is still running. Trading a permanent overcount for a transient undercount that reports an idle runtime under live load is not obviously an improvement — "is anything running at all" is the reading operators lean on hardest. Pairing the edges avoids both: the count stays at 1 for as long as the request has any query in flight, and returns to 0 exactly when the last one leaves. Both alternatives are pinned by the regression test (see the test plan).

The two edges can be observed by different guards, so the dimensions they record have to agree — and they do. `to_protocol_dimensions` interns one `'static` slice per `Protocol`, and the only writer of a context's protocol is `set_flightsql_protocol`, which every FlightSQL handler calls as its first statement, before it runs a query. Each guard also keeps its own captured copy, which pins the pair outright for a request that runs one query at a time. This reasoning is now recorded on the guard so the next person to add a protocol mutation sees what it would break.

`QueryActiveGuard` was the only guard in the tree with this split-predicate shape. Every other paired increment/decrement — `connector-git`, `connector-cosmosdb`, `databricks::sql_warehouse`, `postgres_replication::shared`, `join_accumulator`, cayenne's `memory_account`, `structural_version`, `scan` — releases unconditionally with its own captured amount, and cayenne's `compaction` and `delete::vector_io` already pair on a single atomic edge exactly as this now does. So there is no sibling instance to fix alongside it, and the fix moves this call site onto a pattern the codebase already uses rather than inventing one.

Whether N overlapping siblings should read as `N` rather than `1` is a separate semantics question, already tracked in #12884 — as is the instrument's description string, which still says "concurrent top-level queries" where the code measures "requests with a query running". Both belong with that decision rather than here.

## Test plan

- New `crates/runtime/tests/query_active_count.rs` scrapes a Prometheus-backed `MeterProvider`, so it asserts what an operator actually scrapes rather than a proxy. It lives in its own test binary because the meter install is global and a count assertion is only stable when nothing else records on the series.
- The assertions check the reading **between** drops, not only after the last one. That is what separates the two failure modes — a test that looks only at the end passes under both. Covered: two siblings finishing oldest-first (the count must still read 1 after the first leaves, and 0 after the second); a fan-out of eight, checked before every drop; a genuinely nested pair finishing last-in-first-out; a query started after a sibling pair has drained, proving the count unwound with them; and two concurrent request contexts counted independently.
- Verified the test pins the fix rather than merely passing beside it, on both alternatives:
  - restoring the current `if self.active && exited` gate fails with `query_active_count is 1 above baseline, expected 0` — the permanent leak;
  - applying the patch suggested on the issue fails with `query_active_count is 0 above baseline, expected 1` — the early release, reporting idle under load.
- `make lint`
- `make nextest`

## Review gate

- Adversarial review: `codex` — job `review-msryc5im-bx848r` (`exit=0`, verdict `needs-attention`). One `[medium]` finding: with two siblings, releasing on the guard that incremented clears the gauge while the other query is still running. **Valid, and it changed the fix** — the release moved from the guard's flag onto the request's busy-to-idle edge, and the regression test gained the between-drops assertions. Confirmed empirically rather than taken on faith (see the test plan).
- `/security-review`: no findings. The diff adds no input handling, no I/O, and no new metric label cardinality — the dimensions come from a closed four-variant `Protocol` enum this PR does not touch — so it has no security surface.
- `/simplify`: four agents (reuse, simplification, efficiency, altitude). **Applied:** dropped redundant loop bookkeeping in the fan-out case, dropped a no-op instrument "touch" before the baseline read, and trimmed prose that restated the same mechanism in three places. **Skipped, with reasons:** (a) extracting the Prometheus meter-provider installer now shared with `crates/runtime/tests/metrics.rs` — a real duplication, but the fix edits an unrelated heavy test binary and re-verifying it is not this bug's scope; (b) deleting the guard's `dimensions` field in favour of re-reading at drop — two agents called it dead weight, but keeping it is strictly safer for the single-query request, where it pins the increment and the decrement to one snapshot; (c) renaming `nested_query_level` — the field genuinely tracks both nesting depth and sibling concurrency and no single name covers both, so the doc now states the operative meaning and #12884 is where the model gets revisited.
- Follow-up iteration (`fc8427e38`), after Copilot's review: **engines not re-run — declared skip.** That commit changes two doc comments and nothing else (`git diff -U0` on it contains only `///` lines), so there is no design or security surface for the adversarial or security pass to act on. Both of Copilot's findings were valid and both were wording errors: the guard doc said anchoring the release on the incrementing guard strands the decrement "when that guard finishes last", which is backwards — that case balances, and the decrement is stranded whenever the guard is *not* the last one out; and the fan-out constant called the overlapping guards "nested" when they are concurrent siblings, which is the exact conflation this test exists to prevent. Both threads answered and resolved. `cargo fmt` and the scoped clippy were re-run on the reworded comments (the lib is clean; `doc_markdown` is denied and would have caught a bare identifier).

Fixes #12883

## Checklist

- [x] Root cause identified and fixed, not worked around
- [x] Regression test fails on the old code and passes on the new
- [x] Regression test also pins the failure mode the alternative fix would introduce
- [x] Bug class swept across the repo for sibling instances
- [x] No behaviour change for genuinely nested queries