### PR TITLE
feat(monitoring): improve results cache panels on the Datadog dashboard

### DIFF
--- a/monitoring/datadog-dashboard.json
+++ b/monitoring/datadog-dashboard.json
@@ -945,11 +945,12 @@
               "title": "Cache Hit Rate",
               "title_size": "16",
               "title_align": "left",
-              "type": "query_value",
+              "type": "timeseries",
               "requests": [
                 {
                   "formulas": [
                     {
+                      "alias": "Hit %",
                       "formula": "(query1 / query2) * 100",
                       "number_format": {
                         "unit": {
@@ -957,77 +958,6 @@
                           "unit_name": "percent"
                         }
                       }
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "data_source": "metrics",
-                      "name": "query1",
-                      "query": "sum:spiceai.results_cache_hits.count{$instance,$env,$kube_namespace,$kube_cluster_name,$pod_name}.as_count()",
-                      "aggregator": "sum"
-                    },
-                    {
-                      "data_source": "metrics",
-                      "name": "query2",
-                      "query": "sum:spiceai.results_cache_requests.count{$instance,$env,$kube_namespace,$kube_cluster_name,$pod_name}.as_count()",
-                      "aggregator": "sum"
-                    }
-                  ],
-                  "response_format": "scalar",
-                  "conditional_formats": [
-                    {
-                      "comparator": ">=",
-                      "value": 80,
-                      "palette": "white_on_green"
-                    },
-                    {
-                      "comparator": ">=",
-                      "value": 50,
-                      "palette": "white_on_yellow"
-                    },
-                    {
-                      "comparator": "<",
-                      "value": 50,
-                      "palette": "white_on_red"
-                    }
-                  ]
-                }
-              ],
-              "autoscale": true,
-              "precision": 2,
-              "timeseries_background": {
-                "type": "area"
-              }
-            },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 4,
-              "height": 3
-            }
-          },
-          {
-            "id": 402,
-            "definition": {
-              "title": "Cache Hit/Miss Over Time",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "auto",
-              "legend_columns": [
-                "value"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "alias": "Hit %",
-                      "formula": "(query1 / query2) * 100"
-                    },
-                    {
-                      "alias": "Miss %",
-                      "formula": "((query2 - query1) / query2) * 100"
                     }
                   ],
                   "queries": [
@@ -1048,13 +978,82 @@
                     "line_type": "solid",
                     "line_width": "normal"
                   },
+                  "display_type": "line"
+                }
+              ],
+              "show_legend": true,
+              "legend_layout": "vertical",
+              "legend_columns": [
+                "avg",
+                "min",
+                "value"
+              ],
+              "yaxis": {
+                "include_zero": true,
+                "scale": "linear",
+                "max": "100"
+              }
+            },
+            "layout": {
+              "x": 0,
+              "y": 0,
+              "width": 4,
+              "height": 3
+            }
+          },
+          {
+            "id": 402,
+            "definition": {
+              "title": "Cache Hits and Misses",
+              "title_size": "16",
+              "title_align": "left",
+              "show_legend": true,
+              "legend_layout": "auto",
+              "legend_columns": [
+                "value"
+              ],
+              "type": "timeseries",
+              "requests": [
+                {
+                  "formulas": [
+                    {
+                      "alias": "Hits",
+                      "formula": "query1"
+                    },
+                    {
+                      "alias": "Misses",
+                      "style": {
+                        "palette": "warm",
+                        "palette_index": 4
+                      },
+                      "formula": "query2"
+                    }
+                  ],
+                  "queries": [
+                    {
+                      "data_source": "metrics",
+                      "name": "query1",
+                      "query": "sum:spiceai.results_cache_hits.count{$instance,$env,$kube_namespace,$kube_cluster_name,$pod_name}.as_count()"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "sum:spiceai.results_cache_misses.count{$instance,$env,$kube_namespace,$kube_cluster_name,$pod_name}.as_count()"
+                    }
+                  ],
+                  "response_format": "timeseries",
+                  "style": {
+                    "palette": "green",
+                    "line_type": "solid",
+                    "line_width": "normal"
+                  },
                   "display_type": "area"
                 }
               ],
               "yaxis": {
                 "include_zero": true,
                 "scale": "linear",
-                "max": "100"
+                "max": "auto"
               }
             },
             "layout": {
@@ -1081,7 +1080,13 @@
                   "formulas": [
                     {
                       "alias": "Used",
-                      "formula": "query1"
+                      "formula": "query1",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "byte"
+                        }
+                      }
                     },
                     {
                       "alias": "Max Capacity",
@@ -1089,6 +1094,12 @@
                       "style": {
                         "palette": "gray",
                         "palette_index": 4
+                      },
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "byte"
+                        }
                       }
                     }
                   ],
@@ -1172,39 +1183,69 @@
           {
             "id": 405,
             "definition": {
-              "title": "Cache Evictions",
+              "title": "Cache Evictions by Reason",
               "title_size": "16",
               "title_align": "left",
-              "show_legend": false,
+              "show_legend": true,
               "type": "timeseries",
               "requests": [
                 {
                   "formulas": [
                     {
-                      "alias": "Evictions",
-                      "formula": "query1"
+                      "alias": "Over capacity (size)",
+                      "formula": "query1",
+                      "style": {
+                        "palette": "warm",
+                        "palette_index": 4
+                      }
+                    },
+                    {
+                      "alias": "Expired (TTL)",
+                      "formula": "query2",
+                      "style": {
+                        "palette": "gray",
+                        "palette_index": 2
+                      }
+                    },
+                    {
+                      "alias": "Invalidated (refresh/DML)",
+                      "formula": "query3",
+                      "style": {
+                        "palette": "cool",
+                        "palette_index": 1
+                      }
                     }
                   ],
                   "queries": [
                     {
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:spiceai.results_cache_evictions.count{$instance,$env,$kube_namespace,$kube_cluster_name,$pod_name}.as_count()"
+                      "query": "sum:spiceai.results_cache_evictions.count{$instance,$env,$kube_namespace,$kube_cluster_name,$pod_name,reason:size}.as_count()"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query2",
+                      "query": "sum:spiceai.results_cache_evictions.count{$instance,$env,$kube_namespace,$kube_cluster_name,$pod_name,reason:expired}.as_count()"
+                    },
+                    {
+                      "data_source": "metrics",
+                      "name": "query3",
+                      "query": "sum:spiceai.results_cache_evictions.count{$instance,$env,$kube_namespace,$kube_cluster_name,$pod_name,reason:invalidated}.as_count()"
                     }
                   ],
                   "response_format": "timeseries",
-                  "style": {
-                    "palette": "orange",
-                    "line_type": "solid",
-                    "line_width": "normal"
-                  },
                   "display_type": "bars"
                 }
               ],
               "yaxis": {
                 "include_zero": true,
                 "scale": "linear"
-              }
+              },
+              "legend_layout": "auto",
+              "legend_columns": [
+                "sum",
+                "value"
+              ]
             },
             "layout": {
               "x": 4,
@@ -2834,7 +2875,13 @@
                 {
                   "formulas": [
                     {
-                      "formula": "query1 - query2"
+                      "formula": "query1 - query2",
+                      "number_format": {
+                        "unit": {
+                          "type": "canonical_unit",
+                          "unit_name": "byte"
+                        }
+                      }
                     }
                   ],
                   "queries": [

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1840,7 +1840,41 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "max": 100,
@@ -1849,16 +1883,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 50
-              },
-              {
                 "color": "green",
-                "value": 80
+                "value": null
               }
             ]
           },
@@ -1874,21 +1900,18 @@
       },
       "id": 401,
       "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
+        "legend": {
           "calcs": [
+            "mean",
             "lastNotNull"
           ],
-          "fields": "",
-          "values": false
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto",
-        "text": {
-          "titleSize": 9
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "11.3.1",
@@ -1899,14 +1922,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(results_cache_hit_ratio{instance=~\"($instances)\"}) * 100",
-          "legendFormat": "__auto",
+          "expr": "100 * sum(increase(results_cache_hits{instance=~\"($instances)\"}[$__rate_interval])) / sum(increase(results_cache_requests{instance=~\"($instances)\"}[$__rate_interval]))",
+          "legendFormat": "Hit rate",
           "range": true,
           "refId": "A"
         }
       ],
       "title": "Cache Hit Rate",
-      "type": "gauge"
+      "type": "timeseries",
+      "description": "Share of results-cache lookups served from the cache in each interval, computed from the results_cache_hits and results_cache_requests counters. Unlike the lifetime results_cache_hit_ratio gauge, this reflects the selected time range."
     },
     {
       "datasource": {
@@ -1916,8 +1940,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "dark-green",
-            "mode": "fixed"
+            "mode": "palette-classic"
           },
           "custom": {
             "axisBorderShow": false,
@@ -1946,7 +1969,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "percent"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -1954,7 +1977,7 @@
           },
           "mappings": [],
           "thresholds": {
-            "mode": "percentage",
+            "mode": "absolute",
             "steps": [
               {
                 "color": "green",
@@ -1962,13 +1985,13 @@
               }
             ]
           },
-          "unit": "percent"
+          "unit": "short"
         },
         "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "Miss"
+              "options": "Misses"
             },
             "properties": [
               {
@@ -1991,8 +2014,10 @@
       "id": 402,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -2009,8 +2034,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "100 * sum(increase(results_cache_hits{instance=~\"($instances)\"}[$__rate_interval])) / sum(increase(results_cache_requests{instance=~\"($instances)\"}[$__rate_interval]))",
-          "legendFormat": "Hit",
+          "expr": "sum(increase(results_cache_hits{instance=~\"($instances)\"}[$__rate_interval]))",
+          "legendFormat": "Hits",
           "range": true,
           "refId": "A"
         },
@@ -2020,14 +2045,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "100 * (1 - sum(increase(results_cache_hits{instance=~\"($instances)\"}[$__rate_interval])) / sum(increase(results_cache_requests{instance=~\"($instances)\"}[$__rate_interval])))",
-          "legendFormat": "Miss",
+          "expr": "sum(increase(results_cache_misses{instance=~\"($instances)\"}[$__rate_interval]))",
+          "legendFormat": "Misses",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Cache Hit/Miss Over Time",
-      "type": "timeseries"
+      "title": "Cache Hits and Misses",
+      "type": "timeseries",
+      "description": "Results-cache lookups per interval, split into hits and misses. Stacked, the two add up to every lookup the cache served."
     },
     {
       "datasource": {
@@ -2290,7 +2316,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -2308,7 +2334,53 @@
           },
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Over capacity (size)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expired (TTL)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Invalidated (refresh/DML)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
@@ -2324,7 +2396,7 @@
           ],
           "displayMode": "table",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -2339,14 +2411,37 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(results_cache_evictions{instance=~\"($instances)\"}[$__rate_interval]))",
-          "legendFormat": "Evictions",
+          "expr": "sum(increase(results_cache_evictions{instance=~\"($instances)\", reason=\"size\"}[$__rate_interval]))",
+          "legendFormat": "Over capacity (size)",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(results_cache_evictions{instance=~\"($instances)\", reason=\"expired\"}[$__rate_interval]))",
+          "legendFormat": "Expired (TTL)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(results_cache_evictions{instance=~\"($instances)\", reason=\"invalidated\"}[$__rate_interval]))",
+          "legendFormat": "Invalidated (refresh/DML)",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Cache Evictions",
-      "type": "timeseries"
+      "title": "Cache Evictions by Reason",
+      "type": "timeseries",
+      "description": "Entries removed from the results cache per interval. On an accelerated dataset with a periodic refresh, invalidation is usually the dominant reason; size and expiry are the ones that indicate cache pressure."
     },
     {
       "datasource": {

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1840,41 +1840,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "mode": "thresholds"
           },
           "mappings": [],
           "max": 100,
@@ -1883,8 +1849,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 80
               }
             ]
           },
@@ -1900,18 +1874,21 @@
       },
       "id": 401,
       "options": {
-        "legend": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
           "calcs": [
-            "mean",
             "lastNotNull"
           ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto",
+        "text": {
+          "titleSize": 9
         }
       },
       "pluginVersion": "11.3.1",
@@ -1922,15 +1899,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "100 * sum(increase(results_cache_hits{instance=~\"($instances)\"}[$__rate_interval])) / sum(increase(results_cache_requests{instance=~\"($instances)\"}[$__rate_interval]))",
-          "legendFormat": "Hit rate",
+          "expr": "avg(results_cache_hit_ratio{instance=~\"($instances)\"}) * 100",
+          "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
       "title": "Cache Hit Rate",
-      "type": "timeseries",
-      "description": "Share of results-cache lookups served from the cache in each interval, computed from the results_cache_hits and results_cache_requests counters. Unlike the lifetime results_cache_hit_ratio gauge, this reflects the selected time range."
+      "type": "gauge"
     },
     {
       "datasource": {
@@ -1940,7 +1916,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "dark-green",
+            "mode": "fixed"
           },
           "custom": {
             "axisBorderShow": false,
@@ -1969,7 +1946,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "percent"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -1977,7 +1954,7 @@
           },
           "mappings": [],
           "thresholds": {
-            "mode": "absolute",
+            "mode": "percentage",
             "steps": [
               {
                 "color": "green",
@@ -1985,13 +1962,13 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "percent"
         },
         "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "Misses"
+              "options": "Miss"
             },
             "properties": [
               {
@@ -2014,10 +1991,8 @@
       "id": 402,
       "options": {
         "legend": {
-          "calcs": [
-            "sum"
-          ],
-          "displayMode": "table",
+          "calcs": [],
+          "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
@@ -2034,8 +2009,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(results_cache_hits{instance=~\"($instances)\"}[$__rate_interval]))",
-          "legendFormat": "Hits",
+          "expr": "100 * sum(increase(results_cache_hits{instance=~\"($instances)\"}[$__rate_interval])) / sum(increase(results_cache_requests{instance=~\"($instances)\"}[$__rate_interval]))",
+          "legendFormat": "Hit",
           "range": true,
           "refId": "A"
         },
@@ -2045,15 +2020,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(results_cache_misses{instance=~\"($instances)\"}[$__rate_interval]))",
-          "legendFormat": "Misses",
+          "expr": "100 * (1 - sum(increase(results_cache_hits{instance=~\"($instances)\"}[$__rate_interval])) / sum(increase(results_cache_requests{instance=~\"($instances)\"}[$__rate_interval])))",
+          "legendFormat": "Miss",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Cache Hits and Misses",
-      "type": "timeseries",
-      "description": "Results-cache lookups per interval, split into hits and misses. Stacked, the two add up to every lookup the cache served."
+      "title": "Cache Hit/Miss Over Time",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -2316,7 +2290,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -2334,53 +2308,7 @@
           },
           "unit": "short"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Over capacity (size)"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Expired (TTL)"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "text",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Invalidated (refresh/DML)"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 6,
@@ -2396,7 +2324,7 @@
           ],
           "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "tooltip": {
           "mode": "multi",
@@ -2411,37 +2339,14 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(results_cache_evictions{instance=~\"($instances)\", reason=\"size\"}[$__rate_interval]))",
-          "legendFormat": "Over capacity (size)",
+          "expr": "sum(increase(results_cache_evictions{instance=~\"($instances)\"}[$__rate_interval]))",
+          "legendFormat": "Evictions",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(results_cache_evictions{instance=~\"($instances)\", reason=\"expired\"}[$__rate_interval]))",
-          "legendFormat": "Expired (TTL)",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(results_cache_evictions{instance=~\"($instances)\", reason=\"invalidated\"}[$__rate_interval]))",
-          "legendFormat": "Invalidated (refresh/DML)",
-          "range": true,
-          "refId": "C"
         }
       ],
-      "title": "Cache Evictions by Reason",
-      "type": "timeseries",
-      "description": "Entries removed from the results cache per interval. On an accelerated dataset with a periodic refresh, invalidation is usually the dominant reason; size and expiry are the ones that indicate cache pressure."
+      "title": "Cache Evictions",
+      "type": "timeseries"
     },
     {
       "datasource": {


### PR DESCRIPTION
Datadog dashboard, results cache section improvements

- Split cache evictions by `reason` (`size` / `expired` / `invalidated`).
- Cache Hits and Misses now plots absolute counts, so request volume is visible alongside the ratio. Cache Hit Rate takes over the percentage as a time series, computed from the counters rather than the lifetime `results_cache_hit_ratio` gauge.
- Add byte units to Cache Memory Usage and PVC Storage Usage, matching every other byte-valued panel.

<img width="1130" height="506" alt="image" src="https://github.com/user-attachments/assets/32b8f330-6a9c-4520-85ed-cd4fe3a4adca" />
