### PR TITLE
Use TypedParams for reranker parameters

### DIFF
--- a/crates/runtime/src/model/rerank/mod.rs
+++ b/crates/runtime/src/model/rerank/mod.rs
@@ -19,11 +19,14 @@ limitations under the License.
 //! into a runtime [`llms::rerank::Rerank`] instance. Mirrors
 //! [`crate::model::embed::try_to_embedding`] but targets the reranker trait.
 
+pub mod params;
+
 #[cfg(feature = "models")]
 use llms::rerank::TeiRerank;
 use llms::rerank::{CohereReranker, HttpReranker, JinaReranker, Rerank, VoyageReranker};
+use runtime_parameters_typed::{ParamsError, TypedParams};
 use runtime_secrets::{Secrets, get_params_with_secrets};
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::ExposeSecret;
 use snafu::{OptionExt, ResultExt, Snafu};
 use spicepod::component::rerankers::{Reranker, RerankerPrefix};
 use std::{collections::HashMap, sync::Arc};
@@ -71,6 +74,30 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Wraps a typed-params deserialization failure with the reranker name, same
+/// pattern `try_to_embedding` uses for embedding providers.
+fn params_err(name: &str, e: ParamsError) -> Error {
+    match e {
+        ParamsError::MissingRequired { user_key, .. } => Error::MissingParam {
+            name: name.to_string(),
+            param_key: user_key,
+        },
+        ParamsError::InvalidValue { user_key, reason } => Error::InvalidParam {
+            name: name.to_string(),
+            param_key: user_key,
+            reason,
+        },
+        ParamsError::UnknownParameter {
+            user_key,
+            supported,
+        } => Error::InvalidParam {
+            name: name.to_string(),
+            param_key: user_key,
+            reason: format!("unknown parameter. Supported: {supported}"),
+        },
+    }
+}
+
 /// Construct a `Rerank` instance from a Spicepod `Reranker` component.
 ///
 /// Secret-bearing params (`api_key`, `endpoint`) are resolved through the
@@ -93,7 +120,7 @@ pub async fn try_to_rerank_model(
             )
         })
         .collect();
-    let params = get_params_with_secrets(secrets, &string_params).await;
+    let params = get_params_with_secrets(Arc::clone(&secrets), &string_params).await;
 
     let prefix = component.get_prefix().context(UnknownSourceSnafu {
         from: component.from.clone(),
@@ -101,55 +128,62 @@ pub async fn try_to_rerank_model(
     let model_id = component.get_model_id().context(UnknownSourceSnafu {
         from: component.from.clone(),
     })?;
+    let component_name = format!("reranker {}", component.name);
 
     let reranker: Arc<dyn Rerank> = match prefix {
         RerankerPrefix::Cohere => {
-            let api_key = extract_secret(&params, "api_key")
-                .or_else(|| extract_secret(&params, "cohere_api_key"))
-                .context(MissingParamSnafu {
-                    name: component.name.clone(),
-                    param_key: "api_key".to_string(),
-                })?;
-            let mut c = CohereReranker::try_new(component.name.clone(), api_key)
-                .context(BuildFailedSnafu {
-                    name: component.name.clone(),
-                })?
-                .with_model_id(model_id);
-            if let Some(endpoint) = extract_secret(&params, "endpoint") {
+            let typed = params::cohere::CohereRerankerParams::try_from_params(
+                &component_name,
+                params,
+                &secrets,
+            )
+            .await
+            .map_err(|e| params_err(&component.name, e))?;
+            let mut c =
+                CohereReranker::try_new(component.name.clone(), typed.api_key.expose_secret())
+                    .context(BuildFailedSnafu {
+                        name: component.name.clone(),
+                    })?
+                    .with_model_id(model_id);
+            if let Some(endpoint) = typed.endpoint {
                 c = c.with_endpoint(endpoint);
             }
             Arc::new(c)
         }
         RerankerPrefix::Voyage => {
-            let api_key = extract_secret(&params, "api_key")
-                .or_else(|| extract_secret(&params, "voyage_api_key"))
-                .context(MissingParamSnafu {
-                    name: component.name.clone(),
-                    param_key: "api_key".to_string(),
-                })?;
-            let mut v = VoyageReranker::try_new(component.name.clone(), api_key)
-                .context(BuildFailedSnafu {
-                    name: component.name.clone(),
-                })?
-                .with_model_id(model_id);
-            if let Some(endpoint) = extract_secret(&params, "endpoint") {
+            let typed = params::voyage::VoyageRerankerParams::try_from_params(
+                &component_name,
+                params,
+                &secrets,
+            )
+            .await
+            .map_err(|e| params_err(&component.name, e))?;
+            let mut v =
+                VoyageReranker::try_new(component.name.clone(), typed.api_key.expose_secret())
+                    .context(BuildFailedSnafu {
+                        name: component.name.clone(),
+                    })?
+                    .with_model_id(model_id);
+            if let Some(endpoint) = typed.endpoint {
                 v = v.with_endpoint(endpoint);
             }
             Arc::new(v)
         }
         RerankerPrefix::Jina => {
-            let api_key = extract_secret(&params, "api_key")
-                .or_else(|| extract_secret(&params, "jina_api_key"))
-                .context(MissingParamSnafu {
-                    name: component.name.clone(),
-                    param_key: "api_key".to_string(),
-                })?;
-            let mut j = JinaReranker::try_new(component.name.clone(), api_key)
-                .context(BuildFailedSnafu {
-                    name: component.name.clone(),
-                })?
-                .with_model_id(model_id);
-            if let Some(endpoint) = extract_secret(&params, "endpoint") {
+            let typed = params::jina::JinaRerankerParams::try_from_params(
+                &component_name,
+                params,
+                &secrets,
+            )
+            .await
+            .map_err(|e| params_err(&component.name, e))?;
+            let mut j =
+                JinaReranker::try_new(component.name.clone(), typed.api_key.expose_secret())
+                    .context(BuildFailedSnafu {
+                        name: component.name.clone(),
+                    })?
+                    .with_model_id(model_id);
+            if let Some(endpoint) = typed.endpoint {
                 j = j.with_endpoint(endpoint);
             }
             Arc::new(j)
@@ -158,16 +192,23 @@ pub async fn try_to_rerank_model(
             // For HTTP BYO the `from` *is* the endpoint URL. Model id +
             // auth header are both optional (some self-hosted services pin
             // the model and auth upstream).
+            let typed = params::http::HttpRerankerParams::try_from_params(
+                &component_name,
+                params,
+                &secrets,
+            )
+            .await
+            .map_err(|e| params_err(&component.name, e))?;
             let endpoint = model_id;
             let mut h = HttpReranker::try_new(component.name.clone(), endpoint).context(
                 BuildFailedSnafu {
                     name: component.name.clone(),
                 },
             )?;
-            if let Some(api_key) = extract_secret(&params, "api_key") {
-                h = h.with_api_key(Some(api_key));
+            if let Some(api_key) = typed.api_key {
+                h = h.with_api_key(Some(api_key.expose_secret().to_string()));
             }
-            if let Some(id) = extract_secret(&params, "model") {
+            if let Some(id) = typed.model {
                 h = h.with_model_id(Some(id));
             }
             Arc::new(h)
@@ -178,15 +219,21 @@ pub async fn try_to_rerank_model(
             // `org/model:revision`; recover the two halves before the repo id
             // reaches the Hub (same convention as embeddings/models).
             let (repo_id, revision) = spicepod::component::model::split_hf_model_id(&model_id);
-            let hf_token = extract_secret(&params, "hf_token");
-            let max_seq_length = parse_max_seq_length(&component.name, &params)?;
-            let truncation = parse_truncation(&component.name, &params)?;
+            let typed = params::huggingface::HuggingFaceRerankerParams::try_from_params(
+                &component_name,
+                params,
+                &secrets,
+            )
+            .await
+            .map_err(|e| params_err(&component.name, e))?;
+            let hf_token = typed.hf_token.as_ref().map(ExposeSecret::expose_secret);
+            let truncation = typed.truncate.unwrap_or_default().direction();
             let r = TeiRerank::from_hf(
                 component.name.clone(),
                 repo_id,
                 revision,
-                hf_token.as_deref(),
-                max_seq_length,
+                hf_token,
+                typed.max_seq_length,
                 truncation,
             )
             .await
@@ -197,12 +244,18 @@ pub async fn try_to_rerank_model(
         }
         #[cfg(feature = "models")]
         RerankerPrefix::File => {
-            let max_seq_length = parse_max_seq_length(&component.name, &params)?;
-            let truncation = parse_truncation(&component.name, &params)?;
+            let typed = params::file::FileRerankerParams::try_from_params(
+                &component_name,
+                params,
+                &secrets,
+            )
+            .await
+            .map_err(|e| params_err(&component.name, e))?;
+            let truncation = typed.truncate.unwrap_or_default().direction();
             let r = TeiRerank::from_dir(
                 component.name.clone(),
                 std::path::Path::new(&model_id),
-                max_seq_length,
+                typed.max_seq_length,
                 truncation,
             )
             .await
@@ -221,49 +274,4 @@ pub async fn try_to_rerank_model(
     };
 
     Ok(reranker)
-}
-
-/// Parse the optional `max_seq_length` param (inputs longer than the model's
-/// max are otherwise handled per `truncate`).
-#[cfg(feature = "models")]
-fn parse_max_seq_length(
-    name: &str,
-    params: &HashMap<String, SecretString>,
-) -> Result<Option<usize>> {
-    extract_secret(params, "max_seq_length")
-        .map(|s| {
-            s.parse::<usize>().map_err(|e| Error::InvalidParam {
-                name: name.to_string(),
-                param_key: "max_seq_length".to_string(),
-                reason: format!("expected a non-negative integer, got '{s}': {e}"),
-            })
-        })
-        .transpose()
-}
-
-/// Parse the optional `truncate` param controlling how over-long `(query,
-/// document)` pairs are handled: `none` (reject — default), `end` (keep the
-/// start), or `start` (keep the end).
-#[cfg(feature = "models")]
-fn parse_truncation(
-    name: &str,
-    params: &HashMap<String, SecretString>,
-) -> Result<Option<tokenizers::TruncationDirection>> {
-    match extract_secret(params, "truncate") {
-        None => Ok(None),
-        Some(v) => match v.to_ascii_lowercase().as_str() {
-            "none" => Ok(None),
-            "end" => Ok(Some(tokenizers::TruncationDirection::Right)),
-            "start" => Ok(Some(tokenizers::TruncationDirection::Left)),
-            other => Err(Error::InvalidParam {
-                name: name.to_string(),
-                param_key: "truncate".to_string(),
-                reason: format!("must be one of: none, end, start. Found '{other}'"),
-            }),
-        },
-    }
-}
-
-fn extract_secret(params: &HashMap<String, SecretString>, key: &str) -> Option<String> {
-    params.get(key).map(|v| v.expose_secret().to_string())
 }

--- a/crates/runtime/src/model/rerank/mod.rs
+++ b/crates/runtime/src/model/rerank/mod.rs
@@ -24,6 +24,14 @@ pub mod params;
 #[cfg(feature = "models")]
 use llms::rerank::TeiRerank;
 use llms::rerank::{CohereReranker, HttpReranker, JinaReranker, Rerank, VoyageReranker};
+#[cfg(feature = "models")]
+use params::file::FileRerankerParams;
+#[cfg(feature = "models")]
+use params::huggingface::HuggingFaceRerankerParams;
+use params::{
+    cohere::CohereRerankerParams, http::HttpRerankerParams, jina::JinaRerankerParams,
+    voyage::VoyageRerankerParams,
+};
 use runtime_parameters_typed::{ParamsError, TypedParams};
 use runtime_secrets::{Secrets, get_params_with_secrets};
 use secrecy::ExposeSecret;
@@ -132,13 +140,9 @@ pub async fn try_to_rerank_model(
 
     let reranker: Arc<dyn Rerank> = match prefix {
         RerankerPrefix::Cohere => {
-            let typed = params::cohere::CohereRerankerParams::try_from_params(
-                &component_name,
-                params,
-                &secrets,
-            )
-            .await
-            .map_err(|e| params_err(&component.name, e))?;
+            let typed = CohereRerankerParams::try_from_params(&component_name, params, &secrets)
+                .await
+                .map_err(|e| params_err(&component.name, e))?;
             let mut c =
                 CohereReranker::try_new(component.name.clone(), typed.api_key.expose_secret())
                     .context(BuildFailedSnafu {
@@ -151,13 +155,9 @@ pub async fn try_to_rerank_model(
             Arc::new(c)
         }
         RerankerPrefix::Voyage => {
-            let typed = params::voyage::VoyageRerankerParams::try_from_params(
-                &component_name,
-                params,
-                &secrets,
-            )
-            .await
-            .map_err(|e| params_err(&component.name, e))?;
+            let typed = VoyageRerankerParams::try_from_params(&component_name, params, &secrets)
+                .await
+                .map_err(|e| params_err(&component.name, e))?;
             let mut v =
                 VoyageReranker::try_new(component.name.clone(), typed.api_key.expose_secret())
                     .context(BuildFailedSnafu {
@@ -170,13 +170,9 @@ pub async fn try_to_rerank_model(
             Arc::new(v)
         }
         RerankerPrefix::Jina => {
-            let typed = params::jina::JinaRerankerParams::try_from_params(
-                &component_name,
-                params,
-                &secrets,
-            )
-            .await
-            .map_err(|e| params_err(&component.name, e))?;
+            let typed = JinaRerankerParams::try_from_params(&component_name, params, &secrets)
+                .await
+                .map_err(|e| params_err(&component.name, e))?;
             let mut j =
                 JinaReranker::try_new(component.name.clone(), typed.api_key.expose_secret())
                     .context(BuildFailedSnafu {
@@ -192,13 +188,9 @@ pub async fn try_to_rerank_model(
             // For HTTP BYO the `from` *is* the endpoint URL. Model id +
             // auth header are both optional (some self-hosted services pin
             // the model and auth upstream).
-            let typed = params::http::HttpRerankerParams::try_from_params(
-                &component_name,
-                params,
-                &secrets,
-            )
-            .await
-            .map_err(|e| params_err(&component.name, e))?;
+            let typed = HttpRerankerParams::try_from_params(&component_name, params, &secrets)
+                .await
+                .map_err(|e| params_err(&component.name, e))?;
             let endpoint = model_id;
             let mut h = HttpReranker::try_new(component.name.clone(), endpoint).context(
                 BuildFailedSnafu {
@@ -219,13 +211,10 @@ pub async fn try_to_rerank_model(
             // `org/model:revision`; recover the two halves before the repo id
             // reaches the Hub (same convention as embeddings/models).
             let (repo_id, revision) = spicepod::component::model::split_hf_model_id(&model_id);
-            let typed = params::huggingface::HuggingFaceRerankerParams::try_from_params(
-                &component_name,
-                params,
-                &secrets,
-            )
-            .await
-            .map_err(|e| params_err(&component.name, e))?;
+            let typed =
+                HuggingFaceRerankerParams::try_from_params(&component_name, params, &secrets)
+                    .await
+                    .map_err(|e| params_err(&component.name, e))?;
             let hf_token = typed.hf_token.as_ref().map(ExposeSecret::expose_secret);
             let truncation = typed.truncate.unwrap_or_default().direction();
             let r = TeiRerank::from_hf(
@@ -244,13 +233,9 @@ pub async fn try_to_rerank_model(
         }
         #[cfg(feature = "models")]
         RerankerPrefix::File => {
-            let typed = params::file::FileRerankerParams::try_from_params(
-                &component_name,
-                params,
-                &secrets,
-            )
-            .await
-            .map_err(|e| params_err(&component.name, e))?;
+            let typed = FileRerankerParams::try_from_params(&component_name, params, &secrets)
+                .await
+                .map_err(|e| params_err(&component.name, e))?;
             let truncation = typed.truncate.unwrap_or_default().direction();
             let r = TeiRerank::from_dir(
                 component.name.clone(),

--- a/crates/runtime/src/model/rerank/params/cohere.rs
+++ b/crates/runtime/src/model/rerank/params/cohere.rs
@@ -22,7 +22,7 @@ use secrecy::SecretString;
 #[params(prefix = "cohere")]
 pub struct CohereRerankerParams {
     /// The Cohere API key.
-    #[param(runtime, alias = "cohere_api_key")]
+    #[param(runtime, autoload_secret, alias = "cohere_api_key")]
     pub api_key: SecretString,
     /// The Cohere API base endpoint.
     #[param(runtime)]

--- a/crates/runtime/src/model/rerank/params/cohere.rs
+++ b/crates/runtime/src/model/rerank/params/cohere.rs
@@ -1,0 +1,30 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use runtime_parameters::TypedParams;
+use secrecy::SecretString;
+
+/// Parameters for `from: cohere` rerankers.
+#[derive(TypedParams)]
+#[params(prefix = "cohere")]
+pub struct CohereRerankerParams {
+    /// The Cohere API key.
+    #[param(runtime, alias = "cohere_api_key")]
+    pub api_key: SecretString,
+    /// The Cohere API base endpoint.
+    #[param(runtime)]
+    pub endpoint: Option<String>,
+}

--- a/crates/runtime/src/model/rerank/params/cohere.rs
+++ b/crates/runtime/src/model/rerank/params/cohere.rs
@@ -22,7 +22,7 @@ use secrecy::SecretString;
 #[params(prefix = "cohere")]
 pub struct CohereRerankerParams {
     /// The Cohere API key.
-    #[param(runtime, autoload_secret, alias = "cohere_api_key")]
+    #[param(runtime, alias = "cohere_api_key")]
     pub api_key: SecretString,
     /// The Cohere API base endpoint.
     #[param(runtime)]

--- a/crates/runtime/src/model/rerank/params/file.rs
+++ b/crates/runtime/src/model/rerank/params/file.rs
@@ -1,0 +1,35 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use runtime_parameters::TypedParams;
+
+use super::Truncation;
+
+/// Parameters for `from: file` rerankers — a local cross-encoder reranker
+/// loaded from a directory of model artifacts and run in-process via the
+/// candle TEI backend.
+#[derive(TypedParams)]
+#[params(prefix = "file")]
+pub struct FileRerankerParams {
+    /// The maximum sequence length for the `(query, document)` pair.
+    #[param(runtime)]
+    pub max_seq_length: Option<usize>,
+    /// How to handle a `(query, document)` pair longer than the model's
+    /// maximum sequence length: `none` (default) to reject it, `end` to
+    /// discard the end of the pair, or `start` to discard the start.
+    #[param(runtime)]
+    pub truncate: Option<Truncation>,
+}

--- a/crates/runtime/src/model/rerank/params/http.rs
+++ b/crates/runtime/src/model/rerank/params/http.rs
@@ -1,0 +1,33 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use runtime_parameters::TypedParams;
+use secrecy::SecretString;
+
+/// Parameters for a BYO HTTP reranker (`from: http://` / `https://`), which
+/// speaks a Cohere-compatible request/response shape.
+#[derive(TypedParams)]
+#[params(prefix = "http")]
+pub struct HttpRerankerParams {
+    /// Bearer token sent as the `Authorization` header, if the service
+    /// requires one.
+    #[param(runtime)]
+    pub api_key: Option<SecretString>,
+    /// Model id to send in the request body, if the service expects one
+    /// rather than pinning the model upstream.
+    #[param(runtime)]
+    pub model: Option<String>,
+}

--- a/crates/runtime/src/model/rerank/params/http.rs
+++ b/crates/runtime/src/model/rerank/params/http.rs
@@ -24,7 +24,7 @@ use secrecy::SecretString;
 pub struct HttpRerankerParams {
     /// Bearer token sent as the `Authorization` header, if the service
     /// requires one.
-    #[param(runtime)]
+    #[param(runtime, autoload_secret)]
     pub api_key: Option<SecretString>,
     /// Model id to send in the request body, if the service expects one
     /// rather than pinning the model upstream.

--- a/crates/runtime/src/model/rerank/params/http.rs
+++ b/crates/runtime/src/model/rerank/params/http.rs
@@ -24,7 +24,7 @@ use secrecy::SecretString;
 pub struct HttpRerankerParams {
     /// Bearer token sent as the `Authorization` header, if the service
     /// requires one.
-    #[param(runtime, autoload_secret)]
+    #[param(runtime)]
     pub api_key: Option<SecretString>,
     /// Model id to send in the request body, if the service expects one
     /// rather than pinning the model upstream.

--- a/crates/runtime/src/model/rerank/params/huggingface.rs
+++ b/crates/runtime/src/model/rerank/params/huggingface.rs
@@ -24,8 +24,9 @@ use super::Truncation;
 #[derive(TypedParams)]
 #[params(prefix = "huggingface")]
 pub struct HuggingFaceRerankerParams {
-    /// The Hugging Face access token.
-    #[param(runtime, autoload_secret)]
+    /// The Hugging Face access token. Also accepts `api_key`, matching the
+    /// key name used by the other reranker providers.
+    #[param(runtime, autoload_secret, alias = "api_key")]
     pub hf_token: Option<SecretString>,
     /// The maximum sequence length for the `(query, document)` pair.
     #[param(runtime)]

--- a/crates/runtime/src/model/rerank/params/huggingface.rs
+++ b/crates/runtime/src/model/rerank/params/huggingface.rs
@@ -1,0 +1,38 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use runtime_parameters::TypedParams;
+use secrecy::SecretString;
+
+use super::Truncation;
+
+/// Parameters for `from: huggingface` rerankers — a local cross-encoder
+/// reranker run in-process via the candle TEI backend.
+#[derive(TypedParams)]
+#[params(prefix = "huggingface")]
+pub struct HuggingFaceRerankerParams {
+    /// The Hugging Face access token.
+    #[param(runtime, autoload_secret)]
+    pub hf_token: Option<SecretString>,
+    /// The maximum sequence length for the `(query, document)` pair.
+    #[param(runtime)]
+    pub max_seq_length: Option<usize>,
+    /// How to handle a `(query, document)` pair longer than the model's
+    /// maximum sequence length: `none` (default) to reject it, `end` to
+    /// discard the end of the pair, or `start` to discard the start.
+    #[param(runtime)]
+    pub truncate: Option<Truncation>,
+}

--- a/crates/runtime/src/model/rerank/params/jina.rs
+++ b/crates/runtime/src/model/rerank/params/jina.rs
@@ -22,7 +22,7 @@ use secrecy::SecretString;
 #[params(prefix = "jina")]
 pub struct JinaRerankerParams {
     /// The Jina API key.
-    #[param(runtime, alias = "jina_api_key")]
+    #[param(runtime, autoload_secret, alias = "jina_api_key")]
     pub api_key: SecretString,
     /// The Jina API base endpoint.
     #[param(runtime)]

--- a/crates/runtime/src/model/rerank/params/jina.rs
+++ b/crates/runtime/src/model/rerank/params/jina.rs
@@ -1,0 +1,30 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use runtime_parameters::TypedParams;
+use secrecy::SecretString;
+
+/// Parameters for `from: jina` rerankers.
+#[derive(TypedParams)]
+#[params(prefix = "jina")]
+pub struct JinaRerankerParams {
+    /// The Jina API key.
+    #[param(runtime, alias = "jina_api_key")]
+    pub api_key: SecretString,
+    /// The Jina API base endpoint.
+    #[param(runtime)]
+    pub endpoint: Option<String>,
+}

--- a/crates/runtime/src/model/rerank/params/jina.rs
+++ b/crates/runtime/src/model/rerank/params/jina.rs
@@ -22,7 +22,7 @@ use secrecy::SecretString;
 #[params(prefix = "jina")]
 pub struct JinaRerankerParams {
     /// The Jina API key.
-    #[param(runtime, autoload_secret, alias = "jina_api_key")]
+    #[param(runtime, alias = "jina_api_key")]
     pub api_key: SecretString,
     /// The Jina API base endpoint.
     #[param(runtime)]

--- a/crates/runtime/src/model/rerank/params/mod.rs
+++ b/crates/runtime/src/model/rerank/params/mod.rs
@@ -1,0 +1,231 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Typed parameter structs for each reranker provider, deserialized from
+//! spicepod `params` via `#[derive(TypedParams)]`. Mirrors
+//! `crate::embeddings::params`.
+
+pub mod cohere;
+pub mod file;
+pub mod http;
+pub mod huggingface;
+pub mod jina;
+pub mod voyage;
+
+use std::str::FromStr;
+
+/// How local (TEI-based) reranker models handle a `(query, document)` pair
+/// longer than the model's maximum sequence length. Values are matched
+/// case-insensitively, e.g. `none`, `END`, `Start`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Truncation {
+    /// Reject the whole rerank request with an input-validation error, rather
+    /// than silently dropping part of an over-long `(query, document)` pair.
+    /// Default.
+    #[default]
+    None,
+    /// Discard the end of the pair, keeping the start.
+    End,
+    /// Discard the start of the pair, keeping the end.
+    Start,
+}
+
+impl Truncation {
+    /// `None` when an over-long pair should be rejected; `Some(direction)`
+    /// when it should instead be truncated in that direction. This is the
+    /// value `TeiRerank::from_hf`/`from_dir` take directly.
+    #[must_use]
+    pub fn direction(self) -> Option<tokenizers::TruncationDirection> {
+        match self {
+            Truncation::None => None,
+            Truncation::End => Some(tokenizers::TruncationDirection::Right),
+            Truncation::Start => Some(tokenizers::TruncationDirection::Left),
+        }
+    }
+}
+
+impl FromStr for Truncation {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "none" => Ok(Truncation::None),
+            "end" => Ok(Truncation::End),
+            "start" => Ok(Truncation::Start),
+            other => Err(format!("must be one of: none, end, start. Found '{other}'")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runtime_parameters_typed::TypedParams;
+    use secrecy::{ExposeSecret, SecretString};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    fn params(entries: &[(&str, &str)]) -> HashMap<String, SecretString> {
+        entries
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), SecretString::from((*v).to_string())))
+            .collect()
+    }
+
+    fn empty_secrets() -> Arc<RwLock<runtime_secrets::Secrets>> {
+        Arc::new(RwLock::new(runtime_secrets::Secrets::new()))
+    }
+
+    #[tokio::test]
+    async fn cohere_params_accept_bare_and_aliased_api_key() {
+        let bare = cohere::CohereRerankerParams::try_from_params(
+            "reranker test",
+            params(&[("api_key", "co-1")]),
+            &empty_secrets(),
+        )
+        .await
+        .expect("bare api_key should deserialize");
+        assert_eq!(bare.api_key.expose_secret(), "co-1");
+
+        let aliased = cohere::CohereRerankerParams::try_from_params(
+            "reranker test",
+            params(&[("cohere_api_key", "co-2")]),
+            &empty_secrets(),
+        )
+        .await
+        .expect("cohere_api_key alias should deserialize");
+        assert_eq!(aliased.api_key.expose_secret(), "co-2");
+    }
+
+    #[tokio::test]
+    async fn cohere_params_require_api_key() {
+        let Err(err) = cohere::CohereRerankerParams::try_from_params(
+            "reranker test",
+            params(&[]),
+            &empty_secrets(),
+        )
+        .await
+        else {
+            panic!("cohere api_key is required")
+        };
+        assert!(
+            err.to_string()
+                .contains("Missing required parameter: api_key"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn voyage_params_accept_bare_and_aliased_api_key() {
+        let aliased = voyage::VoyageRerankerParams::try_from_params(
+            "reranker test",
+            params(&[("voyage_api_key", "v-1"), ("endpoint", "https://v.example")]),
+            &empty_secrets(),
+        )
+        .await
+        .expect("voyage_api_key alias should deserialize");
+        assert_eq!(aliased.api_key.expose_secret(), "v-1");
+        assert_eq!(aliased.endpoint.as_deref(), Some("https://v.example"));
+    }
+
+    #[tokio::test]
+    async fn jina_params_accept_bare_and_aliased_api_key() {
+        let aliased = jina::JinaRerankerParams::try_from_params(
+            "reranker test",
+            params(&[("jina_api_key", "j-1")]),
+            &empty_secrets(),
+        )
+        .await
+        .expect("jina_api_key alias should deserialize");
+        assert_eq!(aliased.api_key.expose_secret(), "j-1");
+    }
+
+    #[tokio::test]
+    async fn http_params_are_all_optional() {
+        let typed = http::HttpRerankerParams::try_from_params(
+            "reranker test",
+            params(&[]),
+            &empty_secrets(),
+        )
+        .await
+        .expect("http params should deserialize with nothing set");
+        assert!(typed.api_key.is_none());
+        assert!(typed.model.is_none());
+    }
+
+    #[tokio::test]
+    async fn huggingface_params_parse_truncate_case_insensitively() {
+        let typed = huggingface::HuggingFaceRerankerParams::try_from_params(
+            "reranker test",
+            params(&[
+                ("hf_token", "hf_abc"),
+                ("max_seq_length", "512"),
+                ("truncate", "End"),
+            ]),
+            &empty_secrets(),
+        )
+        .await
+        .expect("huggingface reranker params should deserialize");
+        assert_eq!(
+            typed.hf_token.as_ref().map(ExposeSecret::expose_secret),
+            Some("hf_abc")
+        );
+        assert_eq!(typed.max_seq_length, Some(512));
+        assert_eq!(typed.truncate, Some(Truncation::End));
+    }
+
+    #[tokio::test]
+    async fn huggingface_params_default_truncate_is_absent() {
+        let typed = huggingface::HuggingFaceRerankerParams::try_from_params(
+            "reranker test",
+            params(&[]),
+            &empty_secrets(),
+        )
+        .await
+        .expect("huggingface reranker params should deserialize");
+        assert_eq!(typed.truncate, None);
+        assert_eq!(typed.truncate.unwrap_or_default().direction(), None);
+    }
+
+    #[tokio::test]
+    async fn file_params_reject_unknown_truncate() {
+        let Err(err) = file::FileRerankerParams::try_from_params(
+            "reranker test",
+            params(&[("truncate", "sometimes")]),
+            &empty_secrets(),
+        )
+        .await
+        else {
+            panic!("an unknown truncate value should error")
+        };
+        assert!(
+            err.to_string().contains("must be one of: none, end, start"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn truncation_from_str_is_case_insensitive_and_maps_to_direction() {
+        assert_eq!(Truncation::default(), Truncation::None);
+        assert_eq!(Truncation::None.direction(), None);
+        assert_eq!("END".parse::<Truncation>(), Ok(Truncation::End));
+        assert_eq!("start".parse::<Truncation>(), Ok(Truncation::Start));
+        "nonsense"
+            .parse::<Truncation>()
+            .expect_err("nonsense is not truncation");
+    }
+}

--- a/crates/runtime/src/model/rerank/params/mod.rs
+++ b/crates/runtime/src/model/rerank/params/mod.rs
@@ -189,6 +189,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn huggingface_params_accept_api_key_alias() {
+        // `api_key` mirrors the key name used by the other reranker providers,
+        // so a `huggingface:` reranker doesn't require a `hf_token`-specific key.
+        let typed = huggingface::HuggingFaceRerankerParams::try_from_params(
+            "reranker test",
+            params(&[("api_key", "hf_abc")]),
+            &empty_secrets(),
+        )
+        .await
+        .expect("huggingface reranker params should deserialize");
+        assert_eq!(
+            typed.hf_token.as_ref().map(ExposeSecret::expose_secret),
+            Some("hf_abc")
+        );
+    }
+
+    #[tokio::test]
     async fn huggingface_params_default_truncate_is_absent() {
         let typed = huggingface::HuggingFaceRerankerParams::try_from_params(
             "reranker test",

--- a/crates/runtime/src/model/rerank/params/voyage.rs
+++ b/crates/runtime/src/model/rerank/params/voyage.rs
@@ -1,0 +1,30 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use runtime_parameters::TypedParams;
+use secrecy::SecretString;
+
+/// Parameters for `from: voyage` rerankers.
+#[derive(TypedParams)]
+#[params(prefix = "voyage")]
+pub struct VoyageRerankerParams {
+    /// The Voyage API key.
+    #[param(runtime, alias = "voyage_api_key")]
+    pub api_key: SecretString,
+    /// The Voyage API base endpoint.
+    #[param(runtime)]
+    pub endpoint: Option<String>,
+}

--- a/crates/runtime/src/model/rerank/params/voyage.rs
+++ b/crates/runtime/src/model/rerank/params/voyage.rs
@@ -22,7 +22,7 @@ use secrecy::SecretString;
 #[params(prefix = "voyage")]
 pub struct VoyageRerankerParams {
     /// The Voyage API key.
-    #[param(runtime, autoload_secret, alias = "voyage_api_key")]
+    #[param(runtime, alias = "voyage_api_key")]
     pub api_key: SecretString,
     /// The Voyage API base endpoint.
     #[param(runtime)]

--- a/crates/runtime/src/model/rerank/params/voyage.rs
+++ b/crates/runtime/src/model/rerank/params/voyage.rs
@@ -22,7 +22,7 @@ use secrecy::SecretString;
 #[params(prefix = "voyage")]
 pub struct VoyageRerankerParams {
     /// The Voyage API key.
-    #[param(runtime, alias = "voyage_api_key")]
+    #[param(runtime, autoload_secret, alias = "voyage_api_key")]
     pub api_key: SecretString,
     /// The Voyage API base endpoint.
     #[param(runtime)]


### PR DESCRIPTION
## Summary
Use `#[derive(TypedParams)]` for all `.reranker[].params` YAML parsing. 