### PR TITLE
fix(deps): bump the datafusion pin past the merged unparser fixes (fixes #12406)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6166,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6218,7 +6218,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6242,7 +6242,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6266,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6291,7 +6291,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "futures",
  "log",
@@ -6301,7 +6301,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-compression",
@@ -6338,7 +6338,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6361,7 +6361,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6383,7 +6383,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6405,7 +6405,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6454,12 +6454,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6480,7 +6480,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6502,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6554,7 +6554,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6585,7 +6585,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6605,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6629,7 +6629,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6653,7 +6653,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6668,7 +6668,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6684,7 +6684,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6693,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6703,7 +6703,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "chrono",
@@ -6754,7 +6754,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6789,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "chrono",
@@ -6805,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6857,7 +6857,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "chrono",
@@ -6886,7 +6886,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6898,7 +6898,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -6926,7 +6926,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6954,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -6972,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=edd8861e69c2eb268d4e8e4e6c45485b714eb9ce#edd8861e69c2eb268d4e8e4e6c45485b714eb9ce"
+source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -486,41 +486,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "edd8861e69c2eb268d4e8e4e6c45485b714eb9ce" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" } # branch: spiceai-54
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/crates/data_components/src/federation.rs
+++ b/crates/data_components/src/federation.rs
@@ -142,10 +142,11 @@ mod tests {
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::datasource::TableProvider;
     use datafusion::logical_expr::{
-        ColumnarValue, Expr, Extension, LogicalPlan, LogicalPlanBuilder, ScalarUDF, TableSource,
-        Volatility, builder::LogicalTableSource, create_udf, expr::ScalarFunction,
+        ColumnarValue, Expr, Extension, JoinType, LogicalPlan, LogicalPlanBuilder, ScalarUDF,
+        TableSource, Volatility, builder::LogicalTableSource, create_udf, expr::ScalarFunction,
     };
-    use datafusion::prelude::col;
+    use datafusion::prelude::{col, lit};
+    use datafusion::sql::unparser::Unparser;
     use datafusion_federation::sql::SQLExecutor;
     use datafusion_federation::{FederatedPlanNode, sql::SQLFederationPlanner};
     use datafusion_table_providers::sql::db_connection_pool::{
@@ -312,5 +313,120 @@ mod tests {
 
         // Federation source schema must match the SqlTable schema verbatim.
         assert_eq!(adaptor.source.schema().as_ref(), schema.as_ref());
+    }
+
+    fn table_source(fields: Vec<Field>) -> Arc<dyn TableSource> {
+        Arc::new(LogicalTableSource::new(Arc::new(Schema::new(fields)))) as Arc<dyn TableSource>
+    }
+
+    /// Unparse with the dialect federation itself would use, so these tests read
+    /// the same SQL a remote engine is sent.
+    fn federated_sql(plan: &LogicalPlan) -> String {
+        let executor: Arc<dyn SQLExecutor> =
+            Arc::new(DenyFunctionsSqlExecutor::new(test_sql_table(), None));
+        Unparser::new(executor.dialect().as_ref())
+            .plan_to_sql(plan)
+            .expect("plan should unparse")
+            .to_string()
+    }
+
+    /// Regression test for #12406: a `fetch` the optimizer pushes into a join
+    /// input bounds that input, not the join's output. Dropping it asks the
+    /// remote engine for the whole table and evaluates the join over it, so the
+    /// query can return more rows than the plan it came from.
+    #[test]
+    fn a_fetch_pushed_into_a_join_input_survives_unparsing() {
+        let left = LogicalPlanBuilder::scan_with_filters_fetch(
+            "left_table",
+            table_source(vec![
+                Field::new("id", DataType::Utf8, false),
+                Field::new("name", DataType::Utf8, true),
+            ]),
+            None,
+            vec![col("left_table.id").eq(lit("a"))],
+            Some(5),
+        )
+        .expect("scan left");
+        let right = LogicalPlanBuilder::scan(
+            "right_table",
+            table_source(vec![
+                Field::new("id", DataType::Utf8, false),
+                Field::new("age", DataType::Int32, true),
+            ]),
+            None,
+        )
+        .expect("scan right");
+        let plan = left
+            .join_on(
+                right.build().expect("build right"),
+                JoinType::Inner,
+                [col("left_table.id").eq(col("right_table.id"))],
+            )
+            .expect("join")
+            .build()
+            .expect("build join");
+
+        let sql = federated_sql(&plan);
+
+        // Before the fix the whole `LIMIT 5` was absent from the generated SQL.
+        assert!(
+            sql.contains("LIMIT 5"),
+            "the fetch pushed into the join input must survive: {sql}"
+        );
+        // It bounds only that input, so it has to sit inside the input's own
+        // scope rather than trailing the join.
+        assert!(
+            sql.contains("FROM (SELECT"),
+            "the fetched join input must keep its own scope: {sql}"
+        );
+        let limit = sql.find("LIMIT 5").expect("limit present");
+        let join = sql.find("INNER JOIN").expect("join present");
+        assert!(
+            limit < join,
+            "the limit must bound the input, not the join output: {sql}"
+        );
+    }
+
+    /// Regression test for #12591: SQL evaluates `WHERE` before `LIMIT`, so a
+    /// `Filter` above a `Limit` rendered as one `SELECT` carrying both means the
+    /// opposite of the plan — it can keep rows the plan excludes, and more rows
+    /// than the plan can produce.
+    #[test]
+    fn a_filter_above_a_limit_keeps_the_limit_scoped() {
+        let plan = LogicalPlanBuilder::scan(
+            "t",
+            table_source(vec![
+                Field::new("id", DataType::Utf8, false),
+                Field::new("name", DataType::Utf8, true),
+            ]),
+            None,
+        )
+        .expect("scan")
+        .limit(0, Some(5))
+        .expect("limit")
+        .filter(col("t.id").eq(lit("a")))
+        .expect("filter")
+        .build()
+        .expect("build");
+
+        let sql = federated_sql(&plan);
+
+        // Before the fix this rendered as `... FROM t WHERE (t.id = 'a') LIMIT 5`,
+        // which takes the matching rows and then five of them, rather than five
+        // rows and then the matching ones.
+        let limit = sql
+            .find("LIMIT 5")
+            .expect("the limit must survive unparsing");
+        let filter = sql
+            .find("WHERE")
+            .expect("the filter must survive unparsing");
+        assert!(
+            limit < filter,
+            "the limit must be applied before the filter, not after: {sql}"
+        );
+        assert!(
+            sql.contains("FROM (SELECT"),
+            "the limited input must keep its own scope: {sql}"
+        );
     }
 }

--- a/crates/data_components/src/federation.rs
+++ b/crates/data_components/src/federation.rs
@@ -323,7 +323,7 @@ mod tests {
 
     /// The upstream fixes these guard live in the `spiceai/datafusion` fork on
     /// `spiceai-54`, so nothing here fails if a later pin bump drops them. The
-    /// fork's branch is re-cut per DataFusion major and takes its own tests with
+    /// fork's branch is re-cut per `DataFusion` major and takes its own tests with
     /// it; these stay. Extend them whenever a pin bump carries another unparser
     /// fix — #13081 tracks the three this bump left unguarded.
     ///

--- a/crates/data_components/src/federation.rs
+++ b/crates/data_components/src/federation.rs
@@ -209,12 +209,15 @@ mod tests {
         ))
     }
 
+    fn table_source(fields: Vec<Field>) -> Arc<dyn TableSource> {
+        Arc::new(LogicalTableSource::new(Arc::new(Schema::new(fields))))
+    }
+
     fn scan_with_projection(udf_name: &str) -> LogicalPlan {
-        let schema = Arc::new(Schema::new(vec![
+        let source = table_source(vec![
             Field::new("id", DataType::Int32, false),
             Field::new("val", DataType::Utf8, true),
-        ]));
-        let source = Arc::new(LogicalTableSource::new(schema)) as Arc<dyn TableSource>;
+        ]);
         LogicalPlanBuilder::scan("t", source, None)
             .expect("scan")
             .project(vec![Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -236,9 +239,12 @@ mod tests {
         )
     }
 
+    fn test_executor() -> impl SQLExecutor + 'static {
+        DenyFunctionsSqlExecutor::new(test_sql_table(), None)
+    }
+
     fn federated_plan(plan: LogicalPlan) -> LogicalPlan {
-        let executor: Arc<dyn SQLExecutor> =
-            Arc::new(DenyFunctionsSqlExecutor::new(test_sql_table(), None));
+        let executor: Arc<dyn SQLExecutor> = Arc::new(test_executor());
         let planner = Arc::new(SQLFederationPlanner::new(executor));
         LogicalPlan::Extension(Extension {
             node: Arc::new(FederatedPlanNode::new(plan, planner)),
@@ -315,25 +321,41 @@ mod tests {
         assert_eq!(adaptor.source.schema().as_ref(), schema.as_ref());
     }
 
-    fn table_source(fields: Vec<Field>) -> Arc<dyn TableSource> {
-        Arc::new(LogicalTableSource::new(Arc::new(Schema::new(fields)))) as Arc<dyn TableSource>
-    }
-
-    /// Unparse with the dialect federation itself would use, so these tests read
-    /// the same SQL a remote engine is sent.
+    /// The upstream fixes these guard live in the `spiceai/datafusion` fork on
+    /// `spiceai-54`, so nothing here fails if a later pin bump drops them. The
+    /// fork's branch is re-cut per DataFusion major and takes its own tests with
+    /// it; these stay. Extend them whenever a pin bump carries another unparser
+    /// fix — #13081 tracks the three this bump left unguarded.
+    ///
+    /// This unparses through the federation executor, which supplies no dialect
+    /// here, so the SQL is the default dialect's rather than any one connector's.
+    /// The plan shapes, not the spelling, are what these assert.
     fn federated_sql(plan: &LogicalPlan) -> String {
-        let executor: Arc<dyn SQLExecutor> =
-            Arc::new(DenyFunctionsSqlExecutor::new(test_sql_table(), None));
-        Unparser::new(executor.dialect().as_ref())
+        Unparser::new(test_executor().dialect().as_ref())
             .plan_to_sql(plan)
             .expect("plan should unparse")
             .to_string()
+    }
+
+    /// Assert `first` is rendered before `second`, which pins the clause order
+    /// without pinning the formatting around it.
+    fn assert_precedes(sql: &str, first: &str, second: &str) {
+        let (Some(at_first), Some(at_second)) = (sql.find(first), sql.find(second)) else {
+            panic!("expected both `{first}` and `{second}` in: {sql}");
+        };
+        assert!(
+            at_first < at_second,
+            "expected `{first}` before `{second}` in: {sql}"
+        );
     }
 
     /// Regression test for #12406: a `fetch` the optimizer pushes into a join
     /// input bounds that input, not the join's output. Dropping it asks the
     /// remote engine for the whole table and evaluates the join over it, so the
     /// query can return more rows than the plan it came from.
+    ///
+    /// The scan carries a filter as well as the fetch, which is the shape the
+    /// issue reports and the one the join-input transform rebuilds.
     #[test]
     fn a_fetch_pushed_into_a_join_input_survives_unparsing() {
         let left = LogicalPlanBuilder::scan_with_filters_fetch(
@@ -355,10 +377,12 @@ mod tests {
             ]),
             None,
         )
-        .expect("scan right");
+        .expect("scan right")
+        .build()
+        .expect("build right");
         let plan = left
             .join_on(
-                right.build().expect("build right"),
+                right,
                 JoinType::Inner,
                 [col("left_table.id").eq(col("right_table.id"))],
             )
@@ -366,25 +390,9 @@ mod tests {
             .build()
             .expect("build join");
 
-        let sql = federated_sql(&plan);
-
-        // Before the fix the whole `LIMIT 5` was absent from the generated SQL.
-        assert!(
-            sql.contains("LIMIT 5"),
-            "the fetch pushed into the join input must survive: {sql}"
-        );
-        // It bounds only that input, so it has to sit inside the input's own
+        // The fetch bounds the input, so it is rendered inside that input's own
         // scope rather than trailing the join.
-        assert!(
-            sql.contains("FROM (SELECT"),
-            "the fetched join input must keep its own scope: {sql}"
-        );
-        let limit = sql.find("LIMIT 5").expect("limit present");
-        let join = sql.find("INNER JOIN").expect("join present");
-        assert!(
-            limit < join,
-            "the limit must bound the input, not the join output: {sql}"
-        );
+        assert_precedes(&federated_sql(&plan), "LIMIT 5", "INNER JOIN");
     }
 
     /// Regression test for #12591: SQL evaluates `WHERE` before `LIMIT`, so a
@@ -409,24 +417,8 @@ mod tests {
         .build()
         .expect("build");
 
-        let sql = federated_sql(&plan);
-
-        // Before the fix this rendered as `... FROM t WHERE (t.id = 'a') LIMIT 5`,
-        // which takes the matching rows and then five of them, rather than five
-        // rows and then the matching ones.
-        let limit = sql
-            .find("LIMIT 5")
-            .expect("the limit must survive unparsing");
-        let filter = sql
-            .find("WHERE")
-            .expect("the filter must survive unparsing");
-        assert!(
-            limit < filter,
-            "the limit must be applied before the filter, not after: {sql}"
-        );
-        assert!(
-            sql.contains("FROM (SELECT"),
-            "the limited input must keep its own scope: {sql}"
-        );
+        // The limit has to be taken first, so it is rendered in a scope the
+        // filter sits outside of.
+        assert_precedes(&federated_sql(&plan), "LIMIT 5", "WHERE");
     }
 }


### PR DESCRIPTION
## Summary

The `spiceai/datafusion` pin sat on `edd8861e` while 13 commits merged onto `spiceai-54` behind it, so the runtime kept the defects those fixes correct. Three of the six bugs this closes are wrong-result defects in federated pushdown: the generated SQL asks the remote engine a different question than the plan did, and the answer can contain rows the plan excludes. A fourth, #11827, is a wrong-result risk in the local physical optimizer.

| Fork PR | Defect the runtime still had | Closes |
|---|---|---|
| [#197](https://github.com/spiceai/datafusion/pull/197) | A `fetch` pushed into a join input was dropped, so the remote engine was asked for the whole table and the join ran over it | #12406 |
| [#198](https://github.com/spiceai/datafusion/pull/198) | A `Filter` above a `Limit` was flattened into one `SELECT` carrying both a `WHERE` and a `LIMIT`, which SQL evaluates in the opposite order | #12591 |
| [#201](https://github.com/spiceai/datafusion/pull/201) | A `fetch` on the build side of a semi/anti/mark join landed inside the `EXISTS` correlation, so the limit selected nothing | #12595 |
| `fe9b9c7f` | A predicate on an unnamed projection output was emitted as a quoted identifier the statement does not carry, so the remote engine rejected it | #12599 |
| [#199](https://github.com/spiceai/datafusion/pull/199) | A cancelled task reached an unreachable arm in the physical planner instead of being reported as an error | #7030 |
| `6fb51e7b` | `EagerAggregation` rewrote a `ROLLUP`/`CUBE`/`GROUPING SETS` aggregate into a plain grouping, dropping the grouping-set rows and the `__grouping_id` column | #11827 |

The bump also carries [#191](https://github.com/spiceai/datafusion/pull/191), [#192](https://github.com/spiceai/datafusion/pull/192), [#156](https://github.com/spiceai/datafusion/pull/156) and [#202](https://github.com/spiceai/datafusion/pull/202), which have no open issue here.

## Changes

- All 35 `[patch.crates-io]` pins for `github.com/spiceai/datafusion.git` move from `edd8861e69c2eb268d4e8e4e6c45485b714eb9ce` to `b5cb7bb321acbbff749bb9147130f6b47bb36034` (`spiceai-54` head, 13 commits ahead), plus the matching `Cargo.lock` update. Nothing else in either file changes — same host, same fork, same branch, full 40-char SHA.
- Two regression tests in `crates/data_components/src/federation.rs` assert the properties the first two fixes restore, so a later pin bump that drops them fails here rather than silently. The fork's branch is re-cut per DataFusion major and takes its own tests with it; these stay.

## Behavior change worth knowing about

#198 refuses, with `not_impl_err`, the plan shapes it cannot render faithfully — a `Sort` around the limit, a `HAVING`/`QUALIFY` below it, a projection emitting a column the derived query cannot name. `datafusion-federation` calls `final_sql()?` inside `VirtualExecutionPlan::execute`, so for those shapes a query that previously returned **silently wrong rows** now returns an error instead. That is the intended trade, and the shapes are narrow — a `Filter` directly above a `Limit` comes from an explicit subquery or a rewrite, not from the standard optimizer, which pushes filters below limits.

`6fb51e7b` changes plan selection rather than SQL generation: `EagerAggregation` now declines a partial aggregate whose grouping reports `has_grouping_set()`. On such a plan the rule rebuilt the top grouping with `PhysicalGroupBy::new_single`, which cannot express `null_expr`, `groups`, or `has_grouping_set` — so the rewrite silently narrowed the output. The rule opts out of `schema_check`, so nothing caught it. Where a parent projection or window rebinds the aggregate outputs by index, that surfaced as the `col.name() == matching_name` internal error in #11827 (TPC-DS q36); where nothing rebinds them, it returns a result missing its rollup rows and `__grouping_id` column. Declining the rewrite restores both.

## Performance impact

Where a fetch or filter was previously dropped, the remote engine now receives the `LIMIT` and evaluates it, so these queries send **less** work to the remote and return less data. The scoping fixes wrap the bounded input in a derived table; that is one extra subquery level in the generated SQL, not extra work for the engine. The refusals above cost a pushdown — those queries fall back to erroring rather than executing a wrong plan, so no silently-degraded path was added.

`6fb51e7b` costs an optimization on the plans it declines: an aggregate grouped by `ROLLUP`/`CUBE`/`GROUPING SETS` over a join no longer gets a pre-aggregation pushed below the join, so more rows reach it. That is confined to grouping-set aggregates — the guard reads the *partial* grouping's flag, and plain groupings are untouched, so the accept path is unchanged for every other query. The plans losing the rewrite are the ones it was computing incorrectly.

## Test plan

- `make lint` and `make nextest` run through `make signoff-remote`. Local `make signoff` cannot run from this worktree: it forces `cargo fmt --all`, which walks into `connector-nfs` and resolves the main repo as the workspace root.
- Verified locally instead: `cargo check --workspace` on the new pin with the gate's feature set — **0 errors, 0 warnings**, so the bump introduces no API drift anywhere in the workspace, including `datafusion-federation`, `datafusion-table-providers` and ballista, which all resolve through the same `[patch.crates-io]` entries. Scoped clippy on the touched crate is clean, and its tests pass.
- The two new tests were checked against the **old** pinned rev to confirm they fail there for the right reason: `edd8861e` renders the join plan as `SELECT FROM left_table INNER JOIN right_table ON (...) WHERE (...)` with the `LIMIT 5` absent entirely, and the filter plan as `SELECT * FROM t WHERE (t.id = 'a') LIMIT 5` with the clauses reversed. Both assertions fail on those strings and pass on the new rev.
- Integration suites that snapshot `base_sql=` are the remaining risk surface for this bump; they need docker and run in CI, not locally.
- `6fb51e7b` carries its validation upstream, in `datafusion/physical-optimizer/src/eager_aggregation.rs`: two regression tests over the existing beneficial-join fixture, grouped by `ROLLUP(d_name)` so the grouping set is the only difference from the accept-path fixture — one asserts no pre-aggregation is pushed, one asserts the aggregate output schema still carries `__grouping_id`. Both fail without the guard. No repo-side test is added here; #11827's own repro is `tpcds_q36` on `test/spicepods/tpcds/sf100/accelerated/s3[parquet]-cayenne[file].yaml`, which is a benchmark run rather than a unit test, and it is the confirmation to watch on the next TPC-DS sf100 run.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits"; `grok` not installed
- `/security-review`: no findings. It separately confirmed the supply-chain shape of the diff — only the rev changed, no source/host/registry redirect, no checksum anomaly, and the additions are `#[cfg(test)]`-only.
- `/simplify`: applied — shared the executor and table-source fixtures with the existing tests, folded both order checks into one helper, dropped a formatting-sensitive assertion, and corrected a doc comment that overclaimed which dialect the tests exercise. Light checks re-run green, and the pre-fix strings above were re-checked against the simplified assertions to confirm the cleanup did not neuter them.
- Scoped clippy after the cleanup caught a denied `doc_markdown` (bare `DataFusion` in a doc comment) that the workspace `cargo check` does not see; fixed before sign-off.

Fixes #12406
Fixes #12591
Fixes #12595
Fixes #12599
Fixes #7030
Fixes #11827

Raised while reviewing this bump and left for follow-up: #13081 (three of the five carried unparser fixes still have no repo-side guard).

## Checklist

- [x] The whole workspace compiles on the new pin (`cargo check --workspace`, 0 errors, 0 warnings)
- [x] Regression tests added, and shown to fail on the pre-bump rev
- [x] No source, host, or registry redirect in the dependency change
- [ ] `make signoff` / `Attestation` green
