### PR TITLE
test: remove a test's container when it is done with it, including on failure

### DIFF
--- a/crates/runtime/tests/docker/mod.rs
+++ b/crates/runtime/tests/docker/mod.rs
@@ -45,6 +45,10 @@ use tokio::sync::Semaphore;
 static CONTAINER_SEMAPHORE: LazyLock<Arc<Semaphore>> =
     LazyLock::new(|| Arc::new(Semaphore::new(3)));
 
+/// How long a dropped container waits on the Docker daemon before giving up.
+/// Cleanup is best-effort, and a test process must never hang in it.
+const CLEANUP_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub struct RunningContainer<'a> {
     name: &'a str,
     docker: Docker,
@@ -125,6 +129,14 @@ impl RunningContainer<'_> {
 /// the task. So the removal gets a runtime of its own, on a thread joined
 /// before the drop returns. Best-effort by construction: a failure here must
 /// not mask the test result that is already on its way out.
+///
+/// Two cases this cannot reach, both because `Drop` never runs:
+///
+/// - A container parked in a `static` for the life of the process, as
+///   `tpcds_postgres` does to share one database across its queries. Such a
+///   suite has to remove its container itself.
+/// - A process killed outright rather than unwound (`SIGKILL`, a hard CI
+///   timeout).
 impl Drop for RunningContainer<'_> {
     fn drop(&mut self) {
         if *self.removed.get_mut() {
@@ -133,23 +145,43 @@ impl Drop for RunningContainer<'_> {
 
         let docker = self.docker.clone();
         let name = self.name.to_string();
-        let removal = std::thread::spawn(move || {
-            let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            else {
-                return Err(anyhow::anyhow!("could not build a runtime for cleanup"));
-            };
-            runtime.block_on(remove(&docker, &name))
-        });
+        let removal = std::thread::Builder::new()
+            .name(format!("cleanup-{name}"))
+            .spawn(move || {
+                let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                else {
+                    return Err(anyhow::anyhow!("could not build a runtime for cleanup"));
+                };
+                runtime.block_on(async {
+                    // Bounded: a daemon that accepts the connection and then
+                    // stops answering would otherwise hang the test process
+                    // here, turning a readable failure into a CI timeout.
+                    tokio::time::timeout(CLEANUP_TIMEOUT, remove(&docker, &name))
+                        .await
+                        .unwrap_or_else(|_| {
+                            Err(anyhow::anyhow!(
+                                "timed out after {CLEANUP_TIMEOUT:?} waiting for Docker"
+                            ))
+                        })
+                })
+            });
 
         // Report rather than panic: a panicking `Drop` during an unwind aborts
         // the process, which would replace a readable test failure with none.
-        match removal.join() {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => eprintln!("failed to remove test container {}: {e}", self.name),
-            Err(_) => eprintln!(
+        // `Builder::spawn` is used over `thread::spawn` for the same reason --
+        // it reports a thread that cannot be created instead of panicking, and
+        // exhaustion is the very condition this cleanup exists to relieve.
+        match removal.map(std::thread::JoinHandle::join) {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(e))) => eprintln!("failed to remove test container {}: {e}", self.name),
+            Ok(Err(_)) => eprintln!(
                 "the cleanup thread for test container {} panicked",
+                self.name
+            ),
+            Err(e) => eprintln!(
+                "could not start a cleanup thread for test container {}: {e}",
                 self.name
             ),
         }
@@ -340,6 +372,17 @@ impl<'a> ContainerRunner<'a> {
 
         let _ = self.docker.create_container(Some(options), config).await?;
 
+        // The container exists from here on, so hold it in the guard before
+        // anything else can fail. Starting it, inspecting it, or waiting for it
+        // to report healthy can all return early, and each of those paths would
+        // otherwise leave behind a container no test ever saw.
+        let container = RunningContainer::<'a> {
+            name: self.name,
+            docker: self.docker.clone(),
+            removed: AtomicBool::new(false),
+            _permit: permit,
+        };
+
         self.docker
             .start_container(self.name, None::<StartContainerOptions<String>>)
             .await?;
@@ -373,12 +416,7 @@ impl<'a> ContainerRunner<'a> {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
 
-        Ok(RunningContainer::<'a> {
-            name: self.name,
-            docker: self.docker,
-            removed: AtomicBool::new(false),
-            _permit: permit,
-        })
+        Ok(container)
     }
 
     async fn pull_image(&self) -> Result<(), anyhow::Error> {

--- a/crates/runtime/tests/docker/mod.rs
+++ b/crates/runtime/tests/docker/mod.rs
@@ -17,7 +17,10 @@ limitations under the License.
 
 use std::{
     collections::HashMap,
-    sync::{Arc, LazyLock},
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 
@@ -45,13 +48,20 @@ static CONTAINER_SEMAPHORE: LazyLock<Arc<Semaphore>> =
 pub struct RunningContainer<'a> {
     name: &'a str,
     docker: Docker,
+    /// Whether the container has already been removed, so dropping one a test
+    /// cleaned up explicitly does not attempt it a second time.
+    removed: AtomicBool,
     // Store the permit to release it when the container is dropped
     _permit: tokio::sync::OwnedSemaphorePermit,
 }
 
 impl RunningContainer<'_> {
     pub async fn remove(&self) -> Result<(), anyhow::Error> {
-        remove(&self.docker, self.name).await
+        let result = remove(&self.docker, self.name).await;
+        if result.is_ok() {
+            self.removed.store(true, Ordering::Relaxed);
+        }
+        result
     }
 
     pub async fn stop(&self) -> Result<(), anyhow::Error> {
@@ -102,12 +112,66 @@ impl RunningContainer<'_> {
     }
 }
 
+/// Removes the container when the test that started it is finished with it,
+/// including when that test panicked partway through.
+///
+/// Explicit cleanup cannot cover this on its own: a `.remove()` call at the end
+/// of a test is skipped by the `?` or the failed assertion that ends the test
+/// early, which is exactly when a suite is being run repeatedly.
+///
+/// `Drop` cannot await, and the removal must work whether or not the test's
+/// runtime is still running -- a `#[tokio::test]` drops its runtime while
+/// unwinding, and spawning onto a runtime that is shutting down silently drops
+/// the task. So the removal gets a runtime of its own, on a thread joined
+/// before the drop returns. Best-effort by construction: a failure here must
+/// not mask the test result that is already on its way out.
+impl Drop for RunningContainer<'_> {
+    fn drop(&mut self) {
+        if *self.removed.get_mut() {
+            return;
+        }
+
+        let docker = self.docker.clone();
+        let name = self.name.to_string();
+        let removal = std::thread::spawn(move || {
+            let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            else {
+                return Err(anyhow::anyhow!("could not build a runtime for cleanup"));
+            };
+            runtime.block_on(remove(&docker, &name))
+        });
+
+        // Report rather than panic: a panicking `Drop` during an unwind aborts
+        // the process, which would replace a readable test failure with none.
+        match removal.join() {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => eprintln!("failed to remove test container {}: {e}", self.name),
+            Err(_) => eprintln!(
+                "the cleanup thread for test container {} panicked",
+                self.name
+            ),
+        }
+    }
+}
+
+/// Removes a container that a test has finished with, and every test *must*
+/// reach this -- directly or by dropping its [`RunningContainer`].
+///
+/// A leaked container is not merely untidy: each one holds a running database
+/// and an anonymous volume carrying its data directory, so a few runs of the
+/// suite are enough to exhaust memory (a concurrent build gets OOM-killed) and
+/// tens of gigabytes of disk that nothing reclaims.
 pub async fn remove(docker: &Docker, name: &str) -> Result<(), anyhow::Error> {
     Ok(docker
         .remove_container(
             name,
             Some(RemoveContainerOptions {
                 force: true,
+                // The data directory is an anonymous volume, which outlives the
+                // container unless it is removed with it.
+                v: true,
                 ..Default::default()
             }),
         )
@@ -312,6 +376,7 @@ impl<'a> ContainerRunner<'a> {
         Ok(RunningContainer::<'a> {
             name: self.name,
             docker: self.docker,
+            removed: AtomicBool::new(false),
             _permit: permit,
         })
     }


### PR DESCRIPTION
Integration-test containers were only removed when a test explicitly called `RunningContainer::remove`, so any test that returned early — through `?` or a failed assertion — left a running database behind. Several suites never called it at all. Removal also left the container's anonymous volume, which holds the entire data directory, so even the suites that did clean up leaked storage.

Found on a local checkout carrying **201 leftover containers and 201 volumes (~8 GB)**, the oldest three days old. They are not merely untidy: while they were running, a concurrent `cargo` build was OOM-killed (`signal: 9`).

## What changed

All three changes are in the shared harness (`crates/runtime/tests/docker/mod.rs`), which every container-based suite uses — postgres, mysql, mssql, mongo, oracle, kafka, elasticsearch, abfs, dynamodb, vault, s3, rehydration, tpcds — so no per-suite edits are needed.

- **Remove on `Drop`.** The failing path is now the cleaning path, from the moment the container exists: the guard is constructed immediately after `create_container`, so a failure to start it, inspect it, or reach a healthy state removes it too. The health wait has its own timeout and error return, so that is a path tests take rather than a theoretical one. `Drop` cannot await, and it cannot rely on the ambient runtime: a `#[tokio::test]` drops its runtime while unwinding, and spawning onto a runtime that is shutting down silently discards the task. So the removal gets a runtime of its own on a thread that is joined before the drop returns.
- **Take the volume with the container** (`RemoveContainerOptions { v: true }`). This is why the volume count tracked the container count almost exactly — 204 volumes for 201 containers.
- **A `removed` flag**, so a test that already cleaned up explicitly does not attempt removal twice.
- **A bounded removal** (30s), so a daemon that accepts a connection and then stops answering cannot hang the test process in `Drop` — which would replace the test's own failure output with a CI timeout.
- **`Builder::spawn`** rather than `thread::spawn`, which panics when a thread cannot be created. A panic there aborts the process during an unwind, and thread exhaustion is the condition this cleanup exists to relieve.

Failures inside `Drop` are printed, never panicked: a panicking `Drop` during an unwind aborts the process, which would replace a readable test failure with no output at all.

## Verification

Container and volume counts taken either side of real runs, since compiling proves nothing here:

| scenario | test outcome | containers | volumes |
|---|---|---|---|
| 5 tests passing | ok | 201 → 201 | 204 → 204 |
| a test panicking right after its container starts | FAILED, as intended | 201 → 201 | 204 → 204 |
| a container that never reports healthy (`run()` errors after creating it) | FAILED, as intended | 30 → 30 | 30 → 30 |
| full `postgres::catalog` suite | 12 passed | 201 → 201 | 204 → 204 |

The second row is the case explicit cleanup structurally cannot cover, and is what produced the backlog. The third exercises suites that call `.remove()` explicitly alongside ones that do not, which is what the `removed` flag guards.

`cargo fmt --all -- --check` clean; clippy clean with the gate's `--tests` pedantic flags.

## Not covered

`Drop` does not run for a container parked in a `static` for the life of the process, which is how `tpcds_postgres` shares one database across its queries — that suite still has to remove its own container. Nor does it run for a process killed outright (`SIGKILL`, a hard CI timeout).

A name-prefix sweep at startup would be the obvious way to close both, and it is **unsafe here**: CI runs these tests under nextest, process-per-test, so a sweeping process would delete containers belonging to siblings running concurrently. Closing the `static` case needs a lifecycle owned by the suite that wants the sharing, not a change to the shared harness.

