### PR TITLE
fix(metrics): make component metrics and tests more robust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19493,7 +19493,6 @@ dependencies = [
  "mimalloc",
  "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-prometheus",
  "opentelemetry-zipkin",
  "opentelemetry_sdk",
  "otel-arrow",

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -59,7 +59,6 @@ mimalloc = { version = "0.1.48", optional = true }
 opentelemetry.workspace = true
 opentelemetry-http.workspace = true
 parking_lot.workspace = true
-opentelemetry-prometheus.workspace = true
 opentelemetry-zipkin.workspace = true
 opentelemetry_sdk.workspace = true
 otel-arrow = { path = "../../crates/otel-arrow" }

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -998,6 +998,7 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
 
     if needs_metrics {
         rt.init_cache_metrics();
+        rt.init_component_metrics();
     }
 
     let cloned_rt = Arc::clone(&rt);
@@ -1452,14 +1453,7 @@ fn init_metrics(
 
     // Case 1: Prometheus scrape
     if let Some(registry) = registry {
-        let prometheus_exporter = opentelemetry_prometheus::exporter()
-            .with_registry(registry)
-            .without_scope_info()
-            .without_units()
-            .without_counter_suffixes()
-            .without_target_info()
-            .build()?;
-        provider_builder = provider_builder.with_reader(prometheus_exporter);
+        provider_builder = provider_builder.with_reader(runtime::prometheus_reader(registry)?);
 
         let spice_metrics_exporter =
             OtelArrowExporter::new(spice_metrics::SpiceMetricsExporter::new(df));

--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -201,6 +201,9 @@ pub trait CacheMetrics: Send + Sync {
         Self::record_item_count(0);
         Self::record_size(0);
         Self::record_max_size(0);
+        // A gauge, published because zero is the genuine initial reading:
+        // `calculate_hit_ratio` is 0.0 for an empty request count.
+        Self::update_hit_ratio(0, 0);
         Self::publish_counters_at_zero();
     }
 

--- a/crates/cache/src/metrics.rs
+++ b/crates/cache/src/metrics.rs
@@ -201,8 +201,6 @@ pub trait CacheMetrics: Send + Sync {
         Self::record_item_count(0);
         Self::record_size(0);
         Self::record_max_size(0);
-        // A gauge, published because zero is the genuine initial reading:
-        // `calculate_hit_ratio` is 0.0 for an empty request count.
         Self::update_hit_ratio(0, 0);
         Self::publish_counters_at_zero();
     }

--- a/crates/runtime-metrics/src/catalogs/mod.rs
+++ b/crates/runtime-metrics/src/catalogs/mod.rs
@@ -57,3 +57,10 @@ pub static ACCELERATION_TABLES_BY_KIND: LazyLock<Gauge<u64>> = LazyLock::new(|| 
         )
         .build()
 });
+
+/// Publishes this module's unlabelled counters at zero, so a series a healthy
+/// runtime never increments is exported rather than absent. Lives beside the
+/// declarations so the list cannot drift away from them.
+pub fn publish_counters_at_zero() {
+    LOAD_ERROR.add(0, &[]);
+}

--- a/crates/runtime-metrics/src/catalogs/mod.rs
+++ b/crates/runtime-metrics/src/catalogs/mod.rs
@@ -58,9 +58,7 @@ pub static ACCELERATION_TABLES_BY_KIND: LazyLock<Gauge<u64>> = LazyLock::new(|| 
         .build()
 });
 
-/// Publishes this module's unlabelled counters at zero, so a series a healthy
-/// runtime never increments is exported rather than absent. Lives beside the
-/// declarations so the list cannot drift away from them.
+/// See [`crate::publish_component_counters_at_zero`].
 pub fn publish_counters_at_zero() {
     LOAD_ERROR.add(0, &[]);
 }

--- a/crates/runtime-metrics/src/components/mod.rs
+++ b/crates/runtime-metrics/src/components/mod.rs
@@ -119,3 +119,10 @@ fn metric_callback_type(metric_callback: &ObserveMetricCallback) -> &'static str
         ObserveMetricCallback::F64(_) => "f64",
     }
 }
+
+/// Publishes this module's unlabelled counters at zero, so a series a healthy
+/// runtime never increments is exported rather than absent. Lives beside the
+/// declarations so the list cannot drift away from them.
+pub fn publish_counters_at_zero() {
+    REGISTERED_COUNT.add(0, &[]);
+}

--- a/crates/runtime-metrics/src/components/mod.rs
+++ b/crates/runtime-metrics/src/components/mod.rs
@@ -120,9 +120,7 @@ fn metric_callback_type(metric_callback: &ObserveMetricCallback) -> &'static str
     }
 }
 
-/// Publishes this module's unlabelled counters at zero, so a series a healthy
-/// runtime never increments is exported rather than absent. Lives beside the
-/// declarations so the list cannot drift away from them.
+/// See [`crate::publish_component_counters_at_zero`].
 pub fn publish_counters_at_zero() {
     REGISTERED_COUNT.add(0, &[]);
 }

--- a/crates/runtime-metrics/src/datasets/mod.rs
+++ b/crates/runtime-metrics/src/datasets/mod.rs
@@ -48,3 +48,10 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         )
         .build()
 });
+
+/// Publishes this module's unlabelled counters at zero, so a series a healthy
+/// runtime never increments is exported rather than absent. Lives beside the
+/// declarations so the list cannot drift away from them.
+pub fn publish_counters_at_zero() {
+    LOAD_ERROR.add(0, &[]);
+}

--- a/crates/runtime-metrics/src/datasets/mod.rs
+++ b/crates/runtime-metrics/src/datasets/mod.rs
@@ -49,9 +49,7 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         .build()
 });
 
-/// Publishes this module's unlabelled counters at zero, so a series a healthy
-/// runtime never increments is exported rather than absent. Lives beside the
-/// declarations so the list cannot drift away from them.
+/// See [`crate::publish_component_counters_at_zero`].
 pub fn publish_counters_at_zero() {
     LOAD_ERROR.add(0, &[]);
 }

--- a/crates/runtime-metrics/src/embeddings/mod.rs
+++ b/crates/runtime-metrics/src/embeddings/mod.rs
@@ -40,3 +40,10 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         )
         .build()
 });
+
+/// Publishes this module's unlabelled counters at zero, so a series a healthy
+/// runtime never increments is exported rather than absent. Lives beside the
+/// declarations so the list cannot drift away from them.
+pub fn publish_counters_at_zero() {
+    LOAD_ERROR.add(0, &[]);
+}

--- a/crates/runtime-metrics/src/embeddings/mod.rs
+++ b/crates/runtime-metrics/src/embeddings/mod.rs
@@ -41,9 +41,7 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         .build()
 });
 
-/// Publishes this module's unlabelled counters at zero, so a series a healthy
-/// runtime never increments is exported rather than absent. Lives beside the
-/// declarations so the list cannot drift away from them.
+/// See [`crate::publish_component_counters_at_zero`].
 pub fn publish_counters_at_zero() {
     LOAD_ERROR.add(0, &[]);
 }

--- a/crates/runtime-metrics/src/lib.rs
+++ b/crates/runtime-metrics/src/lib.rs
@@ -43,17 +43,7 @@ pub mod workers;
 /// Publishes every component counter at zero.
 ///
 /// A counter that never fires exports no series at all, and an absent series reads
-/// as a broken exporter rather than as zero (#12687). Each module owns its list,
-/// beside the declarations, so a new counter cannot be forgotten here.
-///
-/// Qualifying is narrow. The emission must be unlabelled: an unlabelled zero in a
-/// labelled family like `dataset_active_count{engine}` is a phantom series nothing
-/// updates, and adds an empty group to `sum by (..)`. Those need one zero per label
-/// value, as `cache::metrics::EvictionReason::ALL` does. Gauges qualify only where
-/// zero is the true initial reading — `results_cache_hit_ratio` does,
-/// `dataset_load_state` does not, since 0 there means `Initializing`.
-///
-/// Call after the meter provider is installed (#12667).
+/// as a broken exporter rather than as zero.
 pub fn publish_component_counters_at_zero() {
     catalogs::publish_counters_at_zero();
     components::publish_counters_at_zero();

--- a/crates/runtime-metrics/src/lib.rs
+++ b/crates/runtime-metrics/src/lib.rs
@@ -39,3 +39,31 @@ pub mod telemetry;
 pub mod tools;
 pub mod views;
 pub mod workers;
+
+/// Publishes every component counter at zero.
+///
+/// A `LazyLock` counter that has never fired exports no series at all, and an
+/// absent series reads as a broken exporter rather than as zero (#12687).
+///
+/// Only counters whose real emission is unlabelled qualify. An unlabelled zero in
+/// a family that is otherwise labelled — `dataset_active_count{engine}`,
+/// `dataset_acceleration_refresh_errors{dataset}` — is a phantom series that no
+/// record will ever update, and it puts an empty group into any `sum by (..)`.
+/// Publishing those needs one zero per known label value, at the point the label
+/// is known, the way `cache::metrics::EvictionReason::ALL` does it.
+///
+/// Gauges qualify only where zero is the genuine initial reading:
+/// `results_cache_hit_ratio` does, `dataset_load_state` does not, because 0 there
+/// means `Initializing`.
+///
+/// Must be called after the operator's meter provider is installed (#12667).
+pub fn publish_component_counters_at_zero() {
+    catalogs::publish_counters_at_zero();
+    components::publish_counters_at_zero();
+    datasets::publish_counters_at_zero();
+    embeddings::publish_counters_at_zero();
+    models::publish_counters_at_zero();
+    rerankers::publish_counters_at_zero();
+    tools::publish_counters_at_zero();
+    views::publish_counters_at_zero();
+}

--- a/crates/runtime-metrics/src/lib.rs
+++ b/crates/runtime-metrics/src/lib.rs
@@ -45,6 +45,9 @@ pub mod workers;
 /// A `LazyLock` counter that has never fired exports no series at all, and an
 /// absent series reads as a broken exporter rather than as zero (#12687).
 ///
+/// Each module owns its own list, beside the declarations, so a counter added
+/// there cannot be forgotten here.
+///
 /// Only counters whose real emission is unlabelled qualify. An unlabelled zero in
 /// a family that is otherwise labelled — `dataset_active_count{engine}`,
 /// `dataset_acceleration_refresh_errors{dataset}` — is a phantom series that no

--- a/crates/runtime-metrics/src/lib.rs
+++ b/crates/runtime-metrics/src/lib.rs
@@ -42,24 +42,18 @@ pub mod workers;
 
 /// Publishes every component counter at zero.
 ///
-/// A `LazyLock` counter that has never fired exports no series at all, and an
-/// absent series reads as a broken exporter rather than as zero (#12687).
+/// A counter that never fires exports no series at all, and an absent series reads
+/// as a broken exporter rather than as zero (#12687). Each module owns its list,
+/// beside the declarations, so a new counter cannot be forgotten here.
 ///
-/// Each module owns its own list, beside the declarations, so a counter added
-/// there cannot be forgotten here.
+/// Qualifying is narrow. The emission must be unlabelled: an unlabelled zero in a
+/// labelled family like `dataset_active_count{engine}` is a phantom series nothing
+/// updates, and adds an empty group to `sum by (..)`. Those need one zero per label
+/// value, as `cache::metrics::EvictionReason::ALL` does. Gauges qualify only where
+/// zero is the true initial reading — `results_cache_hit_ratio` does,
+/// `dataset_load_state` does not, since 0 there means `Initializing`.
 ///
-/// Only counters whose real emission is unlabelled qualify. An unlabelled zero in
-/// a family that is otherwise labelled — `dataset_active_count{engine}`,
-/// `dataset_acceleration_refresh_errors{dataset}` — is a phantom series that no
-/// record will ever update, and it puts an empty group into any `sum by (..)`.
-/// Publishing those needs one zero per known label value, at the point the label
-/// is known, the way `cache::metrics::EvictionReason::ALL` does it.
-///
-/// Gauges qualify only where zero is the genuine initial reading:
-/// `results_cache_hit_ratio` does, `dataset_load_state` does not, because 0 there
-/// means `Initializing`.
-///
-/// Must be called after the operator's meter provider is installed (#12667).
+/// Call after the meter provider is installed (#12667).
 pub fn publish_component_counters_at_zero() {
     catalogs::publish_counters_at_zero();
     components::publish_counters_at_zero();

--- a/crates/runtime-metrics/src/models/mod.rs
+++ b/crates/runtime-metrics/src/models/mod.rs
@@ -48,3 +48,10 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         )
         .build()
 });
+
+/// Publishes this module's unlabelled counters at zero, so a series a healthy
+/// runtime never increments is exported rather than absent. Lives beside the
+/// declarations so the list cannot drift away from them.
+pub fn publish_counters_at_zero() {
+    LOAD_ERROR.add(0, &[]);
+}

--- a/crates/runtime-metrics/src/models/mod.rs
+++ b/crates/runtime-metrics/src/models/mod.rs
@@ -49,9 +49,7 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         .build()
 });
 
-/// Publishes this module's unlabelled counters at zero, so a series a healthy
-/// runtime never increments is exported rather than absent. Lives beside the
-/// declarations so the list cannot drift away from them.
+/// See [`crate::publish_component_counters_at_zero`].
 pub fn publish_counters_at_zero() {
     LOAD_ERROR.add(0, &[]);
 }

--- a/crates/runtime-metrics/src/rerankers/mod.rs
+++ b/crates/runtime-metrics/src/rerankers/mod.rs
@@ -40,3 +40,10 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         )
         .build()
 });
+
+/// Publishes this module's unlabelled counters at zero, so a series a healthy
+/// runtime never increments is exported rather than absent. Lives beside the
+/// declarations so the list cannot drift away from them.
+pub fn publish_counters_at_zero() {
+    LOAD_ERROR.add(0, &[]);
+}

--- a/crates/runtime-metrics/src/rerankers/mod.rs
+++ b/crates/runtime-metrics/src/rerankers/mod.rs
@@ -41,9 +41,7 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         .build()
 });
 
-/// Publishes this module's unlabelled counters at zero, so a series a healthy
-/// runtime never increments is exported rather than absent. Lives beside the
-/// declarations so the list cannot drift away from them.
+/// See [`crate::publish_component_counters_at_zero`].
 pub fn publish_counters_at_zero() {
     LOAD_ERROR.add(0, &[]);
 }

--- a/crates/runtime-metrics/src/tools/mod.rs
+++ b/crates/runtime-metrics/src/tools/mod.rs
@@ -40,3 +40,10 @@ pub static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .with_description("Number of errors loading the LLM tool.")
         .build()
 });
+
+/// Publishes this module's unlabelled counters at zero, so a series a healthy
+/// runtime never increments is exported rather than absent. Lives beside the
+/// declarations so the list cannot drift away from them.
+pub fn publish_counters_at_zero() {
+    LOAD_ERROR.add(0, &[]);
+}

--- a/crates/runtime-metrics/src/tools/mod.rs
+++ b/crates/runtime-metrics/src/tools/mod.rs
@@ -41,9 +41,7 @@ pub static LOAD_ERROR: LazyLock<Counter<u64>> = LazyLock::new(|| {
         .build()
 });
 
-/// Publishes this module's unlabelled counters at zero, so a series a healthy
-/// runtime never increments is exported rather than absent. Lives beside the
-/// declarations so the list cannot drift away from them.
+/// See [`crate::publish_component_counters_at_zero`].
 pub fn publish_counters_at_zero() {
     LOAD_ERROR.add(0, &[]);
 }

--- a/crates/runtime-metrics/src/views/mod.rs
+++ b/crates/runtime-metrics/src/views/mod.rs
@@ -34,9 +34,7 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         .build()
 });
 
-/// Publishes this module's unlabelled counters at zero, so a series a healthy
-/// runtime never increments is exported rather than absent. Lives beside the
-/// declarations so the list cannot drift away from them.
+/// See [`crate::publish_component_counters_at_zero`].
 pub fn publish_counters_at_zero() {
     LOAD_ERROR.add(0, &[]);
 }

--- a/crates/runtime-metrics/src/views/mod.rs
+++ b/crates/runtime-metrics/src/views/mod.rs
@@ -33,3 +33,10 @@ pub static STATUS: LazyLock<Gauge<u64>> = LazyLock::new(|| {
         )
         .build()
 });
+
+/// Publishes this module's unlabelled counters at zero, so a series a healthy
+/// runtime never increments is exported rather than absent. Lives beside the
+/// declarations so the list cannot drift away from them.
+pub fn publish_counters_at_zero() {
+    LOAD_ERROR.add(0, &[]);
+}

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -2328,22 +2328,15 @@ mod tests {
     /// when they are first touched, and that binding survives a later
     /// `set_meter_provider`. So this rewires the meter for the whole process and only
     /// the first caller in it wins -- keep it to a single test, as
-    /// `tests/query_failure_err_code.rs` does.
+    /// `tests/metrics.rs` does.
     fn install_prometheus_meter_provider() -> prometheus::Registry {
         let registry = prometheus::Registry::new();
 
-        let exporter = opentelemetry_prometheus::exporter()
-            .with_registry(registry.clone())
-            .without_scope_info()
-            .without_units()
-            .without_counter_suffixes()
-            .without_target_info()
-            .build()
-            .expect("to build the prometheus exporter");
-
         let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
             .with_resource(opentelemetry_sdk::Resource::builder().build())
-            .with_reader(exporter)
+            .with_reader(
+                crate::prometheus_reader(registry.clone()).expect("to build the prometheus reader"),
+            )
             .build();
         opentelemetry::global::set_meter_provider(provider);
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -134,6 +134,7 @@ pub mod resource_monitor {
 pub(crate) use runtime_parameters as parameters;
 
 pub mod podswatcher;
+pub use metrics_server::prometheus_reader;
 pub mod request;
 mod scheduling;
 pub(crate) use runtime_component::schema_evolution;
@@ -1274,6 +1275,13 @@ impl Runtime {
         if caching.embeddings.is_some() {
             CachedEmbeddingResult::init();
         }
+    }
+
+    /// Publishes the component counters at zero. Must be called after
+    /// `init_metrics` in spiced, for the same reason as
+    /// [`Runtime::init_cache_metrics`].
+    pub fn init_component_metrics(&self) {
+        runtime_metrics::publish_component_counters_at_zero();
     }
 
     /// Requests a loaded extension, or will attempt to load it if part of the autoloaded extensions.

--- a/crates/runtime/src/metrics_server/mod.rs
+++ b/crates/runtime/src/metrics_server/mod.rs
@@ -32,7 +32,9 @@ use hyper::{
     header::{CONTENT_TYPE, RETRY_AFTER},
 };
 use hyper_util::{rt::TokioIo, server::conn::auto::Builder as AutoBuilder};
+use opentelemetry_prometheus::PrometheusExporter;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_sdk::error::OTelSdkError;
 use prometheus::{
     Encoder, TextEncoder,
     proto::{Bucket, Histogram, LabelPair, Metric, MetricFamily, MetricType},
@@ -71,6 +73,30 @@ pub enum Error {
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Builds the Prometheus reader that `/metrics` is served from.
+///
+/// The suffixes a dashboard query has to match are decided here, not at the
+/// instrument: `without_counter_suffixes` keeps `query_executions` from being
+/// exposed as `query_executions_total`, and `without_units` keeps `_milliseconds`
+/// off every duration histogram. `spiced` and the metrics tests share this so
+/// neither can drift on those names.
+///
+/// # Errors
+///
+/// Returns an error when the exporter cannot register its collector with
+/// `registry`.
+pub fn prometheus_reader(
+    registry: prometheus::Registry,
+) -> Result<PrometheusExporter, OTelSdkError> {
+    opentelemetry_prometheus::exporter()
+        .with_registry(registry)
+        .without_scope_info()
+        .without_units()
+        .without_counter_suffixes()
+        .without_target_info()
+        .build()
+}
 
 pub(crate) async fn start<A>(
     bind_address: Option<A>,

--- a/crates/runtime/src/metrics_server/mod.rs
+++ b/crates/runtime/src/metrics_server/mod.rs
@@ -76,12 +76,6 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Builds the Prometheus reader that `/metrics` is served from.
 ///
-/// The suffixes a dashboard query has to match are decided here, not at the
-/// instrument: `without_counter_suffixes` keeps `query_executions` from being
-/// exposed as `query_executions_total`, and `without_units` keeps `_milliseconds`
-/// off every duration histogram. `spiced` and the metrics tests share this so
-/// neither can drift on those names.
-///
 /// # Errors
 ///
 /// Returns an error when the exporter cannot register its collector with

--- a/crates/runtime/tests/metrics.rs
+++ b/crates/runtime/tests/metrics.rs
@@ -25,27 +25,39 @@ limitations under the License.
 //! Metrics live in their own test binary because the install order is global: the
 //! metric handles are `LazyLock`s over `global::meter(..)`, so an instrument first
 //! touched before the `MeterProvider` is installed binds to the no-op meter for the
-//! whole process. Every test here shares one provider, installed by [`PROMETHEUS`]
-//! before any instrument exists — see its comment for what that means for
-//! assertions.
+//! whole process.
+//!
+//! Tests are grouped by what drives the metric rather than one per family, so the
+//! surface needs only two runtimes between them.
 
 #![recursion_limit = "256"]
 
 use std::{
     collections::{HashMap, HashSet},
-    sync::LazyLock,
+    sync::{Arc, LazyLock},
+    time::Duration,
 };
 
 use app::AppBuilder;
-use cache::{metrics::CacheMetrics, result::query::CachedQueryResult};
+use cache::{
+    metrics::CacheMetrics,
+    result::{
+        embeddings::CachedEmbeddingResult, query::CachedQueryResult, search::CachedSearchResult,
+    },
+};
 use futures::StreamExt;
 use opentelemetry::global;
 use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
 use runtime::{Runtime, datafusion::query::QueryBuilder};
-use spicepod::component::runtime::{Query, Runtime as SpicepodRuntime, TaskHistory};
+use spicepod::{
+    acceleration::{Acceleration, Mode, RefreshMode},
+    component::dataset::{Dataset, TimeFormat},
+    component::runtime::{Query, Runtime as SpicepodRuntime, TaskHistory},
+};
 
-/// Metrics every query must report, whatever `runtime.task_history.enabled` is
-/// set to. All are emitted from the query tracker.
+/// Metrics every query must report, whatever `runtime.task_history.enabled` is set
+/// to. `query_processed_bytes` needs a real table: the bytes-processed optimizer
+/// only wraps a plan that scans something.
 const EXPECTED_QUERY_METRICS: &[&str] = &[
     "query_duration_ms",
     "query_execution_duration_ms",
@@ -53,44 +65,92 @@ const EXPECTED_QUERY_METRICS: &[&str] = &[
     "query_failures",
     "query_returned_rows",
     "query_returned_bytes",
+    "query_processed_bytes",
+    "query_active_count",
+    "query_produced_spills",
+    "query_spilled_bytes",
+    "query_spilled_rows",
 ];
 
-/// Gauges that must be scrapable once recorded. Emitted by the mem-tier
-/// repartition sampler in `DataFusion::spawn_mem_tier_repartition_sampler`.
-const EXPECTED_MEMORY_METRICS: &[&str] = &[
+/// Series a loaded, refreshed dataset must report. The `max_timestamp` and `lag`
+/// series are opt-in: they need `runtime.metrics` to name them and the dataset to
+/// declare a `time_column`.
+const EXPECTED_DATASET_METRICS: &[&str] = &[
+    "dataset_active_count",
+    "dataset_acceleration_refresh_duration_ms",
+    "dataset_acceleration_last_refresh_unix_time_ms",
+    "dataset_acceleration_max_timestamp_before_refresh_ms",
+    "dataset_acceleration_max_timestamp_after_refresh_ms",
+    "dataset_acceleration_refresh_lag_ms",
+    "dataset_acceleration_ingestion_lag_ms",
+];
+
+/// Gauges the startup registrations record, all on the global meter.
+///
+/// The per-worker tokio gauges (`tokio_runtime_worker_busy_seconds`,
+/// `..._park_count`, `..._steal_count`) are deliberately absent: they need
+/// `RUSTFLAGS="--cfg tokio_unstable"`, which no Spice build sets.
+const EXPECTED_RUNTIME_GAUGES: &[&str] = &[
     "process_resident_memory_bytes",
     "query_memory_pool_used_bytes",
     "cayenne_compaction_memory_pool_used_bytes",
+    "cayenne_compaction_memory_pool_bytes",
+    "spiced_cpu_budget_cores",
+    "spiced_cpu_budget_millicores",
+    "spiced_cpu_limit_millicores",
+    "spiced_cpu_request_millicores",
+    "tokio_runtime_alive_tasks",
+    "tokio_runtime_workers",
+    "tokio_runtime_global_queue_depth",
 ];
 
-/// Series the SQL results cache must export as soon as it is enabled, whether or
-/// not anything has been recorded on them yet.
-///
-/// Each instrument is a `LazyLock` that only registers with the meter when
-/// something first derefs it, so a counter that has not fired exports nothing at
-/// all — not a zero. On a healthy runtime `results_cache_evictions` and both
-/// stale-while-revalidate counters are exactly the ones that never fire, and an
-/// absent series reads as a broken exporter rather than as "nothing happened".
-const EXPECTED_RESULTS_CACHE_METRICS: &[&str] = &[
-    "results_cache_requests",
-    "results_cache_hits",
-    "results_cache_misses",
-    "results_cache_evictions",
-    "results_cache_stale_swr_count",
-    "results_cache_swr_background_query_count",
-    "results_cache_items_count",
-    "results_cache_size_bytes",
-    "results_cache_max_size_bytes",
+/// Counters `publish_component_counters_at_zero` must emit.
+const EXPECTED_COMPONENT_COUNTERS: &[&str] = &[
+    "dataset_load_errors",
+    "catalog_load_errors",
+    "view_load_errors",
+    "model_load_errors",
+    "embeddings_load_errors",
+    "rerankers_load_errors",
+    "tool_load_errors",
+    "component_metric_registered_count",
+];
+
+/// The caches `Runtime::init_cache_metrics` publishes, by exported name prefix.
+/// `results` rather than `sql_results` is the shipped prefix — see
+/// <https://github.com/spiceai/spiceai/issues/6128>.
+const CACHE_PREFIXES: &[&str] = &["results", "search_results", "embeddings"];
+
+/// Every family `generate_cache_metrics!` declares, minus the prefix.
+const CACHE_SUFFIXES: &[&str] = &[
+    "size_bytes",
+    "max_size_bytes",
+    "requests",
+    "hits",
+    "misses",
+    "hit_ratio",
+    "items_count",
+    "evictions",
+    "stale_rejections",
+    "stale_swr_count",
+    "swr_background_query_count",
 ];
 
 /// Small enough that the sort below cannot fit, large enough that the runtime
 /// still starts.
 const QUERY_MEMORY_LIMIT: &str = "16MiB";
 
-/// A `TopK` cannot spill, so it refuses while batches are polled — the path
-/// under test. `fetch` is deliberately larger than the limit can hold.
+/// A `TopK` cannot spill, so it refuses while batches are polled — the path under
+/// test. `fetch` is deliberately larger than the limit can hold.
 const EXHAUSTING_QUERY: &str =
     "SELECT value FROM generate_series(1, 5000000) ORDER BY value DESC LIMIT 4000000";
+
+/// The epoch second the fixture's first generation of rows carries.
+const FIXTURE_EPOCH_SECONDS: i64 = 1_700_000_000;
+
+/// How much later the second generation is stamped. Large enough that a lag
+/// computed in the wrong unit lands nowhere near it.
+const FIXTURE_EPOCH_STEP_SECONDS: i32 = 3_600;
 
 /// The one `MeterProvider` for this binary, installed before any instrument is
 /// built. Forcing this is the first statement of every test that asserts on a
@@ -107,28 +167,23 @@ static PROMETHEUS: LazyLock<prometheus::Registry> =
 
 /// Installs a `MeterProvider` backed by a scrapable Prometheus registry, as
 /// `spiced` does for the `--metrics` endpoint.
+///
+/// The reader comes from [`runtime::prometheus_reader`] so the test and `spiced`
+/// cannot drift on exposition naming.
 fn install_prometheus_meter_provider() -> prometheus::Registry {
     let registry = prometheus::Registry::new();
 
-    let exporter = opentelemetry_prometheus::exporter()
-        .with_registry(registry.clone())
-        .without_scope_info()
-        .without_units()
-        .without_counter_suffixes()
-        .without_target_info()
-        .build()
-        .expect("to build the prometheus exporter");
-
     let provider = SdkMeterProvider::builder()
         .with_resource(Resource::builder().build())
-        .with_reader(exporter)
+        .with_reader(
+            runtime::prometheus_reader(registry.clone()).expect("to build the prometheus reader"),
+        )
         .build();
     global::set_meter_provider(provider);
 
     registry
 }
 
-/// Every metric family on the registry, by name.
 fn reported_metric_names(registry: &prometheus::Registry) -> HashSet<String> {
     registry
         .gather()
@@ -137,11 +192,43 @@ fn reported_metric_names(registry: &prometheus::Registry) -> HashSet<String> {
         .collect()
 }
 
-/// The names in `reported`, sorted, for an assertion message.
 fn sorted(reported: &HashSet<String>) -> Vec<&String> {
     let mut names: Vec<&String> = reported.iter().collect();
     names.sort();
     names
+}
+
+/// Fails naming every metric in `expected` that `reported` does not carry.
+fn assert_all_reported(reported: &HashSet<String>, expected: &[&str], what: &str) {
+    let missing: Vec<&str> = expected
+        .iter()
+        .copied()
+        .filter(|metric| !reported.contains(*metric))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "{what}: {missing:?} did not reach the metrics pipeline. Reported: {:?}",
+        sorted(reported)
+    );
+}
+
+/// The value of the gauge `name`, which must carry exactly one series.
+///
+/// Taking the first of several would silently pick a winner, so a second dataset
+/// in the fixture app has to fail here rather than assert against an arbitrary one.
+fn gauge_value(registry: &prometheus::Registry, name: &str) -> Option<f64> {
+    let family = registry
+        .gather()
+        .into_iter()
+        .find(|family| family.name() == name)?;
+    let series = family.get_metric();
+    assert_eq!(
+        series.len(),
+        1,
+        "{name} carries {} series, so there is no single value to assert on",
+        series.len()
+    );
+    series.first().map(|m| m.get_gauge().value())
 }
 
 /// The count recorded on `query_failures` for each `err_code` label.
@@ -163,109 +250,171 @@ fn failures_by_err_code(registry: &prometheus::Registry) -> HashMap<String, f64>
         .collect()
 }
 
-/// How much `query_failures{err_code}` grew between two [`failures_by_err_code`]
-/// snapshots.
+/// How much `query_failures{err_code}` grew between two snapshots.
 fn increment(before: &HashMap<String, f64>, after: &HashMap<String, f64>, err_code: &str) -> f64 {
     let at = |counts: &HashMap<String, f64>| counts.get(err_code).copied().unwrap_or(0.0);
     at(after) - at(before)
 }
 
-#[tokio::test]
-async fn query_metrics_are_reported_when_task_history_is_disabled() {
+fn expected_cache_metrics() -> Vec<String> {
+    CACHE_PREFIXES
+        .iter()
+        .flat_map(|prefix| {
+            CACHE_SUFFIXES
+                .iter()
+                .map(move |suffix| format!("{prefix}_cache_{suffix}"))
+        })
+        .collect()
+}
+
+/// The opt-in acceleration metrics the fixture enables.
+///
+/// This is `runtime.metrics`, not the dataset's own `metrics:` — the latter gates
+/// connector component metrics, and setting it here would silently do nothing.
+fn opt_in_acceleration_metrics() -> spicepod::metric::Metrics {
+    let metrics = [
+        runtime_metrics::acceleration::METRIC_MAX_TIMESTAMP_BEFORE_REFRESH_MS,
+        runtime_metrics::acceleration::METRIC_MAX_TIMESTAMP_AFTER_REFRESH_MS,
+        runtime_metrics::acceleration::METRIC_REFRESH_LAG_MS,
+        runtime_metrics::acceleration::METRIC_INGESTION_LAG_MS,
+    ]
+    .into_iter()
+    .map(|name| spicepod::metric::Metric {
+        enabled: true,
+        name: name.to_string(),
+    })
+    .collect();
+    spicepod::metric::Metrics { metrics }
+}
+
+fn fixture_csv(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    dir.join(format!("{name}.csv"))
+}
+
+fn write_fixture_csv(path: &std::path::Path, base_epoch_seconds: i64) {
+    use std::fmt::Write as _;
+
+    let mut csv = String::from("id,score,ts\n");
+    for i in 0..3 {
+        let _ = writeln!(csv, "{},{},{}", i + 1, (i + 1) * 10, base_epoch_seconds + i);
+    }
+    std::fs::write(path, csv).expect("to write the fixture csv");
+}
+
+/// A local file and the built-in `arrow` accelerator need no cargo feature and no
+/// connector registration — `file` self-registers through
+/// `register_data_connector!` — so this works in the gate's feature-less build.
+/// `ts` is a Unix-seconds integer because CSV inference types it as `Int64`.
+fn csv_backed_dataset(dir: &std::path::Path, name: &str) -> Dataset {
+    let csv = fixture_csv(dir, name);
+    write_fixture_csv(&csv, FIXTURE_EPOCH_SECONDS);
+
+    let mut dataset = Dataset::new(format!("file://{}", csv.display()), name);
+    dataset.time_column = Some("ts".to_string());
+    dataset.time_format = Some(TimeFormat::UnixSeconds);
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        engine: Some("arrow".to_string()),
+        mode: Mode::Memory,
+        refresh_mode: Some(RefreshMode::Full),
+        ..Acceleration::default()
+    });
+    dataset
+}
+
+async fn wait_until<F, Fut>(timeout: Duration, mut f: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        if f().await {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}
+
+/// Startup must publish every counter a dashboard panel reads, at zero.
+///
+/// These are exactly the calls `init_cache_metrics` and `init_component_metrics`
+/// make, and nothing else here touches a cache or component instrument, so a
+/// series present afterwards was published by startup rather than by a real event.
+#[test]
+fn startup_publishes_the_cache_and_component_counters_at_zero() {
     let registry = &*PROMETHEUS;
 
-    let app = AppBuilder::new("query_metrics_without_task_history")
-        .with_runtime(SpicepodRuntime {
-            task_history: TaskHistory {
-                enabled: false,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-        .build();
-
-    let rt = Runtime::builder().with_app(app).build().await;
-
-    let mut result = QueryBuilder::new("SELECT 1", rt.datafusion())
-        .build()
-        .run()
-        .await
-        .expect("query to run");
-
-    // The metrics are recorded when the result stream terminates, so drain it.
-    let mut rows = 0;
-    while let Some(batch) = result.data.next().await {
-        rows += batch.expect("batch to stream without error").num_rows();
-    }
-    assert_eq!(rows, 1, "SELECT 1 returns a single row");
-
-    // `query_failures` is recorded on the error path, on its own meter.
-    let failed = QueryBuilder::new("SELECT * FROM does_not_exist", rt.datafusion())
-        .build()
-        .run()
-        .await;
-    assert!(failed.is_err(), "a query on a missing table must fail");
+    CachedQueryResult::init();
+    CachedSearchResult::init();
+    CachedEmbeddingResult::init();
+    runtime_metrics::publish_component_counters_at_zero();
 
     let reported = reported_metric_names(registry);
-    let missing: Vec<&str> = EXPECTED_QUERY_METRICS
-        .iter()
-        .copied()
-        .filter(|metric| !reported.contains(*metric))
-        .collect();
-    assert!(
-        missing.is_empty(),
-        "query metrics {missing:?} were not reported with task history disabled; reported: {:?}",
-        sorted(&reported)
+
+    let cache_metrics = expected_cache_metrics();
+    let cache_metrics: Vec<&str> = cache_metrics.iter().map(String::as_str).collect();
+    assert_all_reported(
+        &reported,
+        &cache_metrics,
+        "cache metrics were not exported after the caches were initialised, so an operator \
+         scraping a healthy runtime cannot tell them from a broken exporter",
+    );
+
+    assert_all_reported(
+        &reported,
+        EXPECTED_COMPONENT_COUNTERS,
+        "component counters were not published at zero, so a dashboard panel on a healthy \
+         runtime reads \"No data\" rather than zero",
     );
 }
 
-#[test]
-fn memory_gauges_are_exported_to_the_operator_metrics_pipeline() {
+/// The startup registrations must land on the operator's provider.
+///
+/// `register_cpu_budget_metrics` and `register_tokio_runtime_metrics` both require
+/// that `init_metrics` has run; forcing [`PROMETHEUS`] first is that ordering.
+#[tokio::test]
+async fn startup_registrations_export_the_process_and_runtime_gauges() {
     let registry = &*PROMETHEUS;
 
-    // Record through the same entry points the sampler calls, so a gauge wired
-    // to the wrong meter fails here rather than silently on an operator's host.
     telemetry::track_process_resident_memory_bytes(1_024, &[]);
     telemetry::cayenne::track_query_memory_pool_used_bytes(2_048, &[]);
     telemetry::cayenne::track_compaction_memory_pool_used_bytes(4_096, &[]);
+    telemetry::cayenne::track_compaction_memory_pool_bytes(8_192, &[]);
 
-    let reported = reported_metric_names(registry);
-    let missing: Vec<&str> = EXPECTED_MEMORY_METRICS
-        .iter()
-        .copied()
-        .filter(|metric| !reported.contains(*metric))
-        .collect();
-    assert!(
-        missing.is_empty(),
-        "memory gauges {missing:?} were recorded but not exported to the Prometheus registry \
-         (a gauge on the anonymous-telemetry meter never reaches /metrics); reported: {:?}",
-        sorted(&reported)
+    // Both optional arms are `Some`: a `None` records nothing at all, so the limit
+    // and request gauges would simply be absent.
+    telemetry::register_cpu_budget_metrics(4, 4_000, "test", Some(4_000), Some(2_000));
+    telemetry::register_tokio_runtime_metrics(vec![("main", tokio::runtime::Handle::current())]);
+
+    assert_all_reported(
+        &reported_metric_names(registry),
+        EXPECTED_RUNTIME_GAUGES,
+        "process and runtime gauges were recorded but not exported to the Prometheus registry \
+         (a gauge on the anonymous-telemetry meter never reaches /metrics)",
     );
 }
 
-/// The sampler's first sample lands before the operator's provider exists, and
-/// the gauge must still reach `/metrics` afterwards.
+/// The sampler's first sample lands before the operator's provider exists, and the
+/// gauge must still reach `/metrics` afterwards.
 ///
 /// `tokio::time::interval` fires its first tick immediately, so
-/// `spawn_mem_tier_repartition_sampler` records before `init_metrics` installs
-/// the Prometheus provider. An instrument cached at that moment binds to the
-/// startup noop provider for the life of the process, which is what kept
+/// `spawn_mem_tier_repartition_sampler` records before `init_metrics` installs the
+/// Prometheus provider. An instrument cached at that moment binds to the startup
+/// noop provider for the life of the process, which is what kept
 /// `query_memory_pool_used_bytes` and `cayenne_compaction_memory_pool_used_bytes`
 /// off `/metrics` entirely — regression test for #12667.
 ///
-/// `process_resident_memory_bytes` is asserted alongside them even though it was
-/// scrapable, because it was only ever scrapable by accident: it is recorded
-/// after a `spawn_blocking(...).await` in the same loop iteration, and that
-/// round-trip happened to outlast the window. Nothing holds that ordering, so it
-/// is pinned here rather than left to survive on timing.
+/// `process_resident_memory_bytes` is asserted alongside them because it was only
+/// ever scrapable by accident: it is recorded after a `spawn_blocking(...).await`
+/// in the same loop iteration, and that round-trip happened to outlast the window.
 ///
-/// [`memory_gauges_are_exported_to_the_operator_metrics_pipeline`] cannot catch
-/// that: it forces [`PROMETHEUS`] first, so it only ever records after the
-/// install. This test records *before* it, which under `cargo nextest` — one
-/// process per test, the gate's runner — means the global provider really is
-/// the noop one at that point. Under `cargo test` a sibling thread may have
-/// installed it already, which costs the test its teeth but not its safety: the
-/// seal below always follows the install, never precedes it.
+/// [`startup_registrations_export_the_process_and_runtime_gauges`] cannot catch
+/// this: it forces [`PROMETHEUS`] first, so it only ever records after the install.
+/// Under `cargo test` a sibling thread may have installed the provider already,
+/// which costs this test its teeth but not its safety — the seal always follows
+/// the install.
 #[test]
 fn a_gauge_recorded_before_the_provider_is_installed_still_reaches_metrics() {
     // Deliberately ahead of `&*PROMETHEUS`: this is the sampler's first tick.
@@ -282,31 +431,27 @@ fn a_gauge_recorded_before_the_provider_is_installed_still_reaches_metrics() {
     telemetry::cayenne::track_query_memory_pool_used_bytes(16_384, &[]);
     telemetry::cayenne::track_compaction_memory_pool_used_bytes(32_768, &[]);
 
-    let reported = reported_metric_names(registry);
-    let missing: Vec<&str> = EXPECTED_MEMORY_METRICS
-        .iter()
-        .copied()
-        .filter(|metric| !reported.contains(*metric))
-        .collect();
-    assert!(
-        missing.is_empty(),
-        "memory gauges {missing:?} were recorded before the meter provider was installed and \
-         never recovered; a gauge cached against the startup noop provider never reaches \
-         /metrics. Reported: {:?}",
-        sorted(&reported)
+    assert_all_reported(
+        &reported_metric_names(registry),
+        &[
+            "process_resident_memory_bytes",
+            "query_memory_pool_used_bytes",
+            "cayenne_compaction_memory_pool_used_bytes",
+        ],
+        "memory gauges were recorded before the meter provider was installed and never \
+         recovered; a gauge cached against the startup noop provider never reaches /metrics",
     );
 }
 
-/// Reads the resident set size directly and touches no instrument, so it needs
-/// no meter provider.
+/// Reads the resident set size directly and touches no instrument, so it needs no
+/// meter provider.
 #[test]
 fn resident_memory_is_a_plausible_reading() {
     let rss = runtime::resource_monitor::process_resident_memory_bytes()
         .expect("resident set size to be readable on a supported platform");
 
-    // A live test process holds more than a page and less than a terabyte. The
-    // point is unit sanity: a kB-vs-bytes mix-up on either arm lands far outside
-    // this band rather than merely looking small.
+    // A live test process holds more than a page and less than a terabyte. A
+    // kB-vs-bytes mix-up on either arm lands far outside this band.
     assert!(
         rss > 1_048_576,
         "resident set size {rss} B is below 1 MiB, which suggests a kB value was reported as bytes"
@@ -314,6 +459,102 @@ fn resident_memory_is_a_plausible_reading() {
     assert!(
         rss < 1_099_511_627_776,
         "resident set size {rss} B exceeds 1 TiB, which suggests a bytes value was scaled again"
+    );
+}
+
+/// A refreshed, accelerated dataset must report the query and refresh families.
+///
+/// One runtime covers three groups. `task_history` is disabled because the query
+/// metrics must not depend on it.
+#[tokio::test]
+async fn an_accelerated_dataset_reports_the_query_and_refresh_families() {
+    let registry = &*PROMETHEUS;
+
+    let dir = tempfile::tempdir().expect("a temporary directory for the fixture");
+    let app = AppBuilder::new("metrics_accelerated_dataset")
+        .with_dataset(csv_backed_dataset(dir.path(), "scores"))
+        .with_runtime(SpicepodRuntime {
+            task_history: TaskHistory {
+                enabled: false,
+                ..Default::default()
+            },
+            metrics: Some(opt_in_acceleration_metrics()),
+            ..Default::default()
+        })
+        .build();
+
+    let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+
+    tokio::time::timeout(Duration::from_mins(1), Arc::clone(&rt).load_components())
+        .await
+        .expect("the dataset to load within a minute");
+    assert!(
+        wait_until(Duration::from_mins(1), || async { rt.status().is_ready() }).await,
+        "the runtime never reported ready, so the dataset never loaded"
+    );
+
+    // Move the source forward before refreshing. An unchanged file lets the
+    // connector answer "nothing to fetch" and return before any lag metric is
+    // recorded, and identical timestamps would make a lag of zero indistinguishable
+    // from a lag never computed.
+    write_fixture_csv(
+        &fixture_csv(dir.path(), "scores"),
+        FIXTURE_EPOCH_SECONDS + i64::from(FIXTURE_EPOCH_STEP_SECONDS),
+    );
+
+    let notifier = rt
+        .datafusion()
+        .refresh_table(&datafusion::common::TableReference::from("scores"), None)
+        .await
+        .expect("the refresh request to be accepted")
+        .expect("an accelerated table to return a refresh notifier");
+    notifier.notified().await;
+
+    let mut result = QueryBuilder::new("SELECT id, score FROM scores", rt.datafusion())
+        .build()
+        .run()
+        .await
+        .expect("query to run");
+
+    // The metrics are recorded when the result stream terminates, so drain it.
+    let mut rows = 0;
+    while let Some(batch) = result.data.next().await {
+        rows += batch.expect("batch to stream without error").num_rows();
+    }
+    assert_eq!(rows, 3, "the fixture csv holds three rows");
+
+    let failed = QueryBuilder::new("SELECT * FROM does_not_exist", rt.datafusion())
+        .build()
+        .run()
+        .await;
+    assert!(failed.is_err(), "a query on a missing table must fail");
+
+    let reported = reported_metric_names(registry);
+    assert_all_reported(
+        &reported,
+        EXPECTED_QUERY_METRICS,
+        "query metrics were not reported with task history disabled",
+    );
+    assert_all_reported(
+        &reported,
+        EXPECTED_DATASET_METRICS,
+        "a loaded and refreshed dataset did not report its acceleration metrics",
+    );
+    assert_all_reported(
+        &reported,
+        &["secrets_store_load_duration_ms"],
+        "building a runtime did not time the secret-store load",
+    );
+
+    // Presence is not enough for a lag gauge: a unit or sign slip leaves the series
+    // on the dashboard and the number wrong.
+    let refresh_lag_ms = gauge_value(registry, "dataset_acceleration_refresh_lag_ms")
+        .expect("the refresh-lag gauge to carry a value");
+    let expected_lag_ms = f64::from(FIXTURE_EPOCH_STEP_SECONDS * 1_000);
+    assert!(
+        (refresh_lag_ms - expected_lag_ms).abs() < f64::EPSILON,
+        "the source moved {FIXTURE_EPOCH_STEP_SECONDS}s forward, so the refresh lag must be \
+         {expected_lag_ms}ms, not {refresh_lag_ms}ms"
     );
 }
 
@@ -377,31 +618,5 @@ async fn a_mid_stream_pool_refusal_is_counted_as_resources_exhausted() {
         increment(&before, &after, "QueryExecutionError") < 1.0,
         "capacity must not also be counted as a generic execution failure; \
          counts went from {before:?} to {after:?}"
-    );
-}
-
-/// The runtime calls `init` for each configured cache at startup, and that is the
-/// only chance an instrument nothing has touched gets to appear on `/metrics`.
-#[test]
-fn cache_counters_are_exported_before_anything_is_recorded() {
-    let registry = &*PROMETHEUS;
-
-    // Exactly what `Runtime::init_cache_metrics` calls once `runtime.caching.sql_results`
-    // is configured. Nothing else in this test touches a cache instrument, so a series
-    // present afterwards was published by `init` rather than by a real cache event.
-    CachedQueryResult::init();
-
-    let reported = reported_metric_names(registry);
-    let missing: Vec<&str> = EXPECTED_RESULTS_CACHE_METRICS
-        .iter()
-        .copied()
-        .filter(|metric| !reported.contains(*metric))
-        .collect();
-    assert!(
-        missing.is_empty(),
-        "cache metrics {missing:?} were not exported after the cache was initialised, so an \
-         operator scraping a healthy runtime cannot tell them from a broken exporter; \
-         reported: {:?}",
-        sorted(&reported)
     );
 }

--- a/crates/runtime/tests/metrics.rs
+++ b/crates/runtime/tests/metrics.rs
@@ -494,7 +494,9 @@ async fn an_accelerated_dataset_reports_the_query_and_refresh_families() {
         .await
         .expect("the refresh request to be accepted")
         .expect("an accelerated table to return a refresh notifier");
-    notifier.notified().await;
+    tokio::time::timeout(Duration::from_mins(1), notifier.notified())
+        .await
+        .expect("the refresh to complete within a minute");
 
     let mut result = QueryBuilder::new("SELECT id, score FROM scores", rt.datafusion())
         .build()

--- a/crates/runtime/tests/metrics.rs
+++ b/crates/runtime/tests/metrics.rs
@@ -25,10 +25,8 @@ limitations under the License.
 //! Metrics live in their own test binary because the install order is global: the
 //! metric handles are `LazyLock`s over `global::meter(..)`, so an instrument first
 //! touched before the `MeterProvider` is installed binds to the no-op meter for the
-//! whole process.
-//!
-//! Tests are grouped by what drives the metric rather than one per family, so the
-//! surface needs only two runtimes between them.
+//! whole process. Tests are grouped by what drives the metric rather than one per
+//! family, so the surface needs only two runtimes between them.
 
 #![recursion_limit = "256"]
 
@@ -73,8 +71,8 @@ const EXPECTED_QUERY_METRICS: &[&str] = &[
 ];
 
 /// Series a loaded, refreshed dataset must report. The `max_timestamp` and `lag`
-/// series are opt-in: they need `runtime.metrics` to name them and the dataset to
-/// declare a `time_column`.
+/// series are off by default: they need `runtime.metrics` to name them and the
+/// dataset to declare a `time_column`.
 const EXPECTED_DATASET_METRICS: &[&str] = &[
     "dataset_active_count",
     "dataset_acceleration_refresh_duration_ms",
@@ -152,16 +150,12 @@ const FIXTURE_EPOCH_SECONDS: i64 = 1_700_000_000;
 /// computed in the wrong unit lands nowhere near it.
 const FIXTURE_EPOCH_STEP_SECONDS: i32 = 3_600;
 
-/// The one `MeterProvider` for this binary, installed before any instrument is
-/// built. Forcing this is the first statement of every test that asserts on a
-/// metric, so the install wins the race however the harness schedules them:
-/// `cargo nextest` gives each test its own process, `cargo test` gives them
-/// threads, and `LazyLock` covers both.
+/// The one `MeterProvider` for this binary. Every test that asserts on a metric
+/// forces this first, so the install wins the race under either test harness.
 ///
-/// Sharing the registry means an assertion must not depend on what siblings
-/// recorded. Presence assertions are safe, because each test records what it
-/// checks. A count assertion is not, so it must compare a before/after delta —
-/// see [`a_mid_stream_pool_refusal_is_counted_as_resources_exhausted`].
+/// The registry is shared, so an assertion must not depend on what siblings
+/// recorded: presence is safe, a count must compare a before/after delta — see
+/// [`a_mid_stream_pool_refusal_is_counted_as_resources_exhausted`].
 static PROMETHEUS: LazyLock<prometheus::Registry> =
     LazyLock::new(install_prometheus_meter_provider);
 
@@ -267,7 +261,7 @@ fn expected_cache_metrics() -> Vec<String> {
         .collect()
 }
 
-/// The opt-in acceleration metrics the fixture enables.
+/// The acceleration metrics the fixture enables. They are off unless named here.
 ///
 /// This is `runtime.metrics`, not the dataset's own `metrics:` — the latter gates
 /// connector component metrics, and setting it here would silently do nothing.
@@ -396,25 +390,18 @@ async fn startup_registrations_export_the_process_and_runtime_gauges() {
     );
 }
 
-/// The sampler's first sample lands before the operator's provider exists, and the
-/// gauge must still reach `/metrics` afterwards.
+/// A gauge recorded before the provider is installed must still reach `/metrics`.
 ///
-/// `tokio::time::interval` fires its first tick immediately, so
-/// `spawn_mem_tier_repartition_sampler` records before `init_metrics` installs the
-/// Prometheus provider. An instrument cached at that moment binds to the startup
-/// noop provider for the life of the process, which is what kept
-/// `query_memory_pool_used_bytes` and `cayenne_compaction_memory_pool_used_bytes`
-/// off `/metrics` entirely — regression test for #12667.
+/// `tokio::time::interval` fires its first tick immediately, so the mem-tier
+/// sampler records before `init_metrics` installs the Prometheus provider. An
+/// instrument cached at that moment binds to the startup noop provider for the life
+/// of the process, which kept `query_memory_pool_used_bytes` and
+/// `cayenne_compaction_memory_pool_used_bytes` off `/metrics` entirely — regression
+/// test for #12667.
 ///
-/// `process_resident_memory_bytes` is asserted alongside them because it was only
-/// ever scrapable by accident: it is recorded after a `spawn_blocking(...).await`
-/// in the same loop iteration, and that round-trip happened to outlast the window.
-///
-/// [`startup_registrations_export_the_process_and_runtime_gauges`] cannot catch
-/// this: it forces [`PROMETHEUS`] first, so it only ever records after the install.
-/// Under `cargo test` a sibling thread may have installed the provider already,
-/// which costs this test its teeth but not its safety — the seal always follows
-/// the install.
+/// Only meaningful under `cargo nextest`, where this test gets its own process. In
+/// a shared process a sibling may have installed the provider already, which costs
+/// the test its teeth but not its safety.
 #[test]
 fn a_gauge_recorded_before_the_provider_is_installed_still_reaches_metrics() {
     // Deliberately ahead of `&*PROMETHEUS`: this is the sampler's first tick.
@@ -464,8 +451,7 @@ fn resident_memory_is_a_plausible_reading() {
 
 /// A refreshed, accelerated dataset must report the query and refresh families.
 ///
-/// One runtime covers three groups. `task_history` is disabled because the query
-/// metrics must not depend on it.
+/// `task_history` is disabled because the query metrics must not depend on it.
 #[tokio::test]
 async fn an_accelerated_dataset_reports_the_query_and_refresh_families() {
     let registry = &*PROMETHEUS;
@@ -540,12 +526,6 @@ async fn an_accelerated_dataset_reports_the_query_and_refresh_families() {
         EXPECTED_DATASET_METRICS,
         "a loaded and refreshed dataset did not report its acceleration metrics",
     );
-    assert_all_reported(
-        &reported,
-        &["secrets_store_load_duration_ms"],
-        "building a runtime did not time the secret-store load",
-    );
-
     // Presence is not enough for a lag gauge: a unit or sign slip leaves the series
     // on the dashboard and the number wrong.
     let refresh_lag_ms = gauge_value(registry, "dataset_acceleration_refresh_lag_ms")


### PR DESCRIPTION
## 📝 Summary

1. **Move the Prometheus reader configuration into a reusable `runtime::prometheus_reader()`.** The exporter builder (`without_scope_info`, `without_units`, `without_counter_suffixes`, `without_target_info`) was hand-rolled in `spiced`'s `init_metrics` and copied again in `crates/runtime/src/init/dataset.rs`. Those names are what dashboards query, so both callers now share one definition. `opentelemetry-prometheus` is dropped from `bin/spiced`, unused after the move.

2. **Fix component metrics that are never exposed**, the same problem #12687 fixed for the cache counters: a `LazyLock` counter that never fires exports no series at all, so the panel reads "No data" rather than zero. Each module now publishes its own at zero, beside the declarations:

   - `dataset_load_errors`
   - `catalog_load_errors`
   - `view_load_errors`
   - `model_load_errors`
   - `embeddings_load_errors`
   - `rerankers_load_errors`
   - `tool_load_errors`
   - `component_metric_registered_count`
   - `results_cache_hit_ratio`, `search_results_cache_hit_ratio`, `embeddings_cache_hit_ratio`

   Only counters whose real emission is unlabelled qualify — an unlabelled zero in a labelled family like `dataset_active_count{engine}` would be a phantom series nothing updates.

3. **Extend `crates/runtime/tests/metrics.rs` from 18 asserted metric families to 70**, in six tests grouped by what drives the metric (whole binary runs in under a second):

   - 33 cache families across `results`, `search_results`, `embeddings`
   - 8 component counters
   - 11 query families, including `query_processed_bytes`, `query_active_count` and the spill trio
   - 7 dataset and acceleration families, including `refresh_lag_ms` asserted by value, not just presence
   - 11 process and runtime gauges: RSS, Cayenne pools, `spiced_cpu_*`, `tokio_runtime_*`
   - `query_failures{err_code}` on a mid-stream memory-pool refusal

## 🔗 Related

Same bug as #12687 (`results_cache_evictions` never exported on a healthy runtime), already fixed for the cache counters and here for the component ones.
