### PR TITLE
fix(cache): compact a sliced result before caching it (fixes #12921)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,6 +3277,7 @@ version = "2.2.0-unstable"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
+ "arrow_tools",
  "async-compression",
  "async-openai",
  "async-stream",

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -472,6 +472,32 @@ fn contains_view_type(data_type: &DataType) -> bool {
     }
 }
 
+/// Whether `data_type` is, or holds anywhere within it, a dictionary.
+///
+/// This recurses because its consumer does: `MutableArrayData::new` builds a
+/// child `MutableArrayData` for every struct field, list value and union
+/// variant, so a dictionary nested inside a container reaches the same
+/// dictionary-key overflow that a top-level one does.
+fn contains_dictionary(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Dictionary(_, _) => true,
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::ListView(field)
+        | DataType::LargeListView(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::Map(field, _)
+        | DataType::RunEndEncoded(_, field) => contains_dictionary(field.data_type()),
+        DataType::Struct(fields) => fields
+            .iter()
+            .any(|field| contains_dictionary(field.data_type())),
+        DataType::Union(fields, _) => fields
+            .iter()
+            .any(|(_, field)| contains_dictionary(field.data_type())),
+        _ => false,
+    }
+}
+
 /// How many bytes are reclaimable from a column retaining `retained` where its
 /// rows need `needed`, or `None` when the copy would not pay for itself.
 fn worth_compacting(retained: usize, needed: usize) -> Option<usize> {
@@ -539,8 +565,10 @@ fn reclaimable_bytes(column: &ArrayRef) -> Option<usize> {
         // dictionary whose value count does not fit its key type — a
         // `Dictionary(UInt8, _)` holding exactly 256 values is valid Arrow and
         // trips it (`build_extend_dictionary` returns `None`, which
-        // `MutableArrayData::with_capacities` unwraps with `expect`).
-        DataType::Dictionary(_, _) => return None,
+        // `MutableArrayData::with_capacities` unwraps with `expect`). Both
+        // reasons hold for a dictionary at any depth: the extend is built per
+        // child, so a `Struct<Dictionary<UInt8, _>>` reaches the same `expect`.
+        data_type if contains_dictionary(data_type) => return None,
         _ => {}
     }
 
@@ -1502,6 +1530,51 @@ mod test {
         assert!(
             Arc::ptr_eq(sliced.column(0), compacted.column(0)),
             "a dictionary column must not be compacted"
+        );
+        assert_eq!(compacted.num_rows(), 1);
+    }
+
+    /// `MutableArrayData` builds an extend per child, so a dictionary nested in
+    /// a struct reaches the same key-overflow `expect` as a top-level one. The
+    /// guard has to recurse to keep it away from that path.
+    #[test]
+    fn compact_retained_buffers_leaves_a_struct_wrapped_full_range_dictionary_alone() {
+        use arrow::array::{DictionaryArray, StructArray, UInt8Array};
+        use arrow::datatypes::UInt8Type;
+
+        let values = StringArray::from(
+            (0..256)
+                .map(|value| format!("value-{value}"))
+                .collect::<Vec<_>>(),
+        );
+        let keys = UInt8Array::from(
+            (0..200_000)
+                .map(|row| u8::try_from(row % 256).unwrap_or_default())
+                .collect::<Vec<_>>(),
+        );
+        let dictionary: ArrayRef = Arc::new(
+            DictionaryArray::<UInt8Type>::try_new(keys, Arc::new(values))
+                .expect("valid dictionary"),
+        );
+        let inner = Field::new("d", dictionary.data_type().clone(), true);
+        let column: ArrayRef = Arc::new(StructArray::from(vec![(
+            Arc::new(inner),
+            Arc::clone(&dictionary),
+        )]));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "s",
+            column.data_type().clone(),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![column]).expect("valid batch");
+        let sliced = batch.slice(100_000, 1);
+
+        // Must not panic, and must hand back the column untouched.
+        let compacted = compact_retained_buffers(&sliced);
+
+        assert!(
+            Arc::ptr_eq(sliced.column(0), compacted.column(0)),
+            "a struct holding a dictionary must not be compacted"
         );
         assert_eq!(compacted.num_rows(), 1);
     }

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -16,8 +16,8 @@ limitations under the License.
 
 use arrow::{
     array::{
-        Array, ArrayRef, ListArray, MutableArrayData, RecordBatch, RecordBatchOptions, StructArray,
-        make_array, new_null_array,
+        Array, ArrayRef, BinaryViewArray, ListArray, MutableArrayData, RecordBatch,
+        RecordBatchOptions, StringViewArray, StructArray, make_array, new_null_array,
     },
     buffer::{Buffer, OffsetBuffer},
     datatypes::{DataType, Field, SchemaRef, TimeUnit},
@@ -441,44 +441,105 @@ const COMPACTION_RETENTION_RATIO: usize = 2;
 const COMPACTION_MIN_RECLAIMED_BYTES: usize = 64 * 1024;
 
 /// Whether a type keeps data in buffers that
-/// [`ArrayData::get_slice_memory_size`] does not walk.
+/// [`ArrayData::get_slice_memory_size`] does not walk, and that
+/// [`compact_view_column`] cannot reach either.
 ///
 /// The view types hold their bytes in variadic data buffers, which the layout
-/// used by `get_slice_memory_size` does not describe — it counts only the
-/// 16-byte views. Every view column would therefore look like it retains far
-/// more than its rows need, and be copied on every store for nothing.
+/// `get_slice_memory_size` reads does not describe — it counts only the
+/// 16-byte views. A top-level view column is measured and compacted by the
+/// view-specific path below; one *nested* inside a container is not reachable
+/// that way, so such a column is measured as if the data buffers were free and
+/// must be left alone rather than copied on every store for nothing.
 fn retains_unmeasured_buffers(data_type: &DataType) -> bool {
     match data_type {
-        DataType::Utf8View | DataType::BinaryView => true,
         DataType::List(field)
         | DataType::LargeList(field)
         | DataType::ListView(field)
         | DataType::LargeListView(field)
         | DataType::FixedSizeList(field, _)
         | DataType::Map(field, _)
-        | DataType::RunEndEncoded(_, field) => retains_unmeasured_buffers(field.data_type()),
+        | DataType::RunEndEncoded(_, field) => contains_view_type(field.data_type()),
         DataType::Struct(fields) => fields
             .iter()
-            .any(|field| retains_unmeasured_buffers(field.data_type())),
+            .any(|field| contains_view_type(field.data_type())),
         DataType::Union(fields, _) => fields
             .iter()
-            .any(|(_, field)| retains_unmeasured_buffers(field.data_type())),
-        DataType::Dictionary(_, value_type) => retains_unmeasured_buffers(value_type),
+            .any(|(_, field)| contains_view_type(field.data_type())),
+        DataType::Dictionary(_, value_type) => contains_view_type(value_type),
         _ => false,
     }
+}
+
+fn contains_view_type(data_type: &DataType) -> bool {
+    matches!(data_type, DataType::Utf8View | DataType::BinaryView)
+        || retains_unmeasured_buffers(data_type)
+}
+
+/// How many bytes a view column retains beyond the bytes its own rows use.
+///
+/// A view array's values live in shared data buffers that slicing never
+/// narrows — `slice` only trims the 16-byte views — so a one-row slice of a
+/// wide-string batch keeps every data buffer of the batch it came from. This
+/// matters by default rather than in a corner: `DataFusion` reads Parquet
+/// `Utf8`/`Binary` columns as `Utf8View`/`BinaryView`
+/// (`schema_force_view_types`), so ordinary string results take this path.
+fn view_reclaimable_bytes(column: &ArrayRef) -> Option<usize> {
+    // `gc` rebuilds both halves of a view array — the views themselves and the
+    // data buffers they point into — so both are counted here. A short-string
+    // column can be almost all views, and a wide-string one almost all data.
+    let (retained, needed) = match column.data_type() {
+        DataType::Utf8View => {
+            let array = column.as_any().downcast_ref::<StringViewArray>()?;
+            (
+                view_bytes(array.views().inner(), array.data_buffers()),
+                compacted_view_bytes(array.len(), array.total_buffer_bytes_used()),
+            )
+        }
+        DataType::BinaryView => {
+            let array = column.as_any().downcast_ref::<BinaryViewArray>()?;
+            (
+                view_bytes(array.views().inner(), array.data_buffers()),
+                compacted_view_bytes(array.len(), array.total_buffer_bytes_used()),
+            )
+        }
+        _ => return None,
+    };
+
+    let reclaimed = retained.checked_sub(needed)?;
+    (reclaimed >= COMPACTION_MIN_RECLAIMED_BYTES
+        && retained >= needed.saturating_mul(COMPACTION_RETENTION_RATIO))
+    .then_some(reclaimed)
+}
+
+/// What a view column's views and data buffers hold today. The null buffer is
+/// excluded because `gc` reuses it as-is, so it is not reclaimable either way.
+fn view_bytes(views: &Buffer, data_buffers: &[Buffer]) -> usize {
+    views.capacity() + data_buffers.iter().map(Buffer::capacity).sum::<usize>()
+}
+
+/// What those same buffers would hold after `gc`: one view per row, and only
+/// the bytes the out-of-line views reference.
+fn compacted_view_bytes(rows: usize, bytes_used: usize) -> usize {
+    rows.saturating_mul(std::mem::size_of::<u128>()) + bytes_used
 }
 
 /// How many bytes compacting `column` would reclaim, or `None` when the copy
 /// would not pay for itself.
 fn reclaimable_bytes(column: &ArrayRef) -> Option<usize> {
+    if matches!(
+        column.data_type(),
+        DataType::Utf8View | DataType::BinaryView
+    ) {
+        return view_reclaimable_bytes(column);
+    }
     if retains_unmeasured_buffers(column.data_type()) {
         return None;
     }
 
     let retained = column.get_array_memory_size();
     // `Err` means the type's buffers cannot be measured from its layout, which
-    // is the same situation as a view type: there is no honest comparison to
-    // make, so leave the column alone.
+    // is the same situation as a nested view type: there is no honest
+    // comparison to make, so leave the column alone.
     let needed = column.to_data().get_slice_memory_size().ok()?;
 
     let reclaimed = retained.checked_sub(needed)?;
@@ -492,10 +553,30 @@ fn reclaimable_bytes(column: &ArrayRef) -> Option<usize> {
 /// This is what [`arrow::compute::concat`] does for more than one array; it
 /// cannot be used here because `concat` returns a single input untouched.
 fn compact_column(column: &ArrayRef) -> ArrayRef {
+    if let Some(compacted) = compact_view_column(column) {
+        return compacted;
+    }
     let data = column.to_data();
     let mut compacted = MutableArrayData::new(vec![&data], false, column.len());
     compacted.extend(0, 0, column.len());
     make_array(compacted.freeze())
+}
+
+/// Rebuilds a view column's data buffers around the bytes its rows actually
+/// reference. `MutableArrayData` copies a view array's data buffers wholesale,
+/// so it cannot do this; `gc` is the kernel that can.
+fn compact_view_column(column: &ArrayRef) -> Option<ArrayRef> {
+    match column.data_type() {
+        DataType::Utf8View => column
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .map(|array| Arc::new(array.gc()) as ArrayRef),
+        DataType::BinaryView => column
+            .as_any()
+            .downcast_ref::<BinaryViewArray>()
+            .map(|array| Arc::new(array.gc()) as ArrayRef),
+        _ => None,
+    }
 }
 
 /// Returns `batch` with every column that retains substantially more memory
@@ -512,6 +593,9 @@ fn compact_column(column: &ArrayRef) -> ArrayRef {
 ///
 /// Columns that are already compact are shared, not copied, so a batch with
 /// nothing to reclaim costs a reference-count clone.
+///
+/// See [`compacted_memory_size`] for deciding whether the copy is worth making
+/// *before* paying for it.
 #[must_use]
 pub fn compact_retained_buffers(batch: &RecordBatch) -> RecordBatch {
     let mut columns: Option<Vec<ArrayRef>> = None;
@@ -542,6 +626,25 @@ pub fn compact_retained_buffers(batch: &RecordBatch) -> RecordBatch {
             batch.clone()
         }
     }
+}
+
+/// Roughly what `batch` would occupy once [`compact_retained_buffers`] has run
+/// over it, computed without copying anything.
+///
+/// A caller that holds a memory budget should bill a batch this, not
+/// `get_array_memory_size`, and should only compact a batch it has decided to
+/// keep — otherwise a result too large to store is copied in full before being
+/// discarded.
+///
+/// It is an estimate, not the exact figure: buffer capacities are rounded up on
+/// allocation, so the compacted batch can measure a little either side of this.
+/// It is meant for deciding whether a copy is worth making, and a caller that
+/// must not exceed a hard limit should still measure what it actually built.
+#[must_use]
+pub fn compacted_memory_size(batch: &RecordBatch) -> usize {
+    let reclaimable: usize = batch.columns().iter().filter_map(reclaimable_bytes).sum();
+
+    batch.get_array_memory_size().saturating_sub(reclaimable)
 }
 
 #[cfg(test)]
@@ -1262,33 +1365,149 @@ mod test {
         );
     }
 
-    /// View columns hold their bytes in buffers `get_slice_memory_size` does
-    /// not walk, so they must be left alone rather than copied on every store.
-    #[test]
-    fn compact_retained_buffers_leaves_view_columns_alone() {
-        use arrow::array::StringViewArray;
-
+    fn wide_view_batch(rows: usize, value_len: usize) -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![Field::new(
             "payload",
             DataType::Utf8View,
             true,
         )]));
-        let values: Vec<String> = (0..2_000)
-            .map(|_| std::iter::repeat_n('v', 4_096).collect())
+        let values: Vec<String> = (0..rows)
+            .map(|row| {
+                std::iter::repeat_n(
+                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
+                    value_len,
+                )
+                .collect()
+            })
             .collect();
-        let batch = RecordBatch::try_new(
+
+        RecordBatch::try_new(
             schema,
             vec![Arc::new(StringViewArray::from_iter_values(values))],
         )
-        .expect("valid batch");
+        .expect("valid batch")
+    }
+
+    /// Slicing a view array trims only its 16-byte views — the data buffers
+    /// holding the values are kept whole. `DataFusion` reads Parquet strings as
+    /// `Utf8View` by default (`schema_force_view_types`), so this is the
+    /// ordinary path for a string result, not a corner of it.
+    #[test]
+    fn compact_retained_buffers_releases_a_view_slices_data_buffers() {
+        let batch = wide_view_batch(2_000, 4_096);
+        let sliced = batch.slice(1_000, 1);
+        assert!(
+            sliced.get_array_memory_size() > 4 * 1024 * 1024,
+            "a view slice retains its parent's data buffers, which is the defect under test; got {}",
+            sliced.get_array_memory_size()
+        );
+
+        let compacted = compact_retained_buffers(&sliced);
+
+        assert_eq!(compacted.num_rows(), 1);
+        let before = sliced
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .expect("StringViewArray");
+        let after = compacted
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .expect("StringViewArray");
+        assert_eq!(after.value(0), before.value(0), "the row's value changed");
+        assert!(
+            compacted.get_array_memory_size() * 100 < sliced.get_array_memory_size(),
+            "a one-row view slice should retain a small fraction of its parent, got {} of {}",
+            compacted.get_array_memory_size(),
+            sliced.get_array_memory_size()
+        );
+    }
+
+    /// A view column whose data buffers are already proportional to its rows
+    /// is shared, not copied.
+    #[test]
+    fn compact_retained_buffers_leaves_a_compact_view_column_untouched() {
+        let batch = wide_view_batch(4, 16);
+
+        let compacted = compact_retained_buffers(&batch);
+
+        assert!(
+            Arc::ptr_eq(batch.column(0), compacted.column(0)),
+            "an already-compact view column was copied"
+        );
+    }
+
+    /// A view nested inside a container cannot be measured or reached by the
+    /// view path, so such a column is left alone rather than copied blindly.
+    #[test]
+    fn compact_retained_buffers_leaves_a_nested_view_column_alone() {
+        use arrow::array::{ArrayRef as _ArrayRef, StringViewArray as _SVA};
+
+        let values: Vec<String> = (0..2_000)
+            .map(|_| std::iter::repeat_n('v', 4_096).collect())
+            .collect();
+        let inner: _ArrayRef = Arc::new(_SVA::from_iter_values(values));
+        let struct_array = StructArray::from(vec![(
+            Arc::new(Field::new("payload", DataType::Utf8View, true)),
+            inner,
+        )]);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "wrapper",
+            struct_array.data_type().clone(),
+            true,
+        )]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(struct_array)]).expect("valid batch");
         let sliced = batch.slice(1_000, 1);
 
         let compacted = compact_retained_buffers(&sliced);
 
         assert!(
             Arc::ptr_eq(sliced.column(0), compacted.column(0)),
-            "a view column must not be compacted"
+            "a nested view column must not be compacted"
         );
+    }
+
+    /// The pre-copy estimate is what a caller bills a batch before deciding to
+    /// pay for the copy, so it has to track what compaction actually produces —
+    /// within the rounding that buffer allocation adds.
+    #[test]
+    fn compacted_memory_size_tracks_the_compacted_batch() {
+        for (name, sliced) in [
+            (
+                "string slice",
+                wide_string_batch(2_000, 4_096).slice(1_000, 1),
+            ),
+            ("view slice", wide_view_batch(2_000, 4_096).slice(1_000, 1)),
+            ("already compact", wide_string_batch(8, 16)),
+        ] {
+            let predicted = compacted_memory_size(&sliced);
+            let actual = compact_retained_buffers(&sliced).get_array_memory_size();
+            let slack = actual / 10 + 4_096;
+            assert!(
+                predicted + slack >= actual && predicted <= actual + slack,
+                "{name}: estimate {predicted} is not within {slack} of the compacted {actual}"
+            );
+        }
+    }
+
+    /// The estimate is what stops a batch too large to cache from being copied
+    /// in full and then discarded, so it must be far below the retained size
+    /// for exactly the slices compaction targets.
+    #[test]
+    fn compacted_memory_size_is_a_small_fraction_of_a_slices_retained_size() {
+        for sliced in [
+            wide_string_batch(2_000, 4_096).slice(1_000, 1),
+            wide_view_batch(2_000, 4_096).slice(1_000, 1),
+        ] {
+            let predicted = compacted_memory_size(&sliced);
+            assert!(
+                predicted * 100 < sliced.get_array_memory_size(),
+                "estimated {predicted} against a retained {}",
+                sliced.get_array_memory_size()
+            );
+        }
     }
 
     /// A batch with no columns keeps its row count.

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -16,11 +16,13 @@ limitations under the License.
 
 use arrow::{
     array::{
-        Array, ArrayRef, BinaryViewArray, ListArray, MutableArrayData, RecordBatch,
-        RecordBatchOptions, StringViewArray, StructArray, make_array, new_null_array,
+        Array, ArrayRef, BinaryViewArray, GenericByteViewArray, ListArray, MutableArrayData,
+        RecordBatch, RecordBatchOptions, StringViewArray, StructArray, make_array, new_null_array,
     },
     buffer::{Buffer, OffsetBuffer},
-    datatypes::{DataType, Field, SchemaRef, TimeUnit},
+    datatypes::{
+        BinaryViewType, ByteViewType, DataType, Field, SchemaRef, StringViewType, TimeUnit,
+    },
     error::ArrowError,
 };
 use arrow_cast::{CastOptions, cast_with_options};
@@ -440,18 +442,18 @@ const COMPACTION_RETENTION_RATIO: usize = 2;
 /// How many bytes a compaction must actually reclaim to be worth its copy.
 const COMPACTION_MIN_RECLAIMED_BYTES: usize = 64 * 1024;
 
-/// Whether a type keeps data in buffers that
-/// [`ArrayData::get_slice_memory_size`] does not walk, and that
-/// [`compact_view_column`] cannot reach either.
+/// Whether a type holds data in variadic buffers, which
+/// [`ArrayData::get_slice_memory_size`] does not walk.
 ///
-/// The view types hold their bytes in variadic data buffers, which the layout
-/// `get_slice_memory_size` reads does not describe — it counts only the
-/// 16-byte views. A top-level view column is measured and compacted by the
-/// view-specific path below; one *nested* inside a container is not reachable
-/// that way, so such a column is measured as if the data buffers were free and
-/// must be left alone rather than copied on every store for nothing.
-fn retains_unmeasured_buffers(data_type: &DataType) -> bool {
+/// The view types are the ones that do: they keep their bytes in data buffers
+/// the layout does not describe, so `get_slice_memory_size` counts only their
+/// 16-byte views. A *top-level* view column is measured and compacted by the
+/// view-specific path below; one nested inside a container is reachable by
+/// neither, so such a column would be measured as if its data buffers were
+/// free, and must be left alone rather than copied on every store for nothing.
+fn contains_view_type(data_type: &DataType) -> bool {
     match data_type {
+        DataType::Utf8View | DataType::BinaryView => true,
         DataType::List(field)
         | DataType::LargeList(field)
         | DataType::ListView(field)
@@ -470,9 +472,13 @@ fn retains_unmeasured_buffers(data_type: &DataType) -> bool {
     }
 }
 
-fn contains_view_type(data_type: &DataType) -> bool {
-    matches!(data_type, DataType::Utf8View | DataType::BinaryView)
-        || retains_unmeasured_buffers(data_type)
+/// How many bytes are reclaimable from a column retaining `retained` where its
+/// rows need `needed`, or `None` when the copy would not pay for itself.
+fn worth_compacting(retained: usize, needed: usize) -> Option<usize> {
+    let reclaimed = retained.checked_sub(needed)?;
+    (reclaimed >= COMPACTION_MIN_RECLAIMED_BYTES
+        && retained >= needed.saturating_mul(COMPACTION_RETENTION_RATIO))
+    .then_some(reclaimed)
 }
 
 /// How many bytes a view column retains beyond the bytes its own rows use.
@@ -483,100 +489,76 @@ fn contains_view_type(data_type: &DataType) -> bool {
 /// matters by default rather than in a corner: `DataFusion` reads Parquet
 /// `Utf8`/`Binary` columns as `Utf8View`/`BinaryView`
 /// (`schema_force_view_types`), so ordinary string results take this path.
-fn view_reclaimable_bytes(column: &ArrayRef) -> Option<usize> {
+///
+/// The ratio this decides on is arrow's own: `InProgressByteViewArray` gcs a
+/// source when its data buffers exceed twice the bytes its views reference
+/// (`arrow-select`, `coalesce/byte_view.rs`), for the same reason.
+fn view_reclaimable_bytes<B: ByteViewType>(column: &ArrayRef) -> Option<usize> {
+    let array = column.as_any().downcast_ref::<GenericByteViewArray<B>>()?;
+
     // `gc` rebuilds both halves of a view array — the views themselves and the
-    // data buffers they point into — so both are counted here. A short-string
-    // column can be almost all views, and a wide-string one almost all data.
-    let (retained, needed) = match column.data_type() {
-        DataType::Utf8View => {
-            let array = column.as_any().downcast_ref::<StringViewArray>()?;
-            (
-                view_bytes(array.views().inner(), array.data_buffers()),
-                compacted_view_bytes(array.len(), array.total_buffer_bytes_used()),
-            )
-        }
-        DataType::BinaryView => {
-            let array = column.as_any().downcast_ref::<BinaryViewArray>()?;
-            (
-                view_bytes(array.views().inner(), array.data_buffers()),
-                compacted_view_bytes(array.len(), array.total_buffer_bytes_used()),
-            )
-        }
-        _ => return None,
-    };
+    // data buffers they point into — so both are counted. A short-string column
+    // can be almost all views, and a wide-string one almost all data. The null
+    // buffer is excluded because `gc` reuses it as-is.
+    let retained = array.views().inner().capacity()
+        + array
+            .data_buffers()
+            .iter()
+            .map(Buffer::capacity)
+            .sum::<usize>();
+    let views_bytes = array.len().saturating_mul(std::mem::size_of::<u128>());
 
-    let reclaimed = retained.checked_sub(needed)?;
-    (reclaimed >= COMPACTION_MIN_RECLAIMED_BYTES
-        && retained >= needed.saturating_mul(COMPACTION_RETENTION_RATIO))
-    .then_some(reclaimed)
-}
+    // `total_buffer_bytes_used` walks every view, so bound the reclaim first:
+    // the compacted array cannot be smaller than its views alone. This is what
+    // keeps an already-compact column — the common case — off that walk.
+    worth_compacting(retained, views_bytes)?;
 
-/// What a view column's views and data buffers hold today. The null buffer is
-/// excluded because `gc` reuses it as-is, so it is not reclaimable either way.
-fn view_bytes(views: &Buffer, data_buffers: &[Buffer]) -> usize {
-    views.capacity() + data_buffers.iter().map(Buffer::capacity).sum::<usize>()
-}
-
-/// What those same buffers would hold after `gc`: one view per row, and only
-/// the bytes the out-of-line views reference.
-fn compacted_view_bytes(rows: usize, bytes_used: usize) -> usize {
-    rows.saturating_mul(std::mem::size_of::<u128>()) + bytes_used
+    worth_compacting(retained, views_bytes + array.total_buffer_bytes_used())
 }
 
 /// How many bytes compacting `column` would reclaim, or `None` when the copy
 /// would not pay for itself.
 fn reclaimable_bytes(column: &ArrayRef) -> Option<usize> {
-    if matches!(
-        column.data_type(),
-        DataType::Utf8View | DataType::BinaryView
-    ) {
-        return view_reclaimable_bytes(column);
-    }
-    if retains_unmeasured_buffers(column.data_type()) {
-        return None;
+    match column.data_type() {
+        DataType::Utf8View => return view_reclaimable_bytes::<StringViewType>(column),
+        DataType::BinaryView => return view_reclaimable_bytes::<BinaryViewType>(column),
+        data_type if contains_view_type(data_type) => return None,
+        _ => {}
     }
 
-    let retained = column.get_array_memory_size();
     // `Err` means the type's buffers cannot be measured from its layout, which
     // is the same situation as a nested view type: there is no honest
     // comparison to make, so leave the column alone.
     let needed = column.to_data().get_slice_memory_size().ok()?;
 
-    let reclaimed = retained.checked_sub(needed)?;
-    (reclaimed >= COMPACTION_MIN_RECLAIMED_BYTES
-        && retained >= needed.saturating_mul(COMPACTION_RETENTION_RATIO))
-    .then_some(reclaimed)
+    worth_compacting(column.get_array_memory_size(), needed)
 }
 
 /// Copies `column`'s rows into buffers sized for exactly those rows.
 ///
-/// This is what [`arrow::compute::concat`] does for more than one array; it
-/// cannot be used here because `concat` returns a single input untouched.
+/// For most types this is what [`arrow::compute::concat`] does for more than
+/// one array; `concat` cannot be used because it returns a single input
+/// untouched. A view array instead needs `gc`, which rebuilds the data buffers
+/// its views point into — `MutableArrayData` copies those wholesale.
 fn compact_column(column: &ArrayRef) -> ArrayRef {
-    if let Some(compacted) = compact_view_column(column) {
-        return compacted;
+    match column.data_type() {
+        DataType::Utf8View => {
+            if let Some(array) = column.as_any().downcast_ref::<StringViewArray>() {
+                return Arc::new(array.gc());
+            }
+        }
+        DataType::BinaryView => {
+            if let Some(array) = column.as_any().downcast_ref::<BinaryViewArray>() {
+                return Arc::new(array.gc());
+            }
+        }
+        _ => {}
     }
+
     let data = column.to_data();
     let mut compacted = MutableArrayData::new(vec![&data], false, column.len());
     compacted.extend(0, 0, column.len());
     make_array(compacted.freeze())
-}
-
-/// Rebuilds a view column's data buffers around the bytes its rows actually
-/// reference. `MutableArrayData` copies a view array's data buffers wholesale,
-/// so it cannot do this; `gc` is the kernel that can.
-fn compact_view_column(column: &ArrayRef) -> Option<ArrayRef> {
-    match column.data_type() {
-        DataType::Utf8View => column
-            .as_any()
-            .downcast_ref::<StringViewArray>()
-            .map(|array| Arc::new(array.gc()) as ArrayRef),
-        DataType::BinaryView => column
-            .as_any()
-            .downcast_ref::<BinaryViewArray>()
-            .map(|array| Arc::new(array.gc()) as ArrayRef),
-        _ => None,
-    }
 }
 
 /// Returns `batch` with every column that retains substantially more memory
@@ -598,22 +580,28 @@ fn compact_view_column(column: &ArrayRef) -> Option<ArrayRef> {
 /// *before* paying for it.
 #[must_use]
 pub fn compact_retained_buffers(batch: &RecordBatch) -> RecordBatch {
-    let mut columns: Option<Vec<ArrayRef>> = None;
+    let plan: Vec<bool> = batch
+        .columns()
+        .iter()
+        .map(|column| reclaimable_bytes(column).is_some())
+        .collect();
 
-    for (idx, column) in batch.columns().iter().enumerate() {
-        if reclaimable_bytes(column).is_none() {
-            continue;
-        }
-        let compacted = compact_column(column);
-        let columns = columns.get_or_insert_with(|| batch.columns().to_vec());
-        if let Some(slot) = columns.get_mut(idx) {
-            *slot = compacted;
-        }
+    if !plan.contains(&true) {
+        return batch.clone();
     }
 
-    let Some(columns) = columns else {
-        return batch.clone();
-    };
+    let columns: Vec<ArrayRef> = batch
+        .columns()
+        .iter()
+        .zip(&plan)
+        .map(|(column, compact)| {
+            if *compact {
+                compact_column(column)
+            } else {
+                Arc::clone(column)
+            }
+        })
+        .collect();
 
     // The row count is carried explicitly so a batch with no columns keeps it.
     let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
@@ -1202,6 +1190,20 @@ mod test {
         );
     }
 
+    /// `rows` strings of `value_len` identical characters, varying by row so a
+    /// compaction that took the wrong row is visible.
+    fn payloads(rows: usize, value_len: usize) -> Vec<String> {
+        (0..rows)
+            .map(|row| {
+                std::iter::repeat_n(
+                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
+                    value_len,
+                )
+                .collect()
+            })
+            .collect()
+    }
+
     /// A batch of wide strings, big enough that slicing one row out of it
     /// retains far more than that row needs.
     fn wide_string_batch(rows: usize, value_len: usize) -> RecordBatch {
@@ -1210,21 +1212,12 @@ mod test {
             Field::new("payload", DataType::Utf8, true),
         ]));
         let ids: Vec<i32> = (0..i32::try_from(rows).expect("rows fits in i32")).collect();
-        let payloads: Vec<String> = (0..rows)
-            .map(|row| {
-                std::iter::repeat_n(
-                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
-                    value_len,
-                )
-                .collect()
-            })
-            .collect();
 
         RecordBatch::try_new(
             schema,
             vec![
                 Arc::new(Int32Array::from(ids)),
-                Arc::new(StringArray::from(payloads)),
+                Arc::new(StringArray::from(payloads(rows, value_len))),
             ],
         )
         .expect("valid batch")
@@ -1301,14 +1294,10 @@ mod test {
             DataType::Utf8,
             true,
         )]));
-        let values: Vec<Option<String>> = (0..2_000)
-            .map(|row| {
-                if row % 3 == 0 {
-                    None
-                } else {
-                    Some(std::iter::repeat_n('x', 4_096).collect())
-                }
-            })
+        let values: Vec<Option<String>> = payloads(2_000, 4_096)
+            .into_iter()
+            .enumerate()
+            .map(|(row, value)| (row % 3 != 0).then_some(value))
             .collect();
         let batch = RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(values))])
             .expect("valid batch");
@@ -1371,19 +1360,11 @@ mod test {
             DataType::Utf8View,
             true,
         )]));
-        let values: Vec<String> = (0..rows)
-            .map(|row| {
-                std::iter::repeat_n(
-                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
-                    value_len,
-                )
-                .collect()
-            })
-            .collect();
-
         RecordBatch::try_new(
             schema,
-            vec![Arc::new(StringViewArray::from_iter_values(values))],
+            vec![Arc::new(StringViewArray::from_iter_values(payloads(
+                rows, value_len,
+            )))],
         )
         .expect("valid batch")
     }
@@ -1442,12 +1423,7 @@ mod test {
     /// view path, so such a column is left alone rather than copied blindly.
     #[test]
     fn compact_retained_buffers_leaves_a_nested_view_column_alone() {
-        use arrow::array::{ArrayRef as _ArrayRef, StringViewArray as _SVA};
-
-        let values: Vec<String> = (0..2_000)
-            .map(|_| std::iter::repeat_n('v', 4_096).collect())
-            .collect();
-        let inner: _ArrayRef = Arc::new(_SVA::from_iter_values(values));
+        let inner: ArrayRef = Arc::new(StringViewArray::from_iter_values(payloads(2_000, 4_096)));
         let struct_array = StructArray::from(vec![(
             Arc::new(Field::new("payload", DataType::Utf8View, true)),
             inner,

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -15,7 +15,10 @@ limitations under the License.
 */
 
 use arrow::{
-    array::{Array, ArrayRef, ListArray, RecordBatch, StructArray, new_null_array},
+    array::{
+        Array, ArrayRef, ListArray, MutableArrayData, RecordBatch, RecordBatchOptions, StructArray,
+        make_array, new_null_array,
+    },
     buffer::{Buffer, OffsetBuffer},
     datatypes::{DataType, Field, SchemaRef, TimeUnit},
     error::ArrowError,
@@ -427,6 +430,118 @@ pub fn replace_column_in_record(
         .collect::<Vec<_>>();
 
     RecordBatch::try_new(schema.into(), columns)
+}
+
+/// How many times its own rows' worth of memory a column may retain before a
+/// compact copy is worth making. A slice that keeps twice what it needs is
+/// still cheaper to hold than to rebuild.
+const COMPACTION_RETENTION_RATIO: usize = 2;
+
+/// How many bytes a compaction must actually reclaim to be worth its copy.
+const COMPACTION_MIN_RECLAIMED_BYTES: usize = 64 * 1024;
+
+/// Whether a type keeps data in buffers that
+/// [`ArrayData::get_slice_memory_size`] does not walk.
+///
+/// The view types hold their bytes in variadic data buffers, which the layout
+/// used by `get_slice_memory_size` does not describe — it counts only the
+/// 16-byte views. Every view column would therefore look like it retains far
+/// more than its rows need, and be copied on every store for nothing.
+fn retains_unmeasured_buffers(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Utf8View | DataType::BinaryView => true,
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::ListView(field)
+        | DataType::LargeListView(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::Map(field, _)
+        | DataType::RunEndEncoded(_, field) => retains_unmeasured_buffers(field.data_type()),
+        DataType::Struct(fields) => fields
+            .iter()
+            .any(|field| retains_unmeasured_buffers(field.data_type())),
+        DataType::Union(fields, _) => fields
+            .iter()
+            .any(|(_, field)| retains_unmeasured_buffers(field.data_type())),
+        DataType::Dictionary(_, value_type) => retains_unmeasured_buffers(value_type),
+        _ => false,
+    }
+}
+
+/// How many bytes compacting `column` would reclaim, or `None` when the copy
+/// would not pay for itself.
+fn reclaimable_bytes(column: &ArrayRef) -> Option<usize> {
+    if retains_unmeasured_buffers(column.data_type()) {
+        return None;
+    }
+
+    let retained = column.get_array_memory_size();
+    // `Err` means the type's buffers cannot be measured from its layout, which
+    // is the same situation as a view type: there is no honest comparison to
+    // make, so leave the column alone.
+    let needed = column.to_data().get_slice_memory_size().ok()?;
+
+    let reclaimed = retained.checked_sub(needed)?;
+    (reclaimed >= COMPACTION_MIN_RECLAIMED_BYTES
+        && retained >= needed.saturating_mul(COMPACTION_RETENTION_RATIO))
+    .then_some(reclaimed)
+}
+
+/// Copies `column`'s rows into buffers sized for exactly those rows.
+///
+/// This is what [`arrow::compute::concat`] does for more than one array; it
+/// cannot be used here because `concat` returns a single input untouched.
+fn compact_column(column: &ArrayRef) -> ArrayRef {
+    let data = column.to_data();
+    let mut compacted = MutableArrayData::new(vec![&data], false, column.len());
+    compacted.extend(0, 0, column.len());
+    make_array(compacted.freeze())
+}
+
+/// Returns `batch` with every column that retains substantially more memory
+/// than its own rows need replaced by a compact copy.
+///
+/// [`RecordBatch::slice`] is zero-copy by design: a sliced batch keeps its
+/// parent's whole buffers alive, and `get_array_memory_size` reports those
+/// retained buffers rather than the rows the slice contains. A single row
+/// carved out of a scan batch — what `LIMIT`/`OFFSET` produces — therefore
+/// costs, and is billed, the entire batch it came from. Anything that holds a
+/// batch past the scan that produced it (the SQL results cache, an in-memory
+/// index) should compact it first, so the memory it pins is proportional to
+/// the rows it kept.
+///
+/// Columns that are already compact are shared, not copied, so a batch with
+/// nothing to reclaim costs a reference-count clone.
+#[must_use]
+pub fn compact_retained_buffers(batch: &RecordBatch) -> RecordBatch {
+    let mut columns: Option<Vec<ArrayRef>> = None;
+
+    for (idx, column) in batch.columns().iter().enumerate() {
+        if reclaimable_bytes(column).is_none() {
+            continue;
+        }
+        let compacted = compact_column(column);
+        let columns = columns.get_or_insert_with(|| batch.columns().to_vec());
+        if let Some(slot) = columns.get_mut(idx) {
+            *slot = compacted;
+        }
+    }
+
+    let Some(columns) = columns else {
+        return batch.clone();
+    };
+
+    // The row count is carried explicitly so a batch with no columns keeps it.
+    let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
+    match RecordBatch::try_new_with_options(batch.schema(), columns, &options) {
+        Ok(compacted) => compacted,
+        Err(e) => {
+            // Compaction preserves every column's type and length, so this is
+            // unreachable; keeping the original is always safe.
+            tracing::warn!("Failed to compact a record batch, keeping it as read: {e}");
+            batch.clone()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -982,5 +1097,210 @@ mod test {
             result.is_err(),
             "non-timestamp overflow should still return an error"
         );
+    }
+
+    /// A batch of wide strings, big enough that slicing one row out of it
+    /// retains far more than that row needs.
+    fn wide_string_batch(rows: usize, value_len: usize) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("payload", DataType::Utf8, true),
+        ]));
+        let ids: Vec<i32> = (0..i32::try_from(rows).expect("rows fits in i32")).collect();
+        let payloads: Vec<String> = (0..rows)
+            .map(|row| {
+                std::iter::repeat_n(
+                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
+                    value_len,
+                )
+                .collect()
+            })
+            .collect();
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringArray::from(payloads)),
+            ],
+        )
+        .expect("valid batch")
+    }
+
+    fn row_payload(batch: &RecordBatch, row: usize) -> String {
+        batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("payload is a StringArray")
+            .value(row)
+            .to_string()
+    }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/12921>.
+    /// A one-row slice of a large batch must not keep the whole batch alive.
+    #[test]
+    fn compact_retained_buffers_releases_a_slices_parent_buffers() {
+        let batch = wide_string_batch(2_000, 4_096);
+        let sliced = batch.slice(1_000, 1);
+        assert_eq!(
+            sliced.get_array_memory_size(),
+            batch.get_array_memory_size(),
+            "a slice retains its parent's buffers, which is the defect under test"
+        );
+
+        let compacted = compact_retained_buffers(&sliced);
+
+        assert_eq!(compacted.num_rows(), 1);
+        assert_eq!(compacted.schema(), sliced.schema());
+        assert_eq!(
+            row_payload(&compacted, 0),
+            row_payload(&sliced, 0),
+            "compaction must preserve the row's value"
+        );
+        assert!(
+            compacted.get_array_memory_size() * 100 < sliced.get_array_memory_size(),
+            "a one-row slice of a 2000-row batch should retain a small fraction of it, got {} of {}",
+            compacted.get_array_memory_size(),
+            sliced.get_array_memory_size()
+        );
+    }
+
+    /// Every row of a multi-row slice survives, in order.
+    #[test]
+    fn compact_retained_buffers_preserves_every_row_of_a_slice() {
+        let batch = wide_string_batch(500, 1_024);
+        let sliced = batch.slice(100, 300);
+
+        let compacted = compact_retained_buffers(&sliced);
+
+        assert_eq!(compacted.num_rows(), sliced.num_rows());
+        for row in 0..sliced.num_rows() {
+            assert_eq!(
+                row_payload(&compacted, row),
+                row_payload(&sliced, row),
+                "row {row} changed under compaction"
+            );
+        }
+        let ids = compacted
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("id is an Int32Array");
+        assert_eq!(ids.value(0), 100, "the slice's first row must be preserved");
+    }
+
+    /// Nulls inside the slice survive, and nulls outside it are not adopted.
+    #[test]
+    fn compact_retained_buffers_preserves_nulls_within_the_slice() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::Utf8,
+            true,
+        )]));
+        let values: Vec<Option<String>> = (0..2_000)
+            .map(|row| {
+                if row % 3 == 0 {
+                    None
+                } else {
+                    Some(std::iter::repeat_n('x', 4_096).collect())
+                }
+            })
+            .collect();
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(values))])
+            .expect("valid batch");
+        let sliced = batch.slice(999, 3);
+
+        let compacted = compact_retained_buffers(&sliced);
+
+        let before = sliced
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("StringArray");
+        let after = compacted
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("StringArray");
+        assert_eq!(after.null_count(), before.null_count());
+        for row in 0..before.len() {
+            assert_eq!(after.is_null(row), before.is_null(row), "row {row} nullity");
+            if !before.is_null(row) {
+                assert_eq!(after.value(row), before.value(row), "row {row} value");
+            }
+        }
+    }
+
+    /// A batch that retains nothing extra is shared, not copied.
+    #[test]
+    fn compact_retained_buffers_leaves_a_compact_batch_untouched() {
+        let batch = wide_string_batch(4, 16);
+
+        let compacted = compact_retained_buffers(&batch);
+
+        for (idx, column) in batch.columns().iter().enumerate() {
+            assert!(
+                Arc::ptr_eq(column, compacted.column(idx)),
+                "column {idx} of an already-compact batch was copied"
+            );
+        }
+    }
+
+    /// A slice small enough that copying it would not pay for itself is left
+    /// alone, so the common case of many small batches costs no copies.
+    #[test]
+    fn compact_retained_buffers_ignores_a_slice_below_the_reclaim_floor() {
+        let batch = wide_string_batch(64, 64);
+        let sliced = batch.slice(1, 1);
+
+        let compacted = compact_retained_buffers(&sliced);
+
+        assert!(
+            Arc::ptr_eq(sliced.column(1), compacted.column(1)),
+            "a slice retaining under the floor should not be copied"
+        );
+    }
+
+    /// View columns hold their bytes in buffers `get_slice_memory_size` does
+    /// not walk, so they must be left alone rather than copied on every store.
+    #[test]
+    fn compact_retained_buffers_leaves_view_columns_alone() {
+        use arrow::array::StringViewArray;
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::Utf8View,
+            true,
+        )]));
+        let values: Vec<String> = (0..2_000)
+            .map(|_| std::iter::repeat_n('v', 4_096).collect())
+            .collect();
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringViewArray::from_iter_values(values))],
+        )
+        .expect("valid batch");
+        let sliced = batch.slice(1_000, 1);
+
+        let compacted = compact_retained_buffers(&sliced);
+
+        assert!(
+            Arc::ptr_eq(sliced.column(0), compacted.column(0)),
+            "a view column must not be compacted"
+        );
+    }
+
+    /// A batch with no columns keeps its row count.
+    #[test]
+    fn compact_retained_buffers_preserves_a_column_less_row_count() {
+        let options = RecordBatchOptions::new().with_row_count(Some(7));
+        let batch =
+            RecordBatch::try_new_with_options(Arc::new(Schema::empty()), Vec::new(), &options)
+                .expect("valid batch");
+
+        let compacted = compact_retained_buffers(&batch);
+
+        assert_eq!(compacted.num_rows(), 7);
     }
 }

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -513,7 +513,17 @@ fn view_reclaimable_bytes<B: ByteViewType>(column: &ArrayRef) -> Option<usize> {
     // keeps an already-compact column — the common case — off that walk.
     worth_compacting(retained, views_bytes)?;
 
-    worth_compacting(retained, views_bytes + array.total_buffer_bytes_used())
+    let bytes_used = array.total_buffer_bytes_used();
+    if bytes_used == 0 {
+        // No view references out-of-line data — either the column has no data
+        // buffers at all, or the slice's own rows all fit inline. `gc` takes a
+        // fast path in both cases that reuses the views buffer as it stands,
+        // which for a slice is the parent's whole allocation. There is nothing
+        // it would reclaim.
+        return None;
+    }
+
+    worth_compacting(retained, views_bytes + bytes_used)
 }
 
 /// How many bytes compacting `column` would reclaim, or `None` when the copy
@@ -523,6 +533,14 @@ fn reclaimable_bytes(column: &ArrayRef) -> Option<usize> {
         DataType::Utf8View => return view_reclaimable_bytes::<StringViewType>(column),
         DataType::BinaryView => return view_reclaimable_bytes::<BinaryViewType>(column),
         data_type if contains_view_type(data_type) => return None,
+        // A dictionary is declined on both counts. `MutableArrayData` shares
+        // the values wholesale rather than narrowing them, so only the keys
+        // could be reclaimed; and it panics outright building an extend for a
+        // dictionary whose value count does not fit its key type — a
+        // `Dictionary(UInt8, _)` holding exactly 256 values is valid Arrow and
+        // trips it (`build_extend_dictionary` returns `None`, which
+        // `MutableArrayData::with_capacities` unwraps with `expect`).
+        DataType::Dictionary(_, _) => return None,
         _ => {}
     }
 
@@ -1442,6 +1460,125 @@ mod test {
         assert!(
             Arc::ptr_eq(sliced.column(0), compacted.column(0)),
             "a nested view column must not be compacted"
+        );
+    }
+
+    /// A `Dictionary(UInt8, _)` holding exactly 256 values is valid Arrow, but
+    /// arrow's `MutableArrayData` panics building an extend for it. Compaction
+    /// must never reach that path — a cache write is not allowed to abort the
+    /// query that filled it.
+    #[test]
+    fn compact_retained_buffers_leaves_a_full_range_dictionary_alone() {
+        use arrow::array::{DictionaryArray, UInt8Array};
+        use arrow::datatypes::UInt8Type;
+
+        let values = StringArray::from(
+            (0..256)
+                .map(|value| format!("value-{value}"))
+                .collect::<Vec<_>>(),
+        );
+        // A key buffer far past the reclaim floor, so nothing but the type
+        // check can keep this column away from compaction.
+        let keys = UInt8Array::from(
+            (0..200_000)
+                .map(|row| u8::try_from(row % 256).unwrap_or_default())
+                .collect::<Vec<_>>(),
+        );
+        let dictionary: ArrayRef = Arc::new(
+            DictionaryArray::<UInt8Type>::try_new(keys, Arc::new(values))
+                .expect("valid dictionary"),
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "d",
+            dictionary.data_type().clone(),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![dictionary]).expect("valid batch");
+        let sliced = batch.slice(100_000, 1);
+
+        // Must not panic, and must hand back the column untouched.
+        let compacted = compact_retained_buffers(&sliced);
+
+        assert!(
+            Arc::ptr_eq(sliced.column(0), compacted.column(0)),
+            "a dictionary column must not be compacted"
+        );
+        assert_eq!(compacted.num_rows(), 1);
+    }
+
+    /// When every value fits inline, `gc` reuses the views buffer as it stands
+    /// — for a slice, that is the parent's whole allocation. Predicting a
+    /// reclaim there would bill an entry less than it holds.
+    #[test]
+    fn compact_retained_buffers_leaves_an_inline_view_column_alone() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::Utf8View,
+            true,
+        )]));
+        // 12 bytes or fewer is stored inline, with no data buffer.
+        let values: Vec<String> = (0..200_000).map(|row| format!("r{row:0>8}")).collect();
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringViewArray::from_iter_values(values))],
+        )
+        .expect("valid batch");
+        let sliced = batch.slice(100_000, 1);
+
+        let compacted = compact_retained_buffers(&sliced);
+
+        assert!(
+            Arc::ptr_eq(sliced.column(0), compacted.column(0)),
+            "an inline-only view column must not be compacted"
+        );
+        assert_eq!(
+            compacted_memory_size(&sliced),
+            sliced.get_array_memory_size(),
+            "and the estimate must not claim a reclaim that gc would not make"
+        );
+    }
+
+    /// The same fast path is reached from the other side: a column that does
+    /// have data buffers, sliced down to rows whose values all fit inline.
+    /// `gc` reuses the views buffer there too, so there is still no reclaim.
+    #[test]
+    fn compact_retained_buffers_leaves_an_inline_slice_of_a_mixed_view_column_alone() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::Utf8View,
+            true,
+        )]));
+        // Row 0 is long enough to force a data buffer; every other row is
+        // inline, so a slice past row 0 references none of it.
+        let mut values: Vec<String> = vec![std::iter::repeat_n('L', 65_536).collect()];
+        values.extend((1..200_000).map(|row| format!("r{row:0>8}")));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringViewArray::from_iter_values(values))],
+        )
+        .expect("valid batch");
+        let sliced = batch.slice(100_000, 1);
+
+        let column = sliced
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .expect("StringViewArray");
+        assert!(
+            !column.data_buffers().is_empty() && column.total_buffer_bytes_used() == 0,
+            "the slice must retain a data buffer while referencing none of it"
+        );
+
+        let compacted = compact_retained_buffers(&sliced);
+
+        assert!(
+            Arc::ptr_eq(sliced.column(0), compacted.column(0)),
+            "an inline-only slice must not be compacted"
+        );
+        assert_eq!(
+            compacted_memory_size(&sliced),
+            sliced.get_array_memory_size(),
+            "and the estimate must not claim a reclaim that gc would not make"
         );
     }
 

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 [dependencies]
 ahash.workspace = true
 arrow.workspace = true
+arrow_tools = { path = "../arrow_tools" }
 async-compression = { version = "0.4", features = [
     "tokio",
     "zstd",

--- a/crates/cache/src/result/mod.rs
+++ b/crates/cache/src/result/mod.rs
@@ -18,6 +18,24 @@ pub mod embeddings;
 pub mod query;
 pub mod search;
 
+use arrow::array::RecordBatch;
+
+/// Compacts batches that retain more memory than their own rows need, so a
+/// cache entry holds — and is billed — what it stores.
+///
+/// Every store of raw batches funnels through here rather than through its
+/// call sites: `LIMIT`/`OFFSET` and top-k plans emit zero-copy slices of the
+/// scan batches they came from, and an entry built from one of those pins the
+/// whole scan batch for the lifetime of the entry. Encoded entries need no
+/// equivalent, because serialization already writes only the rows a batch
+/// holds.
+pub(crate) fn compact_for_storage(mut batches: Vec<RecordBatch>) -> Vec<RecordBatch> {
+    for batch in &mut batches {
+        *batch = arrow_tools::record_batch::compact_retained_buffers(batch);
+    }
+    batches
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheStatus {
     // The request was not eligible for caching, and thus the cache was not checked.

--- a/crates/cache/src/result/query.rs
+++ b/crates/cache/src/result/query.rs
@@ -68,21 +68,6 @@ pub struct CachedQueryResult {
     encoder: Option<Arc<dyn Encoder>>,
 }
 
-/// Compacts batches that retain more memory than their own rows need, so an
-/// entry holds — and is billed — what it stores.
-///
-/// Every raw store funnels through here rather than through its call sites:
-/// `LIMIT`/`OFFSET` emits zero-copy slices of the scan batches they came from,
-/// and an entry built from one of those pins the whole scan batch for the
-/// lifetime of the entry. Encoded entries need no equivalent, because
-/// serialization already writes only the rows the batch holds.
-fn compact_for_storage(mut batches: Vec<RecordBatch>) -> Vec<RecordBatch> {
-    for batch in &mut batches {
-        *batch = arrow_tools::record_batch::compact_retained_buffers(batch);
-    }
-    batches
-}
-
 impl CachedQueryResult {
     /// Create a new cached query result with raw `RecordBatches`.
     ///
@@ -97,7 +82,7 @@ impl CachedQueryResult {
         read_started_at: Instant,
     ) -> Self {
         Self {
-            data: CachedData::Raw(Arc::new(compact_for_storage(batches))),
+            data: CachedData::Raw(Arc::new(super::compact_for_storage(batches))),
             schema,
             input_tables,
             cached_at,
@@ -148,7 +133,7 @@ impl CachedQueryResult {
             let encoded_data = encoder.encode(&records).await?;
             CachedData::Encoded(Bytes::from(encoded_data))
         } else {
-            CachedData::Raw(Arc::new(compact_for_storage(records)))
+            CachedData::Raw(Arc::new(super::compact_for_storage(records)))
         };
 
         Ok(Self {
@@ -460,27 +445,7 @@ mod tests {
         );
     }
 
-    /// A batch of wide strings, large enough that slicing one row out of it
-    /// retains far more than that row needs.
-    fn wide_string_batch(rows: usize) -> RecordBatch {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "payload",
-            DataType::Utf8,
-            false,
-        )]));
-        let payloads: Vec<String> = (0..rows)
-            .map(|row| {
-                std::iter::repeat_n(
-                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
-                    4_096,
-                )
-                .collect()
-            })
-            .collect();
-
-        RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(payloads))])
-            .expect("should create batch")
-    }
+    use crate::utils::tests::wide_string_batch;
 
     fn only_payload(batch: &RecordBatch) -> String {
         batch

--- a/crates/cache/src/result/query.rs
+++ b/crates/cache/src/result/query.rs
@@ -68,6 +68,21 @@ pub struct CachedQueryResult {
     encoder: Option<Arc<dyn Encoder>>,
 }
 
+/// Compacts batches that retain more memory than their own rows need, so an
+/// entry holds — and is billed — what it stores.
+///
+/// Every raw store funnels through here rather than through its call sites:
+/// `LIMIT`/`OFFSET` emits zero-copy slices of the scan batches they came from,
+/// and an entry built from one of those pins the whole scan batch for the
+/// lifetime of the entry. Encoded entries need no equivalent, because
+/// serialization already writes only the rows the batch holds.
+fn compact_for_storage(mut batches: Vec<RecordBatch>) -> Vec<RecordBatch> {
+    for batch in &mut batches {
+        *batch = arrow_tools::record_batch::compact_retained_buffers(batch);
+    }
+    batches
+}
+
 impl CachedQueryResult {
     /// Create a new cached query result with raw `RecordBatches`.
     ///
@@ -82,7 +97,7 @@ impl CachedQueryResult {
         read_started_at: Instant,
     ) -> Self {
         Self {
-            data: CachedData::Raw(Arc::new(batches)),
+            data: CachedData::Raw(Arc::new(compact_for_storage(batches))),
             schema,
             input_tables,
             cached_at,
@@ -133,7 +148,7 @@ impl CachedQueryResult {
             let encoded_data = encoder.encode(&records).await?;
             CachedData::Encoded(Bytes::from(encoded_data))
         } else {
-            CachedData::Raw(Arc::new(records))
+            CachedData::Raw(Arc::new(compact_for_storage(records)))
         };
 
         Ok(Self {
@@ -442,6 +457,100 @@ mod tests {
         assert_eq!(
             sizeable_size as u64, memory_size,
             "Sizeable trait should delegate to memory_size()"
+        );
+    }
+
+    /// A batch of wide strings, large enough that slicing one row out of it
+    /// retains far more than that row needs.
+    fn wide_string_batch(rows: usize) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::Utf8,
+            false,
+        )]));
+        let payloads: Vec<String> = (0..rows)
+            .map(|row| {
+                std::iter::repeat_n(
+                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
+                    4_096,
+                )
+                .collect()
+            })
+            .collect();
+
+        RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(payloads))])
+            .expect("should create batch")
+    }
+
+    fn only_payload(batch: &RecordBatch) -> String {
+        batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("payload is a StringArray")
+            .value(0)
+            .to_string()
+    }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/12921>.
+    /// An entry built from a slice must not hold — or be billed — the batch the
+    /// slice was carved out of.
+    #[test]
+    fn a_sliced_entry_is_billed_its_own_rows_new_raw() {
+        let scan_batch = wide_string_batch(2_000);
+        let sliced = scan_batch.slice(1_000, 1);
+        let cached_at = Instant::now();
+
+        let cached_result = CachedQueryResult::new_raw(
+            vec![sliced.clone()],
+            sliced.schema(),
+            Arc::new(HashSet::new()),
+            cached_at,
+            cached_at,
+        );
+
+        assert!(
+            cached_result.memory_size() * 100 < scan_batch.get_array_memory_size() as u64,
+            "a one-row entry sliced from a 2000-row batch should be billed a small fraction of it, got {} of {}",
+            cached_result.memory_size(),
+            scan_batch.get_array_memory_size()
+        );
+    }
+
+    /// The same store path, exercised through `from_batches` — what background
+    /// revalidation uses — and asserting the row itself survives compaction.
+    #[tokio::test]
+    async fn a_sliced_entry_is_billed_its_own_rows_from_batches() {
+        let scan_batch = wide_string_batch(2_000);
+        let sliced = scan_batch.slice(1_000, 1);
+        let expected_payload = only_payload(&sliced);
+        let cached_at = Instant::now();
+
+        let cached_result = CachedQueryResult::from_batches(
+            vec![sliced.clone()],
+            sliced.schema(),
+            Arc::new(HashSet::new()),
+            cached_at,
+            cached_at,
+            None,
+        )
+        .await
+        .expect("should create cached result");
+
+        assert!(
+            cached_result.memory_size() * 100 < scan_batch.get_array_memory_size() as u64,
+            "a one-row entry should be billed a small fraction of its parent, got {} of {}",
+            cached_result.memory_size(),
+            scan_batch.get_array_memory_size()
+        );
+
+        let records = cached_result.records().await.expect("should decode");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].num_rows(), 1);
+        assert_eq!(
+            only_payload(&records[0]),
+            expected_payload,
+            "compacting the entry must not change the row it holds"
         );
     }
 

--- a/crates/cache/src/result/search.rs
+++ b/crates/cache/src/result/search.rs
@@ -33,16 +33,20 @@ pub struct CachedAggregationResult {
 }
 
 impl CachedAggregationResult {
+    /// Batches are compacted on the way in, for the same reason
+    /// [`crate::CachedQueryResult`] compacts its own: a top-k search plan emits
+    /// zero-copy slices, and storing one as it arrives would pin — and, through
+    /// [`Sizeable`] below, bill — the whole scan batch it was carved from.
     #[must_use]
     pub fn new(
-        records: Arc<Vec<RecordBatch>>,
+        records: Vec<RecordBatch>,
         primary_keys: Vec<String>,
         data_columns: Vec<String>,
         matches: HashMap<String, Vec<String>>,
         schema: SchemaRef,
     ) -> Self {
         Self {
-            records,
+            records: Arc::new(crate::result::compact_for_storage(records)),
             primary_keys,
             data_columns,
             matches,
@@ -84,5 +88,80 @@ impl Sizeable for CachedSearchResult {
                         .sum::<usize>()
             })
             .sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::StringArray;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/12921>.
+    /// A top-k search plan emits slices, and an entry built from one must not
+    /// hold — or be billed — the scan batch it was carved out of.
+    #[test]
+    fn a_sliced_search_result_is_billed_its_own_rows() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::Utf8,
+            false,
+        )]));
+        let payloads: Vec<String> = (0..2_000)
+            .map(|row| {
+                std::iter::repeat_n(
+                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
+                    4_096,
+                )
+                .collect()
+            })
+            .collect();
+        let scan_batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringArray::from(payloads))],
+        )
+        .expect("should create batch");
+        let sliced = scan_batch.slice(1_000, 1);
+        let expected = sliced
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("payload is a StringArray")
+            .value(0)
+            .to_string();
+
+        let result = CachedAggregationResult::new(
+            vec![sliced],
+            vec!["id".to_string()],
+            vec!["payload".to_string()],
+            HashMap::new(),
+            schema,
+        );
+
+        let cached = CachedSearchResult {
+            results: Arc::new(HashMap::from([(
+                TableReference::bare("docs"),
+                result.clone(),
+            )])),
+            input_tables: Arc::new(HashSet::new()),
+        };
+        assert!(
+            cached.get_memory_size() * 100 < scan_batch.get_array_memory_size(),
+            "a one-row search entry should be billed a small fraction of its parent, got {} of {}",
+            cached.get_memory_size(),
+            scan_batch.get_array_memory_size()
+        );
+
+        assert_eq!(result.records.len(), 1);
+        assert_eq!(
+            result.records[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("payload is a StringArray")
+                .value(0),
+            expected,
+            "compacting the entry must not change the row it holds"
+        );
     }
 }

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -218,12 +218,21 @@ pub fn to_cached_record_batch_stream(
                 // Keep a compacted copy rather than the batch as it arrives: a
                 // `LIMIT`/`OFFSET` plan yields zero-copy slices, so retaining
                 // one holds its whole scan batch alive for as long as the entry
-                // lives, and bills the entry for it. Compacting here also makes
-                // `records_size` — which decides whether the result can be
-                // cached at all — the size the entry will actually occupy.
-                let batch = arrow_tools::record_batch::compact_retained_buffers(batch);
-                records_size = records_size.saturating_add(batch.get_array_memory_size());
-                records.push(batch);
+                // lives, and bills the entry for it.
+                //
+                // Bill the batch what it will occupy once compacted, and pay
+                // for the copy only once the result is known to still fit. The
+                // budget is what bounds this work: a result already too large
+                // to cache is abandoned here rather than copied in full and
+                // then discarded.
+                records_size = records_size
+                    .saturating_add(arrow_tools::record_batch::compacted_memory_size(batch));
+                if records_size < raw_size_limit {
+                    records.push(arrow_tools::record_batch::compact_retained_buffers(batch));
+                } else if !records.is_empty() {
+                    records.clear();
+                    records.shrink_to_fit();
+                }
             } else if !records.is_empty() && records_size >= raw_size_limit {
                 // The result can no longer fit in the cache: eagerly drop the
                 // accumulated batches. Caching must be abandoned entirely —

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -215,8 +215,15 @@ pub fn to_cached_record_batch_stream(
 
         while let Some(batch_result) = stream.next().await {
             if records_size < raw_size_limit && let Ok(batch) = &batch_result {
-                records.push(batch.clone());
+                // Keep a compacted copy rather than the batch as it arrives: a
+                // `LIMIT`/`OFFSET` plan yields zero-copy slices, so retaining
+                // one holds its whole scan batch alive for as long as the entry
+                // lives, and bills the entry for it. Compacting here also makes
+                // `records_size` — which decides whether the result can be
+                // cached at all — the size the entry will actually occupy.
+                let batch = arrow_tools::record_batch::compact_retained_buffers(batch);
                 records_size = records_size.saturating_add(batch.get_array_memory_size());
+                records.push(batch);
             } else if !records.is_empty() && records_size >= raw_size_limit {
                 // The result can no longer fit in the cache: eagerly drop the
                 // accumulated batches. Caching must be abandoned entirely —
@@ -1506,6 +1513,119 @@ pub(crate) mod tests {
         assert!(
             cached.is_none(),
             "Unencoded oversized result should NOT be cached"
+        );
+    }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/12921>.
+    ///
+    /// A `LIMIT`/`OFFSET` plan emits `batch.slice(..)`, which keeps its
+    /// parent's buffers alive. A one-row result carved out of a large scan
+    /// batch must be stored — and billed — as one row, not as the scan batch
+    /// it came from. Before the fix the entry was billed the whole parent,
+    /// which is larger than this cache's `max_size`, so it was never stored at
+    /// all and every repeat of the query re-executed.
+    #[tokio::test]
+    async fn a_sliced_result_is_stored_and_billed_as_its_own_rows() {
+        use arrow::array::StringArray;
+        use datafusion::error::DataFusionError;
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+        use futures::TryStreamExt;
+        use spicepod::component::caching::SQLResultsCacheConfig;
+
+        let cache_provider = Arc::new(
+            crate::QueryResultsCacheProvider::try_new(
+                &SQLResultsCacheConfig {
+                    item_ttl: Some("10m".to_string()),
+                    max_size: Some("1MiB".to_string()),
+                    encoding: spicepod::component::caching::Encoding::None,
+                    ..Default::default()
+                },
+                Box::new([]),
+            )
+            .expect("valid cache provider"),
+        );
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::Utf8,
+            false,
+        )]));
+        // 2,000 rows x 4 KiB is ~8 MiB of payload — well past the 1 MiB budget.
+        let payloads: Vec<String> = (0..2_000)
+            .map(|row| {
+                std::iter::repeat_n(
+                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
+                    4_096,
+                )
+                .collect()
+            })
+            .collect();
+        let scan_batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringArray::from(payloads))],
+        )
+        .expect("to create batch");
+        assert!(
+            scan_batch.get_array_memory_size() > 1024 * 1024,
+            "the scan batch must exceed the cache budget for this test to mean anything"
+        );
+
+        // What `LimitStream` yields for `LIMIT 1 OFFSET 1000`.
+        let sliced = scan_batch.slice(1_000, 1);
+        let expected_payload = sliced
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("payload is a StringArray")
+            .value(0)
+            .to_string();
+
+        let raw_cache_key =
+            crate::key::CacheKey::Query("sliced-result", None).as_raw_key(cache_provider.hasher());
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            futures::stream::iter(vec![Ok::<RecordBatch, DataFusionError>(sliced)]),
+        ));
+
+        let cached_stream = to_cached_record_batch_stream(
+            Arc::clone(&cache_provider),
+            stream,
+            raw_cache_key,
+            Arc::new(HashSet::from(["docs".into()])),
+            std::time::Instant::now(),
+        );
+
+        let output = cached_stream
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("stream should be collected successfully");
+        assert_eq!(output.len(), 1);
+        assert_eq!(output[0].num_rows(), 1);
+
+        let cached = cache_provider
+            .get_raw_key(&raw_cache_key)
+            .await
+            .expect("cache lookup should succeed")
+            .expect("a one-row result must fit in a 1 MiB cache");
+
+        assert!(
+            cached.get_memory_size() < 64 * 1024,
+            "a one-row entry should be billed its own row, got {} bytes",
+            cached.get_memory_size()
+        );
+
+        let cached_batches = cached.records().await.expect("cached result should decode");
+        assert_eq!(cached_batches.len(), 1);
+        assert_eq!(cached_batches[0].num_rows(), 1);
+        assert_eq!(
+            cached_batches[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("payload is a StringArray")
+                .value(0),
+            expected_payload,
+            "compacting the entry must not change the row it holds"
         );
     }
 }

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -215,16 +215,23 @@ pub fn to_cached_record_batch_stream(
 
         while let Some(batch_result) = stream.next().await {
             if records_size < raw_size_limit && let Ok(batch) = &batch_result {
-                records.push(batch.clone());
-                // Bill the batch what the entry will hold, not what the batch
-                // retains: a `LIMIT`/`OFFSET` plan yields zero-copy slices, and
-                // storing one compacts it (see `CachedQueryResult`), so it will
-                // cost its own rows rather than the scan batch it was carved
-                // from. Measuring rather than compacting here is what keeps a
-                // result too large to cache from being copied in full before it
-                // is abandoned below.
+                // Accumulate compacted batches, not the batches as they arrive.
+                // A `LIMIT`/`OFFSET` plan yields zero-copy slices, so holding
+                // one keeps its whole scan batch alive until the stream drains
+                // — and `records_size` would then bound a figure unrelated to
+                // what is actually retained.
+                //
+                // Measure before copying, so the copy is only paid for a result
+                // that can still be cached: `compacted_memory_size` is what the
+                // batch will occupy, computed without allocating.
                 records_size = records_size
                     .saturating_add(arrow_tools::record_batch::compacted_memory_size(batch));
+                if records_size < raw_size_limit {
+                    records.push(arrow_tools::record_batch::compact_retained_buffers(batch));
+                } else {
+                    records.clear();
+                    records.shrink_to_fit();
+                }
             } else if !records.is_empty() && records_size >= raw_size_limit {
                 // The result can no longer fit in the cache: eagerly drop the
                 // accumulated batches. Caching must be abandoned entirely —

--- a/crates/cache/src/utils.rs
+++ b/crates/cache/src/utils.rs
@@ -215,24 +215,16 @@ pub fn to_cached_record_batch_stream(
 
         while let Some(batch_result) = stream.next().await {
             if records_size < raw_size_limit && let Ok(batch) = &batch_result {
-                // Keep a compacted copy rather than the batch as it arrives: a
-                // `LIMIT`/`OFFSET` plan yields zero-copy slices, so retaining
-                // one holds its whole scan batch alive for as long as the entry
-                // lives, and bills the entry for it.
-                //
-                // Bill the batch what it will occupy once compacted, and pay
-                // for the copy only once the result is known to still fit. The
-                // budget is what bounds this work: a result already too large
-                // to cache is abandoned here rather than copied in full and
-                // then discarded.
+                records.push(batch.clone());
+                // Bill the batch what the entry will hold, not what the batch
+                // retains: a `LIMIT`/`OFFSET` plan yields zero-copy slices, and
+                // storing one compacts it (see `CachedQueryResult`), so it will
+                // cost its own rows rather than the scan batch it was carved
+                // from. Measuring rather than compacting here is what keeps a
+                // result too large to cache from being copied in full before it
+                // is abandoned below.
                 records_size = records_size
                     .saturating_add(arrow_tools::record_batch::compacted_memory_size(batch));
-                if records_size < raw_size_limit {
-                    records.push(arrow_tools::record_batch::compact_retained_buffers(batch));
-                } else if !records.is_empty() {
-                    records.clear();
-                    records.shrink_to_fit();
-                }
             } else if !records.is_empty() && records_size >= raw_size_limit {
                 // The result can no longer fit in the cache: eagerly drop the
                 // accumulated batches. Caching must be abandoned entirely —
@@ -343,6 +335,32 @@ pub(crate) mod tests {
     use datafusion::execution::config::SessionConfig;
     use datafusion::execution::context::SessionContext;
     use std::collections::HashSet;
+
+    /// A batch of wide strings, large enough that slicing one row out of it
+    /// retains far more than that row needs. Shared with the `result::query`
+    /// tests, which assert against the same premise.
+    pub(crate) fn wide_string_batch(rows: usize) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::Utf8,
+            false,
+        )]));
+        let payloads: Vec<String> = (0..rows)
+            .map(|row| {
+                std::iter::repeat_n(
+                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
+                    4_096,
+                )
+                .collect()
+            })
+            .collect();
+
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(arrow::array::StringArray::from(payloads))],
+        )
+        .expect("should create batch")
+    }
 
     pub(crate) async fn parse_sql_to_logical_plan(sql: &str) -> LogicalPlan {
         let ctx = create_session_context();
@@ -1554,26 +1572,9 @@ pub(crate) mod tests {
             .expect("valid cache provider"),
         );
 
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "payload",
-            DataType::Utf8,
-            false,
-        )]));
         // 2,000 rows x 4 KiB is ~8 MiB of payload — well past the 1 MiB budget.
-        let payloads: Vec<String> = (0..2_000)
-            .map(|row| {
-                std::iter::repeat_n(
-                    char::from(b'a' + u8::try_from(row % 26).unwrap_or_default()),
-                    4_096,
-                )
-                .collect()
-            })
-            .collect();
-        let scan_batch = RecordBatch::try_new(
-            Arc::clone(&schema),
-            vec![Arc::new(StringArray::from(payloads))],
-        )
-        .expect("to create batch");
+        let scan_batch = wide_string_batch(2_000);
+        let schema = scan_batch.schema();
         assert!(
             scan_batch.get_array_memory_size() > 1024 * 1024,
             "the scan batch must exceed the cache budget for this test to mean anything"

--- a/crates/runtime-search/src/search_engine.rs
+++ b/crates/runtime-search/src/search_engine.rs
@@ -727,8 +727,21 @@ fn wrap_cache_to_result(
             while let Some(batch_result) = stream.next().await {
                 if records_size < cache_max_size
                     && let Ok(batch) = &batch_result {
-                        records.push(batch.clone());
-                        records_size += batch.get_array_memory_size();
+                        // Accumulate compacted batches: a top-k plan yields
+                        // zero-copy slices, so holding one keeps its whole scan
+                        // batch alive and bills the entry for it — which would
+                        // reject a small result whose parent happens to be
+                        // large. Measure first so the copy is only paid for a
+                        // result that can still be cached.
+                        records_size = records_size.saturating_add(
+                            arrow_tools::record_batch::compacted_memory_size(batch),
+                        );
+                        if records_size < cache_max_size {
+                            records.push(arrow_tools::record_batch::compact_retained_buffers(batch));
+                        } else {
+                            records.clear();
+                            records.shrink_to_fit();
+                        }
                     }
 
                 yield batch_result;

--- a/crates/runtime-search/src/search_engine.rs
+++ b/crates/runtime-search/src/search_engine.rs
@@ -736,7 +736,7 @@ fn wrap_cache_to_result(
 
             if records_size < cache_max_size {
                 let cached_result = CachedAggregationResult::new(
-                    Arc::new(records),
+                    records,
                     cloned_primary_key,
                     cloned_data_columns,
                     cloned_matches,


### PR DESCRIPTION
## Summary

`RecordBatch::slice` is zero-copy by design: the slice keeps its parent's whole
buffers alive, and `get_array_memory_size` reports those retained buffers rather
than the rows the slice contains. `LIMIT`/`OFFSET` emits exactly that shape
(`LimitStream` yields `batch.slice(..)`), so a one-row result carved out of a
large scan batch pinned — and was billed — the entire batch it came from.

#12921 measured it at **~47.5 MiB per cached one-row entry**, a ~3,100x
overcharge, with two consequences:

- at the default `max_size: 128MiB` only ~3 entries stayed resident, so every
  entry was evicted before reuse, the hit rate collapsed to **0%**, and nothing
  reported an error — the cache silently stopped working;
- at a budget large enough to avoid eviction the memory was genuinely retained:
  200 cached one-row results pinned **9.5 GiB of RSS to hold 3 MiB of data**.

The root cause is that the entry stores the batch as it arrives. Compacting it
on the way in fixes both halves at once: the entry holds only its own rows, and
`get_array_memory_size` — which is what bills it — becomes accurate as a
consequence rather than needing its own correction.

## Changes

`arrow_tools::record_batch`:

- `compact_retained_buffers` returns a batch whose columns hold only the rows
  they contain. A column is copied only when it retains substantially more than
  its rows need (2x, and at least 64 KiB reclaimed), so an already-compact batch
  costs a reference-count clone rather than a copy.
- `compacted_memory_size` reports what that would cost, without copying, so a
  caller with a budget can decide before paying for it.
- View columns (`Utf8View`/`BinaryView`) go through arrow's `gc`, which rebuilds
  both the views and the data buffers they point into. This matters by default
  rather than in a corner: `DataFusion` reads Parquet string and binary columns
  as view types (`schema_force_view_types` defaults to `true`), so ordinary
  string results take that path. `MutableArrayData` copies a view array's data
  buffers wholesale and cannot compact them; `arrow::compute::concat` returns a
  single input untouched, so neither is usable here. The 2x threshold is arrow's
  own for this decision — see `InProgressByteViewArray::set_source` in
  `arrow-select`.
- Three shapes are declined rather than compacted, each because compaction would
  not narrow them: a **dictionary** (`MutableArrayData` shares the values and
  only the keys could be reclaimed — and it *panics* building an extend for a
  dictionary whose value count does not fit its key type, which
  `Dictionary(UInt8, _)` holding 256 values does); a **view whose rows all fit
  inline** (`gc` reuses the views buffer as it stands); and a **view nested
  inside a container**, which neither `get_slice_memory_size` nor `gc` can reach.

`cache` / `runtime-search`:

- Both raw store paths for query results — `CachedQueryResult::new_raw` and
  `from_batches`, the latter being what background revalidation uses — compact
  through one function rather than at their call sites. Encoded entries need no
  equivalent: serialization already writes only the rows a batch holds.
- The **search results cache had the same defect**, which #12921's Scope section
  names: a top-k plan emits slices, and `CachedAggregationResult` held and billed
  whole scan batches. It now builds through the same funnel, and its accumulating
  stream bills the compacted size so a small result whose parent is large is no
  longer rejected outright.
- Both accumulating streams measure a batch before copying it, so a result
  already too large to cache is abandoned rather than copied in full and then
  discarded — while still accumulating *compacted* batches, so what they retain
  stays bounded by what they bill.

### Known limitations, deliberately left

- The reclaim floor is per column, so a wide result whose 200 columns each waste
  60 KiB is skipped although it wastes ~12 MiB in total.
- A view nested in a `Struct`/`List`/`Dictionary` is billed its retained size.

Both fail safe, in the over-billing direction, and neither is reachable from the
default Parquet path (view coercion applies to top-level fields only).

Three other consumers hold batches beyond the scan that produced them and have
the same defect — Cayenne's in-memory tier (where the figure gates admission,
not just eviction), the in-memory accelerator, and the in-memory search index.
Each sits on a hot write path with its own accounting to reconcile, so they are
filed as **#13044** rather than folded in here.

## Test plan

- `make lint`
- `make nextest`
- New unit tests, each verified to fail with its fix neutered: a one-row slice of
  a 2,000-row batch releases its parent's buffers (string and view arrays); cache
  entries built through both query store paths and through the search store path
  are billed their own rows; a sliced result now fits, and is served from, a
  budget it previously overflowed; a full-range dictionary is left alone rather
  than panicking; and an inline-only view slice is neither compacted nor
  discounted.
- Value-preservation coverage that must hold either way: every row of a multi-row
  slice survives in order, nulls inside the slice survive and nulls outside it
  are not adopted, already-compact and nested-view columns are shared rather than
  copied, and a column-less batch keeps its row count.

Fixes #12921

## Checklist

- [x] Tests added for the reported defect and for each finding raised in review
- [x] Lint and unit tests green locally for `arrow_tools`, `cache`, `runtime-search`
- [ ] `make signoff` green and `Attestation` re-run

## Review gate

Attests the panic fix in `5835da6e2a` (a dictionary guard that now recurses), not the PR's original work.

- Adversarial review: **declared skip** — `codex` ran and exited 1 with its own reason, `Your workspace is out of credits`; `grok` is not installed on this host, so no cross-model engine was available.
- Security review: no new external surface. The change only widens a guard that makes compaction *decline* a column, so it strictly reduces the work performed; no deserialization, path handling, authz surface, or new logging of user data. `compacted_memory_size` and `compact_retained_buffers` share the `reclaimable_bytes` predicate, so the wider guard cannot make the cache under-bill what it retains.
- Simplify: the new `contains_dictionary` deliberately mirrors the existing `contains_view_type` beside it rather than unifying the two into one generic walker — that refactor would rewrite code outside this fix's scope.
- Tests: regression test neutered to confirm it is load-bearing (it panics at `transform/mod.rs:680:31` with the guard restored to top-level-only). `arrow_tools` lib suite 151 passed; `cargo fmt --check` and scoped clippy clean.
