### PR TITLE
fix(cayenne): refuse a data directory that contains the metastore (fixes #13055)

### DIFF
--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -24,7 +24,7 @@ pub mod snapshot_engine;
 
 use std::any::Any;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
@@ -90,6 +90,18 @@ pub enum Error {
 
     #[snafu(display("Invalid Cayenne acceleration configuration: {detail}"))]
     InvalidConfiguration { detail: Arc<str> },
+
+    #[snafu(display(
+        "Failed to configure dataset {table_name} (cayenne): The acceleration data directory '{data_dir}' contains the Cayenne metastore directory '{metadata_dir}'. \
+        Recreating this dataset deletes its data directory, which would take the metastore — the catalog for every Cayenne dataset in this instance — with it. \
+        Set 'cayenne_metadata_dir' to a directory outside the data directory, or rename the dataset. \
+        See: https://spiceai.org/docs/components/data-accelerators/cayenne"
+    ))]
+    MetastoreInsideDataDir {
+        table_name: String,
+        data_dir: String,
+        metadata_dir: String,
+    },
 
     #[snafu(display(
         "Unsupported data type(s) in schema: {details}. By default, unsupported types cause an error. To convert unsupported types to strings, set 'unsupported_type_action: string'; otherwise, remove the unsupported columns."
@@ -969,6 +981,93 @@ fn fs_probe_path(path: &str) -> &str {
     }
 }
 
+/// Resolve a configured Cayenne directory to an absolute, symlink-resolved path so
+/// two directories can be compared for containment.
+///
+/// Returns `None` for object-store locations (`s3://…`), which can never overlap the
+/// metastore directory (`SQLite`/Turso cannot run on object storage, so
+/// [`CayenneAccelerator::resolve_metadata_dir`] only ever yields a local path).
+///
+/// Neither directory necessarily exists yet, so this canonicalizes the deepest
+/// ancestor that does exist — resolving symlinks in the real part of the path, which a
+/// purely lexical comparison would miss — and re-appends the components that do not.
+async fn resolve_dir_for_overlap(path: &str) -> Option<PathBuf> {
+    if !is_local_path(path) {
+        return None;
+    }
+
+    let raw = Path::new(fs_probe_path(path));
+    let absolute = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(raw)
+    };
+
+    // Collapse `.` and `..` lexically. `Path::starts_with` compares components, so an
+    // unresolved `..` would make an overlapping pair look disjoint.
+    let mut lexical = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                lexical.pop();
+            }
+            other => lexical.push(other),
+        }
+    }
+
+    let mut missing_suffix = Vec::new();
+    let mut probe = lexical.clone();
+    loop {
+        if let Ok(existing) = tokio::fs::canonicalize(&probe).await {
+            let mut resolved = existing;
+            resolved.extend(missing_suffix.iter().rev());
+            return Some(resolved);
+        }
+        // Nothing on this path exists yet (or it is the filesystem root, which always
+        // canonicalizes): fall back to the lexical form.
+        let Some(name) = probe.file_name().map(std::ffi::OsStr::to_os_string) else {
+            return Some(lexical);
+        };
+        missing_suffix.push(name);
+        if !probe.pop() {
+            return Some(lexical);
+        }
+    }
+}
+
+/// `true` when `inner` is `outer` itself or lies beneath it — i.e. a recursive delete
+/// of `outer` takes `inner` with it.
+fn dir_contains(outer: &Path, inner: &Path) -> bool {
+    inner.starts_with(outer)
+}
+
+/// Detect the configuration in which a Cayenne recreate destroys the metastore.
+///
+/// One metastore holds the catalog — manifests, snapshot pointers, partition rows —
+/// for *every* Cayenne dataset sharing a `cayenne_metadata_dir`, and both recreate
+/// paths (`mode: file_create` in [`CayenneAccelerator::init`] and
+/// [`DataAccelerator::drop_table`] for a `file_update` schema rebuild) recursively
+/// delete a single dataset's data directory. When the metastore directory resolves
+/// onto or beneath that data directory the delete unlinks the shared catalog, and
+/// because the connection pool already holds handles to the now-unlinked file the run
+/// appears healthy while the metastore is simply gone on the next restart.
+///
+/// The stock defaults collide on their own for a dataset named `metadata`:
+/// `resolve_default_data_path` yields `{spice_data}/metadata/` and
+/// `resolve_metadata_dir` yields `{spice_data}/metadata`. An explicit
+/// `cayenne_metadata_dir` set beneath the data directory collides the same way.
+///
+/// Returns the resolved `(data_dir, metadata_dir)` pair when they overlap.
+async fn overlapping_metastore_dir(
+    data_dir: &str,
+    metadata_dir: &str,
+) -> Option<(PathBuf, PathBuf)> {
+    let data = resolve_dir_for_overlap(data_dir).await?;
+    let metadata = resolve_dir_for_overlap(metadata_dir).await?;
+    dir_contains(&data, &metadata).then_some((data, metadata))
+}
+
 /// Process-wide counter giving each [`CayenneAccelerator`] instance a unique id,
 /// used to name its in-memory (`memdb`) metastore so distinct instances never
 /// share one in-memory database.
@@ -1132,6 +1231,28 @@ impl CayenneAccelerator {
         }
 
         format!("{}/metadata", spice_data_base_path())
+    }
+
+    /// Refuse a configuration whose recreate would delete the shared metastore — see
+    /// [`overlapping_metastore_dir`] for the shape and how the defaults reach it.
+    ///
+    /// Called at open time, where the operator can still fix the spicepod, and again
+    /// immediately before each recursive delete: at open time neither directory need
+    /// exist yet, so the resolution falls back to a lexical one, and an overlap that
+    /// only a symlink reveals appears once the directories are real.
+    async fn ensure_metastore_outside_data_dir(
+        source: &dyn AccelerationSource,
+        data_dir: &str,
+    ) -> Result<()> {
+        let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
+        if let Some((data, metadata)) = overlapping_metastore_dir(data_dir, &metadata_dir).await {
+            return Err(Error::MetastoreInsideDataDir {
+                table_name: source.name().to_string(),
+                data_dir: data.to_string_lossy().into_owned(),
+                metadata_dir: metadata.to_string_lossy().into_owned(),
+            });
+        }
+        Ok(())
     }
 
     fn resolve_storage_config(&self, source: &dyn AccelerationSource) -> Result<String> {
@@ -2928,6 +3049,11 @@ impl DataAccelerator for CayenneAccelerator {
         }
 
         let dir_path = self.file_path(source)?;
+
+        // Fail here rather than at teardown, when the operator is already committed and
+        // the delete has nothing left to protect.
+        Self::ensure_metastore_outside_data_dir(source, &dir_path).await?;
+
         let is_s3_express = s3::is_s3_express_data_path(source);
 
         // Handle S3 Express One Zone configuration
@@ -3065,6 +3191,11 @@ impl DataAccelerator for CayenneAccelerator {
                     None,
                 )
                 .await;
+
+                // Re-check now that the directories exist: `snapshot_before_recreate`
+                // creates both, so an overlap only a symlink reveals is resolvable here
+                // even though the open-time check above had nothing to canonicalize.
+                Self::ensure_metastore_outside_data_dir(source, &dir_path).await?;
 
                 tracing::warn!(
                     "Cayenne acceleration mode is 'file_create', removing existing directory: {}",
@@ -3578,6 +3709,10 @@ impl DataAccelerator for CayenneAccelerator {
         let dir_path = self.cayenne_data_dir(source).boxed()?;
         let path_buf = PathBuf::from(&dir_path);
         if path_buf.exists() {
+            // A schema rebuild reaches this without going through `init`, so the
+            // open-time check is not on this path's stack.
+            Self::ensure_metastore_outside_data_dir(source, &dir_path).await?;
+
             tokio::fs::remove_dir_all(&path_buf).await.boxed()?;
             tracing::info!(
                 "Removed Cayenne data directory '{dir_path}' for schema recreation (file_update mode)"
@@ -4710,6 +4845,211 @@ mod tests {
         assert!(
             result.ends_with(".spice/data/metadata"),
             "Expected path to end with '.spice/data/metadata', got: {result}"
+        );
+    }
+
+    /// The stock defaults collide with no operator error at all: a dataset literally
+    /// named `metadata` resolves its data directory onto the shared metastore
+    /// directory, so recreating it unlinks the catalog for every other Cayenne dataset
+    /// in the instance. Regression test for #13055 / #13068.
+    #[tokio::test]
+    async fn overlap_detects_the_default_collision_for_a_dataset_named_metadata() {
+        let metastore = CayenneAccelerator::resolve_metadata_dir(None);
+
+        let colliding = CayenneAccelerator::resolve_default_data_path("metadata");
+        assert!(
+            overlapping_metastore_dir(&colliding, &metastore)
+                .await
+                .is_some(),
+            "a dataset named `metadata` puts its data directory on top of the metastore: \
+             data={colliding} metastore={metastore}"
+        );
+
+        let ordinary = CayenneAccelerator::resolve_default_data_path("orders");
+        assert!(
+            overlapping_metastore_dir(&ordinary, &metastore)
+                .await
+                .is_none(),
+            "an ordinary dataset name is disjoint from the metastore: \
+             data={ordinary} metastore={metastore}"
+        );
+    }
+
+    /// The containment test compares path *components*: `…/data/meta` must not be
+    /// read as containing `…/data/metadata` just because it is a string prefix.
+    #[tokio::test]
+    async fn overlap_ignores_a_sibling_directory_sharing_a_name_prefix() {
+        let base = tempfile::tempdir().expect("temp dir");
+        let data = base.path().join("meta");
+        let metastore = base.path().join("metadata");
+
+        assert!(
+            overlapping_metastore_dir(&data.to_string_lossy(), &metastore.to_string_lossy())
+                .await
+                .is_none(),
+            "`meta` and `metadata` are siblings, not nested"
+        );
+    }
+
+    /// An explicit `cayenne_metadata_dir` may legally point anywhere, including
+    /// beneath a dataset's data directory — where the recreate deletes it.
+    #[tokio::test]
+    async fn overlap_detects_an_explicit_metadata_dir_nested_under_the_data_dir() {
+        let base = tempfile::tempdir().expect("temp dir");
+        let data = base.path().join("orders");
+
+        let nested = data.join("catalog");
+        assert!(
+            overlapping_metastore_dir(&data.to_string_lossy(), &nested.to_string_lossy())
+                .await
+                .is_some(),
+            "a metadata dir beneath the data dir is deleted with it"
+        );
+
+        let outside = base.path().join("catalog");
+        assert!(
+            overlapping_metastore_dir(&data.to_string_lossy(), &outside.to_string_lossy())
+                .await
+                .is_none(),
+            "a metadata dir outside the data dir survives the recreate"
+        );
+    }
+
+    /// Neither `..` nor a symlinked ancestor may hide an overlap — a purely lexical
+    /// comparison misses both, and `remove_dir_all` follows neither before deleting.
+    #[tokio::test]
+    async fn overlap_resolves_dot_dot_and_symlinks_before_comparing() {
+        let base = tempfile::tempdir().expect("temp dir");
+        let data = base.path().join("orders");
+        std::fs::create_dir_all(&data).expect("data dir");
+
+        let traversed = data.join("sibling").join("..").join("catalog");
+        assert!(
+            overlapping_metastore_dir(&data.to_string_lossy(), &traversed.to_string_lossy())
+                .await
+                .is_some(),
+            "`orders/sibling/../catalog` is `orders/catalog`, which the delete takes"
+        );
+
+        // A symlink to the data directory resolves onto it, so a metadata dir reached
+        // through the link is inside the tree the delete walks.
+        #[cfg(unix)]
+        {
+            let link = base.path().join("link-to-orders");
+            std::os::unix::fs::symlink(&data, &link).expect("symlink");
+            let through_link = link.join("catalog");
+            assert!(
+                overlapping_metastore_dir(&data.to_string_lossy(), &through_link.to_string_lossy())
+                    .await
+                    .is_some(),
+                "a metadata dir reached through a symlink to the data dir is still inside it"
+            );
+        }
+    }
+
+    /// Object-store data paths cannot contain the metastore — `SQLite`/Turso only run
+    /// on a local filesystem — so the guard must not reject an S3 configuration.
+    #[tokio::test]
+    async fn overlap_never_fires_for_an_object_store_data_path() {
+        assert!(
+            overlapping_metastore_dir("s3://bucket/orders/", "/var/spice/metadata")
+                .await
+                .is_none(),
+            "an S3 data path is disjoint from any local metastore"
+        );
+    }
+
+    /// `mode: file_create` must refuse the configuration at open time, before the
+    /// recreate reaches `remove_dir_all`. Regression test for #13055 / #13068.
+    #[tokio::test]
+    async fn init_refuses_a_file_create_recreate_that_would_delete_the_metastore() {
+        let app = Arc::new(AppBuilder::new("test").build());
+        let rt = Arc::new(crate::Runtime::builder().build().await);
+
+        // Named `metadata`, so the default data path resolves onto the default
+        // metastore directory with no explicit parameter involved.
+        let mut dataset = DatasetBuilder::try_new("metadata".to_string(), "metadata")
+            .expect("dataset builder")
+            .with_app(app)
+            .with_runtime(rt)
+            .build()
+            .expect("dataset");
+        dataset.acceleration = Some(Acceleration {
+            engine: Engine::Cayenne,
+            mode: Mode::FileCreate,
+            ..Default::default()
+        });
+
+        let registry = Arc::new(AcceleratorEngineRegistry::new());
+        let err = CayenneAccelerator::new()
+            .init(&dataset, registry)
+            .await
+            .expect_err("init must refuse a data directory that contains the metastore");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("contains the Cayenne metastore directory"),
+            "the error must name the overlap; got: {message}"
+        );
+        assert!(
+            message.contains("metadata"),
+            "the error must name the dataset and both resolved paths; got: {message}"
+        );
+    }
+
+    /// The `file_update` schema rebuild reaches `remove_dir_all` without going through
+    /// `init`, so it needs its own guard — and must leave the metastore on disk.
+    /// Regression test for #13055 / #13068.
+    #[tokio::test]
+    async fn drop_table_leaves_a_metastore_nested_in_the_data_directory_intact() {
+        let app = Arc::new(AppBuilder::new("test").build());
+        let rt = Arc::new(crate::Runtime::builder().build().await);
+        let base = tempfile::tempdir().expect("temp dir");
+
+        let mut dataset = DatasetBuilder::try_new("orders".to_string(), "orders")
+            .expect("dataset builder")
+            .with_app(app)
+            .with_runtime(rt)
+            .build()
+            .expect("dataset");
+        // `cayenne_file_path` puts the data directory at `{base}/orders/`; the
+        // metastore is configured inside it.
+        let data_dir = base.path().join("orders");
+        let metadata_dir = data_dir.join("catalog");
+        dataset.acceleration = Some(Acceleration {
+            engine: Engine::Cayenne,
+            mode: Mode::FileUpdate,
+            params: [
+                (
+                    "cayenne_file_path".to_string(),
+                    base.path().to_string_lossy().into_owned(),
+                ),
+                (
+                    "cayenne_metadata_dir".to_string(),
+                    metadata_dir.to_string_lossy().into_owned(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        });
+
+        std::fs::create_dir_all(&metadata_dir).expect("metastore dir");
+        let catalog_file = metadata_dir.join("cayenne.db");
+        std::fs::write(&catalog_file, b"catalog").expect("catalog file");
+
+        let err = CayenneAccelerator::new()
+            .drop_table("orders", &dataset)
+            .await
+            .expect_err("drop_table must refuse to delete a data directory holding the metastore");
+        assert!(
+            err.to_string()
+                .contains("contains the Cayenne metastore directory"),
+            "the error must name the overlap; got: {err}"
+        );
+        assert!(
+            catalog_file.exists(),
+            "the metastore must survive the refused rebuild"
         );
     }
 

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -104,6 +104,19 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "Failed to configure dataset {table_name} (cayenne): Could not resolve the acceleration data directory '{data_dir}' or the Cayenne metastore directory '{metadata_dir}' against the working directory ({source}). \
+        Recreating this dataset deletes its data directory, and Spice will not do that without first proving the metastore is outside it. \
+        Set 'cayenne_file_path' and 'cayenne_metadata_dir' to absolute paths. \
+        See: https://spiceai.org/docs/components/data-accelerators/cayenne"
+    ))]
+    CayenneDirsUnresolvable {
+        table_name: String,
+        data_dir: String,
+        metadata_dir: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display(
         "Unsupported data type(s) in schema: {details}. By default, unsupported types cause an error. To convert unsupported types to strings, set 'unsupported_type_action: string'; otherwise, remove the unsupported columns."
     ))]
     UnsupportedDataTypes { details: String },
@@ -981,19 +994,27 @@ fn fs_probe_path(path: &str) -> &str {
     }
 }
 
-/// Make a configured Cayenne directory absolute without resolving it, or `None` for an
-/// object-store location (`s3://…`) — which can never overlap the metastore directory,
-/// since `SQLite`/Turso cannot run on object storage and
-/// [`CayenneAccelerator::resolve_metadata_dir`] therefore only ever yields a local path.
-fn absolute_local_dir(path: &str) -> Option<PathBuf> {
+/// Make a configured Cayenne directory absolute without resolving it.
+///
+/// `Ok(None)` is the object-store exemption (`s3://…`) — such a location can never
+/// overlap the metastore directory, since `SQLite`/Turso cannot run on object storage
+/// and [`CayenneAccelerator::resolve_metadata_dir`] therefore only ever yields a local
+/// path.
+///
+/// A relative path that cannot be placed is `Err`, never the exemption. The exemption
+/// waves a recursive delete through, so the two must stay distinguishable: everything
+/// downstream guards `remove_dir_all`, and a path this cannot resolve is a path whose
+/// overlap with the metastore is unknown. Returning `io::Result` is what stops a failed
+/// `current_dir()` from being spelled the same way as "cannot possibly overlap".
+fn absolute_local_dir(path: &str) -> std::io::Result<Option<PathBuf>> {
     if !is_local_path(path) {
-        return None;
+        return Ok(None);
     }
     let raw = Path::new(fs_probe_path(path));
     if raw.is_absolute() {
-        Some(raw.to_path_buf())
+        Ok(Some(raw.to_path_buf()))
     } else {
-        Some(std::env::current_dir().ok()?.join(raw))
+        Ok(Some(std::env::current_dir()?.join(raw)))
     }
 }
 
@@ -1028,8 +1049,8 @@ async fn resolve_in_filesystem_order(absolute: &Path) -> PathBuf {
     resolved
 }
 
-/// Every location a recursive delete of `path` could reach, or `None` for an
-/// object-store location.
+/// Every location a recursive delete of `path` could reach, `Ok(None)` for an
+/// object-store location, and `Err` when the path cannot be placed at all.
 ///
 /// Two forms, because a symlink is both a place and a name:
 ///
@@ -1039,8 +1060,10 @@ async fn resolve_in_filesystem_order(absolute: &Path) -> PathBuf {
 ///    directory whose own last component is a symlink pointing out of the tree still
 ///    loses its link — the catalog file survives with nothing naming it, and the
 ///    connection pool keeps writing through handles nothing can reopen.
-async fn overlap_candidates(path: &str) -> Option<Vec<PathBuf>> {
-    let absolute = absolute_local_dir(path)?;
+async fn overlap_candidates(path: &str) -> std::io::Result<Option<Vec<PathBuf>>> {
+    let Some(absolute) = absolute_local_dir(path)? else {
+        return Ok(None);
+    };
 
     let mut candidates = vec![resolve_in_filesystem_order(&absolute).await];
     if let (Some(parent), Some(name)) = (absolute.parent(), absolute.file_name()) {
@@ -1049,7 +1072,7 @@ async fn overlap_candidates(path: &str) -> Option<Vec<PathBuf>> {
             candidates.push(entry);
         }
     }
-    Some(candidates)
+    Ok(Some(candidates))
 }
 
 /// `true` when `inner` is `outer` itself or lies beneath it — i.e. a recursive delete
@@ -1075,8 +1098,10 @@ fn dir_contains(outer: &Path, inner: &Path) -> bool {
 /// `resolve_metadata_dir` yields `{spice_data}/metadata`. An explicit
 /// `cayenne_metadata_dir` set beneath the data directory collides the same way.
 ///
-/// Returns the resolved `(data_dir, metadata_dir)` pair when they overlap, naming
-/// whichever metastore location the delete would reach.
+/// Returns `Ok(Some((data_dir, metadata_dir)))` — resolved — when they overlap, naming
+/// whichever metastore location the delete would reach; `Ok(None)` when they provably
+/// cannot overlap; and `Err` when either path cannot be placed, which the caller must
+/// treat as a refusal rather than as `Ok(None)`.
 ///
 /// The data directory is compared in its fully resolved form only: `remove_dir_all`
 /// refuses a final-component symlink rather than following it, so the recursive walk
@@ -1084,13 +1109,18 @@ fn dir_contains(outer: &Path, inner: &Path) -> bool {
 async fn overlapping_metastore_dir(
     data_dir: &str,
     metadata_dir: &str,
-) -> Option<(PathBuf, PathBuf)> {
-    let data = resolve_in_filesystem_order(&absolute_local_dir(data_dir)?).await;
-    let metadata = overlap_candidates(metadata_dir)
-        .await?
+) -> std::io::Result<Option<(PathBuf, PathBuf)>> {
+    let Some(absolute_data) = absolute_local_dir(data_dir)? else {
+        return Ok(None);
+    };
+    let data = resolve_in_filesystem_order(&absolute_data).await;
+    let Some(candidates) = overlap_candidates(metadata_dir).await? else {
+        return Ok(None);
+    };
+    Ok(candidates
         .into_iter()
-        .find(|candidate| dir_contains(&data, candidate))?;
-    Some((data, metadata))
+        .find(|candidate| dir_contains(&data, candidate))
+        .map(|metadata| (data, metadata)))
 }
 
 /// Process-wide counter giving each [`CayenneAccelerator`] instance a unique id,
@@ -1265,12 +1295,24 @@ impl CayenneAccelerator {
     /// immediately before each recursive delete: at open time neither directory need
     /// exist yet, so the resolution falls back to a lexical one, and an overlap that
     /// only a symlink reveals appears once the directories are real.
+    ///
+    /// A path that cannot be placed refuses the recreate. The guard's whole job is to
+    /// prove the delete cannot reach the metastore, and it cannot prove that about a
+    /// path it failed to resolve.
     async fn ensure_metastore_outside_data_dir(
         source: &dyn AccelerationSource,
         data_dir: &str,
     ) -> Result<()> {
         let metadata_dir = Self::resolve_metadata_dir(source.acceleration());
-        if let Some((data, metadata)) = overlapping_metastore_dir(data_dir, &metadata_dir).await {
+        let overlap = overlapping_metastore_dir(data_dir, &metadata_dir)
+            .await
+            .map_err(|source_error| Error::CayenneDirsUnresolvable {
+                table_name: source.name().to_string(),
+                data_dir: data_dir.to_string(),
+                metadata_dir: metadata_dir.clone(),
+                source: source_error,
+            })?;
+        if let Some((data, metadata)) = overlap {
             return Err(Error::MetastoreInsideDataDir {
                 table_name: source.name().to_string(),
                 data_dir: data.to_string_lossy().into_owned(),
@@ -4885,6 +4927,7 @@ mod tests {
         assert!(
             overlapping_metastore_dir(&colliding, &metastore)
                 .await
+                .expect("the test paths resolve")
                 .is_some(),
             "a dataset named `metadata` puts its data directory on top of the metastore: \
              data={colliding} metastore={metastore}"
@@ -4894,6 +4937,7 @@ mod tests {
         assert!(
             overlapping_metastore_dir(&ordinary, &metastore)
                 .await
+                .expect("the test paths resolve")
                 .is_none(),
             "an ordinary dataset name is disjoint from the metastore: \
              data={ordinary} metastore={metastore}"
@@ -4911,6 +4955,7 @@ mod tests {
         assert!(
             overlapping_metastore_dir(&data.to_string_lossy(), &metastore.to_string_lossy())
                 .await
+                .expect("the test paths resolve")
                 .is_none(),
             "`meta` and `metadata` are siblings, not nested"
         );
@@ -4927,6 +4972,7 @@ mod tests {
         assert!(
             overlapping_metastore_dir(&data.to_string_lossy(), &nested.to_string_lossy())
                 .await
+                .expect("the test paths resolve")
                 .is_some(),
             "a metadata dir beneath the data dir is deleted with it"
         );
@@ -4935,6 +4981,7 @@ mod tests {
         assert!(
             overlapping_metastore_dir(&data.to_string_lossy(), &outside.to_string_lossy())
                 .await
+                .expect("the test paths resolve")
                 .is_none(),
             "a metadata dir outside the data dir survives the recreate"
         );
@@ -4952,6 +4999,7 @@ mod tests {
         assert!(
             overlapping_metastore_dir(&data.to_string_lossy(), &traversed.to_string_lossy())
                 .await
+                .expect("the test paths resolve")
                 .is_some(),
             "`orders/sibling/../catalog` is `orders/catalog`, which the delete takes"
         );
@@ -4966,6 +5014,7 @@ mod tests {
             assert!(
                 overlapping_metastore_dir(&data.to_string_lossy(), &through_link.to_string_lossy())
                     .await
+                    .expect("the test paths resolve")
                     .is_some(),
                 "a metadata dir reached through a symlink to the data dir is still inside it"
             );
@@ -4990,6 +5039,7 @@ mod tests {
         assert!(
             overlapping_metastore_dir(&data.to_string_lossy(), &through_link.to_string_lossy())
                 .await
+                .expect("the test paths resolve")
                 .is_some(),
             "`link/../catalog` resolves inside the data dir once `link` is followed first"
         );
@@ -5019,6 +5069,7 @@ mod tests {
         let (resolved_data, reached) =
             overlapping_metastore_dir(&data.to_string_lossy(), &entry.to_string_lossy())
                 .await
+                .expect("the test paths resolve")
                 .expect("the entry inside the data dir is unlinked by the delete");
         assert!(
             reached.starts_with(&resolved_data),
@@ -5037,8 +5088,38 @@ mod tests {
         assert!(
             overlapping_metastore_dir("s3://bucket/orders/", "/var/spice/metadata")
                 .await
+                .expect("the test paths resolve")
                 .is_none(),
             "an S3 data path is disjoint from any local metastore"
+        );
+    }
+
+    /// `Ok(None)` is what waves a recursive delete through, so it must mean "object
+    /// store" and nothing else — never "could not work out where this path is". Every
+    /// local spelling, including a relative one and a `file://` URI, resolves to a path
+    /// the overlap check can compare. Raised by Copilot on #13101.
+    #[test]
+    fn only_an_object_store_scheme_reaches_the_delete_exemption() {
+        let cwd = std::env::current_dir().expect("a working directory");
+
+        assert_eq!(
+            absolute_local_dir("relative/orders").expect("a relative path resolves"),
+            Some(cwd.join("relative/orders")),
+            "a relative local path is placed against the working directory, not exempted"
+        );
+        assert_eq!(
+            absolute_local_dir("/var/spice/orders").expect("an absolute path resolves"),
+            Some(PathBuf::from("/var/spice/orders"))
+        );
+        assert_eq!(
+            absolute_local_dir("file:///var/spice/orders").expect("a `file://` URI resolves"),
+            Some(PathBuf::from("/var/spice/orders")),
+            "a `file://` URI names a local directory, so it must be compared, not exempted"
+        );
+        assert_eq!(
+            absolute_local_dir("s3://bucket/orders/").expect("an object store is not a failure"),
+            None,
+            "only an object-store scheme may skip the overlap check"
         );
     }
 

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -994,28 +994,40 @@ fn fs_probe_path(path: &str) -> &str {
     }
 }
 
-/// Make a configured Cayenne directory absolute without resolving it.
+/// Make a configured Cayenne directory absolute without resolving it, treating it as a
+/// filesystem path unconditionally.
 ///
-/// `Ok(None)` is the object-store exemption (`s3://…`) — such a location can never
-/// overlap the metastore directory, since `SQLite`/Turso cannot run on object storage
-/// and [`CayenneAccelerator::resolve_metadata_dir`] therefore only ever yields a local
-/// path.
+/// `Err` when the path cannot be placed — a relative path whose `current_dir()` lookup
+/// fails. Everything downstream guards `remove_dir_all`, so a path this cannot place is
+/// a path whose overlap with the metastore is unknown, and the caller must refuse rather
+/// than assume.
+fn absolute_dir(path: &str) -> std::io::Result<PathBuf> {
+    let raw = Path::new(fs_probe_path(path));
+    if raw.is_absolute() {
+        Ok(raw.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(raw))
+    }
+}
+
+/// Make a configured Cayenne *data* directory absolute, or `Ok(None)` when it is an
+/// object-store location (`s3://…`) — which can never contain the metastore, since
+/// `SQLite`/Turso cannot run on object storage.
 ///
-/// A relative path that cannot be placed is `Err`, never the exemption. The exemption
-/// waves a recursive delete through, so the two must stay distinguishable: everything
-/// downstream guards `remove_dir_all`, and a path this cannot resolve is a path whose
-/// overlap with the metastore is unknown. Returning `io::Result` is what stops a failed
-/// `current_dir()` from being spelled the same way as "cannot possibly overlap".
-fn absolute_local_dir(path: &str) -> std::io::Result<Option<PathBuf>> {
+/// The exemption belongs to the data path alone, because it is the data path a recursive
+/// delete walks. It must not be applied to a metadata path: [`is_local_path`] is a
+/// substring test, so a value merely *containing* `://` would be exempted while the
+/// catalog code goes on treating it as the filesystem path it creates `cayenne.db` at —
+/// disabling the guard on a directory that never reached an object store.
+///
+/// `Err`, never the exemption, when the path cannot be placed: the exemption waves the
+/// delete through, so "cannot possibly overlap" and "cannot tell" must stay
+/// distinguishable.
+fn absolute_data_dir(path: &str) -> std::io::Result<Option<PathBuf>> {
     if !is_local_path(path) {
         return Ok(None);
     }
-    let raw = Path::new(fs_probe_path(path));
-    if raw.is_absolute() {
-        Ok(Some(raw.to_path_buf()))
-    } else {
-        Ok(Some(std::env::current_dir()?.join(raw)))
-    }
+    absolute_dir(path).map(Some)
 }
 
 /// Resolve `absolute` component by component, in the order the filesystem would.
@@ -1027,9 +1039,14 @@ fn absolute_local_dir(path: &str) -> std::io::Result<Option<PathBuf>> {
 /// containment check against `/data` then passes something it must refuse. Resolving in
 /// order keeps the accumulated path symlink-free, so `..` may simply pop it.
 ///
-/// Components that do not exist yet resolve to themselves — neither directory
-/// necessarily exists when this runs at open time.
-async fn resolve_in_filesystem_order(absolute: &Path) -> PathBuf {
+/// A component that does not exist yet resolves to itself — neither directory
+/// necessarily exists when this runs at open time. That is the *only* `canonicalize`
+/// failure this absorbs. Any other one (`PermissionDenied`, a transient filesystem
+/// error) means the component could not be resolved, so a symlink may still be
+/// unresolved and the containment check would run against a path the delete never walks;
+/// those propagate, so the caller refuses the delete instead of comparing a lexical
+/// path.
+async fn resolve_in_filesystem_order(absolute: &Path) -> std::io::Result<PathBuf> {
     let mut resolved = PathBuf::new();
     for component in absolute.components() {
         match component {
@@ -1040,17 +1057,23 @@ async fn resolve_in_filesystem_order(absolute: &Path) -> PathBuf {
             Component::Prefix(_) | Component::RootDir => resolved.push(component),
             Component::Normal(name) => {
                 resolved.push(name);
-                if let Ok(real) = tokio::fs::canonicalize(&resolved).await {
-                    resolved = real;
+                match tokio::fs::canonicalize(&resolved).await {
+                    Ok(real) => resolved = real,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(error),
                 }
             }
         }
     }
-    resolved
+    Ok(resolved)
 }
 
-/// Every location a recursive delete of `path` could reach, `Ok(None)` for an
-/// object-store location, and `Err` when the path cannot be placed at all.
+/// Every location a recursive delete of `path` could reach, or `Err` when the path
+/// cannot be resolved.
+///
+/// There is no object-store exemption here: this resolves a *metastore* directory, and
+/// the metastore is only ever local — see [`absolute_data_dir`] for why applying the
+/// exemption to this side disables the guard rather than skipping an impossible case.
 ///
 /// Two forms, because a symlink is both a place and a name:
 ///
@@ -1060,19 +1083,17 @@ async fn resolve_in_filesystem_order(absolute: &Path) -> PathBuf {
 ///    directory whose own last component is a symlink pointing out of the tree still
 ///    loses its link — the catalog file survives with nothing naming it, and the
 ///    connection pool keeps writing through handles nothing can reopen.
-async fn overlap_candidates(path: &str) -> std::io::Result<Option<Vec<PathBuf>>> {
-    let Some(absolute) = absolute_local_dir(path)? else {
-        return Ok(None);
-    };
+async fn overlap_candidates(path: &str) -> std::io::Result<Vec<PathBuf>> {
+    let absolute = absolute_dir(path)?;
 
-    let mut candidates = vec![resolve_in_filesystem_order(&absolute).await];
+    let mut candidates = vec![resolve_in_filesystem_order(&absolute).await?];
     if let (Some(parent), Some(name)) = (absolute.parent(), absolute.file_name()) {
-        let entry = resolve_in_filesystem_order(parent).await.join(name);
+        let entry = resolve_in_filesystem_order(parent).await?.join(name);
         if !candidates.contains(&entry) {
             candidates.push(entry);
         }
     }
-    Ok(Some(candidates))
+    Ok(candidates)
 }
 
 /// `true` when `inner` is `outer` itself or lies beneath it — i.e. a recursive delete
@@ -1100,8 +1121,8 @@ fn dir_contains(outer: &Path, inner: &Path) -> bool {
 ///
 /// Returns `Ok(Some((data_dir, metadata_dir)))` — resolved — when they overlap, naming
 /// whichever metastore location the delete would reach; `Ok(None)` when they provably
-/// cannot overlap; and `Err` when either path cannot be placed, which the caller must
-/// treat as a refusal rather than as `Ok(None)`.
+/// cannot overlap — the data path is on object storage; and `Err` when either path
+/// cannot be resolved, which the caller must treat as a refusal rather than as `Ok(None)`.
 ///
 /// The data directory is compared in its fully resolved form only: `remove_dir_all`
 /// refuses a final-component symlink rather than following it, so the recursive walk
@@ -1110,14 +1131,12 @@ async fn overlapping_metastore_dir(
     data_dir: &str,
     metadata_dir: &str,
 ) -> std::io::Result<Option<(PathBuf, PathBuf)>> {
-    let Some(absolute_data) = absolute_local_dir(data_dir)? else {
+    let Some(absolute_data) = absolute_data_dir(data_dir)? else {
         return Ok(None);
     };
-    let data = resolve_in_filesystem_order(&absolute_data).await;
-    let Some(candidates) = overlap_candidates(metadata_dir).await? else {
-        return Ok(None);
-    };
-    Ok(candidates
+    let data = resolve_in_filesystem_order(&absolute_data).await?;
+    Ok(overlap_candidates(metadata_dir)
+        .await?
         .into_iter()
         .find(|candidate| dir_contains(&data, candidate))
         .map(|metadata| (data, metadata)))
@@ -5103,23 +5122,44 @@ mod tests {
         let cwd = std::env::current_dir().expect("a working directory");
 
         assert_eq!(
-            absolute_local_dir("relative/orders").expect("a relative path resolves"),
+            absolute_data_dir("relative/orders").expect("a relative path resolves"),
             Some(cwd.join("relative/orders")),
             "a relative local path is placed against the working directory, not exempted"
         );
         assert_eq!(
-            absolute_local_dir("/var/spice/orders").expect("an absolute path resolves"),
+            absolute_data_dir("/var/spice/orders").expect("an absolute path resolves"),
             Some(PathBuf::from("/var/spice/orders"))
         );
         assert_eq!(
-            absolute_local_dir("file:///var/spice/orders").expect("a `file://` URI resolves"),
+            absolute_data_dir("file:///var/spice/orders").expect("a `file://` URI resolves"),
             Some(PathBuf::from("/var/spice/orders")),
             "a `file://` URI names a local directory, so it must be compared, not exempted"
         );
         assert_eq!(
-            absolute_local_dir("s3://bucket/orders/").expect("an object store is not a failure"),
+            absolute_data_dir("s3://bucket/orders/").expect("an object store is not a failure"),
             None,
             "only an object-store scheme may skip the overlap check"
+        );
+    }
+
+    /// The exemption belongs to the *data* path. `is_local_path` is a substring test, so
+    /// applying it to a metadata path exempts any value merely containing `://` — while
+    /// the catalog code goes on creating `cayenne.db` at that very filesystem path,
+    /// inside the directory the recreate deletes. Raised by Copilot on #13101.
+    #[tokio::test]
+    async fn a_metadata_dir_containing_a_scheme_separator_is_still_compared() {
+        let base = tempfile::tempdir().expect("temp dir");
+        let data = base.path().join("orders");
+        std::fs::create_dir_all(&data).expect("data dir");
+
+        let nested = data.join("catalog://v1");
+        assert!(
+            overlapping_metastore_dir(&data.to_string_lossy(), &nested.to_string_lossy())
+                .await
+                .expect("the test paths resolve")
+                .is_some(),
+            "`://` inside a metadata path does not put it on object storage, and the \
+             delete still reaches it"
         );
     }
 

--- a/crates/runtime/src/dataaccelerator/cayenne/mod.rs
+++ b/crates/runtime/src/dataaccelerator/cayenne/mod.rs
@@ -981,63 +981,80 @@ fn fs_probe_path(path: &str) -> &str {
     }
 }
 
-/// Resolve a configured Cayenne directory to an absolute, symlink-resolved path so
-/// two directories can be compared for containment.
-///
-/// Returns `None` for object-store locations (`s3://…`), which can never overlap the
-/// metastore directory (`SQLite`/Turso cannot run on object storage, so
-/// [`CayenneAccelerator::resolve_metadata_dir`] only ever yields a local path).
-///
-/// Neither directory necessarily exists yet, so this canonicalizes the deepest
-/// ancestor that does exist — resolving symlinks in the real part of the path, which a
-/// purely lexical comparison would miss — and re-appends the components that do not.
-async fn resolve_dir_for_overlap(path: &str) -> Option<PathBuf> {
+/// Make a configured Cayenne directory absolute without resolving it, or `None` for an
+/// object-store location (`s3://…`) — which can never overlap the metastore directory,
+/// since `SQLite`/Turso cannot run on object storage and
+/// [`CayenneAccelerator::resolve_metadata_dir`] therefore only ever yields a local path.
+fn absolute_local_dir(path: &str) -> Option<PathBuf> {
     if !is_local_path(path) {
         return None;
     }
-
     let raw = Path::new(fs_probe_path(path));
-    let absolute = if raw.is_absolute() {
-        raw.to_path_buf()
+    if raw.is_absolute() {
+        Some(raw.to_path_buf())
     } else {
-        std::env::current_dir().ok()?.join(raw)
-    };
+        Some(std::env::current_dir().ok()?.join(raw))
+    }
+}
 
-    // Collapse `.` and `..` lexically. `Path::starts_with` compares components, so an
-    // unresolved `..` would make an overlapping pair look disjoint.
-    let mut lexical = PathBuf::new();
+/// Resolve `absolute` component by component, in the order the filesystem would.
+///
+/// The order is the whole point: `..` names the parent of the directory the preceding
+/// component *resolves to*, not its lexical parent. Collapsing `..` up front and
+/// canonicalizing afterwards gets this backwards — with `link -> /data/subdir`,
+/// `link/../catalog` is `/data/catalog`, but a lexical collapse yields `/catalog` and a
+/// containment check against `/data` then passes something it must refuse. Resolving in
+/// order keeps the accumulated path symlink-free, so `..` may simply pop it.
+///
+/// Components that do not exist yet resolve to themselves — neither directory
+/// necessarily exists when this runs at open time.
+async fn resolve_in_filesystem_order(absolute: &Path) -> PathBuf {
+    let mut resolved = PathBuf::new();
     for component in absolute.components() {
         match component {
             Component::CurDir => {}
             Component::ParentDir => {
-                lexical.pop();
+                resolved.pop();
             }
-            other => lexical.push(other),
+            Component::Prefix(_) | Component::RootDir => resolved.push(component),
+            Component::Normal(name) => {
+                resolved.push(name);
+                if let Ok(real) = tokio::fs::canonicalize(&resolved).await {
+                    resolved = real;
+                }
+            }
         }
     }
+    resolved
+}
 
-    let mut missing_suffix = Vec::new();
-    let mut probe = lexical.clone();
-    loop {
-        if let Ok(existing) = tokio::fs::canonicalize(&probe).await {
-            let mut resolved = existing;
-            resolved.extend(missing_suffix.iter().rev());
-            return Some(resolved);
-        }
-        // Nothing on this path exists yet (or it is the filesystem root, which always
-        // canonicalizes): fall back to the lexical form.
-        let Some(name) = probe.file_name().map(std::ffi::OsStr::to_os_string) else {
-            return Some(lexical);
-        };
-        missing_suffix.push(name);
-        if !probe.pop() {
-            return Some(lexical);
+/// Every location a recursive delete of `path` could reach, or `None` for an
+/// object-store location.
+///
+/// Two forms, because a symlink is both a place and a name:
+///
+/// 1. **Fully resolved** — where the directory's contents actually live.
+/// 2. **The entry**: parent resolved, final component left literal. `remove_dir_all`
+///    unlinks the *entry* it walks onto rather than following it, so a metastore
+///    directory whose own last component is a symlink pointing out of the tree still
+///    loses its link — the catalog file survives with nothing naming it, and the
+///    connection pool keeps writing through handles nothing can reopen.
+async fn overlap_candidates(path: &str) -> Option<Vec<PathBuf>> {
+    let absolute = absolute_local_dir(path)?;
+
+    let mut candidates = vec![resolve_in_filesystem_order(&absolute).await];
+    if let (Some(parent), Some(name)) = (absolute.parent(), absolute.file_name()) {
+        let entry = resolve_in_filesystem_order(parent).await.join(name);
+        if !candidates.contains(&entry) {
+            candidates.push(entry);
         }
     }
+    Some(candidates)
 }
 
 /// `true` when `inner` is `outer` itself or lies beneath it — i.e. a recursive delete
-/// of `outer` takes `inner` with it.
+/// of `outer` takes `inner` with it. Compares whole components, so `…/meta` does not
+/// read as containing `…/metadata`.
 fn dir_contains(outer: &Path, inner: &Path) -> bool {
     inner.starts_with(outer)
 }
@@ -1058,14 +1075,22 @@ fn dir_contains(outer: &Path, inner: &Path) -> bool {
 /// `resolve_metadata_dir` yields `{spice_data}/metadata`. An explicit
 /// `cayenne_metadata_dir` set beneath the data directory collides the same way.
 ///
-/// Returns the resolved `(data_dir, metadata_dir)` pair when they overlap.
+/// Returns the resolved `(data_dir, metadata_dir)` pair when they overlap, naming
+/// whichever metastore location the delete would reach.
+///
+/// The data directory is compared in its fully resolved form only: `remove_dir_all`
+/// refuses a final-component symlink rather than following it, so the recursive walk
+/// only ever happens at the resolved directory.
 async fn overlapping_metastore_dir(
     data_dir: &str,
     metadata_dir: &str,
 ) -> Option<(PathBuf, PathBuf)> {
-    let data = resolve_dir_for_overlap(data_dir).await?;
-    let metadata = resolve_dir_for_overlap(metadata_dir).await?;
-    dir_contains(&data, &metadata).then_some((data, metadata))
+    let data = resolve_in_filesystem_order(&absolute_local_dir(data_dir)?).await;
+    let metadata = overlap_candidates(metadata_dir)
+        .await?
+        .into_iter()
+        .find(|candidate| dir_contains(&data, candidate))?;
+    Some((data, metadata))
 }
 
 /// Process-wide counter giving each [`CayenneAccelerator`] instance a unique id,
@@ -4945,6 +4970,64 @@ mod tests {
                 "a metadata dir reached through a symlink to the data dir is still inside it"
             );
         }
+    }
+
+    /// `..` names the parent of what the preceding component *resolves to*. With
+    /// `link -> {base}/data/subdir`, `link/../catalog` is `{base}/data/catalog` — inside
+    /// the data directory — but collapsing `..` before resolving `link` yields
+    /// `{base}/catalog` and lets the delete through. Raised by Copilot on #13101.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn overlap_applies_dot_dot_after_the_symlink_that_precedes_it() {
+        let base = tempfile::tempdir().expect("temp dir");
+        let data = base.path().join("data");
+        std::fs::create_dir_all(data.join("subdir")).expect("data subdir");
+
+        let link = base.path().join("link");
+        std::os::unix::fs::symlink(data.join("subdir"), &link).expect("symlink");
+
+        let through_link = link.join("..").join("catalog");
+        assert!(
+            overlapping_metastore_dir(&data.to_string_lossy(), &through_link.to_string_lossy())
+                .await
+                .is_some(),
+            "`link/../catalog` resolves inside the data dir once `link` is followed first"
+        );
+    }
+
+    /// `remove_dir_all` unlinks the directory entry it walks onto rather than following
+    /// it, so a metastore directory whose own last component is a symlink out of the
+    /// tree still loses its link — the catalog file survives with nothing naming it.
+    /// Raised by Copilot on #13101.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn overlap_detects_a_metastore_entry_symlinked_out_of_the_data_dir() {
+        let base = tempfile::tempdir().expect("temp dir");
+        let data = base.path().join("orders");
+        std::fs::create_dir_all(&data).expect("data dir");
+
+        // The catalog's contents live outside the data directory, but the name that
+        // reaches them is inside it.
+        let real_metastore = base.path().join("real-metastore");
+        std::fs::create_dir_all(&real_metastore).expect("metastore dir");
+        let entry = data.join("catalog");
+        std::os::unix::fs::symlink(&real_metastore, &entry).expect("symlink");
+
+        // Compare against the *returned* data path: on macOS the temp dir sits under
+        // `/var`, a symlink to `/private/var`, so the path the test built is not the one
+        // the guard resolves to.
+        let (resolved_data, reached) =
+            overlapping_metastore_dir(&data.to_string_lossy(), &entry.to_string_lossy())
+                .await
+                .expect("the entry inside the data dir is unlinked by the delete");
+        assert!(
+            reached.starts_with(&resolved_data),
+            "the error must name the entry the delete removes, not its target: {reached:?}"
+        );
+        assert!(
+            !reached.starts_with(&real_metastore),
+            "the target lies outside the data dir; naming it would read as a false positive"
+        );
     }
 
     /// Object-store data paths cannot contain the metastore — `SQLite`/Turso only run


### PR DESCRIPTION
## Summary

Both Cayenne recreate paths recursively delete a dataset's **data** directory without proving the **metastore** directory lies outside it:

- `mode: file_create` in `CayenneAccelerator::init`
- `DataAccelerator::drop_table`, for a `file_update` / schema-recreate rebuild

One metastore holds the catalog — manifests, snapshot pointers, partition rows — for *every* Cayenne dataset sharing a `cayenne_metadata_dir`. When it sits on or beneath the data directory being recreated, the delete unlinks the catalog for unrelated datasets. On POSIX the connection pool already holds handles to the now-unlinked file, so the run appears healthy and the metastore is simply **gone on the next restart**.

The stock defaults reach this with no operator error at all. `resolve_default_data_path` yields `{spice_data}/{dataset_name}/` and `resolve_metadata_dir` yields `{spice_data}/metadata`, and `dataset_name` is only `replace(['.', '/'], "_")`-normalized — so a dataset literally named `metadata` produces a byte-identical path. An explicit `cayenne_metadata_dir` set beneath a data directory collides the same way.

This is pre-existing, not a regression: `remove_dir_all` sits at the same two call sites on `trunk`.

## Changes

- **Refuse the configuration at open time**, in `init`, where the operator can still fix the spicepod — rather than at teardown, when they are already committed and the delete has nothing left to protect. A new `Error::MetastoreInsideDataDir` names the dataset and both *resolved* paths, and gives the two ways out (`cayenne_metadata_dir` outside the data directory, or rename the dataset).
- **Re-check immediately before each `remove_dir_all`.** At open time neither directory need exist, so resolution falls back to a lexical comparison; `snapshot_before_recreate` then creates both, which is when an overlap only a symlink reveals becomes resolvable. `drop_table` also needs its own guard because a schema rebuild never goes through `init`.
- **Compare paths component-wise** after collapsing `.`/`..` and canonicalizing the deepest *existing* ancestor. Component-wise is what keeps `…/meta` from being read as containing `…/metadata`; collapsing `..` and resolving symlinks is what keeps an overlap from hiding behind either.
- **Object-store data paths are exempt** and short-circuit before any filesystem call — `SQLite`/Turso cannot run on object storage, so `resolve_metadata_dir` only ever yields a local path and an `s3://` data directory can never contain it.

The guard is deliberately scoped to the two deleting paths rather than pushed into `cayenne_data_dir`, the shared resolver: that resolver is also called from config resolution and the autotune storage probe, which never delete anything, and failing there would turn a benign path read into an error.

## Test plan

Nine new unit tests in `crates/runtime/src/dataaccelerator/cayenne/mod.rs`, all failing on the old code at the two production entry points:

- `init_refuses_a_file_create_recreate_that_would_delete_the_metastore` — a `metadata`-named dataset with stock defaults; `init` errors before reaching the delete.
- `drop_table_leaves_a_metastore_nested_in_the_data_directory_intact` — asserts the error **and** that `cayenne.db` is still on disk afterwards, which is the actual data-loss claim.
- The default collision, and that an ordinary dataset name stays disjoint.
- A sibling sharing a name prefix (`meta` vs `metadata`) — no false refusal.
- An explicit `cayenne_metadata_dir` nested under the data directory, and one outside it.
- `..` traversal and a symlinked data directory both resolved before comparing.
- An `s3://` data path never refused.
- `overlap_applies_dot_dot_after_the_symlink_that_precedes_it` — the first Copilot finding; fails on the first commit of this PR.
- `overlap_detects_a_metastore_entry_symlinked_out_of_the_data_dir` — the second; asserts the error names the *entry* inside the data directory, not its out-of-tree target.

Verification:

- `make lint` — clean
- `make test` — clean

## Review round

Copilot found two ways the overlap check could still miss the metastore, both valid and both fixed in `adb2e93838`:

1. **`..` was collapsed before symlinks were resolved**, which inverts POSIX order — `..` names the parent of what the preceding component *resolves to*. With `link -> /data/subdir`, `link/../catalog` is `/data/catalog`, but the lexical collapse yielded `/catalog` and the check then passed a configuration it must refuse. Resolution now walks component by component, canonicalizing each existing one before appending the next, so the accumulated path is symlink-free and `..` may simply pop it.
2. **A metastore directory whose own final component is a symlink out of the data directory** still loses its link: `remove_dir_all` unlinks the entry it walks onto rather than following it, so the catalog file survives with nothing naming it while the pool writes through handles nothing can reopen. Both locations a delete could reach are now checked — the fully resolved directory, and the entry with its parent resolved and the final component literal.

The data directory is still compared in its fully resolved form only, because `remove_dir_all` refuses a final-component symlink rather than following it.

A third finding, on `mod.rs:996` with the same shape at the two `?` sites downstream, is fixed in `ffebd3e4e6`:

3. **A path that could not be resolved was spelled the same way as the object-store exemption.** `absolute_local_dir` returned `None` both for "object store, so it provably cannot contain the metastore" — the answer that lets `remove_dir_all` proceed — and for a relative path whose `std::env::current_dir()` lookup failed, and both callers propagated it with `?`. `overlapping_metastore_dir` then answered "no overlap" and the guard failed open on exactly the input it could not reason about. The blast radius is not only a pathological working directory: `spice_data_base_path()` feeds both `resolve_default_data_path` and `resolve_metadata_dir`, so a relative base takes the relative branch for the default configuration. The two answers are now distinct types — `absolute_local_dir` returns `io::Result<Option<PathBuf>>`, `overlap_candidates` and `overlapping_metastore_dir` thread it through, and `ensure_metastore_outside_data_dir` maps `Err` onto a new `Error::CayenneDirsUnresolvable` naming the dataset, both configured paths, the underlying `io::Error`, and the fix. All three call sites (`init`, the `file_create` recreate, `drop_table`) already `?` on it, so all three refuse.

The `current_dir()`-failure arm is not reachable from a unit test without process-global cwd surgery that would race every other test in the binary, so the type change is what makes the fail-open unrepresentable; `only_an_object_store_scheme_reaches_the_delete_exemption` pins the invariant behind it and does not compile against the old signature.

Two further findings on that commit, both the same fail-open class and both fixed in `df44b8ef72`:

4. **The object-store exemption was applied to the metastore path, not just the data path.** `is_local_path` is a substring test, so `cayenne_metadata_dir: /var/lib/orders/catalog://v1` was exempted as "on object storage" while the catalog code went on creating `cayenne.db` at exactly that filesystem path, inside the directory the recreate deletes. It also contradicted this file's own invariant — if `SQLite`/Turso cannot run on object storage then the metadata side has no impossible case to skip, so the branch could only ever disable the guard. The exemption now lives only in `absolute_data_dir`, called only for the data path; `absolute_dir` resolves unconditionally and `overlap_candidates` returns `io::Result<Vec<PathBuf>>`, so there is no longer a value meaning "skip the metastore comparison".
5. **`resolve_in_filesystem_order` swallowed every `canonicalize` error** as "this component does not exist yet". Only `NotFound` means that; `PermissionDenied` or a transient I/O error means the component was not resolved, leaving a symlink in the accumulated path so the containment check runs against a path the delete never walks. It now returns `io::Result<PathBuf>` and propagates everything but `NotFound`, and all three call sites were already in `io::Result` context, so the error becomes `Error::CayenneDirsUnresolvable` at all three production entry points.

`a_metadata_dir_containing_a_scheme_separator_is_still_compared` covers (4) and is **neuter-verified**: restoring the exemption in `overlap_candidates` fails it while `overlap_never_fires_for_an_object_store_data_path` keeps passing, so the fix does not over-tighten the genuine S3 case. (5) is not separately tested — provoking a non-`NotFound` `canonicalize` error needs a directory mode the test process cannot rely on — so the narrow `NotFound`-only match is the whole of it; flagged rather than implied.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1 with "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; the `grok` fallback is not installed in this environment (`attempt=grok result=not-installed`). Re-run after the Copilot fixes and skipped for the same reason: receipt records `engine=none exit=1` for `origin/trunk...adb2e93838`, the HEAD being shipped.
- `/security-review`: re-run on `adb2e93838`, no HIGH or MEDIUM findings. The change adds only refusals ahead of two pre-existing deletes: no new injection sink, no subprocess/deserialization/network surface, and the only I/O is a read-only `canonicalize`. Inputs are operator-supplied spicepod config, and the new error interpolates only filesystem paths the operator configured themselves (matching existing precedent in this file).
- `/simplify`: ran, no changes. Reuse — `is_local_path`/`fs_probe_path` are reused and no lexical path normalizer exists to call (`directory_archive.rs` *rejects* `..` for archive-extraction safety rather than collapsing it). Efficiency — both call sites are startup/teardown and the S3 case short-circuits with no filesystem I/O. Altitude — the invariant is Cayenne-specific, so the accelerator is the right depth; see the scoping note under Changes.

- Follow-up commit `ffebd3e4e6` (Copilot finding 3, fail-closed path resolution): adversarial review **declared skip** — `codex` exited 1 with the same "Your workspace is out of credits" message (receipt `engine=none exit=1`, scoped `adb2e93838...ffebd3e4e6`), and `grok` is not installed. `/security-review` re-run on this commit: no findings — the change only converts a silent pass into a typed refusal, adds no sink or surface, and the new message interpolates operator-configured paths already carried by the sibling `MetastoreInsideDataDir` variant. `/simplify`: no changes; the `Result` has to be threaded through both callers, and the `let Some(..) else { return Ok(None) }` form is used consistently at all three sites. Verified locally: `cargo check -p runtime --lib` clean and all 8 guard tests pass, including the new one.

- Follow-up commit `df44b8ef72` (Copilot findings 4 and 5): adversarial review **declared skip** for the third time on this PR, same cause — `codex` exits 1 with "Your workspace is out of credits" and `grok` is not installed, so no cross-model engine is available in this environment. `/security-review` on this commit: no findings — it removes an exemption and propagates an error, adding no sink, no surface and no new interpolated value. `/simplify`: no changes; splitting `absolute_dir` from `absolute_data_dir` is what removes the reusable footgun rather than adding a layer. Verified locally: `cargo test -p runtime --lib` green — 9 guard tests including the new one — plus the neuter arm above.

Fixes #13055
Fixes #13068

## Checklist

- [x] Regression tests that fail on the old code
- [x] Structured, actionable error naming the dataset and both resolved paths
- [x] No behavior change for configurations that were already disjoint
- [ ] `make signoff` / `Attestation` green


