### PR TITLE
fix(build): give every non-member package its own workspace root (fixes #13093)

### DIFF
--- a/.github/actions/check-code-changes/action.yml
+++ b/.github/actions/check-code-changes/action.yml
@@ -59,9 +59,12 @@ inputs:
         - 'scripts/check_table_layers.py'
         - 'scripts/check_rust_gate_paths.py'
         - 'scripts/check_module_reachability.py'
-        # The reachability guard's own regression harness runs in `lint-rust`,
-        # so a change to it changes what the Rust gate enforces.
+        - 'scripts/check_workspace_membership.py'
+        # The reachability and workspace-membership guards run their own
+        # regression harnesses in `lint-rust`, so a change to either changes what
+        # the Rust gate enforces.
         - 'scripts/test_check_module_reachability.py'
+        - 'scripts/test_check_workspace_membership.py'
         - 'rust-toolchain'
         - 'rust-toolchain.toml'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -277,7 +277,7 @@ jobs:
               return;
             }
 
-            const rustAffecting = /(\.rs$|(^|\/)Cargo\.(toml|lock)$|(^|\/)rust-toolchain(\.toml)?$|(^|\/)\.cargo\/|(^|\/)\.?(clippy|rustfmt)\.toml$|(^|\/)nextest\.toml$|(^|\/)layers\.toml$|^scripts\/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability)\.py$|^Makefile$)/;
+            const rustAffecting = /(\.rs$|(^|\/)Cargo\.(toml|lock)$|(^|\/)rust-toolchain(\.toml)?$|(^|\/)\.cargo\/|(^|\/)\.?(clippy|rustfmt)\.toml$|(^|\/)nextest\.toml$|(^|\/)layers\.toml$|^scripts\/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability|workspace_membership)\.py$|^Makefile$)/;
             for (const file of files) {
               // A rename off a .rs path changes Rust sources even though the new
               // name doesn't match, so both sides of the rename must be clean.

--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,10 @@ lint-rust:
 	python3 scripts/check_table_layers.py
 	## Rust-gate path-list guard (fast, no compile): the sign-off, Attestation, and merge-queue path lists must agree. See docs/dev/ci_signoff.md
 	python3 scripts/check_rust_gate_paths.py
+	## Workspace-membership guard (fast, no compile): a package outside the root workspace must declare its own, or an ancestor manifest claims it and cargo metadata fails
+	## Its parser and the cargo behaviour it relies on are exercised first: in a plain checkout every manifest resolves, so the live-tree scan alone cannot tell a correct manifest from a broken one
+	python3 scripts/test_check_workspace_membership.py
+	python3 scripts/check_workspace_membership.py
 	## Unreachable-module guard (fast, no compile): every file under a crate's src/ must be reachable from its crate root, or nothing compiles it
 	## Its parser is exercised first: the live-tree scan only covers the shapes today's workspace happens to contain, so a parser regression for any other shape would pass unnoticed
 	python3 scripts/test_check_module_reachability.py

--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,10 @@ lint: lint-rust
 
 # Full workspace lint (default), or scoped via PACKAGES=… for a fast fail-first pass.
 lint-rust:
+	## Workspace-membership guard (fast, no compile): a package outside the root workspace must declare its own, or an ancestor manifest claims it and cargo metadata fails. Runs before cargo fmt, which is one of the things that failure breaks. See docs/dev/ci_signoff.md
+	## Its parser is exercised first: in a plain checkout every manifest resolves, so the live-tree scan alone cannot tell a correct manifest from a broken one
+	python3 scripts/test_check_workspace_membership.py
+	python3 scripts/check_workspace_membership.py
 	cargo fmt $(_FMT_FLAGS) -- --check
 	## Crate-layering guard (fast, no compile): no crate may depend on a higher tier. See docs/dev/crate_layering.md
 	python3 scripts/check_crate_layers.py
@@ -262,10 +266,6 @@ lint-rust:
 	python3 scripts/check_table_layers.py
 	## Rust-gate path-list guard (fast, no compile): the sign-off, Attestation, and merge-queue path lists must agree. See docs/dev/ci_signoff.md
 	python3 scripts/check_rust_gate_paths.py
-	## Workspace-membership guard (fast, no compile): a package outside the root workspace must declare its own, or an ancestor manifest claims it and cargo metadata fails
-	## Its parser and the cargo behaviour it relies on are exercised first: in a plain checkout every manifest resolves, so the live-tree scan alone cannot tell a correct manifest from a broken one
-	python3 scripts/test_check_workspace_membership.py
-	python3 scripts/check_workspace_membership.py
 	## Unreachable-module guard (fast, no compile): every file under a crate's src/ must be reachable from its crate root, or nothing compiles it
 	## Its parser is exercised first: the live-tree scan only covers the shapes today's workspace happens to contain, so a parser regression for any other shape would pass unnoticed
 	python3 scripts/test_check_module_reachability.py

--- a/crates/data-connectors/connector-nfs/Cargo.toml
+++ b/crates/data-connectors/connector-nfs/Cargo.toml
@@ -1,11 +1,9 @@
 # This crate is excluded from the workspace because it requires system libnfs library.
 # Build with: cargo build -p connector-nfs --manifest-path crates/data-connectors/connector-nfs/Cargo.toml
 
-# Its own workspace root, so the exclusion holds wherever the repository is checked out.
-# The root manifest excludes this crate by a path relative to itself, which does not match a
-# checkout nested inside another one (a `git worktree` under the primary clone): cargo then
-# resolves the nearest ancestor manifest instead and rejects the package as believing it is in
-# a workspace it is not a member of. That aborts `cargo fmt --all` for the whole tree.
+# Prevent this from interfering with workspaces: the root manifest's `exclude` entry holds only
+# in a top-level checkout, and `bin/spiced` path-depends on this crate, so without its own
+# workspace root a nested checkout aborts `cargo fmt --all`. See docs/dev/ci_signoff.md
 [workspace]
 
 [package]

--- a/crates/data-connectors/connector-nfs/Cargo.toml
+++ b/crates/data-connectors/connector-nfs/Cargo.toml
@@ -1,5 +1,13 @@
 # This crate is excluded from the workspace because it requires system libnfs library.
 # Build with: cargo build -p connector-nfs --manifest-path crates/data-connectors/connector-nfs/Cargo.toml
+
+# Its own workspace root, so the exclusion holds wherever the repository is checked out.
+# The root manifest excludes this crate by a path relative to itself, which does not match a
+# checkout nested inside another one (a `git worktree` under the primary clone): cargo then
+# resolves the nearest ancestor manifest instead and rejects the package as believing it is in
+# a workspace it is not a member of. That aborts `cargo fmt --all` for the whole tree.
+[workspace]
+
 [package]
 name = "connector-nfs"
 edition = "2024"

--- a/crates/libnfs/Cargo.toml
+++ b/crates/libnfs/Cargo.toml
@@ -1,5 +1,5 @@
-# This crate is excluded from the workspace because it requires system libnfs library.
-# Build with: cargo build -p libnfs --manifest-path crates/libnfs/Cargo.toml
+# This crate is a workspace member, but it requires the system libnfs library, so the
+# compile-time gates pass `--exclude libnfs`. Build with: cargo build -p libnfs
 [package]
 name = "libnfs"
 version = "0.1.0"

--- a/crates/vendor/lopdf/pdfutil/Cargo.toml
+++ b/crates/vendor/lopdf/pdfutil/Cargo.toml
@@ -1,3 +1,7 @@
+# Its own workspace root: this package is not a member of the repository's root workspace,
+# and cargo would otherwise bind it to the nearest ancestor workspace manifest.
+[workspace]
+
 [package]
 authors = ["Junfeng Liu <china.liujunfeng@gmail.com>"]
 description = "A utility for PDF document manipulation."

--- a/crates/vendor/lopdf/pdfutil/Cargo.toml
+++ b/crates/vendor/lopdf/pdfutil/Cargo.toml
@@ -1,5 +1,4 @@
-# Its own workspace root: this package is not a member of the repository's root workspace,
-# and cargo would otherwise bind it to the nearest ancestor workspace manifest.
+# Prevent this from interfering with workspaces. See docs/dev/ci_signoff.md
 [workspace]
 
 [package]

--- a/crates/vendor/ttf-parser/benches/Cargo.toml
+++ b/crates/vendor/ttf-parser/benches/Cargo.toml
@@ -1,3 +1,7 @@
+# Its own workspace root: this package is not a member of the repository's root workspace,
+# and cargo would otherwise bind it to the nearest ancestor workspace manifest.
+[workspace]
+
 [package]
 name = "benchmarks"
 version = "0.1.0"

--- a/crates/vendor/ttf-parser/benches/Cargo.toml
+++ b/crates/vendor/ttf-parser/benches/Cargo.toml
@@ -1,5 +1,4 @@
-# Its own workspace root: this package is not a member of the repository's root workspace,
-# and cargo would otherwise bind it to the nearest ancestor workspace manifest.
+# Prevent this from interfering with workspaces. See docs/dev/ci_signoff.md
 [workspace]
 
 [package]

--- a/crates/vendor/ttf-parser/c-api/Cargo.toml
+++ b/crates/vendor/ttf-parser/c-api/Cargo.toml
@@ -1,3 +1,7 @@
+# Its own workspace root: this package is not a member of the repository's root workspace,
+# and cargo would otherwise bind it to the nearest ancestor workspace manifest.
+[workspace]
+
 [package]
 name = "ttf-parser-capi"
 version = "0.25.1"

--- a/crates/vendor/ttf-parser/c-api/Cargo.toml
+++ b/crates/vendor/ttf-parser/c-api/Cargo.toml
@@ -1,5 +1,4 @@
-# Its own workspace root: this package is not a member of the repository's root workspace,
-# and cargo would otherwise bind it to the nearest ancestor workspace manifest.
+# Prevent this from interfering with workspaces. See docs/dev/ci_signoff.md
 [workspace]
 
 [package]

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -183,8 +183,8 @@ files the gate itself reads**:
   the root `clippy.toml`; `[.]rustfmt.toml`
 - `.config/nextest.toml` — retries, slow-test timeouts, test groups
 - `layers.toml`, `scripts/check_crate_layers.py`,
-  `scripts/check_rust_gate_paths.py`, and
-  `scripts/check_module_reachability.py` — the no-compile guards it runs
+  `scripts/check_rust_gate_paths.py`, `scripts/check_module_reachability.py`,
+  and `scripts/check_workspace_membership.py` — the no-compile guards it runs
 - the root `Makefile` — it holds every `-Dclippy::…` flag the gate enforces
 
 The merge queue still runs the full suite on the merged result — its
@@ -222,6 +222,32 @@ The walk handles the cases a regex over `mod` alone gets wrong — `#[path = "�
 redirects, declarations behind `#[cfg(…)]` (still declarations), inline
 `mod x { … }` nesting, and `mod` tokens inside comments and string literals.
 `scripts/test_check_module_reachability.py` covers each one.
+
+### The workspace-membership guard
+
+`make lint-rust` also runs `scripts/check_workspace_membership.py`, which fails
+when a tracked package is neither a member of the root workspace nor its own
+workspace root. Cargo resolves such a package's workspace by walking up the
+directory tree, so whichever ancestor manifest it reaches first claims it — and
+rejects it, because the package is not in that workspace's `members`.
+
+`workspace.exclude` does not settle this. It excludes a path relative to the
+manifest that declares it, so it stops matching as soon as the repository is
+checked out *inside* another copy of itself, which is where agent `git worktree`
+checkouts under `.claude/worktrees/` live. The nested root excludes the package
+correctly, cargo keeps walking, and the outer root claims it. The failure is not
+local to that package: `cargo fmt --all` resolves it while walking the tree, so
+`make lint` and `make signoff` abort before running a single check
+([#13093](https://github.com/spiceai/spiceai/issues/13093)). An empty
+`[workspace]` table in the package's own manifest ends the walk wherever the
+repository sits.
+
+The guard checks the declaration rather than probing whether `cargo metadata`
+resolves today: in a plain checkout the root `exclude` does match, so a probe
+passes on exactly the manifests the guard exists to catch.
+`scripts/test_check_workspace_membership.py` covers the parser and rebuilds the
+nested-checkout shape with cargo, so the behaviour the guard relies on is pinned
+rather than assumed.
 
 ### Dependabot bumps are fast-tracked
 

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -235,19 +235,28 @@ rejects it, because the package is not in that workspace's `members`.
 manifest that declares it, so it stops matching as soon as the repository is
 checked out *inside* another copy of itself, which is where agent `git worktree`
 checkouts under `.claude/worktrees/` live. The nested root excludes the package
-correctly, cargo keeps walking, and the outer root claims it. The failure is not
-local to that package: `cargo fmt --all` resolves it while walking the tree, so
-`make lint` and `make signoff` abort before running a single check
-([#13093](https://github.com/spiceai/spiceai/issues/13093)). An empty
+correctly, cargo keeps walking, and the outer root claims it. An empty
 `[workspace]` table in the package's own manifest ends the walk wherever the
 repository sits.
+
+When a workspace member path-depends on the claimed package, the failure stops
+being local to it: resolving the member resolves the dependency, so `cargo fmt
+--all` aborts and takes `make lint` and `make signoff` with it before a single
+check runs. That is how
+[#13093](https://github.com/spiceai/spiceai/issues/13093) presented —
+`bin/spiced` has an optional path dependency on `connector-nfs`. A package
+nothing depends on fails only when addressed directly, but it is the same defect
+one dependency edge away from the same outcome. The guard therefore runs ahead
+of `cargo fmt --check`, unlike the other guards: a guard placed after it would
+never be reached to explain what the raw cargo error means.
 
 The guard checks the declaration rather than probing whether `cargo metadata`
 resolves today: in a plain checkout the root `exclude` does match, so a probe
 passes on exactly the manifests the guard exists to catch.
 `scripts/test_check_workspace_membership.py` covers the parser and rebuilds the
-nested-checkout shape with cargo, so the behaviour the guard relies on is pinned
-rather than assumed.
+nested-checkout shape with cargo — including the path dependency that puts the
+package on the walk — so the behaviour the guard relies on is pinned rather than
+assumed.
 
 ### Dependabot bumps are fast-tracked
 

--- a/scripts/check_workspace_membership.py
+++ b/scripts/check_workspace_membership.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Workspace-membership guard.
+#
+# Every package in the tree must be reachable from exactly one workspace root.
+# A package that is NOT a member of the repository's root workspace has to say
+# so itself, with an empty `[workspace]` table in its own manifest. Otherwise
+# cargo resolves its workspace by walking up the directory tree, and whichever
+# ancestor manifest it lands on claims the package:
+#
+#   error: current package believes it's in a workspace when it's not:
+#   current:   .../.claude/worktrees/<name>/crates/data-connectors/connector-nfs/Cargo.toml
+#   workspace: .../Cargo.toml
+#
+# The root manifest's `exclude` list does not prevent this, because it excludes
+# a path relative to *itself*. When the repository is checked out inside another
+# copy of itself — which is where `git worktree` checkouts under `.claude/`
+# live — the nested copy's path does not match the outer root's `exclude` entry,
+# the outer root claims the package, and the resolution fails. That aborts
+# `cargo metadata`, and with it `cargo fmt --all`, `make lint`, and `make
+# signoff` for the whole tree (#13093).
+#
+# The check is on the DECLARATION, not on whether `cargo metadata` currently
+# resolves: in a plain checkout the root `exclude` does match, so a resolution
+# probe passes on exactly the manifests this guard exists to catch.
+#
+# Usage:
+#   scripts/check_workspace_membership.py         # validate (exit 1 on violation)
+#   scripts/check_workspace_membership.py --list  # print every package and its workspace root
+#
+# Pure stdlib; no third-party deps. Python 3.11+ for tomllib.
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:
+    # Exit 2 (tooling/config error), never 1 — 1 signals an actual violation.
+    print(
+        "error: this script needs Python 3.11+ for the stdlib `tomllib` module "
+        f"(found {sys.version_info.major}.{sys.version_info.minor}). "
+        "Install/select a newer python3 and re-run `make lint-rust`.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def read_manifest(path: Path) -> dict:
+    """Parse a manifest, or exit 2 — an unreadable manifest is a tooling error."""
+    try:
+        with path.open("rb") as f:
+            return tomllib.load(f)
+    except FileNotFoundError:
+        print(f"error: manifest not found at {path}.", file=sys.stderr)
+        raise SystemExit(2)
+    except tomllib.TOMLDecodeError as e:
+        print(f"error: {path} is not valid TOML: {e}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def is_package(manifest: dict) -> bool:
+    """A manifest that defines a package. A virtual manifest defines only a workspace."""
+    return "package" in manifest
+
+
+def declares_workspace(manifest: dict) -> bool:
+    """A manifest that is its own workspace root, however it fills the table in."""
+    return "workspace" in manifest
+
+
+def find_violations(
+    manifests: dict[Path, dict], members: set[Path], root: Path
+) -> list[Path]:
+    """Non-member packages that leave their workspace root to an ancestor lookup.
+
+    `manifests` maps a manifest path to its parsed contents, `members` holds the
+    manifest paths of the root workspace's members, and `root` is the repository
+    root manifest.
+    """
+    return sorted(
+        path
+        for path, manifest in manifests.items()
+        if path != root
+        and path not in members
+        and is_package(manifest)
+        and not declares_workspace(manifest)
+    )
+
+
+def tracked_manifests() -> list[Path]:
+    """Every `Cargo.toml` git tracks, so a nested worktree's copies stay out of it."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO), "ls-files", "-z", "--", "*Cargo.toml"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as e:
+        print(f"error: could not list tracked manifests: {e}", file=sys.stderr)
+        raise SystemExit(2)
+    return [REPO / p for p in out.split("\0") if p]
+
+
+def workspace_members() -> set[Path]:
+    """Manifest paths of the root workspace's members, from cargo itself."""
+    try:
+        out = subprocess.run(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+            cwd=REPO,
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout
+    except FileNotFoundError:
+        print("error: `cargo` not found on PATH.", file=sys.stderr)
+        raise SystemExit(2)
+    except subprocess.CalledProcessError as e:
+        print(f"error: `cargo metadata` failed:\n{e.stderr}", file=sys.stderr)
+        raise SystemExit(2)
+    return {Path(p["manifest_path"]) for p in json.loads(out)["packages"]}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="print every tracked package and which workspace root owns it",
+    )
+    args = parser.parse_args()
+
+    root = REPO / "Cargo.toml"
+    members = workspace_members()
+    manifests = {p: read_manifest(p) for p in tracked_manifests()}
+
+    if args.list:
+        for path in sorted(manifests):
+            manifest = manifests[path]
+            if not is_package(manifest) and path != root:
+                continue
+            if path == root or path in members:
+                owner = "root workspace"
+            elif declares_workspace(manifest):
+                owner = "itself"
+            else:
+                owner = "UNDECLARED"
+            print(f"{owner:<15} {path.relative_to(REPO).as_posix()}")
+        return 0
+
+    violations = find_violations(manifests, members, root)
+    if not violations:
+        return 0
+
+    print(
+        "error: these packages are not members of the root workspace and do not "
+        "declare a workspace of their own, so cargo resolves their workspace by "
+        "walking up to an ancestor manifest:",
+        file=sys.stderr,
+    )
+    for path in violations:
+        print(f"  {path.relative_to(REPO).as_posix()}", file=sys.stderr)
+    print(
+        "\nAdd an empty `[workspace]` table to each manifest above, or add the "
+        "package to `workspace.members` in the root Cargo.toml. Excluding it via "
+        "`workspace.exclude` is not enough: that entry is a path relative to the "
+        "root manifest, so it stops matching as soon as the repository is checked "
+        "out inside another copy of itself (a `git worktree` under .claude/).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_workspace_membership.py
+++ b/scripts/check_workspace_membership.py
@@ -17,13 +17,22 @@
 # a path relative to *itself*. When the repository is checked out inside another
 # copy of itself — which is where `git worktree` checkouts under `.claude/`
 # live — the nested copy's path does not match the outer root's `exclude` entry,
-# the outer root claims the package, and the resolution fails. That aborts
-# `cargo metadata`, and with it `cargo fmt --all`, `make lint`, and `make
-# signoff` for the whole tree (#13093).
+# the outer root claims the package, and the resolution fails.
+#
+# A package a workspace member path-depends on is resolved as part of walking
+# that member, so the failure is not local to it: it aborts `cargo fmt --all`,
+# and with it `make lint` and `make signoff`, for the whole tree (#13093). A
+# package nothing depends on fails only when addressed directly, but it is the
+# same defect one dependency edge away from the same outcome.
 #
 # The check is on the DECLARATION, not on whether `cargo metadata` currently
 # resolves: in a plain checkout the root `exclude` does match, so a resolution
 # probe passes on exactly the manifests this guard exists to catch.
+#
+# Membership is read from the ROOT workspace only. A legitimate nested
+# sub-workspace would have its own members flagged here; none exists today, and
+# the remedy if one appears is to union in the members of every manifest that
+# declares a workspace of its own.
 #
 # Usage:
 #   scripts/check_workspace_membership.py         # validate (exit 1 on violation)
@@ -77,20 +86,16 @@ def declares_workspace(manifest: dict) -> bool:
     return "workspace" in manifest
 
 
-def find_violations(
-    manifests: dict[Path, dict], members: set[Path], root: Path
-) -> list[Path]:
+def find_violations(manifests: dict[Path, dict], members: set[Path]) -> list[Path]:
     """Non-member packages that leave their workspace root to an ancestor lookup.
 
-    `manifests` maps a manifest path to its parsed contents, `members` holds the
-    manifest paths of the root workspace's members, and `root` is the repository
-    root manifest.
+    The root manifest needs no special case: a workspace root declares
+    `[workspace]` by definition, and this repository's is virtual besides.
     """
     return sorted(
         path
         for path, manifest in manifests.items()
-        if path != root
-        and path not in members
+        if path not in members
         and is_package(manifest)
         and not declares_workspace(manifest)
     )
@@ -112,26 +117,39 @@ def tracked_manifests() -> list[Path]:
 
 
 def workspace_members() -> set[Path]:
-    """Manifest paths of the root workspace's members, from cargo itself."""
+    """Manifest paths of the root workspace's members, from cargo itself.
+
+    `--locked` because this is a fast, side-effect-free lint guard, and it opens
+    `lint-rust`: it should fail on a stale `Cargo.lock` rather than rewrite one.
+    """
     try:
         out = subprocess.run(
-            ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+            ["cargo", "metadata", "--no-deps", "--locked", "--format-version", "1"],
             cwd=REPO,
             capture_output=True,
             check=True,
             text=True,
         ).stdout
     except FileNotFoundError:
-        print("error: `cargo` not found on PATH.", file=sys.stderr)
+        print(
+            "error: `cargo` not found on PATH — is the Rust toolchain installed?",
+            file=sys.stderr,
+        )
         raise SystemExit(2)
     except subprocess.CalledProcessError as e:
         print(f"error: `cargo metadata` failed:\n{e.stderr}", file=sys.stderr)
         raise SystemExit(2)
-    return {Path(p["manifest_path"]) for p in json.loads(out)["packages"]}
+    try:
+        return {Path(p["manifest_path"]) for p in json.loads(out)["packages"]}
+    except (json.JSONDecodeError, KeyError) as e:
+        print(f"error: could not read `cargo metadata` output: {e}", file=sys.stderr)
+        raise SystemExit(2)
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description="Check that every package outside the root workspace declares its own."
+    )
     parser.add_argument(
         "--list",
         action="store_true",
@@ -139,26 +157,36 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    root = REPO / "Cargo.toml"
     members = workspace_members()
     manifests = {p: read_manifest(p) for p in tracked_manifests()}
+    violations = find_violations(manifests, members)
 
     if args.list:
-        for path in sorted(manifests):
-            manifest = manifests[path]
-            if not is_package(manifest) and path != root:
+        # Classified by the same predicate the check uses, so the listing cannot
+        # disagree with the verdict.
+        undeclared = set(violations)
+        for path, manifest in sorted(manifests.items()):
+            if not is_package(manifest):
                 continue
-            if path == root or path in members:
+            if path in members:
                 owner = "root workspace"
-            elif declares_workspace(manifest):
-                owner = "itself"
-            else:
+            elif path in undeclared:
                 owner = "UNDECLARED"
+            else:
+                owner = "itself"
             print(f"{owner:<15} {path.relative_to(REPO).as_posix()}")
         return 0
 
-    violations = find_violations(manifests, members, root)
     if not violations:
+        outside = sum(
+            1
+            for path, manifest in manifests.items()
+            if is_package(manifest) and path not in members
+        )
+        print(
+            f"workspace membership OK: {len(manifests)} tracked manifest(s), "
+            f"{outside} outside the root workspace, each declaring its own."
+        )
         return 0
 
     print(

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -726,7 +726,7 @@ post_pending_status() {
 # sync with `rustAffecting` in .github/workflows/pr.yml and covered by the
 # check-code-changes filter; `scripts/check_rust_gate_paths.py` enforces both,
 # and docs/dev/ci_signoff.md explains why each path is here.
-RUST_AFFECTING_PATH_PATTERN='(\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)rust-toolchain(\.toml)?$|(^|/)\.cargo/|(^|/)\.?(clippy|rustfmt)\.toml$|(^|/)nextest\.toml$|(^|/)layers\.toml$|^scripts/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability)\.py$|^Makefile$)'
+RUST_AFFECTING_PATH_PATTERN='(\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)rust-toolchain(\.toml)?$|(^|/)\.cargo/|(^|/)\.?(clippy|rustfmt)\.toml$|(^|/)nextest\.toml$|(^|/)layers\.toml$|^scripts/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability|workspace_membership)\.py$|^Makefile$)'
 
 # True when the branch delta vs trunk can affect Rust lint/build/tests.
 # Prints nothing. Exit 0 = has Rust-affecting changes (or unknown — run checks).

--- a/scripts/test_check_workspace_membership.py
+++ b/scripts/test_check_workspace_membership.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Tests for scripts/check_workspace_membership.py.
+#
+# The last case is the one that matters: it rebuilds the nested-checkout shape
+# from #13093 with cargo itself, so the guard is pinned to the behaviour it
+# exists to prevent rather than to an assumption about it. The live-tree scan
+# cannot stand in for that — in a plain checkout the root `exclude` matches and
+# every manifest resolves, including the ones this guard rejects.
+#
+# Run: python3 scripts/test_check_workspace_membership.py
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_workspace_membership import (  # noqa: E402
+    declares_workspace,
+    find_violations,
+    is_package,
+)
+
+failures = 0
+checks = 0
+
+
+def check(name: str, got, want) -> None:
+    global failures, checks
+    checks += 1
+    if got == want:
+        print(f"  ok: {name}")
+    else:
+        failures += 1
+        print(f"  FAIL: {name}\n    got:  {got!r}\n    want: {want!r}")
+
+
+def parse(source: str) -> dict:
+    return tomllib.loads(source)
+
+
+PACKAGE = '[package]\nname = "p"\nversion = "0.0.0"\nedition = "2024"\n'
+
+print("is_package / declares_workspace")
+check("a package manifest is a package", is_package(parse(PACKAGE)), True)
+check(
+    "a virtual manifest is not a package",
+    is_package(parse('[workspace]\nmembers = ["a"]\n')),
+    False,
+)
+check(
+    "an empty [workspace] table declares a workspace",
+    declares_workspace(parse("[workspace]\n" + PACKAGE)),
+    True,
+)
+check(
+    "a [workspace] carrying keys still declares one",
+    declares_workspace(parse('[workspace]\nmembers = []\n' + PACKAGE)),
+    True,
+)
+check(
+    "[workspace.package] alone does not declare one",
+    # Inherited-field tables key off `workspace`, so a manifest that only reads
+    # them (`version.workspace = true`) must not be mistaken for a root.
+    declares_workspace(parse(PACKAGE + '[dependencies]\nx = { workspace = true }\n')),
+    False,
+)
+
+print("\nfind_violations")
+root = Path("/repo/Cargo.toml")
+member = Path("/repo/crates/a/Cargo.toml")
+loose = Path("/repo/crates/b/Cargo.toml")
+virtual_child = Path("/repo/crates/c/Cargo.toml")
+
+check(
+    "a non-member package with no [workspace] is a violation",
+    find_violations(
+        {root: parse('[workspace]\nmembers = ["crates/a"]\n'), loose: parse(PACKAGE)},
+        {member},
+        root,
+    ),
+    [loose],
+)
+check(
+    "the same package is clean once it declares its own workspace",
+    find_violations(
+        {
+            root: parse('[workspace]\nmembers = ["crates/a"]\n'),
+            loose: parse("[workspace]\n" + PACKAGE),
+        },
+        {member},
+        root,
+    ),
+    [],
+)
+check(
+    "a member does not need to declare a workspace",
+    find_violations(
+        {root: parse('[workspace]\nmembers = ["crates/a"]\n'), member: parse(PACKAGE)},
+        {member},
+        root,
+    ),
+    [],
+)
+check(
+    "the root manifest is never its own violation",
+    # It defines the workspace every member resolves to, and a virtual root has
+    # no `[package]` table to test.
+    find_violations({root: parse('[workspace]\nmembers = []\n')}, set(), root),
+    [],
+)
+check(
+    "a non-member virtual manifest is not a package, so it is skipped",
+    find_violations(
+        {
+            root: parse('[workspace]\nmembers = ["crates/a"]\n'),
+            virtual_child: parse('[workspace]\nmembers = ["d"]\n'),
+        },
+        {member},
+        root,
+    ),
+    [],
+)
+check(
+    "every violating manifest is reported, not just the first",
+    find_violations(
+        {
+            root: parse('[workspace]\nmembers = []\n'),
+            loose: parse(PACKAGE),
+            virtual_child: parse(PACKAGE),
+        },
+        set(),
+        root,
+    ),
+    [loose, virtual_child],
+)
+
+print("\nnested checkout (cargo)")
+
+
+def nested_tree(directory: str, *, package_declares_workspace: bool) -> Path:
+    """The #13093 shape: a checkout that excludes a package, inside one that does not.
+
+    Both roots exclude the path `pkg` relative to themselves, so the inner root
+    excludes exactly the package below it — the arrangement the repository has
+    for `crates/data-connectors/connector-nfs`. Returns the package manifest.
+    """
+    workspace = '[workspace]\nresolver = "3"\nmembers = []\nexclude = ["pkg"]\n'
+    outer = Path(directory) / "outer"
+    pkg = outer / "nested" / "pkg"
+    (pkg / "src").mkdir(parents=True)
+    (outer / "Cargo.toml").write_text(workspace, encoding="utf-8")
+    (outer / "nested" / "Cargo.toml").write_text(workspace, encoding="utf-8")
+    (pkg / "src" / "lib.rs").write_text("", encoding="utf-8")
+    manifest = pkg / "Cargo.toml"
+    manifest.write_text(
+        ("[workspace]\n\n" if package_declares_workspace else "") + PACKAGE,
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def resolves(manifest: Path) -> bool:
+    """Whether cargo can settle the package's workspace at all."""
+    return (
+        subprocess.run(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1",
+             "--manifest-path", str(manifest)],
+            capture_output=True,
+            text=True,
+        ).returncode
+        == 0
+    )
+
+
+with tempfile.TemporaryDirectory() as d:
+    # Without the declaration the inner root's `exclude` does not end the search:
+    # cargo keeps walking up, and the outer root — whose `exclude` names a path
+    # one level too shallow to match — claims the package and the resolve fails.
+    check(
+        "a nested non-member package with no [workspace] does not resolve",
+        resolves(nested_tree(d, package_declares_workspace=False)),
+        False,
+    )
+
+with tempfile.TemporaryDirectory() as d:
+    check(
+        "the same package resolves once it declares its own workspace",
+        resolves(nested_tree(d, package_declares_workspace=True)),
+        True,
+    )
+
+print()
+if failures:
+    print(f"{failures} of {checks} checks failed")
+    raise SystemExit(1)
+print(f"all {checks} checks passed")

--- a/scripts/test_check_workspace_membership.py
+++ b/scripts/test_check_workspace_membership.py
@@ -16,16 +16,20 @@ from __future__ import annotations
 import subprocess
 import sys
 import tempfile
-import tomllib
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+# Imported before `tomllib` so that on Python < 3.11 the guard's own actionable
+# message is what prints. This file runs first in `lint-rust`, so importing
+# `tomllib` here directly would front the recipe with a raw ModuleNotFoundError.
 from check_workspace_membership import (  # noqa: E402
     declares_workspace,
     find_violations,
     is_package,
 )
+
+import tomllib  # noqa: E402
 
 failures = 0
 checks = 0
@@ -60,19 +64,16 @@ check(
     True,
 )
 check(
-    "a [workspace] carrying keys still declares one",
-    declares_workspace(parse('[workspace]\nmembers = []\n' + PACKAGE)),
-    True,
-)
-check(
-    "[workspace.package] alone does not declare one",
-    # Inherited-field tables key off `workspace`, so a manifest that only reads
-    # them (`version.workspace = true`) must not be mistaken for a root.
+    "an inherited `workspace = true` value does not declare one",
+    # `workspace = true` on a dependency reads a value from the workspace this
+    # package belongs to. It is nested under `dependencies`, so it must not be
+    # mistaken for the top-level table that makes a package a root.
     declares_workspace(parse(PACKAGE + '[dependencies]\nx = { workspace = true }\n')),
     False,
 )
 
 print("\nfind_violations")
+ROOT_MANIFEST = parse('[workspace]\nmembers = ["crates/a"]\n')
 root = Path("/repo/Cargo.toml")
 member = Path("/repo/crates/a/Cargo.toml")
 loose = Path("/repo/crates/b/Cargo.toml")
@@ -80,63 +81,34 @@ virtual_child = Path("/repo/crates/c/Cargo.toml")
 
 check(
     "a non-member package with no [workspace] is a violation",
-    find_violations(
-        {root: parse('[workspace]\nmembers = ["crates/a"]\n'), loose: parse(PACKAGE)},
-        {member},
-        root,
-    ),
+    find_violations({root: ROOT_MANIFEST, loose: parse(PACKAGE)}, {member}),
     [loose],
 )
 check(
     "the same package is clean once it declares its own workspace",
     find_violations(
-        {
-            root: parse('[workspace]\nmembers = ["crates/a"]\n'),
-            loose: parse("[workspace]\n" + PACKAGE),
-        },
-        {member},
-        root,
+        {root: ROOT_MANIFEST, loose: parse("[workspace]\n" + PACKAGE)}, {member}
     ),
     [],
 )
 check(
     "a member does not need to declare a workspace",
-    find_violations(
-        {root: parse('[workspace]\nmembers = ["crates/a"]\n'), member: parse(PACKAGE)},
-        {member},
-        root,
-    ),
-    [],
-)
-check(
-    "the root manifest is never its own violation",
-    # It defines the workspace every member resolves to, and a virtual root has
-    # no `[package]` table to test.
-    find_violations({root: parse('[workspace]\nmembers = []\n')}, set(), root),
+    find_violations({root: ROOT_MANIFEST, member: parse(PACKAGE)}, {member}),
     [],
 )
 check(
     "a non-member virtual manifest is not a package, so it is skipped",
     find_violations(
-        {
-            root: parse('[workspace]\nmembers = ["crates/a"]\n'),
-            virtual_child: parse('[workspace]\nmembers = ["d"]\n'),
-        },
+        {root: ROOT_MANIFEST, virtual_child: parse('[workspace]\nmembers = ["d"]\n')},
         {member},
-        root,
     ),
     [],
 )
 check(
     "every violating manifest is reported, not just the first",
     find_violations(
-        {
-            root: parse('[workspace]\nmembers = []\n'),
-            loose: parse(PACKAGE),
-            virtual_child: parse(PACKAGE),
-        },
-        set(),
-        root,
+        {root: ROOT_MANIFEST, loose: parse(PACKAGE), virtual_child: parse(PACKAGE)},
+        {member},
     ),
     [loose, virtual_child],
 )
@@ -149,51 +121,84 @@ def nested_tree(directory: str, *, package_declares_workspace: bool) -> Path:
 
     Both roots exclude the path `pkg` relative to themselves, so the inner root
     excludes exactly the package below it — the arrangement the repository has
-    for `crates/data-connectors/connector-nfs`. Returns the package manifest.
+    for `crates/data-connectors/connector-nfs`. A member of the inner workspace
+    path-depends on `pkg`, which is what puts the excluded package on the
+    dependency walk and so makes `cargo fmt --all` resolve it. Returns the inner
+    workspace root.
     """
-    workspace = '[workspace]\nresolver = "3"\nmembers = []\nexclude = ["pkg"]\n'
     outer = Path(directory) / "outer"
-    pkg = outer / "nested" / "pkg"
+    inner = outer / "nested"
+    pkg = inner / "pkg"
+    app = inner / "app"
     (pkg / "src").mkdir(parents=True)
-    (outer / "Cargo.toml").write_text(workspace, encoding="utf-8")
-    (outer / "nested" / "Cargo.toml").write_text(workspace, encoding="utf-8")
-    (pkg / "src" / "lib.rs").write_text("", encoding="utf-8")
-    manifest = pkg / "Cargo.toml"
-    manifest.write_text(
+    (app / "src").mkdir(parents=True)
+    # Both roots exclude `pkg` relative to themselves, so only the inner one
+    # actually names this package. The outer root must otherwise be a valid,
+    # empty workspace: give it a member it does not have and cargo fails on
+    # *that* instead, which would pass the negative case for the wrong reason.
+    (outer / "Cargo.toml").write_text(
+        '[workspace]\nresolver = "3"\nmembers = []\nexclude = ["pkg"]\n',
+        encoding="utf-8",
+    )
+    (inner / "Cargo.toml").write_text(
+        '[workspace]\nresolver = "3"\nmembers = ["app"]\nexclude = ["pkg"]\n',
+        encoding="utf-8",
+    )
+    # Already rustfmt-clean, so a formatting difference cannot be mistaken for
+    # the resolution failure under test.
+    (pkg / "src" / "lib.rs").write_text("pub fn f() {}\n", encoding="utf-8")
+    (app / "src" / "lib.rs").write_text("pub fn g() {}\n", encoding="utf-8")
+    (app / "Cargo.toml").write_text(
+        '[package]\nname = "app"\nversion = "0.0.0"\nedition = "2024"\n\n'
+        '[dependencies]\np = { path = "../pkg", optional = true }\n',
+        encoding="utf-8",
+    )
+    (pkg / "Cargo.toml").write_text(
         ("[workspace]\n\n" if package_declares_workspace else "") + PACKAGE,
         encoding="utf-8",
     )
-    return manifest
+    return inner
 
 
-def resolves(manifest: Path) -> bool:
-    """Whether cargo can settle the package's workspace at all."""
-    return (
-        subprocess.run(
-            ["cargo", "metadata", "--no-deps", "--format-version", "1",
-             "--manifest-path", str(manifest)],
-            capture_output=True,
-            text=True,
-        ).returncode
-        == 0
+def fmt_all(workspace_root: Path) -> tuple[int, str]:
+    """Run the gate's opening command, returning its status and combined output.
+
+    This is the harm the issue reports: `cargo fmt --all` aborting for the whole
+    tree because one package it path-walks into cannot be resolved.
+    """
+    p = subprocess.run(
+        ["cargo", "fmt", "--all", "--", "--check"],
+        cwd=workspace_root,
+        capture_output=True,
+        text=True,
     )
+    return p.returncode, p.stdout + p.stderr
 
 
 with tempfile.TemporaryDirectory() as d:
     # Without the declaration the inner root's `exclude` does not end the search:
     # cargo keeps walking up, and the outer root — whose `exclude` names a path
-    # one level too shallow to match — claims the package and the resolve fails.
+    # one level too shallow to match — claims the package. `cargo fmt --all`
+    # reaches it through `app`'s path dependency and dies on the whole tree.
+    status, output = fmt_all(nested_tree(d, package_declares_workspace=False))
+    check("cargo fmt --all fails when the package declares no workspace", status != 0, True)
+    # Asserted on the message, not just the status: every other way this fixture
+    # could fail (a malformed root, a formatting difference, a missing member)
+    # also exits non-zero, and would pass the check above for the wrong reason.
     check(
-        "a nested non-member package with no [workspace] does not resolve",
-        resolves(nested_tree(d, package_declares_workspace=False)),
-        False,
+        "...and it fails on the workspace resolution, not something else",
+        "believes it's in a workspace when it's not" in output,
+        True,
     )
 
 with tempfile.TemporaryDirectory() as d:
+    status, output = fmt_all(nested_tree(d, package_declares_workspace=True))
+    # Compared as a pair so a failure reports cargo's own reason rather than
+    # just "1 != 0".
     check(
-        "the same package resolves once it declares its own workspace",
-        resolves(nested_tree(d, package_declares_workspace=True)),
-        True,
+        "the same tree formats once the package declares its own workspace",
+        (status, output.strip()[:200]),
+        (0, ""),
     )
 
 print()

--- a/vendor/mysql-common-derive/Cargo.toml
+++ b/vendor/mysql-common-derive/Cargo.toml
@@ -9,6 +9,10 @@
 #   output (`FromValue`/`FromRow`) is unchanged for valid input.
 #
 # Wired in via `[patch.crates-io]` in the workspace root Cargo.toml.
+# Its own workspace root: this package is not a member of the repository's root workspace,
+# and cargo would otherwise bind it to the nearest ancestor workspace manifest.
+[workspace]
+
 [package]
 name = "mysql-common-derive"
 edition = "2021"

--- a/vendor/mysql-common-derive/Cargo.toml
+++ b/vendor/mysql-common-derive/Cargo.toml
@@ -9,8 +9,7 @@
 #   output (`FromValue`/`FromRow`) is unchanged for valid input.
 #
 # Wired in via `[patch.crates-io]` in the workspace root Cargo.toml.
-# Its own workspace root: this package is not a member of the repository's root workspace,
-# and cargo would otherwise bind it to the nearest ancestor workspace manifest.
+# Prevent this from interfering with workspaces. See docs/dev/ci_signoff.md
 [workspace]
 
 [package]


### PR DESCRIPTION
## Summary

A package that is not a member of the root workspace has to declare a workspace of its own.
`workspace.exclude` cannot do it: the entry is a path relative to the manifest that declares it, so
it stops matching as soon as the repository is checked out *inside* another copy of itself — which
is where `git worktree` checkouts under `.claude/worktrees/` live. The nested root excludes the
package correctly, cargo keeps walking up, and the outer root claims it:

```
`cargo metadata` exited with an error: error: current package believes it's in a workspace when it's not:
current:   .../.claude/worktrees/<name>/crates/data-connectors/connector-nfs/Cargo.toml
workspace: .../Cargo.toml
```

`bin/spiced` carries an optional **path dependency** on `connector-nfs`, and resolving a member
resolves its path dependencies — so that one unresolvable package aborts `cargo fmt --all`, and with
it `make lint` and `make signoff`, for the whole tree. The gate died before running a single check,
leaving `make signoff-remote` as the only route, which the hygiene guidance wants to be the
exception.

Four more tracked packages had the same defect latently — three vendored sub-crates and the
`mysql-common-derive` patch source. Nothing path-depends on them, so they failed only when addressed
directly, but that is the same defect one dependency edge away from the same outcome. Fixing all
five lets the new guard's invariant be unconditional instead of carrying an exemption list that
would rot.

## Changes

- An empty `[workspace]` table in each of the five affected manifests. Cargo's own suggested remedy,
  and location-independent — unlike excluding `.claude/`, which would leave a plain clone-inside-a-clone broken.
- `scripts/check_workspace_membership.py` — fails `lint-rust` on any tracked package that is neither
  a root-workspace member nor its own workspace root. It runs **ahead of `cargo fmt --check`**,
  unlike the other guards, because fmt is one of the things the condition breaks: a guard placed
  after it would never be reached to explain the raw cargo error.
- `scripts/test_check_workspace_membership.py` — parser cases plus a fixture that rebuilds the
  nested-checkout shape with cargo, including the path dependency that puts the package on the walk.
- Wired into all three Rust-gate path lists, as `scripts/check_rust_gate_paths.py` requires.
- `crates/libnfs/Cargo.toml` claimed to be excluded from the workspace while being a member — the
  same false statement that makes the exclusion look unavoidable.

The guard checks the **declaration**, not whether `cargo metadata` resolves today: in a plain
checkout the root `exclude` does match, so a resolution probe passes on exactly the manifests this
guard exists to catch. That is what makes it non-vacuous in CI.

Workspace metadata is byte-identical before and after — 143 members, same targets — so the
`[workspace]` additions change nothing about how the root workspace resolves, and the
`[patch.crates-io]` entry still resolves to the vendored `mysql-common-derive`.

## Test plan

- `make lint` — green (the fmt line it used to abort on now passes from a nested worktree, which is
  the fix).
- `make test` / `make nextest` via `make signoff`.
- Guard neutered against the pre-fix manifests: fails, naming all five. Restored: passes.
- Regression fixture asserted in both directions, on cargo's own message rather than exit status
  alone — a malformed root, a missing member, and an unformatted source all exit non-zero and would
  otherwise pass for the wrong reason, which the first version of the fixture did.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1 with "Your workspace is out of credits. Ask
  your workspace owner to refill in order to continue."; `grok` is not installed. Receipt
  `engine=none exit=1 job=none`, head `f5c9501141`. Its angles were run by hand and found the
  ordering defect fixed above: `cargo fmt --all` was the first line of `lint-rust`, so in the broken
  tree fmt aborted before the guard could ever explain why.
- `/security-review`: no findings. The new code passes argument lists rather than shell strings,
  parses TOML with `tomllib`, and the three CI path-list edits all *widen* what counts as
  Rust-affecting, so they can only cause more validation to run.
- `/simplify`: applied — dead `root` parameter dropped (an agent proved it by neutering the clause
  and re-running the suite green), `--list` sourced from the same predicate as the check, a vacuous
  test case deleted, a test name that asserted the opposite of the behaviour corrected, `--locked`
  added to match the sibling guard's policy, a success line added, and the manifest comments cut to
  the one-line form the vendored tree already uses. It also corrected a load-bearing claim of mine:
  `cargo fmt --all` walks path dependencies, it does not resolve every package. Deferred:
  #13121 (the five guards duplicate four helpers, already drifted on `--locked` and error handling).

Fixes #13093

Also filed while here: #13120 (`vendor/` matches no `code_changes` glob, so a PR confined to it gets
`Rust Lint` and `Build and Test` reported green from zero steps in the merge queue).

## Checklist

- [ ] `make lint` passes
- [ ] `make test` passes
- [x] Regression test fails on the old code and passes on the new
- [x] Issue linked