### PR TITLE
fix(udfs): return NULL for a vector distance that is not defined (refs #11263)

### DIFF
--- a/crates/runtime-datafusion-udfs/src/cosine_distance.rs
+++ b/crates/runtime-datafusion-udfs/src/cosine_distance.rs
@@ -28,6 +28,16 @@ limitations under the License.
 //! Both paths return `(1 - cosine_similarity) / 2` ∈ `[0, 1]` (0 = identical,
 //! 1 = opposite). Zero-magnitude vectors have undefined cosine direction; both
 //! paths treat them as orthogonal and return 0.5.
+//!
+//! A vector carrying `NaN` or an infinity has no distance at all, and both
+//! paths above return NULL for it. That matters for ranking: `_score` is
+//! `1 - distance`, so any fabricated distance for a failed embedding competes
+//! with real matches, and NULL is what keeps it out of the results.
+//!
+//! The NULL applies to these kernels only. `cosine_distance` is allowed to
+//! federate, where it unparses to the engine's own function (`DuckDB`'s
+//! `array_cosine_distance`) and that engine decides what a non-finite input
+//! scores — see #13088.
 
 use arrow::array::{
     Array, ArrayRef, Float64Array, Float64Builder, GenericListArray, LargeListArray, ListArray,
@@ -181,7 +191,9 @@ pub(crate) fn cosine_distance_inner(args: &[ArrayRef]) -> DataFusionResult<Array
         // divide by 2 to map into the standard [0, 1] distance range.
         // Zero-magnitude vectors have an undefined direction; simsimd treats the
         // dot product as zero (orthogonal), yielding distance 0.5.
-        (FixedSizeList(_, _), FixedSizeList(_, _)) => compute_fsl_f32_cosine(args),
+        (FixedSizeList(_, _), FixedSizeList(_, _)) => {
+            compute_fsl_f32(args, Kernel::Cosine, |v| v / 2.0)
+        }
         (List(_), List(_)) => general_cosine_distance::<i32>(args),
         (LargeList(_), LargeList(_)) => general_cosine_distance::<i64>(args),
         (array_type1, array_type2) => {
@@ -190,35 +202,6 @@ pub(crate) fn cosine_distance_inner(args: &[ArrayRef]) -> DataFusionResult<Array
             )
         }
     }
-}
-
-/// Compute cosine distance for `FixedSizeList<Float32>` with a non-finite safety guard.
-fn compute_fsl_f32_cosine(args: &[ArrayRef]) -> DataFusionResult<ArrayRef> {
-    let result = compute_fsl_f32(args, Kernel::Cosine, |v| v / 2.0)?;
-    let float64 = result
-        .as_any()
-        .downcast_ref::<arrow::array::Float64Array>()
-        .ok_or_else(|| {
-            DataFusionError::Internal("compute_fsl_f32 should return Float64Array".to_string())
-        })?;
-
-    // Safety net: convert any non-finite output to NULL to prevent NaN from
-    // sorting ahead of real scores in `ORDER BY _score DESC`.
-    let mut builder = arrow::array::Float64Builder::with_capacity(float64.len());
-    for i in 0..float64.len() {
-        if float64.is_null(i) {
-            builder.append_null();
-        } else {
-            let v = float64.value(i);
-            if v.is_finite() {
-                builder.append_value(v);
-            } else {
-                builder.append_null();
-            }
-        }
-    }
-
-    Ok(Arc::new(builder.finish()) as ArrayRef)
 }
 
 fn general_cosine_distance<O: OffsetSizeTrait>(arrays: &[ArrayRef]) -> DataFusionResult<ArrayRef> {
@@ -293,7 +276,7 @@ fn general_cosine_distance_f64<O: OffsetSizeTrait>(
             return exec_err!("Both arrays must have the same length");
         }
 
-        builder.append_value(cosine_distance_f64(
+        builder.append_option(cosine_distance_f64(
             &raw1[start1..end1],
             &raw2[start2..end2],
         ));
@@ -340,7 +323,7 @@ fn general_cosine_distance_f32<O: OffsetSizeTrait>(
             return exec_err!("Both arrays must have the same length");
         }
 
-        builder.append_value(cosine_distance_f32(
+        builder.append_option(cosine_distance_f32(
             &raw1[start1..end1],
             &raw2[start2..end2],
         ));
@@ -408,7 +391,7 @@ fn compute_cosine_distance(
         if f1.len() != f2.len() {
             return exec_err!("Both arrays must have the same length");
         }
-        return Ok(Some(cosine_distance_f64(f1.values(), f2.values())));
+        return Ok(cosine_distance_f64(f1.values(), f2.values()));
     }
 
     // Float32: same, promote while accumulating.
@@ -420,7 +403,7 @@ fn compute_cosine_distance(
         if f1.len() != f2.len() {
             return exec_err!("Both arrays must have the same length");
         }
-        return Ok(Some(cosine_distance_f32(f1.values(), f2.values())));
+        return Ok(cosine_distance_f32(f1.values(), f2.values()));
     }
 
     let float_vals1 = convert_to_f64_array(&value1)?;
@@ -430,18 +413,20 @@ fn compute_cosine_distance(
         return exec_err!("Both arrays must have the same length");
     }
 
-    Ok(Some(cosine_distance_f64(
+    Ok(cosine_distance_f64(
         float_vals1.values(),
         float_vals2.values(),
-    )))
+    ))
 }
 
 /// Computes the cosine distance between two equal-length f64 vectors.
 ///
-/// Zero-magnitude vectors have no defined direction; they are treated as
-/// orthogonal (cosine similarity = 0), returning distance `0.5`, consistent
-/// with the SIMD path.
-fn cosine_distance_f64(x: &[f64], y: &[f64]) -> f64 {
+/// Returns `None` when the distance is undefined — an input carrying `NaN` or
+/// an infinity, or an accumulation that overflows — so the caller can emit
+/// NULL instead of a fabricated score. A zero-magnitude vector is *defined*
+/// input with no direction; it is treated as orthogonal and yields `0.5`,
+/// matching the SIMD path.
+fn cosine_distance_f64(x: &[f64], y: &[f64]) -> Option<f64> {
     let mut x_length: f64 = 0.0;
     let mut y_length: f64 = 0.0;
     let mut sum_squares: f64 = 0.0;
@@ -452,22 +437,11 @@ fn cosine_distance_f64(x: &[f64], y: &[f64]) -> f64 {
         sum_squares += a * b;
     }
 
-    let similarity = sum_squares / (x_length.sqrt() * y_length.sqrt());
-
-    // Zero-magnitude vectors produce NaN (0/0); treat as zero similarity
-    // (orthogonal) so behavior matches the SIMD path → distance 0.5.
-    let similarity = if similarity.is_finite() {
-        similarity
-    } else {
-        0.0
-    };
-
-    // Convert cosine similarity [-1.0, 1.0] to cosine distance [0.0, 1.0]
-    (1.0 - similarity) / 2.0
+    cosine_distance_from_accumulators(x_length, y_length, sum_squares)
 }
 
 /// Float32 variant of [`cosine_distance_f64`]; accumulates in f64.
-fn cosine_distance_f32(x: &[f32], y: &[f32]) -> f64 {
+fn cosine_distance_f32(x: &[f32], y: &[f32]) -> Option<f64> {
     let mut x_length: f64 = 0.0;
     let mut y_length: f64 = 0.0;
     let mut sum_squares: f64 = 0.0;
@@ -480,18 +454,43 @@ fn cosine_distance_f32(x: &[f32], y: &[f32]) -> f64 {
         sum_squares += a * b;
     }
 
+    cosine_distance_from_accumulators(x_length, y_length, sum_squares)
+}
+
+/// Shared tail of the scalar cosine kernels: turn the three accumulators into a
+/// distance in `[0, 1]`, or `None` when the result is not defined.
+fn cosine_distance_from_accumulators(
+    x_length: f64,
+    y_length: f64,
+    sum_squares: f64,
+) -> Option<f64> {
+    // Screening the accumulators covers every non-finite element without a
+    // branch per element: squaring sends `NaN` and either infinity into the
+    // matching length, so a poisoned vector cannot present a finite one. It
+    // must come *before* the zero-magnitude branch below — a `NaN` vector
+    // measured against a zero vector would otherwise be answered 0.5 on the
+    // strength of the zero side alone.
+    if !x_length.is_finite() || !y_length.is_finite() || !sum_squares.is_finite() {
+        return None;
+    }
+
+    // A zero-magnitude vector has no direction; both paths call it orthogonal.
+    if x_length == 0.0 || y_length == 0.0 {
+        return Some(0.5);
+    }
+
     let similarity = sum_squares / (x_length.sqrt() * y_length.sqrt());
-    let similarity = if similarity.is_finite() {
-        similarity
-    } else {
-        0.0
-    };
-    (1.0 - similarity) / 2.0
+    if !similarity.is_finite() {
+        return None;
+    }
+
+    // Convert cosine similarity [-1.0, 1.0] to cosine distance [0.0, 1.0]
+    Some((1.0 - similarity) / 2.0)
 }
 
 /// Thin wrapper kept for unit tests that construct `Float64Array`s directly.
 #[cfg(test)]
-fn cosine_distance(x: &Float64Array, y: &Float64Array) -> f64 {
+fn cosine_distance(x: &Float64Array, y: &Float64Array) -> Option<f64> {
     cosine_distance_f64(x.values(), y.values())
 }
 
@@ -531,38 +530,35 @@ mod tests {
     use arrow_schema::Field;
 
     use super::{CosineDistance, compute_cosine_distance, cosine_distance, cosine_distance_inner};
-    use crate::vector_simd::testing::fsl_f32;
+    use crate::vector_simd::testing::{fsl_f32, list_f32};
     use arrow::array::AsArray;
     use arrow::datatypes::Float64Type;
     use arrow_schema::DataType;
     use datafusion::logical_expr::ScalarUDFImpl;
 
+    /// Evaluates the scalar kernel and asserts the pair has a defined distance.
+    fn defined_distance(x: &[f64], y: &[f64]) -> f64 {
+        cosine_distance(
+            &Float64Array::from(x.to_vec()),
+            &Float64Array::from(y.to_vec()),
+        )
+        .expect("finite inputs must yield a defined distance")
+    }
+
     #[test]
     fn test_cosine_distance() {
         // Identical vectors -> similarity 1 -> distance 0.
-        assert!(
-            cosine_distance(
-                &Float64Array::from(vec![1.0, 2.0, 3.0]),
-                &Float64Array::from(vec![1.0, 2.0, 3.0]),
-            )
-            .abs()
-                < f64::EPSILON
-        );
+        assert!(defined_distance(&[1.0, 2.0, 3.0], &[1.0, 2.0, 3.0]).abs() < f64::EPSILON);
 
         // Opposite vectors -> similarity -1 -> distance 1.
         assert!(
-            (cosine_distance(
-                &Float64Array::from(vec![1.0, 2.0, 3.0]),
-                &Float64Array::from(vec![-1.0, -2.0, -3.0]),
-            ) - 1.0)
-                .abs()
-                < f64::EPSILON
+            (defined_distance(&[1.0, 2.0, 3.0], &[-1.0, -2.0, -3.0]) - 1.0).abs() < f64::EPSILON
         );
 
         // Arbitrary vectors stay within the normalized [0, 1] range.
-        assert!((0.0..=1.0).contains(&cosine_distance(
-            &Float64Array::from(vec![1000.0, 2000.0, 30.0]),
-            &Float64Array::from(vec![-42.0, 123.0, -3.0]),
+        assert!((0.0..=1.0).contains(&defined_distance(
+            &[1000.0, 2000.0, 30.0],
+            &[-42.0, 123.0, -3.0]
         )));
     }
 
@@ -571,18 +567,9 @@ mod tests {
         // Zero-magnitude vectors are treated as orthogonal → distance 0.5,
         // consistent with the SIMD path.
         let half = |d: f64| (d - 0.5).abs() < 1e-10;
-        assert!(half(cosine_distance(
-            &Float64Array::from(vec![0.0, 0.0, 0.0]),
-            &Float64Array::from(vec![1.0, 2.0, 3.0]),
-        )));
-        assert!(half(cosine_distance(
-            &Float64Array::from(vec![1.0, 2.0, 3.0]),
-            &Float64Array::from(vec![0.0, 0.0, 0.0]),
-        )));
-        assert!(half(cosine_distance(
-            &Float64Array::from(vec![0.0, 0.0]),
-            &Float64Array::from(vec![0.0, 0.0]),
-        )));
+        assert!(half(defined_distance(&[0.0, 0.0, 0.0], &[1.0, 2.0, 3.0])));
+        assert!(half(defined_distance(&[1.0, 2.0, 3.0], &[0.0, 0.0, 0.0])));
+        assert!(half(defined_distance(&[0.0, 0.0], &[0.0, 0.0])));
     }
 
     #[test]
@@ -673,6 +660,134 @@ mod tests {
             !out.is_null(0) && (out.value(0) - 0.5).abs() < 1e-5,
             "expected 0.5 for zero-magnitude vector, got {}",
             out.value(0)
+        );
+    }
+
+    // --- non-finite input tests (regression test for #11263) ---
+
+    #[test]
+    fn non_finite_input_is_null_on_every_dispatch_path() {
+        // A vector carrying NaN or infinity has no defined cosine distance. Both
+        // dispatch paths must report that the same way, otherwise the answer
+        // depends on whether the column is a FixedSizeList or a List.
+        for probe in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let fsl = cosine_distance_inner(&[
+                fsl_f32(&[&[probe, 2.0, 3.0]]) as ArrayRef,
+                fsl_f32(&[&[1.0_f32, 2.0, 3.0]]) as ArrayRef,
+            ])
+            .expect("fsl path evaluates");
+            let fsl = fsl.as_primitive::<Float64Type>();
+
+            let list = cosine_distance_inner(&[
+                list_f32::<i32>(&[&[probe, 2.0, 3.0]]),
+                list_f32::<i32>(&[&[1.0_f32, 2.0, 3.0]]),
+            ])
+            .expect("list path evaluates");
+            let list = list.as_primitive::<Float64Type>();
+
+            assert!(
+                fsl.is_null(0),
+                "FixedSizeList path must return NULL for {probe} input, got {}",
+                fsl.value(0)
+            );
+            assert!(
+                list.is_null(0),
+                "List path must return NULL for {probe} input, got {} — it disagrees with the \
+                 FixedSizeList path, so the same query answers differently per column type",
+                list.value(0)
+            );
+        }
+    }
+
+    #[test]
+    fn zero_magnitude_stays_orthogonal_on_every_dispatch_path() {
+        // A zero vector is finite and well-defined input; both paths keep
+        // treating it as orthogonal (0.5). This is what separates it from the
+        // non-finite case above, which is undefined rather than orthogonal.
+        let fsl = cosine_distance_inner(&[
+            fsl_f32(&[&[0.0_f32, 0.0, 0.0]]) as ArrayRef,
+            fsl_f32(&[&[1.0_f32, 2.0, 3.0]]) as ArrayRef,
+        ])
+        .expect("fsl path evaluates");
+        let fsl = fsl.as_primitive::<Float64Type>();
+
+        let list = cosine_distance_inner(&[
+            list_f32::<i32>(&[&[0.0_f32, 0.0, 0.0]]),
+            list_f32::<i32>(&[&[1.0_f32, 2.0, 3.0]]),
+        ])
+        .expect("list path evaluates");
+        let list = list.as_primitive::<Float64Type>();
+
+        assert!(
+            !fsl.is_null(0) && (fsl.value(0) - 0.5).abs() < 1e-5,
+            "FixedSizeList path: expected 0.5 for a zero vector"
+        );
+        assert!(
+            !list.is_null(0) && (list.value(0) - 0.5).abs() < 1e-5,
+            "List path: expected 0.5 for a zero vector, got {}",
+            list.value(0)
+        );
+    }
+
+    #[test]
+    fn non_finite_measured_against_a_zero_vector_is_still_null() {
+        // Pins the ordering rule in `cosine_distance_from_accumulators`: the
+        // zero-magnitude short-circuit must not answer for a poisoned vector.
+        let fsl = cosine_distance_inner(&[
+            fsl_f32(&[&[f32::NAN, 2.0, 3.0]]) as ArrayRef,
+            fsl_f32(&[&[0.0_f32, 0.0, 0.0]]) as ArrayRef,
+        ])
+        .expect("fsl path evaluates");
+        assert!(
+            fsl.as_primitive::<Float64Type>().is_null(0),
+            "FixedSizeList path: NaN vs a zero vector must be NULL"
+        );
+
+        let list = cosine_distance_inner(&[
+            list_f32::<i32>(&[&[f32::NAN, 2.0, 3.0]]),
+            list_f32::<i32>(&[&[0.0_f32, 0.0, 0.0]]),
+        ])
+        .expect("list path evaluates");
+        let list = list.as_primitive::<Float64Type>();
+        assert!(
+            list.is_null(0),
+            "List path: NaN vs a zero vector must be NULL, got {}",
+            list.value(0)
+        );
+
+        // Both argument orders, since only one accumulator is poisoned.
+        let swapped = cosine_distance_inner(&[
+            list_f32::<i32>(&[&[0.0_f32, 0.0, 0.0]]),
+            list_f32::<i32>(&[&[f32::NAN, 2.0, 3.0]]),
+        ])
+        .expect("list path evaluates");
+        assert!(
+            swapped.as_primitive::<Float64Type>().is_null(0),
+            "List path: a zero vector vs NaN must be NULL too"
+        );
+    }
+
+    #[test]
+    fn non_finite_input_is_null_for_large_list_and_f64() {
+        // The LargeList dispatch and the Float64 element path share the same
+        // kernels; neither may reintroduce a fabricated score.
+        let out = cosine_distance_inner(&[
+            list_f32::<i64>(&[&[f32::NAN, 2.0, 3.0]]),
+            list_f32::<i64>(&[&[1.0_f32, 2.0, 3.0]]),
+        ])
+        .expect("large list path evaluates");
+        assert!(
+            out.as_primitive::<Float64Type>().is_null(0),
+            "LargeList path must return NULL for NaN input"
+        );
+
+        // Float64 elements reach `compute_cosine_distance`'s zero-copy arm.
+        let nan: ArrayRef = Arc::new(Float64Array::from(vec![f64::NAN, 2.0, 3.0]));
+        let ok: ArrayRef = Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0]));
+        let result = compute_cosine_distance(Some(nan), Some(ok)).expect("evaluates");
+        assert!(
+            result.is_none(),
+            "Float64 element path must return NULL for NaN input, got {result:?}"
         );
     }
 

--- a/crates/runtime-datafusion-udfs/src/vector_simd.rs
+++ b/crates/runtime-datafusion-udfs/src/vector_simd.rs
@@ -72,6 +72,25 @@ pub(crate) enum Kernel {
 }
 
 impl Kernel {
+    /// Whether a non-finite input can reach this kernel's output as a finite,
+    /// plausible-looking number.
+    ///
+    /// `Dot` and `L2Squared` accumulate their inputs directly, so `NaN` or an
+    /// infinity propagates and the output check below catches it for free.
+    /// `Cosine` normalizes, and `simsimd` answers **0** — distance 0, an exact
+    /// match — for a row carrying `NaN`. Nothing about the output distinguishes
+    /// that from two genuinely parallel vectors, so this kernel is the one that
+    /// has to screen its input. The shared non-finite test drives all three
+    /// kernels, so if this is ever wrong for `Dot`/`L2Squared` — a simsimd
+    /// change, a different SIMD dispatch — that test fails rather than the
+    /// missing guard going unnoticed.
+    fn hides_non_finite_input(self) -> bool {
+        match self {
+            Self::Dot | Self::L2Squared => false,
+            Self::Cosine => true,
+        }
+    }
+
     fn apply(self, a: &[f32], b: &[f32]) -> Option<f64> {
         match self {
             Self::Dot => f32::dot(a, b),
@@ -150,6 +169,26 @@ fn as_fsl(arr: &ArrayRef) -> DataFusionResult<&FixedSizeListArray> {
         })
 }
 
+/// Returns `true` when every element of `values` is finite.
+///
+/// Branch-free by design; see the note in the body for why.
+#[inline]
+fn all_finite(values: &[f32]) -> bool {
+    // An `f32` is non-finite exactly when every exponent bit is set, so the
+    // test is a mask-and-compare with no branch. Branch-free is the point: a
+    // short-circuiting `iter().all(f32::is_finite)` cannot auto-vectorize, and
+    // over a 10000x1536 batch it cost ~4x the kernel it guards. Two other forms
+    // measured worse than this one and are recorded so they are not retried —
+    // a float `acc += v * 0.0` chain (~7x, serial FP dependency) and an 8-lane
+    // manual split (~2x, defeats the compiler's own reduction).
+    const EXPONENT_MASK: u32 = 0x7F80_0000;
+    let mut non_finite: u32 = 0;
+    for &v in values {
+        non_finite |= u32::from((v.to_bits() & EXPONENT_MASK) == EXPONENT_MASK);
+    }
+    non_finite == 0
+}
+
 fn flat_f32(fsl: &FixedSizeListArray) -> DataFusionResult<&[f32]> {
     let values = fsl.values();
     let f32 = values
@@ -213,6 +252,8 @@ where
     let b_inner = b.values().logical_nulls();
     let check_inner_nulls = a_inner.is_some() || b_inner.is_some();
 
+    let screen_input = kernel.hides_non_finite_input();
+
     let n = a.len();
     let mut builder = Float64Builder::with_capacity(n);
     let iter = flat_a.chunks_exact(dim).zip(flat_b.chunks_exact(dim));
@@ -235,12 +276,28 @@ where
                 continue;
             }
         }
+        // A non-finite element makes the whole row's score undefined, and the
+        // kernels do not report that themselves: `simsimd`'s `cos` answers 0 —
+        // distance 0, an exact match — for a row carrying NaN, which puts a
+        // failed embedding at the top of `ORDER BY _score DESC`. Screen the
+        // input rather than the output, because a fabricated score is finite.
+        if screen_input && (!all_finite(slice_a) || !all_finite(slice_b)) {
+            builder.append_null();
+            continue;
+        }
         let raw = kernel.apply(slice_a, slice_b).ok_or_else(|| {
             DataFusionError::Execution(
                 "vector_simd: simsimd returned None (length mismatch)".to_string(),
             )
         })?;
-        builder.append_value(post_process(raw));
+        // Finite inputs can still overflow to a non-finite result; NULL is the
+        // honest answer there too.
+        let value = post_process(raw);
+        if value.is_finite() {
+            builder.append_value(value);
+        } else {
+            builder.append_null();
+        }
     }
 
     Ok(Arc::new(builder.finish()) as ArrayRef)
@@ -284,6 +341,9 @@ pub(crate) fn compute_fsl_f32_l2_norm(array: &ArrayRef) -> DataFusionResult<Arra
                 continue;
             }
         }
+        // No input screen here: a sum of squares has no cancelling terms, so a
+        // non-finite element always reaches `sq` as NaN or an infinity and the
+        // check below catches it. Same reasoning as `Kernel::hides_non_finite_input`.
         let sq = f32::dot(slice, slice).ok_or_else(|| {
             DataFusionError::Execution("vector_simd: simsimd dot returned None".to_string())
         })?;
@@ -291,7 +351,12 @@ pub(crate) fn compute_fsl_f32_l2_norm(array: &ArrayRef) -> DataFusionResult<Arra
             clippy::cast_possible_truncation,
             reason = "sq fits in f32 by construction (bounded by input f32 magnitudes)"
         )]
-        builder.append_value((sq as f32).sqrt());
+        let norm = (sq as f32).sqrt();
+        if norm.is_finite() {
+            builder.append_value(norm);
+        } else {
+            builder.append_null();
+        }
     }
     Ok(Arc::new(builder.finish()) as ArrayRef)
 }
@@ -300,6 +365,19 @@ pub(crate) fn compute_fsl_f32_l2_norm(array: &ArrayRef) -> DataFusionResult<Arra
 pub(crate) mod testing {
     use super::*;
     use arrow_schema::Field;
+
+    /// Builds a `List<Float32>` (`O = i32`) or `LargeList<Float32>` (`O = i64`)
+    /// with one row per slice. Sibling of [`fsl_f32`] for the non-SIMD dispatch
+    /// paths.
+    pub(crate) fn list_f32<O: arrow::array::OffsetSizeTrait>(rows: &[&[f32]]) -> ArrayRef {
+        Arc::new(arrow::array::GenericListArray::<O>::from_iter_primitive::<
+            arrow::datatypes::Float32Type,
+            _,
+            _,
+        >(
+            rows.iter().map(|r| Some(r.iter().copied().map(Some)))
+        )) as ArrayRef
+    }
 
     pub(crate) fn fsl_f32(rows: &[&[f32]]) -> Arc<FixedSizeListArray> {
         let dim = i32::try_from(rows[0].len()).expect("dim fits in i32");
@@ -342,6 +420,69 @@ mod tests {
         let out = out.as_primitive::<Float64Type>();
         // 1^2 + 2^2 + 2^2 = 9
         assert!((out.value(0) - 9.0).abs() < 1e-5);
+    }
+
+    /// Regression test for #11263.
+    ///
+    /// Every kernel behind `compute_fsl_f32` must refuse a row carrying a
+    /// non-finite element. `Kernel::Cosine` is the one that made this visible:
+    /// `simsimd` answers 0 — distance 0, an exact match — rather than NaN, so a
+    /// guard on the *output* passes it through and a failed embedding ranks
+    /// first. Asserting on the raw kernel output is what keeps this honest: an
+    /// output-only guard makes the cosine case pass and this one fail.
+    #[test]
+    fn non_finite_input_row_is_null_for_every_kernel() {
+        for probe in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            for (label, kernel) in [
+                ("dot", Kernel::Dot),
+                ("l2sq", Kernel::L2Squared),
+                ("cosine", Kernel::Cosine),
+            ] {
+                // Row 0 is poisoned; row 1 is clean and must still be scored,
+                // so one bad vector cannot void the rest of the batch.
+                let a = testing::fsl_f32(&[&[probe, 2.0, 3.0], &[1.0, 2.0, 3.0]]);
+                let b = testing::fsl_f32(&[&[1.0_f32, 2.0, 3.0], &[1.0, 2.0, 3.0]]);
+                let out = compute_fsl_f32(&[a as ArrayRef, b as ArrayRef], kernel, |v| v)
+                    .expect("kernel evaluates");
+                let out = out.as_primitive::<Float64Type>();
+                assert!(
+                    out.is_null(0),
+                    "{label} kernel must return NULL for a {probe} element, got {}",
+                    out.value(0)
+                );
+                assert!(
+                    !out.is_null(1),
+                    "{label} kernel must still score the clean row in the same batch"
+                );
+            }
+        }
+    }
+
+    /// A zero vector is finite, defined input — it stays scored, which is what
+    /// separates it from the non-finite rows above.
+    #[test]
+    fn zero_magnitude_row_is_still_scored() {
+        let a = testing::fsl_f32(&[&[0.0_f32, 0.0, 0.0]]);
+        let b = testing::fsl_f32(&[&[1.0_f32, 2.0, 3.0]]);
+        let out = compute_fsl_f32(&[a as ArrayRef, b as ArrayRef], Kernel::Cosine, |v| v / 2.0)
+            .expect("kernel evaluates");
+        let out = out.as_primitive::<Float64Type>();
+        assert!(
+            !out.is_null(0) && (out.value(0) - 0.5).abs() < 1e-5,
+            "a zero vector is orthogonal, not undefined"
+        );
+    }
+
+    #[test]
+    fn l2_norm_non_finite_row_is_null() {
+        let a = testing::fsl_f32(&[&[f32::NAN, 2.0, 3.0], &[3.0, 4.0, 0.0]]) as ArrayRef;
+        let out = compute_fsl_f32_l2_norm(&a).expect("kernel evaluates");
+        let out = out.as_primitive::<arrow::datatypes::Float32Type>();
+        assert!(out.is_null(0), "NaN element must yield a NULL norm");
+        assert!(
+            !out.is_null(1) && (out.value(1) - 5.0).abs() < 1e-5,
+            "the clean row must still report its norm"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A vector carrying `NaN` or an infinity has no cosine distance, L2 distance, inner product or norm — but the kernels answered one anyway, and the two dispatch paths did not agree on which one.

| input | `FixedSizeList<Float32>` (SIMD) | `List` / `LargeList` (scalar) |
|---|---|---|
| element is `NaN` / `±Inf` | **0** — distance 0, an exact match | 0.5 |
| zero-magnitude vector | 0.5 | 0.5 |

The `FixedSizeList` column is what embedding columns actually use, and `vector_search` passes its query vector as a `FixedSizeList` literal, so the production path is the one that answered **"perfect match"**. `_score` is `1 - distance`, so a failed embedding scored `1.0` and sorted above every real result; under `EmbeddingAggregation::Max` one corrupt chunk took its whole document to the top.

Root cause is that the guard on that path screened the kernel's **output** for non-finiteness. `simsimd`'s `cos` normalizes and returns a finite `0` for a `NaN` row, and nothing about that output distinguishes it from two genuinely parallel vectors — so an output guard cannot catch it.

## Changes

- Screen the **input** at the shared chokepoint, not the output. Only `Cosine` needs it: `Dot` and `L2Squared` accumulate their inputs directly, so a non-finite element reaches their output and the existing check catches it for free. `Kernel::hides_non_finite_input` records which is which, and the shared test drives all three kernels, so if that ever stops holding the test fails rather than a guard silently going missing.
- The scalar cosine kernels screen their three accumulators, which covers every non-finite element without a per-element branch. This check must precede the zero-magnitude branch — a `NaN` vector measured against a *zero* vector would otherwise be answered 0.5 on the strength of the zero side alone. That ordering has its own regression test.
- `l2_norm` needs no input screen at all: a sum of squares has no cancelling terms, so a non-finite element always reaches the result.
- Zero-magnitude vectors are unchanged. They are defined input with no direction, and both paths still call them orthogonal (0.5).

NULL is already a reachable score today (a null embedding row produces one), and the score aggregates are `max`/`avg`/`sum`, which skip nulls — so a poisoned chunk stops competing rather than starting to.

## Performance impact

This is a hot path, so it was measured, not assumed — `cargo bench -p runtime-datafusion-udfs --bench cosine_distance`, 10000 rows x 1536 dims:

| | trunk | this PR |
|---|---|---|
| cosine (SIMD) | 4.72 ms | 7.65 ms (**+62%**) |
| `inner_product`, `l2_distance`, `l2_norm` | — | unaffected (free output check) |

The screen's formulation was tuned against that benchmark; four alternatives measured worse and are recorded in the code so they are not retried: short-circuiting `iter().all(f32::is_finite)` (+296%, blocks auto-vectorization), a float `acc += v * 0.0` chain (+600%, serial FP dependency), an 8-lane manual split (+110%), and scanning both whole buffers up front (+60%).

Roughly **half** the remaining cost is rescanning the broadcast query literal once per row; removing it needs a signature change to the shared `make_scalar_function`, so it is filed as #13090 rather than grown into this PR. Correctness is the priority here per CLAUDE.md, but the number is real and a maintainer should see it.

## Not fixed here

- **The formula divergence in the same issue** — local `(1 - sim) / 2` vs federated `1 - sim`. It changes user-visible `_score` on *every* row and drifts the whole search snapshot suite, and #11263 explicitly parks it for a maintainer decision. This PR changes only which rows are NULL, not the scale of any defined score.
- #13088 — the federated path unparses to `array_cosine_distance` and does not inherit this NULL contract.
- #13089 — the write-side guards test `all(v == 0.0 || v.is_nan())` instead of `any(!v.is_finite())`, and DuckDB's own `validate_vector` is never called on write.

## Test plan
- [x] Added regression test for a non-finite element on every dispatch path (`FixedSizeList`, `List`, `LargeList`, `Float64` elements) and every kernel (`Dot`, `L2Squared`, `Cosine`, `l2_norm`)
- [x] Added edge case tests for non-finite-vs-zero-magnitude in both argument orders, zero-magnitude staying orthogonal, and a clean row in the same batch as a poisoned one still being scored
- [x] Each of the four guards was independently neutered and confirmed to fail a test, so none of them is vacuous — the neuter is also what surfaced the missing non-finite-vs-zero-vector case
- [x] `make lint` passes (workspace-wide `cargo fmt --all -- --check` + full clippy — not a per-crate scoped invocation)
- [x] `make test` passes
- [x] `make signoff` run after the final push (`Attestation` check is green)

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits"; `grok` not installed. Its angles were run by hand instead, and two produced changes: the FSL path was verified to be what `vector_search` actually uses (`embeddings/udtf.rs:885`), and the performance question was measured rather than asserted — which is what caught a 4x regression in the first formulation.
- `/security-review`: no findings. The diff adds no SQL, I/O, auth, or logging; the behavior it removes was itself the exploitable direction (a writable `NaN` embedding ranked first in every search, a ranking-manipulation primitive in a RAG pipeline).
- `/simplify`: applied — dropped a redundant whole-buffer prescan in `l2_norm`, inlined a wrapper that had become a pass-through, replaced hand-rolled `Option` matches with `append_option`, and replaced two duplicated test builders with one generic helper in the shared `testing` module. Three findings were out of scope and filed as #13088, #13089 and #13090. Light checks re-run green.

Refs #11263 — deliberately **not** `Fixes`. The issue's headline defect is the local-vs-federated
formula divergence listed under *Not fixed here*, which #11263 itself parks for a maintainer
decision; this PR fixes the non-finite-input hazard filed alongside it. #11263 stays open until
that decision is made.
