### PR TITLE
fix(connectors): keep the projected schema when a query returns no rows (fixes #13015)

### DIFF
--- a/crates/data-connectors/connector-clickhouse/src/conn.rs
+++ b/crates/data-connectors/connector-clickhouse/src/conn.rs
@@ -25,13 +25,14 @@ use async_stream::stream;
 use clickhouse_rs::{Block, ClientHandle, Pool};
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::EmptyRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::{
     self, AsyncDbConnection, DbConnection,
 };
 use futures::lock::Mutex;
-use futures::{Stream, StreamExt, stream};
+use futures::{Stream, StreamExt};
 use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
@@ -226,7 +227,7 @@ impl<'a> AsyncDbConnection<ClientHandle, &'a dyn Sync> for ClickhouseConnection 
 /// contradicts the columns the query selected.
 fn empty_result_stream(projected_schema: Option<SchemaRef>) -> SendableRecordBatchStream {
     let schema = projected_schema.unwrap_or_else(|| Arc::new(Schema::empty()));
-    Box::pin(RecordBatchStreamAdapter::new(schema, stream::empty()))
+    Box::pin(EmptyRecordBatchStream::new(schema))
 }
 
 fn query_to_stream(

--- a/crates/data-connectors/connector-clickhouse/src/conn.rs
+++ b/crates/data-connectors/connector-clickhouse/src/conn.rs
@@ -319,9 +319,9 @@ mod tests {
     use super::*;
     use arrow::datatypes::DataType;
 
-    /// Regression test for #13015: a query the server answered with no blocks
-    /// reported `Schema::empty()`, so an empty result dropped every projected
-    /// column instead of returning an empty table with the right columns.
+    /// Regression test for #13015: a query the server answers with no blocks
+    /// must still carry the projected schema, so an empty result is an empty
+    /// table with the columns the query selected rather than no columns at all.
     #[test]
     fn empty_result_stream_keeps_the_projected_schema() {
         let projected: SchemaRef = Arc::new(Schema::new(vec![

--- a/crates/data-connectors/connector-clickhouse/src/conn.rs
+++ b/crates/data-connectors/connector-clickhouse/src/conn.rs
@@ -184,16 +184,13 @@ impl<'a> AsyncDbConnection<ClientHandle, &'a dyn Sync> for ClickhouseConnection 
         &self,
         sql: &str,
         _: &[&'a dyn Sync],
-        _projected_schema: Option<SchemaRef>,
+        projected_schema: Option<SchemaRef>,
     ) -> Result<SendableRecordBatchStream, Box<dyn std::error::Error + Send + Sync>> {
         let conn = self.pool.get_handle().await.context(ConnectionPoolSnafu)?;
         let mut block_stream = conn.query_owned(sql).stream_blocks();
         let first_block = block_stream.next().await;
         if first_block.is_none() {
-            return Ok(Box::pin(RecordBatchStreamAdapter::new(
-                Arc::new(Schema::empty()),
-                stream::empty(),
-            )));
+            return Ok(empty_result_stream(projected_schema));
         }
         let first_block = first_block
             .unwrap_or(Ok(Block::new()))
@@ -219,6 +216,17 @@ impl<'a> AsyncDbConnection<ClientHandle, &'a dyn Sync> for ClickhouseConnection 
         // Shouldn't be an issue for now since we don't have a data accelerator for now.
         Ok(0)
     }
+}
+
+/// The stream for a result set the server answered with no blocks.
+///
+/// Every other schema on this path is read off the first block, so when there is
+/// no block the schema has to come from the projected schema the plan was built
+/// from. Falling back to [`Schema::empty`] would hand back a stream whose schema
+/// contradicts the columns the query selected.
+fn empty_result_stream(projected_schema: Option<SchemaRef>) -> SendableRecordBatchStream {
+    let schema = projected_schema.unwrap_or_else(|| Arc::new(Schema::empty()));
+    Box::pin(RecordBatchStreamAdapter::new(schema, stream::empty()))
 }
 
 fn query_to_stream(
@@ -309,6 +317,40 @@ fn map_clickhouse_type_to_arrow(type_str: &str) -> Result<DataType, clickhouse_r
 mod tests {
     use super::*;
     use arrow::datatypes::DataType;
+
+    /// Regression test for #13015: a query the server answered with no blocks
+    /// reported `Schema::empty()`, so an empty result dropped every projected
+    /// column instead of returning an empty table with the right columns.
+    #[test]
+    fn empty_result_stream_keeps_the_projected_schema() {
+        let projected: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let mut stream = empty_result_stream(Some(Arc::clone(&projected)));
+
+        assert_eq!(
+            stream.schema().as_ref(),
+            projected.as_ref(),
+            "an empty result must carry the projected schema"
+        );
+        assert!(
+            futures::executor::block_on(stream.next()).is_none(),
+            "an empty result must not yield a batch"
+        );
+    }
+
+    #[test]
+    fn empty_result_stream_without_a_projection_has_no_columns() {
+        let stream = empty_result_stream(None);
+
+        assert_eq!(
+            stream.schema().fields().len(),
+            0,
+            "with no projected schema there is nothing to preserve"
+        );
+    }
 
     #[test]
     fn test_map_clickhouse_type_to_arrow() {

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -1123,19 +1123,14 @@ impl SqlWarehouseApi {
     async fn fetch_external_links(
         self: Arc<Self>,
         result_object: Value,
+        projected_schema: Option<SchemaRef>,
     ) -> Result<SendableRecordBatchStream, Error> {
         let token = self.token_provider.get_token();
         let initial_external_link = Self::extract_external_links(result_object)?;
 
         // If no external link, return an empty stream
         if initial_external_link.is_none() {
-            let empty_stream: Pin<
-                Box<dyn Stream<Item = Result<RecordBatch, DataFusionError>> + Send>,
-            > = Box::pin(stream::empty::<Result<RecordBatch, DataFusionError>>());
-            return Ok(Box::pin(RecordBatchStreamAdapter::new(
-                Arc::new(Schema::empty()),
-                empty_stream,
-            )) as SendableRecordBatchStream);
+            return Ok(empty_result_stream(projected_schema));
         }
 
         let token = token.clone();
@@ -1230,13 +1225,7 @@ impl SqlWarehouseApi {
             Some(Ok(batch)) => batch,
             Some(Err(e)) => return Err(e),
             None => {
-                let empty_stream: Pin<
-                    Box<dyn Stream<Item = Result<RecordBatch, DataFusionError>> + Send>,
-                > = Box::pin(stream::empty::<Result<RecordBatch, DataFusionError>>());
-                return Ok(Box::pin(RecordBatchStreamAdapter::new(
-                    Arc::new(Schema::empty()),
-                    empty_stream,
-                )) as SendableRecordBatchStream);
+                return Ok(empty_result_stream(projected_schema));
             }
         };
 
@@ -1957,7 +1946,7 @@ impl<'a> AsyncDbConnection<Arc<SqlWarehouseApi>, &'a dyn Sync> for SqlWarehouseC
         })?;
 
         let mut stream = Arc::clone(&self.api)
-            .fetch_external_links(response)
+            .fetch_external_links(response, None)
             .await
             .map_err(|e| dbconnection::Error::UnableToGetSchemas {
                 source: Box::new(e),
@@ -1999,7 +1988,7 @@ impl<'a> AsyncDbConnection<Arc<SqlWarehouseApi>, &'a dyn Sync> for SqlWarehouseC
         &self,
         sql: &str,
         _: &[&'a dyn Sync],
-        _projected_schema: Option<SchemaRef>,
+        projected_schema: Option<SchemaRef>,
     ) -> Result<SendableRecordBatchStream, Box<dyn std::error::Error + Send + Sync>> {
         let token = self.api.token_provider.get_token();
         let payload = json!({
@@ -2034,7 +2023,12 @@ impl<'a> AsyncDbConnection<Arc<SqlWarehouseApi>, &'a dyn Sync> for SqlWarehouseC
             .build()
         })?;
 
-        Ok(SqlWarehouseApi::fetch_external_links(Arc::clone(&self.api), result_object).await?)
+        Ok(SqlWarehouseApi::fetch_external_links(
+            Arc::clone(&self.api),
+            result_object,
+            projected_schema,
+        )
+        .await?)
     }
 
     async fn execute(
@@ -2044,6 +2038,21 @@ impl<'a> AsyncDbConnection<Arc<SqlWarehouseApi>, &'a dyn Sync> for SqlWarehouseC
     ) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
         Ok(NotImplementedSnafu.fail()?)
     }
+}
+
+/// The stream for a statement whose result carried no chunks.
+///
+/// Every other schema on this path is read off the first batch, so when there is
+/// no batch the schema has to come from the projected schema the plan was built
+/// from. Falling back to [`Schema::empty`] would hand back a stream whose schema
+/// contradicts the columns the query selected. Callers with no plan behind them
+/// — schema discovery, for one — pass `None` and keep the empty schema.
+fn empty_result_stream(projected_schema: Option<SchemaRef>) -> SendableRecordBatchStream {
+    let schema = projected_schema.unwrap_or_else(|| Arc::new(Schema::empty()));
+    let empty_stream: Pin<Box<dyn Stream<Item = Result<RecordBatch, DataFusionError>> + Send>> =
+        Box::pin(stream::empty::<Result<RecordBatch, DataFusionError>>());
+
+    Box::pin(RecordBatchStreamAdapter::new(schema, empty_stream)) as SendableRecordBatchStream
 }
 
 fn databricks_dialect() -> super::dialect::DatabricksDialect {
@@ -2078,6 +2087,40 @@ mod tests {
     use super::*;
     use arrow::datatypes::DataType;
     use serde_json::json;
+
+    /// Regression test for #13015: a statement whose result carried no chunks
+    /// reported `Schema::empty()`, so an empty result dropped every projected
+    /// column instead of returning an empty table with the right columns.
+    #[test]
+    fn empty_result_stream_keeps_the_projected_schema() {
+        let projected: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let mut stream = empty_result_stream(Some(Arc::clone(&projected)));
+
+        assert_eq!(
+            stream.schema().as_ref(),
+            projected.as_ref(),
+            "an empty result must carry the projected schema"
+        );
+        assert!(
+            futures::executor::block_on(stream.next()).is_none(),
+            "an empty result must not yield a batch"
+        );
+    }
+
+    #[test]
+    fn empty_result_stream_without_a_projection_has_no_columns() {
+        let stream = empty_result_stream(None);
+
+        assert_eq!(
+            stream.schema().fields().len(),
+            0,
+            "schema discovery has no plan behind it and keeps the empty schema"
+        );
+    }
 
     /// Helper to create a valid Databricks schema response JSON.
     fn make_schema_response(data_array: &Value) -> Value {

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -2086,9 +2086,9 @@ mod tests {
     use arrow::datatypes::DataType;
     use serde_json::json;
 
-    /// Regression test for #13015: a statement whose result carried no chunks
-    /// reported `Schema::empty()`, so an empty result dropped every projected
-    /// column instead of returning an empty table with the right columns.
+    /// Regression test for #13015: a statement whose result carries no chunks
+    /// must still carry the projected schema, so an empty result is an empty
+    /// table with the columns the query selected rather than no columns at all.
     #[test]
     fn empty_result_stream_keeps_the_projected_schema() {
         let projected: SchemaRef = Arc::new(Schema::new(vec![

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -22,7 +22,8 @@ use arrow::{
 use async_trait::async_trait;
 use datafusion::{
     datasource::TableProvider, error::DataFusionError, execution::SendableRecordBatchStream,
-    physical_plan::stream::RecordBatchStreamAdapter, sql::TableReference,
+    physical_plan::EmptyRecordBatchStream, physical_plan::stream::RecordBatchStreamAdapter,
+    sql::TableReference,
 };
 use datafusion_table_providers::sql::{
     db_connection_pool::{
@@ -2049,10 +2050,7 @@ impl<'a> AsyncDbConnection<Arc<SqlWarehouseApi>, &'a dyn Sync> for SqlWarehouseC
 /// — schema discovery, for one — pass `None` and keep the empty schema.
 fn empty_result_stream(projected_schema: Option<SchemaRef>) -> SendableRecordBatchStream {
     let schema = projected_schema.unwrap_or_else(|| Arc::new(Schema::empty()));
-    let empty_stream: Pin<Box<dyn Stream<Item = Result<RecordBatch, DataFusionError>> + Send>> =
-        Box::pin(stream::empty::<Result<RecordBatch, DataFusionError>>());
-
-    Box::pin(RecordBatchStreamAdapter::new(schema, empty_stream)) as SendableRecordBatchStream
+    Box::pin(EmptyRecordBatchStream::new(schema))
 }
 
 fn databricks_dialect() -> super::dialect::DatabricksDialect {

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -824,9 +824,9 @@ mod tests {
     use arrow::util::display;
     use std::sync::Arc;
 
-    /// Regression test for #13015: a query Snowflake answered with no batches
-    /// reported `Schema::empty()`, so an empty result dropped every projected
-    /// column instead of returning an empty table with the right columns.
+    /// Regression test for #13015: a query Snowflake answers with no batches
+    /// must still carry the projected schema, so an empty result is an empty
+    /// table with the columns the query selected rather than no columns at all.
     #[test]
     fn empty_result_stream_keeps_the_projected_schema() {
         let projected: SchemaRef = Arc::new(Schema::new(vec![

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -196,7 +196,7 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
         &self,
         sql: &str,
         _: &[&'a dyn Sync],
-        _projected_schema: Option<SchemaRef>,
+        projected_schema: Option<SchemaRef>,
     ) -> Result<SendableRecordBatchStream, Box<dyn std::error::Error + Send + Sync>> {
         let start = Instant::now();
         tracing::debug!("Snowflake: executing query");
@@ -218,10 +218,7 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
         });
 
         let Some(first_batch) = transformed_stream.next().await else {
-            return Ok(Box::pin(RecordBatchStreamAdapter::new(
-                Arc::new(Schema::empty()),
-                stream::empty(),
-            )));
+            return Ok(empty_result_stream(projected_schema));
         };
 
         let batch = first_batch?;
@@ -249,6 +246,17 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
     ) -> Result<u64, Box<dyn std::error::Error + Send + Sync>> {
         return NotImplementedSnafu.fail()?;
     }
+}
+
+/// The stream for a query Snowflake answered with no batches.
+///
+/// Every other schema on this path is read off the first batch, so when there is
+/// no batch the schema has to come from the projected schema the plan was built
+/// from. Falling back to [`Schema::empty`] would hand back a stream whose schema
+/// contradicts the columns the query selected.
+fn empty_result_stream(projected_schema: Option<SchemaRef>) -> SendableRecordBatchStream {
+    let schema = projected_schema.unwrap_or_else(|| Arc::new(Schema::empty()));
+    Box::pin(RecordBatchStreamAdapter::new(schema, stream::empty()))
 }
 
 fn to_execution_error(e: impl Into<Box<dyn std::error::Error>>) -> DataFusionError {
@@ -814,6 +822,40 @@ mod tests {
     use arrow::datatypes::{DataType, Field};
     use arrow::util::display;
     use std::sync::Arc;
+
+    /// Regression test for #13015: a query Snowflake answered with no batches
+    /// reported `Schema::empty()`, so an empty result dropped every projected
+    /// column instead of returning an empty table with the right columns.
+    #[test]
+    fn empty_result_stream_keeps_the_projected_schema() {
+        let projected: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let mut stream = empty_result_stream(Some(Arc::clone(&projected)));
+
+        assert_eq!(
+            stream.schema().as_ref(),
+            projected.as_ref(),
+            "an empty result must carry the projected schema"
+        );
+        assert!(
+            futures::executor::block_on(stream.next()).is_none(),
+            "an empty result must not yield a batch"
+        );
+    }
+
+    #[test]
+    fn empty_result_stream_without_a_projection_has_no_columns() {
+        let stream = empty_result_stream(None);
+
+        assert_eq!(
+            stream.schema().fields().len(),
+            0,
+            "with no projected schema there is nothing to preserve"
+        );
+    }
 
     #[test]
     fn test_cast_sf_timestamp_ntz_seconds_precision_to_arrow_timestamp() {

--- a/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
+++ b/crates/db_connection_pool/src/dbconnection/snowflakeconn.rs
@@ -32,6 +32,7 @@ use arrow::temporal_conversions::NANOSECONDS;
 use async_trait::async_trait;
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::EmptyRecordBatchStream;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::sql::TableReference;
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::{
@@ -256,7 +257,7 @@ impl<'a> AsyncDbConnection<Arc<SnowflakeApi>, &'a dyn Sync> for SnowflakeConnect
 /// contradicts the columns the query selected.
 fn empty_result_stream(projected_schema: Option<SchemaRef>) -> SendableRecordBatchStream {
     let schema = projected_schema.unwrap_or_else(|| Arc::new(Schema::empty()));
-    Box::pin(RecordBatchStreamAdapter::new(schema, stream::empty()))
+    Box::pin(EmptyRecordBatchStream::new(schema))
 }
 
 fn to_execution_error(e: impl Into<Box<dyn std::error::Error>>) -> DataFusionError {


### PR DESCRIPTION
## Summary

Three `query_arrow` implementations read the result stream's schema off the first batch the server
returns, and when there is no first batch they fall back to `Schema::empty()` — discarding the
`projected_schema` argument that exists to answer exactly that case. The stream then advertises no
columns for a query whose plan selected several.

| connector | site |
|---|---|
| ClickHouse | `connector-clickhouse/src/conn.rs` — the server returned no blocks |
| Snowflake | `db_connection_pool/src/dbconnection/snowflakeconn.rs` — the stream yielded no batches |
| Databricks SQL Warehouse | `data_components/src/databricks/sql_warehouse.rs` — two sites: a result carrying no external links, and a link stream that yields no batch |

ODBC takes `_projected_schema` and discards it too, but is **not** affected: it derives the schema
from the prepared statement before executing, so a zero-row result keeps its columns. MSSQL and
Oracle already thread the projected schema through their own exec plans, and are the shape this
follows.

## Scope — what this fixes, and what it does not

#13015 describes downstream operators failing on a schema mismatch or seeing the wrong column set.
**That is not reachable on current code, and this PR does not claim it.** Both paths that execute
these connectors — `SqlExec::execute` and the federation `VirtualExecutionPlan::execute` in
`datafusion-table-providers` — build the stream the same way:

```rust
let fut = get_stream(pool, sql, Arc::clone(&schema));   // schema = the plan's
let stream = futures::stream::once(fut).try_flatten();
Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
```

`try_flatten` is generic over `Stream` and structurally cannot call `RecordBatchStream::schema()`;
it polls items only. An empty result contributes no items, and the outer adapter re-advertises the
plan's schema — so the empty schema is masked before any operator sees it. All 12 `get_stream` call
sites in the pinned fork, and every non-test consumer in this repo, were checked; none reads the
inner stream's schema, and nothing treats an empty schema as an "empty result" sentinel.

What remains is a latent trap rather than a live wrong result: `RecordBatchStream::schema()` is
contractually the schema of the batches, the argument that would satisfy it is dropped on the floor,
and the masking is a property of two callers rather than of the interface. A new exec path, or a
direct connection consumer, gets the wrong column set with nothing to warn it.

For ClickHouse the fixed branch is also provably the *only* empty-result route: the driver filters
empty blocks itself (`stream_blocks.rs:115`, `… && !block.is_empty()`), so `block_to_arrow`'s own
zero-row guard is unreachable from this path and cannot produce a zero-column batch.

## Changes

- Each connector resolves the empty-result schema from `projected_schema`, falling back to
  `Schema::empty()` only when the caller had no plan behind it.
- Databricks threads the schema into `fetch_external_links`, which owns both of its empty exits. Its
  other caller — schema discovery in `schemas()` — has no plan and passes `None`, preserving today's
  behavior exactly.
- Each connector keeps its own two-line helper rather than sharing one: the three crates
  (`connector-clickhouse`, `data_components`, `db_connection_pool`) have no common home that could
  host it without a new dependency edge, and the shared part is now DataFusion's
  `EmptyRecordBatchStream` rather than anything this repo would own.
- Schema *inference* sites that return `Schema::empty()` from an empty sample set
  (`connector-dynamodb`, `connector-cosmosdb`) are deliberately untouched: they have no projected
  schema to fall back to, and cosmosdb documents that callers map the condition to an error.

## Test plan

- `make lint`
- `make nextest`
- New unit tests at each of the three sites assert the empty-result stream carries the projected
  schema and yields no batch, plus the `None` fallback. The projected-schema assertion was neutered
  against the pre-fix `Schema::empty()` and fails without the change.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` not installed
- `/security-review`: no findings — the diff adds no input parsing, query construction, I/O, authz boundary, or logging; the one new value flows from the query planner into a schema describing a stream that emits nothing
- `/simplify`: applied — the hand-rolled `RecordBatchStreamAdapter::new(schema, stream::empty())` was
  replaced at all three sites with DataFusion's own `EmptyRecordBatchStream`, which the runtime
  already uses elsewhere; that also removed an explicit `Pin<Box<dyn Stream<..>>>` annotation in the
  Databricks helper. Light checks re-run green, which caught the follow-on unused `futures::stream`
  import the change left in the ClickHouse module
- Follow-up commit `b3b58c6b6e` (this pass, unblocking the review threads): **declared skip** —
  the change is three test doc comments, no executable code; `rustfmt --check` clean on all
  three files and the diff against `trunk` is confined to the PR's own files

The deeper fix — enforcing the projected schema once in the shared `query_arrow` wrapper so no
connector can forget it — is filed as #13077: it lives in the pinned `datafusion-table-providers`
fork and needs a fork PR plus a rev bump, so it cannot land here.

Fixes #13015
