### PR TITLE
fix(search): one definition of an unusable embedding, enforced at every vector write path (fixes #13089)

### DIFF
--- a/crates/search/src/index/duckdb/write.rs
+++ b/crates/search/src/index/duckdb/write.rs
@@ -27,7 +27,7 @@ use llms::embeddings::{Embed, EmbeddingInput};
 use snafu::{ResultExt, Snafu};
 use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
-use crate::index::{duckdb::DuckDBVectorIndex, embedding_col};
+use crate::index::{duckdb::DuckDBVectorIndex, embedding_col, write_util};
 
 #[derive(Debug, Snafu)]
 pub(super) enum WriteError {
@@ -54,6 +54,14 @@ pub(super) enum WriteError {
         expected: usize,
         actual: usize,
         row_index: usize,
+    },
+
+    #[snafu(display(
+        "Failed to build DuckDB vector embedding column: the embedding at row {row_index} {reason}, so it cannot be indexed. Check the embedding model's output for that row. See: https://spiceai.org/docs/components/embeddings"
+    ))]
+    UnusableEmbedding {
+        row_index: usize,
+        reason: &'static str,
     },
 }
 
@@ -179,6 +187,17 @@ fn create_embedding_array(
     for (row, embedding) in embedding_vectors.iter().enumerate() {
         match embedding {
             Some(vector) if vector.len() == expected => {
+                // Unlike the row-filtering backends (S3 Vectors, in-memory, Elasticsearch),
+                // this column is written beside the source row in the accelerated table, so
+                // there is no row to drop — and an unusable vector cannot be quietly stored
+                // either: HNSW builds neighbour lists from these values, so one undefined
+                // distance degrades the results returned for other rows. Reject the write.
+                if let Some(defect) = write_util::embedding_defect(vector) {
+                    return Err(WriteError::UnusableEmbedding {
+                        row_index: row,
+                        reason: defect.reason(),
+                    });
+                }
                 builder.values().append_slice(vector);
                 builder.append(true);
             }
@@ -198,4 +217,71 @@ fn create_embedding_array(
     }
 
     Ok(Arc::new(builder.finish()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The DuckDB write path is the one site that cannot skip the row — the embedding is a
+    /// column beside the source data — so an unusable vector has to fail the write rather
+    /// than reach the HNSW index, where an undefined distance degrades the neighbour lists
+    /// other rows are found through. Before this fix nothing was checked here at all:
+    /// `validate_vector` was only ever called on the query vector (regression test for
+    /// #13089).
+    #[test]
+    fn a_partially_non_finite_embedding_is_rejected() {
+        let embeddings = vec![Some(vec![1.0, 2.0, 3.0]), Some(vec![1.0, f32::NAN, 3.0])];
+
+        let err = create_embedding_array(&embeddings, 3)
+            .expect_err("a NaN element must not reach the vector index");
+
+        let WriteError::UnusableEmbedding { row_index, reason } = err else {
+            panic!("expected UnusableEmbedding, got {err:?}");
+        };
+        assert_eq!(row_index, 1);
+        assert!(
+            reason.contains("NaN"),
+            "the message must name the defect, got '{reason}'"
+        );
+    }
+
+    #[test]
+    fn an_infinite_element_is_rejected() {
+        let embeddings = vec![Some(vec![f32::INFINITY, 2.0, 3.0])];
+
+        let err = create_embedding_array(&embeddings, 3)
+            .expect_err("an infinite element must not reach the vector index");
+
+        assert!(matches!(
+            err,
+            WriteError::UnusableEmbedding { row_index: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn an_all_zero_embedding_is_rejected() {
+        let embeddings = vec![Some(vec![0.0, 0.0, 0.0])];
+
+        let err = create_embedding_array(&embeddings, 3)
+            .expect_err("a vector with no direction must not reach the vector index");
+
+        assert!(matches!(
+            err,
+            WriteError::UnusableEmbedding { row_index: 0, .. }
+        ));
+    }
+
+    /// A NULL embedding is not a defect: the row simply has nothing to index, and the list
+    /// slot is null. Rejecting it would fail every batch with a NULL search column.
+    #[test]
+    fn a_null_embedding_stays_a_null_slot() {
+        let embeddings = vec![Some(vec![1.0, 2.0, 3.0]), None];
+
+        let array = create_embedding_array(&embeddings, 3).expect("a null embedding is allowed");
+
+        assert_eq!(array.len(), 2);
+        assert!(!array.is_null(0));
+        assert!(array.is_null(1));
+    }
 }

--- a/crates/search/src/index/duckdb/write.rs
+++ b/crates/search/src/index/duckdb/write.rs
@@ -27,7 +27,9 @@ use llms::embeddings::{Embed, EmbeddingInput};
 use snafu::{ResultExt, Snafu};
 use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
-use crate::index::{duckdb::DuckDBVectorIndex, embedding_col, write_util};
+use crate::index::{
+    EmbeddingDefect, SkippedEmbeddings, duckdb::DuckDBVectorIndex, embedding_col, embedding_defect,
+};
 
 #[derive(Debug, Snafu)]
 pub(super) enum WriteError {
@@ -54,14 +56,6 @@ pub(super) enum WriteError {
         expected: usize,
         actual: usize,
         row_index: usize,
-    },
-
-    #[snafu(display(
-        "Failed to build DuckDB vector embedding column: the embedding at row {row_index} {reason}, so it cannot be indexed. Check the embedding model's output for that row. See: https://spiceai.org/docs/components/embeddings"
-    ))]
-    UnusableEmbedding {
-        row_index: usize,
-        reason: &'static str,
     },
 }
 
@@ -184,23 +178,26 @@ fn create_embedding_array(
     let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), dim);
     builder = builder.with_field(Field::new_list_field(DataType::Float32, false));
 
+    let mut non_finite = SkippedEmbeddings::default();
+    let mut all_zero = SkippedEmbeddings::default();
+
     for (row, embedding) in embedding_vectors.iter().enumerate() {
-        match embedding {
-            Some(vector) if vector.len() == expected => {
-                // Unlike the row-filtering backends (S3 Vectors, in-memory, Elasticsearch),
-                // this column is written beside the source row in the accelerated table, so
-                // there is no row to drop — and an unusable vector cannot be quietly stored
-                // either: HNSW builds neighbour lists from these values, so one undefined
-                // distance degrades the results returned for other rows. Reject the write.
-                if let Some(defect) = write_util::embedding_defect(vector) {
-                    return Err(WriteError::UnusableEmbedding {
-                        row_index: row,
-                        reason: defect.reason(),
-                    });
+        // An unusable vector must not reach the column: HNSW builds its neighbour lists
+        // from these values, so one undefined distance degrades the results returned for
+        // other rows. Storing a null instead keeps the row and its data — it is simply not
+        // searchable, the same state a row with no text to embed is already in.
+        let usable = match embedding {
+            Some(vector) if vector.len() == expected => match embedding_defect(vector) {
+                Some(EmbeddingDefect::NonFinite) => {
+                    non_finite.record(row);
+                    None
                 }
-                builder.values().append_slice(vector);
-                builder.append(true);
-            }
+                Some(EmbeddingDefect::AllZero) => {
+                    all_zero.record(row);
+                    None
+                }
+                None => Some(vector),
+            },
             Some(vector) => {
                 return Err(WriteError::EmbeddingDimensionMismatch {
                     expected,
@@ -208,13 +205,21 @@ fn create_embedding_array(
                     row_index: row,
                 });
             }
-            None => {
-                // Store `f32` child values, not `Option<f32>`; the list slot represents a null embedding.
-                builder.values().append_value_n(0.0, expected);
-                builder.append(false);
-            }
+            None => None,
+        };
+
+        if let Some(vector) = usable {
+            builder.values().append_slice(vector);
+            builder.append(true);
+        } else {
+            // Store `f32` child values, not `Option<f32>`; the list slot represents a null embedding.
+            builder.values().append_value_n(0.0, expected);
+            builder.append(false);
         }
     }
+
+    non_finite.warn("the DuckDB vector index", EmbeddingDefect::NonFinite);
+    all_zero.warn("the DuckDB vector index", EmbeddingDefect::AllZero);
 
     Ok(Arc::new(builder.finish()))
 }
@@ -223,65 +228,49 @@ fn create_embedding_array(
 mod tests {
     use super::*;
 
-    /// The DuckDB write path is the one site that cannot skip the row — the embedding is a
-    /// column beside the source data — so an unusable vector has to fail the write rather
-    /// than reach the HNSW index, where an undefined distance degrades the neighbour lists
-    /// other rows are found through. Before this fix nothing was checked here at all:
-    /// `validate_vector` was only ever called on the query vector (regression test for
-    /// #13089).
+    /// Nothing was checked on this path at all before the fix — `validate_vector` was only
+    /// ever called on the query vector — so an unusable vector was written into the
+    /// HNSW-indexed column, where an undefined distance degrades the neighbour lists other
+    /// rows are found through (regression test for #13089).
+    ///
+    /// The row keeps its slot either way: dropping it would drop the source data the
+    /// accelerated table exists to serve, and would desynchronize this column from the
+    /// other columns of the same `RecordBatch`. Which vectors count as unusable is
+    /// [`crate::index::embedding_defect`]'s contract and is tested there.
     #[test]
-    fn a_partially_non_finite_embedding_is_rejected() {
-        let embeddings = vec![Some(vec![1.0, 2.0, 3.0]), Some(vec![1.0, f32::NAN, 3.0])];
+    fn an_unusable_embedding_becomes_a_null_slot_without_dropping_its_row() {
+        let embeddings = vec![
+            Some(vec![1.0, 2.0, 3.0]),               // usable
+            Some(vec![1.0, f32::NAN, 3.0]),          // one NaN among real values
+            Some(vec![f32::INFINITY, 2.0, 3.0]),     // +inf
+            Some(vec![1.0, 2.0, f32::NEG_INFINITY]), // -inf
+            Some(vec![0.0, 0.0, 0.0]),               // no direction
+            None,                                    // nothing to embed
+            Some(vec![4.0, 5.0, 6.0]),               // usable
+        ];
 
-        let err = create_embedding_array(&embeddings, 3)
-            .expect_err("a NaN element must not reach the vector index");
+        let array = create_embedding_array(&embeddings, 3)
+            .expect("the batch is written, minus the unusable vectors");
 
-        let WriteError::UnusableEmbedding { row_index, reason } = err else {
-            panic!("expected UnusableEmbedding, got {err:?}");
-        };
-        assert_eq!(row_index, 1);
-        assert!(
-            reason.contains("NaN"),
-            "the message must name the defect, got '{reason}'"
+        assert_eq!(array.len(), 7, "every row keeps its slot");
+        assert_eq!(
+            (0..7).map(|i| array.is_null(i)).collect::<Vec<_>>(),
+            vec![false, true, true, true, true, true, false]
         );
     }
 
+    /// A dimension mismatch stays an error: it means the column and the model disagree
+    /// about the index's shape, which no row-level disposition can paper over.
     #[test]
-    fn an_infinite_element_is_rejected() {
-        let embeddings = vec![Some(vec![f32::INFINITY, 2.0, 3.0])];
+    fn a_dimension_mismatch_still_fails_the_write() {
+        let embeddings = vec![Some(vec![1.0, 2.0])];
 
         let err = create_embedding_array(&embeddings, 3)
-            .expect_err("an infinite element must not reach the vector index");
+            .expect_err("a wrong-width vector is a configuration error, not a bad row");
 
         assert!(matches!(
             err,
-            WriteError::UnusableEmbedding { row_index: 0, .. }
+            WriteError::EmbeddingDimensionMismatch { row_index: 0, .. }
         ));
-    }
-
-    #[test]
-    fn an_all_zero_embedding_is_rejected() {
-        let embeddings = vec![Some(vec![0.0, 0.0, 0.0])];
-
-        let err = create_embedding_array(&embeddings, 3)
-            .expect_err("a vector with no direction must not reach the vector index");
-
-        assert!(matches!(
-            err,
-            WriteError::UnusableEmbedding { row_index: 0, .. }
-        ));
-    }
-
-    /// A NULL embedding is not a defect: the row simply has nothing to index, and the list
-    /// slot is null. Rejecting it would fail every batch with a NULL search column.
-    #[test]
-    fn a_null_embedding_stays_a_null_slot() {
-        let embeddings = vec![Some(vec![1.0, 2.0, 3.0]), None];
-
-        let array = create_embedding_array(&embeddings, 3).expect("a null embedding is allowed");
-
-        assert_eq!(array.len(), 2);
-        assert!(!array.is_null(0));
-        assert!(array.is_null(1));
     }
 }

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -38,6 +38,7 @@ use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
 use crate::index::elasticsearch::ElasticsearchIndex;
 use crate::index::embedding_col;
+use crate::index::write_util::{self, EmbeddingDefect};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -253,8 +254,8 @@ fn build_documents(
 
     let mut null_pk_skips: usize = 0;
     let mut null_pk_samples: Vec<usize> = Vec::new();
-    let mut zero_or_nan_skips: usize = 0;
-    let mut zero_or_nan_samples: Vec<usize> = Vec::new();
+    let mut all_zero_skips: usize = 0;
+    let mut all_zero_samples: Vec<usize> = Vec::new();
     let mut non_finite_skips: usize = 0;
     let mut non_finite_samples: Vec<usize> = Vec::new();
     let mut missing_embedding_skips: usize = 0;
@@ -288,20 +289,22 @@ fn build_documents(
             });
         }
 
-        if embedding.iter().all(|&x| x == 0.0 || x.is_nan()) {
-            zero_or_nan_skips += 1;
-            if zero_or_nan_samples.len() < SAMPLE_LIMIT {
-                zero_or_nan_samples.push(row);
+        match write_util::embedding_defect(embedding) {
+            Some(EmbeddingDefect::AllZero) => {
+                all_zero_skips += 1;
+                if all_zero_samples.len() < SAMPLE_LIMIT {
+                    all_zero_samples.push(row);
+                }
+                continue;
             }
-            continue;
-        }
-
-        if embedding.iter().any(|x| !x.is_finite()) {
-            non_finite_skips += 1;
-            if non_finite_samples.len() < SAMPLE_LIMIT {
-                non_finite_samples.push(row);
+            Some(EmbeddingDefect::NonFinite) => {
+                non_finite_skips += 1;
+                if non_finite_samples.len() < SAMPLE_LIMIT {
+                    non_finite_samples.push(row);
+                }
+                continue;
             }
-            continue;
+            None => {}
         }
 
         let mut doc = serde_json::Map::with_capacity(column_encoders.len() + 1);
@@ -340,9 +343,9 @@ fn build_documents(
             "Skipped {null_pk_skips} record(s) for Elasticsearch index '{es_index}': NULL primary key value(s) (would produce non-idempotent auto-generated document IDs). Sample row indices: {null_pk_samples:?}"
         );
     }
-    if zero_or_nan_skips > 0 {
+    if all_zero_skips > 0 {
         tracing::warn!(
-            "Skipped {zero_or_nan_skips} record(s) for Elasticsearch index '{es_index}': embedding vector is all zeros or NaN. Sample row indices: {zero_or_nan_samples:?}"
+            "Skipped {all_zero_skips} record(s) for Elasticsearch index '{es_index}': embedding vector is all zeroes, so it has no direction to search by. Sample row indices: {all_zero_samples:?}"
         );
     }
     if non_finite_skips > 0 {

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -38,7 +38,7 @@ use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
 use crate::index::elasticsearch::ElasticsearchIndex;
 use crate::index::embedding_col;
-use crate::index::write_util::{self, EmbeddingDefect};
+use crate::index::{EmbeddingDefect, embedding_defect};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -289,22 +289,16 @@ fn build_documents(
             });
         }
 
-        match write_util::embedding_defect(embedding) {
-            Some(EmbeddingDefect::AllZero) => {
-                all_zero_skips += 1;
-                if all_zero_samples.len() < SAMPLE_LIMIT {
-                    all_zero_samples.push(row);
-                }
-                continue;
+        if let Some(defect) = embedding_defect(embedding) {
+            let (skips, samples) = match defect {
+                EmbeddingDefect::AllZero => (&mut all_zero_skips, &mut all_zero_samples),
+                EmbeddingDefect::NonFinite => (&mut non_finite_skips, &mut non_finite_samples),
+            };
+            *skips += 1;
+            if samples.len() < SAMPLE_LIMIT {
+                samples.push(row);
             }
-            Some(EmbeddingDefect::NonFinite) => {
-                non_finite_skips += 1;
-                if non_finite_samples.len() < SAMPLE_LIMIT {
-                    non_finite_samples.push(row);
-                }
-                continue;
-            }
-            None => {}
+            continue;
         }
 
         let mut doc = serde_json::Map::with_capacity(column_encoders.len() + 1);
@@ -345,12 +339,14 @@ fn build_documents(
     }
     if all_zero_skips > 0 {
         tracing::warn!(
-            "Skipped {all_zero_skips} record(s) for Elasticsearch index '{es_index}': embedding vector is all zeroes, so it has no direction to search by. Sample row indices: {all_zero_samples:?}"
+            "Skipped {all_zero_skips} record(s) for Elasticsearch index '{es_index}': the embedding vector {defect}, so it cannot be searched. Sample row indices: {all_zero_samples:?}",
+            defect = EmbeddingDefect::AllZero
         );
     }
     if non_finite_skips > 0 {
         tracing::warn!(
-            "Skipped {non_finite_skips} record(s) for Elasticsearch index '{es_index}': embedding vector contains non-finite values (NaN or infinity). Sample row indices: {non_finite_samples:?}"
+            "Skipped {non_finite_skips} record(s) for Elasticsearch index '{es_index}': the embedding vector {defect}, so it cannot be searched. Sample row indices: {non_finite_samples:?}",
+            defect = EmbeddingDefect::NonFinite
         );
     }
     if missing_embedding_skips > 0 {
@@ -472,11 +468,11 @@ fn create_embedding_array(
     builder = builder.with_field(item_field);
 
     for (row, emb) in embedding_vectors.iter().enumerate() {
-        match emb {
-            Some(v) if v.len() == expected => {
-                builder.values().append_slice(v);
-                builder.append(true);
-            }
+        // `build_documents` has already left an unusable vector out of Elasticsearch; leave
+        // it out of the column too, so the batch that lands in the accelerated table agrees
+        // with the index about which rows are searchable.
+        let usable = match emb {
+            Some(v) if v.len() == expected => embedding_defect(v).is_none().then_some(v),
             Some(v) => {
                 return Err(Error::EmbeddingDimensionMismatch {
                     index: es_index.to_string(),
@@ -485,11 +481,16 @@ fn create_embedding_array(
                     row_index: row,
                 });
             }
-            None => {
-                // Store `f32` child values, not `Option<f32>`; the list slot represents a null embedding.
-                builder.values().append_value_n(0.0, expected);
-                builder.append(false);
-            }
+            None => None,
+        };
+
+        if let Some(v) = usable {
+            builder.values().append_slice(v);
+            builder.append(true);
+        } else {
+            // Store `f32` child values, not `Option<f32>`; the list slot represents a null embedding.
+            builder.values().append_value_n(0.0, expected);
+            builder.append(false);
         }
     }
 

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -206,17 +206,21 @@ impl MemoryVectorIndex {
             .map(|(key, vector)| {
                 let keep = match (key, vector) {
                     (Some(key), Some(vector)) => {
-                        // All-zero / all-NaN vectors have no defined direction and
-                        // would corrupt similarity scores — skip them.
-                        let valid = !vector.iter().all(|&v| v == 0.0 || v.is_nan());
-                        if valid {
-                            keys.push(key.clone());
-                        } else {
-                            tracing::warn!(
-                                "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes or contains only invalid values"
-                            );
+                        // A vector with no defined direction, or with an element that makes
+                        // every distance undefined, would corrupt similarity scores — skip it.
+                        match write_util::embedding_defect(vector) {
+                            None => {
+                                keys.push(key.clone());
+                                true
+                            }
+                            Some(defect) => {
+                                let reason = defect.reason();
+                                tracing::warn!(
+                                    "Skipping record '{key}' for memory vector index '{INDEX_NAME}': the embedding vector {reason}, so it cannot be searched."
+                                );
+                                false
+                            }
                         }
-                        valid
                     }
                     (None, _) => {
                         tracing::warn!(
@@ -542,12 +546,45 @@ mod tests {
         ))
     }
 
+    /// Returns a vector whose second element is `NAN` for row 2, and a usable vector
+    /// otherwise — the shape a provider produces when one response is corrupt.
+    #[derive(Debug)]
+    struct OneNanEmbed;
+
+    #[async_trait]
+    impl Embed for OneNanEmbed {
+        async fn embed(&self, input: EmbeddingInput) -> llms::embeddings::Result<Vec<Vec<f32>>> {
+            let vector_for = |text: &str| {
+                if text == "row 2" {
+                    vec![1.0, f32::NAN, 3.0]
+                } else {
+                    byte_vector(text)
+                }
+            };
+            match input {
+                EmbeddingInput::String(s) => Ok(vec![vector_for(&s)]),
+                EmbeddingInput::StringArray(v) => {
+                    Ok(v.iter().map(|s| vector_for(s)).collect::<Vec<_>>())
+                }
+                _ => Ok(vec![]),
+            }
+        }
+
+        fn size(&self) -> i32 {
+            DIM
+        }
+    }
+
     fn memory_index() -> MemoryVectorIndex {
+        memory_index_with(Arc::new(ByteEmbed))
+    }
+
+    fn memory_index_with(embedder: Arc<dyn Embed>) -> MemoryVectorIndex {
         MemoryVectorIndex::try_new(
             "content".to_string(),
             vec![Field::new("id", DataType::Int64, false)],
             MetadataColumns::none(),
-            Arc::new(ByteEmbed),
+            embedder,
             embed_udf(),
             "model_name".to_string(),
             MemoryDistanceMetric::Cosine,
@@ -609,6 +646,26 @@ mod tests {
             .on_write_complete()
             .await
             .expect("the write window closes");
+    }
+
+    /// A vector that mixes real values with a `NaN` is not indexable: every distance
+    /// computed against it is undefined. The `all(|v| v == 0.0 || v.is_nan())` filter this
+    /// replaced only caught a vector that was *entirely* zeroes and NaNs, so row 2 was
+    /// stored and searched (regression test for #13089).
+    #[tokio::test]
+    async fn a_partially_non_finite_embedding_is_not_indexed() {
+        let index = memory_index_with(Arc::new(OneNanEmbed));
+
+        index
+            .compute_index(vec![batch(&[1, 2, 3])])
+            .await
+            .expect("the rows are indexed");
+
+        assert_eq!(
+            indexed_ids(&index),
+            vec![1, 3],
+            "row 2's embedding carries a NaN, so it has no usable distance to any query"
+        );
     }
 
     /// The regression test. A `refresh_mode: full` refresh removes a row by not re-sending

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -44,7 +44,7 @@ use snafu::{ResultExt, Snafu, ensure};
 use spice_table::{Index, WriteWindow};
 
 use crate::index::{
-    SearchIndex, VectorIndex, embedding_col,
+    SearchIndex, VectorIndex, embedding_col, embedding_defect,
     memory::{
         provider::{MemoryVectorListTable, MemoryVectorQueryTable},
         store::MemoryVectorStore,
@@ -206,17 +206,14 @@ impl MemoryVectorIndex {
             .map(|(key, vector)| {
                 let keep = match (key, vector) {
                     (Some(key), Some(vector)) => {
-                        // A vector with no defined direction, or with an element that makes
-                        // every distance undefined, would corrupt similarity scores — skip it.
-                        match write_util::embedding_defect(vector) {
+                        match embedding_defect(vector) {
                             None => {
                                 keys.push(key.clone());
                                 true
                             }
                             Some(defect) => {
-                                let reason = defect.reason();
                                 tracing::warn!(
-                                    "Skipping record '{key}' for memory vector index '{INDEX_NAME}': the embedding vector {reason}, so it cannot be searched."
+                                    "Skipping record '{key}' for memory vector index '{INDEX_NAME}': the embedding vector {defect}, so it cannot be searched."
                                 );
                                 false
                             }

--- a/crates/search/src/index/mod.rs
+++ b/crates/search/src/index/mod.rs
@@ -252,6 +252,87 @@ fn embedding_col(search_column: &str) -> String {
     format!("{search_column}_embedding")
 }
 
+/// Why an embedding vector cannot be indexed.
+///
+/// [`Display`](std::fmt::Display) renders the defect as a sentence fragment, so a caller that
+/// already names the index and the row can splice it into its own message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmbeddingDefect {
+    /// At least one element is `NaN` or infinite, so every distance computed against the
+    /// vector is undefined. For a graph index (DuckDB HNSW) a single such vector also
+    /// degrades the neighbour lists other rows are found through.
+    NonFinite,
+    /// Every element is zero, so the vector has no direction and cosine distance against
+    /// it is undefined.
+    AllZero,
+}
+
+impl std::fmt::Display for EmbeddingDefect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NonFinite => f.write_str("contains a NaN or infinite value"),
+            Self::AllZero => f.write_str("is all zeroes"),
+        }
+    }
+}
+
+/// The single definition of "this embedding cannot be indexed", shared by every write path
+/// so that one backend cannot disagree with another about what a usable vector is.
+///
+/// Returns `None` when the vector is usable. The test is per element and includes the
+/// infinities, so a vector that mixes real values with a `NaN` — `[NaN, 2.0, 3.0]` — is
+/// rejected.
+///
+/// A write-side guard does not remove the need for the read side to screen the same values:
+/// [`native_vector::NativeVectorIndex`] indexes a column written by the accelerator sink, and
+/// `cosine_distance` is registered for any numeric list column, so a vector can reach a query
+/// with no Spice-side embedding code on the path. Today only `cosine_distance` screens a
+/// non-finite value on that end (#13127).
+pub(crate) fn embedding_defect(vector: &[f32]) -> Option<EmbeddingDefect> {
+    if vector.iter().any(|value| !value.is_finite()) {
+        return Some(EmbeddingDefect::NonFinite);
+    }
+
+    if vector.iter().all(|&value| value == 0.0) {
+        return Some(EmbeddingDefect::AllZero);
+    }
+
+    None
+}
+
+/// Counts the rows a write path left out of its index, so that a batch in which the
+/// embedding model has degraded logs once with a sample of the rows rather than once per
+/// row — up to 8192 warnings, for a defect whose cause is the same on every row.
+#[derive(Debug, Default)]
+pub(crate) struct SkippedEmbeddings {
+    count: usize,
+    /// The first few row indices, to make the batch findable without logging all of them.
+    sample: Vec<usize>,
+}
+
+impl SkippedEmbeddings {
+    const SAMPLE_LIMIT: usize = 5;
+
+    pub(crate) fn record(&mut self, row: usize) {
+        self.count += 1;
+        if self.sample.len() < Self::SAMPLE_LIMIT {
+            self.sample.push(row);
+        }
+    }
+
+    /// Emit one warning for everything recorded, naming `context` (the index the rows were
+    /// destined for). Does nothing when no row was skipped.
+    pub(crate) fn warn(&self, context: &str, defect: EmbeddingDefect) {
+        if self.count == 0 {
+            return;
+        }
+        let (count, sample) = (self.count, &self.sample);
+        tracing::warn!(
+            "Not indexing {count} row(s) for {context}: the embedding vector {defect}, so it cannot be searched. Sample row indices: {sample:?}"
+        );
+    }
+}
+
 /// Projection expressions selecting `fields` by name — the key columns
 /// [`VectorIndex::list_all_entry_keys`] promises, used both to narrow a listing to them and to
 /// bring two stores' listings to a common schema before combining them.
@@ -263,6 +344,51 @@ pub(crate) fn primary_key_projection(fields: &[Field]) -> Vec<Expr> {
 mod tests {
     use super::*;
     use std::any::Any;
+
+    #[test]
+    fn usable_embeddings_have_no_defect() {
+        assert_eq!(embedding_defect(&[1.0, 2.0, 3.0]), None);
+        // One zero among real values still leaves a direction.
+        assert_eq!(embedding_defect(&[0.0, 0.0, 1.0]), None);
+        assert_eq!(embedding_defect(&[-1.0, 0.0, f32::MIN_POSITIVE]), None);
+    }
+
+    /// The gap this predicate exists to close: a vector that mixes real values with a
+    /// single non-finite element. `all(|x| x == 0.0 || x.is_nan())` reported these as
+    /// usable, and they were written and indexed (regression test for #13089).
+    #[test]
+    fn a_single_non_finite_element_makes_a_vector_unusable() {
+        for vector in [
+            vec![f32::NAN, 2.0, 3.0],
+            vec![1.0, f32::NAN, 3.0],
+            vec![1.0, 2.0, f32::INFINITY],
+            vec![f32::NEG_INFINITY, 2.0, 3.0],
+            // The all-zero filter did catch these two; they must stay caught.
+            vec![f32::NAN, f32::NAN],
+            vec![0.0, f32::NAN],
+        ] {
+            assert_eq!(
+                embedding_defect(&vector),
+                Some(EmbeddingDefect::NonFinite),
+                "expected {vector:?} to be rejected as non-finite"
+            );
+        }
+    }
+
+    #[test]
+    fn an_all_zero_vector_has_no_direction() {
+        assert_eq!(
+            embedding_defect(&[0.0, 0.0]),
+            Some(EmbeddingDefect::AllZero)
+        );
+        // IEEE-754 negative zero compares equal to zero, and carries no direction either.
+        assert_eq!(
+            embedding_defect(&[-0.0, 0.0, -0.0]),
+            Some(EmbeddingDefect::AllZero)
+        );
+        // An empty vector has no direction; the dimension checks reject it separately.
+        assert_eq!(embedding_defect(&[]), Some(EmbeddingDefect::AllZero));
+    }
 
     #[test]
     fn as_search_index_recognizes_a_known_concrete_type() {

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -27,8 +27,8 @@ use snafu::{ResultExt, Snafu};
 use spice_table::Index;
 
 use crate::index::write_util::{
-    self, embed_column, extract_and_format_primary_key, sort_columns_alphabetically,
-    update_embedding_column_in_batch,
+    self, embed_column, embedding_defect, extract_and_format_primary_key,
+    sort_columns_alphabetically, update_embedding_column_in_batch,
 };
 use crate::index::{SearchIndex, embedding_col, s3_vectors::S3Vector};
 
@@ -184,9 +184,9 @@ async fn process_single_batch(
     )
     .map_err(|e| Error::from(*e))?;
 
-    // Filter out zero vectors to prevent cosine similarity calculation errors
+    // Drop records whose embedding cannot be searched, so they never reach the index.
     let (filtered_embeddings, filtered_primary_key, filtered_metadata) =
-        filter_zero_vectors(embedding_vectors, primary_key, metadata, index.name());
+        filter_unusable_vectors(embedding_vectors, primary_key, metadata, index.name());
 
     let spill_index = index.spill_index().await.context(CannotWriteIndexSnafu {
         index: index.name().to_string(),
@@ -264,18 +264,16 @@ pub fn extract_and_format_metadata(
     Ok(metadata)
 }
 
-/// Filter out invalid embedding vectors where all values are either zero or NaN.
+/// Drop the records whose embedding cannot be indexed, per [`embedding_defect`].
 ///
-/// This filters vectors that consist entirely of invalid values (zeros and/or NaNs).
-/// A vector with any valid non-zero, non-NaN value is kept.
 /// For example:
-/// - `[0.0, 0.0]` -> filtered (all zeros)
-/// - `[NaN, NaN]` -> filtered (all NaN)
-/// - `[0.0, NaN]` -> filtered (all values are either zero or NaN)
-/// - `[1.0, 0.0]` -> kept (has a valid non-zero value)
-/// - `[1.0, NaN]` -> kept (has a valid non-NaN value)
+/// - `[0.0, 0.0]` -> filtered (all zeroes)
+/// - `[NaN, NaN]` -> filtered (not finite)
+/// - `[0.0, NaN]` -> filtered (not finite)
+/// - `[1.0, NaN]` -> filtered (not finite — one bad element makes every distance undefined)
+/// - `[1.0, 0.0]` -> kept
 #[expect(clippy::type_complexity)]
-fn filter_zero_vectors(
+fn filter_unusable_vectors(
     mut embeddings: Vec<Option<Vec<f32>>>,
     mut primary_keys: Vec<Option<String>>,
     mut metadata: HashMap<String, Vec<Option<Value>>>,
@@ -288,15 +286,15 @@ fn filter_zero_vectors(
     // Filter in reverse order to avoid index shifting when removing elements
     for i in (0..embeddings.len()).rev() {
         if let Some(embedding) = &embeddings[i]
-            // Single pass: check if all values are zero or NaN (both are invalid embeddings)
-            && embedding.iter().all(|&x| x == 0.0 || x.is_nan())
+            && let Some(defect) = embedding_defect(embedding)
         {
             let key_str = primary_keys
                 .get(i)
                 .and_then(|k| k.as_ref().map(String::as_str))
                 .unwrap_or("unknown");
+            let reason = defect.reason();
             tracing::warn!(
-                "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values"
+                "Skipping record '{key_str}' for S3 Vector index '{index_name}': the embedding vector {reason}, so it cannot be searched."
             );
 
             embeddings.remove(i);
@@ -317,7 +315,7 @@ mod tests {
     use arrow_schema::{DataType, Schema, UnionFields, UnionMode};
 
     #[test]
-    fn test_filter_zero_vectors() {
+    fn test_filter_unusable_vectors() {
         use serde_json::Value;
         use std::collections::HashMap;
 
@@ -345,7 +343,7 @@ mod tests {
         );
 
         let (filtered_embeddings, filtered_keys, filtered_metadata) =
-            filter_zero_vectors(embeddings, keys, metadata, "test_index");
+            filter_unusable_vectors(embeddings, keys, metadata, "test_index");
 
         assert_eq!(filtered_embeddings.len(), 3);
         assert_eq!(filtered_keys.len(), 3);
@@ -357,7 +355,7 @@ mod tests {
         assert_eq!(filtered_embeddings[2], Some(vec![3.0, 4.0]));
     }
 
-    /// Test that filter_zero_vectors correctly filters out NaN embeddings.
+    /// Test that `filter_unusable_vectors` correctly filters out NaN embeddings.
     #[test]
     fn test_filter_nan_vectors() {
         use serde_json::Value;
@@ -390,7 +388,7 @@ mod tests {
         );
 
         let (filtered_embeddings, filtered_keys, filtered_metadata) =
-            filter_zero_vectors(embeddings, keys, metadata, "test_index");
+            filter_unusable_vectors(embeddings, keys, metadata, "test_index");
 
         // Should keep only the 2 valid vectors
         assert_eq!(filtered_embeddings.len(), 2);
@@ -402,6 +400,35 @@ mod tests {
         assert_eq!(filtered_embeddings[1], Some(vec![3.0, 4.0]));
         assert_eq!(filtered_keys[0], Some("key1".to_string()));
         assert_eq!(filtered_keys[1], Some("key4".to_string()));
+    }
+
+    /// A vector that mixes real values with a non-finite one is unusable: every distance
+    /// computed against it is undefined. The `all(|x| x == 0.0 || x.is_nan())` filter this
+    /// replaced kept these (regression test for #13089).
+    #[test]
+    fn partially_non_finite_vectors_are_filtered() {
+        use serde_json::Value;
+        use std::collections::HashMap;
+
+        let embeddings = vec![
+            Some(vec![f32::NAN, 2.0, 3.0]), // Filter out — one NaN among real values
+            Some(vec![1.0, f32::INFINITY, 3.0]), // Filter out — +inf
+            Some(vec![1.0, 2.0, f32::NEG_INFINITY]), // Filter out — -inf
+            Some(vec![1.0, 2.0, 3.0]),      // Keep
+        ];
+        let keys = (1..=4).map(|i| Some(format!("key{i}"))).collect::<Vec<_>>();
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "test".to_string(),
+            vec![Some(Value::String("a".to_string())); 4],
+        );
+
+        let (filtered_embeddings, filtered_keys, filtered_metadata) =
+            filter_unusable_vectors(embeddings, keys, metadata, "test_index");
+
+        assert_eq!(filtered_embeddings, vec![Some(vec![1.0, 2.0, 3.0])]);
+        assert_eq!(filtered_keys, vec![Some("key4".to_string())]);
+        assert_eq!(filtered_metadata["test"].len(), 1);
     }
 
     #[test]

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -27,10 +27,10 @@ use snafu::{ResultExt, Snafu};
 use spice_table::Index;
 
 use crate::index::write_util::{
-    self, embed_column, embedding_defect, extract_and_format_primary_key,
-    sort_columns_alphabetically, update_embedding_column_in_batch,
+    self, embed_column, extract_and_format_primary_key, sort_columns_alphabetically,
+    update_embedding_column_in_batch,
 };
-use crate::index::{SearchIndex, embedding_col, s3_vectors::S3Vector};
+use crate::index::{SearchIndex, embedding_col, embedding_defect, s3_vectors::S3Vector};
 
 #[derive(Snafu, Debug)]
 pub enum Error {
@@ -292,9 +292,8 @@ fn filter_unusable_vectors(
                 .get(i)
                 .and_then(|k| k.as_ref().map(String::as_str))
                 .unwrap_or("unknown");
-            let reason = defect.reason();
             tracing::warn!(
-                "Skipping record '{key_str}' for S3 Vector index '{index_name}': the embedding vector {reason}, so it cannot be searched."
+                "Skipping record '{key_str}' for S3 Vector index '{index_name}': the embedding vector {defect}, so it cannot be searched."
             );
 
             embeddings.remove(i);

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -93,6 +93,49 @@ pub enum Error {
     },
 }
 
+/// Why an embedding vector cannot be indexed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmbeddingDefect {
+    /// At least one element is `NaN` or infinite, so every distance computed against the
+    /// vector is undefined. For a graph index (DuckDB HNSW) a single such vector also
+    /// degrades the neighbour lists other rows are found through.
+    NonFinite,
+    /// Every element is zero, so the vector has no direction and cosine distance against
+    /// it is undefined.
+    AllZero,
+}
+
+impl EmbeddingDefect {
+    /// The defect as a message fragment, for a log line or an error that already names the
+    /// index and the row.
+    pub(crate) fn reason(self) -> &'static str {
+        match self {
+            Self::NonFinite => "contains a NaN or infinite value",
+            Self::AllZero => "is all zeroes",
+        }
+    }
+}
+
+/// The single definition of "this embedding cannot be indexed", shared by every write path
+/// so that one backend cannot disagree with another about what a usable vector is.
+///
+/// Returns `None` when the vector is usable. The test is per element and includes the
+/// infinities, so a vector that mixes real values with a `NaN` — `[NaN, 2.0, 3.0]` — is
+/// rejected. The read side screens the same values (`cosine_distance` returns NULL for a
+/// distance that is not defined), and both ends need the check: a vector column can reach
+/// an index from a source with no Spice-side embedding code on the path.
+pub(crate) fn embedding_defect(vector: &[f32]) -> Option<EmbeddingDefect> {
+    if vector.iter().any(|value| !value.is_finite()) {
+        return Some(EmbeddingDefect::NonFinite);
+    }
+
+    if vector.iter().all(|&value| value == 0.0) {
+        return Some(EmbeddingDefect::AllZero);
+    }
+
+    None
+}
+
 /// Given a [`RecordBatch`] of data from a [`crate::index::SearchIndex`]'s associated
 /// `TableProvider`, extract and format the primary key into one string per row.
 ///
@@ -364,6 +407,51 @@ mod tests {
     use super::*;
     use arrow::array::{FixedSizeListArray, Float32Array, Float32Builder, Int32Array, StringArray};
     use arrow::datatypes::{DataType, Schema};
+
+    #[test]
+    fn usable_embeddings_have_no_defect() {
+        assert_eq!(embedding_defect(&[1.0, 2.0, 3.0]), None);
+        // One zero among real values still leaves a direction.
+        assert_eq!(embedding_defect(&[0.0, 0.0, 1.0]), None);
+        assert_eq!(embedding_defect(&[-1.0, 0.0, f32::MIN_POSITIVE]), None);
+    }
+
+    /// The gap this predicate exists to close: a vector that mixes real values with a
+    /// single non-finite element. `all(|x| x == 0.0 || x.is_nan())` reported these as
+    /// usable, and they were written and indexed (regression test for #13089).
+    #[test]
+    fn a_single_non_finite_element_makes_a_vector_unusable() {
+        for vector in [
+            vec![f32::NAN, 2.0, 3.0],
+            vec![1.0, f32::NAN, 3.0],
+            vec![1.0, 2.0, f32::INFINITY],
+            vec![f32::NEG_INFINITY, 2.0, 3.0],
+            // The all-zero filter did catch these two; they must stay caught.
+            vec![f32::NAN, f32::NAN],
+            vec![0.0, f32::NAN],
+        ] {
+            assert_eq!(
+                embedding_defect(&vector),
+                Some(EmbeddingDefect::NonFinite),
+                "expected {vector:?} to be rejected as non-finite"
+            );
+        }
+    }
+
+    #[test]
+    fn an_all_zero_vector_has_no_direction() {
+        assert_eq!(
+            embedding_defect(&[0.0, 0.0]),
+            Some(EmbeddingDefect::AllZero)
+        );
+        // IEEE-754 negative zero compares equal to zero, and carries no direction either.
+        assert_eq!(
+            embedding_defect(&[-0.0, 0.0, -0.0]),
+            Some(EmbeddingDefect::AllZero)
+        );
+        // An empty vector has no direction; the dimension checks reject it separately.
+        assert_eq!(embedding_defect(&[]), Some(EmbeddingDefect::AllZero));
+    }
 
     // Helper function to create a test RecordBatch with text and embedding columns
     #[expect(clippy::cast_sign_loss)]

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Store-agnostic helpers shared by external-store [`crate::index::VectorIndex`]
-//! implementations (S3 Vectors, in-memory): primary-key formatting, search-column
-//! embedding, and embedding-column construction on write.
+//! Store-agnostic helpers shared by [`crate::index::VectorIndex`] implementations:
+//! primary-key formatting, search-column embedding, and embedding-column construction on
+//! write.
 
 use std::{num::TryFromIntError, sync::Arc};
 
@@ -31,7 +31,7 @@ use serde_json::Value;
 use snafu::{ResultExt, Snafu};
 use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
-use crate::index::embedding_col;
+use crate::index::{EmbeddingDefect, SkippedEmbeddings, embedding_col, embedding_defect};
 
 #[derive(Snafu, Debug)]
 #[snafu(visibility(pub(crate)))]
@@ -91,49 +91,6 @@ pub enum Error {
         actual: usize,
         row_index: usize,
     },
-}
-
-/// Why an embedding vector cannot be indexed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum EmbeddingDefect {
-    /// At least one element is `NaN` or infinite, so every distance computed against the
-    /// vector is undefined. For a graph index (DuckDB HNSW) a single such vector also
-    /// degrades the neighbour lists other rows are found through.
-    NonFinite,
-    /// Every element is zero, so the vector has no direction and cosine distance against
-    /// it is undefined.
-    AllZero,
-}
-
-impl EmbeddingDefect {
-    /// The defect as a message fragment, for a log line or an error that already names the
-    /// index and the row.
-    pub(crate) fn reason(self) -> &'static str {
-        match self {
-            Self::NonFinite => "contains a NaN or infinite value",
-            Self::AllZero => "is all zeroes",
-        }
-    }
-}
-
-/// The single definition of "this embedding cannot be indexed", shared by every write path
-/// so that one backend cannot disagree with another about what a usable vector is.
-///
-/// Returns `None` when the vector is usable. The test is per element and includes the
-/// infinities, so a vector that mixes real values with a `NaN` — `[NaN, 2.0, 3.0]` — is
-/// rejected. The read side screens the same values (`cosine_distance` returns NULL for a
-/// distance that is not defined), and both ends need the check: a vector column can reach
-/// an index from a source with no Spice-side embedding code on the path.
-pub(crate) fn embedding_defect(vector: &[f32]) -> Option<EmbeddingDefect> {
-    if vector.iter().any(|value| !value.is_finite()) {
-        return Some(EmbeddingDefect::NonFinite);
-    }
-
-    if vector.iter().all(|&value| value == 0.0) {
-        return Some(EmbeddingDefect::AllZero);
-    }
-
-    None
 }
 
 /// Given a [`RecordBatch`] of data from a [`crate::index::SearchIndex`]'s associated
@@ -328,6 +285,13 @@ pub fn update_embedding_column_in_batch(
 }
 
 /// Create an Arrow array from embedding vectors.
+///
+/// A vector that cannot be indexed ([`embedding_defect`]) becomes a null slot rather than a
+/// stored value. The backends that call this also drop such a record from their own store,
+/// but the batch built here is what lands in the accelerated table — and a vector column
+/// there is searchable on its own, through `native_vector_indexes_for_schema`, so leaving
+/// the value in the column would make the column and the index disagree about which rows
+/// are searchable.
 #[expect(clippy::cast_sign_loss)]
 pub fn create_embedding_array(
     embedding_vectors: &[Option<Vec<f32>>],
@@ -356,6 +320,8 @@ pub fn create_embedding_array(
     builder = builder.with_field(field);
 
     let expected_dim = dimension as usize;
+    let mut non_finite = SkippedEmbeddings::default();
+    let mut all_zero = SkippedEmbeddings::default();
     for (row_index, embedding_opt) in embedding_vectors.iter().enumerate() {
         if let Some(embedding) = embedding_opt {
             // Validate embedding dimension matches expected dimension
@@ -365,6 +331,15 @@ pub fn create_embedding_array(
                     actual: embedding.len(),
                     row_index,
                 }));
+            }
+            if let Some(defect) = embedding_defect(embedding) {
+                match defect {
+                    EmbeddingDefect::NonFinite => non_finite.record(row_index),
+                    EmbeddingDefect::AllZero => all_zero.record(row_index),
+                }
+                builder.values().append_value_n(0.0, expected_dim);
+                builder.append(false);
+                continue;
             }
             // Optimized: append_slice automatically marks all values as valid
             // without needing to allocate a separate validity vector
@@ -377,6 +352,9 @@ pub fn create_embedding_array(
             builder.append(false);
         }
     }
+
+    non_finite.warn("the embedding column", EmbeddingDefect::NonFinite);
+    all_zero.warn("the embedding column", EmbeddingDefect::AllZero);
 
     Ok(Arc::new(builder.finish()))
 }
@@ -407,51 +385,6 @@ mod tests {
     use super::*;
     use arrow::array::{FixedSizeListArray, Float32Array, Float32Builder, Int32Array, StringArray};
     use arrow::datatypes::{DataType, Schema};
-
-    #[test]
-    fn usable_embeddings_have_no_defect() {
-        assert_eq!(embedding_defect(&[1.0, 2.0, 3.0]), None);
-        // One zero among real values still leaves a direction.
-        assert_eq!(embedding_defect(&[0.0, 0.0, 1.0]), None);
-        assert_eq!(embedding_defect(&[-1.0, 0.0, f32::MIN_POSITIVE]), None);
-    }
-
-    /// The gap this predicate exists to close: a vector that mixes real values with a
-    /// single non-finite element. `all(|x| x == 0.0 || x.is_nan())` reported these as
-    /// usable, and they were written and indexed (regression test for #13089).
-    #[test]
-    fn a_single_non_finite_element_makes_a_vector_unusable() {
-        for vector in [
-            vec![f32::NAN, 2.0, 3.0],
-            vec![1.0, f32::NAN, 3.0],
-            vec![1.0, 2.0, f32::INFINITY],
-            vec![f32::NEG_INFINITY, 2.0, 3.0],
-            // The all-zero filter did catch these two; they must stay caught.
-            vec![f32::NAN, f32::NAN],
-            vec![0.0, f32::NAN],
-        ] {
-            assert_eq!(
-                embedding_defect(&vector),
-                Some(EmbeddingDefect::NonFinite),
-                "expected {vector:?} to be rejected as non-finite"
-            );
-        }
-    }
-
-    #[test]
-    fn an_all_zero_vector_has_no_direction() {
-        assert_eq!(
-            embedding_defect(&[0.0, 0.0]),
-            Some(EmbeddingDefect::AllZero)
-        );
-        // IEEE-754 negative zero compares equal to zero, and carries no direction either.
-        assert_eq!(
-            embedding_defect(&[-0.0, 0.0, -0.0]),
-            Some(EmbeddingDefect::AllZero)
-        );
-        // An empty vector has no direction; the dimension checks reject it separately.
-        assert_eq!(embedding_defect(&[]), Some(EmbeddingDefect::AllZero));
-    }
 
     // Helper function to create a test RecordBatch with text and embedding columns
     #[expect(clippy::cast_sign_loss)]
@@ -523,6 +456,30 @@ mod tests {
             ],
         )
         .expect("valid composite primary key batch")
+    }
+
+    /// The record is dropped from the index's own store by the caller, but the batch this
+    /// builds is what lands in the accelerated table — where the vector column is
+    /// searchable in its own right. Leaving the value in would make the column and the
+    /// index disagree about which rows are searchable (regression test for #13089).
+    #[test]
+    fn an_unusable_embedding_becomes_a_null_slot() {
+        let embeddings = vec![
+            Some(vec![1.0, 2.0, 3.0]),
+            Some(vec![1.0, f32::NAN, 3.0]),
+            Some(vec![0.0, 0.0, 0.0]),
+            None,
+            Some(vec![4.0, 5.0, 6.0]),
+        ];
+
+        let array = create_embedding_array(&embeddings, 3)
+            .expect("the batch is built, minus the unusable vectors");
+
+        assert_eq!(array.len(), 5, "every row keeps its slot");
+        assert_eq!(
+            (0..5).map(|i| array.is_null(i)).collect::<Vec<_>>(),
+            vec![false, true, true, true, false]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

"Invalid embedding" had four different definitions across the vector write paths, and three of them accepted a vector like `[NaN, 2.0, 3.0]`.

The root cause is the predicate itself: S3 Vectors (`s3_vectors/write.rs`) and the in-memory index (`memory/mod.rs`) both tested `all(|x| x == 0.0 || x.is_nan())`, which asks "is *every* element bad" — so one `NaN` among real values read as usable, and neither test looked at the infinities at all. The DuckDB HNSW write path checked nothing: `validate_vector` exists and is correct, but it was only ever called on the *query* vector, never on write. Elasticsearch was the only complete check.

A vector with an undefined element is not merely a bad row for itself. Every distance computed against it is undefined, and for a graph index the values go into HNSW's neighbour lists, so one such vector degrades the results returned for *other* rows.

## Changes

- **One predicate, `index::embedding_defect`**, next to `embedding_col` in `crates/search/src/index/mod.rs`. A vector is unusable if any element is not finite, or if it has no direction because every element is zero. `EmbeddingDefect` renders as a sentence fragment so each site keeps its own message.
- **Each write path keeps its own disposition**, which is what differs legitimately between them:
  - S3 Vectors, in-memory, Elasticsearch — skip the record (what they already did for the all-zero case).
  - DuckDB — store a null slot. The embedding sits beside the source row in the accelerated table, so there is no record to drop, and failing the batch would discard rows whose only defect is one bad vector. A null slot is the state a row with no text to embed is already in, and it is what the read side (`embedding IS NOT NULL`) already excludes.
- **The materialized column is gated too**, in `write_util`'s and Elasticsearch's `create_embedding_array`. Those backends skip the record from their *own* store, but the batch they return lands in the accelerated table — where a `FixedSizeList<Float32, N>` column is searchable in its own right via `native_vector_indexes_for_schema`. Without this the column and the index disagreed about which rows are searchable.
- **Skipped rows are tallied and logged once per batch** with a sample of row indices, rather than once per row. A degraded embedding model produces a whole bad batch, and the per-row form would emit up to 8192 warnings for one cause.

`native_vector.rs` is deliberately unchanged: it is a pass-through whose column is written by the accelerator sink, so a screen there would scan data Spice did not produce, on the accelerator's write path. That case is the read side's, which is where #13127 picks it up.

## Performance impact

The screen is one pass over each vector on the happy path (the all-zero test short-circuits on the first non-zero element, which for a dense embedding is element 0). For the two backends whose old predicate short-circuited on the first ordinary element this is a real increase — but it is inherent: a `NaN` at position 1500 cannot be found without reading position 1500. Measured against the same batch's JSON encoding, network upload, or HNSW construction it is well under 1%. `EmbeddingDefect` renders from `&'static str`, so the log and error paths allocate nothing.

## Test plan

- `make lint`
- `make test`
- New: the predicate's contract (`index/mod.rs`) — mixed real/`NaN`, `±inf`, all-zero, `-0.0`, empty; each write path's disposition (`s3_vectors`, `memory` end-to-end through `compute_index` with an embedder that returns one `NaN` row, `duckdb`, `write_util`); and that a dimension mismatch still fails the write rather than being downgraded to a null.
- Every new test was verified load-bearing by neutering `embedding_defect` back to the pre-fix `all(|x| x == 0.0 || x.is_nan())`: 6 tests fail across all five sites, and the two pre-existing S3 Vectors tests still pass, confirming the old cases stay caught. Re-run after the review pass, since the DuckDB disposition changed underneath it.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1 with "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` is not installed in this environment. Its angles were run by hand instead, and the deepest one changed the fix: the original revision failed the entire DuckDB write batch on one bad vector, which propagates as a `StreamError::External` and would stop ingestion for the dataset — discarding good rows to punish one bad vector. That became the null-slot disposition above.
- `/security-review`: no findings. The predicate is a pure function over `&[f32]`; the new messages carry a row index and a `&'static str` fragment, no user data or credentials.
- `/simplify`: applied — moved the predicate out of the `llms`-gated `write_util` into `index::mod`, replaced `reason()` with `Display`, collapsed the duplicated null-slot encoding and the two identical Elasticsearch match arms, normalized three import styles to one, unified the Elasticsearch log wording with the shared vocabulary, and cut four DuckDB tests to the one that covers the site-specific behaviour. Two findings were out of scope and filed as #13127 and #13128. Light checks and the neuter re-run green.

Fixes #13089

## Checklist

- [x] Regression test fails on the old code and passes on the new
- [x] Whole bug class fixed, not just the reported instance
- [x] Scoped `cargo clippy -p search --lib --tests --features duckdb,elasticsearch` clean
- [ ] `make lint` (run via `make signoff`)
- [ ] `make test` (run via `make signoff`)
