### PR TITLE
fix(ci): let enforce-pull-with-spice pass on a PR any App opened

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -79,14 +79,21 @@ jobs:
           required_label_prefixes: 'kind/,area/'
           banned_labels: 'invalid,wontfix,nomerge,duplicate'
           # GitHub's assignees API silently drops App accounts, so `auto_assign_author`
-          # below cannot satisfy `require_assignee` on a Dependabot PR — the required
+          # below cannot satisfy `require_assignee` on a PR an App opened — the required
           # check is then red forever with nothing any author or reviewer can do about
           # it. #12358 is the shape: every other gate green, blocked solely on
           # `❌ At least one assignee is required`, until a maintainer hand-assigned
           # themselves. `pr.yml` already fast-tracks Dependabot for the same reason.
+          #
+          # The exemption keys on the author's account *type* rather than naming one
+          # App, because the API behaviour it works around is a property of App
+          # accounts in general: `github-actions[bot]` hits it too, which is why every
+          # `Update openapi.json` PR the schema workflow opens is unmergeable. Our own
+          # bots (`claudespice`, `grokspice`) are ordinary `User` accounts and are
+          # unaffected — they can be assigned, so they must still carry an assignee.
           # This exempts nothing else — the title-length, `kind/`/`area/` label and
-          # banned-label gates still apply to dependency bumps exactly as before.
-          require_assignee: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && 'false' || 'true' }}
+          # banned-label gates still apply to App-authored PRs exactly as before.
+          require_assignee: ${{ github.event.pull_request.user.type == 'Bot' && 'false' || 'true' }}
           auto_label: 'true'
           # No auto_label_size: GitHub applies size labels natively now, and the
           # action's input defaults to false, so leaving it out is the whole


### PR DESCRIPTION
Fixes #13115

## The problem

`enforce-pull-with-spice` is a required status check on `trunk`, and its `require_assignee` gate cannot be satisfied by a PR a GitHub App opened. The workflow already documents why:

> GitHub's assignees API silently drops App accounts, so `auto_assign_author` below cannot satisfy `require_assignee` … the required check is then red forever with nothing any author or reviewer can do about it.

The exemption added for that named a single App by login:

```yaml
require_assignee: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && 'false' || 'true' }}
```

`github-actions[bot]` is an App account too, so it hits the same API behaviour and was never covered.

## What it costs

Every `Update openapi.json` PR the schema workflow opens is structurally unmergeable. Six are open, all carrying a **byte-identical** 101-line diff, reopened over three weeks because the change never lands — #11989, #12269, #12374, #12457, #12787, #12945, none with an assignee. #11989 is approved by a core maintainer with every other check green, and its diff adds the already-shipped `POST /v1/datasets/{name}/cdc` route ([routes.rs:341](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/http/routes.rs#L341)) to the published schema.

## Changes

Key the exemption on the author's account **type**, because the API behaviour it works around is a property of App accounts in general rather than of one App.

Verified against the API that this does not loosen the gate for us: `claudespice` and `grokspice` are ordinary `User` accounts, so they still have to carry an assignee — which matters, since assignment is how our tooling finds its own PRs again. Only `type == 'Bot'` (App) authors are exempt, and every other gate — title length, `kind/`/`area/` labels, banned labels — still applies to them exactly as before.

`pr.yml`'s separate Dependabot fast-track is deliberately left alone: it verifies commit signatures to establish that the single commit really is Dependabot's, which is a trust boundary rather than an API workaround.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(...)"` parses the workflow.
- Account types confirmed live: `#13107` → `claudespice`/`User`, `#12721` → `grokspice`/`User`, `#11989` → `github-actions[bot]`/`Bot`.
- No test references the `dependabot[bot]` literal in this file (`scripts/`, `.github/workflows/`), so nothing is pinned to the old form.

Note that landing this alone does not turn the six openapi PRs green: `pull_request_target` runs are suppressed for events raised by `GITHUB_TOKEN`, so their `opened` events start no run at all. Each still needs an `area/` label added by a human — which both supplies the missing label and fires the `labeled` event that makes the check finally report.

## Review gate

- Adversarial review: `codex` 0.144.4 — **declared skip**, engine unavailable (exits 1, "Your workspace is out of credits").
- `/security-review`: no HIGH or MEDIUM findings. `user.type` is a GitHub-assigned account enum, not attacker-settable; the value is evaluated by the Actions expression engine and passed as an action input, never into a `run:` shell; no `checkout` of PR code and no `permissions` change, so the `pull_request_target` surface is unchanged.
