### PR TITLE
fix(runtime): bound the spicepod apply so an unloadable dataset cannot wedge it (fixes #12862)

### DIFF
--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -81,7 +81,7 @@ use util::{error_spaced, warn_spaced};
 /// This bounds one dataset, not one apply: `apply_dataset_diff` updates changed
 /// datasets sequentially, so an apply changing several of them can spend this
 /// bound once per dataset.
-const HOT_RELOAD_INITIAL_REFRESH_TIMEOUT: Duration = Duration::from_secs(300);
+const HOT_RELOAD_INITIAL_REFRESH_TIMEOUT: Duration = Duration::from_mins(5);
 
 impl Runtime {
     pub(crate) async fn load_datasets(self: Arc<Self>) {
@@ -1957,14 +1957,14 @@ async fn await_hot_reload_initial_refresh(
     // `notify_waiters` is what both producers call. So a refresh completing
     // between here and the `select!` still wakes this wait; constructing after
     // the check would drop it and cost the whole bound.
-    let notified = notifier.notified();
+    let refresh_notified = notifier.notified();
 
     if initial_load_completed() {
         return Ok(());
     }
 
     tokio::select! {
-        () = notified => return Ok(()),
+        () = refresh_notified => return Ok(()),
         () = shutdown_token.cancelled() => return Ok(()),
         () = tokio::time::sleep(timeout) => {}
     }

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -73,11 +73,14 @@ use util::{error_spaced, warn_spaced};
 /// complete its first refresh before abandoning the in-place swap and reloading
 /// the dataset from scratch.
 ///
-/// `apply_app` holds `apply_app_lock` for the duration, so this is the longest a
-/// single changed dataset can delay the applies queued behind it. Sized to cover
-/// an ordinary reload of a non-file acceleration — file accelerations do not take
-/// this path at all (`accelerated_dataset_supports_hot_reload`) — while still
-/// recovering without a process restart when the refresh never completes.
+/// Sized to cover an ordinary reload of a non-file acceleration — file
+/// accelerations do not take this path at all
+/// (`accelerated_dataset_supports_hot_reload`) — while still recovering without a
+/// process restart when the refresh never completes.
+///
+/// This bounds one dataset, not one apply: `apply_dataset_diff` updates changed
+/// datasets sequentially, so an apply changing several of them can spend this
+/// bound once per dataset.
 const HOT_RELOAD_INITIAL_REFRESH_TIMEOUT: Duration = Duration::from_secs(300);
 
 impl Runtime {
@@ -1092,20 +1095,23 @@ impl Runtime {
                 // File accelerated datasets don't support hot reload.
                 if Self::accelerated_dataset_supports_hot_reload(&ds, &*connector) {
                     tracing::info!("Accelerated Dataset {} updating...", &ds.name);
-                    if matches!(
-                        Arc::clone(&self)
-                            .reload_accelerated_dataset(Arc::clone(&ds), Arc::clone(&connector))
-                            .await,
-                        Ok(())
-                    ) {
-                        self.status
-                            .update_dataset(&ds.name, status::ComponentStatus::Ready);
-                        return;
+                    match Arc::clone(&self)
+                        .reload_accelerated_dataset(Arc::clone(&ds), Arc::clone(&connector))
+                        .await
+                    {
+                        Ok(()) => {
+                            self.status
+                                .update_dataset(&ds.name, status::ComponentStatus::Ready);
+                            return;
+                        }
+                        // The reason is the only thing that distinguishes a swap
+                        // that could not be built from one whose acceleration
+                        // never finished loading, and the fallback hides both.
+                        Err(err) => tracing::warn!(
+                            "Falling back to a full reload of dataset {}: {err}",
+                            ds.name
+                        ),
                     }
-                    tracing::debug!(
-                        "Failed to create accelerated table for dataset {}, falling back to full dataset reload",
-                        ds.name
-                    );
                 }
 
                 Arc::clone(&self)
@@ -1269,11 +1275,11 @@ impl Runtime {
                 })?,
         );
 
-        let notifier = accelerated_table.refresher().on_complete_notification();
+        let refresher = accelerated_table.refresher();
+        let notifier = refresher.on_complete_notification();
 
         // wait for accelerated table to be ready
         if let Some(notifier) = notifier {
-            let refresher = accelerated_table.refresher();
             await_hot_reload_initial_refresh(
                 &ds.name,
                 &|| refresher.initial_load_completed(),
@@ -1678,7 +1684,11 @@ impl Runtime {
         // child racing its parent would fail for good rather than retry.
         let mut added_futures: HashMap<TableReference, Pin<Box<dyn Future<Output = ()> + Send>>> =
             HashMap::new();
-        let mut added_localpod = Vec::new();
+        // Keyed by parent so several localpod datasets reading from one newly added
+        // dataset all chain behind the same load, rather than the first one
+        // consuming it and the rest racing it.
+        let mut localpod_by_parent: HashMap<TableReference, Vec<(Arc<Dataset>, BootstrapStatus)>> =
+            HashMap::new();
 
         for ds in &datasets_to_apply {
             let bootstrap_status = match init_results.get(&ds.name) {
@@ -1702,14 +1712,15 @@ impl Runtime {
                 .update_dataset(&ds.name, status::ComponentStatus::Initializing);
 
             if ds.source() == LOCALPOD_DATACONNECTOR {
-                added_localpod.push((Arc::clone(ds), bootstrap_status));
+                localpod_by_parent
+                    .entry(TableReference::parse_str(ds.path()))
+                    .or_default()
+                    .push((Arc::clone(ds), bootstrap_status));
                 continue;
             }
 
-            // The runtime's shared semaphore is what makes these loads honor
-            // `runtime.dataset_load_parallelism`; the per-dataset
-            // `Semaphore::MAX_PERMITS` this replaces opted every reconcile load out
-            // of that budget.
+            // The runtime's shared semaphore is what keeps these loads inside the
+            // `runtime.dataset_load_parallelism` budget.
             let runtime = Arc::clone(&self);
             let ds_clone = Arc::clone(ds);
             let load_semaphore = Arc::clone(&self.dataset_load_semaphore);
@@ -1723,19 +1734,6 @@ impl Runtime {
             );
         }
 
-        // Grouped by parent so several localpod datasets reading from one newly
-        // added dataset all chain behind the same load, rather than the first one
-        // consuming it and the rest racing it.
-        let mut localpod_by_parent: HashMap<TableReference, Vec<(Arc<Dataset>, BootstrapStatus)>> =
-            HashMap::new();
-        for (ds, bootstrap_status) in added_localpod {
-            localpod_by_parent
-                .entry(TableReference::parse_str(ds.path()))
-                .or_default()
-                .push((ds, bootstrap_status));
-        }
-
-        let mut to_spawn: Vec<Pin<Box<dyn Future<Output = ()> + Send>>> = Vec::new();
         for (parent, children) in localpod_by_parent {
             // Chain behind the parent only when this same diff adds it. A parent
             // that is unchanged, or that was updated in the loop above, is already
@@ -1743,7 +1741,7 @@ impl Runtime {
             let parent_future = added_futures.remove(&parent);
             let runtime = Arc::clone(&self);
             let load_semaphore = Arc::clone(&self.dataset_load_semaphore);
-            to_spawn.push(Box::pin(async move {
+            tokio::spawn(async move {
                 if let Some(parent_future) = parent_future {
                     parent_future.await;
                 }
@@ -1755,11 +1753,10 @@ impl Runtime {
                     )
                 }))
                 .await;
-            }));
+            });
         }
-        to_spawn.extend(added_futures.into_values());
 
-        for load in to_spawn {
+        for load in added_futures.into_values() {
             tokio::spawn(load);
         }
 
@@ -1919,20 +1916,27 @@ pub struct RegisterDatasetContext {
 /// loaded yet.
 ///
 /// The wait is bounded because `apply_app` holds `apply_app_lock` across it, and
-/// three shapes never deliver the notification at all:
+/// three shapes never deliver a notification the caller can see:
 ///
 /// - a `refresh_mode: changes` stream that never produces a ready envelope — the
 ///   notifier fires only when one is applied;
-/// - a completion landing between the table's construction and this
-///   `notified()` registering. [`tokio::sync::Notify::notify_waiters`] stores no
-///   permit, so that wakeup is lost, and a `RefreshMode::Full` dataset with no
-///   `check_interval` never fires a second one;
+/// - a refresh completing before this wait is entered at all.
+///   [`tokio::sync::Notify::notify_waiters`] stores no permit, so that wakeup is
+///   gone, and a `RefreshMode::Full` dataset with no `check_interval` never fires
+///   a second one;
 /// - a cluster scheduler, which notifies waiters from inside the builder —
-///   before any caller can subscribe — precisely because it runs no refresh.
+///   before any caller holds the notifier — precisely because it runs no refresh.
 ///
-/// The last two leave the table already loaded, so `initial_load_completed` is
-/// consulted on both sides of the wait: a lost wakeup resolves as success rather
-/// than burning the timeout and then discarding a table that is ready.
+/// Only the second is recoverable here, and only via `initial_load_completed`:
+/// the refresher sets that flag just *after* it notifies (`Refresher::start`), so
+/// the flag is what remains once the edge is gone. It is read after the bound as
+/// well as before it, so a wakeup that predates this call resolves as success
+/// instead of discarding a table that is loaded.
+///
+/// The scheduler shape is not recoverable here — nothing local ever sets the flag
+/// on a scheduler — so it spends the bound and then takes the full reload. That is
+/// still strictly better than the unbounded wait it replaces, which never
+/// returned at all; removing the edge at its source is #13086.
 ///
 /// Returns `Ok(())` when the table loaded (or the runtime is shutting down), and
 /// [`Error::HotReloadRefreshTimedOut`] when the bound expires with the table
@@ -1944,13 +1948,14 @@ async fn await_hot_reload_initial_refresh(
     shutdown_token: &tokio_util::sync::CancellationToken,
     timeout: Duration,
 ) -> Result<()> {
-    if initial_load_completed() {
-        return Ok(());
-    }
-
-    // Register the waiter before re-checking, so a completion racing this check
-    // is caught by the `notified()` future rather than lost between the two.
+    // Built before the check below, not after: a `Notified` "is guaranteed to
+    // receive wakeups from `notify_waiters()` as soon as it has been created,
+    // even if it has not yet been polled" (`tokio::sync::Notify::notified`), and
+    // `notify_waiters` is what both producers call. So a refresh completing
+    // between here and the `select!` still wakes this wait; constructing after
+    // the check would drop it and cost the whole bound.
     let notified = notifier.notified();
+
     if initial_load_completed() {
         return Ok(());
     }
@@ -1961,16 +1966,13 @@ async fn await_hot_reload_initial_refresh(
         () = tokio::time::sleep(timeout) => {}
     }
 
-    // The timeout is a backstop, not the verdict: a wakeup lost before the
-    // `notified()` above leaves a table that is loaded and must not be discarded.
+    // The bound is a backstop, not the verdict: a wakeup that fired before this
+    // wait was even entered leaves a table that is loaded and must not be
+    // discarded.
     if initial_load_completed() {
         return Ok(());
     }
 
-    tracing::warn!(
-        "Dataset {dataset_name} did not complete a refresh within {}s of its acceleration being recreated; reloading it from scratch instead.",
-        timeout.as_secs()
-    );
     HotReloadRefreshTimedOutSnafu {
         dataset: dataset_name.clone(),
         timeout_secs: timeout.as_secs(),
@@ -2346,9 +2348,16 @@ mod tests {
         }
     }
 
-    /// A connector whose construction always fails with an error nothing
-    /// classifies as permanent, so `load_dataset` retries it with unbounded
-    /// backoff — the shape an unreachable source produces.
+    /// A connector whose construction never completes — a source that accepts
+    /// the connection attempt and never answers.
+    ///
+    /// The other shape of the same hazard is a construction that fails
+    /// *transiently*, which `load_dataset` retries with unbounded backoff. Both
+    /// leave an inline await with nothing to come back from, and the fix is one
+    /// `tokio::spawn` that does not care which it was, so one fixture covers it.
+    /// This one is preferred because it writes no metrics: a failing load
+    /// increments the process-wide `dataset_load_errors` counter that
+    /// `a_dataset_connector_failure_counts_one_load_error` reads as a delta.
     struct UnreachableConnectorFactory;
 
     impl DataConnectorFactory for UnreachableConnectorFactory {
@@ -2360,7 +2369,7 @@ mod tests {
             &self,
             _params: ConnectorParams,
         ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>> {
-            Box::pin(async { Err("connection refused".into()) })
+            Box::pin(std::future::pending())
         }
 
         fn prefix(&self) -> &'static str {
@@ -2376,26 +2385,12 @@ mod tests {
         spicepod::component::dataset::Dataset::new(from, name)
     }
 
-    /// Polls `predicate` until it holds or `bound` elapses, so readiness is waited
-    /// on rather than slept through.
-    async fn settles_within<F>(bound: Duration, mut predicate: F) -> bool
-    where
-        F: FnMut() -> bool,
-    {
-        tokio::time::timeout(bound, async {
-            while !predicate() {
-                tokio::time::sleep(Duration::from_millis(20)).await;
-            }
-        })
-        .await
-        .is_ok()
-    }
-
     /// Regression test for #12862: `apply_dataset_diff` awaited each added
-    /// dataset's `load_dataset` inline, and that retries a transient failure with
-    /// unbounded Fibonacci backoff. `apply_app` holds `apply_app_lock` across the
-    /// whole diff, so a single unreachable source parked that apply — and every
-    /// apply queued behind it — until the process restarted.
+    /// dataset's `load_dataset` inline, and a load that does not complete — a
+    /// source that never answers, or a transient failure retried with unbounded
+    /// Fibonacci backoff — therefore parked that apply. `apply_app` holds
+    /// `apply_app_lock` across the whole diff, so every apply queued behind it
+    /// was parked too, until the process restarted.
     ///
     /// The bound here is wall-clock on purpose: the failure it guards against is
     /// an apply that never returns, so the assertion has to be "returns at all".
@@ -2429,7 +2424,7 @@ mod tests {
 
         let healthy = TableReference::parse_str("healthy");
         assert!(
-            settles_within(Duration::from_secs(30), || {
+            test_framework::utils::wait_until_true(Duration::from_secs(30), || async {
                 matches!(
                     runtime.status().get_dataset_statuses().get(&healthy),
                     Some(status::ComponentStatus::Ready | status::ComponentStatus::Refreshing)
@@ -2440,7 +2435,7 @@ mod tests {
         );
 
         // The lock is only proven released by a second apply completing while the
-        // first apply's dataset is still retrying in the background.
+        // first apply's dataset is still stuck in the background.
         let third = Arc::new(
             app::AppBuilder::new("bounded_apply")
                 .with_dataset(spicepod_dataset("never_reachable:any", "unreachable"))
@@ -2458,8 +2453,9 @@ mod tests {
             "the third spicepod adds a dataset, so it must apply"
         );
 
-        // Stops the unreachable dataset's retry loop, which otherwise outlives the
-        // test on a task holding its own `Arc<Runtime>`.
+        // The stuck load's task outlives the test holding its own `Arc<Runtime>`;
+        // marking shutdown will not unstick a connector already inside `create`,
+        // but it stops the runtime the remaining assertions no longer need.
         runtime.status.mark_shutdown();
     }
 
@@ -2467,7 +2463,6 @@ mod tests {
     /// #12862: it was untimed, and `apply_app_lock` is held across it.
     mod hot_reload_initial_refresh {
         use super::*;
-        use std::sync::atomic::AtomicUsize;
         use tokio::sync::Notify;
         use tokio_util::sync::CancellationToken;
 
@@ -2479,9 +2474,8 @@ mod tests {
             TableReference::bare("reloading")
         }
 
-        /// A table already loaded when the wait begins — the cluster-scheduler
-        /// shape, where the builder notifies waiters before any caller can
-        /// subscribe — must not wait at all.
+        /// A table already loaded when the wait begins must not wait at all —
+        /// the refresh finished before the reload got here.
         #[tokio::test(start_paused = true)]
         async fn an_already_loaded_table_does_not_wait() {
             let started = tokio::time::Instant::now();
@@ -2556,15 +2550,48 @@ mod tests {
             );
         }
 
+        /// A completion landing between the `Notified`'s construction and the
+        /// `select!` must still wake the wait, which is why the future is built
+        /// before the loaded-check rather than after it. Build it after and this
+        /// notification is dropped, costing the whole bound. The closure is the
+        /// seam: it runs in exactly that window.
+        #[tokio::test(start_paused = true)]
+        async fn a_completion_racing_the_loaded_check_is_not_missed() {
+            let notifier = Arc::new(Notify::new());
+            let notify_from = Arc::clone(&notifier);
+            let notifies_then_reports_unloaded = move || {
+                notify_from.notify_waiters();
+                false
+            };
+
+            let started = tokio::time::Instant::now();
+            await_hot_reload_initial_refresh(
+                &reloading(),
+                &notifies_then_reports_unloaded,
+                &notifier,
+                &CancellationToken::new(),
+                TIMEOUT,
+            )
+            .await
+            .expect("a completion racing the wait setup must wake it, not be missed");
+
+            assert_eq!(
+                started.elapsed(),
+                Duration::ZERO,
+                "a registered waiter must be woken immediately, not at the bound"
+            );
+        }
+
         /// `Notify::notify_waiters` stores no permit, so a completion landing
-        /// between the table's construction and the `notified()` registration is
-        /// lost. The table is loaded regardless, and must not be discarded.
+        /// before the waiter is registered is lost. The table is loaded
+        /// regardless, and must not be discarded.
         #[tokio::test(start_paused = true)]
         async fn a_lost_wakeup_resolves_as_loaded_at_the_bound() {
-            // False for both pre-wait checks, true for the backstop check: the
-            // refresh completed while nothing was subscribed.
+            // False for the pre-wait check, true for the backstop check: the
+            // refresh completed while nothing was subscribed, and the refresher
+            // sets the flag just after it notifies.
             let checks = AtomicUsize::new(0);
-            let loaded = || checks.fetch_add(1, Ordering::SeqCst) >= 2;
+            let loaded = || checks.fetch_add(1, Ordering::SeqCst) >= 1;
 
             await_hot_reload_initial_refresh(
                 &reloading(),

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -14,7 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Instant};
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use crate::cluster::partition::get_partition_filter_exprs;
 use crate::dataaccelerator::BootstrapStatus;
@@ -25,11 +31,11 @@ use crate::init::dataset_initialization::DatasetInitialization;
 use crate::{
     AcceleratedTableInvalidChangesSnafu, AcceleratorEngineNotAvailableSnafu,
     AcceleratorInitializationFailedSnafu, DurableWriteBackUnsupportedBySourceSnafu, Error,
-    FullTextSearchRequiresAccelerationSnafu, LogErrors, OdbcNotInstalledSnafu,
-    PermanentDatasetFailureSnafu, Result, Runtime, UnableToAttachDataConnectorSnafu,
-    UnableToBuildDatasetSnafu, UnableToCreateAcceleratedTableSnafu,
-    UnableToInitializeDataConnectorSnafu, UnableToLoadDatasetConnectorSnafu,
-    UnknownDataConnectorSnafu,
+    FullTextSearchRequiresAccelerationSnafu, HotReloadRefreshTimedOutSnafu, LogErrors,
+    OdbcNotInstalledSnafu, PermanentDatasetFailureSnafu, Result, Runtime,
+    UnableToAttachDataConnectorSnafu, UnableToBuildDatasetSnafu,
+    UnableToCreateAcceleratedTableSnafu, UnableToInitializeDataConnectorSnafu,
+    UnableToLoadDatasetConnectorSnafu, UnknownDataConnectorSnafu,
     accelerated::AcceleratedTable,
     component::dataset::{
         Dataset,
@@ -62,6 +68,17 @@ use snafu::prelude::*;
 use tokio::sync::Semaphore;
 use util::{RetryError, fibonacci_backoff::FibonacciBackoffBuilder, retry};
 use util::{error_spaced, warn_spaced};
+
+/// How long a hot reload waits for the accelerated table it just recreated to
+/// complete its first refresh before abandoning the in-place swap and reloading
+/// the dataset from scratch.
+///
+/// `apply_app` holds `apply_app_lock` for the duration, so this is the longest a
+/// single changed dataset can delay the applies queued behind it. Sized to cover
+/// an ordinary reload of a non-file acceleration — file accelerations do not take
+/// this path at all (`accelerated_dataset_supports_hot_reload`) — while still
+/// recovering without a process restart when the refresh never completes.
+const HOT_RELOAD_INITIAL_REFRESH_TIMEOUT: Duration = Duration::from_secs(300);
 
 impl Runtime {
     pub(crate) async fn load_datasets(self: Arc<Self>) {
@@ -1256,7 +1273,15 @@ impl Runtime {
 
         // wait for accelerated table to be ready
         if let Some(notifier) = notifier {
-            notifier.notified().await;
+            let refresher = accelerated_table.refresher();
+            await_hot_reload_initial_refresh(
+                &ds.name,
+                &|| refresher.initial_load_completed(),
+                &notifier,
+                &self.status.shutdown_token(),
+                HOT_RELOAD_INITIAL_REFRESH_TIMEOUT,
+            )
+            .await?;
         }
 
         // recreate the scheduler, which also recreates with any updated parameters
@@ -1638,6 +1663,23 @@ impl Runtime {
             .initialize_datasets_accelerators(&datasets_to_apply)
             .await;
 
+        // Added datasets are loaded on spawned tasks rather than awaited inline:
+        // `load_dataset` retries a transient failure with unbounded Fibonacci
+        // backoff, and `apply_app` holds `apply_app_lock` across this whole
+        // function, so awaiting one unreachable source parks this apply and every
+        // apply queued behind it until the process restarts. A dataset that cannot
+        // load lands in an error state reported through `status` and is retried on
+        // the next apply.
+        //
+        // Built here and spawned below so a localpod dataset can be chained behind
+        // the dataset it reads from, exactly as `load_datasets` does at startup:
+        // `LocalPodConnector::read_provider` raises `InvalidTableName` when its
+        // parent is not registered yet, and that is classified permanent, so a
+        // child racing its parent would fail for good rather than retry.
+        let mut added_futures: HashMap<TableReference, Pin<Box<dyn Future<Output = ()> + Send>>> =
+            HashMap::new();
+        let mut added_localpod = Vec::new();
+
         for ds in &datasets_to_apply {
             let bootstrap_status = match init_results.get(&ds.name) {
                 Some(Ok(status)) => status.clone(),
@@ -1653,17 +1695,72 @@ impl Runtime {
 
             if existing_datasets.iter().any(|d| d.name == ds.name) {
                 Arc::clone(&self).update_dataset(Arc::clone(ds)).await;
-            } else {
-                self.status
-                    .update_dataset(&ds.name, status::ComponentStatus::Initializing);
-                Arc::clone(&self)
-                    .load_dataset(
-                        Arc::clone(ds),
-                        bootstrap_status,
-                        Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
-                    )
-                    .await;
+                continue;
             }
+
+            self.status
+                .update_dataset(&ds.name, status::ComponentStatus::Initializing);
+
+            if ds.source() == LOCALPOD_DATACONNECTOR {
+                added_localpod.push((Arc::clone(ds), bootstrap_status));
+                continue;
+            }
+
+            // The runtime's shared semaphore is what makes these loads honor
+            // `runtime.dataset_load_parallelism`; the per-dataset
+            // `Semaphore::MAX_PERMITS` this replaces opted every reconcile load out
+            // of that budget.
+            let runtime = Arc::clone(&self);
+            let ds_clone = Arc::clone(ds);
+            let load_semaphore = Arc::clone(&self.dataset_load_semaphore);
+            added_futures.insert(
+                ds.name.clone(),
+                Box::pin(async move {
+                    runtime
+                        .load_dataset(ds_clone, bootstrap_status, load_semaphore)
+                        .await;
+                }),
+            );
+        }
+
+        // Grouped by parent so several localpod datasets reading from one newly
+        // added dataset all chain behind the same load, rather than the first one
+        // consuming it and the rest racing it.
+        let mut localpod_by_parent: HashMap<TableReference, Vec<(Arc<Dataset>, BootstrapStatus)>> =
+            HashMap::new();
+        for (ds, bootstrap_status) in added_localpod {
+            localpod_by_parent
+                .entry(TableReference::parse_str(ds.path()))
+                .or_default()
+                .push((ds, bootstrap_status));
+        }
+
+        let mut to_spawn: Vec<Pin<Box<dyn Future<Output = ()> + Send>>> = Vec::new();
+        for (parent, children) in localpod_by_parent {
+            // Chain behind the parent only when this same diff adds it. A parent
+            // that is unchanged, or that was updated in the loop above, is already
+            // registered.
+            let parent_future = added_futures.remove(&parent);
+            let runtime = Arc::clone(&self);
+            let load_semaphore = Arc::clone(&self.dataset_load_semaphore);
+            to_spawn.push(Box::pin(async move {
+                if let Some(parent_future) = parent_future {
+                    parent_future.await;
+                }
+                join_all(children.into_iter().map(|(ds, bootstrap_status)| {
+                    Arc::clone(&runtime).load_dataset(
+                        ds,
+                        bootstrap_status,
+                        Arc::clone(&load_semaphore),
+                    )
+                }))
+                .await;
+            }));
+        }
+        to_spawn.extend(added_futures.into_values());
+
+        for load in to_spawn {
+            tokio::spawn(load);
         }
 
         // Remove datasets that are no longer in the app
@@ -1815,6 +1912,70 @@ pub struct RegisterDatasetContext {
     source: String,
     accelerated_table: Option<Arc<AcceleratedTable>>,
     bootstrap_status: BootstrapStatus,
+}
+
+/// Wait for the accelerated table a hot reload just recreated to complete its
+/// first refresh, so the in-place swap does not register a table that has not
+/// loaded yet.
+///
+/// The wait is bounded because `apply_app` holds `apply_app_lock` across it, and
+/// three shapes never deliver the notification at all:
+///
+/// - a `refresh_mode: changes` stream that never produces a ready envelope — the
+///   notifier fires only when one is applied;
+/// - a completion landing between the table's construction and this
+///   `notified()` registering. [`tokio::sync::Notify::notify_waiters`] stores no
+///   permit, so that wakeup is lost, and a `RefreshMode::Full` dataset with no
+///   `check_interval` never fires a second one;
+/// - a cluster scheduler, which notifies waiters from inside the builder —
+///   before any caller can subscribe — precisely because it runs no refresh.
+///
+/// The last two leave the table already loaded, so `initial_load_completed` is
+/// consulted on both sides of the wait: a lost wakeup resolves as success rather
+/// than burning the timeout and then discarding a table that is ready.
+///
+/// Returns `Ok(())` when the table loaded (or the runtime is shutting down), and
+/// [`Error::HotReloadRefreshTimedOut`] when the bound expires with the table
+/// still unloaded, which drops the in-place swap in favour of a full reload.
+async fn await_hot_reload_initial_refresh(
+    dataset_name: &TableReference,
+    initial_load_completed: &(dyn Fn() -> bool + Sync),
+    notifier: &tokio::sync::Notify,
+    shutdown_token: &tokio_util::sync::CancellationToken,
+    timeout: Duration,
+) -> Result<()> {
+    if initial_load_completed() {
+        return Ok(());
+    }
+
+    // Register the waiter before re-checking, so a completion racing this check
+    // is caught by the `notified()` future rather than lost between the two.
+    let notified = notifier.notified();
+    if initial_load_completed() {
+        return Ok(());
+    }
+
+    tokio::select! {
+        () = notified => return Ok(()),
+        () = shutdown_token.cancelled() => return Ok(()),
+        () = tokio::time::sleep(timeout) => {}
+    }
+
+    // The timeout is a backstop, not the verdict: a wakeup lost before the
+    // `notified()` above leaves a table that is loaded and must not be discarded.
+    if initial_load_completed() {
+        return Ok(());
+    }
+
+    tracing::warn!(
+        "Dataset {dataset_name} did not complete a refresh within {}s of its acceleration being recreated; reloading it from scratch instead.",
+        timeout.as_secs()
+    );
+    HotReloadRefreshTimedOutSnafu {
+        dataset: dataset_name.clone(),
+        timeout_secs: timeout.as_secs(),
+    }
+    .fail()
 }
 
 /// Returns `true` when a dataset load failure cannot be cleared by retrying it.
@@ -2182,6 +2343,265 @@ mod tests {
             let table = datafusion::datasource::MemTable::try_new(schema, vec![vec![]])
                 .expect("empty MemTable with a single column");
             Ok(Arc::new(table) as Arc<dyn TableProvider>)
+        }
+    }
+
+    /// A connector whose construction always fails with an error nothing
+    /// classifies as permanent, so `load_dataset` retries it with unbounded
+    /// backoff — the shape an unreachable source produces.
+    struct UnreachableConnectorFactory;
+
+    impl DataConnectorFactory for UnreachableConnectorFactory {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn create(
+            &self,
+            _params: ConnectorParams,
+        ) -> Pin<Box<dyn Future<Output = NewDataConnectorResult> + Send>> {
+            Box::pin(async { Err("connection refused".into()) })
+        }
+
+        fn prefix(&self) -> &'static str {
+            "never_reachable"
+        }
+
+        fn parameters(&self) -> &'static [ParameterSpec] {
+            &[]
+        }
+    }
+
+    fn spicepod_dataset(from: &str, name: &str) -> spicepod::component::dataset::Dataset {
+        spicepod::component::dataset::Dataset::new(from, name)
+    }
+
+    /// Polls `predicate` until it holds or `bound` elapses, so readiness is waited
+    /// on rather than slept through.
+    async fn settles_within<F>(bound: Duration, mut predicate: F) -> bool
+    where
+        F: FnMut() -> bool,
+    {
+        tokio::time::timeout(bound, async {
+            while !predicate() {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    /// Regression test for #12862: `apply_dataset_diff` awaited each added
+    /// dataset's `load_dataset` inline, and that retries a transient failure with
+    /// unbounded Fibonacci backoff. `apply_app` holds `apply_app_lock` across the
+    /// whole diff, so a single unreachable source parked that apply — and every
+    /// apply queued behind it — until the process restarted.
+    ///
+    /// The bound here is wall-clock on purpose: the failure it guards against is
+    /// an apply that never returns, so the assertion has to be "returns at all".
+    #[tokio::test]
+    async fn an_unreachable_added_dataset_does_not_block_the_apply() {
+        register_connector_factory("never_reachable", Arc::new(UnreachableConnectorFactory)).await;
+        register_connector_factory("schema_only", Arc::new(SchemaOnlyConnectorFactory)).await;
+
+        let runtime = Arc::new(
+            crate::Runtime::builder()
+                .with_app(app::AppBuilder::new("bounded_apply").build())
+                .build()
+                .await,
+        );
+
+        let reloaded = Arc::new(
+            app::AppBuilder::new("bounded_apply")
+                .with_dataset(spicepod_dataset("never_reachable:any", "unreachable"))
+                .with_dataset(spicepod_dataset("schema_only:any", "healthy"))
+                .build(),
+        );
+        assert!(
+            tokio::time::timeout(
+                Duration::from_secs(30),
+                Arc::clone(&runtime).apply_app(reloaded)
+            )
+            .await
+            .expect("an added dataset that cannot load must not hold the apply lock"),
+            "the reloaded spicepod differs from the booted one, so it must apply"
+        );
+
+        let healthy = TableReference::parse_str("healthy");
+        assert!(
+            settles_within(Duration::from_secs(30), || {
+                matches!(
+                    runtime.status().get_dataset_statuses().get(&healthy),
+                    Some(status::ComponentStatus::Ready | status::ComponentStatus::Refreshing)
+                )
+            })
+            .await,
+            "the dataset alongside the unreachable one must still become queryable"
+        );
+
+        // The lock is only proven released by a second apply completing while the
+        // first apply's dataset is still retrying in the background.
+        let third = Arc::new(
+            app::AppBuilder::new("bounded_apply")
+                .with_dataset(spicepod_dataset("never_reachable:any", "unreachable"))
+                .with_dataset(spicepod_dataset("schema_only:any", "healthy"))
+                .with_dataset(spicepod_dataset("schema_only:any", "healthy_too"))
+                .build(),
+        );
+        assert!(
+            tokio::time::timeout(
+                Duration::from_secs(30),
+                Arc::clone(&runtime).apply_app(third)
+            )
+            .await
+            .expect("a later apply must not inherit the earlier apply's wait"),
+            "the third spicepod adds a dataset, so it must apply"
+        );
+
+        // Stops the unreachable dataset's retry loop, which otherwise outlives the
+        // test on a task holding its own `Arc<Runtime>`.
+        runtime.status.mark_shutdown();
+    }
+
+    /// The wait a hot reload performs on the recreated table's first refresh.
+    /// #12862: it was untimed, and `apply_app_lock` is held across it.
+    mod hot_reload_initial_refresh {
+        use super::*;
+        use std::sync::atomic::AtomicUsize;
+        use tokio::sync::Notify;
+        use tokio_util::sync::CancellationToken;
+
+        /// The production bound, so these arms cannot drift from it. A paused
+        /// clock makes its size irrelevant to how long they take.
+        const TIMEOUT: Duration = HOT_RELOAD_INITIAL_REFRESH_TIMEOUT;
+
+        fn reloading() -> TableReference {
+            TableReference::bare("reloading")
+        }
+
+        /// A table already loaded when the wait begins — the cluster-scheduler
+        /// shape, where the builder notifies waiters before any caller can
+        /// subscribe — must not wait at all.
+        #[tokio::test(start_paused = true)]
+        async fn an_already_loaded_table_does_not_wait() {
+            let started = tokio::time::Instant::now();
+            await_hot_reload_initial_refresh(
+                &reloading(),
+                &|| true,
+                &Notify::new(),
+                &CancellationToken::new(),
+                TIMEOUT,
+            )
+            .await
+            .expect("a table that has already loaded needs no notification");
+
+            assert_eq!(
+                started.elapsed(),
+                Duration::ZERO,
+                "a loaded table must be recognised before the wait, not after it"
+            );
+        }
+
+        /// The ordinary case: the refresh completes and notifies.
+        #[tokio::test(start_paused = true)]
+        async fn a_completion_notification_ends_the_wait() {
+            let notifier = Arc::new(Notify::new());
+            let notify_from = Arc::clone(&notifier);
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                notify_from.notify_waiters();
+            });
+
+            let started = tokio::time::Instant::now();
+            await_hot_reload_initial_refresh(
+                &reloading(),
+                &|| false,
+                &notifier,
+                &CancellationToken::new(),
+                TIMEOUT,
+            )
+            .await
+            .expect("a notified refresh completes the wait");
+
+            assert!(
+                started.elapsed() < TIMEOUT,
+                "the wait must end on the notification, not on the bound"
+            );
+        }
+
+        /// A `refresh_mode: changes` stream that never produces a ready envelope
+        /// never fires the notifier. Before #12862 this held the apply lock for
+        /// the life of the process.
+        #[tokio::test(start_paused = true)]
+        async fn a_refresh_that_never_completes_gives_up_at_the_bound() {
+            let started = tokio::time::Instant::now();
+            let err = await_hot_reload_initial_refresh(
+                &reloading(),
+                &|| false,
+                &Notify::new(),
+                &CancellationToken::new(),
+                TIMEOUT,
+            )
+            .await
+            .expect_err("a refresh that never completes must not wait forever");
+
+            assert!(
+                matches!(err, Error::HotReloadRefreshTimedOut { .. }),
+                "expected the hot-reload bound to be reported, got: {err}"
+            );
+            assert_eq!(
+                started.elapsed(),
+                TIMEOUT,
+                "the wait must last exactly the bound it was given"
+            );
+        }
+
+        /// `Notify::notify_waiters` stores no permit, so a completion landing
+        /// between the table's construction and the `notified()` registration is
+        /// lost. The table is loaded regardless, and must not be discarded.
+        #[tokio::test(start_paused = true)]
+        async fn a_lost_wakeup_resolves_as_loaded_at_the_bound() {
+            // False for both pre-wait checks, true for the backstop check: the
+            // refresh completed while nothing was subscribed.
+            let checks = AtomicUsize::new(0);
+            let loaded = || checks.fetch_add(1, Ordering::SeqCst) >= 2;
+
+            await_hot_reload_initial_refresh(
+                &reloading(),
+                &loaded,
+                &Notify::new(),
+                &CancellationToken::new(),
+                TIMEOUT,
+            )
+            .await
+            .expect("a wakeup lost before the wait must not discard a loaded table");
+        }
+
+        /// Shutdown ends the wait without reporting a reload failure.
+        #[tokio::test(start_paused = true)]
+        async fn shutdown_ends_the_wait() {
+            let token = CancellationToken::new();
+            let cancel = token.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                cancel.cancel();
+            });
+
+            let started = tokio::time::Instant::now();
+            await_hot_reload_initial_refresh(
+                &reloading(),
+                &|| false,
+                &Notify::new(),
+                &token,
+                TIMEOUT,
+            )
+            .await
+            .expect("a runtime shutting down is not a failed reload");
+
+            assert!(
+                started.elapsed() < TIMEOUT,
+                "shutdown must not wait out the bound"
+            );
         }
     }
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -1674,8 +1674,11 @@ impl Runtime {
         // backoff, and `apply_app` holds `apply_app_lock` across this whole
         // function, so awaiting one unreachable source parks this apply and every
         // apply queued behind it until the process restarts. A dataset that cannot
-        // load lands in an error state reported through `status` and is retried on
-        // the next apply.
+        // load lands in an error state reported through `status`; a transient
+        // failure keeps retrying inside its own spawned task, while a permanent one
+        // is re-attempted only when the dataset's configuration changes — an
+        // identically-configured dataset is filtered out of `datasets_to_apply`
+        // above, so a later apply schedules no fresh load for it. Tracked in #13098.
         //
         // Built here and spawned below so a localpod dataset can be chained behind
         // the dataset it reads from, exactly as `load_datasets` does at startup:

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -393,6 +393,17 @@ pub enum Error {
     #[snafu(display("Unable to receive accelerated table status: {source}"))]
     UnableToReceiveAcceleratedTableStatus { source: RecvError },
 
+    #[snafu(display(
+        "Failed to reload dataset {dataset}: its acceleration did not complete a refresh within {timeout_secs}s of being recreated. \
+        Reloading the dataset from scratch instead. \
+        Check that the dataset's source is reachable, and for 'refresh_mode: changes' that its change stream is producing data. \
+        See: https://spiceai.org/docs/components/data-accelerators"
+    ))]
+    HotReloadRefreshTimedOut {
+        dataset: TableReference,
+        timeout_secs: u64,
+    },
+
     #[snafu(display("Unable to start local metrics: {source}"))]
     UnableToStartLocalMetrics { source: spice_metrics::Error },
 


### PR DESCRIPTION
## Summary

An in-process spicepod apply could stall forever while holding `apply_app_lock`, blocking that apply
and every apply queued behind it until the process was restarted. `apply_app` holds that lock across
the whole reconcile, so any unbounded wait inside it wedges the apply path. Two independent causes,
both in `crates/runtime/src/init/dataset.rs`.

**An added dataset was awaited inline.** `apply_dataset_diff` awaited `load_dataset` for each added
dataset, and a load that does not complete — a source that never answers, or a transient failure
retried with unbounded Fibonacci backoff — parked the apply. The same call passed a fresh
`Semaphore::new(Semaphore::MAX_PERMITS)`, so reconcile loads were serial *and* outside
`runtime.dataset_load_parallelism`, the budget the startup path enforces through the runtime's shared
semaphore.

**The hot-reload wait was untimed.** `reload_accelerated_dataset` waited on the recreated accelerated
table's completion notifier with no bound. That notifier is edge-triggered — `notify_waiters` stores
no permit — and three shapes never deliver a notification the caller can see:

- a `refresh_mode: changes` stream that never produces a ready envelope, since the notifier fires
  only when one is applied (the shape the issue describes);
- a refresh completing before the caller subscribes, which for a `RefreshMode::Full` dataset with no
  `check_interval` is the only notification there will ever be;
- a cluster scheduler, which fires the notifier from inside the accelerated-table builder — before
  any caller can hold it — precisely because it runs no local refresh.

## Changes

- `apply_dataset_diff` spawns added-dataset loads instead of awaiting them, on the runtime's shared
  `dataset_load_semaphore` so they stay inside `runtime.dataset_load_parallelism`. A dataset that
  cannot load lands in an error state reported through `status` and is retried on the next apply.
- Localpod datasets added by the same diff are chained behind the dataset they read from.
  `LocalPodConnector::read_provider` raises `InvalidTableName` when its parent is not registered, and
  that is classified *permanent* (`DataConnectorError::is_retriable`), so a child racing its parent
  would fail for good rather than retry. Children are keyed by parent so several readers of one new
  dataset all chain behind the same load instead of the first one consuming it.
- `reload_accelerated_dataset` waits through a new bounded helper, `await_hot_reload_initial_refresh`:
  shutdown-aware, backstopped by `HOT_RELOAD_INITIAL_REFRESH_TIMEOUT` (300s), and ordered so the
  `Notified` is constructed *before* the loaded-check. That ordering is load-bearing: a `Notified`
  "is guaranteed to receive wakeups from `notify_waiters()` as soon as it has been created, even if it
  has not yet been polled", and `notify_waiters` is what both producers call — so building it after the
  check would drop a completion landing in that window and spend the whole bound.
  `initial_load_completed` is read after the bound as well as before it, because the refresher sets
  that flag just *after* it notifies, so the flag is what remains once the edge is gone.
- `update_dataset` now logs the reason it falls back to a full reload. It tested
  `matches!(…, Ok(()))` and discarded the error, so nothing distinguished a swap that could not be
  built from an acceleration that never finished loading.

## Scope, and what this deliberately does not fix

- **Catalogs have the identical defect, one function earlier under the same lock.**
  `apply_catalog_diff` awaits `load_catalog`, which also retries unbounded, and it runs *before*
  `apply_dataset_diff` — so this PR does not make the apply bounded on its own. Not folded in because
  spawning catalog loads drops an ordering guarantee the current code provides for free (a localpod
  dataset can read a catalog-provided table, and `InvalidTableName` is permanent). Filed as #13082
  with the two candidate shapes and the regression test any fix owes.
- **The cluster-scheduler shape is bounded here, not fixed.** Nothing local ever sets
  `initial_load_completed` on a scheduler, so that shape spends the bound and then takes the full
  reload — still strictly better than the unbounded wait it replaces, which never returned at all.
  Removing the edge at its source, plus the four other uncompensated `on_complete_notification()`
  callers that can hang the same way, is #13086.
- **The bound is per changed dataset, not per apply.** Changed datasets are still updated
  sequentially, so an apply touching several accelerated datasets can spend the bound once per
  dataset. Called out in the constant's doc rather than left implicit.
- **`load_datasets` holds a diverging copy of this orchestration**, and the startup copy fails the
  *second* localpod reader of one parent with a false "Parent dataset doesn't exist". Extracting a
  shared helper changes startup dataset loading, well outside this wedge, so it is #13087.

## Test plan

- `make lint`
- `make nextest`
- New unit tests in `crates/runtime/src/init/dataset.rs`:
  - `an_unreachable_added_dataset_does_not_block_the_apply` — a connector whose construction never
    completes, added alongside a healthy dataset. Asserts the apply returns, the healthy dataset still
    becomes queryable, and a second apply completes while the first dataset is still stuck. Fails by
    timeout without the fix.
  - `hot_reload_initial_refresh::*` — six arms: already-loaded returns without waiting, a notification
    ends the wait, a completion racing the loaded-check is not missed, a refresh that never completes
    gives up at the bound with `HotReloadRefreshTimedOut`, a lost wakeup resolves as loaded, and
    shutdown ends the wait.
- Neutered to confirm each test fails for its own reason, re-run after `/simplify`:
  - restoring the inline `await` → `an_unreachable_added_dataset_does_not_block_the_apply` failed at
    its 30s bound, all 6 nextest retries;
  - making the bound return `Ok(())` → `a_refresh_that_never_completes_gives_up_at_the_bound` failed;
  - constructing the `Notified` after the loaded-check →
    `a_completion_racing_the_loaded_check_is_not_missed` failed (5 passed, 1 failed).
  Everything else stayed green in each arm.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` not installed, so no cross-model fallback was available.
- `/security-review`: no findings — the diff adds no input parsing, SQL, filesystem or network surface, auth boundary, `unsafe`, or dependency; the one new user-visible message carries a dataset name and a timeout.
- `/simplify`: applied. Its most valuable catch was a doc comment of mine that claimed the cluster-scheduler shape "leaves the table already loaded" — it does not, since `initial_load_complete` defaults to `false` and nothing on a scheduler ever sets it; that shape spends the bound and then falls back, and the comment now says so. Also dropped two intermediate collections, a comment narrating the previous implementation, a duplicated `refresher()` call, a redundant import, and a local poll helper in favour of `test_framework::utils::wait_until_true`. One of its findings was **wrong and reverted**: it reported that `notified()` does not register a waiter until first polled, so I added `Notified::enable()` — but tokio guarantees `notify_waiters()` wakeups from construction, `notify_waiters` is the only producer here, and the neuter proved the arm covering `enable()` passed with it removed. The `enable()` is gone and the comment now cites the documented guarantee instead. Skipped: the shared-helper extraction (#13087), the level-triggered notifier (#13086), and a pre-existing O(n·m) scan. Light checks re-run green (22/22 under nextest).
- Follow-up commit `de459bdb2d` (pedantic-clippy spelling only): review gate **declared skip**. The `similar_names` rename and `Duration::from_mins(5)` for `from_secs(300)` are clippy's own suggested forms, change no behaviour, and add no surface — nothing for an adversarial or security pass to weigh. `cargo fmt --check` clean on the file; the remote sign-off is the verifier.

Fixes #12862

## Checklist

- [x] Root cause identified and stated
- [x] Regression tests that fail on the old code
- [x] Neuter arms run after `/simplify`
- [x] Out-of-scope findings filed (#13082, #13086, #13087) rather than folded in
- [ ] `make signoff` green and `Attestation` re-run
