### PR TITLE
feat(cli): add transactional Spice Cloud connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17182,6 +17182,7 @@ dependencies = [
  "cloud-connect-crypto",
  "dirs",
  "fs4",
+ "futures",
  "gethostname",
  "getrandom 0.3.4",
  "http 1.4.1",
@@ -17206,6 +17207,7 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "uuid 1.23.2",
+ "windows-sys 0.61.2",
  "x509-parser 0.18.1",
  "zeroize",
 ]
@@ -19365,8 +19367,10 @@ dependencies = [
  "tracing-subscriber",
  "urlencoding",
  "uuid 1.23.2",
+ "windows-sys 0.61.2",
  "wiremock",
  "yaml",
+ "zeroize",
  "zip 7.2.0",
 ]
 
@@ -19389,6 +19393,7 @@ dependencies = [
 name = "spice-cloud-client"
 version = "2.2.0-unstable"
 dependencies = [
+ "futures",
  "reqwest 0.13.4",
  "serde",
  "serde_json",

--- a/bin/spice/Cargo.toml
+++ b/bin/spice/Cargo.toml
@@ -36,6 +36,7 @@ reqwest = { workspace = true, features = ["stream"] }
 # Serialization
 serde.workspace = true
 serde_json.workspace = true
+zeroize = "1.8"
 
 # Environment files
 dotenv.workspace = true
@@ -110,9 +111,18 @@ test-framework = { path = "../../crates/test-framework" }
 # Tracing/opentelemetry for trace ID handling
 opentelemetry.workspace = true
 
-# Unix signal handling, and the effective-uid check `spice connect service` gates on
+# Unix signal handling, terminal tests, and local account inspection.
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["signal", "process", "user"] }
+nix = { version = "0.29", features = ["signal", "process", "term", "user"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Memory",
+] }
 [build-dependencies]
 # None needed - we use include_str! for version
 

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -156,7 +156,19 @@ impl CloudClient {
     /// Create a new authenticated cloud client with an explicit bearer token,
     /// acting on `org`.
     pub fn with_token_for_org(token: impl Into<String>, org: Option<&str>) -> Result<Self> {
-        let mut inner = InnerCloudClient::new(&get_base_url())
+        Self::with_token_for_org_at(token, org, &get_base_url())
+    }
+
+    /// Create an authenticated client against an explicit Cloud API base URL.
+    ///
+    /// Cloud Connect uses this for `--endpoint` and local HTTP fixtures; every
+    /// other Cloud command continues to use [`Self::with_token_for_org`].
+    pub fn with_token_for_org_at(
+        token: impl Into<String>,
+        org: Option<&str>,
+        base_url: &str,
+    ) -> Result<Self> {
+        let mut inner = InnerCloudClient::new(base_url)
             .map_err(map_cloud_error(None))?
             .with_token(token);
         if let Some(org) = org {
@@ -849,6 +861,9 @@ fn map_cloud_error(org: Option<&str>) -> impl Fn(spice_cloud_client::error::Erro
                 format!("Spice Cloud request failed with status {status}: {message}"),
             ),
             CloudError::HttpRequest { source } => Error::HttpRequestFailed { source },
+            CloudError::ResponseTooLarge => Error::InvalidResponse {
+                message: "Spice Cloud response exceeded the 64 KiB limit".to_string(),
+            },
             CloudError::JsonParse { source } => Error::InvalidResponse {
                 message: format!("Failed to parse response: {source}"),
             },

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -861,8 +861,8 @@ fn map_cloud_error(org: Option<&str>) -> impl Fn(spice_cloud_client::error::Erro
                 format!("Spice Cloud request failed with status {status}: {message}"),
             ),
             CloudError::HttpRequest { source } => Error::HttpRequestFailed { source },
-            CloudError::ResponseTooLarge => Error::InvalidResponse {
-                message: "Spice Cloud response exceeded the 64 KiB limit".to_string(),
+            CloudError::ResponseTooLarge { limit } => Error::InvalidResponse {
+                message: format!("Spice Cloud response exceeded the {limit} byte limit"),
             },
             CloudError::JsonParse { source } => Error::InvalidResponse {
                 message: format!("Failed to parse response: {source}"),

--- a/bin/spice/src/commands/connect/mod.rs
+++ b/bin/spice/src/commands/connect/mod.rs
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! `spice connect` — Spice Cloud Connect instance management.
+//! `spice connect` — enroll this directory with Spice Cloud, create its
+//! project transactionally, and manage the resulting instance.
 //!
 //! Two distinct use cases share this command:
 //!
@@ -32,8 +33,12 @@ limitations under the License.
 //!    deprecation notice and behaves like `spice add <pod>` with Spice.ai
 //!    Cloud authentication headers.
 
+mod naming;
+mod project;
 mod service;
+mod state;
 mod status;
+mod transaction;
 
 use std::{
     path::{Path, PathBuf},
@@ -46,8 +51,10 @@ use crate::error::{Error, Result};
 use crate::output::OutputFormat;
 use clap::{Args, Subcommand};
 use runtime_cloud_connect::config::{CloudConnectConfig, IDENTITY_FILE};
+use runtime_cloud_connect::enrollment_key::EnrollmentKey;
+use zeroize::Zeroizing;
 
-use status::{ConnectStatus, ConnectionState};
+use status::ConnectStatus;
 
 /// File (relative to the config dir) holding a `--endpoint` override so later
 /// `spiced` starts reach the same control plane the enroll did.
@@ -56,17 +63,23 @@ const CLOUD_ENDPOINT_FILE: &str = "cloud-endpoint";
 /// Arguments for the `spice connect` command.
 #[derive(Args, Debug)]
 #[command(
-    about = "Manage this host's Spice Cloud Connect state (or add a cloud-hosted Spicepod)",
-    long_about = r#"`spice connect` manages this directory's Spice Cloud Connect state.
+    about = "Connect this directory to Spice Cloud and manage its instance",
+    long_about = r#"`spice connect` enrolls this directory with Spice Cloud and manages its instance.
 
-Enrollment is performed by the runtime, not this command: mint an enrollment
-key in the Spice Cloud portal and start the runtime with it —
+With a logged-in user session, the command resolves one owner/admin
+organization, enrolls the local instance, and atomically creates and attaches a
+new project. Without a login, an interactive terminal offers inline login
+(recommended) or secure enrollment-key entry. Enrollment-key mode always
+leaves the instance unattached and prints the Cloud-provided recovery link.
 
-  spiced --token <enrollment-key>
+The transaction is retry-safe: an interrupted enrollment reuses its durable
+operation and key material, while project creation uses the enrolled instance's
+single attachment as its exact replay key. Existing identities always win and
+are never duplicated.
 
-The runtime enrolls before it serves traffic, stores the issued identity under
-`.spice/`, and every later `spiced` or `spice run` start in that directory
-reconnects automatically from the identity alone.
+NON-INTERACTIVE
+  Login mode requires both --org <org> and --project <name>.
+  Key mode requires --token <enrollment-key> and rejects --project.
 
   spice connect status                    Show this directory's Cloud
                                           connection, service, and deployment
@@ -108,6 +121,10 @@ DEPRECATED POD-ADD BEHAVIOR:
   spice connect <org>/<pod>               Deprecated; use `spice add <org>/<pod>`.
 
 EXAMPLES
+  spice connect
+  spice connect --org acme --project retail-analytics
+  spice connect --token <enrollment-key> --org acme
+  spice connect --dir /srv/edge --region us-west-2
   spice connect status
   spice connect status --output json
   sudo spice connect service install
@@ -126,6 +143,25 @@ pub struct ConnectArgs {
     /// runtime as `spiced --token <enrollment-key>`.
     #[arg(value_name = "TARGET")]
     pub target: Option<String>,
+
+    /// Organization to enroll into, or the expected organization for an
+    /// enrollment key. Login mode validates owner/admin membership.
+    #[arg(long, value_name = "SLUG")]
+    pub org: Option<String>,
+
+    /// Project to create and attach. Required for non-interactive login mode;
+    /// rejected in enrollment-key mode.
+    #[arg(long, value_name = "SLUG")]
+    pub project: Option<String>,
+
+    /// One-time enrollment key. The value is redacted from Debug/errors and is
+    /// never persisted. This mode always remains unattached.
+    #[arg(long, value_name = "SECRET")]
+    pub token: Option<EnrollmentKeyArgument>,
+
+    /// Declared location label for the enrolled instance.
+    #[arg(long, value_name = "LABEL")]
+    pub region: Option<String>,
 
     /// Override the Spice Cloud endpoint used when inspecting state or
     /// reporting a release. Defaults to `https://api.spice.ai`. Also
@@ -193,6 +229,35 @@ pub struct StatusArgs {
     pub output: OutputFormat,
 }
 
+/// A raw enrollment-key argument whose command-line parsing cannot echo an
+/// invalid secret. Validation happens after `clap` has rendered its own
+/// diagnostics, and both `Debug` and destruction keep the raw value out of
+/// logs and reusable memory.
+#[derive(Clone)]
+pub struct EnrollmentKeyArgument(Zeroizing<String>);
+
+impl std::str::FromStr for EnrollmentKeyArgument {
+    type Err = std::convert::Infallible;
+
+    fn from_str(raw: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(Self(Zeroizing::new(raw.to_string())))
+    }
+}
+
+impl std::fmt::Debug for EnrollmentKeyArgument {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("EnrollmentKeyArgument([REDACTED])")
+    }
+}
+
+impl EnrollmentKeyArgument {
+    fn into_enrollment_key(self) -> Result<EnrollmentKey> {
+        EnrollmentKey::parse(self.0.as_str()).map_err(|source| Error::InvalidUsage {
+            message: source.to_string(),
+        })
+    }
+}
+
 impl ConnectArgs {
     /// Whether this invocation writes JSON to stdout, so the dispatcher can
     /// suppress the version banner that would otherwise foul it.
@@ -237,6 +302,15 @@ pub async fn execute(ctx: &RuntimeContext, args: ConnectArgs) -> Result<()> {
 
     if let Some(cmd) = args.command {
         reject_cloud_region(args.cloud_region.as_deref())?;
+        if args.org.is_some()
+            || args.project.is_some()
+            || args.token.is_some()
+            || args.region.is_some()
+        {
+            return Err(Error::InvalidUsage {
+                message: "--org, --project, --token, and --region apply to enrollment, not to a `connect` subcommand.".to_string(),
+            });
+        }
         return match cmd {
             ConnectCommand::Status(status_args) => {
                 print_status(&config_dir, args.endpoint.as_deref(), status_args.output).await
@@ -245,7 +319,7 @@ pub async fn execute(ctx: &RuntimeContext, args: ConnectArgs) -> Result<()> {
                 remove_identity(&config_dir, args.endpoint.as_deref(), args.yes, args.force).await
             }
             ConnectCommand::Service(service_args) => {
-                let endpoint = resolved_endpoint(&config_dir, args.endpoint.as_deref())?;
+                let endpoint = endpoint_for_local_reporting(&config_dir, args.endpoint.as_deref());
                 service::cli::execute(
                     ctx,
                     service_args,
@@ -258,36 +332,55 @@ pub async fn execute(ctx: &RuntimeContext, args: ConnectArgs) -> Result<()> {
         };
     }
 
-    // Rejected on the Cloud Connect branches only. The deprecated pod-add
-    // fallthrough below is a Spice.ai Cloud fetch, where `--cloud-region` has
-    // always been meaningful, so refusing it there would be a regression.
-    let Some(target) = args.target.as_deref() else {
-        reject_cloud_region(args.cloud_region.as_deref())?;
-        return connect_existing(&config_dir, args.endpoint.as_deref()).await;
-    };
+    if let Some(target) = args.target.as_deref() {
+        if args.org.is_some()
+            || args.project.is_some()
+            || args.token.is_some()
+            || args.region.is_some()
+        {
+            return Err(Error::InvalidUsage {
+                message: "--org, --project, --token, and --region cannot be combined with the deprecated `connect <org>/<pod>` form.".to_string(),
+            });
+        }
 
-    // A secret must never ride a positional argument. Reject canonical keys
-    // and close near misses — and never echo either — instead of falling
-    // through to the pod-add path, which would treat the key as a pod name and
-    // reproduce it in errors and requests.
-    if runtime_cloud_connect::enrollment_key::looks_like_enrollment_key(target) {
-        return Err(Error::InvalidArgument {
-            message: "An enrollment key is not accepted as a positional argument. \
-                      Enrollment is performed by the runtime: start it with \
-                      `spiced --token <enrollment-key>` from the instance directory. \
-                      See: https://spiceai.org/docs"
-                .to_string(),
-        });
+        // A secret must never ride a positional argument. Reject canonical keys
+        // and close near misses without echoing either.
+        if runtime_cloud_connect::enrollment_key::looks_like_enrollment_key(target) {
+            return Err(Error::InvalidArgument {
+                message: "An enrollment key is not accepted as a positional argument. Pass it with `spice connect --token <enrollment-key>`. See: https://spiceai.org/docs".to_string(),
+            });
+        }
+
+        eprintln!(
+            "warning: `spice connect <org>/<pod>` is deprecated and will be removed in a future release; use `spice add {target}` instead."
+        );
+        return execute_add_or_connect(
+            ctx,
+            AddArgs {
+                pod_path: target.to_string(),
+            },
+            true,
+        )
+        .await;
     }
 
-    // Deprecated pod-add behavior, forwarded to `spice add`.
-    eprintln!(
-        "warning: `spice connect <org>/<pod>` is deprecated and will be removed in a future release; use `spice add {target}` instead."
-    );
-    let add_args = AddArgs {
-        pod_path: target.to_string(),
-    };
-    execute_add_or_connect(ctx, add_args, true).await
+    reject_cloud_region(args.cloud_region.as_deref())?;
+    let token = args
+        .token
+        .map(EnrollmentKeyArgument::into_enrollment_key)
+        .transpose()?;
+    transaction::execute(
+        ctx,
+        transaction::ConnectRequest {
+            org: args.org,
+            project: args.project,
+            token,
+            region: args.region,
+            dir: args.dir,
+            endpoint: args.endpoint,
+        },
+    )
+    .await
 }
 
 /// Reject `--cloud-region` on Cloud Connect state-management commands.
@@ -324,36 +417,9 @@ fn reject_cloud_region(cloud_region: Option<&str>) -> Result<()> {
     })
 }
 
-/// Bare `spice connect` (no subcommand, no pod path): report the existing
-/// per-directory state.
-///
-/// A directory with no identity has nothing this command can act on —
-/// enrollment belongs to the runtime — so it errors with the exact command that
-/// does enroll.
-async fn connect_existing(config_dir: &Path, endpoint: Option<&str>) -> Result<()> {
-    let status = collect_status(config_dir, endpoint).await?;
-    if status.connection.state != ConnectionState::NotConnected {
-        if status.connection.state == ConnectionState::Enrolled {
-            println!("This host is already enrolled with Spice Cloud.");
-            println!();
-        }
-        return render_status(&status, OutputFormat::Table);
-    }
-
-    Err(Error::InvalidArgument {
-        message: format!(
-            "This directory ({}) is not connected to Spice Cloud. Mint an enrollment key in \
-             the Spice Cloud portal and start the runtime with it: \
-             `spiced --token <enrollment-key>`. Later starts reconnect automatically from the \
-             stored identity. See: https://spiceai.org/docs",
-            instance_dir_for(config_dir).display()
-        ),
-    })
-}
-
 /// Collect the one status snapshot used by the bare and explicit status forms.
 async fn collect_status(config_dir: &Path, endpoint: Option<&str>) -> Result<ConnectStatus> {
-    let endpoint = resolved_endpoint(config_dir, endpoint)?;
+    let endpoint = endpoint_for_local_reporting(config_dir, endpoint);
     Ok(ConnectStatus::collect(
         service::backend(),
         &instance_dir_for(config_dir),
@@ -476,14 +542,21 @@ async fn release_instance(
     config_dir: &Path,
     endpoint: Option<&str>,
     identity: &runtime_cloud_connect::Identity,
-) -> Result<ReleaseVerdict> {
-    let endpoint = resolved_endpoint(config_dir, endpoint)?;
+) -> ReleaseVerdict {
+    let endpoint = match resolved_endpoint(config_dir, endpoint) {
+        Ok(endpoint) => endpoint,
+        Err(error) => {
+            return ReleaseVerdict::Unconfirmed {
+                reason: format!("the persisted control-plane binding is unusable: {error}"),
+            };
+        }
+    };
     let ca = (!identity.ca_bundle_pem.is_empty()).then_some(identity.ca_bundle_pem.as_str());
 
-    Ok(classify_release(
+    classify_release(
         runtime_cloud_connect::release::release(&endpoint, identity, ca).await,
         &endpoint,
-    ))
+    )
 }
 
 /// [`release_instance`] without the request: the classification of what the
@@ -536,6 +609,11 @@ async fn remove_identity(
     assume_yes: bool,
     force: bool,
 ) -> Result<()> {
+    let _connect_lock = state::ConnectLock::acquire(config_dir, "remove")
+        .await
+        .map_err(|error| Error::CloudConnectIo {
+            message: error.to_string(),
+        })?;
     // Own the complete state transition before inspecting any file. Without
     // this boundary, removal can clear old state while enrollment is still
     // promoting a replacement identity under the same directory lock.
@@ -549,6 +627,8 @@ async fn remove_identity(
 
     let identity_path = config_dir.join(IDENTITY_FILE);
     let draft_path = runtime_cloud_connect::EnrollmentDraft::path_in(config_dir);
+    let journal_path = config_dir.join(state::CONNECT_OPERATION_FILE);
+    let project_journal_path = config_dir.join(state::PROJECT_OPERATION_FILE);
     let endpoint_path = config_dir.join(CLOUD_ENDPOINT_FILE);
     let cache_path = config_dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE);
     let instance_dir = instance_dir_for(config_dir);
@@ -564,10 +644,19 @@ async fn remove_identity(
 
     let had_identity = identity.is_some();
     let had_draft = draft_path.exists();
+    let had_journal = journal_path.exists();
+    let had_project_journal = project_journal_path.exists();
     let had_endpoint = endpoint_path.exists();
     let had_cache = cache_path.exists();
 
-    if !had_identity && !had_draft && !had_endpoint && !had_cache && installed.is_none() {
+    if !had_identity
+        && !had_draft
+        && !had_journal
+        && !had_project_journal
+        && !had_endpoint
+        && !had_cache
+        && installed.is_none()
+    {
         println!("Spice Cloud Connect: nothing to remove.");
         return Ok(());
     }
@@ -601,7 +690,7 @@ async fn remove_identity(
     // Reported before anything is cleared: the identity leaf is the credential
     // that authorises the release, so it has to still exist.
     if let Some(ref identity) = identity {
-        match release_instance(config_dir, endpoint, identity).await? {
+        match release_instance(config_dir, endpoint, identity).await {
             ReleaseVerdict::Confirmed { outcome } => {
                 println!("Released this instance in Spice Cloud.");
                 if !outcome.status.is_empty() {
@@ -682,6 +771,16 @@ async fn remove_identity(
                 message: format!("remove enrollment draft: {e}"),
             })?;
     }
+    if had_journal {
+        state::ConnectOperation::delete(config_dir).map_err(|e| Error::CloudConnectIo {
+            message: format!("remove enrollment journal: {e}"),
+        })?;
+    }
+    if had_project_journal {
+        state::ProjectOperation::delete(config_dir).map_err(|e| Error::CloudConnectIo {
+            message: format!("remove project assignment journal: {e}"),
+        })?;
+    }
     // Also clear any `cloud-endpoint` override so a later enrollment
     // without `SPICE_CLOUD_ENDPOINT` doesn't silently keep using the stale
     // endpoint.
@@ -746,28 +845,84 @@ fn confirm(prompt: &str) -> Result<bool> {
     ))
 }
 
-/// Resolve the endpoint `spiced` will actually contact, mirroring the
-/// precedence used at runtime: an explicit `--endpoint` first, then the
-/// `SPICE_CLOUD_ENDPOINT` env var, then the on-disk `cloud-endpoint` override
-/// in the config dir, then the built-in default.
+/// Resolve the control-plane endpoint from explicit process configuration,
+/// durable enrollment state, or the legacy instance-local endpoint file.
 fn resolved_endpoint(config_dir: &Path, explicit: Option<&str>) -> Result<String> {
-    if let Some(endpoint) = explicit.filter(|e| !e.is_empty()) {
-        return Ok(endpoint.to_string());
+    let requested = explicit
+        .filter(|endpoint| !endpoint.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            std::env::var("SPICE_CLOUD_ENDPOINT")
+                .ok()
+                .filter(|endpoint| !endpoint.is_empty())
+        })
+        .map(|endpoint| {
+            runtime_cloud_connect::config::normalize_control_plane_endpoint(&endpoint).map_err(
+                |source| Error::InvalidUsage {
+                    message: format!("invalid Cloud Connect endpoint: {source}"),
+                },
+            )
+        })
+        .transpose()?;
+
+    let identity =
+        runtime_cloud_connect::IdentityStore::load_optional(&config_dir.join(IDENTITY_FILE))
+            .map_err(|source| Error::CloudConnectIo {
+                message: format!("load enrolled Cloud Connect endpoint: {source}"),
+            })?;
+    let bound = match identity.and_then(|identity| identity.control_plane_endpoint) {
+        Some(endpoint) => Some(endpoint),
+        None => runtime_cloud_connect::EnrollmentDraft::load_optional(config_dir)
+            .map_err(|source| Error::CloudConnectIo {
+                message: format!("load pending Cloud Connect endpoint: {source}"),
+            })?
+            .map(|draft| draft.binding.endpoint),
     }
-    if let Ok(env) = std::env::var("SPICE_CLOUD_ENDPOINT")
-        && !env.is_empty()
+    .map(|endpoint| {
+        runtime_cloud_connect::config::normalize_control_plane_endpoint(&endpoint).map_err(
+            |source| Error::CloudConnectIo {
+                message: format!("stored Cloud Connect endpoint is invalid: {source}"),
+            },
+        )
+    })
+    .transpose()?;
+
+    if let (Some(requested), Some(bound)) = (requested.as_deref(), bound.as_deref())
+        && requested != bound
     {
-        return Ok(env);
-    }
-    match runtime_cloud_connect::CloudConnectConfig::read_enroll_endpoint_override(config_dir) {
-        Ok(Some(endpoint)) => Ok(endpoint),
-        Ok(None) => Ok(runtime_cloud_connect::config::DEFAULT_ENDPOINT.to_string()),
-        Err(source) => Err(Error::CloudConnectIo {
+        return Err(Error::InvalidUsage {
             message: format!(
-                "read the Cloud Connect endpoint override at {}: {source}",
-                config_dir.join(CLOUD_ENDPOINT_FILE).display()
+                "endpoint {requested} does not match this instance's enrolled control plane {bound}"
             ),
-        }),
+        });
+    }
+
+    if let Some(endpoint) = requested.or(bound) {
+        return Ok(endpoint);
+    }
+
+    runtime_cloud_connect::CloudConnectConfig::read_normalized_enroll_endpoint_override(config_dir)
+        .map_err(|source| Error::CloudConnectIo {
+            message: source.to_string(),
+        })?
+        .map_or_else(
+            || Ok(runtime_cloud_connect::config::DEFAULT_ENDPOINT.to_string()),
+            Ok,
+        )
+}
+
+/// Resolve the endpoint for operations whose primary purpose is local state
+/// inspection or service management. A damaged endpoint binding must not hide
+/// an unreadable identity report or block stop, uninstall, and log access.
+fn endpoint_for_local_reporting(config_dir: &Path, explicit: Option<&str>) -> String {
+    match resolved_endpoint(config_dir, explicit) {
+        Ok(endpoint) => endpoint,
+        Err(error) => {
+            eprintln!(
+                "Cloud Connect endpoint could not be resolved for this local operation: {error}"
+            );
+            runtime_cloud_connect::config::DEFAULT_ENDPOINT.to_string()
+        }
     }
 }
 
@@ -1078,36 +1233,37 @@ mod tests {
         let dir = tempfile::tempdir().expect("create tempdir");
         assert_eq!(
             resolved_endpoint(dir.path(), Some("https://explicit.example"))
-                .expect("explicit endpoint"),
+                .expect("resolve explicit endpoint"),
             "https://explicit.example"
         );
     }
 
     #[test]
-    fn resolved_endpoint_reads_the_on_disk_override_then_the_default() {
+    fn resolved_endpoint_uses_an_unbound_legacy_override() {
         let dir = tempfile::tempdir().expect("create tempdir");
 
         // Nothing on disk: the built-in default.
         assert_eq!(
-            resolved_endpoint(dir.path(), None).expect("default endpoint"),
+            resolved_endpoint(dir.path(), None).expect("resolve default endpoint"),
             runtime_cloud_connect::config::DEFAULT_ENDPOINT
         );
 
-        // The override file wins over the default.
+        // Before a durable binding exists, the legacy operator-authored file
+        // is the only record of a private control plane.
         std::fs::write(
             dir.path().join(CLOUD_ENDPOINT_FILE),
             "https://override.example\n",
         )
         .expect("write override");
         assert_eq!(
-            resolved_endpoint(dir.path(), None).expect("persisted endpoint"),
+            resolved_endpoint(dir.path(), None).expect("resolve endpoint with unbound file"),
             "https://override.example"
         );
 
         // A blank override is not an endpoint.
         std::fs::write(dir.path().join(CLOUD_ENDPOINT_FILE), "  \n").expect("write blank override");
         assert_eq!(
-            resolved_endpoint(dir.path(), None).expect("blank override uses the default"),
+            resolved_endpoint(dir.path(), None).expect("resolve endpoint with blank file"),
             runtime_cloud_connect::config::DEFAULT_ENDPOINT
         );
     }
@@ -1137,9 +1293,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn local_status_reports_an_unreadable_identity_when_endpoint_resolution_fails() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        std::fs::write(dir.path().join(IDENTITY_FILE), "not valid identity JSON")
+            .expect("write malformed identity");
+
+        let status = collect_status(dir.path(), None)
+            .await
+            .expect("local status collection remains available");
+
+        assert_eq!(status.connection.state, status::ConnectionState::Unreadable);
+        assert_eq!(
+            status.connection.endpoint,
+            runtime_cloud_connect::config::DEFAULT_ENDPOINT
+        );
+    }
+
+    #[tokio::test]
     async fn removal_does_not_touch_state_without_enrollment_transaction_ownership() {
         let dir = tempfile::tempdir().expect("create tempdir");
-        let config_dir = dir.path().join(".spice");
+        let config_dir = dir
+            .path()
+            .canonicalize()
+            .expect("canonical tempdir")
+            .join(".spice");
         let active =
             runtime_cloud_connect::EnrollmentTransactionLock::try_acquire_async(&config_dir)
                 .await
@@ -1256,7 +1433,11 @@ mod tests {
         // directory a retry can finish the removal from. Clearing the identity
         // first would orphan a registry row nobody local can release any more.
         let dir = tempfile::tempdir().expect("create tempdir");
-        let config_dir = dir.path().join(".spice");
+        let config_dir = dir
+            .path()
+            .canonicalize()
+            .expect("canonical tempdir")
+            .join(".spice");
         std::fs::create_dir_all(&config_dir).expect("create config dir");
 
         let identity_path = config_dir.join(IDENTITY_FILE);
@@ -1304,6 +1485,7 @@ mod tests {
             org_name: None,
             app_name: None,
             monitor_url: None,
+            control_plane_endpoint: None,
         }
     }
 }

--- a/bin/spice/src/commands/connect/naming.rs
+++ b/bin/spice/src/commands/connect/naming.rs
@@ -1,0 +1,168 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Project-name suggestions for the interactive Cloud Connect flow.
+
+use std::path::Path;
+
+use rand::RngExt as _;
+
+pub(super) const PROJECT_NAME_MIN_LEN: usize = 4;
+pub(super) const PROJECT_NAME_MAX_LEN: usize = 38;
+
+const FALLBACK_ADJECTIVES: &[&str] = &[
+    "amber", "bright", "calm", "clever", "crisp", "eager", "gentle", "lively", "rapid", "steady",
+    "vivid", "warm",
+];
+
+/// Validate a project name exactly as the connect contract accepts it.
+pub(super) fn validate_project_name(name: &str) -> std::result::Result<(), &'static str> {
+    if !(PROJECT_NAME_MIN_LEN..=PROJECT_NAME_MAX_LEN).contains(&name.len()) {
+        return Err("must be between 4 and 38 characters");
+    }
+    if !name
+        .bytes()
+        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err("must contain only lowercase letters, digits, and dashes");
+    }
+    if name.starts_with('-') || name.ends_with('-') {
+        return Err("must start and end with a letter or digit");
+    }
+    Ok(())
+}
+
+/// Derive the editable first suggestion from a canonical instance directory.
+///
+/// The result uses the directory basename when it can produce a valid name.
+/// An unusable basename gets exactly one CLI-local `adjective-spice` fallback.
+pub(super) fn initial_suggestion(directory: &Path) -> String {
+    let derived = directory
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .map(normalize_basename)
+        .unwrap_or_default();
+    if validate_project_name(&derived).is_ok() {
+        return derived;
+    }
+
+    let mut rng = rand::rng();
+    let index = rng.random_range(0..FALLBACK_ADJECTIVES.len());
+    format!("{}-spice", FALLBACK_ADJECTIVES[index])
+}
+
+fn normalize_basename(value: &str) -> String {
+    let mut normalized = String::with_capacity(value.len().min(PROJECT_NAME_MAX_LEN));
+    let mut separator_pending = false;
+
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() {
+            if separator_pending
+                && !normalized.is_empty()
+                && normalized.len() < PROJECT_NAME_MAX_LEN
+            {
+                normalized.push('-');
+            }
+            separator_pending = false;
+            if normalized.len() == PROJECT_NAME_MAX_LEN {
+                break;
+            }
+            normalized.push(byte.to_ascii_lowercase() as char);
+        } else if !normalized.is_empty() {
+            separator_pending = true;
+        }
+    }
+
+    normalized.truncate(PROJECT_NAME_MAX_LEN);
+    while normalized.ends_with('-') {
+        normalized.pop();
+    }
+    normalized
+}
+
+/// Suggest the next editable name after an authoritative create conflict.
+pub(super) fn collision_suggestion(base: &str, number: u32) -> String {
+    let suffix = format!("-{number}");
+    let base_budget = PROJECT_NAME_MAX_LEN.saturating_sub(suffix.len());
+    let mut truncated = base[..base.len().min(base_budget)].trim_end_matches('-');
+    if truncated.len() < PROJECT_NAME_MIN_LEN {
+        truncated = "spice";
+    }
+    format!("{truncated}{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_directory_basename_is_normalized() {
+        assert_eq!(
+            normalize_basename("  Retail__Analytics 2026 "),
+            "retail-analytics-2026"
+        );
+        assert_eq!(normalize_basename("A".repeat(60).as_str()).len(), 38);
+        assert_eq!(normalize_basename("café/東京"), "caf");
+    }
+
+    #[test]
+    fn unusable_basename_gets_one_valid_local_fallback() {
+        let suggestion = initial_suggestion(Path::new("/tmp/---"));
+        validate_project_name(&suggestion).expect("fallback must be valid");
+        assert!(suggestion.ends_with("-spice"));
+    }
+
+    #[test]
+    fn explicit_names_are_validated_without_rewriting() {
+        for invalid in ["ABC", "abc", "-valid", "valid-", "has space", "a_b"] {
+            assert!(validate_project_name(invalid).is_err(), "{invalid}");
+        }
+        validate_project_name("valid-project-2").expect("valid project name");
+    }
+
+    #[test]
+    fn normalization_and_collision_suffixes_preserve_the_name_contract() {
+        let alphabet = [b'a', b'Z', b'0', b'-', b'_', b' ', 0xf0, b'.'];
+        let mut state = 0x5eed_u64;
+        for length in 0..256 {
+            let mut input = Vec::with_capacity(length);
+            for _ in 0..length {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1);
+                input.push(alphabet[usize::from(state.to_le_bytes()[0]) % alphabet.len()]);
+            }
+            let lossy = String::from_utf8_lossy(&input);
+            let normalized = normalize_basename(&lossy);
+            assert!(normalized.len() <= PROJECT_NAME_MAX_LEN);
+            assert!(normalized.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'
+            }));
+            assert!(!normalized.starts_with('-'));
+            assert!(!normalized.ends_with('-'));
+
+            let base = if validate_project_name(&normalized).is_ok() {
+                normalized
+            } else {
+                "steady-spice".to_string()
+            };
+            for number in [2, 9, 10, 999, u32::MAX] {
+                validate_project_name(&collision_suggestion(&base, number))
+                    .expect("collision suggestion must stay valid");
+            }
+        }
+    }
+}

--- a/bin/spice/src/commands/connect/project.rs
+++ b/bin/spice/src/commands/connect/project.rs
@@ -19,6 +19,7 @@ limitations under the License.
 use futures::StreamExt as _;
 use reqwest::{StatusCode, redirect::Policy};
 use runtime_cloud_connect::Identity;
+use runtime_cloud_connect::config::is_loopback_host;
 use runtime_cloud_connect::enroll::SessionToken;
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
@@ -84,36 +85,15 @@ impl Error {
         )
     }
 
-    #[must_use]
-    pub(super) fn is_retryable(&self) -> bool {
-        matches!(self, Self::Transport { .. } | Self::ResponseBody { .. })
-            || matches!(
-                self,
-                Self::Denied {
-                    retryable: true,
-                    ..
-                }
-            )
-    }
-
     /// A response that may have followed a committed mutation but did not
     /// prove the authoritative result. Exact replay is the only safe recovery.
+    ///
+    /// The complement is exactly the non-retryable structured denial, which
+    /// proves the requested mutation did not commit — so a negated call is how
+    /// a caller asks "is it accurate to report this identity as unattached?".
     #[must_use]
     pub(super) fn is_attachment_ambiguous(&self) -> bool {
         !matches!(
-            self,
-            Self::Denied {
-                retryable: false,
-                ..
-            }
-        )
-    }
-
-    /// A non-retryable structured denial proves that the requested mutation
-    /// did not commit, so reporting the still-unattached identity is accurate.
-    #[must_use]
-    pub(super) fn is_authoritative_non_mutation(&self) -> bool {
-        matches!(
             self,
             Self::Denied {
                 retryable: false,
@@ -305,17 +285,6 @@ fn parse_denial(status: StatusCode, body: &[u8]) -> std::result::Result<Error, E
         code,
         retryable: transport_retryable,
     })
-}
-
-fn is_loopback_host(host: &str) -> bool {
-    let host = host
-        .strip_prefix('[')
-        .and_then(|host| host.strip_suffix(']'))
-        .unwrap_or(host);
-    host.eq_ignore_ascii_case("localhost")
-        || host
-            .parse::<std::net::IpAddr>()
-            .is_ok_and(|ip| ip.is_loopback())
 }
 
 async fn bounded_body(response: reqwest::Response) -> std::result::Result<Vec<u8>, Error> {
@@ -657,7 +626,6 @@ mod tests {
             code: ProjectErrorCode::ProjectNameConflict,
             retryable: false,
         };
-        assert!(denied.is_authoritative_non_mutation());
         assert!(!denied.is_attachment_ambiguous());
 
         for ambiguous in [
@@ -667,7 +635,6 @@ mod tests {
             },
         ] {
             assert!(ambiguous.is_attachment_ambiguous());
-            assert!(!ambiguous.is_authoritative_non_mutation());
         }
     }
 }

--- a/bin/spice/src/commands/connect/project.rs
+++ b/bin/spice/src/commands/connect/project.rs
@@ -1,0 +1,673 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Narrow client for the atomic Cloud Connect project operation.
+
+use futures::StreamExt as _;
+use reqwest::{StatusCode, redirect::Policy};
+use runtime_cloud_connect::Identity;
+use runtime_cloud_connect::enroll::SessionToken;
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+const PROJECT_PATH: &str = "/v1/cloud-connect/project";
+const MAX_RESPONSE_BYTES: usize = 64 * 1024;
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[derive(Debug, Snafu)]
+pub(super) enum Error {
+    #[snafu(display(
+        "Failed to create and attach the Spice Cloud project: the request could not be sent"
+    ))]
+    Transport { source: reqwest::Error },
+
+    #[snafu(display(
+        "Failed to create and attach the Spice Cloud project: the response could not be read"
+    ))]
+    ResponseBody { source: reqwest::Error },
+
+    #[snafu(display(
+        "Failed to create and attach the Spice Cloud project: the response exceeded the 64 KiB limit"
+    ))]
+    ResponseTooLarge,
+
+    #[snafu(display(
+        "Failed to create and attach the Spice Cloud project: the server returned an invalid response ({reason})"
+    ))]
+    InvalidResponse { reason: &'static str },
+
+    #[snafu(display(
+        "Spice Cloud did not create the project ({status}, code={code}, retryable={retryable})"
+    ))]
+    Denied {
+        status: u16,
+        code: ProjectErrorCode,
+        retryable: bool,
+    },
+}
+
+impl Error {
+    #[must_use]
+    pub(super) fn is_name_conflict(&self) -> bool {
+        matches!(
+            self,
+            Self::Denied {
+                status: 409,
+                code: ProjectErrorCode::ProjectNameConflict,
+                retryable: false,
+            }
+        )
+    }
+
+    #[must_use]
+    pub(super) fn is_already_attached(&self) -> bool {
+        matches!(
+            self,
+            Self::Denied {
+                status: 409,
+                code: ProjectErrorCode::InstanceAlreadyAttached,
+                retryable: false,
+            }
+        )
+    }
+
+    #[must_use]
+    pub(super) fn is_retryable(&self) -> bool {
+        matches!(self, Self::Transport { .. } | Self::ResponseBody { .. })
+            || matches!(
+                self,
+                Self::Denied {
+                    retryable: true,
+                    ..
+                }
+            )
+    }
+
+    /// A response that may have followed a committed mutation but did not
+    /// prove the authoritative result. Exact replay is the only safe recovery.
+    #[must_use]
+    pub(super) fn is_attachment_ambiguous(&self) -> bool {
+        !matches!(
+            self,
+            Self::Denied {
+                retryable: false,
+                ..
+            }
+        )
+    }
+
+    /// A non-retryable structured denial proves that the requested mutation
+    /// did not commit, so reporting the still-unattached identity is accurate.
+    #[must_use]
+    pub(super) fn is_authoritative_non_mutation(&self) -> bool {
+        matches!(
+            self,
+            Self::Denied {
+                retryable: false,
+                ..
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProjectErrorCode {
+    InvalidProjectName,
+    Unauthenticated,
+    Forbidden,
+    InstanceNotFound,
+    ProjectNameConflict,
+    InstanceNotEnrolled,
+    InstanceAlreadyAttached,
+    RateLimited,
+    Internal,
+    Unknown,
+}
+
+impl ProjectErrorCode {
+    fn parse(value: Option<&str>) -> Self {
+        match value {
+            Some("invalid_project_name") => Self::InvalidProjectName,
+            Some("unauthenticated") => Self::Unauthenticated,
+            Some("forbidden") => Self::Forbidden,
+            Some("instance_not_found") => Self::InstanceNotFound,
+            Some("project_name_conflict") => Self::ProjectNameConflict,
+            Some("instance_not_enrolled") => Self::InstanceNotEnrolled,
+            Some("instance_already_attached") => Self::InstanceAlreadyAttached,
+            Some("rate_limited") => Self::RateLimited,
+            Some("internal") => Self::Internal,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl std::fmt::Display for ProjectErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::InvalidProjectName => "invalid_project_name",
+            Self::Unauthenticated => "unauthenticated",
+            Self::Forbidden => "forbidden",
+            Self::InstanceNotFound => "instance_not_found",
+            Self::ProjectNameConflict => "project_name_conflict",
+            Self::InstanceNotEnrolled => "instance_not_enrolled",
+            Self::InstanceAlreadyAttached => "instance_already_attached",
+            Self::RateLimited => "rate_limited",
+            Self::Internal => "internal",
+            Self::Unknown => "unknown",
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct ProjectAttachment {
+    pub instance_id: String,
+    pub organization: String,
+    pub project_id: i64,
+    pub project_name: String,
+    pub monitor_url: String,
+}
+
+pub(super) struct ProjectClient {
+    http: reqwest::Client,
+    url: String,
+}
+
+impl std::fmt::Debug for ProjectClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProjectClient").finish_non_exhaustive()
+    }
+}
+
+impl ProjectClient {
+    pub(super) fn new(endpoint: &str) -> std::result::Result<Self, Error> {
+        let parsed = reqwest::Url::parse(endpoint).map_err(|_| Error::InvalidResponse {
+            reason: "the Cloud endpoint was not an absolute URL",
+        })?;
+        let local_http =
+            parsed.scheme() == "http" && parsed.host_str().is_some_and(is_loopback_host);
+        let http = reqwest::Client::builder()
+            // Shorter than the transaction's replay window so a single lost
+            // response cannot consume the entire exact-replay opportunity.
+            .timeout(REQUEST_TIMEOUT)
+            .connect_timeout(std::time::Duration::from_secs(10))
+            // A redirect must never carry the user bearer to another origin.
+            .redirect(Policy::none())
+            // Plain HTTP exists only for an explicit loopback fixture.
+            .https_only(!local_http)
+            .build()
+            .map_err(|source| Error::Transport { source })?;
+        Ok(Self {
+            http,
+            url: format!("{}{PROJECT_PATH}", endpoint.trim_end_matches('/')),
+        })
+    }
+
+    pub(super) async fn create(
+        &self,
+        token: &SessionToken,
+        organization: &str,
+        mutation: &ProjectMutation,
+    ) -> std::result::Result<ProjectAttachment, Error> {
+        let response = self
+            .http
+            .post(&self.url)
+            .bearer_auth(token.expose_secret())
+            .header("X-Org-Name", organization)
+            .json(mutation)
+            .send()
+            .await
+            .map_err(|source| Error::Transport { source })?;
+        let status = response.status();
+        if status.is_redirection() {
+            return Err(Error::InvalidResponse {
+                reason: "redirect responses are not allowed",
+            });
+        }
+        let body = bounded_body(response).await?;
+
+        if !matches!(status, StatusCode::OK | StatusCode::CREATED) {
+            return Err(parse_denial(status, &body)?);
+        }
+
+        let result = serde_json::from_slice::<ProjectResponse>(&body).map_err(|_| {
+            Error::InvalidResponse {
+                reason: "response was not the documented JSON object",
+            }
+        })?;
+        let monitor_url =
+            validate_response(&result, organization, &mutation.instance_id, &mutation.name)?;
+
+        Ok(ProjectAttachment {
+            instance_id: result.instance_id,
+            organization: result.organization.name,
+            project_id: result.project.id,
+            project_name: result.project.name,
+            monitor_url,
+        })
+    }
+}
+
+fn parse_denial(status: StatusCode, body: &[u8]) -> std::result::Result<Error, Error> {
+    let wire = serde_json::from_slice::<ErrorWire>(body).map_err(|_| Error::InvalidResponse {
+        reason: "non-success response was not the documented JSON object",
+    })?;
+    let code = ProjectErrorCode::parse(wire.code.as_deref());
+    let documented = matches!(
+        (status, code),
+        (
+            StatusCode::BAD_REQUEST,
+            ProjectErrorCode::InvalidProjectName
+        ) | (StatusCode::UNAUTHORIZED, ProjectErrorCode::Unauthenticated)
+            | (StatusCode::FORBIDDEN, ProjectErrorCode::Forbidden)
+            | (
+                StatusCode::NOT_FOUND,
+                ProjectErrorCode::InstanceNotFound | ProjectErrorCode::InstanceNotEnrolled
+            )
+            | (
+                StatusCode::CONFLICT,
+                ProjectErrorCode::ProjectNameConflict | ProjectErrorCode::InstanceAlreadyAttached
+            )
+            | (StatusCode::TOO_MANY_REQUESTS, ProjectErrorCode::RateLimited)
+            | (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ProjectErrorCode::Internal
+            )
+    );
+    if !documented {
+        return Err(Error::InvalidResponse {
+            reason: "non-success response status and code did not match the documented contract",
+        });
+    }
+    let transport_retryable = matches!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS | StatusCode::REQUEST_TIMEOUT
+    ) || status.is_server_error();
+    if wire.retryable != transport_retryable {
+        return Err(Error::InvalidResponse {
+            reason: "non-success response retryability did not match its status",
+        });
+    }
+    Ok(Error::Denied {
+        status: status.as_u16(),
+        code,
+        retryable: transport_retryable,
+    })
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    let host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
+async fn bounded_body(response: reqwest::Response) -> std::result::Result<Vec<u8>, Error> {
+    let mut stream = response.bytes_stream();
+    let mut body = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|source| Error::ResponseBody { source })?;
+        if body.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
+            return Err(Error::ResponseTooLarge);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn validate_response(
+    response: &ProjectResponse,
+    expected_org: &str,
+    expected_instance: &str,
+    expected_name: &str,
+) -> std::result::Result<String, Error> {
+    if response.instance_id != expected_instance {
+        return Err(Error::InvalidResponse {
+            reason: "instance_id did not match the request",
+        });
+    }
+    if !response
+        .organization
+        .name
+        .eq_ignore_ascii_case(expected_org)
+    {
+        return Err(Error::InvalidResponse {
+            reason: "organization did not match the request",
+        });
+    }
+    if response.project.name != expected_name {
+        return Err(Error::InvalidResponse {
+            reason: "project name did not match the request",
+        });
+    }
+    if response.project.id <= 0 {
+        return Err(Error::InvalidResponse {
+            reason: "project id was not positive",
+        });
+    }
+    if response
+        .organization
+        .name
+        .chars()
+        .chain(response.project.name.chars())
+        .any(char::is_control)
+    {
+        return Err(Error::InvalidResponse {
+            reason: "project metadata contained control characters",
+        });
+    }
+    let monitor_url =
+        reqwest::Url::parse(&response.monitor_url).map_err(|_| Error::InvalidResponse {
+            reason: "monitor_url was not an absolute URL",
+        })?;
+    let local_http =
+        monitor_url.scheme() == "http" && monitor_url.host_str().is_some_and(is_loopback_host);
+    if (monitor_url.scheme() != "https" && !local_http)
+        || monitor_url.host_str().is_none()
+        || !monitor_url.username().is_empty()
+        || monitor_url.password().is_some()
+    {
+        return Err(Error::InvalidResponse {
+            reason: "monitor_url was not a safe HTTP URL",
+        });
+    }
+    Ok(monitor_url.to_string())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct ProjectMutation {
+    pub(super) instance_id: String,
+    pub(super) name: String,
+    pub(super) cert_pem: String,
+    pub(super) pop_sig: String,
+}
+
+impl ProjectMutation {
+    pub(super) fn signed(
+        identity: &Identity,
+        organization: &str,
+        name: &str,
+    ) -> std::result::Result<Self, Error> {
+        let proof_payload = format!(
+            "spice-cloud-connect/project/v1\n{organization}\n{}\n{name}",
+            identity.identifier
+        );
+        let pop_sig = runtime_cloud_connect::sign_identity_proof(
+            &identity.private_key_pem,
+            proof_payload.as_bytes(),
+        )
+        .map_err(|_| Error::InvalidResponse {
+            reason: "the enrolled identity could not sign the project request",
+        })?;
+        Ok(Self {
+            instance_id: identity.identifier.clone(),
+            name: name.to_string(),
+            cert_pem: identity.identity_cert_pem.clone(),
+            pop_sig,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct ProjectResponse {
+    instance_id: String,
+    organization: NamedResource,
+    project: NamedResource,
+    monitor_url: String,
+}
+
+#[derive(Deserialize)]
+struct NamedResource {
+    id: i64,
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct ErrorWire {
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    retryable: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const TOKEN: &str = "login-secret-that-must-not-leak";
+
+    fn test_identity() -> Identity {
+        let key_pair = rcgen::KeyPair::generate().expect("generate project proof key");
+        let certificate = rcgen::CertificateParams::new(Vec::<String>::new())
+            .expect("build project proof certificate parameters")
+            .self_signed(&key_pair)
+            .expect("sign project proof certificate");
+        Identity {
+            identifier: "inst_8fa21c".to_string(),
+            identity_cert_pem: certificate.pem(),
+            private_key_pem: key_pair.serialize_pem(),
+            public_key_pem: key_pair.public_key_pem(),
+            ca_bundle_pem: String::new(),
+            gateway_addr: String::new(),
+            not_after_unix: None,
+            enc_private_key_pem: String::new(),
+            enc_public_key_pem: String::new(),
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+            app_id: None,
+            org_name: None,
+            app_name: None,
+            monitor_url: None,
+            control_plane_endpoint: None,
+        }
+    }
+
+    fn test_mutation(identity: &Identity) -> ProjectMutation {
+        ProjectMutation::signed(identity, "acme", "retail-analytics")
+            .expect("sign project mutation")
+    }
+
+    fn success_body() -> serde_json::Value {
+        serde_json::json!({
+            "instance_id": "inst_8fa21c",
+            "organization": {"id": 42, "name": "acme"},
+            "project": {"id": 314, "name": "retail-analytics"},
+            "monitor_url": "https://spice.ai/acme/retail-analytics/monitor"
+        })
+    }
+
+    #[tokio::test]
+    async fn first_create_sends_the_exact_atomic_project_contract() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(PROJECT_PATH))
+            .and(header("Authorization", format!("Bearer {TOKEN}")))
+            .and(header("X-Org-Name", "acme"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(success_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+        let result = ProjectClient::new(&server.uri())
+            .expect("client")
+            .create(&SessionToken::new(TOKEN.to_string()), "acme", &mutation)
+            .await
+            .expect("project created");
+        assert_eq!(result.project_id, 314);
+        assert_eq!(result.project_name, "retail-analytics");
+        let requests = server
+            .received_requests()
+            .await
+            .expect("read received project request");
+        let request: serde_json::Value =
+            serde_json::from_slice(&requests[0].body).expect("parse project request body");
+        assert_eq!(request["instance_id"], "inst_8fa21c");
+        assert_eq!(request["name"], "retail-analytics");
+        assert_eq!(request["cert_pem"], identity.identity_cert_pem);
+        assert!(
+            request["pop_sig"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty()),
+            "project request must carry a proof-of-possession signature"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_replay_accepts_the_same_project_with_status_200() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(PROJECT_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+            .expect(2)
+            .mount(&server)
+            .await;
+        let client = ProjectClient::new(&server.uri()).expect("client");
+        let token = SessionToken::new(TOKEN.to_string());
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+
+        for _ in 0..2 {
+            client
+                .create(&token, "acme", &mutation)
+                .await
+                .expect("exact replay succeeds");
+        }
+    }
+
+    #[tokio::test]
+    async fn project_conflicts_are_typed_and_server_detail_is_redacted() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                "code": "project_name_conflict",
+                "error": format!("{TOKEN} acme retail-analytics https://private.example"),
+                "retryable": false
+            })))
+            .mount(&server)
+            .await;
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+        let err = ProjectClient::new(&server.uri())
+            .expect("client")
+            .create(&SessionToken::new(TOKEN.to_string()), "acme", &mutation)
+            .await
+            .expect_err("conflict");
+
+        assert!(err.is_name_conflict());
+        let rendered = format!("{err:?} {err}");
+        for secret in [TOKEN, "acme", "retail-analytics", "private.example"] {
+            assert!(!rendered.contains(secret), "leaked {secret}: {rendered}");
+        }
+    }
+
+    #[tokio::test]
+    async fn mismatched_success_is_not_persistable_attachment_state() {
+        let server = MockServer::start().await;
+        let mut body = success_body();
+        body["instance_id"] = serde_json::Value::String("inst_other".to_string());
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(body))
+            .mount(&server)
+            .await;
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+        let err = ProjectClient::new(&server.uri())
+            .expect("client")
+            .create(&SessionToken::new(TOKEN.to_string()), "acme", &mutation)
+            .await
+            .expect_err("mismatch must fail closed");
+        assert!(matches!(err, Error::InvalidResponse { .. }));
+    }
+
+    #[tokio::test]
+    async fn plaintext_remote_monitor_url_is_rejected() {
+        let server = MockServer::start().await;
+        let mut body = success_body();
+        body["monitor_url"] =
+            serde_json::Value::String("http://example.invalid/monitor".to_string());
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(body))
+            .mount(&server)
+            .await;
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+        let err = ProjectClient::new(&server.uri())
+            .expect("client")
+            .create(&SessionToken::new(TOKEN.to_string()), "acme", &mutation)
+            .await
+            .expect_err("plaintext remote monitor URL must fail closed");
+        assert!(matches!(err, Error::InvalidResponse { .. }));
+    }
+
+    #[tokio::test]
+    async fn project_redirect_is_rejected_without_forwarding_the_bearer() {
+        let source = MockServer::start().await;
+        let target = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/stolen"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&target)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(PROJECT_PATH))
+            .respond_with(
+                ResponseTemplate::new(307)
+                    .insert_header("Location", format!("{}/stolen", target.uri())),
+            )
+            .expect(1)
+            .mount(&source)
+            .await;
+
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+        let err = ProjectClient::new(&source.uri())
+            .expect("client")
+            .create(&SessionToken::new(TOKEN.to_string()), "acme", &mutation)
+            .await
+            .expect_err("redirect must fail closed");
+        assert!(matches!(err, Error::InvalidResponse { .. }), "{err}");
+        target.verify().await;
+    }
+
+    #[test]
+    fn only_authoritative_denials_are_safe_to_report_as_unattached() {
+        let denied = Error::Denied {
+            status: 409,
+            code: ProjectErrorCode::ProjectNameConflict,
+            retryable: false,
+        };
+        assert!(denied.is_authoritative_non_mutation());
+        assert!(!denied.is_attachment_ambiguous());
+
+        for ambiguous in [
+            Error::ResponseTooLarge,
+            Error::InvalidResponse {
+                reason: "invalid success body",
+            },
+        ] {
+            assert!(ambiguous.is_attachment_ambiguous());
+            assert!(!ambiguous.is_authoritative_non_mutation());
+        }
+    }
+}

--- a/bin/spice/src/commands/connect/state.rs
+++ b/bin/spice/src/commands/connect/state.rs
@@ -1,0 +1,1332 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Per-directory serialization and the non-secret enrollment journal.
+
+use std::fs::{File, OpenOptions, TryLockError};
+use std::io::{Read as _, Seek as _, Write as _};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use runtime_cloud_connect::EnrollmentDraft;
+use runtime_cloud_connect::identity::Identity;
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt as _, Snafu};
+
+use super::project::ProjectMutation;
+
+pub(super) const CONNECT_OPERATION_FILE: &str = "connect-operation.json";
+pub(super) const PROJECT_OPERATION_FILE: &str = "connect-project-operation.json";
+pub(super) const CONNECT_LOCK_FILE: &str = "connect.lock";
+pub(super) const CONNECT_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+
+const CONNECT_OPERATION_SCHEMA_VERSION: u32 = 3;
+const PROJECT_OPERATION_SCHEMA_VERSION: u32 = 3;
+const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+const MAX_JOURNAL_BYTES: u64 = 256 * 1024;
+
+#[derive(Debug, Snafu)]
+pub(super) enum Error {
+    #[snafu(display("Failed to access Cloud Connect state at {}: {source}", path.display()))]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to parse the Cloud Connect enrollment journal at {}: {source}", path.display()))]
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("Failed to serialize the Cloud Connect enrollment journal: {source}"))]
+    Serialize { source: serde_json::Error },
+
+    #[snafu(display(
+        "Cloud Connect state for this directory is already being changed{owner}. Wait for that command to finish, then retry."
+    ))]
+    LockTimeout { owner: String },
+
+    #[snafu(display("The Cloud Connect enrollment journal did not match this directory or identity. It was quarantined at {} and was not replayed.", journal.display()))]
+    Quarantined { journal: PathBuf },
+
+    #[snafu(display(
+        "A retry-safe Cloud Connect enrollment is already pending for different parameters ({reason}). Retry with the original organization and endpoint, or run `spice connect remove --yes` to explicitly abandon it. The exact-replay state was preserved."
+    ))]
+    PendingRequestMismatch { reason: String },
+
+    #[snafu(display(
+        "A retry-safe Cloud Connect project assignment is already pending for different parameters ({reason}). Retry the original command or run `spice connect remove --yes` to explicitly abandon it. The exact-replay state was preserved."
+    ))]
+    PendingProjectMismatch { reason: String },
+
+    #[snafu(display("The Cloud Connect enrollment journal at {} uses unsupported schema {found}; expected schema {CONNECT_OPERATION_SCHEMA_VERSION}.", path.display()))]
+    UnsupportedSchema { path: PathBuf, found: u32 },
+}
+
+pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Held for the complete enrollment/project mutation boundary.
+#[derive(Debug)]
+pub(super) struct ConnectLock {
+    _file: File,
+}
+
+impl ConnectLock {
+    pub(super) async fn acquire(config_dir: &Path, action: &'static str) -> Result<Self> {
+        Self::acquire_with_timeout(config_dir, action, CONNECT_LOCK_TIMEOUT).await
+    }
+
+    pub(super) async fn acquire_with_timeout(
+        config_dir: &Path,
+        action: &'static str,
+        timeout: Duration,
+    ) -> Result<Self> {
+        let config_dir = config_dir.to_path_buf();
+        let lock_path = config_dir.join(CONNECT_LOCK_FILE);
+        tokio::task::spawn_blocking(move || acquire_lock(&config_dir, action, timeout))
+            .await
+            .map_err(|source| Error::Io {
+                path: lock_path,
+                source: std::io::Error::other(format!("lock task panicked: {source}")),
+            })?
+    }
+}
+
+fn acquire_lock(config_dir: &Path, action: &str, timeout: Duration) -> Result<ConnectLock> {
+    let config_dir = canonical_config_directory(config_dir)?;
+    validate_existing_directory_chain(&config_dir)?;
+    std::fs::create_dir_all(&config_dir).context(IoSnafu {
+        path: config_dir.clone(),
+    })?;
+    validate_existing_directory_chain(&config_dir)?;
+    let path = config_dir.join(CONNECT_LOCK_FILE);
+    #[cfg(not(windows))]
+    let mut options = OpenOptions::new();
+    #[cfg(not(windows))]
+    options.create(true).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options
+            .mode(0o600)
+            // Never follow an attacker-controlled repository symlink or block
+            // on a FIFO/device before checking the descriptor below.
+            .custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK);
+    }
+    #[cfg(not(windows))]
+    let mut file = options
+        .open(&path)
+        .context(IoSnafu { path: path.clone() })?;
+    #[cfg(windows)]
+    let mut file = open_windows_owner_only_lock(&path).context(IoSnafu { path: path.clone() })?;
+    let metadata = file.metadata().context(IoSnafu { path: path.clone() })?;
+    if !metadata.is_file() {
+        return Err(Error::Io {
+            path,
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "the Cloud Connect mutation lock must be a regular file",
+            ),
+        });
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        use std::os::unix::fs::PermissionsExt as _;
+        if metadata.nlink() != 1 {
+            return Err(Error::Io {
+                path,
+                source: std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "the Cloud Connect mutation lock must not be hard-linked",
+                ),
+            });
+        }
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .context(IoSnafu { path: path.clone() })?;
+    }
+    #[cfg(windows)]
+    validate_windows_lock(&file).context(IoSnafu { path: path.clone() })?;
+    let started = Instant::now();
+
+    loop {
+        match file.try_lock() {
+            Ok(()) => break,
+            Err(TryLockError::WouldBlock) if started.elapsed() < timeout => {
+                std::thread::sleep(
+                    LOCK_RETRY_INTERVAL.min(timeout.saturating_sub(started.elapsed())),
+                );
+            }
+            Err(TryLockError::WouldBlock) => {
+                let owner = lock_owner_suffix(&mut file);
+                return Err(Error::LockTimeout { owner });
+            }
+            Err(TryLockError::Error(source)) => {
+                return Err(Error::Io { path, source });
+            }
+        }
+    }
+
+    file.set_len(0).context(IoSnafu { path: path.clone() })?;
+    file.rewind().context(IoSnafu { path: path.clone() })?;
+    writeln!(file, "pid={} action={action}", std::process::id())
+        .context(IoSnafu { path: path.clone() })?;
+    file.sync_data().context(IoSnafu { path: path.clone() })?;
+    sync_parent_directory(&path).context(IoSnafu { path })?;
+    Ok(ConnectLock { _file: file })
+}
+
+/// Resolve every existing component of a config path before creating or
+/// opening its mutation lock.
+///
+/// This deliberately accepts a symlink supplied as the instance directory or
+/// by `SPICE_CONFIG_DIR`, but reduces it to the same physical directory as its
+/// target. Missing tail components are appended only after the nearest
+/// existing ancestor has been canonicalized, so the directory-chain checks
+/// below never reject a legitimate symlinked ancestor or create a second lock
+/// through a path alias.
+fn canonical_config_directory(path: &Path) -> Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .context(IoSnafu {
+                path: path.to_path_buf(),
+            })?
+    };
+    let mut cursor = absolute.as_path();
+    let mut missing = Vec::new();
+    loop {
+        match std::fs::symlink_metadata(cursor) {
+            Ok(_) => {
+                let mut resolved = std::fs::canonicalize(cursor).context(IoSnafu {
+                    path: cursor.to_path_buf(),
+                })?;
+                if !resolved.is_dir() {
+                    return Err(Error::Io {
+                        path: cursor.to_path_buf(),
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "the Cloud Connect config path must resolve to a directory",
+                        ),
+                    });
+                }
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Ok(resolved);
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                let Some(name) = cursor.file_name() else {
+                    return Err(Error::Io {
+                        path: absolute,
+                        source,
+                    });
+                };
+                missing.push(name.to_os_string());
+                let Some(parent) = cursor.parent() else {
+                    return Err(Error::Io {
+                        path: absolute,
+                        source,
+                    });
+                };
+                cursor = parent;
+            }
+            Err(source) => {
+                return Err(Error::Io {
+                    path: cursor.to_path_buf(),
+                    source,
+                });
+            }
+        }
+    }
+}
+
+fn validate_existing_directory_chain(path: &Path) -> Result<()> {
+    let mut ancestors = path.ancestors().collect::<Vec<_>>();
+    ancestors.reverse();
+    for ancestor in ancestors {
+        let metadata = match std::fs::symlink_metadata(ancestor) {
+            Ok(metadata) => metadata,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(source) => {
+                return Err(Error::Io {
+                    path: ancestor.to_path_buf(),
+                    source,
+                });
+            }
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            return Err(Error::Io {
+                path: ancestor.to_path_buf(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "the Cloud Connect config path must contain only real directories",
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn open_windows_owner_only_lock(path: &Path) -> std::io::Result<File> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::{FromRawHandle as _, RawHandle};
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE, LocalFree};
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1, SE_FILE_OBJECT,
+        SetSecurityInfo,
+    };
+    use windows_sys::Win32::Security::{
+        DACL_SECURITY_INFORMATION, GetSecurityDescriptorDacl, PROTECTED_DACL_SECURITY_INFORMATION,
+        SECURITY_ATTRIBUTES,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_READ,
+        FILE_GENERIC_WRITE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_ALWAYS,
+    };
+
+    let path = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    // Protected DACL granting generic-all only to the file owner. Passing it
+    // at creation avoids a window in which a newly-created repository-local
+    // lock inherits broader directory permissions.
+    let sddl = "D:P(A;;GA;;;OW)"
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let mut descriptor = std::ptr::null_mut();
+    let converted = unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl.as_ptr(),
+            SDDL_REVISION_1,
+            &mut descriptor,
+            std::ptr::null_mut(),
+        )
+    };
+    if converted == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let mut security = SECURITY_ATTRIBUTES {
+        nLength: u32::try_from(std::mem::size_of::<SECURITY_ATTRIBUTES>()).unwrap_or(u32::MAX),
+        lpSecurityDescriptor: descriptor,
+        bInheritHandle: 0,
+    };
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            &mut security,
+            OPEN_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        unsafe {
+            let _ = LocalFree(descriptor.cast());
+        }
+        return Err(std::io::Error::last_os_error());
+    }
+    let mut dacl_present = 0;
+    let mut dacl = std::ptr::null_mut();
+    let mut dacl_defaulted = 0;
+    let got_dacl = unsafe {
+        GetSecurityDescriptorDacl(
+            descriptor,
+            &mut dacl_present,
+            &mut dacl,
+            &mut dacl_defaulted,
+        )
+    };
+    if got_dacl == 0 || dacl_present == 0 {
+        let source = if got_dacl == 0 {
+            std::io::Error::last_os_error()
+        } else {
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "owner-only lock descriptor did not contain a DACL",
+            )
+        };
+        unsafe {
+            let _ = LocalFree(descriptor.cast());
+            let _ = CloseHandle(handle);
+        }
+        return Err(source);
+    }
+    let acl_result = unsafe {
+        SetSecurityInfo(
+            handle,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            dacl,
+            std::ptr::null_mut(),
+        )
+    };
+    unsafe {
+        let _ = LocalFree(descriptor.cast());
+    }
+    if acl_result != 0 {
+        unsafe {
+            let _ = CloseHandle(handle);
+        }
+        return Err(std::io::Error::from_raw_os_error(
+            i32::try_from(acl_result).unwrap_or(i32::MAX),
+        ));
+    }
+    Ok(unsafe { File::from_raw_handle(handle as RawHandle) })
+}
+
+#[cfg(windows)]
+fn validate_windows_lock(file: &File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+        GetFileInformationByHandle,
+    };
+
+    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    let result =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle().cast(), &mut information) };
+    if result == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if information.dwFileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT) != 0
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the Cloud Connect state path must be a regular file, not a directory or reparse point",
+        ));
+    }
+    if information.nNumberOfLinks != 1 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the Cloud Connect state path must not be hard-linked",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn open_windows_regular_file_for_read(path: &Path) -> std::io::Result<File> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::{FromRawHandle as _, RawHandle};
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_READ, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+
+    let path = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            FILE_GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(std::io::Error::last_os_error());
+    }
+    let file = unsafe { File::from_raw_handle(handle as RawHandle) };
+    validate_windows_lock(&file)?;
+    Ok(file)
+}
+
+fn lock_owner_suffix(file: &mut File) -> String {
+    file.rewind()
+        .and_then(|()| {
+            let mut value = String::new();
+            file.read_to_string(&mut value).map(|_| value)
+        })
+        .ok()
+        .map(|value| {
+            value
+                .chars()
+                .filter(|character| !character.is_control())
+                .take(160)
+                .collect::<String>()
+        })
+        .filter(|value| !value.is_empty())
+        .map(|value| format!(" ({value})"))
+        .unwrap_or_default()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum EnrollmentPhase {
+    Prepared,
+    Enrolled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ConnectOperation {
+    pub schema_version: u32,
+    pub directory: PathBuf,
+    pub enrollment_operation_id: String,
+    pub organization: String,
+    pub endpoint: String,
+    pub region: Option<String>,
+    pub phase: EnrollmentPhase,
+    pub instance_id: Option<String>,
+}
+
+impl ConnectOperation {
+    pub(super) fn prepare(
+        config_dir: &Path,
+        directory: &Path,
+        enrollment_operation_id: &str,
+        organization: &str,
+        endpoint: &str,
+        region: Option<&str>,
+    ) -> Result<Self> {
+        if let Some(existing) = Self::load_optional(config_dir)? {
+            if existing.schema_version == CONNECT_OPERATION_SCHEMA_VERSION
+                && existing.directory == directory
+                && existing.enrollment_operation_id == enrollment_operation_id
+                && existing.organization.eq_ignore_ascii_case(organization)
+                && existing.endpoint == endpoint
+                && region.is_none_or(|region| existing.region.as_deref() == Some(region))
+                && existing.phase == EnrollmentPhase::Prepared
+            {
+                return Ok(existing);
+            }
+            return Err(Error::PendingRequestMismatch {
+                reason: format!(
+                    "journal operation {}, organization {}, endpoint {}, region {}",
+                    existing.enrollment_operation_id,
+                    existing.organization,
+                    existing.endpoint,
+                    existing.region.as_deref().unwrap_or("unspecified")
+                ),
+            });
+        }
+
+        let operation = Self {
+            schema_version: CONNECT_OPERATION_SCHEMA_VERSION,
+            directory: directory.to_path_buf(),
+            enrollment_operation_id: enrollment_operation_id.to_string(),
+            organization: organization.to_string(),
+            endpoint: endpoint.to_string(),
+            region: region.map(ToString::to_string),
+            phase: EnrollmentPhase::Prepared,
+            instance_id: None,
+        };
+        operation.store(config_dir)?;
+        Ok(operation)
+    }
+
+    pub(super) fn mark_enrolled(&mut self, config_dir: &Path, identity: &Identity) -> Result<()> {
+        self.phase = EnrollmentPhase::Enrolled;
+        self.instance_id = Some(identity.identifier.clone());
+        if !self.organization.is_empty()
+            && !identity
+                .org_name
+                .as_deref()
+                .is_some_and(|org| org.eq_ignore_ascii_case(&self.organization))
+        {
+            return Err(Error::PendingRequestMismatch {
+                reason: format!(
+                    "the enrolled identity organization did not match requested organization {}",
+                    self.organization
+                ),
+            });
+        }
+        self.store(config_dir)
+    }
+
+    pub(super) fn delete(config_dir: &Path) -> Result<()> {
+        remove_if_exists(&config_dir.join(CONNECT_OPERATION_FILE))
+    }
+
+    pub(super) fn load_optional(config_dir: &Path) -> Result<Option<Self>> {
+        let path = config_dir.join(CONNECT_OPERATION_FILE);
+        let raw = match read_bounded_regular_file(&path, MAX_JOURNAL_BYTES) {
+            Ok(raw) => String::from_utf8(raw).map_err(|source| Error::Io {
+                path: path.clone(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, source),
+            })?,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(Error::Io { path, source }),
+        };
+        let operation =
+            serde_json::from_str::<Self>(&raw).context(ParseSnafu { path: path.clone() })?;
+        if operation.schema_version != CONNECT_OPERATION_SCHEMA_VERSION {
+            return Err(Error::UnsupportedSchema {
+                path,
+                found: operation.schema_version,
+            });
+        }
+        Ok(Some(operation))
+    }
+
+    /// Reconcile a leftover enrollment journal before any new mutation.
+    ///
+    /// A matching durable identity makes the journal obsolete. Any positive
+    /// mismatch is quarantined together with the provisional draft so it can
+    /// never be replayed under this directory by accident.
+    pub(super) fn reconcile(
+        config_dir: &Path,
+        directory: &Path,
+        endpoint: &str,
+        identity: Option<&Identity>,
+    ) -> Result<()> {
+        let Some(operation) = Self::load_optional(config_dir)? else {
+            return Ok(());
+        };
+        let directory_matches = operation.directory == directory;
+        if identity.is_none() && (!directory_matches || operation.endpoint != endpoint) {
+            return Err(Error::PendingRequestMismatch {
+                reason: format!(
+                    "directory {}, endpoint {}",
+                    operation.directory.display(),
+                    operation.endpoint
+                ),
+            });
+        }
+        let identity_matches = identity.is_none_or(|identity| {
+            operation
+                .instance_id
+                .as_deref()
+                .is_none_or(|instance_id| instance_id == identity.identifier)
+                && identity.org_name.as_deref().is_none_or(|org| {
+                    operation.organization.is_empty()
+                        || org.eq_ignore_ascii_case(&operation.organization)
+                })
+        });
+        let missing_identity_after_enroll =
+            identity.is_none() && operation.phase == EnrollmentPhase::Enrolled;
+
+        if !directory_matches || !identity_matches || missing_identity_after_enroll {
+            let path = config_dir.join(CONNECT_OPERATION_FILE);
+            let journal = quarantine(config_dir, &path)?;
+            let draft = EnrollmentDraft::path_in(config_dir);
+            if draft.exists() {
+                let _ = quarantine(config_dir, &draft)?;
+            }
+            return Err(Error::Quarantined { journal });
+        }
+
+        if identity.is_some() {
+            Self::delete(config_dir)?;
+        }
+        Ok(())
+    }
+
+    fn store(&self, config_dir: &Path) -> Result<()> {
+        let path = config_dir.join(CONNECT_OPERATION_FILE);
+        let body = serde_json::to_vec_pretty(self).context(SerializeSnafu)?;
+        atomic_write_owner_only(&path, &body)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ProjectOperation {
+    pub schema_version: u32,
+    pub directory: PathBuf,
+    pub endpoint: String,
+    pub organization: String,
+    pub request: ProjectMutation,
+}
+
+impl ProjectOperation {
+    pub(super) fn prepare(
+        config_dir: &Path,
+        directory: &Path,
+        endpoint: &str,
+        organization: &str,
+        request: ProjectMutation,
+    ) -> Result<Self> {
+        if let Some(existing) = Self::load_optional(config_dir)? {
+            if existing.directory == directory
+                && existing.endpoint == endpoint
+                && existing.organization.eq_ignore_ascii_case(organization)
+                && existing.request.instance_id == request.instance_id
+                && existing.request.name == request.name
+            {
+                return Ok(existing);
+            }
+            return Err(Error::PendingProjectMismatch {
+                reason: format!(
+                    "organization {}, endpoint {}, instance {}, project {}",
+                    existing.organization,
+                    existing.endpoint,
+                    existing.request.instance_id,
+                    existing.request.name
+                ),
+            });
+        }
+        let operation = Self {
+            schema_version: PROJECT_OPERATION_SCHEMA_VERSION,
+            directory: directory.to_path_buf(),
+            endpoint: endpoint.to_string(),
+            organization: organization.to_string(),
+            request,
+        };
+        operation.store(config_dir)?;
+        Ok(operation)
+    }
+
+    pub(super) fn reconcile(
+        config_dir: &Path,
+        directory: &Path,
+        endpoint: &str,
+        identity: Option<&Identity>,
+    ) -> Result<Option<Self>> {
+        let Some(operation) = Self::load_optional(config_dir)? else {
+            return Ok(None);
+        };
+        let matches_identity = identity.is_some_and(|identity| {
+            identity.identifier == operation.request.instance_id
+                && identity
+                    .org_name
+                    .as_deref()
+                    .is_some_and(|org| org.eq_ignore_ascii_case(&operation.organization))
+        });
+        if operation.directory != directory || operation.endpoint != endpoint || !matches_identity {
+            return Err(Error::PendingProjectMismatch {
+                reason: format!(
+                    "organization {}, endpoint {}, instance {}, project {}",
+                    operation.organization,
+                    operation.endpoint,
+                    operation.request.instance_id,
+                    operation.request.name
+                ),
+            });
+        }
+        let Some(identity) = identity else {
+            return Err(Error::PendingProjectMismatch {
+                reason: "the enrolled identity is missing".to_string(),
+            });
+        };
+        if identity.app_id.is_some() {
+            let matches_attachment = identity
+                .org_name
+                .as_deref()
+                .is_some_and(|org| org.eq_ignore_ascii_case(&operation.organization))
+                && identity.app_name.as_deref() == Some(operation.request.name.as_str());
+            if matches_attachment {
+                Self::delete(config_dir)?;
+                return Ok(None);
+            }
+            return Err(Error::PendingProjectMismatch {
+                reason: "the durable identity has a different project attachment".to_string(),
+            });
+        }
+        Ok(Some(operation))
+    }
+
+    pub(super) fn load_optional(config_dir: &Path) -> Result<Option<Self>> {
+        let path = config_dir.join(PROJECT_OPERATION_FILE);
+        let raw = match read_bounded_regular_file(&path, MAX_JOURNAL_BYTES) {
+            Ok(raw) => String::from_utf8(raw).map_err(|source| Error::Io {
+                path: path.clone(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, source),
+            })?,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(Error::Io { path, source }),
+        };
+        let operation =
+            serde_json::from_str::<Self>(&raw).context(ParseSnafu { path: path.clone() })?;
+        if operation.schema_version != PROJECT_OPERATION_SCHEMA_VERSION {
+            return Err(Error::UnsupportedSchema {
+                path,
+                found: operation.schema_version,
+            });
+        }
+        Ok(Some(operation))
+    }
+
+    pub(super) fn delete(config_dir: &Path) -> Result<()> {
+        remove_if_exists(&config_dir.join(PROJECT_OPERATION_FILE))
+    }
+
+    fn store(&self, config_dir: &Path) -> Result<()> {
+        let path = config_dir.join(PROJECT_OPERATION_FILE);
+        let body = serde_json::to_vec_pretty(self).context(SerializeSnafu)?;
+        atomic_write_owner_only(&path, &body)
+    }
+}
+
+fn read_bounded_regular_file(path: &Path, max_bytes: u64) -> std::io::Result<Vec<u8>> {
+    #[cfg(not(windows))]
+    let mut options = OpenOptions::new();
+    #[cfg(not(windows))]
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK);
+    }
+    #[cfg(not(windows))]
+    let file = options.open(path)?;
+    #[cfg(windows)]
+    let file = open_windows_regular_file_for_read(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.len() > max_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the Cloud Connect state file was not a bounded regular file",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        if metadata.nlink() != 1 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "the Cloud Connect state file must not be hard-linked",
+            ));
+        }
+    }
+    let mut bytes = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
+    file.take(max_bytes.saturating_add(1))
+        .read_to_end(&mut bytes)?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > max_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the Cloud Connect state file exceeded its size limit",
+        ));
+    }
+    Ok(bytes)
+}
+
+pub(super) fn atomic_write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context(IoSnafu {
+            path: parent.to_path_buf(),
+        })?;
+    }
+    let candidate = path.with_file_name(format!(
+        ".{}.{}.candidate",
+        path.file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or(CONNECT_OPERATION_FILE),
+        rand::random::<u64>()
+    ));
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&candidate).context(IoSnafu {
+        path: candidate.clone(),
+    })?;
+    file.write_all(bytes).context(IoSnafu {
+        path: candidate.clone(),
+    })?;
+    file.sync_all().context(IoSnafu {
+        path: candidate.clone(),
+    })?;
+    drop(file);
+    if let Err(source) = promote_candidate(&candidate, path) {
+        let _ = std::fs::remove_file(&candidate);
+        return Err(Error::Io {
+            path: path.to_path_buf(),
+            source,
+        });
+    }
+    sync_parent_directory(path).context(IoSnafu {
+        path: path.to_path_buf(),
+    })
+}
+
+#[cfg(unix)]
+fn promote_candidate(candidate: &Path, path: &Path) -> std::io::Result<()> {
+    std::fs::rename(candidate, path)
+}
+
+#[cfg(windows)]
+fn promote_candidate(candidate: &Path, path: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_REPARSE_POINT, GetFileAttributesW, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+        REPLACEFILE_WRITE_THROUGH, ReplaceFileW,
+    };
+
+    let candidate = candidate
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let path = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let attributes = unsafe { GetFileAttributesW(path.as_ptr()) };
+    if attributes != u32::MAX && attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Cloud Connect state destinations must not be reparse points",
+        ));
+    }
+    let result = if attributes == u32::MAX {
+        unsafe { MoveFileExW(candidate.as_ptr(), path.as_ptr(), MOVEFILE_WRITE_THROUGH) }
+    } else {
+        unsafe {
+            ReplaceFileW(
+                path.as_ptr(),
+                candidate.as_ptr(),
+                std::ptr::null(),
+                REPLACEFILE_WRITE_THROUGH,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        }
+    };
+    if result == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn promote_candidate(candidate: &Path, path: &Path) -> std::io::Result<()> {
+    std::fs::rename(candidate, path)
+}
+
+/// Exercise the legacy non-replacing-filesystem rollback behavior in tests.
+/// Production Windows builds use `ReplaceFileW`, which is atomic and requires
+/// no backup window.
+#[cfg(test)]
+fn promote_candidate_without_replace(candidate: &Path, path: &Path) -> std::io::Result<()> {
+    if path.exists() {
+        let file_name = path
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or(CONNECT_OPERATION_FILE);
+        let backup = path.with_file_name(format!(".{file_name}.{}.backup", rand::random::<u64>()));
+        std::fs::rename(path, &backup)?;
+        match std::fs::rename(candidate, path) {
+            Ok(()) => std::fs::remove_file(backup),
+            Err(promote_source) => {
+                std::fs::rename(&backup, path).map_err(|rollback_source| {
+                    std::io::Error::other(format!(
+                        "replacement failed ({promote_source}); rollback from {} also failed ({rollback_source})",
+                        backup.display()
+                    ))
+                })?;
+                Err(promote_source)
+            }
+        }
+    } else {
+        std::fs::rename(candidate, path)
+    }
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> std::io::Result<()> {
+    std::fs::File::open(path.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+fn quarantine(config_dir: &Path, path: &Path) -> Result<PathBuf> {
+    let epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let stem = path
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("connect-state");
+    let extension = path
+        .extension()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("json");
+    let quarantined = config_dir.join(format!(
+        "{stem}.quarantine.{epoch}.{}.{extension}",
+        std::process::id()
+    ));
+    std::fs::rename(path, &quarantined).context(IoSnafu {
+        path: path.to_path_buf(),
+    })?;
+    Ok(quarantined)
+}
+
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(Error::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity(instance: &str, org: &str) -> Identity {
+        Identity {
+            identifier: instance.to_string(),
+            identity_cert_pem: "CERT".to_string(),
+            private_key_pem: "KEY".to_string(),
+            public_key_pem: "PUB".to_string(),
+            ca_bundle_pem: String::new(),
+            gateway_addr: "gateway.test:443".to_string(),
+            not_after_unix: None,
+            enc_private_key_pem: String::new(),
+            enc_public_key_pem: String::new(),
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+            app_id: None,
+            org_name: Some(org.to_string()),
+            app_name: None,
+            monitor_url: None,
+            control_plane_endpoint: None,
+        }
+    }
+
+    #[test]
+    fn enrolled_identity_retires_the_matching_enrollment_journal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut operation = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("prepare");
+        operation
+            .mark_enrolled(dir.path(), &identity("inst_1", "acme"))
+            .expect("mark enrolled");
+        ConnectOperation::reconcile(
+            dir.path(),
+            dir.path(),
+            "https://api.spice.ai",
+            Some(&identity("inst_1", "acme")),
+        )
+        .expect("reconcile");
+        assert!(!dir.path().join(CONNECT_OPERATION_FILE).exists());
+    }
+
+    #[test]
+    fn mismatched_identity_is_quarantined_and_never_replayed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut operation = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("prepare");
+        operation
+            .mark_enrolled(dir.path(), &identity("inst_1", "acme"))
+            .expect("mark enrolled");
+        let err = ConnectOperation::reconcile(
+            dir.path(),
+            dir.path(),
+            "https://api.spice.ai",
+            Some(&identity("inst_other", "acme")),
+        )
+        .expect_err("mismatch must quarantine");
+        assert!(matches!(err, Error::Quarantined { .. }));
+        assert!(!dir.path().join(CONNECT_OPERATION_FILE).exists());
+        assert!(
+            std::fs::read_dir(dir.path())
+                .expect("read dir")
+                .flatten()
+                .any(|entry| entry.file_name().to_string_lossy().contains("quarantine"))
+        );
+    }
+
+    #[test]
+    fn changed_pending_request_preserves_exact_replay_state() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let draft = EnrollmentDraft::path_in(dir.path());
+        std::fs::write(&draft, "exact replay material").expect("write draft sentinel");
+        ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            "https://control-a.example",
+            None,
+        )
+        .expect("prepare");
+
+        let endpoint_error =
+            ConnectOperation::reconcile(dir.path(), dir.path(), "https://control-b.example", None)
+                .expect_err("changed endpoint must fail closed");
+        assert!(matches!(
+            endpoint_error,
+            Error::PendingRequestMismatch { .. }
+        ));
+        let org_error = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "globex",
+            "https://control-a.example",
+            None,
+        )
+        .expect_err("changed organization must fail closed");
+        assert!(matches!(org_error, Error::PendingRequestMismatch { .. }));
+        assert_eq!(
+            std::fs::read_to_string(draft).expect("draft remains"),
+            "exact replay material"
+        );
+        let operation = ConnectOperation::load_optional(dir.path())
+            .expect("load journal")
+            .expect("journal remains");
+        assert_eq!(operation.enrollment_operation_id, "operation-1");
+        assert_eq!(operation.organization, "acme");
+        assert_eq!(operation.endpoint, "https://control-a.example");
+    }
+
+    #[test]
+    fn changed_pending_region_preserves_exact_replay_state() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            "https://api.spice.ai",
+            Some("us-east-1"),
+        )
+        .expect("prepare");
+        let error = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            "https://api.spice.ai",
+            Some("eu-west-1"),
+        )
+        .expect_err("changed region must fail closed");
+        assert!(matches!(error, Error::PendingRequestMismatch { .. }));
+        let operation = ConnectOperation::load_optional(dir.path())
+            .expect("load operation")
+            .expect("operation remains");
+        assert_eq!(operation.region.as_deref(), Some("us-east-1"));
+    }
+
+    #[test]
+    fn enrolled_organization_cannot_replace_the_requested_organization() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut operation = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("prepare");
+        let error = operation
+            .mark_enrolled(dir.path(), &identity("inst_1", "globex"))
+            .expect_err("response org must not rewrite request authority");
+        assert!(matches!(error, Error::PendingRequestMismatch { .. }));
+        assert_eq!(operation.organization, "acme");
+    }
+
+    #[test]
+    fn project_operation_persists_only_the_exact_request_for_server_replay() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let request = ProjectMutation {
+            instance_id: "inst_1".to_string(),
+            name: "retail".to_string(),
+            cert_pem: "certificate".to_string(),
+            pop_sig: "signature".to_string(),
+        };
+        let operation = ProjectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "https://api.spice.ai",
+            "acme",
+            request.clone(),
+        )
+        .expect("prepare project operation");
+        let recovered = ProjectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "https://api.spice.ai",
+            "acme",
+            request,
+        )
+        .expect("recover exact operation");
+        assert_eq!(recovered, operation);
+    }
+
+    #[tokio::test]
+    async fn lock_wait_is_bounded_and_reports_only_owner_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_dir = dir.path().canonicalize().expect("canonical tempdir");
+        let first = ConnectLock::acquire_with_timeout(
+            &config_dir,
+            "first-action",
+            Duration::from_millis(100),
+        )
+        .await
+        .expect("first lock");
+        let err = ConnectLock::acquire_with_timeout(
+            &config_dir,
+            "second-action",
+            Duration::from_millis(120),
+        )
+        .await
+        .expect_err("second lock must time out");
+        let rendered = err.to_string();
+        assert!(rendered.contains("pid="));
+        assert!(rendered.contains("first-action"));
+        drop(first);
+        ConnectLock::acquire_with_timeout(&config_dir, "third-action", Duration::from_millis(100))
+            .await
+            .expect("lock released");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mutation_lock_rejects_symlinks_without_touching_the_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("important.txt");
+        std::fs::write(&target, "must remain unchanged").expect("write target");
+        let config = dir.path().join("config");
+        std::fs::create_dir_all(&config).expect("create config");
+        symlink(&target, config.join(CONNECT_LOCK_FILE)).expect("create lock symlink");
+
+        ConnectLock::acquire_with_timeout(&config, "connect", Duration::from_millis(50))
+            .await
+            .expect_err("a symlink must not become the mutation lock");
+        assert_eq!(
+            std::fs::read_to_string(target).expect("read target"),
+            "must remain unchanged"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mutation_lock_canonicalizes_a_symlinked_config_ancestor() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let real_root = dir.path().join("real");
+        let real_config = real_root.join("instance/.spice");
+        std::fs::create_dir_all(&real_config).expect("create real config directory");
+        let alias_root = dir.path().join("current");
+        symlink(&real_root, &alias_root).expect("create config ancestor symlink");
+        let alias_config = alias_root.join("instance/.spice");
+
+        let first = ConnectLock::acquire_with_timeout(
+            &real_config,
+            "canonical-owner",
+            Duration::from_millis(100),
+        )
+        .await
+        .expect("acquire through canonical path");
+        let error = ConnectLock::acquire_with_timeout(
+            &alias_config,
+            "alias-owner",
+            Duration::from_millis(100),
+        )
+        .await
+        .expect_err("the alias must contend on the canonical lock");
+        assert!(matches!(error, Error::LockTimeout { .. }));
+        drop(first);
+
+        ConnectLock::acquire_with_timeout(
+            &alias_config,
+            "alias-after-release",
+            Duration::from_millis(100),
+        )
+        .await
+        .expect("acquire through symlinked config ancestor");
+    }
+
+    #[test]
+    fn non_replacing_promotion_replaces_an_existing_journal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join(CONNECT_OPERATION_FILE);
+        let candidate = dir.path().join("candidate");
+        std::fs::write(&target, "prepared").expect("write old journal");
+        std::fs::write(&candidate, "enrolled").expect("write new journal");
+
+        promote_candidate_without_replace(&candidate, &target).expect("promote replacement");
+        assert_eq!(
+            std::fs::read_to_string(&target).expect("read promoted journal"),
+            "enrolled"
+        );
+        assert!(!candidate.exists());
+        assert!(
+            std::fs::read_dir(dir.path())
+                .expect("read directory")
+                .flatten()
+                .all(|entry| !entry.file_name().to_string_lossy().ends_with(".backup"))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_is_owner_only_and_contains_no_credentials() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().expect("tempdir");
+        ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("prepare");
+        let path = dir.path().join(CONNECT_OPERATION_FILE);
+        let mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+        let raw = std::fs::read_to_string(path).expect("journal");
+        assert!(!raw.contains("token"));
+        assert!(!raw.contains("private_key"));
+    }
+}

--- a/bin/spice/src/commands/connect/state.rs
+++ b/bin/spice/src/commands/connect/state.rs
@@ -73,11 +73,39 @@ pub(super) enum Error {
     ))]
     PendingProjectMismatch { reason: String },
 
-    #[snafu(display("The Cloud Connect enrollment journal at {} uses unsupported schema {found}; expected schema {CONNECT_OPERATION_SCHEMA_VERSION}.", path.display()))]
-    UnsupportedSchema { path: PathBuf, found: u32 },
+    #[snafu(display("The Cloud Connect enrollment journal at {} uses unsupported schema {found}; expected schema {expected}.", path.display()))]
+    UnsupportedSchema {
+        path: PathBuf,
+        found: u32,
+        expected: u32,
+    },
 }
 
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// The non-secret identity fields journal reconciliation compares against.
+///
+/// Reconciliation runs on a blocking task, so handing it the whole [`Identity`]
+/// would copy the PEM-encoded certificate and both private keys onto the heap —
+/// where nothing zeroizes them — to perform four string comparisons.
+#[derive(Debug, Clone)]
+pub(super) struct IdentityFacts {
+    identifier: String,
+    org_name: Option<String>,
+    app_id: Option<String>,
+    app_name: Option<String>,
+}
+
+impl From<&Identity> for IdentityFacts {
+    fn from(identity: &Identity) -> Self {
+        Self {
+            identifier: identity.identifier.clone(),
+            org_name: identity.org_name.clone(),
+            app_id: identity.app_id.clone(),
+            app_name: identity.app_name.clone(),
+        }
+    }
+}
 
 /// Held for the complete enrollment/project mutation boundary.
 #[derive(Debug)]
@@ -586,6 +614,7 @@ impl ConnectOperation {
             return Err(Error::UnsupportedSchema {
                 path,
                 found: operation.schema_version,
+                expected: CONNECT_OPERATION_SCHEMA_VERSION,
             });
         }
         Ok(Some(operation))
@@ -600,7 +629,7 @@ impl ConnectOperation {
         config_dir: &Path,
         directory: &Path,
         endpoint: &str,
-        identity: Option<&Identity>,
+        identity: Option<&IdentityFacts>,
     ) -> Result<()> {
         let Some(operation) = Self::load_optional(config_dir)? else {
             return Ok(());
@@ -703,7 +732,7 @@ impl ProjectOperation {
         config_dir: &Path,
         directory: &Path,
         endpoint: &str,
-        identity: Option<&Identity>,
+        identity: Option<&IdentityFacts>,
     ) -> Result<Option<Self>> {
         let Some(operation) = Self::load_optional(config_dir)? else {
             return Ok(None);
@@ -764,6 +793,7 @@ impl ProjectOperation {
             return Err(Error::UnsupportedSchema {
                 path,
                 found: operation.schema_version,
+                expected: PROJECT_OPERATION_SCHEMA_VERSION,
             });
         }
         Ok(Some(operation))
@@ -1038,7 +1068,7 @@ mod tests {
             dir.path(),
             dir.path(),
             "https://api.spice.ai",
-            Some(&identity("inst_1", "acme")),
+            Some(&IdentityFacts::from(&identity("inst_1", "acme"))),
         )
         .expect("reconcile");
         assert!(!dir.path().join(CONNECT_OPERATION_FILE).exists());
@@ -1063,7 +1093,7 @@ mod tests {
             dir.path(),
             dir.path(),
             "https://api.spice.ai",
-            Some(&identity("inst_other", "acme")),
+            Some(&IdentityFacts::from(&identity("inst_other", "acme"))),
         )
         .expect_err("mismatch must quarantine");
         assert!(matches!(err, Error::Quarantined { .. }));

--- a/bin/spice/src/commands/connect/transaction.rs
+++ b/bin/spice/src/commands/connect/transaction.rs
@@ -1,0 +1,1627 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! The resumable `spice connect` enrollment and project transaction.
+
+use std::cell::Cell;
+use std::io::IsTerminal as _;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::{Confirm, Input, Password, Select};
+use runtime_cloud_connect::enroll::{
+    EnrollNowOutcome, EnrollmentAuthority, InstanceFacts, RetryPolicy, SessionToken,
+};
+use runtime_cloud_connect::enrollment_key::EnrollmentKey;
+use runtime_cloud_connect::identity::{AppAttachment, Identity, IdentityStore};
+use runtime_cloud_connect::{CloudConnectConfig, EnrollmentTransactionLock};
+
+use crate::commands::cloud::{CloudClient, org as cloud_org};
+use crate::commands::login::connect_org::{
+    OrgResolution, resolve_connect_organization_with_client,
+};
+use crate::commands::login::session::{CredentialStore, LoginContinuation, login_inline};
+use crate::context::RuntimeContext;
+use crate::error::{CloudErrorCode, Error, Result};
+
+use super::naming::{collision_suggestion, initial_suggestion, validate_project_name};
+use super::project::{ProjectAttachment, ProjectClient, ProjectMutation};
+use super::state::{ConnectLock, ConnectOperation, ProjectOperation};
+
+pub(super) struct ConnectRequest {
+    pub org: Option<String>,
+    pub project: Option<String>,
+    pub token: Option<EnrollmentKey>,
+    pub region: Option<String>,
+    pub dir: Option<PathBuf>,
+    pub endpoint: Option<String>,
+}
+
+struct EnrollmentResult {
+    identity: Identity,
+    recovery_url: Option<String>,
+    already_enrolled: bool,
+}
+
+struct TransactionEndpoint {
+    value: String,
+    persist_file: bool,
+    permits_stored_credentials: bool,
+}
+
+const PROJECT_RETRY_DEADLINE: Duration = Duration::from_secs(30);
+const PROJECT_MAX_ATTEMPTS: u32 = 5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthChoice {
+    Login,
+    EnrollmentKey,
+}
+
+trait Prompter {
+    fn interactive(&self) -> bool;
+    async fn choose_auth(&mut self) -> Result<Option<AuthChoice>>;
+    async fn read_enrollment_key(&mut self, portal_url: &str) -> Result<Option<String>>;
+    async fn confirm_project_assignment(&mut self) -> Result<Option<bool>>;
+    async fn project_name(&mut self, suggestion: &str) -> Result<Option<String>>;
+}
+
+struct TerminalPrompter {
+    interactive: bool,
+}
+
+impl TerminalPrompter {
+    fn new() -> Self {
+        Self {
+            interactive: std::io::stdin().is_terminal(),
+        }
+    }
+}
+
+impl Prompter for TerminalPrompter {
+    fn interactive(&self) -> bool {
+        self.interactive
+    }
+
+    async fn choose_auth(&mut self) -> Result<Option<AuthChoice>> {
+        let result = tokio::task::spawn_blocking(|| {
+            Select::with_theme(&ColorfulTheme::default())
+                .with_prompt("Connect this directory to Spice Cloud")
+                .items([
+                    "Log in to Spice Cloud (recommended)",
+                    "Use an enrollment key",
+                ])
+                .default(0)
+                .interact_opt()
+        })
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("authentication-choice task panicked: {source}"),
+        })?;
+        map_optional_prompt(result, "authentication choice").map(|choice| {
+            choice.map(|index| {
+                if index == 0 {
+                    AuthChoice::Login
+                } else {
+                    AuthChoice::EnrollmentKey
+                }
+            })
+        })
+    }
+
+    async fn read_enrollment_key(&mut self, portal_url: &str) -> Result<Option<String>> {
+        println!("Open this URL to create or copy an enrollment key:");
+        println!("{portal_url}");
+        println!();
+        let open_url = portal_url.to_string();
+        tokio::task::spawn_blocking(move || {
+            // The printed URL is authoritative recovery when the platform has
+            // no opener or the opener fails.
+            let _ = system_open::that(open_url);
+        });
+        let result = tokio::task::spawn_blocking(|| {
+            Password::with_theme(&ColorfulTheme::default())
+                .with_prompt("Enrollment key")
+                .interact()
+        })
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("enrollment-key prompt task panicked: {source}"),
+        })?;
+        map_required_prompt(result, "enrollment key")
+    }
+
+    async fn confirm_project_assignment(&mut self) -> Result<Option<bool>> {
+        let result = tokio::task::spawn_blocking(|| {
+            Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt("Create a project for this instance now?")
+                .default(false)
+                .interact_opt()
+        })
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("project confirmation task panicked: {source}"),
+        })?;
+        map_optional_prompt(result, "project confirmation")
+    }
+
+    async fn project_name(&mut self, suggestion: &str) -> Result<Option<String>> {
+        let suggestion = suggestion.to_string();
+        let result = tokio::task::spawn_blocking(move || {
+            Input::<String>::with_theme(&ColorfulTheme::default())
+                .with_prompt("Project name")
+                .default(suggestion)
+                .allow_empty(false)
+                .interact_text()
+        })
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("project-name prompt task panicked: {source}"),
+        })?;
+        map_required_prompt(result, "project name")
+    }
+}
+
+fn map_optional_prompt<T>(result: dialoguer::Result<Option<T>>, what: &str) -> Result<Option<T>> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(dialoguer::Error::IO(source))
+            if matches!(
+                source.kind(),
+                std::io::ErrorKind::Interrupted | std::io::ErrorKind::UnexpectedEof
+            ) =>
+        {
+            Ok(None)
+        }
+        Err(source) => Err(Error::CloudConnectIo {
+            message: format!("read {what}: {source}"),
+        }),
+    }
+}
+
+fn map_required_prompt<T>(result: dialoguer::Result<T>, what: &str) -> Result<Option<T>> {
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(dialoguer::Error::IO(source))
+            if matches!(
+                source.kind(),
+                std::io::ErrorKind::Interrupted | std::io::ErrorKind::UnexpectedEof
+            ) =>
+        {
+            Ok(None)
+        }
+        Err(source) => Err(Error::CloudConnectIo {
+            message: format!("read {what}: {source}"),
+        }),
+    }
+}
+
+struct LoginCredential {
+    token: SessionToken,
+    credential_org: Option<String>,
+}
+
+struct FlowTelemetry {
+    auth_path: Cell<&'static str>,
+    completion: Cell<&'static str>,
+    failure_stage: Cell<&'static str>,
+}
+
+impl FlowTelemetry {
+    fn new() -> Self {
+        Self {
+            auth_path: Cell::new("unknown"),
+            completion: Cell::new("failed"),
+            failure_stage: Cell::new("initialization"),
+        }
+    }
+
+    fn auth(&self, path: &'static str) {
+        self.auth_path.set(path);
+    }
+
+    fn stage(&self, stage: &'static str) {
+        self.failure_stage.set(stage);
+    }
+
+    fn complete(&self, outcome: &'static str) {
+        self.completion.set(outcome);
+        self.failure_stage.set("none");
+    }
+}
+
+impl Drop for FlowTelemetry {
+    fn drop(&mut self) {
+        tracing::debug!(
+            target: "spice_cli::connect",
+            auth_path = self.auth_path.get(),
+            completion = self.completion.get(),
+            failure_stage = self.failure_stage.get(),
+            "Spice Connect flow completed"
+        );
+    }
+}
+
+pub(super) async fn execute(ctx: &RuntimeContext, request: ConnectRequest) -> Result<()> {
+    execute_with(ctx, request, &mut TerminalPrompter::new()).await
+}
+
+async fn execute_with<P: Prompter>(
+    ctx: &RuntimeContext,
+    request: ConnectRequest,
+    prompter: &mut P,
+) -> Result<()> {
+    let telemetry = FlowTelemetry::new();
+    preflight_request(&request)?;
+    telemetry.stage("local_state");
+    let directory = canonical_instance_directory(request.dir.as_deref()).await?;
+    let config_dir = CloudConnectConfig::resolve_config_dir(Some(&directory));
+    let identity_path = config_dir.join(runtime_cloud_connect::config::IDENTITY_FILE);
+    if !prompter.interactive()
+        && request.token.is_none()
+        && (request.org.is_none() || request.project.is_none())
+        && !identity_path.exists()
+    {
+        return Err(invalid_usage(
+            "non-interactive Cloud Connect requires either a login with --org <org> --project <name>, or --token <enrollment-key>.",
+        ));
+    }
+    let _lock = ConnectLock::acquire(&config_dir, "connect")
+        .await
+        .map_err(|error| state_error(&error))?;
+    let identity = load_identity(&identity_path).await?;
+    if let Some(identity) = identity.as_ref() {
+        validate_existing_identity(&identity_path, identity)?;
+    }
+    let (draft, _, _) = load_operations(&config_dir).await?;
+    let resolved_endpoint = resolve_transaction_endpoint(
+        &config_dir,
+        request.endpoint.as_deref(),
+        identity.as_ref(),
+        draft.as_ref(),
+    )?;
+    let endpoint = resolved_endpoint.value.clone();
+    reconcile_journal(&config_dir, &directory, &endpoint, identity.as_ref()).await?;
+    let project_operation =
+        reconcile_project_journal(&config_dir, &directory, &endpoint, identity.as_ref()).await?;
+
+    if let Some(identity) = identity {
+        telemetry.auth("existing");
+        return existing_identity_flow(
+            &request,
+            prompter,
+            ExistingIdentityContext {
+                config_dir: &config_dir,
+                directory: &directory,
+                identity_path: &identity_path,
+                endpoint: &endpoint,
+                persist_endpoint_file: resolved_endpoint.persist_file,
+                permits_stored_credentials: resolved_endpoint.permits_stored_credentials,
+                identity,
+                pending_project: project_operation,
+            },
+            &telemetry,
+        )
+        .await;
+    }
+
+    if let Some(key) = request.token {
+        telemetry.auth("token");
+        telemetry.stage("enrollment");
+        let enrolled = enroll(
+            ctx,
+            &config_dir,
+            &directory,
+            &resolved_endpoint,
+            request.region,
+            request.org.clone().unwrap_or_default(),
+            EnrollmentAuthority::Token {
+                key,
+                expected_org: request.org,
+            },
+        )
+        .await?;
+        print_enrollment_result(&enrolled);
+        telemetry.complete(if enrolled.identity.app_id.is_some() {
+            "already_attached"
+        } else {
+            "unattached"
+        });
+        return Ok(());
+    }
+
+    if !prompter.interactive() && (request.org.is_none() || request.project.is_none()) {
+        return Err(invalid_usage(
+            "non-interactive Cloud Connect requires either a login with --org <org> --project <name>, or --token <enrollment-key>.",
+        ));
+    }
+
+    telemetry.stage("authentication");
+    let login = match if resolved_endpoint.permits_stored_credentials {
+        stored_user_login(&endpoint, request.org.as_deref()).await?
+    } else {
+        None
+    } {
+        Some(login) => login,
+        None if !prompter.interactive() => {
+            if !resolved_endpoint.permits_stored_credentials {
+                return Err(legacy_endpoint_requires_explicit_authority(&endpoint));
+            }
+            return Err(invalid_usage(
+                "non-interactive Cloud Connect requires either a login with --org <org> --project <name>, or --token <enrollment-key>.",
+            ));
+        }
+        None => match prompter.choose_auth().await? {
+            Some(AuthChoice::Login) => {
+                if !resolved_endpoint.permits_stored_credentials {
+                    return Err(legacy_endpoint_requires_explicit_authority(&endpoint));
+                }
+                match login_inline(CredentialStore::EnvFile).await? {
+                    LoginContinuation::Authenticated(session) => LoginCredential {
+                        token: SessionToken::new(session.access_token().to_string()),
+                        credential_org: Some(session.org_name().to_string()),
+                    },
+                    LoginContinuation::Cancelled => {
+                        telemetry.complete("cancelled");
+                        return Ok(());
+                    }
+                }
+            }
+            Some(AuthChoice::EnrollmentKey) => {
+                telemetry.auth("token");
+                let Some(raw) = prompter.read_enrollment_key(&connect_portal_url()).await? else {
+                    telemetry.complete("cancelled");
+                    return Ok(());
+                };
+                let key = EnrollmentKey::parse(&raw).map_err(|source| Error::InvalidUsage {
+                    message: source.to_string(),
+                })?;
+                telemetry.stage("enrollment");
+                let enrolled = enroll(
+                    ctx,
+                    &config_dir,
+                    &directory,
+                    &resolved_endpoint,
+                    request.region,
+                    request.org.clone().unwrap_or_default(),
+                    EnrollmentAuthority::Token {
+                        key,
+                        expected_org: request.org,
+                    },
+                )
+                .await?;
+                print_enrollment_result(&enrolled);
+                telemetry.complete(if enrolled.identity.app_id.is_some() {
+                    "already_attached"
+                } else {
+                    "unattached"
+                });
+                return Ok(());
+            }
+            None => {
+                telemetry.complete("cancelled");
+                return Ok(());
+            }
+        },
+    };
+    telemetry.auth("login");
+
+    let management = CloudClient::with_token_for_org_at(
+        login.token.expose_secret().to_string(),
+        None,
+        &endpoint,
+    )?;
+    telemetry.stage("organization_selection");
+    let selected = match resolve_connect_organization_with_client(
+        &management,
+        request.org.as_deref(),
+        login.credential_org.as_deref(),
+        prompter.interactive(),
+    )
+    .await
+    {
+        Ok(OrgResolution::Selected(org)) => org,
+        Ok(OrgResolution::Cancelled) => {
+            telemetry.complete("cancelled");
+            return Ok(());
+        }
+        Err(error)
+            if request.org.is_none()
+                && prompter.interactive()
+                && error.cloud_code() == Some(CloudErrorCode::Forbidden) =>
+        {
+            eprintln!("{error}");
+            eprintln!(
+                "An owner or admin can supply an enrollment key instead; that path enrolls this instance without creating a project."
+            );
+            telemetry.auth("token");
+            let Some(raw) = prompter.read_enrollment_key(&connect_portal_url()).await? else {
+                telemetry.complete("cancelled");
+                return Ok(());
+            };
+            let key = EnrollmentKey::parse(&raw).map_err(|source| Error::InvalidUsage {
+                message: source.to_string(),
+            })?;
+            telemetry.stage("enrollment");
+            let enrolled = enroll(
+                ctx,
+                &config_dir,
+                &directory,
+                &resolved_endpoint,
+                request.region,
+                request.org.clone().unwrap_or_default(),
+                EnrollmentAuthority::Token {
+                    key,
+                    expected_org: request.org,
+                },
+            )
+            .await?;
+            print_enrollment_result(&enrolled);
+            telemetry.complete(if enrolled.identity.app_id.is_some() {
+                "already_attached"
+            } else {
+                "unattached"
+            });
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    };
+
+    telemetry.stage("enrollment");
+    let enrolled = enroll(
+        ctx,
+        &config_dir,
+        &directory,
+        &resolved_endpoint,
+        request.region,
+        selected.name.clone(),
+        EnrollmentAuthority::AuthenticatedSession {
+            access_token: login.token.clone(),
+            org: selected.name.clone(),
+        },
+    )
+    .await?;
+
+    if enrolled.already_enrolled && enrolled.identity.app_id.is_some() {
+        print_attached(&enrolled.identity);
+        telemetry.complete("already_attached");
+        return Ok(());
+    }
+
+    telemetry.stage("project_assignment");
+    let project =
+        project_name_after_enrollment(request.project.as_deref(), &directory, prompter).await?;
+    let Some(project) = project else {
+        print_unattached(&enrolled.identity, enrolled.recovery_url.as_deref());
+        telemetry.complete("unattached");
+        return Ok(());
+    };
+    let assignment = assign_project(
+        ProjectAssignmentContext {
+            endpoint: &endpoint,
+            config_dir: &config_dir,
+            directory: &directory,
+            token: &login.token,
+            organization: &selected.name,
+            identity: &enrolled.identity,
+            recovery_url: enrolled.recovery_url.as_deref(),
+        },
+        project,
+        prompter,
+    )
+    .await?;
+    telemetry.complete(match assignment {
+        ProjectAssignment::Attached => "attached",
+        ProjectAssignment::Cancelled => "cancelled",
+    });
+    Ok(())
+}
+
+struct ExistingIdentityContext<'a> {
+    config_dir: &'a Path,
+    directory: &'a Path,
+    identity_path: &'a Path,
+    endpoint: &'a str,
+    persist_endpoint_file: bool,
+    permits_stored_credentials: bool,
+    identity: Identity,
+    pending_project: Option<ProjectOperation>,
+}
+
+async fn existing_identity_flow<P: Prompter>(
+    request: &ConnectRequest,
+    prompter: &mut P,
+    context: ExistingIdentityContext<'_>,
+    telemetry: &FlowTelemetry,
+) -> Result<()> {
+    let ExistingIdentityContext {
+        config_dir,
+        directory,
+        identity_path,
+        endpoint,
+        persist_endpoint_file,
+        permits_stored_credentials,
+        identity,
+        pending_project,
+    } = context;
+    if identity.app_id.is_some() {
+        if let Some(asserted) = request.org.as_deref() {
+            let stored = identity.org_name.as_deref().ok_or_else(|| {
+                invalid_usage(
+                    "the stored attachment has no organization metadata, so --org cannot be verified.",
+                )
+            })?;
+            if !stored.eq_ignore_ascii_case(asserted) {
+                return Err(invalid_usage(format!(
+                    "this instance is already attached in organization {stored}; --org {asserted} does not match."
+                )));
+            }
+        }
+        if let Some(asserted) = request.project.as_deref() {
+            let stored = identity.app_name.as_deref().ok_or_else(|| {
+                invalid_usage(
+                    "the stored attachment has no project metadata, so --project cannot be verified.",
+                )
+            })?;
+            if stored != asserted {
+                return Err(invalid_usage(format!(
+                    "this instance is already attached to project {stored}; --project {asserted} does not match."
+                )));
+            }
+        }
+        if persist_endpoint_file {
+            persist_endpoint(config_dir, endpoint).await?;
+        }
+        print_attached(&identity);
+        telemetry.complete("already_attached");
+        return Ok(());
+    }
+
+    let fixed_org = identity
+        .org_name
+        .as_deref()
+        .filter(|org| !org.is_empty())
+        .ok_or_else(|| Error::CloudConnectIo {
+            message: format!(
+                "the existing unattached identity at {} has no Cloud-provided organization metadata; update the runtime and reconnect before assigning a project",
+                identity_path.display()
+            ),
+        })?;
+    if let Some(asserted) = request.org.as_deref()
+        && !asserted.eq_ignore_ascii_case(fixed_org)
+    {
+        return Err(invalid_usage(format!(
+            "this instance is enrolled in organization {fixed_org}, not {asserted}. Run `spice connect remove` before enrolling it into another organization."
+        )));
+    }
+
+    if let Some(pending) = pending_project.as_ref() {
+        if !pending.organization.eq_ignore_ascii_case(fixed_org)
+            || pending.request.instance_id != identity.identifier
+        {
+            return Err(Error::CloudConnectIo {
+                message: "the pending project transaction does not match the enrolled identity"
+                    .to_string(),
+            });
+        }
+        if let Some(asserted) = request.project.as_deref()
+            && asserted != pending.request.name
+        {
+            return Err(invalid_usage(format!(
+                "project attachment for {} is already pending; retry that exact project name.",
+                pending.request.name
+            )));
+        }
+    }
+
+    let explicit_project = pending_project
+        .as_ref()
+        .map(|operation| operation.request.name.as_str())
+        .or(request.project.as_deref());
+    if !prompter.interactive() {
+        if explicit_project.is_none() {
+            print_unattached(&identity, None);
+            telemetry.complete("unattached");
+            return Ok(());
+        }
+        if request.org.is_none() && pending_project.is_none() {
+            return Err(invalid_usage(
+                "non-interactive project setup requires both --org <org> and --project <name>.",
+            ));
+        }
+    }
+
+    if persist_endpoint_file {
+        persist_endpoint(config_dir, endpoint).await?;
+    }
+
+    telemetry.stage("authentication");
+    if !permits_stored_credentials {
+        return Err(legacy_endpoint_requires_explicit_authority(endpoint));
+    }
+    let mut login = stored_user_login(endpoint, Some(fixed_org)).await?;
+    if login.is_none() && prompter.interactive() {
+        login = match login_inline(CredentialStore::EnvFile).await? {
+            LoginContinuation::Authenticated(session) => Some(LoginCredential {
+                token: SessionToken::new(session.access_token().to_string()),
+                credential_org: Some(session.org_name().to_string()),
+            }),
+            LoginContinuation::Cancelled => {
+                print_unattached(&identity, None);
+                telemetry.complete("cancelled");
+                return Ok(());
+            }
+        };
+    }
+    let Some(login) = login else {
+        return Err(org_credential_missing(fixed_org));
+    };
+    if let Some(credential_org) = login.credential_org.as_deref()
+        && !credential_org.eq_ignore_ascii_case(fixed_org)
+    {
+        return Err(org_credential_wrong_org(fixed_org, credential_org));
+    }
+    let token = login.token;
+    telemetry.auth("login");
+    if explicit_project.is_none() {
+        let confirmed = prompter.confirm_project_assignment().await?;
+        if confirmed != Some(true) {
+            print_unattached(&identity, None);
+            telemetry.complete(if confirmed.is_none() {
+                "cancelled"
+            } else {
+                "unattached"
+            });
+            return Ok(());
+        }
+    }
+
+    telemetry.stage("project_assignment");
+    let project = project_name_after_enrollment(
+        explicit_project,
+        &super::instance_dir_for(config_dir),
+        prompter,
+    )
+    .await?;
+    let Some(project) = project else {
+        print_unattached(&identity, None);
+        telemetry.complete("cancelled");
+        return Ok(());
+    };
+    let assignment = assign_project(
+        ProjectAssignmentContext {
+            endpoint,
+            config_dir,
+            directory,
+            token: &token,
+            organization: fixed_org,
+            identity: &identity,
+            recovery_url: None,
+        },
+        project,
+        prompter,
+    )
+    .await?;
+    telemetry.complete(match assignment {
+        ProjectAssignment::Attached => "attached",
+        ProjectAssignment::Cancelled => "cancelled",
+    });
+    Ok(())
+}
+
+async fn stored_user_login(
+    endpoint: &str,
+    org_hint: Option<&str>,
+) -> Result<Option<LoginCredential>> {
+    if let Some(org) = org_hint
+        && let Some(token) = cloud_org::token_for_org(org)
+    {
+        return Ok(Some(LoginCredential {
+            token: SessionToken::new(token),
+            credential_org: Some(org.to_string()),
+        }));
+    }
+    let token = cloud_org::default_token();
+    let Some(token) = token else {
+        return Ok(None);
+    };
+    let client = CloudClient::with_token_for_org_at(token.clone(), None, endpoint)?;
+    let Some(context) = client.optional_user_auth_context().await? else {
+        // Service-account credentials have no user auth context. Their
+        // organization is fixed by the issuer and remains server-authorized.
+        return Ok(Some(LoginCredential {
+            token: SessionToken::new(token),
+            credential_org: None,
+        }));
+    };
+    if let Some(org) = org_hint
+        && !context.org_name.eq_ignore_ascii_case(org)
+    {
+        return Err(org_credential_wrong_org(org, &context.org_name));
+    }
+    Ok(Some(LoginCredential {
+        token: SessionToken::new(token),
+        credential_org: (!context.org_name.is_empty()).then_some(context.org_name),
+    }))
+}
+
+fn org_credential_wrong_org(requested: &str, actual: &str) -> Error {
+    Error::cloud_with_hint(
+        CloudErrorCode::OrgCredentialMissing,
+        format!(
+            "No Spice Cloud credential is stored for organization '{requested}'; your selected credential belongs to '{actual}'."
+        ),
+        format!(
+            "Authenticate for it with 'spice cloud login pat --org {requested}' (or 'spice cloud login api --org {requested}' for automation)."
+        ),
+    )
+}
+
+fn org_credential_missing(org: &str) -> Error {
+    Error::cloud_with_hint(
+        CloudErrorCode::OrgCredentialMissing,
+        format!("No Spice Cloud credential is stored for organization '{org}'."),
+        format!(
+            "Authenticate for it with 'spice cloud login pat --org {org}' (or 'spice cloud login api --org {org}' for automation), or set {}.",
+            cloud_org::org_token_var(org)
+        ),
+    )
+}
+
+fn legacy_endpoint_requires_explicit_authority(endpoint: &str) -> Error {
+    invalid_usage(format!(
+        "the repository-local cloud-endpoint file selects {endpoint}, so Spice will not send a stored or newly-created login credential there without explicit authority. Re-run with --endpoint {endpoint}, set SPICE_CLOUD_ENDPOINT, or use --token <enrollment-key>."
+    ))
+}
+
+async fn enroll(
+    ctx: &RuntimeContext,
+    config_dir: &Path,
+    directory: &Path,
+    endpoint: &TransactionEndpoint,
+    region: Option<String>,
+    journal_org: String,
+    authority: EnrollmentAuthority,
+) -> Result<EnrollmentResult> {
+    if let Some(region) = region.as_deref()
+        && !runtime_cloud_connect::is_valid_instance_region(region)
+    {
+        return Err(invalid_usage(format!(
+            "invalid --region value '{region}': expected 2-64 lowercase letters, digits, and hyphens, starting and ending with a letter or digit."
+        )));
+    }
+    let runtime_version = ctx
+        .runtime_version()
+        .unwrap_or_else(|_| crate::commands::version::cli_version());
+    let mut config =
+        CloudConnectConfig::from_env_at(runtime_version.clone(), config_dir.to_path_buf());
+    config.enroll_endpoint.clone_from(&endpoint.value);
+    if endpoint.persist_file {
+        persist_endpoint(config_dir, &endpoint.value).await?;
+    }
+    let endpoint = endpoint.value.as_str();
+
+    let enrollment_transaction = EnrollmentTransactionLock::acquire_async(config_dir)
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("acquire retry-safe enrollment transaction: {source}"),
+        })?;
+
+    let prepare_dir = config_dir.to_path_buf();
+    let canonical_dir = directory.to_path_buf();
+    let journal_endpoint = endpoint.to_string();
+    let draft_binding = runtime_cloud_connect::EnrollmentRequestBinding {
+        endpoint: endpoint.to_string(),
+        authority: match &authority {
+            EnrollmentAuthority::Token { expected_org, .. } => {
+                runtime_cloud_connect::EnrollmentAuthorityBinding::Token {
+                    expected_org: expected_org.clone(),
+                }
+            }
+            EnrollmentAuthority::AuthenticatedSession { org, .. } => {
+                runtime_cloud_connect::EnrollmentAuthorityBinding::AuthenticatedSession {
+                    organization: org.clone(),
+                }
+            }
+        },
+    };
+    let (enrollment_transaction, mut operation) = tokio::task::spawn_blocking(move || {
+        let facts = InstanceFacts::gather(&runtime_version);
+        let draft = enrollment_transaction
+            .load_or_create(&facts, region.as_deref(), &draft_binding)
+            .map_err(|source| Error::CloudConnectIo {
+                message: format!("prepare retry-safe enrollment: {source}"),
+            })?;
+        let operation = ConnectOperation::prepare(
+            &prepare_dir,
+            &canonical_dir,
+            &draft.enrollment_operation_id,
+            &journal_org,
+            &journal_endpoint,
+            region.as_deref(),
+        )
+        .map_err(|error| state_error(&error))?;
+        Ok::<_, Error>((enrollment_transaction, operation))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("enrollment preparation task panicked: {source}"),
+    })??;
+
+    config.instance_region = operation.region.clone();
+    let (identity, recovery_url, already_enrolled) =
+        match runtime_cloud_connect::enroll::enroll_now_with_transaction(
+            &config,
+            &authority,
+            RetryPolicy::INTERACTIVE,
+            enrollment_transaction,
+        )
+        .await
+        .map_err(|source| Error::CloudConnectEnroll {
+            message: source.to_string(),
+        })? {
+            EnrollNowOutcome::AlreadyEnrolled { identity } => (identity, None, true),
+            EnrollNowOutcome::Enrolled { identity, metadata } => {
+                (identity, metadata.new_project_url, false)
+            }
+        };
+
+    let finish_dir = config_dir.to_path_buf();
+    let finish_identity = identity.clone();
+    tokio::task::spawn_blocking(move || {
+        operation
+            .mark_enrolled(&finish_dir, &finish_identity)
+            .map_err(|error| state_error(&error))?;
+        ConnectOperation::delete(&finish_dir).map_err(|error| state_error(&error))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("enrollment journal finalization task panicked: {source}"),
+    })??;
+    Ok(EnrollmentResult {
+        identity,
+        recovery_url,
+        already_enrolled,
+    })
+}
+
+async fn project_name_after_enrollment<P: Prompter>(
+    explicit: Option<&str>,
+    directory: &Path,
+    prompter: &mut P,
+) -> Result<Option<String>> {
+    if let Some(name) = explicit {
+        validate_project_name(name)
+            .map_err(|reason| invalid_usage(format!("invalid --project value: {reason}.")))?;
+        return Ok(Some(name.to_string()));
+    }
+    if !prompter.interactive() {
+        return Err(invalid_usage(
+            "non-interactive project setup requires both --org <org> and --project <name>.",
+        ));
+    }
+
+    let suggestion = initial_suggestion(directory);
+    loop {
+        let Some(name) = prompter.project_name(&suggestion).await? else {
+            return Ok(None);
+        };
+        match validate_project_name(&name) {
+            Ok(()) => return Ok(Some(name)),
+            Err(reason) => eprintln!("Project name {reason}."),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectAssignment {
+    Attached,
+    Cancelled,
+}
+
+struct ProjectAssignmentContext<'a> {
+    endpoint: &'a str,
+    config_dir: &'a Path,
+    directory: &'a Path,
+    token: &'a SessionToken,
+    organization: &'a str,
+    identity: &'a Identity,
+    recovery_url: Option<&'a str>,
+}
+
+async fn assign_project<P: Prompter>(
+    context: ProjectAssignmentContext<'_>,
+    first_name: String,
+    prompter: &mut P,
+) -> Result<ProjectAssignment> {
+    let client = ProjectClient::new(context.endpoint).map_err(|error| project_error(&error))?;
+    let base = first_name.clone();
+    let mut name = first_name;
+    let mut collision_number = 2_u32;
+    let started = Instant::now();
+    let mut retry_attempt = 0_u32;
+
+    loop {
+        let operation = prepare_project_operation(&context, &name).await?;
+        match client
+            .create(context.token, context.organization, &operation.request)
+            .await
+        {
+            Ok(attachment) => {
+                persist_attachment(context.config_dir, &attachment).await?;
+                delete_project_operation(context.config_dir).await?;
+                println!(
+                    "Spice Cloud Connect: connected to {} / {}",
+                    attachment.organization, attachment.project_name
+                );
+                println!("Monitor: {}", attachment.monitor_url);
+                return Ok(ProjectAssignment::Attached);
+            }
+            Err(error) if error.is_name_conflict() && prompter.interactive() => {
+                delete_project_operation(context.config_dir).await?;
+                eprintln!(
+                    "A project named '{name}' already exists. Choose a new name; the existing project was not linked."
+                );
+                let suggestion = collision_suggestion(&base, collision_number);
+                collision_number = collision_number.saturating_add(1);
+                loop {
+                    let Some(next) = prompter.project_name(&suggestion).await? else {
+                        print_unattached(context.identity, context.recovery_url);
+                        return Ok(ProjectAssignment::Cancelled);
+                    };
+                    match validate_project_name(&next) {
+                        Ok(()) => {
+                            name = next;
+                            break;
+                        }
+                        Err(reason) => eprintln!("Project name {reason}."),
+                    }
+                }
+                retry_attempt = 0;
+            }
+            Err(error) if error.is_name_conflict() => {
+                delete_project_operation(context.config_dir).await?;
+                print_unattached(context.identity, context.recovery_url);
+                return Err(project_error(&error));
+            }
+            // The control plane knows this instance has an attachment, but
+            // does not return enough state in this denial to persist it
+            // locally. Never tell the operator it is unattached.
+            Err(error) if error.is_already_attached() => return Err(project_error(&error)),
+            Err(error)
+                if (error.is_retryable() || error.is_attachment_ambiguous())
+                    && retry_attempt + 1 < PROJECT_MAX_ATTEMPTS
+                    && started.elapsed() < PROJECT_RETRY_DEADLINE =>
+            {
+                let exponential = 200_u64
+                    .saturating_mul(1_u64.checked_shl(retry_attempt.min(4)).unwrap_or(u64::MAX));
+                let window_ms = exponential.min(2_000);
+                retry_attempt = retry_attempt.saturating_add(1);
+                let delay = Duration::from_millis(rand::random_range(1..=window_ms));
+                tokio::time::sleep(delay).await;
+            }
+            Err(error) if error.is_authoritative_non_mutation() => {
+                delete_project_operation(context.config_dir).await?;
+                print_unattached(context.identity, context.recovery_url);
+                return Err(project_error(&error));
+            }
+            Err(error) => return Err(ambiguous_project_error(&error)),
+        }
+    }
+}
+
+async fn prepare_project_operation(
+    context: &ProjectAssignmentContext<'_>,
+    project_name: &str,
+) -> Result<ProjectOperation> {
+    let config_dir = context.config_dir.to_path_buf();
+    let directory = context.directory.to_path_buf();
+    let endpoint = context.endpoint.to_string();
+    let organization = context.organization.to_string();
+    let project_name = project_name.to_string();
+    let request = ProjectMutation::signed(context.identity, context.organization, &project_name)
+        .map_err(|error| project_error(&error))?;
+    tokio::task::spawn_blocking(move || {
+        ProjectOperation::prepare(&config_dir, &directory, &endpoint, &organization, request)
+            .map_err(|error| state_error(&error))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("project journal preparation task panicked: {source}"),
+    })?
+}
+
+async fn delete_project_operation(config_dir: &Path) -> Result<()> {
+    let config_dir = config_dir.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        ProjectOperation::delete(&config_dir).map_err(|error| state_error(&error))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("project journal cleanup task panicked: {source}"),
+    })?
+}
+
+async fn persist_attachment(config_dir: &Path, attachment: &ProjectAttachment) -> Result<()> {
+    let identity_path = config_dir.join(runtime_cloud_connect::config::IDENTITY_FILE);
+    let attachment = AppAttachment {
+        app_id: attachment.project_id.to_string(),
+        org_name: Some(attachment.organization.clone()),
+        app_name: Some(attachment.project_name.clone()),
+        monitor_url: Some(attachment.monitor_url.clone()),
+    };
+    tokio::task::spawn_blocking(move || {
+        IdentityStore::set_attachment(&identity_path, Some(&attachment)).map_err(|source| {
+            Error::CloudConnectIo {
+                message: format!("persist project attachment: {source}"),
+            }
+        })
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("project attachment persistence task panicked: {source}"),
+    })??
+    .ok_or_else(|| Error::CloudConnectIo {
+        message: "the enrolled identity disappeared before project attachment was persisted"
+            .to_string(),
+    })?;
+    Ok(())
+}
+
+async fn load_identity(path: &Path) -> Result<Option<Identity>> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking({
+        let path = path.clone();
+        move || IdentityStore::load_optional(&path)
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("identity load task panicked: {source}"),
+    })?
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("load identity at {}: {source}", path.display()),
+    })
+}
+
+fn validate_existing_identity(path: &Path, identity: &Identity) -> Result<()> {
+    if let Some(reason) = identity.reconnect_validation_error() {
+        return Err(Error::CloudConnectIo {
+            message: format!(
+                "the Cloud Connect identity at {} is unusable ({reason}); run `spice connect remove --yes` before enrolling again",
+                path.display()
+            ),
+        });
+    }
+    if identity.is_expired() {
+        return Err(Error::CloudConnectIo {
+            message: format!(
+                "the Cloud Connect identity at {} is expired; start spiced to renew it before assigning or reporting a project",
+                path.display()
+            ),
+        });
+    }
+    for (field, value) in [
+        ("organization", identity.org_name.as_deref()),
+        ("project", identity.app_name.as_deref()),
+    ] {
+        if value.is_some_and(|value| value.chars().any(char::is_control)) {
+            return Err(Error::CloudConnectIo {
+                message: format!(
+                    "the Cloud Connect identity at {} has unsafe {field} metadata",
+                    path.display()
+                ),
+            });
+        }
+    }
+    if identity
+        .monitor_url
+        .as_deref()
+        .is_some_and(|url| safe_recovery_url(url).is_none())
+    {
+        return Err(Error::CloudConnectIo {
+            message: format!(
+                "the Cloud Connect identity at {} has an unsafe monitor URL",
+                path.display()
+            ),
+        });
+    }
+    Ok(())
+}
+
+async fn load_operations(
+    config_dir: &Path,
+) -> Result<(
+    Option<runtime_cloud_connect::EnrollmentDraft>,
+    Option<ConnectOperation>,
+    Option<ProjectOperation>,
+)> {
+    let config_dir = config_dir.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let draft = runtime_cloud_connect::EnrollmentDraft::load_optional(&config_dir).map_err(
+            |source| Error::CloudConnectIo {
+                message: format!("load enrollment draft: {source}"),
+            },
+        )?;
+        let enrollment =
+            ConnectOperation::load_optional(&config_dir).map_err(|error| state_error(&error))?;
+        let project =
+            ProjectOperation::load_optional(&config_dir).map_err(|error| state_error(&error))?;
+        Ok::<_, Error>((draft, enrollment, project))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("Cloud Connect journal load task panicked: {source}"),
+    })?
+}
+
+fn resolve_transaction_endpoint(
+    config_dir: &Path,
+    explicit: Option<&str>,
+    identity: Option<&Identity>,
+    draft: Option<&runtime_cloud_connect::EnrollmentDraft>,
+) -> Result<TransactionEndpoint> {
+    let environment = std::env::var("SPICE_CLOUD_ENDPOINT").ok();
+    resolve_transaction_endpoint_with_env(
+        config_dir,
+        explicit,
+        environment.as_deref(),
+        identity,
+        draft,
+    )
+}
+
+fn resolve_transaction_endpoint_with_env(
+    config_dir: &Path,
+    explicit: Option<&str>,
+    environment: Option<&str>,
+    identity: Option<&Identity>,
+    draft: Option<&runtime_cloud_connect::EnrollmentDraft>,
+) -> Result<TransactionEndpoint> {
+    let requested = explicit
+        .filter(|endpoint| !endpoint.is_empty())
+        .or_else(|| environment.filter(|endpoint| !endpoint.is_empty()))
+        .map(normalize_control_plane_endpoint)
+        .transpose()?;
+    let bound = identity
+        .and_then(|identity| identity.control_plane_endpoint.as_deref())
+        .or_else(|| draft.map(|draft| draft.binding.endpoint.as_str()))
+        .map(normalize_control_plane_endpoint)
+        .transpose()?;
+    if let (Some(requested), Some(bound)) = (requested.as_deref(), bound.as_deref())
+        && requested != bound
+    {
+        return Err(invalid_usage(format!(
+            "--endpoint {requested} does not match this pending or enrolled instance's control plane {bound}."
+        )));
+    }
+    if let Some(value) = requested {
+        return Ok(TransactionEndpoint {
+            value,
+            persist_file: true,
+            permits_stored_credentials: true,
+        });
+    }
+    if let Some(value) = bound {
+        return Ok(TransactionEndpoint {
+            value,
+            persist_file: true,
+            permits_stored_credentials: true,
+        });
+    }
+
+    let legacy = CloudConnectConfig::read_normalized_enroll_endpoint_override(config_dir).map_err(
+        |source| Error::CloudConnectIo {
+            message: source.to_string(),
+        },
+    )?;
+    let permits_stored_credentials = legacy.is_none();
+    Ok(TransactionEndpoint {
+        value: legacy
+            .unwrap_or_else(|| runtime_cloud_connect::config::DEFAULT_ENDPOINT.to_string()),
+        // The legacy file already contains its operator-authored value, while
+        // the compiled default needs no state file. Only an explicit request
+        // or durable binding is eligible to create/replace this file.
+        persist_file: false,
+        permits_stored_credentials,
+    })
+}
+
+async fn reconcile_journal(
+    config_dir: &Path,
+    directory: &Path,
+    endpoint: &str,
+    identity: Option<&Identity>,
+) -> Result<()> {
+    let config_dir = config_dir.to_path_buf();
+    let directory = directory.to_path_buf();
+    let endpoint = endpoint.to_string();
+    let identity = identity.cloned();
+    tokio::task::spawn_blocking(move || {
+        ConnectOperation::reconcile(&config_dir, &directory, &endpoint, identity.as_ref())
+            .map_err(|error| state_error(&error))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("enrollment journal reconciliation task panicked: {source}"),
+    })?
+}
+
+async fn reconcile_project_journal(
+    config_dir: &Path,
+    directory: &Path,
+    endpoint: &str,
+    identity: Option<&Identity>,
+) -> Result<Option<ProjectOperation>> {
+    let config_dir = config_dir.to_path_buf();
+    let directory = directory.to_path_buf();
+    let endpoint = endpoint.to_string();
+    let identity = identity.cloned();
+    tokio::task::spawn_blocking(move || {
+        ProjectOperation::reconcile(&config_dir, &directory, &endpoint, identity.as_ref())
+            .map_err(|error| state_error(&error))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("project journal reconciliation task panicked: {source}"),
+    })?
+}
+
+async fn persist_endpoint(config_dir: &Path, endpoint: &str) -> Result<()> {
+    let path = config_dir.join(super::CLOUD_ENDPOINT_FILE);
+    let endpoint = endpoint.to_string();
+    tokio::task::spawn_blocking(move || {
+        super::state::atomic_write_owner_only(&path, format!("{endpoint}\n").as_bytes())
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("endpoint persistence task panicked: {source}"),
+    })?
+    .map_err(|error| state_error(&error))
+}
+
+async fn canonical_instance_directory(explicit: Option<&Path>) -> Result<PathBuf> {
+    let directory = match explicit {
+        Some(directory) => directory.to_path_buf(),
+        None => std::env::current_dir().map_err(|source| Error::CloudConnectIo {
+            message: format!("resolve current instance directory: {source}"),
+        })?,
+    };
+    let reported = directory.clone();
+    tokio::task::spawn_blocking(move || std::fs::canonicalize(directory))
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("directory canonicalization task panicked: {source}"),
+        })?
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!(
+                "canonicalize instance directory {}: {source}",
+                reported.display()
+            ),
+        })
+}
+
+fn connect_portal_url() -> String {
+    format!(
+        "{}/connect",
+        crate::commands::login::spice_base_url().trim_end_matches('/')
+    )
+}
+
+fn normalize_control_plane_endpoint(endpoint: &str) -> Result<String> {
+    runtime_cloud_connect::config::normalize_control_plane_endpoint(endpoint)
+        .map_err(|source| invalid_usage(format!("invalid --endpoint: {source}.")))
+}
+
+#[cfg(test)]
+fn validate_control_plane_endpoint(endpoint: &str) -> Result<()> {
+    normalize_control_plane_endpoint(endpoint).map(|_| ())
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    let host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
+fn print_unattached(identity: &Identity, recovery_url: Option<&str>) {
+    let org = identity.org_name.as_deref().unwrap_or("Spice Cloud");
+    println!("Spice Cloud Connect: connected to {org} — not yet attached to a project");
+    let recovery_url = recovery_url
+        .and_then(safe_recovery_url)
+        .unwrap_or_else(connect_portal_url);
+    println!("Create one: {recovery_url}");
+}
+
+fn print_enrollment_result(enrolled: &EnrollmentResult) {
+    if enrolled.identity.app_id.is_some() {
+        print_attached(&enrolled.identity);
+    } else {
+        print_unattached(&enrolled.identity, enrolled.recovery_url.as_deref());
+    }
+}
+
+fn safe_recovery_url(candidate: &str) -> Option<String> {
+    let parsed = reqwest::Url::parse(candidate).ok()?;
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return None;
+    }
+    let local_http = parsed.scheme() == "http" && parsed.host_str().is_some_and(is_loopback_host);
+    if parsed.scheme() != "https" && !local_http {
+        return None;
+    }
+    Some(parsed.to_string())
+}
+
+fn preflight_request(request: &ConnectRequest) -> Result<()> {
+    if request.token.is_some() && request.project.is_some() {
+        return Err(invalid_usage(
+            "--project cannot be used with --token; an enrollment key can enroll an instance but cannot create a project.",
+        ));
+    }
+    if let Some(project) = request.project.as_deref() {
+        validate_project_name(project)
+            .map_err(|reason| invalid_usage(format!("invalid --project value: {reason}.")))?;
+    }
+    if let Some(org) = request.org.as_deref() {
+        cloud_org::validate_org_name(org)?;
+    }
+    if let Some(region) = request.region.as_deref()
+        && !runtime_cloud_connect::is_valid_instance_region(region)
+    {
+        return Err(invalid_usage(format!(
+            "invalid --region value '{region}': expected 2-64 lowercase letters, digits, and hyphens, starting and ending with a letter or digit."
+        )));
+    }
+    if let Some(endpoint) = request.endpoint.as_deref() {
+        normalize_control_plane_endpoint(endpoint)?;
+    }
+    if request.endpoint.is_none()
+        && let Ok(endpoint) = std::env::var("SPICE_CLOUD_ENDPOINT")
+        && !endpoint.is_empty()
+    {
+        normalize_control_plane_endpoint(&endpoint)?;
+    }
+    Ok(())
+}
+
+fn print_attached(identity: &Identity) {
+    let org = identity.org_name.as_deref().unwrap_or("Spice Cloud");
+    let project = identity.app_name.as_deref().unwrap_or("attached project");
+    println!("Spice Cloud Connect: connected to {org} / {project}");
+    if let Some(url) = identity.monitor_url.as_deref() {
+        println!("Monitor: {url}");
+    }
+}
+
+fn invalid_usage(message: impl Into<String>) -> Error {
+    Error::InvalidUsage {
+        message: message.into(),
+    }
+}
+
+fn state_error(source: &super::state::Error) -> Error {
+    Error::CloudConnectIo {
+        message: source.to_string(),
+    }
+}
+
+fn project_error(source: &super::project::Error) -> Error {
+    Error::CloudConnectProject {
+        message: source.to_string(),
+    }
+}
+
+fn ambiguous_project_error(source: &super::project::Error) -> Error {
+    Error::CloudConnectProject {
+        message: format!(
+            "{source}. The attachment result is unknown because the server may have committed the request before the response failed. Retry the exact same command to reconcile it; do not create another project."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ScriptedPrompter {
+        interactive: bool,
+        auth: Option<AuthChoice>,
+        key: Option<String>,
+        confirm: Option<bool>,
+        names: std::collections::VecDeque<Option<String>>,
+    }
+
+    impl Prompter for ScriptedPrompter {
+        fn interactive(&self) -> bool {
+            self.interactive
+        }
+
+        async fn choose_auth(&mut self) -> Result<Option<AuthChoice>> {
+            Ok(self.auth.take())
+        }
+
+        async fn read_enrollment_key(&mut self, _portal_url: &str) -> Result<Option<String>> {
+            Ok(self.key.take())
+        }
+
+        async fn confirm_project_assignment(&mut self) -> Result<Option<bool>> {
+            Ok(self.confirm.take())
+        }
+
+        async fn project_name(&mut self, _suggestion: &str) -> Result<Option<String>> {
+            Ok(self.names.pop_front().flatten())
+        }
+    }
+
+    #[tokio::test]
+    async fn scripted_auth_choice_has_exact_two_paths() {
+        let mut prompt = ScriptedPrompter {
+            interactive: true,
+            auth: Some(AuthChoice::Login),
+            key: None,
+            confirm: None,
+            names: std::collections::VecDeque::new(),
+        };
+        assert_eq!(
+            prompt.choose_auth().await.expect("choice"),
+            Some(AuthChoice::Login)
+        );
+        prompt.auth = Some(AuthChoice::EnrollmentKey);
+        assert_eq!(
+            prompt.choose_auth().await.expect("choice"),
+            Some(AuthChoice::EnrollmentKey)
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_and_eof_are_clean_prompt_outcomes() {
+        let mut prompt = ScriptedPrompter {
+            interactive: true,
+            auth: None,
+            key: None,
+            confirm: None,
+            names: std::collections::VecDeque::from([None]),
+        };
+        assert_eq!(prompt.choose_auth().await.expect("cancel"), None);
+        assert_eq!(
+            prompt.project_name("steady-spice").await.expect("eof"),
+            None
+        );
+    }
+
+    #[test]
+    fn terminal_prompt_interrupt_and_eof_map_to_clean_cancellation() {
+        for kind in [
+            std::io::ErrorKind::Interrupted,
+            std::io::ErrorKind::UnexpectedEof,
+        ] {
+            let optional = map_optional_prompt::<usize>(
+                Err(dialoguer::Error::IO(std::io::Error::from(kind))),
+                "test prompt",
+            )
+            .expect("cancellation is not an error");
+            assert_eq!(optional, None);
+            let required = map_required_prompt::<String>(
+                Err(dialoguer::Error::IO(std::io::Error::from(kind))),
+                "test prompt",
+            )
+            .expect("cancellation is not an error");
+            assert_eq!(required, None);
+        }
+    }
+
+    #[test]
+    fn telemetry_vocabulary_contains_no_customer_values() {
+        let telemetry = FlowTelemetry::new();
+        telemetry.auth("login");
+        telemetry.stage("project_assignment");
+        assert_eq!(telemetry.auth_path.get(), "login");
+        assert_eq!(telemetry.failure_stage.get(), "project_assignment");
+    }
+
+    #[test]
+    fn control_plane_endpoint_requires_https_except_for_loopback_fixtures() {
+        for valid in [
+            "https://api.spice.ai",
+            "https://cloud.example.test/api",
+            "http://127.0.0.1:8090",
+            "http://[::1]:8090",
+            "http://localhost:8090",
+        ] {
+            validate_control_plane_endpoint(valid).expect("valid control-plane URL");
+        }
+        for invalid in [
+            "not-a-url",
+            "http://cloud.example.test",
+            "ftp://127.0.0.1/file",
+            "https://user:secret@cloud.example.test",
+            "https://cloud.example.test?token=secret",
+            "https://cloud.example.test#fragment",
+        ] {
+            validate_control_plane_endpoint(invalid).expect_err("unsafe URL must fail");
+        }
+    }
+
+    #[test]
+    fn explicit_project_and_region_are_validated_before_mutation() {
+        let request = ConnectRequest {
+            org: Some("acme".to_string()),
+            project: Some("INVALID PROJECT".to_string()),
+            token: None,
+            region: Some("lab-seoul".to_string()),
+            dir: None,
+            endpoint: None,
+        };
+        assert!(preflight_request(&request).is_err());
+
+        let request = ConnectRequest {
+            project: Some("valid-project".to_string()),
+            region: Some("INVALID_REGION".to_string()),
+            ..request
+        };
+        assert!(preflight_request(&request).is_err());
+    }
+
+    #[test]
+    fn fresh_transactions_use_the_compiled_endpoint_without_a_binding() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fresh = resolve_transaction_endpoint_with_env(dir.path(), None, None, None, None)
+            .expect("resolve fresh endpoint");
+        assert_eq!(fresh.value, runtime_cloud_connect::config::DEFAULT_ENDPOINT);
+        assert!(!fresh.persist_file);
+        assert!(fresh.permits_stored_credentials);
+    }
+
+    #[test]
+    fn fresh_transactions_honor_but_do_not_rewrite_the_legacy_endpoint() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        std::fs::write(
+            dir.path().join("cloud-endpoint"),
+            "https://private.example/\n",
+        )
+        .expect("write endpoint override");
+        let resolved = resolve_transaction_endpoint_with_env(dir.path(), None, None, None, None)
+            .expect("resolve legacy endpoint");
+        assert_eq!(resolved.value, "https://private.example");
+        assert!(!resolved.persist_file);
+        assert!(!resolved.permits_stored_credentials);
+    }
+
+    #[test]
+    fn unsafe_cloud_recovery_urls_are_never_opened_or_printed() {
+        assert_eq!(
+            safe_recovery_url("https://spice.ai/connect").as_deref(),
+            Some("https://spice.ai/connect")
+        );
+        assert_eq!(
+            safe_recovery_url("http://127.0.0.1:8080/connect").as_deref(),
+            Some("http://127.0.0.1:8080/connect")
+        );
+        for unsafe_url in [
+            "javascript:alert(1)",
+            "http://attacker.example/connect",
+            "https://user:secret@spice.ai/connect",
+        ] {
+            assert_eq!(safe_recovery_url(unsafe_url), None);
+        }
+    }
+}

--- a/bin/spice/src/commands/connect/transaction.rs
+++ b/bin/spice/src/commands/connect/transaction.rs
@@ -23,6 +23,7 @@ use std::time::{Duration, Instant};
 
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Confirm, Input, Password, Select};
+use runtime_cloud_connect::config::is_loopback_host;
 use runtime_cloud_connect::enroll::{
     EnrollNowOutcome, EnrollmentAuthority, InstanceFacts, RetryPolicy, SessionToken,
 };
@@ -40,7 +41,7 @@ use crate::error::{CloudErrorCode, Error, Result};
 
 use super::naming::{collision_suggestion, initial_suggestion, validate_project_name};
 use super::project::{ProjectAttachment, ProjectClient, ProjectMutation};
-use super::state::{ConnectLock, ConnectOperation, ProjectOperation};
+use super::state::{ConnectLock, ConnectOperation, IdentityFacts, ProjectOperation};
 
 pub(super) struct ConnectRequest {
     pub org: Option<String>,
@@ -57,10 +58,43 @@ struct EnrollmentResult {
     already_enrolled: bool,
 }
 
+/// How the control plane for this transaction was chosen. Both downstream
+/// rules are functions of this, so the source is carried instead of the
+/// derived flags — that keeps "persist a file we were never given" and
+/// "withhold a credential we are allowed to send" unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EndpointSource {
+    /// `--endpoint` or `SPICE_CLOUD_ENDPOINT`.
+    Explicit,
+    /// The durable identity or pending draft binding.
+    Bound,
+    /// The operator-authored instance-local `cloud-endpoint` file.
+    LegacyFile,
+    /// No binding, no override: the compiled-in public control plane.
+    CompiledDefault,
+}
+
 struct TransactionEndpoint {
     value: String,
-    persist_file: bool,
-    permits_stored_credentials: bool,
+    source: EndpointSource,
+}
+
+impl TransactionEndpoint {
+    /// Only an explicit request or a durable binding is eligible to create or
+    /// replace the endpoint file: the legacy file already holds its own value,
+    /// and the compiled default needs no state file at all.
+    fn persist_file(&self) -> bool {
+        matches!(
+            self.source,
+            EndpointSource::Explicit | EndpointSource::Bound
+        )
+    }
+
+    /// A repo-local `cloud-endpoint` file does not authorize sending a stored
+    /// login credential to the control plane it names.
+    fn permits_stored_credentials(&self) -> bool {
+        !matches!(self.source, EndpointSource::LegacyFile)
+    }
 }
 
 const PROJECT_RETRY_DEADLINE: Duration = Duration::from_secs(30);
@@ -193,21 +227,10 @@ fn map_optional_prompt<T>(result: dialoguer::Result<Option<T>>, what: &str) -> R
     }
 }
 
+/// The same interrupt/EOF-to-cancellation mapping for a prompt whose success
+/// value is unconditional.
 fn map_required_prompt<T>(result: dialoguer::Result<T>, what: &str) -> Result<Option<T>> {
-    match result {
-        Ok(value) => Ok(Some(value)),
-        Err(dialoguer::Error::IO(source))
-            if matches!(
-                source.kind(),
-                std::io::ErrorKind::Interrupted | std::io::ErrorKind::UnexpectedEof
-            ) =>
-        {
-            Ok(None)
-        }
-        Err(source) => Err(Error::CloudConnectIo {
-            message: format!("read {what}: {source}"),
-        }),
-    }
+    map_optional_prompt(result.map(Some), what)
 }
 
 struct LoginCredential {
@@ -309,8 +332,8 @@ async fn execute_with<P: Prompter>(
                 directory: &directory,
                 identity_path: &identity_path,
                 endpoint: &endpoint,
-                persist_endpoint_file: resolved_endpoint.persist_file,
-                permits_stored_credentials: resolved_endpoint.permits_stored_credentials,
+                persist_endpoint_file: resolved_endpoint.persist_file(),
+                permits_stored_credentials: resolved_endpoint.permits_stored_credentials(),
                 identity,
                 pending_project: project_operation,
             },
@@ -351,14 +374,14 @@ async fn execute_with<P: Prompter>(
     }
 
     telemetry.stage("authentication");
-    let login = match if resolved_endpoint.permits_stored_credentials {
+    let login = match if resolved_endpoint.permits_stored_credentials() {
         stored_user_login(&endpoint, request.org.as_deref()).await?
     } else {
         None
     } {
         Some(login) => login,
         None if !prompter.interactive() => {
-            if !resolved_endpoint.permits_stored_credentials {
+            if !resolved_endpoint.permits_stored_credentials() {
                 return Err(legacy_endpoint_requires_explicit_authority(&endpoint));
             }
             return Err(invalid_usage(
@@ -367,7 +390,7 @@ async fn execute_with<P: Prompter>(
         }
         None => match prompter.choose_auth().await? {
             Some(AuthChoice::Login) => {
-                if !resolved_endpoint.permits_stored_credentials {
+                if !resolved_endpoint.permits_stored_credentials() {
                     return Err(legacy_endpoint_requires_explicit_authority(&endpoint));
                 }
                 match login_inline(CredentialStore::EnvFile).await? {
@@ -797,20 +820,13 @@ async fn enroll(
     journal_org: String,
     authority: EnrollmentAuthority,
 ) -> Result<EnrollmentResult> {
-    if let Some(region) = region.as_deref()
-        && !runtime_cloud_connect::is_valid_instance_region(region)
-    {
-        return Err(invalid_usage(format!(
-            "invalid --region value '{region}': expected 2-64 lowercase letters, digits, and hyphens, starting and ending with a letter or digit."
-        )));
-    }
     let runtime_version = ctx
         .runtime_version()
         .unwrap_or_else(|_| crate::commands::version::cli_version());
     let mut config =
         CloudConnectConfig::from_env_at(runtime_version.clone(), config_dir.to_path_buf());
     config.enroll_endpoint.clone_from(&endpoint.value);
-    if endpoint.persist_file {
+    if endpoint.persist_file() {
         persist_endpoint(config_dir, &endpoint.value).await?;
     }
     let endpoint = endpoint.value.as_str();
@@ -1003,7 +1019,7 @@ async fn assign_project<P: Prompter>(
             // locally. Never tell the operator it is unattached.
             Err(error) if error.is_already_attached() => return Err(project_error(&error)),
             Err(error)
-                if (error.is_retryable() || error.is_attachment_ambiguous())
+                if error.is_attachment_ambiguous()
                     && retry_attempt + 1 < PROJECT_MAX_ATTEMPTS
                     && started.elapsed() < PROJECT_RETRY_DEADLINE =>
             {
@@ -1014,7 +1030,7 @@ async fn assign_project<P: Prompter>(
                 let delay = Duration::from_millis(rand::random_range(1..=window_ms));
                 tokio::time::sleep(delay).await;
             }
-            Err(error) if error.is_authoritative_non_mutation() => {
+            Err(error) if !error.is_attachment_ambiguous() => {
                 delete_project_operation(context.config_dir).await?;
                 print_unattached(context.identity, context.recovery_url);
                 return Err(project_error(&error));
@@ -1211,15 +1227,13 @@ fn resolve_transaction_endpoint_with_env(
     if let Some(value) = requested {
         return Ok(TransactionEndpoint {
             value,
-            persist_file: true,
-            permits_stored_credentials: true,
+            source: EndpointSource::Explicit,
         });
     }
     if let Some(value) = bound {
         return Ok(TransactionEndpoint {
             value,
-            persist_file: true,
-            permits_stored_credentials: true,
+            source: EndpointSource::Bound,
         });
     }
 
@@ -1228,15 +1242,15 @@ fn resolve_transaction_endpoint_with_env(
             message: source.to_string(),
         },
     )?;
-    let permits_stored_credentials = legacy.is_none();
-    Ok(TransactionEndpoint {
-        value: legacy
-            .unwrap_or_else(|| runtime_cloud_connect::config::DEFAULT_ENDPOINT.to_string()),
-        // The legacy file already contains its operator-authored value, while
-        // the compiled default needs no state file. Only an explicit request
-        // or durable binding is eligible to create/replace this file.
-        persist_file: false,
-        permits_stored_credentials,
+    Ok(match legacy {
+        Some(value) => TransactionEndpoint {
+            value,
+            source: EndpointSource::LegacyFile,
+        },
+        None => TransactionEndpoint {
+            value: runtime_cloud_connect::config::DEFAULT_ENDPOINT.to_string(),
+            source: EndpointSource::CompiledDefault,
+        },
     })
 }
 
@@ -1249,7 +1263,7 @@ async fn reconcile_journal(
     let config_dir = config_dir.to_path_buf();
     let directory = directory.to_path_buf();
     let endpoint = endpoint.to_string();
-    let identity = identity.cloned();
+    let identity = identity.map(IdentityFacts::from);
     tokio::task::spawn_blocking(move || {
         ConnectOperation::reconcile(&config_dir, &directory, &endpoint, identity.as_ref())
             .map_err(|error| state_error(&error))
@@ -1269,7 +1283,7 @@ async fn reconcile_project_journal(
     let config_dir = config_dir.to_path_buf();
     let directory = directory.to_path_buf();
     let endpoint = endpoint.to_string();
-    let identity = identity.cloned();
+    let identity = identity.map(IdentityFacts::from);
     tokio::task::spawn_blocking(move || {
         ProjectOperation::reconcile(&config_dir, &directory, &endpoint, identity.as_ref())
             .map_err(|error| state_error(&error))
@@ -1329,17 +1343,6 @@ fn normalize_control_plane_endpoint(endpoint: &str) -> Result<String> {
 #[cfg(test)]
 fn validate_control_plane_endpoint(endpoint: &str) -> Result<()> {
     normalize_control_plane_endpoint(endpoint).map(|_| ())
-}
-
-fn is_loopback_host(host: &str) -> bool {
-    let host = host
-        .strip_prefix('[')
-        .and_then(|host| host.strip_suffix(']'))
-        .unwrap_or(host);
-    host.eq_ignore_ascii_case("localhost")
-        || host
-            .parse::<std::net::IpAddr>()
-            .is_ok_and(|ip| ip.is_loopback())
 }
 
 fn print_unattached(identity: &Identity, recovery_url: Option<&str>) {
@@ -1587,8 +1590,9 @@ mod tests {
         let fresh = resolve_transaction_endpoint_with_env(dir.path(), None, None, None, None)
             .expect("resolve fresh endpoint");
         assert_eq!(fresh.value, runtime_cloud_connect::config::DEFAULT_ENDPOINT);
-        assert!(!fresh.persist_file);
-        assert!(fresh.permits_stored_credentials);
+        assert_eq!(fresh.source, EndpointSource::CompiledDefault);
+        assert!(!fresh.persist_file());
+        assert!(fresh.permits_stored_credentials());
     }
 
     #[test]
@@ -1602,8 +1606,9 @@ mod tests {
         let resolved = resolve_transaction_endpoint_with_env(dir.path(), None, None, None, None)
             .expect("resolve legacy endpoint");
         assert_eq!(resolved.value, "https://private.example");
-        assert!(!resolved.persist_file);
-        assert!(!resolved.permits_stored_credentials);
+        assert_eq!(resolved.source, EndpointSource::LegacyFile);
+        assert!(!resolved.persist_file());
+        assert!(!resolved.permits_stored_credentials());
     }
 
     #[test]

--- a/bin/spice/src/commands/login/mod.rs
+++ b/bin/spice/src/commands/login/mod.rs
@@ -475,7 +475,7 @@ fn credentialed_client() -> Result<reqwest::Client> {
 }
 
 /// Get the Spice.ai base URL.
-fn get_spice_base_url() -> String {
+pub(crate) fn spice_base_url() -> String {
     if let Ok(url) = std::env::var("SPICE_BASE_URL") {
         return url;
     }

--- a/bin/spice/src/commands/login/session.rs
+++ b/bin/spice/src/commands/login/session.rs
@@ -203,7 +203,7 @@ pub(super) struct BrowserLogin {
 
 impl BrowserLogin {
     pub(super) fn new() -> Self {
-        Self::at(super::get_spice_base_url())
+        Self::at(super::spice_base_url())
     }
 
     /// A flow against an explicit base URL. Tests point this at a mock server;

--- a/bin/spice/src/error.rs
+++ b/bin/spice/src/error.rs
@@ -192,6 +192,10 @@ pub enum Error {
     #[snafu(display("Invalid argument: {message}"))]
     InvalidArgument { message: String },
 
+    /// Invalid command usage that should use Clap's usage-error exit code.
+    #[snafu(display("Invalid argument: {message}"))]
+    InvalidUsage { message: String },
+
     /// A Spice Cloud operation failed, carrying a stable code scripts can branch on.
     #[snafu(display(
         "{message}{}",
@@ -277,6 +281,10 @@ pub enum Error {
     /// a non-zero status instead of aborting.
     #[snafu(display("{message}"))]
     NotImplemented { message: String },
+
+    /// Atomic Cloud Connect project creation/attachment failed.
+    #[snafu(display("Failed to create and attach the Spice Cloud project: {message}"))]
+    CloudConnectProject { message: String },
 }
 
 impl Error {
@@ -366,9 +374,9 @@ impl Error {
             // validation, so it belongs on the same code clap already uses for
             // a usage error — otherwise automation cannot tell bad input from
             // an operation that tried and failed.
-            Self::InvalidArgument { .. } | Self::ServiceNotInstalled { .. } => {
-                Self::USAGE_EXIT_CODE
-            }
+            Self::InvalidArgument { .. }
+            | Self::InvalidUsage { .. }
+            | Self::ServiceNotInstalled { .. } => Self::USAGE_EXIT_CODE,
             Self::Interrupted => Self::INTERRUPTED_EXIT_CODE,
             _ => Self::FAILURE_EXIT_CODE,
         }

--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -813,7 +813,9 @@ fn machine_error_code(error: &spice::error::Error) -> &'static str {
         spice::error::Error::RuntimeExecution { .. } => "runtime_execution",
         spice::error::Error::RuntimeVersion { .. } => "runtime_version",
         spice::error::Error::Environment { .. } => "environment",
-        spice::error::Error::InvalidArgument { .. } => "invalid_argument",
+        spice::error::Error::InvalidArgument { .. } | spice::error::Error::InvalidUsage { .. } => {
+            "invalid_argument"
+        }
         spice::error::Error::Cloud { code, .. } => code.as_str(),
         spice::error::Error::DeviceAuthorizationDenied => "device_authorization_denied",
         spice::error::Error::HomeDirectoryNotFound => "home_directory_not_found",
@@ -824,6 +826,7 @@ fn machine_error_code(error: &spice::error::Error) -> &'static str {
         spice::error::Error::NoModelsConfigured => "no_models_configured",
         spice::error::Error::CloudConnectIo { .. } => "cloud_connect_io",
         spice::error::Error::CloudConnectEnroll { .. } => "cloud_connect_enroll",
+        spice::error::Error::CloudConnectProject { .. } => "cloud_connect_project",
         spice::error::Error::ServiceNotInstalled { .. } => "service_not_installed",
         spice::error::Error::ServiceUnavailable { .. } => "service_unavailable",
         spice::error::Error::Interrupted => "interrupted",

--- a/bin/spice/tests/cli_integration.rs
+++ b/bin/spice/tests/cli_integration.rs
@@ -781,63 +781,139 @@ mod connect {
     use super::*;
 
     #[test]
-    fn test_connect_help_describes_runtime_enrollment_and_state_management() {
-        let mut cmd = spice_cmd();
-        cmd.arg("connect")
+    fn test_connect_help() {
+        let output = spice_cmd()
+            .arg("connect")
             .arg("--help")
-            .assert()
-            .success()
-            .stdout(predicate::str::contains("spiced --token <enrollment-key>"))
-            .stdout(predicate::str::contains("status"))
-            .stdout(predicate::str::contains("remove"))
-            .stdout(predicate::str::contains("service install"))
-            .stdout(predicate::str::contains("--install").not())
-            .stdout(predicate::str::contains("SPICE-ADOPT").not())
-            .stdout(predicate::str::contains("pending-adopt-code").not())
-            .stdout(predicate::str::contains("--app-name").not())
-            .stdout(predicate::str::contains("--create").not());
-    }
-
-    #[test]
-    fn positional_enrollment_keys_are_rejected_without_echoing_the_secret() {
-        let secret = "A".repeat(32);
-        for key in [
-            format!("spice-enroll-{secret}"),
-            format!("spice-enroll-{secret}!"),
-            format!("SPICE-ENROLL-{secret}"),
-            format!("spice_enroll_{secret}"),
-            format!("\u{feff}spice-enroll-{secret}"),
-            format!("spice-enroll-{secret}\n"),
-            format!("spcie-enroll-{secret}"),
-            format!("acme/spice-enroll-{secret}"),
+            .output()
+            .expect("run connect help");
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).expect("help is utf8");
+        insta::assert_snapshot!("connect_help", stdout);
+        for expected in [
+            "--org",
+            "--project",
+            "--token",
+            "--region",
+            "status",
+            "remove",
+            "service",
         ] {
-            spice_cmd()
-                .arg("connect")
-                .arg(&key)
-                .assert()
-                .failure()
-                .stdout(predicate::str::contains("spiced --token"))
-                .stdout(predicate::str::contains(key.clone()).not())
-                .stdout(predicate::str::contains(secret.clone()).not())
-                .stderr(predicate::str::contains(key).not())
-                .stderr(predicate::str::contains(secret.clone()).not());
+            assert!(stdout.contains(expected), "missing {expected} from help");
+        }
+        for removed in ["--install", "--app-name", "--create", "SPICE-ADOPT"] {
+            assert!(
+                !stdout.contains(removed),
+                "legacy surface {removed} remains"
+            );
         }
     }
 
     #[test]
-    fn deleted_enrollment_flags_do_not_parse() {
-        for flag in ["--app-name", "--create", "--region"] {
+    fn removed_connect_surface_does_not_parse() {
+        for removed in ["--app-name", "--create", "--install"] {
             spice_cmd()
                 .arg("connect")
-                .arg(flag)
+                .arg(removed)
                 .assert()
-                .failure()
-                .stderr(predicate::str::contains("unexpected argument"));
+                .code(2)
+                .stderr(
+                    predicate::str::contains("unexpected argument")
+                        .or(predicate::str::contains("unrecognized subcommand")),
+                );
         }
     }
 
     #[test]
-    fn install_rejects_a_malformed_persisted_identity_before_service_setup() {
+    fn malformed_enrollment_key_is_never_echoed() {
+        const MALFORMED_KEY: &str = "spice-enroll-THIS_SHOULD_NEVER_LEAK";
+        let instance = TempDir::new().expect("create instance directory");
+        let output = spice_cmd()
+            .arg("connect")
+            .arg("--token")
+            .arg(MALFORMED_KEY)
+            .arg("--dir")
+            .arg(instance.path())
+            .output()
+            .expect("run connect with malformed enrollment key");
+
+        assert!(!output.status.success());
+        let rendered = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            rendered.contains("not a valid enrollment key"),
+            "unexpected validation output: {rendered}"
+        );
+        assert!(
+            !rendered.contains(MALFORMED_KEY),
+            "malformed enrollment key leaked: {rendered}"
+        );
+    }
+
+    #[test]
+    fn rejected_positional_enrollment_key_is_never_echoed() {
+        const POSITIONAL_KEY: &str = "spice-enroll-POSITIONAL_SHOULD_NEVER_LEAK";
+        for machine in [false, true] {
+            let mut command = spice_cmd();
+            if machine {
+                command.arg("--machine");
+            }
+            let output = command
+                .arg("connect")
+                .arg(POSITIONAL_KEY)
+                .output()
+                .expect("reject positional enrollment key");
+            assert_eq!(output.status.code(), Some(2));
+            let rendered = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                !rendered.contains(POSITIONAL_KEY),
+                "positional enrollment key leaked: {rendered}"
+            );
+            assert!(
+                rendered.contains("--token <enrollment-key>"),
+                "safe rejection did not identify the supported argument: {rendered}"
+            );
+            if machine {
+                let value: serde_json::Value =
+                    serde_json::from_str(rendered.trim()).expect("machine parse failure is JSON");
+                assert_eq!(value["error"]["code"], "invalid_argument");
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_project_and_region_fail_before_local_state_is_created() {
+        for invalid_args in [
+            ["--project", "INVALID PROJECT"],
+            ["--region", "INVALID_REGION"],
+        ] {
+            let instance = TempDir::new().expect("create instance directory");
+            let output = spice_cmd()
+                .arg("connect")
+                .arg("--org")
+                .arg("acme")
+                .args(invalid_args)
+                .arg("--dir")
+                .arg(instance.path())
+                .output()
+                .expect("run invalid preflight");
+            assert_eq!(output.status.code(), Some(2));
+            assert!(
+                !instance.path().join(".spice").exists(),
+                "invalid input created durable state"
+            );
+        }
+    }
+
+    #[test]
+    fn service_install_rejects_a_malformed_persisted_identity_before_setup() {
         let config_dir = TempDir::new().expect("create config directory");
         fs::write(config_dir.path().join("identity.json"), "not valid JSON")
             .expect("write malformed identity");
@@ -847,12 +923,14 @@ mod connect {
             .args(["connect", "service", "install"])
             .assert()
             .failure()
-            .stdout(predicate::str::contains("validate the durable"))
+            .stdout(predicate::str::contains(
+                "load enrolled Cloud Connect endpoint",
+            ))
             .stdout(predicate::str::contains("not valid JSON").not());
     }
 
     #[test]
-    fn install_rejects_a_missing_identity_before_service_setup() {
+    fn service_install_rejects_a_missing_identity_before_setup() {
         let config_dir = TempDir::new().expect("create config directory");
 
         spice_cmd()
@@ -865,7 +943,7 @@ mod connect {
     }
 
     #[test]
-    fn install_rejects_a_parseable_but_unusable_identity_before_service_setup() {
+    fn service_install_rejects_an_unusable_identity_without_leaking_it() {
         let config_dir = TempDir::new().expect("create config directory");
         fs::write(
             config_dir.path().join("identity.json"),
@@ -891,6 +969,115 @@ mod connect {
             .stdout(predicate::str::contains("private-key-that-must-not-be-printed").not());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_connect_auth_menu_on_a_real_pseudo_terminal() {
+        use std::io::{Read as _, Write as _};
+        use std::process::{Command as StdCommand, Stdio};
+        use std::time::{Duration, Instant};
+
+        let instance = TempDir::new().expect("create instance directory");
+        let home = TempDir::new().expect("create isolated home");
+        let pty = nix::pty::openpty(None, None).expect("open pseudo terminal");
+        let slave = std::fs::File::from(pty.slave);
+        let stdin = slave.try_clone().expect("clone pseudo terminal input");
+        let stdout = slave.try_clone().expect("clone pseudo terminal output");
+
+        let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin!("spice"))
+            .arg("connect")
+            .arg("--dir")
+            .arg(instance.path())
+            .env("HOME", home.path())
+            .env_remove("SPICE_CONFIG_DIR")
+            .env_remove("SPICE_SPICEAI_TOKEN")
+            .stdin(Stdio::from(stdin))
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(slave))
+            .spawn()
+            .expect("spawn spice under pseudo terminal");
+
+        let mut master = std::fs::File::from(pty.master);
+        let mut reader = master.try_clone().expect("clone pseudo terminal reader");
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let reader_capture = std::sync::Arc::clone(&captured);
+        let reader = std::thread::spawn(move || {
+            let mut chunk = [0_u8; 1024];
+            while let Ok(count) = reader.read(&mut chunk) {
+                if count == 0 {
+                    break;
+                }
+                reader_capture
+                    .lock()
+                    .expect("lock pseudo terminal capture")
+                    .extend_from_slice(&chunk[..count]);
+            }
+        });
+
+        let wait_for_output = |needle: &str| {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while Instant::now() < deadline {
+                let found = {
+                    let bytes = captured.lock().expect("lock pseudo terminal capture");
+                    String::from_utf8_lossy(&bytes).contains(needle)
+                };
+                if found {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            let bytes = captured.lock().expect("lock pseudo terminal capture");
+            panic!(
+                "pseudo terminal never rendered {needle:?}: {}",
+                String::from_utf8_lossy(&bytes)
+            );
+        };
+
+        wait_for_output("Use an enrollment key");
+        master
+            .write_all(b"\x1b[B\r")
+            .expect("choose enrollment-key path");
+        master.flush().expect("flush terminal input");
+        wait_for_output("Enrollment key");
+        master
+            .write_all(b"not-a-key\r")
+            .expect("submit malformed secret");
+        master.flush().expect("flush secret input");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let status = loop {
+            if let Some(status) = child.try_wait().expect("poll spice process") {
+                break status;
+            }
+            if Instant::now() >= deadline {
+                child.kill().expect("terminate stuck pseudo terminal test");
+                let bytes = captured.lock().expect("lock pseudo terminal capture");
+                panic!(
+                    "spice connect did not reject terminal input within 10 seconds: {}",
+                    String::from_utf8_lossy(&bytes)
+                );
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        };
+        drop(master);
+        reader.join().expect("join terminal reader");
+        let captured = captured.lock().expect("lock final terminal capture");
+        let output = String::from_utf8_lossy(&captured);
+        assert_eq!(
+            status.code(),
+            Some(2),
+            "unexpected terminal result: {output}"
+        );
+        assert!(
+            output.contains("Log in to Spice Cloud (recommended)")
+                && output.contains("Use an enrollment key"),
+            "the exact two authentication choices were not rendered: {output}"
+        );
+        assert!(
+            !output.contains("not-a-key"),
+            "secret input leaked: {output}"
+        );
+    }
+
     #[test]
     fn status_uses_signed_expiry_without_treating_the_host_clock_as_credential_authority() {
         use rcgen::{CertificateParams, KeyPair};
@@ -914,6 +1101,7 @@ mod connect {
             // Deliberately inconsistent: status and activation must trust the
             // signed certificate rather than this unsigned cache field.
             not_after_unix: Some(4_102_444_800),
+            control_plane_endpoint: None,
             enc_private_key_pem: material.enc_private_key_pem,
             enc_public_key_pem: material.enc_public_key_pem,
             enc_previous_private_key_pem: String::new(),

--- a/bin/spice/tests/connect_transaction.rs
+++ b/bin/spice/tests/connect_transaction.rs
@@ -1,0 +1,960 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![expect(clippy::expect_used, reason = "process-level integration-test harness")]
+
+use std::collections::BTreeMap;
+use std::io::{Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use assert_cmd::{Command, cargo::cargo_bin_cmd};
+use rcgen::{
+    BasicConstraints, CertificateParams, CertificateSigningRequestParams, DnType,
+    ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose,
+};
+use tempfile::TempDir;
+
+const LOGIN_TOKEN: &str = "fixture-login-token";
+const INSTANCE_ID: &str = "inst_fixture_1401";
+const PROJECT_NAME: &str = "fault-replay";
+const NOT_AFTER_UNIX: u64 = 1_893_456_000;
+const NOT_AFTER_RFC3339: &str = "2030-01-01T00:00:00Z";
+
+fn spice_cmd() -> Command {
+    cargo_bin_cmd!("spice")
+}
+
+struct Request {
+    method: String,
+    path: String,
+    headers: BTreeMap<String, String>,
+    body: String,
+}
+
+#[derive(Default)]
+struct FixtureState {
+    requests: Vec<Request>,
+    enrollment_bodies: Vec<String>,
+    enrollment_operations: Vec<String>,
+    project_bodies: Vec<String>,
+    instance_mutations: usize,
+    project_mutations: usize,
+    enrollment_response: Option<String>,
+}
+
+struct TestCa {
+    cert_pem: String,
+    issuer: Issuer<'static, KeyPair>,
+}
+
+impl TestCa {
+    fn new() -> Self {
+        let key = KeyPair::generate().expect("generate fixture CA key");
+        let mut params = CertificateParams::default();
+        params
+            .distinguished_name
+            .push(DnType::CommonName, "Spice Connect Test CA");
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages = vec![
+            KeyUsagePurpose::KeyCertSign,
+            KeyUsagePurpose::CrlSign,
+            KeyUsagePurpose::DigitalSignature,
+        ];
+        let cert_pem = params
+            .self_signed(&key)
+            .expect("self-sign fixture CA")
+            .pem();
+        Self {
+            cert_pem,
+            issuer: Issuer::new(params, key),
+        }
+    }
+
+    fn sign_csr(&self, csr_pem: &str) -> String {
+        let mut request =
+            CertificateSigningRequestParams::from_pem(csr_pem).expect("parse enrollment CSR");
+        request.params.not_after = time::OffsetDateTime::from_unix_timestamp(
+            i64::try_from(NOT_AFTER_UNIX).expect("fixture expiry fits i64"),
+        )
+        .expect("valid fixture expiry");
+        request
+            .signed_by(&self.issuer)
+            .expect("sign enrollment CSR")
+            .pem()
+    }
+}
+
+struct Fixture {
+    endpoint: String,
+    state: Arc<Mutex<FixtureState>>,
+    thread: std::thread::JoinHandle<()>,
+}
+
+impl Fixture {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind HTTP fixture");
+        listener
+            .set_nonblocking(true)
+            .expect("make HTTP fixture nonblocking");
+        let endpoint = format!("http://{}", listener.local_addr().expect("fixture address"));
+        let state = Arc::new(Mutex::new(FixtureState::default()));
+        let server_state = Arc::clone(&state);
+        let thread = std::thread::spawn(move || {
+            let ca = TestCa::new();
+            let deadline = Instant::now() + Duration::from_secs(20);
+            while Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("make accepted fixture connection blocking");
+                        serve_one(&mut stream, &server_state, &ca);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if server_state
+                            .lock()
+                            .expect("lock fixture state")
+                            .requests
+                            .len()
+                            >= 5
+                        {
+                            return;
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("accept HTTP fixture request: {error}"),
+                }
+            }
+            panic!("HTTP fixture did not receive all expected requests within 20 seconds");
+        });
+        Self {
+            endpoint,
+            state,
+            thread,
+        }
+    }
+
+    fn finish(self) -> Arc<Mutex<FixtureState>> {
+        self.thread.join().expect("HTTP fixture completed");
+        self.state
+    }
+}
+
+fn serve_one(stream: &mut TcpStream, state: &Arc<Mutex<FixtureState>>, ca: &TestCa) {
+    let request = read_request(stream);
+    let mut state = state.lock().expect("lock fixture state");
+    let response = match (request.method.as_str(), request.path.as_str()) {
+        ("GET", "/api/spice-cli/auth") => Some((
+            200,
+            serde_json::json!({
+                "username": "fixture-user",
+                "email": "fixture@example.invalid",
+                "org": {"name": "acme"},
+                "app": null
+            })
+            .to_string(),
+        )),
+        ("GET", "/v1/orgs") => Some((
+            200,
+            serde_json::json!({
+                "orgs": [{"id": 42, "name": "acme", "display_name": "Acme", "role": "owner"}]
+            })
+            .to_string(),
+        )),
+        ("POST", "/v1/cloud-connect/enroll") => {
+            assert_eq!(
+                request.headers.get("authorization").map(String::as_str),
+                Some("Bearer fixture-login-token")
+            );
+            assert_eq!(
+                request.headers.get("x-org-name").map(String::as_str),
+                Some("acme")
+            );
+            let operation = request
+                .headers
+                .get("idempotency-key")
+                .expect("enrollment operation header")
+                .clone();
+            uuid::Uuid::parse_str(&operation).expect("canonical enrollment operation UUID");
+            let body: serde_json::Value =
+                serde_json::from_str(&request.body).expect("authenticated enrollment body JSON");
+            let object = body.as_object().expect("enrollment body is an object");
+            let mut keys = object.keys().map(String::as_str).collect::<Vec<_>>();
+            keys.sort_unstable();
+            assert_eq!(
+                keys,
+                ["csr_pem", "enc_pubkey_pem", "instance", "kind", "region"]
+            );
+            assert_eq!(body["kind"], "standalone");
+            assert_eq!(body["region"], "lab-seoul");
+            for field in ["fingerprint", "hostname", "os", "arch", "runtime_version"] {
+                assert!(
+                    body["instance"][field]
+                        .as_str()
+                        .is_some_and(|value| !value.is_empty()),
+                    "missing canonical instance fact {field}"
+                );
+            }
+            state.enrollment_operations.push(operation);
+            state.enrollment_bodies.push(request.body.clone());
+            if state.instance_mutations == 0 {
+                state.instance_mutations = 1;
+                state.enrollment_response = Some(
+                    serde_json::json!({
+                        "kind": "standalone",
+                        "instance_id": INSTANCE_ID,
+                        "identity_cert_pem": ca.sign_csr(
+                            body["csr_pem"].as_str().expect("enrollment CSR")
+                        ),
+                        "ca_bundle_pem": ca.cert_pem.clone(),
+                        "gateway_addr": "127.0.0.1:443",
+                        "not_after": NOT_AFTER_RFC3339,
+                        "organization": {"id": 42, "name": "acme"},
+                        "region": "lab-seoul",
+                        "portal": {"new_project_url": "https://spice.ai/acme/new?instance=inst_fixture_1401"},
+                        "attachment": null,
+                        "recovered": true
+                    })
+                    .to_string(),
+                );
+                // Commit the mutation, then lose the response. The driver's
+                // bounded retry must replay the exact operation and body.
+                None
+            } else {
+                Some((
+                    200,
+                    state
+                        .enrollment_response
+                        .clone()
+                        .expect("committed enrollment response"),
+                ))
+            }
+        }
+        ("POST", "/v1/cloud-connect/project") => {
+            assert_eq!(
+                request.headers.get("authorization").map(String::as_str),
+                Some("Bearer fixture-login-token")
+            );
+            assert_eq!(
+                request.headers.get("x-org-name").map(String::as_str),
+                Some("acme")
+            );
+            state.project_bodies.push(request.body.clone());
+            if state.project_mutations == 0 {
+                state.project_mutations = 1;
+                // The atomic endpoint committed; its first response is lost.
+                None
+            } else {
+                Some((
+                    200,
+                    serde_json::json!({
+                        "instance_id": INSTANCE_ID,
+                        "organization": {"id": 42, "name": "acme"},
+                        "project": {"id": 314, "name": PROJECT_NAME},
+                        "monitor_url": "https://spice.ai/acme/fault-replay/monitor"
+                    })
+                    .to_string(),
+                ))
+            }
+        }
+        route => panic!("unexpected fixture route: {route:?}"),
+    };
+    state.requests.push(request);
+    drop(state);
+    if let Some((status, body)) = response {
+        write_response(stream, status, &body);
+    }
+}
+
+fn read_request(stream: &mut TcpStream) -> Request {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set fixture read timeout");
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    loop {
+        let count = stream.read(&mut chunk).expect("read HTTP fixture request");
+        assert_ne!(count, 0, "request closed before its body arrived");
+        bytes.extend_from_slice(&chunk[..count]);
+        let text = String::from_utf8_lossy(&bytes);
+        let Some(header_end) = text.find("\r\n\r\n") else {
+            continue;
+        };
+        let content_length = text[..header_end]
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().expect("content length"))
+            })
+            .unwrap_or_default();
+        if bytes.len() >= header_end + 4 + content_length {
+            break;
+        }
+    }
+
+    let text = String::from_utf8(bytes).expect("HTTP fixture request is utf8");
+    let (head, body) = text.split_once("\r\n\r\n").expect("HTTP separator");
+    let mut lines = head.lines();
+    let request_line = lines.next().expect("HTTP request line");
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts.next().expect("HTTP method").to_string();
+    let path = request_parts.next().expect("HTTP path").to_string();
+    let headers = lines
+        .filter_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            Some((name.to_ascii_lowercase(), value.trim().to_string()))
+        })
+        .collect();
+    Request {
+        method,
+        path,
+        headers,
+        body: body.to_string(),
+    }
+}
+
+fn write_response(stream: &mut TcpStream, status: u16, body: &str) {
+    let reason = if status == 200 { "OK" } else { "Created" };
+    write!(
+        stream,
+        "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    )
+    .expect("write HTTP fixture response");
+}
+
+fn connect_command(instance: &TempDir, home: &TempDir, endpoint: &str, project: &str) -> Command {
+    let mut command = spice_cmd();
+    command
+        .current_dir(instance.path())
+        .env("HOME", home.path())
+        .env("SPICE_SPICEAI_TOKEN", LOGIN_TOKEN)
+        .env("SPICE_SPICEAI_TOKEN_ACME", LOGIN_TOKEN)
+        .env_remove("SPICE_CONFIG_DIR")
+        .env_remove("SPICE_CLOUD_ENDPOINT")
+        .arg("connect")
+        .arg("--org")
+        .arg("acme")
+        .arg("--project")
+        .arg(project)
+        .arg("--region")
+        .arg("lab-seoul")
+        .arg("--endpoint")
+        .arg(endpoint);
+    command
+}
+
+fn unattached_identity() -> runtime_cloud_connect::Identity {
+    let ca = TestCa::new();
+    let key = KeyPair::generate().expect("generate existing identity key");
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "Existing Spice Connect Identity");
+    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+    params.not_after = time::OffsetDateTime::from_unix_timestamp(
+        i64::try_from(NOT_AFTER_UNIX).expect("fixture expiry fits i64"),
+    )
+    .expect("valid fixture expiry");
+    let certificate = params
+        .signed_by(&key, &ca.issuer)
+        .expect("sign existing identity certificate")
+        .pem();
+    runtime_cloud_connect::Identity {
+        identifier: INSTANCE_ID.to_string(),
+        identity_cert_pem: certificate,
+        private_key_pem: key.serialize_pem(),
+        public_key_pem: key.public_key_pem(),
+        ca_bundle_pem: ca.cert_pem,
+        gateway_addr: "127.0.0.1:443".to_string(),
+        not_after_unix: Some(NOT_AFTER_UNIX),
+        enc_private_key_pem: String::new(),
+        enc_public_key_pem: String::new(),
+        enc_previous_private_key_pem: String::new(),
+        cache_key_b64: String::new(),
+        app_id: None,
+        org_name: Some("acme".to_string()),
+        app_name: None,
+        monitor_url: None,
+        control_plane_endpoint: None,
+    }
+}
+
+#[test]
+fn corrupted_existing_identity_fails_before_project_mutation() {
+    let instance = TempDir::new().expect("create instance directory");
+    let home = TempDir::new().expect("create isolated home");
+    let config_dir = instance.path().join(".spice");
+    let mut identity = unattached_identity();
+    identity.private_key_pem = "not-a-private-key".to_string();
+    runtime_cloud_connect::IdentityStore::store(&config_dir.join("identity.json"), &identity)
+        .expect("store corrupted identity fixture");
+
+    let output = connect_command(&instance, &home, "http://127.0.0.1:9", PROJECT_NAME)
+        .output()
+        .expect("run connect with corrupted identity");
+    assert!(!output.status.success());
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(rendered.contains("identity") && rendered.contains("unusable"));
+    assert!(!config_dir.join("connect-project-operation.json").exists());
+    assert!(!config_dir.join("cloud-endpoint").exists());
+}
+
+#[test]
+fn existing_unattached_identity_reaches_project_without_auth_context() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind recovery fixture");
+    let endpoint = format!(
+        "http://{}",
+        listener.local_addr().expect("recovery fixture address")
+    );
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept recovery request");
+        let request = read_request(&mut stream);
+        if request.path == "/api/spice-cli/auth" {
+            write_response(&mut stream, 404, "{}");
+            return request;
+        }
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/v1/cloud-connect/project");
+        assert_eq!(
+            request.headers.get("authorization").map(String::as_str),
+            Some("Bearer fixture-login-token")
+        );
+        assert_eq!(
+            request.headers.get("x-org-name").map(String::as_str),
+            Some("acme")
+        );
+        let body: serde_json::Value =
+            serde_json::from_str(&request.body).expect("project recovery body JSON");
+        assert_eq!(body["instance_id"], INSTANCE_ID);
+        assert_eq!(body["name"], PROJECT_NAME);
+        write_response(
+            &mut stream,
+            201,
+            &serde_json::json!({
+                "instance_id": INSTANCE_ID,
+                "organization": {"id": 42, "name": "acme"},
+                "project": {"id": 314, "name": PROJECT_NAME},
+                "monitor_url": "https://spice.ai/acme/fault-replay/monitor"
+            })
+            .to_string(),
+        );
+        request
+    });
+
+    let instance = TempDir::new().expect("create instance directory");
+    let home = TempDir::new().expect("create isolated home");
+    let config_dir = instance.path().join(".spice");
+    runtime_cloud_connect::IdentityStore::store(
+        &config_dir.join("identity.json"),
+        &unattached_identity(),
+    )
+    .expect("store enrolled unattached identity");
+
+    connect_command(&instance, &home, &endpoint, PROJECT_NAME)
+        .assert()
+        .success();
+
+    let request = server.join().expect("recovery fixture completed");
+    assert_eq!(
+        request.path, "/v1/cloud-connect/project",
+        "the project operation must not depend on legacy auth context"
+    );
+    let identity =
+        runtime_cloud_connect::IdentityStore::load_optional(&config_dir.join("identity.json"))
+            .expect("load recovered identity")
+            .expect("recovered identity exists");
+    assert_eq!(identity.app_id.as_deref(), Some("314"));
+    assert_eq!(identity.app_name.as_deref(), Some(PROJECT_NAME));
+    assert_eq!(
+        std::fs::read_to_string(config_dir.join("cloud-endpoint"))
+            .expect("custom endpoint is persisted")
+            .trim(),
+        endpoint
+    );
+}
+
+#[test]
+fn a_default_credential_for_another_org_never_reaches_a_mutation() {
+    for existing_identity in [false, true] {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind credential fixture");
+        let endpoint = format!(
+            "http://{}",
+            listener.local_addr().expect("credential fixture address")
+        );
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept credential probe");
+            let request = read_request(&mut stream);
+            assert_eq!(request.method, "GET");
+            assert_eq!(request.path, "/api/spice-cli/auth");
+            write_response(
+                &mut stream,
+                200,
+                &serde_json::json!({
+                    "username": "fixture-user",
+                    "email": "fixture@example.invalid",
+                    "org": {"name": "globex"},
+                    "app": null
+                })
+                .to_string(),
+            );
+            request
+        });
+
+        let instance = TempDir::new().expect("create instance directory");
+        let home = TempDir::new().expect("create isolated home");
+        let config_dir = instance.path().join(".spice");
+        if existing_identity {
+            runtime_cloud_connect::IdentityStore::store(
+                &config_dir.join("identity.json"),
+                &unattached_identity(),
+            )
+            .expect("store enrolled unattached identity");
+        }
+
+        let output = spice_cmd()
+            .current_dir(instance.path())
+            .env("HOME", home.path())
+            .env("SPICE_SPICEAI_TOKEN", LOGIN_TOKEN)
+            .env_remove("SPICE_SPICEAI_TOKEN_ACME")
+            .env_remove("SPICE_CONFIG_DIR")
+            .env_remove("SPICE_CLOUD_ENDPOINT")
+            .arg("connect")
+            .arg("--org")
+            .arg("acme")
+            .arg("--project")
+            .arg(PROJECT_NAME)
+            .arg("--endpoint")
+            .arg(&endpoint)
+            .output()
+            .expect("run connect with mismatched default credential");
+        assert_eq!(output.status.code(), Some(4));
+        let rendered = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(rendered.contains("globex"), "unexpected error: {rendered}");
+        assert!(rendered.contains("acme"), "unexpected error: {rendered}");
+        assert!(
+            !config_dir.join("connect-operation.json").exists(),
+            "enrollment mutation journal must not be created"
+        );
+        assert!(
+            !config_dir.join("connect-project-operation.json").exists(),
+            "project mutation journal must not be created"
+        );
+
+        let request = server.join().expect("credential fixture completed");
+        assert_eq!(request.path, "/api/spice-cli/auth");
+    }
+}
+
+#[test]
+fn project_name_conflict_keeps_the_existing_identity_unattached() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind conflict fixture");
+    let endpoint = format!(
+        "http://{}",
+        listener.local_addr().expect("conflict fixture address")
+    );
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept conflict request");
+        let request = read_request(&mut stream);
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/v1/cloud-connect/project");
+        let body: serde_json::Value =
+            serde_json::from_str(&request.body).expect("project conflict body JSON");
+        assert_eq!(body["instance_id"], INSTANCE_ID);
+        assert_eq!(body["name"], PROJECT_NAME);
+        write_response(
+            &mut stream,
+            409,
+            &serde_json::json!({
+                "code": "project_name_conflict",
+                "retryable": false
+            })
+            .to_string(),
+        );
+    });
+
+    let instance = TempDir::new().expect("create instance directory");
+    let home = TempDir::new().expect("create isolated home");
+    let config_dir = instance.path().join(".spice");
+    runtime_cloud_connect::IdentityStore::store(
+        &config_dir.join("identity.json"),
+        &unattached_identity(),
+    )
+    .expect("store enrolled unattached identity");
+
+    let output = connect_command(&instance, &home, &endpoint, PROJECT_NAME)
+        .output()
+        .expect("run conflicting project assignment");
+    assert!(!output.status.success());
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        rendered.contains("project_name_conflict"),
+        "unexpected conflict output: {rendered}"
+    );
+    server.join().expect("conflict fixture completed");
+
+    let identity =
+        runtime_cloud_connect::IdentityStore::load_optional(&config_dir.join("identity.json"))
+            .expect("load identity after conflict")
+            .expect("identity remains durable");
+    assert_eq!(identity.app_id, None);
+    assert_eq!(identity.app_name, None);
+}
+
+#[test]
+fn remote_attachment_conflict_never_reports_the_instance_as_unattached() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind attachment fixture");
+    let endpoint = format!(
+        "http://{}",
+        listener.local_addr().expect("attachment fixture address")
+    );
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept attachment request");
+        let request = read_request(&mut stream);
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/v1/cloud-connect/project");
+        write_response(
+            &mut stream,
+            409,
+            &serde_json::json!({
+                "code": "instance_already_attached",
+                "retryable": false
+            })
+            .to_string(),
+        );
+    });
+
+    let instance = TempDir::new().expect("create instance directory");
+    let home = TempDir::new().expect("create isolated home");
+    let config_dir = instance.path().join(".spice");
+    runtime_cloud_connect::IdentityStore::store(
+        &config_dir.join("identity.json"),
+        &unattached_identity(),
+    )
+    .expect("store locally unattached identity");
+
+    let output = connect_command(&instance, &home, &endpoint, PROJECT_NAME)
+        .output()
+        .expect("run remote attachment conflict");
+    assert!(!output.status.success());
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        rendered.contains("instance_already_attached"),
+        "unexpected attachment conflict output: {rendered}"
+    );
+    assert!(
+        !rendered.contains("not yet attached"),
+        "remote attachment was reported as unattached: {rendered}"
+    );
+    server.join().expect("attachment fixture completed");
+}
+
+#[test]
+fn ambiguous_committed_project_response_is_replayed_and_never_reports_unattached() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ambiguous fixture");
+    let endpoint = format!(
+        "http://{}",
+        listener.local_addr().expect("ambiguous fixture address")
+    );
+    let server = std::thread::spawn(move || {
+        let mut bodies = Vec::new();
+        for attempt in 0..6 {
+            let (mut stream, _) = listener.accept().expect("accept ambiguous request");
+            let request = read_request(&mut stream);
+            assert_eq!(request.path, "/v1/cloud-connect/project");
+            bodies.push(request.body);
+            // A 2xx proves only that a response arrived; an invalid body cannot
+            // prove whether the atomic server mutation committed.
+            if attempt < 5 {
+                write_response(&mut stream, 200, "{}");
+            } else {
+                write_response(
+                    &mut stream,
+                    200,
+                    &serde_json::json!({
+                        "instance_id": INSTANCE_ID,
+                        "organization": {"id": 42, "name": "acme"},
+                        "project": {"id": 314, "name": PROJECT_NAME},
+                        "monitor_url": "https://spice.ai/acme/fault-replay/monitor"
+                    })
+                    .to_string(),
+                );
+            }
+        }
+        bodies
+    });
+
+    let instance = TempDir::new().expect("create instance directory");
+    let home = TempDir::new().expect("create isolated home");
+    let config_dir = instance.path().join(".spice");
+    runtime_cloud_connect::IdentityStore::store(
+        &config_dir.join("identity.json"),
+        &unattached_identity(),
+    )
+    .expect("store locally unattached identity");
+
+    let output = connect_command(&instance, &home, &endpoint, PROJECT_NAME)
+        .output()
+        .expect("run ambiguous project assignment");
+    assert!(!output.status.success());
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        rendered.contains("attachment result is unknown"),
+        "ambiguous result was not explicit: {rendered}"
+    );
+    assert!(
+        !rendered.contains("not yet attached"),
+        "ambiguous commit was reported as unattached: {rendered}"
+    );
+    assert!(
+        config_dir.join("connect-project-operation.json").exists(),
+        "an ambiguous process exit must retain exact project replay state"
+    );
+    connect_command(&instance, &home, &endpoint, PROJECT_NAME)
+        .assert()
+        .success();
+    let bodies = server.join().expect("ambiguous fixture completed");
+    assert_eq!(bodies.len(), 6);
+    assert!(
+        bodies.windows(2).all(|pair| pair[0] == pair[1]),
+        "every recovery attempt must replay the exact request"
+    );
+    assert!(
+        !config_dir.join("connect-project-operation.json").exists(),
+        "durable local attachment must retire project replay state"
+    );
+    let identity =
+        runtime_cloud_connect::IdentityStore::load_optional(&config_dir.join("identity.json"))
+            .expect("load recovered attachment")
+            .expect("identity remains");
+    assert_eq!(identity.app_name.as_deref(), Some(PROJECT_NAME));
+}
+
+#[test]
+fn response_loss_replays_exact_mutations_without_duplicates() {
+    let fixture = Fixture::start();
+    let instance = TempDir::new().expect("create instance directory");
+    let home = TempDir::new().expect("create isolated home");
+
+    connect_command(&instance, &home, &fixture.endpoint, PROJECT_NAME)
+        .assert()
+        .success();
+
+    let config_dir = instance.path().join(".spice");
+    let first_identity =
+        runtime_cloud_connect::IdentityStore::load_optional(&config_dir.join("identity.json"))
+            .expect("load identity after response-loss recovery")
+            .expect("enrollment and project attachment are durable");
+    assert_eq!(first_identity.identifier, INSTANCE_ID);
+    assert_eq!(first_identity.app_id.as_deref(), Some("314"));
+    assert_eq!(first_identity.org_name.as_deref(), Some("acme"));
+    assert!(
+        !config_dir.join("connect-operation.json").exists(),
+        "a durable identity retires the enrollment journal"
+    );
+
+    connect_command(&instance, &home, &fixture.endpoint, PROJECT_NAME)
+        .assert()
+        .success();
+
+    let conflict = connect_command(&instance, &home, &fixture.endpoint, "different-project")
+        .output()
+        .expect("run attached identity with conflicting project assertion");
+    assert!(!conflict.status.success());
+    let conflict_output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&conflict.stdout),
+        String::from_utf8_lossy(&conflict.stderr)
+    );
+    assert!(
+        conflict_output.contains("already attached to project fault-replay"),
+        "unexpected conflict error: {conflict_output}"
+    );
+
+    let identity =
+        runtime_cloud_connect::IdentityStore::load_optional(&config_dir.join("identity.json"))
+            .expect("load attached identity")
+            .expect("attached identity exists");
+    assert_eq!(identity.identifier, INSTANCE_ID);
+    assert_eq!(identity.app_id.as_deref(), Some("314"));
+    assert_eq!(identity.app_name.as_deref(), Some(PROJECT_NAME));
+    assert_eq!(
+        identity.monitor_url.as_deref(),
+        Some("https://spice.ai/acme/fault-replay/monitor")
+    );
+
+    let state = fixture.finish();
+    let state = state.lock().expect("lock final fixture state");
+    assert_eq!(state.instance_mutations, 1, "instance must be created once");
+    assert_eq!(state.project_mutations, 1, "project must be created once");
+    assert_eq!(state.enrollment_bodies.len(), 2, "enrollment was replayed");
+    assert_eq!(state.enrollment_bodies[0], state.enrollment_bodies[1]);
+    assert_eq!(
+        state.enrollment_operations[0], state.enrollment_operations[1],
+        "replay must carry the same idempotency key"
+    );
+    assert_eq!(
+        state.project_bodies.len(),
+        2,
+        "project request was replayed"
+    );
+    assert_eq!(state.project_bodies[0], state.project_bodies[1]);
+    let project: serde_json::Value =
+        serde_json::from_str(&state.project_bodies[0]).expect("project body JSON");
+    assert_eq!(project["instance_id"], INSTANCE_ID);
+    assert_eq!(project["name"], PROJECT_NAME);
+}
+
+#[test]
+fn token_mode_stays_unattached_and_existing_identity_prevents_reenrollment() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind token fixture");
+    let endpoint = format!("http://{}", listener.local_addr().expect("fixture address"));
+    let server = std::thread::spawn(move || {
+        let ca = TestCa::new();
+        let (mut stream, _) = listener.accept().expect("accept token enrollment");
+        let request = read_request(&mut stream);
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/v1/cloud-connect/enroll");
+        assert!(!request.headers.contains_key("authorization"));
+        assert!(!request.headers.contains_key("x-org-name"));
+        uuid::Uuid::parse_str(
+            request
+                .headers
+                .get("idempotency-key")
+                .expect("token enrollment operation header"),
+        )
+        .expect("canonical enrollment operation UUID");
+        let body: serde_json::Value =
+            serde_json::from_str(&request.body).expect("token enrollment body JSON");
+        let object = body
+            .as_object()
+            .expect("token enrollment body is an object");
+        let mut keys = object.keys().map(String::as_str).collect::<Vec<_>>();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "csr_pem",
+                "enc_pubkey_pem",
+                "expected_org",
+                "instance",
+                "kind",
+                "token"
+            ]
+        );
+        assert_eq!(body["kind"], "standalone");
+        assert_eq!(body["expected_org"], "acme");
+        assert_eq!(
+            body["token"],
+            "spice-enroll-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        );
+        let identity_cert_pem =
+            ca.sign_csr(body["csr_pem"].as_str().expect("token enrollment CSR"));
+        write_response(
+            &mut stream,
+            200,
+            &serde_json::json!({
+                "kind": "standalone",
+                "instance_id": "inst_token_fixture",
+                "identity_cert_pem": identity_cert_pem,
+                "ca_bundle_pem": ca.cert_pem,
+                "gateway_addr": "127.0.0.1:443",
+                "not_after": NOT_AFTER_RFC3339,
+                "organization": {"id": 42, "name": "acme"},
+                "region": "us-east-1",
+                "portal": {"new_project_url": "https://spice.ai/acme/new?instance=inst_token_fixture"},
+                "attachment": null,
+                "recovered": false
+            })
+            .to_string(),
+        );
+    });
+
+    let instance = TempDir::new().expect("create instance directory");
+    let home = TempDir::new().expect("create isolated home");
+    let first = spice_cmd()
+        .current_dir(instance.path())
+        .env("HOME", home.path())
+        .env_remove("SPICE_CONFIG_DIR")
+        .env_remove("SPICE_SPICEAI_TOKEN")
+        .arg("connect")
+        .arg("--token")
+        .arg("spice-enroll-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+        .arg("--org")
+        .arg("acme")
+        .arg("--endpoint")
+        .arg(&endpoint)
+        .output()
+        .expect("run token enrollment");
+    assert!(
+        first.status.success(),
+        "token enrollment failed: {}{}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let first_output = String::from_utf8_lossy(&first.stdout);
+    assert!(first_output.contains("not yet attached to a project"));
+    assert!(first_output.contains("https://spice.ai/acme/new?instance=inst_token_fixture"));
+    server.join().expect("token fixture completed");
+
+    let config_dir = instance.path().join(".spice");
+    let identity =
+        runtime_cloud_connect::IdentityStore::load_optional(&config_dir.join("identity.json"))
+            .expect("load token identity")
+            .expect("token identity exists");
+    assert_eq!(identity.app_id, None);
+    assert_eq!(identity.app_name, None);
+
+    // The fixture is gone. Success proves the existing identity won before
+    // the fresh token could be redeemed or any HTTP mutation was attempted.
+    spice_cmd()
+        .current_dir(instance.path())
+        .env("HOME", home.path())
+        .env_remove("SPICE_CONFIG_DIR")
+        .env_remove("SPICE_SPICEAI_TOKEN")
+        .arg("connect")
+        .arg("--token")
+        .arg("spice-enroll-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
+        .arg("--org")
+        .arg("acme")
+        .arg("--endpoint")
+        .arg(&endpoint)
+        .assert()
+        .success();
+}

--- a/bin/spice/tests/snapshots/cli_integration__connect__connect_help.snap
+++ b/bin/spice/tests/snapshots/cli_integration__connect__connect_help.snap
@@ -1,0 +1,141 @@
+---
+source: bin/spice/tests/cli_integration.rs
+expression: stdout
+---
+`spice connect` enrolls this directory with Spice Cloud and manages its instance.
+
+With a logged-in user session, the command resolves one owner/admin
+organization, enrolls the local instance, and atomically creates and attaches a
+new project. Without a login, an interactive terminal offers inline login
+(recommended) or secure enrollment-key entry. Enrollment-key mode always
+leaves the instance unattached and prints the Cloud-provided recovery link.
+
+The transaction is retry-safe: an interrupted enrollment reuses its durable
+operation and key material, while project creation uses the enrolled instance's
+single attachment as its exact replay key. Existing identities always win and
+are never duplicated.
+
+NON-INTERACTIVE
+  Login mode requires both --org <org> and --project <name>.
+  Key mode requires --token <enrollment-key> and rejects --project.
+
+  spice connect status                    Show this directory's Cloud
+                                          connection, service, and deployment
+                                          state. `--output json` prints the
+                                          same report for automation.
+  spice connect service install           Install and start `spiced` as a
+                                          persistent service so the instance
+                                          survives reboots and closed
+                                          terminals. Re-run to upgrade in
+                                          place: latest binary, rewritten
+                                          service definition, service
+                                          restarted, identity untouched.
+  spice connect service ...               The rest of the service lifecycle:
+                                          uninstall, start, stop, restart,
+                                          status, logs.
+  spice connect remove                    Release this instance: report the
+                                          release to Spice Cloud, uninstall the
+                                          service when one was installed, and
+                                          clear the local identity on disk.
+                                          A running `spiced` keeps its
+                                          in-memory identity until it is
+                                          restarted or the cloud sends a Remove
+                                          command (a mere stream drop just
+                                          reconnects with the same identity),
+                                          so restart spiced to stop remote
+                                          management immediately.
+
+Use `--dir <path>` to manage an instance rooted at a different directory:
+per-instance state lives under `<dir>/.spice`, so multiple instances on one
+host enroll independently. `SPICE_CONFIG_DIR` overrides the derived location
+entirely and wins over `--dir`.
+
+A service needs either Linux with systemd or macOS with launchd. Containers
+pass the enrollment key directly to the runtime (`spiced --token`) under the
+container runtime's restart policy; Windows enrolls and runs under the user's
+own supervisor.
+
+DEPRECATED POD-ADD BEHAVIOR:
+  spice connect <org>/<pod>               Deprecated; use `spice add <org>/<pod>`.
+
+EXAMPLES
+  spice connect
+  spice connect --org acme --project retail-analytics
+  spice connect --token <enrollment-key> --org acme
+  spice connect --dir /srv/edge --region us-west-2
+  spice connect status
+  spice connect status --output json
+  sudo spice connect service install
+  sudo spice connect remove
+
+Docs: https://spiceai.org/docs
+
+Usage: spice connect [OPTIONS] [TARGET] [COMMAND]
+
+Commands:
+  status   Show this directory's Spice Cloud Connect state: connection, service, and deployment, from one snapshot
+  remove   Release this instance: report the release to Spice Cloud, uninstall an installed service, and clear the local identity. spiced will continue running unmanaged after the next restart
+  service  Install and manage the persistent service for this instance directory
+  help     Print this message or the help of the given subcommand(s)
+
+Arguments:
+  [TARGET]
+          A Spicepod path (`<org>/<pod>`) for the deprecated pod-add behavior. Secrets are never accepted positionally: enrollment keys go to the runtime as `spiced --token <enrollment-key>`
+
+Options:
+  -v, --verbose...
+          Increase log verbosity (-v for debug, -vv for trace)
+
+      --machine
+          Machine-readable mode for LLMs and automation: prefer JSON output where supported and always emit structured JSON errors
+
+      --api-key <API_KEY>
+          API key used to authenticate with the runtime or Spice.ai Cloud
+          
+          [env: SPICE_API_KEY=]
+
+      --cloud
+          Target Spice.ai Cloud instead of a local runtime (requires --api-key)
+
+      --org <SLUG>
+          Organization to enroll into, or the expected organization for an enrollment key. Login mode validates owner/admin membership
+
+      --cloud-region <CLOUD_REGION>
+          Spice.ai Cloud runtime endpoint region used with --cloud.
+          
+          Not declared `requires = "cloud"`, because clap's generic missing-required-argument error is the wrong diagnosis on `spice connect`: there the flag is a confusion with `--region` (where the instance runs) or `--endpoint` (which control plane to enroll against), and the command says so itself. The `--cloud` requirement is enforced for every other command by [`validate_cloud_region_usage`].
+
+      --project <SLUG>
+          Project to create and attach. Required for non-interactive login mode; rejected in enrollment-key mode
+
+      --http-endpoint <HTTP_ENDPOINT>
+          HTTP endpoint of the Spice runtime to talk to (default `http://127.0.0.1:8090`).
+          
+          The default is applied by the runtime context rather than by clap, so that omitting this flag stays distinguishable from passing the default value: `spice sql` refuses to send a natural-language query to an HTTP endpoint nobody chose. See #11005.
+
+      --token <SECRET>
+          One-time enrollment key. The value is redacted from Debug/errors and is never persisted. This mode always remains unattached
+
+      --region <LABEL>
+          Declared location label for the enrolled instance
+
+      --tls-root-certificate-file <TLS_ROOT_CERTIFICATE_FILE>
+          Path to a PEM root certificate used to verify the runtime's TLS server certificate
+
+      --endpoint <URL>
+          Override the Spice Cloud endpoint used when inspecting state or reporting a release. Defaults to `https://api.spice.ai`. Also configurable via `SPICE_CLOUD_ENDPOINT`
+
+      --dir <PATH>
+          The instance directory: per-instance Cloud Connect state (the enrolled identity) lives under `<dir>/.spice`. Defaults to the current directory. `SPICE_CONFIG_DIR` overrides the derived `.spice` location entirely. Applies to `status`, `remove`, and `service`
+
+  -y, --yes
+          Skip the confirmation prompt. Applies to `remove`, which otherwise asks before releasing the instance and stopping its service
+
+      --force
+          Clear this directory's local state even when Spice Cloud could not confirm the release. Applies to `remove`, which otherwise keeps the identity so a retry can finish. Use it when the instance is already deleted in the portal, or when the control plane that issued it is gone: the portal-side delete is authoritative either way
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -297,7 +297,10 @@ fn read_disk_endpoint(config_dir: &Path) -> DiskControlPlaneEndpoint {
 /// Build a [`CloudConnectConfig`] from env + on-disk state.
 fn build_config(runtime_version: &str) -> CloudConnectConfig {
     let mut config = CloudConnectConfig::from_env(runtime_version);
-    if std::env::var_os("SPICE_CLOUD_ENDPOINT").is_none() {
+    let Some(requested) = std::env::var_os("SPICE_CLOUD_ENDPOINT")
+        .and_then(|value| value.into_string().ok())
+        .filter(|value| !value.is_empty())
+    else {
         match read_disk_endpoint(&config.config_dir) {
             DiskControlPlaneEndpoint::Resolved(endpoint) => config.enroll_endpoint = endpoint,
             DiskControlPlaneEndpoint::Absent => {}
@@ -307,8 +310,46 @@ fn build_config(runtime_version: &str) -> CloudConnectConfig {
             // cross-control-plane request.
             DiskControlPlaneEndpoint::Invalid => config.enroll_endpoint.clear(),
         }
+        return config;
+    };
+
+    match reconcile_requested_endpoint(&requested, read_bound_endpoint(&config.config_dir)) {
+        Ok(endpoint) => config.enroll_endpoint = endpoint,
+        Err(reason) => {
+            tracing::error!("Spice Cloud Connect is disabled for this start because {reason}");
+            config.enroll_endpoint.clear();
+        }
     }
     config
+}
+
+/// Reconcile `SPICE_CLOUD_ENDPOINT` against the control plane bound on disk.
+///
+/// An environment override never silently retargets an instance that already
+/// enrolled somewhere: renewal would send this instance's credential to a
+/// control plane it never enrolled with. `spice connect` rejects exactly this
+/// mismatch, so the runtime has to agree with it rather than quietly win.
+///
+/// The legacy endpoint file is deliberately not consulted — it is superseded
+/// once a binding exists, and it was never an enrollment.
+fn reconcile_requested_endpoint(
+    requested: &str,
+    bound: DiskControlPlaneEndpoint,
+) -> std::result::Result<String, String> {
+    let requested = runtime_cloud_connect::config::normalize_control_plane_endpoint(requested)
+        .map_err(|error| {
+            format!("SPICE_CLOUD_ENDPOINT is not a usable control-plane endpoint: {error}")
+        })?;
+    match bound {
+        DiskControlPlaneEndpoint::Absent => Ok(requested),
+        DiskControlPlaneEndpoint::Resolved(bound) if requested == bound => Ok(bound),
+        DiskControlPlaneEndpoint::Resolved(bound) => Err(format!(
+            "SPICE_CLOUD_ENDPOINT ({requested}) does not match the control plane this instance enrolled with ({bound}). Unset the variable, or release the instance with `spice connect remove` before enrolling elsewhere."
+        )),
+        DiskControlPlaneEndpoint::Invalid => {
+            Err("the control-plane binding on disk could not be read, so the requested endpoint cannot be checked against it.".to_string())
+        }
+    }
 }
 
 /// Why a `--token` bootstrap could not produce a durable identity. Every
@@ -2075,6 +2116,40 @@ mod tests {
         assert_eq!(read_disk_endpoint(&dir), DiskControlPlaneEndpoint::Invalid);
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An environment override must not retarget an enrolled instance: renewal
+    /// would carry this instance's credential to a control plane it never
+    /// enrolled with. `spice connect` refuses the same mismatch.
+    #[test]
+    fn an_environment_endpoint_never_overrides_a_durable_binding() {
+        let bound = || DiskControlPlaneEndpoint::Resolved("https://bound.example".to_string());
+
+        assert_eq!(
+            reconcile_requested_endpoint("https://bound.example/", bound()),
+            Ok("https://bound.example".to_string())
+        );
+        assert!(
+            reconcile_requested_endpoint("https://elsewhere.example", bound()).is_err(),
+            "a mismatched environment endpoint must fail closed"
+        );
+        assert!(
+            reconcile_requested_endpoint(
+                "https://elsewhere.example",
+                DiskControlPlaneEndpoint::Invalid
+            )
+            .is_err(),
+            "an unreadable binding must fail closed rather than trust the environment"
+        );
+        assert_eq!(
+            reconcile_requested_endpoint("https://fresh.example", DiskControlPlaneEndpoint::Absent),
+            Ok("https://fresh.example".to_string()),
+            "without a binding the environment endpoint still selects the control plane"
+        );
+        assert!(
+            reconcile_requested_endpoint("not a url", DiskControlPlaneEndpoint::Absent).is_err(),
+            "an unusable environment endpoint must fail closed"
+        );
     }
 
     #[tokio::test]

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -156,19 +156,7 @@ impl StartupState {
 }
 
 pub(crate) async fn load_startup_state() -> StartupState {
-    let mut config = CloudConnectConfig::from_env(env!("CARGO_PKG_VERSION"));
-    if std::env::var_os("SPICE_CLOUD_ENDPOINT").is_none()
-        && let Err(error) = apply_endpoint_override(&mut config)
-    {
-        tracing::error!(
-            "Spice Cloud Connect is disabled for this start because the enrollment endpoint override at {} could not be read safely: {error}",
-            config.config_dir.join("cloud-endpoint").display()
-        );
-        let mut state = load_startup_state_from_config(&config).await;
-        state.reconnectable_identity = None;
-        return state;
-    }
-    load_startup_state_from_config(&config).await
+    load_startup_state_from_config(&build_config(env!("CARGO_PKG_VERSION"))).await
 }
 
 /// Load the durable activation snapshot without making an optional Cloud
@@ -220,11 +208,107 @@ fn identity_contents_were_observed(error: &runtime_cloud_connect::Error) -> bool
 /// the caller cannot silently renew against another control plane.
 fn apply_endpoint_override(config: &mut CloudConnectConfig) -> std::io::Result<()> {
     if let Some(override_endpoint) =
-        CloudConnectConfig::read_enroll_endpoint_override(&config.config_dir)?
+        CloudConnectConfig::read_normalized_enroll_endpoint_override(&config.config_dir)
+            .map_err(std::io::Error::other)?
     {
         config.enroll_endpoint = override_endpoint;
     }
     Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum DiskControlPlaneEndpoint {
+    Absent,
+    Resolved(String),
+    Invalid,
+}
+
+/// Read the control plane durably bound by enrollment. A malformed durable
+/// state file is distinct from an absent binding: callers must fail closed
+/// instead of silently substituting the public control plane.
+fn read_bound_endpoint(config_dir: &Path) -> DiskControlPlaneEndpoint {
+    let identity_path = config_dir.join(runtime_cloud_connect::config::IDENTITY_FILE);
+    let identity = match runtime_cloud_connect::IdentityStore::load_optional(&identity_path) {
+        Ok(identity) => identity,
+        Err(error) => {
+            tracing::warn!(
+                "Spice Cloud Connect could not read the enrolled control-plane binding in {}: {error}",
+                identity_path.display()
+            );
+            return DiskControlPlaneEndpoint::Invalid;
+        }
+    };
+    if let Some(endpoint) = identity.and_then(|identity| identity.control_plane_endpoint) {
+        return normalize_disk_endpoint(config_dir, &endpoint, "enrolled");
+    }
+
+    match runtime_cloud_connect::EnrollmentDraft::load_optional(config_dir) {
+        Ok(Some(draft)) => normalize_disk_endpoint(config_dir, &draft.binding.endpoint, "pending"),
+        Ok(None) => DiskControlPlaneEndpoint::Absent,
+        Err(error) => {
+            tracing::warn!(
+                "Spice Cloud Connect could not read the pending control-plane binding in {}: {error}",
+                config_dir.display()
+            );
+            DiskControlPlaneEndpoint::Invalid
+        }
+    }
+}
+
+fn normalize_disk_endpoint(
+    config_dir: &Path,
+    endpoint: &str,
+    binding: &str,
+) -> DiskControlPlaneEndpoint {
+    match runtime_cloud_connect::config::normalize_control_plane_endpoint(endpoint) {
+        Ok(endpoint) => DiskControlPlaneEndpoint::Resolved(endpoint),
+        Err(error) => {
+            tracing::warn!(
+                "Spice Cloud Connect found an invalid {binding} control-plane binding in {}: {error}",
+                config_dir.display()
+            );
+            DiskControlPlaneEndpoint::Invalid
+        }
+    }
+}
+
+/// Resolve the endpoint stored on disk. A durable identity/draft binding wins;
+/// the operator-authored legacy file is consulted only before a binding exists
+/// and is then promoted into the identity by enrollment or successful renewal.
+fn read_disk_endpoint(config_dir: &Path) -> DiskControlPlaneEndpoint {
+    match read_bound_endpoint(config_dir) {
+        DiskControlPlaneEndpoint::Absent => {}
+        resolved => return resolved,
+    }
+
+    match CloudConnectConfig::read_normalized_enroll_endpoint_override(config_dir) {
+        Ok(Some(endpoint)) => DiskControlPlaneEndpoint::Resolved(endpoint),
+        Ok(None) => DiskControlPlaneEndpoint::Absent,
+        Err(error) => {
+            tracing::warn!(
+                "Spice Cloud Connect could not read the configured control-plane endpoint in {}: {error}",
+                config_dir.display()
+            );
+            DiskControlPlaneEndpoint::Invalid
+        }
+    }
+}
+
+/// Build a [`CloudConnectConfig`] from env + on-disk state.
+fn build_config(runtime_version: &str) -> CloudConnectConfig {
+    let mut config = CloudConnectConfig::from_env(runtime_version);
+    if std::env::var_os("SPICE_CLOUD_ENDPOINT").is_none() {
+        match read_disk_endpoint(&config.config_dir) {
+            DiskControlPlaneEndpoint::Resolved(endpoint) => config.enroll_endpoint = endpoint,
+            DiskControlPlaneEndpoint::Absent => {}
+            // Leave an invalid value in the config so enrollment/renewal client
+            // construction refuses to send credentials anywhere. Falling back
+            // to the public endpoint would turn a local read error into a
+            // cross-control-plane request.
+            DiskControlPlaneEndpoint::Invalid => config.enroll_endpoint.clear(),
+        }
+    }
+    config
 }
 
 /// Why a `--token` bootstrap could not produce a durable identity. Every
@@ -1949,6 +2033,50 @@ mod tests {
         dir
     }
 
+    #[test]
+    fn legacy_endpoint_file_is_used_only_until_a_durable_binding_exists() {
+        let dir = scratch_dir("legacy-control-plane-endpoint");
+        std::fs::write(
+            dir.join("cloud-endpoint"),
+            "https://legacy-control.example/\n",
+        )
+        .expect("write legacy endpoint");
+        assert_eq!(
+            read_disk_endpoint(&dir),
+            DiskControlPlaneEndpoint::Resolved("https://legacy-control.example".to_string())
+        );
+
+        let identity_path = dir.join(IDENTITY_FILE);
+        enroll_with_a_cache_key(&identity_path);
+        let mut identity = IdentityStore::load_optional(&identity_path)
+            .expect("load identity")
+            .expect("identity exists");
+        identity.control_plane_endpoint = Some("https://bound-control.example".to_string());
+        IdentityStore::store(&identity_path, &identity).expect("store durable binding");
+        assert_eq!(
+            read_disk_endpoint(&dir),
+            DiskControlPlaneEndpoint::Resolved("https://bound-control.example".to_string())
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unreadable_durable_binding_never_falls_back_to_an_endpoint_file() {
+        let dir = scratch_dir("invalid-control-plane-binding");
+        std::fs::write(dir.join(IDENTITY_FILE), "not identity JSON")
+            .expect("write invalid identity");
+        std::fs::write(
+            dir.join("cloud-endpoint"),
+            "https://attacker-controlled.example\n",
+        )
+        .expect("write fallback endpoint");
+
+        assert_eq!(read_disk_endpoint(&dir), DiskControlPlaneEndpoint::Invalid);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[tokio::test]
     async fn an_unusable_identity_disables_cloud_connect_without_aborting_startup() {
         let dir = scratch_dir("unusable-startup-identity");
@@ -2764,6 +2892,7 @@ views:
             org_name: None,
             app_name: None,
             monitor_url: None,
+            control_plane_endpoint: None,
             enc_private_key_pem: mock_pem,
             enc_public_key_pem: "-----BEGIN PUBLIC KEY-----\nMOCKENC\n-----END PUBLIC KEY-----\n"
                 .to_string(),

--- a/bin/spiced/tests/cloud_connect_bootstrap.rs
+++ b/bin/spiced/tests/cloud_connect_bootstrap.rs
@@ -79,8 +79,10 @@ fn sign_enrollment_csr(csr_pem: &str) -> (String, String) {
         .self_signed(&ca_key)
         .expect("self-sign enrollment test CA");
     let issuer = Issuer::new(ca_params, ca_key);
-    let identity_certificate = CertificateSigningRequestParams::from_pem(csr_pem)
-        .expect("parse enrollment CSR")
+    let mut identity_params =
+        CertificateSigningRequestParams::from_pem(csr_pem).expect("parse enrollment CSR");
+    identity_params.params.not_after = rcgen::date_time_ymd(2099, 1, 1);
+    let identity_certificate = identity_params
         .signed_by(&issuer)
         .expect("sign enrollment CSR");
     (identity_certificate.pem(), ca_certificate.pem())

--- a/crates/runtime-cloud-connect/Cargo.toml
+++ b/crates/runtime-cloud-connect/Cargo.toml
@@ -47,7 +47,8 @@ rand = { workspace = true }
 # backend in every build target.
 rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs", "x509-parser"] }
 # Out-of-band HTTPS enroll/renew against the cloud control plane.
-reqwest = { workspace = true }
+futures.workspace = true
+reqwest = { workspace = true, features = ["stream"] }
 spice-cloud-client = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -60,7 +61,7 @@ tonic-prost = "0.14"
 tracing = { workspace = true }
 # Parse the stored client leaf before honoring existing-identity precedence;
 # the leaf's public key must match the persisted private key.
-x509-parser = "0.18"
+x509-parser = { version = "0.18", features = ["verify-aws"] }
 # Enrollment operation IDs (`Idempotency-Key`) for retry-safe enrollment.
 uuid = { workspace = true, features = ["v4"] }
 # Key material and decrypted secret values are held in `Zeroizing` so a freed
@@ -71,6 +72,15 @@ zeroize = "1.8"
 # Refuse symlink and special-file enrollment locks before privileged callers
 # change permissions or wait for the advisory lock.
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Memory",
+] }
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/crates/runtime-cloud-connect/src/client.rs
+++ b/crates/runtime-cloud-connect/src/client.rs
@@ -317,6 +317,19 @@ impl ClientDriver {
         let expected_public_key_pem = current.public_key_pem.clone();
         let outcome = client.renew(&current, &material).await?;
 
+        // Identities written before endpoint binding was added relied on the
+        // instance-local `cloud-endpoint` file. `spiced` resolves that legacy
+        // source before constructing this client; the first successful renewal
+        // promotes the exact endpoint that accepted the credential into the
+        // identity so every later start is independent of the migration file.
+        let control_plane_endpoint = match current.control_plane_endpoint.as_deref() {
+            Some(endpoint) => Some(endpoint.to_string()),
+            None => Some(
+                crate::config::normalize_control_plane_endpoint(&self.config.enroll_endpoint)
+                    .map_err(|error| client.invalid_renew_response(error.to_string()))?,
+            ),
+        };
+
         let mut rotated = Identity {
             identifier: current.identifier,
             identity_cert_pem: outcome.identity_cert_pem,
@@ -337,6 +350,7 @@ impl ClientDriver {
             org_name: current.org_name,
             app_name: current.app_name,
             monitor_url: current.monitor_url,
+            control_plane_endpoint,
             // Seeded with the OUTGOING keypair and rotated by the call below,
             // which shifts it into `enc_previous_private_key_pem` — assigning
             // `material` here instead would leave the retained key equal to the
@@ -1847,6 +1861,7 @@ mod tests {
             org_name: None,
             app_name: None,
             monitor_url: None,
+            control_plane_endpoint: None,
         };
         current.ensure_cache_key();
         IdentityStore::store(&identity_path, &current).expect("store current identity");
@@ -1909,6 +1924,7 @@ mod tests {
             org_name: None,
             app_name: None,
             monitor_url: None,
+            control_plane_endpoint: None,
         }
     }
 

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -19,11 +19,75 @@ limitations under the License.
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use snafu::Snafu;
+
 /// Default enroll endpoint for the Spice Cloud control plane (state
 /// plane): the base URL the out-of-band HTTPS `/v1/cloud-connect/enroll`
 /// and `/v1/cloud-connect/renew` requests are made against. The gateway
 /// (stream) address is returned by the enroll response, not configured.
 pub const DEFAULT_ENDPOINT: &str = "https://api.spice.ai";
+
+#[derive(Debug, Snafu)]
+#[snafu(display(
+    "the control-plane endpoint must be an absolute HTTPS base URL without credentials, query, or fragment (plain HTTP is allowed only for a loopback fixture)"
+))]
+pub struct InvalidControlPlaneEndpoint;
+
+#[derive(Debug, Snafu)]
+pub enum EnrollmentEndpointOverrideError {
+    #[snafu(display(
+        "Failed to read the Cloud Connect endpoint override at {}: {source}",
+        path.display()
+    ))]
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display(
+        "The Cloud Connect endpoint override at {} is invalid: {source}",
+        path.display()
+    ))]
+    Invalid {
+        path: PathBuf,
+        source: InvalidControlPlaneEndpoint,
+    },
+}
+
+/// Validate and canonicalize a Cloud Connect control-plane base URL.
+///
+/// # Errors
+///
+/// Returns [`InvalidControlPlaneEndpoint`] for unsafe or non-base URLs.
+pub fn normalize_control_plane_endpoint(
+    endpoint: &str,
+) -> std::result::Result<String, InvalidControlPlaneEndpoint> {
+    let parsed = reqwest::Url::parse(endpoint).map_err(|_| InvalidControlPlaneEndpoint)?;
+    if !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || parsed.host_str().is_none()
+    {
+        return Err(InvalidControlPlaneEndpoint);
+    }
+    let local_http = parsed.scheme() == "http" && parsed.host_str().is_some_and(is_loopback_host);
+    if parsed.scheme() != "https" && !local_http {
+        return Err(InvalidControlPlaneEndpoint);
+    }
+    Ok(parsed.to_string().trim_end_matches('/').to_string())
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    let host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
 
 /// Default lead time before the identity cert's `not_after` at which the
 /// client renews. The cloud issues 24h leaves, so a 12h lead yields the
@@ -208,6 +272,36 @@ impl CloudConnectConfig {
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty())
         })
+    }
+
+    /// Read and normalize the legacy instance-local control-plane endpoint.
+    ///
+    /// Enrollment and state-management front ends share this helper so a
+    /// fresh or pre-binding instance cannot choose different control planes in
+    /// `spice` and `spiced`. Durable identity/draft bindings still take
+    /// precedence at each caller; this file is only the fallback before such a
+    /// binding exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file exists but is unsafe/unreadable, or when
+    /// its non-empty value is not a safe control-plane base URL.
+    pub fn read_normalized_enroll_endpoint_override(
+        config_dir: &Path,
+    ) -> std::result::Result<Option<String>, EnrollmentEndpointOverrideError> {
+        let path = config_dir.join("cloud-endpoint");
+        let Some(endpoint) = Self::read_enroll_endpoint_override(config_dir).map_err(|source| {
+            EnrollmentEndpointOverrideError::Read {
+                path: path.clone(),
+                source,
+            }
+        })?
+        else {
+            return Ok(None);
+        };
+        normalize_control_plane_endpoint(&endpoint)
+            .map(Some)
+            .map_err(|source| EnrollmentEndpointOverrideError::Invalid { path, source })
     }
 
     /// Resolve the Cloud Connect config directory to its canonical location.
@@ -460,6 +554,7 @@ mod tests {
         let config = CloudConnectConfig::from_env("v0.0.0-test");
         let identity = crate::identity::Identity {
             identifier: "inst_test".to_string(),
+            control_plane_endpoint: None,
             identity_cert_pem: String::new(),
             private_key_pem: String::new(),
             public_key_pem: String::new(),
@@ -501,6 +596,17 @@ mod tests {
                 .as_deref(),
             Some("https://cloud.example.test")
         );
+        assert_eq!(
+            CloudConnectConfig::read_normalized_enroll_endpoint_override(dir.path())
+                .expect("normalize override")
+                .as_deref(),
+            Some("https://cloud.example.test")
+        );
+
+        std::fs::write(dir.path().join("cloud-endpoint"), "not an endpoint\n")
+            .expect("write invalid override");
+        CloudConnectConfig::read_normalized_enroll_endpoint_override(dir.path())
+            .expect_err("an invalid configured endpoint must fail closed");
     }
 
     #[cfg(unix)]

--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -78,7 +78,13 @@ pub fn normalize_control_plane_endpoint(
     Ok(parsed.to_string().trim_end_matches('/').to_string())
 }
 
-fn is_loopback_host(host: &str) -> bool {
+/// Whether a URL host names the loopback interface.
+///
+/// This is the sole gate on sending a credential over plaintext HTTP, so every
+/// caller that decides `https_only` must ask this one function rather than
+/// re-deriving the rule.
+#[must_use]
+pub fn is_loopback_host(host: &str) -> bool {
     let host = host
         .strip_prefix('[')
         .and_then(|host| host.strip_suffix(']'))

--- a/crates/runtime-cloud-connect/src/draft.rs
+++ b/crates/runtime-cloud-connect/src/draft.rs
@@ -251,7 +251,7 @@ impl EnrollmentTransactionLock {
         match read_bounded_regular_file(&self.draft_path, MAX_DRAFT_BYTES) {
             Ok(contents) => {
                 let draft = EnrollmentDraft::load_published(&self.draft_path, &contents)?;
-                draft.validate_request(&self.draft_path, region, binding)?;
+                draft.validate_request(&self.draft_path, binding)?;
                 Ok(draft)
             }
             Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
@@ -535,7 +535,7 @@ impl EnrollmentDraft {
         match read_bounded_regular_file(path, MAX_DRAFT_BYTES) {
             Ok(contents) => {
                 let draft = Self::parse_at(path, &contents)?;
-                draft.validate_request(path, region, binding)?;
+                draft.validate_request(path, binding)?;
                 return Ok(draft);
             }
             Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
@@ -567,12 +567,14 @@ impl EnrollmentDraft {
         Ok(draft)
     }
 
-    fn validate_request(
-        &self,
-        path: &Path,
-        _region: Option<&str>,
-        binding: &EnrollmentRequestBinding,
-    ) -> Result<()> {
+    /// Confirm a retry targets the same control plane and authority as the
+    /// durable draft.
+    ///
+    /// The declared region is deliberately not part of the replay key: a
+    /// resumed enrollment keeps the region recorded when the draft was
+    /// published, so a differing `--region` on a retry must not invalidate
+    /// exact-replay state.
+    fn validate_request(&self, path: &Path, binding: &EnrollmentRequestBinding) -> Result<()> {
         let authority_matches = match (&self.binding.authority, &binding.authority) {
             (
                 EnrollmentAuthorityBinding::Token { .. },

--- a/crates/runtime-cloud-connect/src/draft.rs
+++ b/crates/runtime-cloud-connect/src/draft.rs
@@ -68,9 +68,28 @@ const LOCK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis
 const REMOVAL_LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
 #[cfg(test)]
 const REMOVAL_LOCK_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+const MAX_DRAFT_BYTES: u64 = 1024 * 1024;
 
 /// Current schema of the draft file.
-const DRAFT_SCHEMA_VERSION: u32 = 2;
+const DRAFT_SCHEMA_VERSION: u32 = 3;
+
+/// Non-secret enrollment authority facts for one operation. The actual
+/// bearer/enrollment key is deliberately absent. Token assertions may change
+/// during recovery; an authenticated operation remains bound to its org.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum EnrollmentAuthorityBinding {
+    Token { expected_org: Option<String> },
+    AuthenticatedSession { organization: String },
+}
+
+/// Control-plane and authority provenance for one enrollment operation.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct EnrollmentRequestBinding {
+    pub endpoint: String,
+    pub authority: EnrollmentAuthorityBinding,
+}
 
 #[derive(Deserialize)]
 struct DraftSchemaHeader {
@@ -118,6 +137,12 @@ pub enum Error {
 
     #[snafu(display("Failed to generate enrollment key material: {source}"))]
     Material { source: crate::identity::Error },
+
+    #[snafu(display(
+        "The pending enrollment at {} belongs to a different control plane or authority. Retry with the original endpoint and organization; the exact-replay state was preserved",
+        path.display()
+    ))]
+    RequestBindingMismatch { path: PathBuf },
 
     #[snafu(display(
         "Another live process is still enrolling this config directory under the lock at {}. Wait for that process to finish and retry",
@@ -192,15 +217,51 @@ impl EnrollmentTransactionLock {
         self.draft_path.parent() == path.parent()
     }
 
-    pub(crate) fn load_or_create(
+    /// Acquire exclusive ownership of a config directory's enrollment
+    /// transaction without blocking a Tokio worker thread.
+    ///
+    /// Callers that need to publish additional retry state beside the
+    /// enrollment draft retain this guard and pass it to
+    /// `enroll_now_with_transaction`, closing the gap between the two durable
+    /// writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the transaction cannot be acquired or the blocking
+    /// task panics.
+    pub async fn acquire_async(config_dir: &Path) -> Result<Self> {
+        let config_dir = config_dir.to_path_buf();
+        tokio::task::spawn_blocking(move || Self::acquire(&config_dir))
+            .await
+            .map_err(|source| Error::AcquireTaskPanicked { source })?
+    }
+
+    /// Load the published draft, or durably create it while this transaction
+    /// owns the directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the draft cannot be read, validated, or published.
+    pub fn load_or_create(
         &self,
         instance: &InstanceFacts,
         region: Option<&str>,
+        binding: &EnrollmentRequestBinding,
     ) -> Result<EnrollmentDraft> {
-        match crate::identity::read_regular_file_optional(&self.draft_path) {
-            Ok(Some(contents)) => EnrollmentDraft::load_published(&self.draft_path, &contents),
-            Ok(None) => {
-                EnrollmentDraft::publish_locked(&self.draft_path, &self.file, instance, region)
+        match read_bounded_regular_file(&self.draft_path, MAX_DRAFT_BYTES) {
+            Ok(contents) => {
+                let draft = EnrollmentDraft::load_published(&self.draft_path, &contents)?;
+                draft.validate_request(&self.draft_path, region, binding)?;
+                Ok(draft)
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                EnrollmentDraft::publish_locked(
+                    &self.draft_path,
+                    &self.file,
+                    instance,
+                    region,
+                    binding,
+                )
             }
             Err(source) => Err(Error::Io {
                 path: self.draft_path.clone(),
@@ -260,6 +321,10 @@ pub struct EnrollmentDraft {
     /// process reuses this value even if its command-line configuration
     /// changed while the operation was pending.
     pub region: Option<String>,
+    /// The normalized control-plane endpoint and non-secret authority facts.
+    /// These prevent a lost response from being replayed to another cloud or
+    /// under a different organization by a later process.
+    pub binding: EnrollmentRequestBinding,
 }
 
 impl std::fmt::Debug for EnrollmentDraft {
@@ -274,6 +339,7 @@ impl std::fmt::Debug for EnrollmentDraft {
             .field("enc_public_key_pem", &"[PUBLIC KEY]")
             .field("instance", &self.instance)
             .field("region", &self.region)
+            .field("binding", &self.binding)
             .finish()
     }
 }
@@ -283,6 +349,20 @@ impl EnrollmentDraft {
     #[must_use]
     pub fn path_in(config_dir: &Path) -> PathBuf {
         config_dir.join(ENROLLMENT_DRAFT_FILE)
+    }
+
+    /// Load an existing draft without creating or mutating enrollment state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for unreadable, malformed, or unsupported draft data.
+    pub fn load_optional(config_dir: &Path) -> Result<Option<Self>> {
+        let path = Self::path_in(config_dir);
+        match read_bounded_regular_file(&path, MAX_DRAFT_BYTES) {
+            Ok(contents) => Self::parse_at(&path, &contents).map(Some),
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(source) => Err(Error::Io { path, source }),
+        }
     }
 
     fn lock_path(path: &Path) -> PathBuf {
@@ -306,16 +386,17 @@ impl EnrollmentDraft {
         config_dir: &Path,
         instance: &InstanceFacts,
         region: Option<&str>,
+        binding: &EnrollmentRequestBinding,
     ) -> Result<Self> {
-        EnrollmentTransactionLock::acquire(config_dir)?.load_or_create(instance, region)
+        EnrollmentTransactionLock::acquire(config_dir)?.load_or_create(instance, region, binding)
     }
 
-    fn parse_at(path: &Path, contents: &str) -> Result<Self> {
+    fn parse_at(path: &Path, contents: &[u8]) -> Result<Self> {
         // Read only the version first. A future schema may add fields that the
         // current strict draft parser deliberately rejects, but operators must
         // still receive the unsupported-schema recovery guidance rather than a
         // generic parse error that obscures the pending enrollment identity.
-        let header = serde_json::from_str::<DraftSchemaHeader>(contents).context(ParseSnafu {
+        let header = serde_json::from_slice::<DraftSchemaHeader>(contents).context(ParseSnafu {
             path: path.to_path_buf(),
         })?;
         if header.schema_version != DRAFT_SCHEMA_VERSION {
@@ -324,7 +405,7 @@ impl EnrollmentDraft {
                 found: header.schema_version,
             });
         }
-        let draft = serde_json::from_str::<Self>(contents).context(ParseSnafu {
+        let draft = serde_json::from_slice::<Self>(contents).context(ParseSnafu {
             path: path.to_path_buf(),
         })?;
         if let Some(reason) = draft.material().validation_error() {
@@ -336,14 +417,19 @@ impl EnrollmentDraft {
         Ok(draft)
     }
 
-    fn load_published(path: &Path, contents: &str) -> Result<Self> {
+    fn load_published(path: &Path, contents: &[u8]) -> Result<Self> {
         Self::parse_at(path, contents)
     }
 
     /// Generate a fresh draft and persist it at `path` before returning it,
     /// so the operation ID is durable before the first request that uses it.
     #[cfg(test)]
-    fn create_at(path: &Path, instance: &InstanceFacts, region: Option<&str>) -> Result<Self> {
+    fn create_at(
+        path: &Path,
+        instance: &InstanceFacts,
+        region: Option<&str>,
+        binding: &EnrollmentRequestBinding,
+    ) -> Result<Self> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).context(IoSnafu {
                 path: parent.to_path_buf(),
@@ -352,7 +438,7 @@ impl EnrollmentDraft {
 
         let lock_path = Self::lock_path(path);
         let publication_lock = Self::acquire_publication_lock(&lock_path)?;
-        Self::publish_locked(path, &publication_lock, instance, region)
+        Self::publish_locked(path, &publication_lock, instance, region, binding)
     }
 
     #[cfg(test)]
@@ -367,7 +453,9 @@ impl EnrollmentDraft {
         #[cfg(unix)]
         use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 
+        #[cfg(not(windows))]
         let mut options = std::fs::OpenOptions::new();
+        #[cfg(not(windows))]
         options.create(true).read(true).write(true);
         #[cfg(unix)]
         options
@@ -375,9 +463,16 @@ impl EnrollmentDraft {
             // A hostile FIFO/device must never block a privileged caller
             // before the descriptor's file type can be checked below.
             .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        #[cfg(not(windows))]
         let file = options.open(lock_path).context(IoSnafu {
             path: lock_path.to_path_buf(),
         })?;
+        #[cfg(windows)]
+        let file = crate::identity::open_windows_owner_only_file(lock_path, false, false).context(
+            IoSnafu {
+                path: lock_path.to_path_buf(),
+            },
+        )?;
         #[cfg(unix)]
         if !file
             .metadata()
@@ -399,6 +494,10 @@ impl EnrollmentDraft {
             .context(IoSnafu {
                 path: lock_path.to_path_buf(),
             })?;
+        #[cfg(windows)]
+        crate::identity::validate_windows_regular_single_link(&file).context(IoSnafu {
+            path: lock_path.to_path_buf(),
+        })?;
         file.sync_all().context(IoSnafu {
             path: lock_path.to_path_buf(),
         })?;
@@ -427,14 +526,19 @@ impl EnrollmentDraft {
         _publication_lock: &std::fs::File,
         instance: &InstanceFacts,
         region: Option<&str>,
+        binding: &EnrollmentRequestBinding,
     ) -> Result<Self> {
         // A caller may have observed NotFound before acquiring the lock, but
         // another process can publish before this process owns it. Re-read
         // while locked so a delayed creator cannot replace the durable winner
         // through the atomic rename below.
-        match crate::identity::read_regular_file_optional(path) {
-            Ok(Some(contents)) => return Self::parse_at(path, &contents),
-            Ok(None) => {}
+        match read_bounded_regular_file(path, MAX_DRAFT_BYTES) {
+            Ok(contents) => {
+                let draft = Self::parse_at(path, &contents)?;
+                draft.validate_request(path, region, binding)?;
+                return Ok(draft);
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
             Err(source) => {
                 return Err(Error::Io {
                     path: path.to_path_buf(),
@@ -454,12 +558,42 @@ impl EnrollmentDraft {
             enc_public_key_pem: material.enc_public_key_pem,
             instance: instance.clone(),
             region: region.map(str::to_string),
+            binding: binding.clone(),
         };
         let bytes = serde_json::to_vec_pretty(&draft).context(SerializeSnafu)?;
         crate::identity::atomic_write_owner_only(path, &bytes).context(IoSnafu {
             path: path.to_path_buf(),
         })?;
         Ok(draft)
+    }
+
+    fn validate_request(
+        &self,
+        path: &Path,
+        _region: Option<&str>,
+        binding: &EnrollmentRequestBinding,
+    ) -> Result<()> {
+        let authority_matches = match (&self.binding.authority, &binding.authority) {
+            (
+                EnrollmentAuthorityBinding::Token { .. },
+                EnrollmentAuthorityBinding::Token { .. },
+            ) => true,
+            (
+                EnrollmentAuthorityBinding::AuthenticatedSession {
+                    organization: persisted,
+                },
+                EnrollmentAuthorityBinding::AuthenticatedSession {
+                    organization: requested,
+                },
+            ) => persisted == requested,
+            _ => false,
+        };
+        if self.binding.endpoint != binding.endpoint || !authority_matches {
+            return Err(Error::RequestBindingMismatch {
+                path: path.to_path_buf(),
+            });
+        }
+        Ok(())
     }
 
     /// Remove the draft for `config_dir`. A missing file is success. Deletion
@@ -521,9 +655,63 @@ impl EnrollmentDraft {
     }
 }
 
+fn read_bounded_regular_file(path: &Path, max_bytes: u64) -> std::io::Result<Vec<u8>> {
+    use std::io::Read as _;
+
+    #[cfg(not(windows))]
+    let mut options = std::fs::OpenOptions::new();
+    #[cfg(not(windows))]
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    #[cfg(not(windows))]
+    let file = options.open(path)?;
+    #[cfg(windows)]
+    let file = crate::identity::open_windows_regular_file_for_read(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.len() > max_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the enrollment draft was not a bounded regular file",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        if metadata.nlink() != 1 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "the enrollment draft must not be hard-linked",
+            ));
+        }
+    }
+    let mut bytes = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
+    file.take(max_bytes.saturating_add(1))
+        .read_to_end(&mut bytes)?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > max_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the enrollment draft exceeded its size limit",
+        ));
+    }
+    Ok(bytes)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_binding() -> EnrollmentRequestBinding {
+        EnrollmentRequestBinding {
+            endpoint: "https://api.spice.ai".to_string(),
+            authority: EnrollmentAuthorityBinding::Token {
+                expected_org: Some("acme".to_string()),
+            },
+        }
+    }
 
     fn test_instance(runtime_version: &str) -> InstanceFacts {
         InstanceFacts {
@@ -540,6 +728,7 @@ mod tests {
             config_dir,
             &test_instance("v2.2.0-test"),
             Some("us-west-2"),
+            &test_binding(),
         )
     }
 
@@ -566,7 +755,8 @@ mod tests {
         let second = EnrollmentDraft::load_or_create(
             dir.path(),
             &test_instance("v9.9.9-replacement"),
-            Some("eu-west-1"),
+            Some("us-west-2"),
+            &test_binding(),
         )
         .expect("reload");
 
@@ -578,6 +768,82 @@ mod tests {
         assert_eq!(first.csr_pem, second.csr_pem);
         assert_eq!(first.instance, second.instance);
         assert_eq!(first.region, second.region);
+    }
+
+    #[test]
+    fn token_recovery_reuses_the_draft_across_a_new_assertion_and_region() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let first = load_or_create(dir.path()).expect("create");
+        let recovered = EnrollmentDraft::load_or_create(
+            dir.path(),
+            &test_instance("v9.9.9-replacement"),
+            Some("eu-west-1"),
+            &EnrollmentRequestBinding {
+                endpoint: "https://api.spice.ai".to_string(),
+                authority: EnrollmentAuthorityBinding::Token {
+                    expected_org: Some("corrected-org".to_string()),
+                },
+            },
+        )
+        .expect("a new token assertion recovers the exact operation");
+
+        assert_eq!(
+            recovered.enrollment_operation_id,
+            first.enrollment_operation_id
+        );
+        assert_eq!(recovered.region, first.region);
+        assert_eq!(recovered.binding, first.binding);
+    }
+
+    #[test]
+    fn recovery_rejects_another_endpoint_or_authenticated_org() {
+        let endpoint_dir = tempfile::tempdir().expect("endpoint tempdir");
+        load_or_create(endpoint_dir.path()).expect("create token draft");
+        let endpoint_error = EnrollmentDraft::load_or_create(
+            endpoint_dir.path(),
+            &test_instance("v2.2.0-test"),
+            Some("us-west-2"),
+            &EnrollmentRequestBinding {
+                endpoint: "https://other.example".to_string(),
+                authority: EnrollmentAuthorityBinding::Token { expected_org: None },
+            },
+        )
+        .expect_err("another endpoint cannot receive the persisted operation");
+        assert!(
+            matches!(endpoint_error, Error::RequestBindingMismatch { .. }),
+            "{endpoint_error}"
+        );
+
+        let auth_dir = tempfile::tempdir().expect("auth tempdir");
+        let original = EnrollmentRequestBinding {
+            endpoint: "https://api.spice.ai".to_string(),
+            authority: EnrollmentAuthorityBinding::AuthenticatedSession {
+                organization: "acme".to_string(),
+            },
+        };
+        EnrollmentDraft::load_or_create(
+            auth_dir.path(),
+            &test_instance("v2.2.0-test"),
+            None,
+            &original,
+        )
+        .expect("create authenticated draft");
+        let org_error = EnrollmentDraft::load_or_create(
+            auth_dir.path(),
+            &test_instance("v2.2.0-test"),
+            None,
+            &EnrollmentRequestBinding {
+                endpoint: original.endpoint,
+                authority: EnrollmentAuthorityBinding::AuthenticatedSession {
+                    organization: "other".to_string(),
+                },
+            },
+        )
+        .expect_err("another authenticated org cannot receive the operation");
+        assert!(
+            matches!(org_error, Error::RequestBindingMismatch { .. }),
+            "{org_error}"
+        );
     }
 
     #[test]
@@ -701,7 +967,8 @@ mod tests {
         let delayed = EnrollmentDraft::create_at(
             &path,
             &test_instance("v9.9.9-delayed"),
-            Some("eu-central-1"),
+            Some("us-west-2"),
+            &test_binding(),
         )
         .expect("delayed creator loads the winner");
 
@@ -824,7 +1091,11 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let transaction = EnrollmentTransactionLock::acquire(dir.path()).expect("acquire lock");
         transaction
-            .load_or_create(&test_instance("v2.2.0-test"), Some("us-west-2"))
+            .load_or_create(
+                &test_instance("v2.2.0-test"),
+                Some("us-west-2"),
+                &test_binding(),
+            )
             .expect("publish draft while locked");
 
         let error = EnrollmentDraft::delete(dir.path()).expect_err("live enrollment owns draft");
@@ -844,7 +1115,11 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let transaction = EnrollmentTransactionLock::acquire(dir.path()).expect("acquire lock");
         transaction
-            .load_or_create(&test_instance("v2.2.0-test"), Some("us-west-2"))
+            .load_or_create(
+                &test_instance("v2.2.0-test"),
+                Some("us-west-2"),
+                &test_binding(),
+            )
             .expect("publish draft while locked");
 
         let started = std::time::Instant::now();
@@ -1026,6 +1301,7 @@ mod tests {
         assert_eq!(
             fields,
             vec![
+                "binding",
                 "csr_pem",
                 "enc_private_key_pem",
                 "enc_public_key_pem",

--- a/crates/runtime-cloud-connect/src/enroll.rs
+++ b/crates/runtime-cloud-connect/src/enroll.rs
@@ -50,12 +50,16 @@ limitations under the License.
 use std::{sync::Arc, time::Duration};
 
 use base64::Engine as _;
+use futures::StreamExt as _;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use snafu::{ResultExt, Snafu};
 use zeroize::Zeroizing;
 
 use crate::config::CloudConnectConfig;
-use crate::draft::{EnrollmentDraft, EnrollmentTransactionLock};
+use crate::draft::{
+    EnrollmentAuthorityBinding, EnrollmentDraft, EnrollmentRequestBinding,
+    EnrollmentTransactionLock,
+};
 use crate::enrollment_key::EnrollmentKey;
 use crate::identity::{EnrollmentMaterial, Identity, IdentityStore};
 
@@ -77,6 +81,8 @@ pub const INTERACTIVE_RETRY_DEADLINE: Duration = Duration::from_mins(2);
 const RETRY_BACKOFF_BASE: Duration = Duration::from_secs(1);
 /// Full-jitter backoff ceiling: no retry window grows past this.
 const RETRY_BACKOFF_CAP: Duration = Duration::from_secs(30);
+/// Maximum body accepted from the enrollment control plane.
+const MAX_RESPONSE_BYTES: usize = 64 * 1024;
 
 /// A logged-in Spice Cloud session's bearer token, wrapped so it cannot
 /// leak through `Debug` and is wiped on drop. Constructed by callers that
@@ -216,6 +222,11 @@ pub enum Error {
 
     #[snafu(display("Failed to read the Spice Cloud response from {url}: {source}"))]
     ResponseBody { url: String, source: reqwest::Error },
+
+    #[snafu(display(
+        "Failed to read the Spice Cloud response from {url}: the body exceeded the 64 KiB limit"
+    ))]
+    ResponseTooLarge { url: String },
 
     #[snafu(display("Failed to decode the Spice Cloud response from {url}: {reason}"))]
     ResponseDecode { url: String, reason: String },
@@ -484,6 +495,11 @@ impl EnrollClient {
     /// used — the production path, where the cloud serves a
     /// publicly-trusted certificate.
     pub(crate) fn new(config: &CloudConnectConfig) -> Result<Self> {
+        let base = crate::config::normalize_control_plane_endpoint(&config.enroll_endpoint)
+            .map_err(|source| Error::InvalidResponse {
+                url: config.enroll_endpoint.clone(),
+                reason: source.to_string(),
+            })?;
         let mut builder = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .connect_timeout(Duration::from_secs(10))
@@ -499,12 +515,11 @@ impl EnrollClient {
             }
         }
         let http = builder.build().context(ClientBuildSnafu)?;
-        let base = config.enroll_endpoint.trim_end_matches('/');
         Ok(Self {
             http,
             enroll_url: format!("{base}{ENROLL_PATH}"),
             renew_url: format!("{base}{RENEW_PATH}"),
-            base_url: base.to_string(),
+            base_url: base,
             ca_cert_pem: config.ca_cert_pem.clone(),
         })
     }
@@ -695,13 +710,7 @@ impl EnrollClient {
 
         let status = response.status();
         if status.is_success() {
-            let body = response
-                .bytes()
-                .await
-                .map_err(|source| Error::ResponseBody {
-                    url: url.to_string(),
-                    source,
-                })?;
+            let body = bounded_response_body(url, response).await?;
             return serde_json::from_slice::<Resp>(&body).map_err(|source| {
                 let reason = format!("failed to decode response body: {source}");
                 Error::ResponseDecode {
@@ -720,8 +729,8 @@ impl EnrollClient {
         // why. A proxy or defensive server can echo a rejected credential,
         // so redact the authority before parsing or bounding the message and
         // again after JSON decoding (escapes can reconstruct it).
-        let (code, message) = match response.text().await {
-            Ok(text) => parse_error_body(&text, sensitive),
+        let (code, message) = match bounded_response_body(url, response).await {
+            Ok(body) => parse_error_body(&String::from_utf8_lossy(&body), sensitive),
             Err(_) => (None, String::new()),
         };
         let message = match skew {
@@ -750,6 +759,24 @@ impl EnrollClient {
             })
         }
     }
+}
+
+async fn bounded_response_body(url: &str, response: reqwest::Response) -> Result<Vec<u8>> {
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|source| Error::ResponseBody {
+            url: url.to_string(),
+            source,
+        })?;
+        if body.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
+            return Err(Error::ResponseTooLarge {
+                url: url.to_string(),
+            });
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
 }
 
 fn redact_sensitive(text: &str, sensitive: Option<&str>) -> String {
@@ -1067,7 +1094,35 @@ pub async fn enroll_now(
                 })
             })
             .context(DraftSnafu)?;
+    enroll_now_with_transaction(config, authority, retry, enrollment_transaction).await
+}
+
+/// Enroll while retaining a transaction acquired by the caller.
+///
+/// This entry point lets a caller bind its own crash-recovery journal to the
+/// exact enrollment draft before any request is sent. The supplied guard is
+/// held through identity promotion and draft cleanup.
+///
+/// # Errors
+///
+/// Returns the same errors as [`enroll_now`].
+pub async fn enroll_now_with_transaction(
+    config: &CloudConnectConfig,
+    authority: &EnrollmentAuthority,
+    retry: RetryPolicy,
+    enrollment_transaction: EnrollmentTransactionLock,
+) -> std::result::Result<EnrollNowOutcome, EnrollNowError> {
     let enrollment_transaction = Arc::new(enrollment_transaction);
+    let config_dir = config.config_dir.clone();
+    let normalized_endpoint = crate::config::normalize_control_plane_endpoint(
+        &config.enroll_endpoint,
+    )
+    .map_err(|source| EnrollNowError::Client {
+        source: Error::InvalidResponse {
+            url: config.enroll_endpoint.clone(),
+            reason: source.to_string(),
+        },
+    })?;
 
     // Existing identity wins without redeeming the supplied authority.
     let identity_path = config.identity_path.clone();
@@ -1118,9 +1173,22 @@ pub async fn enroll_now(
     let facts = InstanceFacts::gather(&config.runtime_version);
     let draft_facts = facts.clone();
     let draft_region = config.instance_region.clone();
+    let draft_binding = EnrollmentRequestBinding {
+        endpoint: normalized_endpoint,
+        authority: match authority {
+            EnrollmentAuthority::Token { expected_org, .. } => EnrollmentAuthorityBinding::Token {
+                expected_org: expected_org.clone(),
+            },
+            EnrollmentAuthority::AuthenticatedSession { org, .. } => {
+                EnrollmentAuthorityBinding::AuthenticatedSession {
+                    organization: org.clone(),
+                }
+            }
+        },
+    };
     let draft_transaction = Arc::clone(&enrollment_transaction);
     let draft = tokio::task::spawn_blocking(move || {
-        draft_transaction.load_or_create(&draft_facts, draft_region.as_deref())
+        draft_transaction.load_or_create(&draft_facts, draft_region.as_deref(), &draft_binding)
     })
     .await
     .unwrap_or_else(|join| {
@@ -1149,6 +1217,33 @@ pub async fn enroll_now(
     // optional portal metadata must not discard the issued identity. Normalize
     // harmless surrounding whitespace and treat a blank org as absent.
     let normalized_org_name = outcome.metadata.organization.name.trim().to_string();
+    let expected_org = match authority {
+        EnrollmentAuthority::AuthenticatedSession { org, .. } => Some(org.as_str()),
+        EnrollmentAuthority::Token { expected_org, .. } => expected_org.as_deref(),
+    }
+    .filter(|org| !org.is_empty());
+    validate_enrollment_organization(&client.enroll_url, expected_org, &normalized_org_name)
+        .map_err(|source| EnrollNowError::Rejected { source })?;
+    validate_enrollment_region(
+        &client.enroll_url,
+        draft.region.as_deref(),
+        outcome.metadata.region.as_deref(),
+    )
+    .map_err(|source| EnrollNowError::Rejected { source })?;
+    for (field, value) in [
+        ("instance_id", outcome.instance_id.as_str()),
+        ("gateway_addr", outcome.gateway_addr.as_str()),
+        ("organization", normalized_org_name.as_str()),
+    ] {
+        if value.chars().any(char::is_control) {
+            return Err(EnrollNowError::Rejected {
+                source: Error::InvalidResponse {
+                    url: client.enroll_url.clone(),
+                    reason: format!("{field} contained control characters"),
+                },
+            });
+        }
+    }
     let org_name = (!normalized_org_name.is_empty()).then(|| normalized_org_name.clone());
     outcome.metadata.organization.name = normalized_org_name;
 
@@ -1170,6 +1265,7 @@ pub async fn enroll_now(
         org_name,
         app_name: None,
         monitor_url: None,
+        control_plane_endpoint: Some(draft.binding.endpoint.clone()),
         enc_private_key_pem: material.enc_private_key_pem,
         enc_public_key_pem: material.enc_public_key_pem,
         // A fresh enrollment has no prior key to retain.
@@ -1221,6 +1317,35 @@ pub async fn enroll_now(
         identity,
         metadata: outcome.metadata,
     })
+}
+
+fn validate_enrollment_organization(url: &str, expected: Option<&str>, actual: &str) -> Result<()> {
+    if expected
+        .filter(|expected| !expected.is_empty())
+        .is_some_and(|expected| !actual.eq_ignore_ascii_case(expected))
+    {
+        return Err(Error::InvalidResponse {
+            url: url.to_string(),
+            reason: "organization did not match the authenticated enrollment authority".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_enrollment_region(
+    url: &str,
+    expected: Option<&str>,
+    actual: Option<&str>,
+) -> Result<()> {
+    if let Some(expected) = expected
+        && actual != Some(expected)
+    {
+        return Err(Error::InvalidResponse {
+            url: url.to_string(),
+            reason: "region did not match the durable enrollment request".to_string(),
+        });
+    }
+    Ok(())
 }
 
 async fn cleanup_enrollment_draft(enrollment_transaction: &Arc<EnrollmentTransactionLock>) {
@@ -1277,6 +1402,20 @@ pub(crate) fn sign_pop_payload(
         .sign(&rng, payload)
         .map_err(|source| format!("signing failed: {source}"))?;
     Ok(base64::engine::general_purpose::STANDARD.encode(signature.as_ref()))
+}
+
+/// Sign a domain-separated control-plane request with an enrolled identity.
+/// Servers verify the signature against `identity_cert_pem` before mutating
+/// state, so knowing an instance identifier is not sufficient authority.
+///
+/// # Errors
+///
+/// Returns a redaction-safe reason when the stored private key is unusable.
+pub fn sign_identity_proof(
+    private_key_pem: &str,
+    payload: &[u8],
+) -> std::result::Result<String, String> {
+    sign_pop_payload(private_key_pem, payload)
 }
 
 /// Parse an RFC 3339 `not_after` timestamp from an enroll response into Unix
@@ -1427,6 +1566,16 @@ mod tests {
     }
 
     #[test]
+    fn enrollment_response_organization_must_match_the_authority() {
+        validate_enrollment_organization("https://api.spice.ai", Some("acme"), "ACME")
+            .expect("organization comparison is case-insensitive");
+        let error =
+            validate_enrollment_organization("https://api.spice.ai", Some("acme"), "globex")
+                .expect_err("cross-organization identity must fail closed");
+        assert!(matches!(error, Error::InvalidResponse { .. }));
+    }
+
+    #[test]
     fn rejection_classification() {
         // Only an authoritative 4xx cloud rejection is terminal; everything
         // else is retryable.
@@ -1558,6 +1707,42 @@ mod tests {
             !err.is_terminal_enrollment_failure(),
             "an incomplete response can succeed when the operation is replayed"
         );
+    }
+
+    #[tokio::test]
+    async fn oversized_enrollment_responses_are_bounded() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let address = listener.local_addr().expect("test server address");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+            let mut request = [0_u8; 4096];
+            let _ = socket.read(&mut request).await.expect("read request");
+            let body = vec![b'x'; MAX_RESPONSE_BYTES + 1];
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            socket
+                .write_all(headers.as_bytes())
+                .await
+                .expect("write headers");
+            socket.write_all(&body).await.expect("write body");
+        });
+
+        let base = format!("http://{address}");
+        let url = format!("{base}/oversized");
+        let client = EnrollClient::new(&test_config(&base)).expect("client");
+        let request = client.http.get(&url);
+        let error = client
+            .send::<serde_json::Value>(&url, request, None)
+            .await
+            .expect_err("oversized body must fail");
+        server.await.expect("test server task");
+        assert!(matches!(error, Error::ResponseTooLarge { .. }));
     }
 
     #[tokio::test]

--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -222,6 +222,11 @@ pub struct Identity {
     /// route metadata. Scoped to the attachment; cleared on detach.
     #[serde(default)]
     pub monitor_url: Option<String>,
+    /// Normalized control-plane endpoint that issued this identity. Bound at
+    /// enrollment so later commands never trust an unrelated repository file
+    /// when deciding where to send credentials.
+    #[serde(default)]
+    pub control_plane_endpoint: Option<String>,
 }
 
 /// The control plane's app attachment state for this instance, as one tuple:
@@ -278,6 +283,7 @@ impl std::fmt::Debug for Identity {
             .field("org_name", &self.org_name)
             .field("app_name", &self.app_name)
             .field("monitor_url", &self.monitor_url)
+            .field("control_plane_endpoint", &self.control_plane_endpoint)
             .finish()
     }
 }
@@ -317,9 +323,13 @@ impl Identity {
     /// existing-identity precedence rule. Credentials, the cloud identifier,
     /// and a durable gateway address are always required; a process-local
     /// override may redirect a running client but cannot activate an identity.
-    pub(crate) fn reconnect_validation_error(&self) -> Option<&'static str> {
+    #[must_use]
+    pub fn reconnect_validation_error(&self) -> Option<&'static str> {
         if self.identifier.trim().is_empty() {
             return Some("the cloud-assigned instance identifier is empty");
+        }
+        if self.identifier.chars().any(char::is_control) {
+            return Some("the cloud-assigned instance identifier contains control characters");
         }
         if self.identity_cert_pem.trim().is_empty() {
             return Some("the client identity certificate is empty");
@@ -359,6 +369,9 @@ impl Identity {
         if self.gateway_addr.trim().is_empty() {
             return Some("the gateway address is empty");
         }
+        if self.gateway_addr.chars().any(char::is_control) {
+            return Some("the gateway address contains control characters");
+        }
         match (
             self.enc_private_key_pem.trim().is_empty(),
             self.enc_public_key_pem.trim().is_empty(),
@@ -389,6 +402,11 @@ impl Identity {
                 }
             }
             _ => return Some("the secret-delivery keypair is incomplete"),
+        }
+        if let Some(endpoint) = self.control_plane_endpoint.as_deref()
+            && crate::config::normalize_control_plane_endpoint(endpoint).is_err()
+        {
+            return Some("the bound control-plane endpoint is invalid");
         }
         None
     }
@@ -656,33 +674,16 @@ pub(crate) fn read_regular_file_optional(path: &Path) -> std::io::Result<Option<
 
     #[cfg(windows)]
     let mut file = {
-        use std::os::windows::fs::{MetadataExt as _, OpenOptionsExt as _};
-
         match validate_state_path_ancestors(path) {
             Ok(()) => {}
             Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(source) => return Err(source),
         }
-
-        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
-        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-        let file = match std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-            .open(path)
-        {
+        match open_windows_regular_file_for_read(path) {
             Ok(file) => file,
             Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(source) => return Err(source),
-        };
-        let metadata = file.metadata()?;
-        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 || !metadata.is_file() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "the state path must be a regular file",
-            ));
         }
-        file
     };
 
     #[cfg(not(any(unix, windows)))]
@@ -914,6 +915,207 @@ fn validate_state_path_ancestors(_path: &Path) -> std::io::Result<()> {
         std::io::ErrorKind::Unsupported,
         "secure state-file reads are unsupported on this platform",
     ))
+}
+
+/// Open or create a Windows state file with a protected owner-only DACL.
+///
+/// `create_new` refuses an existing destination. `truncate` replaces an
+/// existing destination; otherwise an existing regular file is opened in
+/// place. Every disposition opens the reparse point itself so validation can
+/// reject it instead of following it.
+#[cfg(windows)]
+pub(crate) fn open_windows_owner_only_file(
+    path: &Path,
+    create_new: bool,
+    truncate: bool,
+) -> std::io::Result<std::fs::File> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::{FromRawHandle as _, RawHandle};
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE, LocalFree};
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1, SE_FILE_OBJECT,
+        SetSecurityInfo,
+    };
+    use windows_sys::Win32::Security::{
+        DACL_SECURITY_INFORMATION, GetSecurityDescriptorDacl, PROTECTED_DACL_SECURITY_INFORMATION,
+        SECURITY_ATTRIBUTES,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        CREATE_ALWAYS, CREATE_NEW, CreateFileW, FILE_ATTRIBUTE_NORMAL,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_ALWAYS,
+    };
+
+    let path = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let sddl = "D:P(A;;GA;;;OW)"
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let mut descriptor = std::ptr::null_mut();
+    let converted = unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl.as_ptr(),
+            SDDL_REVISION_1,
+            &mut descriptor,
+            std::ptr::null_mut(),
+        )
+    };
+    if converted == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let mut security = SECURITY_ATTRIBUTES {
+        nLength: u32::try_from(std::mem::size_of::<SECURITY_ATTRIBUTES>()).unwrap_or(u32::MAX),
+        lpSecurityDescriptor: descriptor,
+        bInheritHandle: 0,
+    };
+    let disposition = if create_new {
+        CREATE_NEW
+    } else if truncate {
+        CREATE_ALWAYS
+    } else {
+        OPEN_ALWAYS
+    };
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            &mut security,
+            disposition,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        unsafe {
+            let _ = LocalFree(descriptor.cast());
+        }
+        return Err(std::io::Error::last_os_error());
+    }
+
+    let mut dacl_present = 0;
+    let mut dacl = std::ptr::null_mut();
+    let mut dacl_defaulted = 0;
+    let got_dacl = unsafe {
+        GetSecurityDescriptorDacl(
+            descriptor,
+            &mut dacl_present,
+            &mut dacl,
+            &mut dacl_defaulted,
+        )
+    };
+    if got_dacl == 0 || dacl_present == 0 {
+        let source = if got_dacl == 0 {
+            std::io::Error::last_os_error()
+        } else {
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "owner-only state-file descriptor did not contain a DACL",
+            )
+        };
+        unsafe {
+            let _ = LocalFree(descriptor.cast());
+            let _ = CloseHandle(handle);
+        }
+        return Err(source);
+    }
+    let acl_result = unsafe {
+        SetSecurityInfo(
+            handle,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            dacl,
+            std::ptr::null_mut(),
+        )
+    };
+    unsafe {
+        let _ = LocalFree(descriptor.cast());
+    }
+    if acl_result != 0 {
+        unsafe {
+            let _ = CloseHandle(handle);
+        }
+        return Err(std::io::Error::from_raw_os_error(
+            i32::try_from(acl_result).unwrap_or(i32::MAX),
+        ));
+    }
+
+    let file = unsafe { std::fs::File::from_raw_handle(handle as RawHandle) };
+    validate_windows_regular_single_link(&file)?;
+    Ok(file)
+}
+
+/// Reject Windows directories, reparse points, and multiply-linked state
+/// files after opening the object itself rather than following it.
+#[cfg(windows)]
+pub(crate) fn validate_windows_regular_single_link(file: &std::fs::File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+        GetFileInformationByHandle,
+    };
+
+    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    let result =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle().cast(), &mut information) };
+    if result == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if information.dwFileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT) != 0
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the state path must be a regular file, not a directory or reparse point",
+        ));
+    }
+    if information.nNumberOfLinks != 1 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the state path must not be hard-linked",
+        ));
+    }
+    Ok(())
+}
+
+/// Open a Windows state file without following a reparse point.
+#[cfg(windows)]
+pub(crate) fn open_windows_regular_file_for_read(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use std::os::windows::io::{FromRawHandle as _, RawHandle};
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_READ, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+
+    let path = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            FILE_GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(std::io::Error::last_os_error());
+    }
+    let file = unsafe { std::fs::File::from_raw_handle(handle as RawHandle) };
+    validate_windows_regular_single_link(&file)?;
+    Ok(file)
 }
 
 impl IdentityStore {
@@ -1175,6 +1377,13 @@ impl IdentityStore {
         merged.org_name = current.org_name;
         merged.app_name = current.app_name;
         merged.monitor_url = current.monitor_url;
+        // A durable binding already on disk wins over a stale renewal clone.
+        // A legacy identity has no binding, so retain the endpoint the renewal
+        // just proved by succeeding and promote it atomically with the rotated
+        // credential.
+        if current.control_plane_endpoint.is_some() {
+            merged.control_plane_endpoint = current.control_plane_endpoint;
+        }
         Self::store_locked(path, &merged)?;
         Ok(CredentialUpdateOutcome::Stored(merged))
     }
@@ -1736,6 +1945,7 @@ mod tests {
             org_name: None,
             app_name: None,
             monitor_url: None,
+            control_plane_endpoint: None,
             enc_private_key_pem: encryption_keypair.to_pkcs8_pem().to_string(),
             enc_public_key_pem: encryption_keypair.public_key_spki_pem(),
             enc_previous_private_key_pem: String::new(),
@@ -2596,6 +2806,46 @@ mod tests {
             Some("https://spice.ai/acme/retail-analytics/monitor")
         );
         assert_eq!(merged.org_name.as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn credential_update_backfills_but_never_replaces_the_control_plane_binding() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("identity.json");
+        let legacy = sample_identity();
+        IdentityStore::store(&path, &legacy).expect("store legacy identity");
+
+        let mut renewed = legacy.clone();
+        renewed.control_plane_endpoint = Some("https://private.example".to_string());
+        let CredentialUpdateOutcome::Stored(backfilled) = IdentityStore::store_credential_update(
+            &path,
+            &legacy.identifier,
+            &legacy.public_key_pem,
+            &renewed,
+        )
+        .expect("store endpoint backfill") else {
+            panic!("the legacy credential generation must remain present");
+        };
+        assert_eq!(
+            backfilled.control_plane_endpoint.as_deref(),
+            Some("https://private.example")
+        );
+
+        let mut stale_renewal = backfilled.clone();
+        stale_renewal.control_plane_endpoint = Some("https://wrong.example".to_string());
+        let CredentialUpdateOutcome::Stored(preserved) = IdentityStore::store_credential_update(
+            &path,
+            &backfilled.identifier,
+            &backfilled.public_key_pem,
+            &stale_renewal,
+        )
+        .expect("store stale renewal") else {
+            panic!("the bound credential generation must remain present");
+        };
+        assert_eq!(
+            preserved.control_plane_endpoint.as_deref(),
+            Some("https://private.example")
+        );
     }
 
     #[test]

--- a/crates/runtime-cloud-connect/src/lib.rs
+++ b/crates/runtime-cloud-connect/src/lib.rs
@@ -99,10 +99,13 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
 pub use config::CloudConnectConfig;
-pub use draft::{EnrollmentDraft, EnrollmentTransactionLock};
+pub use draft::{
+    EnrollmentAuthorityBinding, EnrollmentDraft, EnrollmentRequestBinding,
+    EnrollmentTransactionLock,
+};
 pub use enroll::{
     EnrollNowError, EnrollNowOutcome, EnrollmentAuthority, EnrollmentMetadata, RetryPolicy,
-    SessionToken, enroll_now,
+    SessionToken, enroll_now, enroll_now_with_transaction, sign_identity_proof,
 };
 pub use enrollment_key::{EnrollmentKey, InvalidEnrollmentKey};
 pub use handlers::{
@@ -498,22 +501,29 @@ mod tests {
     }
 
     fn test_identity() -> Identity {
-        use rcgen::{CertificateParams, KeyPair};
+        use rcgen::{CertificateParams, ExtendedKeyUsagePurpose, KeyPair};
 
         let material = IdentityStore::generate_enrollment().expect("generate enrollment material");
         let keypair = KeyPair::from_pem(&material.private_key_pem).expect("parse identity key");
-        let certificate = CertificateParams::new(Vec::<String>::new())
-            .expect("certificate parameters")
-            .self_signed(&keypair)
-            .expect("sign certificate");
+        let mut params =
+            CertificateParams::new(Vec::<String>::new()).expect("certificate parameters");
+        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+        let certificate = params.self_signed(&keypair).expect("sign certificate");
+        let (_, parsed_certificate) =
+            x509_parser::prelude::parse_x509_certificate(certificate.der().as_ref())
+                .expect("parse test identity certificate");
+        let not_after_unix = u64::try_from(parsed_certificate.validity().not_after.timestamp())
+            .expect("test identity expiry after the Unix epoch");
+        let certificate_pem = certificate.pem();
         Identity {
             identifier: "inst_test".to_string(),
-            identity_cert_pem: certificate.pem(),
+            identity_cert_pem: certificate_pem.clone(),
             private_key_pem: material.private_key_pem,
             public_key_pem: material.public_key_pem,
-            ca_bundle_pem: String::new(),
+            ca_bundle_pem: certificate_pem,
             gateway_addr: "gateway.example:443".to_string(),
-            not_after_unix: None,
+            not_after_unix: Some(not_after_unix),
+            control_plane_endpoint: None,
             enc_private_key_pem: material.enc_private_key_pem,
             enc_public_key_pem: material.enc_public_key_pem,
             enc_previous_private_key_pem: String::new(),
@@ -530,17 +540,25 @@ mod tests {
         not_before: (i32, u8, u8),
         not_after: (i32, u8, u8),
     ) {
-        use rcgen::{CertificateParams, KeyPair};
+        use rcgen::{CertificateParams, ExtendedKeyUsagePurpose, KeyPair};
 
         let keypair = KeyPair::from_pem(&identity.private_key_pem).expect("parse identity key");
         let mut params =
             CertificateParams::new(Vec::<String>::new()).expect("certificate parameters");
         params.not_before = rcgen::date_time_ymd(not_before.0, not_before.1, not_before.2);
         params.not_after = rcgen::date_time_ymd(not_after.0, not_after.1, not_after.2);
-        identity.identity_cert_pem = params
-            .self_signed(&keypair)
-            .expect("sign certificate")
-            .pem();
+        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+        let certificate = params.self_signed(&keypair).expect("sign certificate");
+        let (_, parsed_certificate) =
+            x509_parser::prelude::parse_x509_certificate(certificate.der().as_ref())
+                .expect("parse test identity certificate");
+        identity.not_after_unix = Some(
+            u64::try_from(parsed_certificate.validity().not_after.timestamp())
+                .expect("test identity expiry after the Unix epoch"),
+        );
+        let certificate_pem = certificate.pem();
+        identity.identity_cert_pem.clone_from(&certificate_pem);
+        identity.ca_bundle_pem = certificate_pem;
     }
 
     fn set_certificate_validity_from_now(
@@ -581,7 +599,6 @@ mod tests {
         let config = test_config(dir.path());
         let mut identity = test_identity();
         set_certificate_validity(&mut identity, (2019, 1, 1), (2020, 1, 1));
-        identity.not_after_unix = Some(4_102_444_800);
         IdentityStore::store(&config.identity_path, &identity).expect("store expired identity");
         let expired = load_reconnectable_identity(&config)
             .expect("the control plane decides whether the identity remains renewable")

--- a/crates/runtime-cloud-connect/src/release.rs
+++ b/crates/runtime-cloud-connect/src/release.rs
@@ -44,6 +44,7 @@ limitations under the License.
 
 use std::time::Duration;
 
+use futures::StreamExt as _;
 use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 
@@ -54,6 +55,7 @@ pub const RELEASE_PATH: &str = "/v1/cloud-connect/release";
 
 /// Domain-separation prefix of the release proof-of-possession payload.
 const POP_DOMAIN: &str = "spice-cloud-connect/release/v1";
+const MAX_RELEASE_RESPONSE_BYTES: usize = 64 * 1024;
 
 /// Errors from the host-initiated release call.
 #[derive(Debug, Snafu)]
@@ -215,31 +217,64 @@ pub async fn release(
 
     let status = response.status();
     if !status.is_success() {
-        let message = match response.text().await {
-            Ok(text) => serde_json::from_str::<ErrorBody>(&text)
-                .map_or_else(|_| bounded(&text, 256), |body| body.error),
+        let message = match bounded_response_body(response).await {
+            Ok(bytes) => {
+                let text = String::from_utf8_lossy(&bytes);
+                serde_json::from_str::<ErrorBody>(&text)
+                    .map_or_else(|_| bounded(&text, 256), |body| body.error)
+            }
             Err(_) => String::new(),
         };
         return Err(Error::Rejected {
             status: status.as_u16(),
-            message,
+            message: sanitize_terminal_text(&message),
         });
     }
 
     // A control plane that answers 2xx with no body (or an unexpected one) has
     // still accepted the release, so treat an undecodable body as success with
     // nothing extra to report rather than failing a completed operation.
-    let wire = response
-        .json::<ReleaseResponseWire>()
+    let wire = bounded_response_body(response)
         .await
+        .ok()
+        .and_then(|body| serde_json::from_slice::<ReleaseResponseWire>(&body).ok())
         .unwrap_or(ReleaseResponseWire {
             status: String::new(),
             app_name: None,
         });
     Ok(ReleaseOutcome {
-        status: wire.status,
-        app_name: wire.app_name,
+        status: sanitize_terminal_text(&wire.status),
+        app_name: wire.app_name.map(|name| sanitize_terminal_text(&name)),
     })
+}
+
+fn sanitize_terminal_text(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                '�'
+            } else {
+                character
+            }
+        })
+        .take(1024)
+        .collect()
+}
+
+async fn bounded_response_body(response: reqwest::Response) -> std::io::Result<Vec<u8>> {
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(std::io::Error::other)?;
+        if body.len().saturating_add(chunk.len()) > MAX_RELEASE_RESPONSE_BYTES {
+            return Err(std::io::Error::other(
+                "release response exceeded the 64 KiB limit",
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
 }
 
 /// Longest prefix of `s` no longer than `max` bytes on a char boundary.
@@ -300,6 +335,7 @@ mod tests {
             org_name: None,
             app_name: None,
             monitor_url: None,
+            control_plane_endpoint: None,
             enc_private_key_pem: String::new(),
             enc_public_key_pem: String::new(),
             enc_previous_private_key_pem: String::new(),
@@ -450,6 +486,7 @@ mod tests {
             org_name: None,
             app_name: None,
             monitor_url: None,
+            control_plane_endpoint: None,
         };
         let public_key_pem = key_pair.public_key_pem();
         (identity, public_key_pem)

--- a/crates/runtime-cloud-connect/tests/enrollment_flow.rs
+++ b/crates/runtime-cloud-connect/tests/enrollment_flow.rs
@@ -86,6 +86,7 @@ fn reconnect_identity(identifier: &str, gateway_addr: String) -> runtime_cloud_c
         org_name: None,
         app_name: None,
         monitor_url: None,
+        control_plane_endpoint: None,
         enc_private_key_pem: String::new(),
         enc_public_key_pem: String::new(),
         enc_previous_private_key_pem: String::new(),

--- a/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
@@ -2430,6 +2430,12 @@ async fn an_existing_identity_wins_without_redeeming_the_key() {
         dir.path(),
         &runtime_cloud_connect::enroll::InstanceFacts::gather(&config.runtime_version),
         config.instance_region.as_deref(),
+        &runtime_cloud_connect::EnrollmentRequestBinding {
+            endpoint: config.enroll_endpoint.trim_end_matches('/').to_string(),
+            authority: runtime_cloud_connect::EnrollmentAuthorityBinding::Token {
+                expected_org: None,
+            },
+        },
     )
     .expect("create a stale enrollment draft");
     assert!(

--- a/crates/spice-cloud-client/Cargo.toml
+++ b/crates/spice-cloud-client/Cargo.toml
@@ -9,7 +9,8 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-reqwest.workspace = true
+futures.workspace = true
+reqwest = { workspace = true, features = ["stream"] }
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true

--- a/crates/spice-cloud-client/src/client.rs
+++ b/crates/spice-cloud-client/src/client.rs
@@ -18,6 +18,7 @@ limitations under the License.
 
 use std::time::Duration;
 
+use futures::StreamExt as _;
 use reqwest::{Client, RequestBuilder};
 use snafu::ResultExt;
 
@@ -33,6 +34,8 @@ use crate::types::{
 
 const DEFAULT_BASE_URL: &str = "https://api.spice.ai";
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_RESPONSE_BYTES: usize = 64 * 1024;
+const MAX_SUCCESS_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 
 /// Header carrying the organization a management request should act on. Tokens
 /// minted for a single org ignore it; the server is the authority on membership.
@@ -43,14 +46,27 @@ const ORG_HEADER: &str = "X-Org-Name";
 /// Both constructors go through here so the settings cannot drift apart — in particular the
 /// same-origin redirect policy, which is what keeps a bearer token, and the auth code that
 /// `exchange_code` puts in a request body, from following a `Location` off origin.
-fn build_http_client(timeout: Duration) -> Result<Client> {
+fn build_http_client(base_url: &str, timeout: Duration) -> Result<Client> {
+    let allow_local_http = reqwest::Url::parse(base_url)
+        .is_ok_and(|url| url.scheme() == "http" && url.host_str().is_some_and(is_loopback_host));
     Client::builder()
         .connect_timeout(Duration::from_secs(10))
         .timeout(timeout)
-        .https_only(true)
+        .https_only(!allow_local_http)
         .redirect(same_origin_redirect_policy())
         .build()
         .context(HttpRequestSnafu)
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    let host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
 }
 
 /// HTTP client for the Spice Cloud API.
@@ -72,7 +88,7 @@ impl CloudClient {
     /// Use [`Self::with_token`] to set an authentication token, and
     /// [`Self::with_timeout`] to override the default 30-second timeout.
     pub fn new(base_url: &str) -> Result<Self> {
-        let client = build_http_client(DEFAULT_TIMEOUT)?;
+        let client = build_http_client(base_url, DEFAULT_TIMEOUT)?;
 
         Ok(Self {
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -110,7 +126,7 @@ impl CloudClient {
     ///
     /// Returns an error if the HTTP client cannot be rebuilt with the given timeout.
     pub fn with_timeout(mut self, timeout: Duration) -> Result<Self> {
-        self.client = build_http_client(timeout)?;
+        self.client = build_http_client(&self.base_url, timeout)?;
         Ok(self)
     }
 
@@ -581,11 +597,13 @@ impl CloudClient {
         response: reqwest::Response,
     ) -> Result<T> {
         let status = response.status();
-        let body = response.text().await.context(HttpRequestSnafu)?;
+        if status.is_success() {
+            let body = bounded_response_body(response, MAX_SUCCESS_RESPONSE_BYTES).await?;
+            return serde_json::from_slice(&body)
+                .map_err(|source| error::Error::JsonParse { source });
+        }
+        let body = self.sanitized_error_body(response).await?;
         match status.as_u16() {
-            200..=202 => {
-                serde_json::from_str(&body).map_err(|source| error::Error::JsonParse { source })
-            }
             401 => error::UnauthorizedSnafu {
                 message: body_or("invalid or expired token", &body),
             }
@@ -612,10 +630,13 @@ impl CloudClient {
 
     async fn handle_empty_response(&self, response: reqwest::Response) -> Result<()> {
         let status = response.status();
-        let body = response.text().await.context(HttpRequestSnafu)?;
+        if status.is_success() {
+            let _ = bounded_response_body(response, MAX_SUCCESS_RESPONSE_BYTES).await?;
+            return Ok(());
+        }
+        let body = self.sanitized_error_body(response).await?;
 
         match status.as_u16() {
-            200..=204 => Ok(()),
             401 => error::UnauthorizedSnafu {
                 message: body_or("invalid or expired token", &body),
             }
@@ -644,6 +665,12 @@ impl CloudClient {
         self.token.as_deref().unwrap_or("")
     }
 
+    async fn sanitized_error_body(&self, response: reqwest::Response) -> Result<String> {
+        let bytes = bounded_response_body(response, MAX_RESPONSE_BYTES).await?;
+        let raw = String::from_utf8_lossy(&bytes);
+        Ok(redact_response_body(&raw, self.token.as_deref()))
+    }
+
     /// Apply the bearer token and, when set, the org context header.
     ///
     /// An org name that cannot be encoded as a header value surfaces as a
@@ -655,6 +682,48 @@ impl CloudClient {
             Some(org) => request.header(ORG_HEADER, org),
             None => request,
         }
+    }
+}
+
+async fn bounded_response_body(response: reqwest::Response, limit: usize) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context(HttpRequestSnafu)?;
+        if bytes.len().saturating_add(chunk.len()) > limit {
+            return error::ResponseTooLargeSnafu.fail();
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+fn redact_response_body(body: &str, sensitive: Option<&str>) -> String {
+    let Some(sensitive) = sensitive.filter(|value| !value.is_empty()) else {
+        return body.to_string();
+    };
+    let redacted = body.replace(sensitive, "[REDACTED]");
+    let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&redacted) else {
+        return redacted;
+    };
+    redact_json_strings(&mut json, sensitive);
+    serde_json::to_string(&json).unwrap_or(redacted)
+}
+
+fn redact_json_strings(value: &mut serde_json::Value, sensitive: &str) {
+    match value {
+        serde_json::Value::String(value) => *value = value.replace(sensitive, "[REDACTED]"),
+        serde_json::Value::Array(values) => {
+            for value in values {
+                redact_json_strings(value, sensitive);
+            }
+        }
+        serde_json::Value::Object(values) => {
+            for value in values.values_mut() {
+                redact_json_strings(value, sensitive);
+            }
+        }
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
     }
 }
 
@@ -712,10 +781,21 @@ fn oauth_host(host: &str) -> Option<String> {
 mod tests {
     use super::{
         CloudClient, DEFAULT_TIMEOUT, auth_exchange_result, auth_exchange_status_is_pending,
-        same_origin_redirect_policy,
+        redact_response_body, same_origin_redirect_policy,
     };
     use crate::types::{AuthContext, AuthContextApp, AuthContextOrg, AuthContextRaw};
     use crate::{error, types::AuthExchangeResponse};
+
+    #[test]
+    fn management_error_bodies_redact_raw_and_json_escaped_bearers() {
+        let token = "secret-token";
+        let raw = redact_response_body("proxy echoed secret-token", Some(token));
+        assert!(!raw.contains(token));
+        let escaped =
+            redact_response_body(r#"{"error":"secret\u002dtoken was rejected"}"#, Some(token));
+        assert!(!escaped.contains(token));
+        assert!(escaped.contains("[REDACTED]"));
+    }
 
     /// Both constructors must install the same-origin redirect policy, or a bearer token —
     /// and the auth code `exchange_code` puts in a request body — could follow a `Location`
@@ -823,6 +903,31 @@ mod tests {
             reachable.requests().is_empty(),
             "neither constructor's client should have reached a plain-http origin"
         );
+    }
+
+    #[tokio::test]
+    async fn loopback_base_allows_plain_http_fixtures_and_preserves_it_when_retimed() {
+        let reachable = crate::test_support::Stub::serve(|_| crate::test_support::ok_with("ok"));
+        let base_url = reachable.url("");
+        let client = CloudClient::new(&base_url).expect("loopback client should build");
+        client
+            .client
+            .get(reachable.url("/first"))
+            .send()
+            .await
+            .expect("loopback HTTP should be allowed");
+
+        let retimed = client
+            .with_timeout(std::time::Duration::from_secs(5))
+            .expect("loopback client should be retimed");
+        retimed
+            .client
+            .get(reachable.url("/second"))
+            .send()
+            .await
+            .expect("retimed loopback HTTP should remain allowed");
+
+        assert_eq!(reachable.requests().len(), 2);
     }
 
     #[test]

--- a/crates/spice-cloud-client/src/client.rs
+++ b/crates/spice-cloud-client/src/client.rs
@@ -691,7 +691,7 @@ async fn bounded_response_body(response: reqwest::Response, limit: usize) -> Res
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.context(HttpRequestSnafu)?;
         if bytes.len().saturating_add(chunk.len()) > limit {
-            return error::ResponseTooLargeSnafu.fail();
+            return error::ResponseTooLargeSnafu { limit }.fail();
         }
         bytes.extend_from_slice(&chunk);
     }
@@ -719,9 +719,16 @@ fn redact_json_strings(value: &mut serde_json::Value, sensitive: &str) {
             }
         }
         serde_json::Value::Object(values) => {
-            for value in values.values_mut() {
-                redact_json_strings(value, sensitive);
+            // Keys carry the credential just as easily as values, and parsing
+            // decodes an escaped key back to its literal bytes — so a key the
+            // raw replacement above could not match is reconstructed here and
+            // would be re-emitted by the serialization that follows.
+            let mut redacted = serde_json::Map::with_capacity(values.len());
+            for (key, mut value) in std::mem::take(values) {
+                redact_json_strings(&mut value, sensitive);
+                redacted.insert(key.replace(sensitive, "[REDACTED]"), value);
             }
+            *values = redacted;
         }
         serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
     }
@@ -795,6 +802,28 @@ mod tests {
             redact_response_body(r#"{"error":"secret\u002dtoken was rejected"}"#, Some(token));
         assert!(!escaped.contains(token));
         assert!(escaped.contains("[REDACTED]"));
+    }
+
+    /// An escaped credential in an object *key* survives the raw replacement,
+    /// and parsing decodes it back to the literal token, so serializing the
+    /// tree again would publish it.
+    #[test]
+    fn management_error_bodies_redact_bearers_hidden_in_object_keys() {
+        let token = "secret-token";
+        for body in [
+            // Escaped in the key, so the raw replacement cannot match it.
+            r#"{"secret\u002dtoken":"rejected"}"#,
+            r#"{"outer":{"secret\u002dtoken":["rejected"]}}"#,
+            // Literal in the key, for the path the raw replacement does cover.
+            r#"{"secret-token":"rejected"}"#,
+        ] {
+            let redacted = redact_response_body(body, Some(token));
+            assert!(
+                !redacted.contains(token),
+                "object key leaked the bearer: {redacted}"
+            );
+            assert!(redacted.contains("[REDACTED]"), "{redacted}");
+        }
     }
 
     /// Both constructors must install the same-origin redirect policy, or a bearer token —

--- a/crates/spice-cloud-client/src/error.rs
+++ b/crates/spice-cloud-client/src/error.rs
@@ -29,9 +29,11 @@ pub enum Error {
     #[snafu(display("HTTP request failed: {source}"))]
     HttpRequest { source: reqwest::Error },
 
-    /// The server returned a body larger than the client accepts.
-    #[snafu(display("Response body exceeded the 64 KiB limit"))]
-    ResponseTooLarge,
+    /// The server returned a body larger than the client accepts. The limit
+    /// differs per call site, so it travels with the error rather than being
+    /// named in the message.
+    #[snafu(display("Response body exceeded the {limit} byte limit"))]
+    ResponseTooLarge { limit: usize },
 
     /// The server returned 401 Unauthorized.
     #[snafu(display("Unauthorized: {message}"))]

--- a/crates/spice-cloud-client/src/error.rs
+++ b/crates/spice-cloud-client/src/error.rs
@@ -29,6 +29,10 @@ pub enum Error {
     #[snafu(display("HTTP request failed: {source}"))]
     HttpRequest { source: reqwest::Error },
 
+    /// The server returned a body larger than the client accepts.
+    #[snafu(display("Response body exceeded the 64 KiB limit"))]
+    ResponseTooLarge,
+
     /// The server returned 401 Unauthorized.
     #[snafu(display("Unauthorized: {message}"))]
     Unauthorized { message: String },


### PR DESCRIPTION
## Summary

`spice connect` now enrolls this directory with Spice Cloud and attaches it to a project in one resumable transaction. Before this change the command could only report state that a `spiced --token` start had already created, and pointed the user at the runtime to enroll.

## What's in this change

### One transaction, three entry paths

A single flow — serialized per instance directory by a lock file and backed by a non-secret journal under `.spice/` — dispatches on what the directory already holds:

- **Existing identity**: never re-enrolls. The stored identity is validated and reused; only the project step runs, and only while the instance is still unattached. An already-attached instance reports its attachment instead of being given a second project.
- **Login**: resolves exactly one owner/admin organization from the user session, enrolls the instance, then atomically creates and attaches the project. An interactive terminal with no session offers inline login or secure enrollment-key entry.
- **Enrollment key** (`--token`): enrolls against the key's expected organization, always leaves the instance unattached, and prints the Cloud-provided recovery link. No stored credential is required, so first-project recovery works without an existing auth context.

### Explicit organization/project selection and directory naming

`--org`, `--project`, `--region`, and `--token` are new inputs on `spice connect`. Non-interactive login mode requires both `--org` and `--project`; key mode requires `--token` and rejects `--project`. Interactive runs suggest a project name derived from the instance directory's basename, normalized to the accepted contract (4–38 characters, lowercase letters, digits and dashes, no leading or trailing dash), with a single `<adjective>-spice` fallback when the basename cannot yield a valid name, and a fresh suggestion after a name conflict. Invalid `--project` and `--region` values fail with the usage exit code before any durable state is written.

### Retry, recovery, and attachment

- Enrollment resumes from its durable draft and idempotency key, so an interrupted run cannot mint a sibling instance.
- Project creation replays against the enrolled instance's single attachment as its exact key, retries retryable denials within a bounded budget (5 attempts, 30s), and otherwise surfaces a distinct `cloud_connect_project` error code. A name conflict re-prompts rather than failing the transaction.
- A journal that does not match this directory and identity is quarantined instead of replayed. A pending operation recorded for different parameters errors and preserves the exact-replay state instead of silently re-targeting.
- The control plane is bound at enrollment. Both `spiced` and the CLI resolve it from the identity, then from a pending draft; an `--endpoint`/`SPICE_CLOUD_ENDPOINT` value that disagrees with that binding is a usage error, and unreadable durable state fails closed rather than falling back to the public control plane.

### Stage-only telemetry

The flow records the auth path, completion outcome, and failure stage from a fixed vocabulary and emits them once, at DEBUG, when the flow ends. No organization, project, directory, endpoint, or key material is recorded, and nothing is visible at the default log level.

### Superseded inputs

The instance-local `cloud-endpoint` file is no longer authoritative once enrollment has bound a control plane: it is consulted only before a binding exists, and while it is in force stored credentials are withheld rather than sent to an endpoint the instance never enrolled against. `--cloud-region` is refused on every Cloud Connect path with the reason. The retired enrollment surface (`--app-name`, `--create`, `--install`, `SPICE-ADOPT`) stays unparseable, now asserted at clap's usage exit code, and an enrollment key passed positionally is rejected without echoing it in either human or `--machine` output.

### Not in this change

Runtime foreground launch and service lifecycle are separate concerns and are untouched here. `spice connect` enrolls and attaches; it does not start `spiced` in the foreground, and the `spice connect service` install/start/stop/uninstall behavior is unchanged.

## Verification

- `cargo fmt` and `cargo check` clean across every touched crate.
- 144 `spice connect` unit tests; 8 connect-transaction tests.
- `runtime-cloud-connect`: 224 unit, 9 contract, 6 enrollment-flow, and 36 standalone end-to-end tests.
- `spiced` Cloud Connect bootstrap: 2/2.
- Focused warnings-denied Clippy over the touched crates and targets.
- Mutation/non-vacuity checks for journal replay, project-name conflict, cross-organization endpoint rejection, existing-identity precedence, and corrupt-state handling: each assertion fails when the behavior it covers is inverted.

Pull requests targeting `byoc` skip lab signoff.

Closes spicehq/spiceai#1401

Part of spicehq/spiceai#1396
