### PR TITLE
docs(stacked-prs): correct when a restack forfeits the sign-off

### DIFF
--- a/docs/dev/stacked_prs.md
+++ b/docs/dev/stacked_prs.md
@@ -85,8 +85,12 @@ Nothing here needs a rebase. Keep stacks shallow — each extra level multiplies
 restack work below — and prefer landing the parent before starting a third level.
 
 Do **not** merge `trunk` into the child at this stage. `BEHIND` does not block the
-merge queue, and a `trunk` merge discards a passing `make signoff` attestation, so it
-costs a full re-signoff for nothing.
+merge queue, so the merge buys nothing — and it is churn a reviewer has to read past.
+
+It does not necessarily cost a re-signoff, though: **Attestation** inherits a sign-off
+across a *conflict-free* base merge (see [Sign-off after a restack](#sign-off-after-a-restack)).
+What forfeits the attestation is resolving a conflict, which is why the restack below
+needs a fresh one and this merge might not.
 
 ---
 
@@ -307,9 +311,10 @@ other. `--cached` for the same reason as above — it compares `trunk` against t
 which is what the merge commit will record; without it an unstaged correction makes the
 stats look right while the commit still carries the wrong content.
 
-**5. Commit, push, then re-run `make signoff`.** Sign-off attests the *pushed* HEAD
-from a clean checkout (`docs/dev/ci_signoff.md`), and the merge is a new commit, so the
-previous attestation no longer covers it:
+**5. Commit, push, then re-run `make signoff`.** A restack forfeits the previous
+attestation — not merely because the merge is a new commit, but because it **resolved
+conflicts**. See [Sign-off after a restack](#sign-off-after-a-restack) for when a base
+merge inherits instead:
 
 ```bash
 git commit                                # completes the --no-commit merge
@@ -325,6 +330,41 @@ happened. `git status` cannot tell you that — it is clean either way.
 
 ---
 
+## Sign-off after a restack
+
+A restack almost always needs a fresh `make signoff`, but not for the reason it looks
+like, and the exception is worth knowing because the gate takes hours.
+
+**Attestation binds to a commit, and inherits across clean base merges.**
+`docs/dev/ci_signoff.md` is authoritative: **Attestation** walks up to 100 successive
+merge commits on the first-parent chain looking for a sign-off. `HEAD` must merge the
+current base commit, each older merged base must appear in order on the base branch's
+first-parent history, and **every merge tree must exactly match Git's conflict-free
+automatic result**. A plain `git merge origin/trunk` that Git resolves on its own
+therefore costs nothing — the existing attestation carries forward.
+
+**Resolving a conflict forfeits it, by design.** So do an amended merge, an octopus
+merge, and a merge from any branch other than the base. A resolution is code that has
+never been compiled: the merge can be textually clean and still semantically broken, and
+a sign-off against the merge commit is exactly what finds that out.
+
+**For a Rust branch, a restack forfeits it in practice.** The checklist above requires
+`Cargo.lock` to be taken from `trunk` and re-resolved by cargo — a resolution, so
+inheritance is lost on that file alone, before any source conflict. Assume you will re-run
+sign-off after a restack.
+
+**Where the exception pays off** is the ordinary case this document tells you to avoid
+anyway: merging the base into a branch that has no conflicts with it. If you do that and
+Git resolves it silently, do not reflexively re-run the gate — let **Attestation** try to
+inherit first.
+
+**Retargeting is not a sign-off event.** When the parent merges, GitHub retargets the
+child's base to `trunk` on its own (timeline event `automatic_base_change_succeeded`) —
+no `gh pr edit --base` needed. That changes a pointer, not a commit, so it neither
+invalidates nor supplies an attestation. The restack is what changes the commit.
+
+---
+
 ## Checklist
 
 - [ ] Child PR based on the parent branch while the parent is open.
@@ -335,4 +375,7 @@ happened. `git status` cannot tell you that — it is clean either way.
 - [ ] `Cargo.lock` taken from `trunk` and re-resolved by cargo — before the audit, so the
       audit sees it.
 - [ ] `restack_stacked_branch.sh audit` clean, and re-run if anything changed after it.
-- [ ] Merge committed and pushed, then `make signoff` re-run on the new pushed HEAD.
+- [ ] Merge committed and pushed, then `make signoff` re-run on the new pushed HEAD —
+      required whenever the restack resolved a conflict, which for a Rust branch is
+      effectively always (`Cargo.lock` alone). Check
+      [Sign-off after a restack](#sign-off-after-a-restack) before assuming.

--- a/docs/dev/stacked_prs.md
+++ b/docs/dev/stacked_prs.md
@@ -88,9 +88,9 @@ Do **not** merge `trunk` into the child at this stage. `BEHIND` does not block t
 merge queue, so the merge buys nothing — and it is churn a reviewer has to read past.
 
 It does not necessarily cost a re-signoff, though: **Attestation** inherits a sign-off
-across a *conflict-free* base merge (see [Sign-off after a restack](#sign-off-after-a-restack)).
-What forfeits the attestation is resolving a conflict, which is why the restack below
-needs a fresh one and this merge might not.
+across a base merge whose tree is Git's own conflict-free result (see [Sign-off after a
+restack](#sign-off-after-a-restack)). That is why the restack below usually needs a fresh
+sign-off — it resolves and corrects the merge — while this one might not.
 
 ---
 
@@ -311,17 +311,20 @@ other. `--cached` for the same reason as above — it compares `trunk` against t
 which is what the merge commit will record; without it an unstaged correction makes the
 stats look right while the commit still carries the wrong content.
 
-**5. Commit, push, then re-run `make signoff`.** A restack forfeits the previous
-attestation — not merely because the merge is a new commit, but because it **resolved
-conflicts**. See [Sign-off after a restack](#sign-off-after-a-restack) for when a base
-merge inherits instead:
+**5. Commit, push, then sign off if the merge needs it.** Sign-off attests the *pushed*
+HEAD from a clean checkout (`docs/dev/ci_signoff.md`). A restack usually forfeits the
+previous attestation — not because the merge is a new commit, but because the tree it
+records differs from Git's automatic merge result, which is what a conflict resolution or
+an audit correction makes it do. A restack that needed neither still inherits. [Sign-off
+after a restack](#sign-off-after-a-restack) has the two commands that tell you which case
+you are in:
 
 ```bash
 git commit                                # completes the --no-commit merge
 git rev-list --parents -n1 HEAD | wc -w   # 3 = a real merge, 2 = no merge happened
 git status --short                        # must be clean before signing off
 git push
-make signoff
+make signoff                              # skip only if the merge tree checks out below
 ```
 
 Count the parents *of the commit you just made*, rather than trusting it to have merged
@@ -332,31 +335,48 @@ happened. `git status` cannot tell you that — it is clean either way.
 
 ## Sign-off after a restack
 
-A restack almost always needs a fresh `make signoff`, but not for the reason it looks
-like, and the exception is worth knowing because the gate takes hours.
+A restack usually needs a fresh `make signoff`, but not for the reason it looks like, and
+the exception is worth knowing because the gate takes hours.
 
 **Attestation binds to a commit, and inherits across clean base merges.**
 `docs/dev/ci_signoff.md` is authoritative: **Attestation** walks up to 100 successive
 merge commits on the first-parent chain looking for a sign-off. `HEAD` must merge the
 current base commit, each older merged base must appear in order on the base branch's
 first-parent history, and **every merge tree must exactly match Git's conflict-free
-automatic result**. A plain `git merge origin/trunk` that Git resolves on its own
-therefore costs nothing — the existing attestation carries forward.
+automatic result** — the workflow re-runs the merge with `git merge-tree` on each merge's
+two parents and compares the tree that produces against the tree the commit recorded. A
+plain `git merge origin/trunk` that Git resolves on its own therefore costs nothing: the
+existing attestation carries forward.
 
-**Resolving a conflict forfeits it, by design.** So do an amended merge, an octopus
-merge, and a merge from any branch other than the base. A resolution is code that has
-never been compiled: the merge can be textually clean and still semantically broken, and
-a sign-off against the merge commit is exactly what finds that out.
+**What forfeits it is a recorded tree that differs from that automatic result** — the
+test is the tree, not the procedure that produced it. Resolving a conflict does it, and
+unavoidably: CI's own re-run conflicts on the same paths, so no resolution inherits,
+however careful. Correcting the merge afterwards does it too, which is the whole point of
+the audit in step 4 — the stacked-restack failure mode is a *clean* merge whose result is
+wrong, and the `git rm` that fixes it is a departure from what Git produced. An amended
+merge, an octopus merge, a merge from a branch other than the base, and any further commit
+on top all forfeit it as well.
 
-**For a Rust branch, a restack forfeits it in practice.** The checklist above requires
-`Cargo.lock` to be taken from `trunk` and re-resolved by cargo — a resolution, so
-inheritance is lost on that file alone, before any source conflict. Assume you will re-run
-sign-off after a restack.
+**Check rather than guess**, on the merge commit before you decide to spend hours:
 
-**Where the exception pays off** is the ordinary case this document tells you to avoid
-anyway: merging the base into a branch that has no conflicts with it. If you do that and
-Git resolves it silently, do not reflexively re-run the gate — let **Attestation** try to
-inherit first.
+```bash
+git merge-tree --write-tree --no-messages HEAD^1 HEAD^2   # exits non-zero if conflicted
+git rev-parse HEAD^{tree}                                 # what the merge actually recorded
+```
+
+A zero exit and two identical OIDs mean a sign-off reachable back along the first-parent
+chain still inherits, and re-running the gate buys nothing. Anything else means it does
+not. One condition the commands cannot check: `HEAD^2` has to be the base branch's
+*current* tip when **Attestation** runs, so a `trunk` that moves on before it does costs
+you the inheritance — merge the new tip rather than reaching for the gate.
+
+**`Cargo.lock` is the usual reason they differ on a Rust branch**, but not automatically.
+Step 3 takes `trunk`'s lockfile and lets cargo re-add the branch's crates; that only
+departs from the automatic result when the branch touched the lockfile itself. A branch
+that changed no manifest restores the same bytes Git would have taken and stays
+inheritable. One that added or bumped a dependency will not — either the lockfile
+conflicted outright, or it merged textually into something cargo then rewrote. The two
+commands above settle it either way.
 
 **Retargeting is not a sign-off event.** When the parent merges, GitHub retargets the
 child's base to `trunk` on its own (timeline event `automatic_base_change_succeeded`) —
@@ -376,6 +396,7 @@ invalidates nor supplies an attestation. The restack is what changes the commit.
       audit sees it.
 - [ ] `restack_stacked_branch.sh audit` clean, and re-run if anything changed after it.
 - [ ] Merge committed and pushed, then `make signoff` re-run on the new pushed HEAD —
-      required whenever the restack resolved a conflict, which for a Rust branch is
-      effectively always (`Cargo.lock` alone). Check
-      [Sign-off after a restack](#sign-off-after-a-restack) before assuming.
+      required whenever the recorded merge tree differs from Git's automatic result, which
+      any conflict resolution or audit correction guarantees. Confirm with the two commands
+      in [Sign-off after a restack](#sign-off-after-a-restack) rather than assuming either
+      way.


### PR DESCRIPTION
## 📝 Summary

`docs/dev/stacked_prs.md` said in two places that merging the base branch discards a passing `make signoff` attestation. That contradicts `docs/dev/ci_signoff.md`, which documents the opposite for the clean case: **Attestation** walks up to 100 successive merge commits on the first-parent chain and inherits a sign-off, provided `HEAD` merges the current base commit and every merge tree exactly matches Git's conflict-free automatic result.

The practical cost of the inaccuracy is a re-run of a multi-hour gate that would have carried forward on its own.

What actually forfeits the attestation is a **recorded tree that differs from that automatic result** — the test is the tree, not the procedure that produced it. `.github/workflows/pr.yml` re-runs `git merge-tree` on the merge's two parents and compares. So the guide's instruction to re-run sign-off after a restack is usually right; its stated reason ("the merge is a new commit") is not, and the condition is not "did you hit a conflict" either:

- A **conflict-free** merge that you then correct forfeits inheritance with no conflict involved — which is the ordinary outcome of the audit step, since the stacked-restack failure mode is a clean merge whose result is wrong.
- Resolving a conflict forfeits it unavoidably, because CI's own re-run conflicts on the same paths.
- An amended merge, an octopus merge, a merge from a branch other than the base, or any further commit on top forfeit it too.

Rather than leave the reader estimating which case they are in, the new section hands them the check CI performs, so they can decide before spending hours:

```bash
git merge-tree --write-tree --no-messages HEAD^1 HEAD^2   # exits non-zero if conflicted
git rev-parse HEAD^{tree}                                 # what the merge actually recorded
```

## 🔗 Related

Found while restacking #13096 onto `trunk` after #13045 merged — 7 conflicts, so it genuinely needed a fresh sign-off, but I nearly re-ran it on the basis of the incorrect rationale rather than the correct one.

## 📚 Docs

This is the docs change. Adds a **Sign-off after a restack** section, corrects the two inaccurate statements, and qualifies the checklist item.

Also records something not previously written down: when the parent merges, **GitHub retargets the child PR's base to `trunk` by itself** (timeline event `automatic_base_change_succeeded`), so nobody needs `gh pr edit --base trunk`. And since retargeting moves a pointer rather than a commit, it neither invalidates nor supplies an attestation — the restack is what changes the commit.

## 👀 Notes for Reviewers

Worth checking my reading of the inheritance conditions against `ci_signoff.md` lines 124-133 and the *Validate inherited developer sign-off* step in `pr.yml` — I have restated them rather than quoted them, and the precise conditions (current base commit, first-parent ordering, exact tree match) are what make the difference between inheriting and not.

The two commands above are verified against this repo: a clean historical merge prints the same OID at exit 0, a conflicting pair exits 1 with stage lines. The one condition they cannot check is that `HEAD^2` must still be the base tip when **Attestation** runs; the section says so.
