### PR TITLE
fix(bench): time the engine instead of the results cache, and validate ClickBench

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -2,8 +2,16 @@ name: build_and_release
 
 on:
   push:
+    # Release branches build for the same reason trunk does: the `build` job uploads
+    # each commit's spiced to MinIO, and that upload is the only source the daily
+    # `testoperator dispatch` has for a branch's binary. Without it the dispatch
+    # walks back ten commits, finds nothing, and the branch silently loses its
+    # benchmark coverage. `setup-matrix` already recognizes release branches; only
+    # the trigger was missing. Releasing stays tag-gated — the `publish` job runs
+    # for `refs/tags/v*` alone.
     branches:
       - trunk
+      - release/**
     tags:
       - v*
     paths-ignore:

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -98,6 +98,14 @@ on:
         required: false
         type: boolean
         default: false
+      # Defaults on because a benchmark should time the engine, not the cache. Turn
+      # it off only for a spicepod that is benchmarking the cache itself, such as
+      # those under test/spicepods/tpch/sf5/cache.
+      disable_caching:
+        description: 'Bypass the SQL results cache so the timings measure query execution?'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   run-bench:
@@ -489,6 +497,12 @@ jobs:
           connection.close()
           PY
 
+      # `--disable-caching` sends `Cache-Control: no-cache` on the benchmark's Flight
+      # connection. It is load-bearing: `runtime.caching.sql_results` is enabled by
+      # default with a one-second `item_ttl`, and the harness runs one warmup query
+      # followed by N timed iterations of the identical SQL back-to-back. Without it
+      # the warmup populates the cache and every timed iteration is a cache read, so
+      # the recorded durations describe the cache rather than the engine.
       - name: Run the benchmark test - ${{ github.event.inputs.spicepod_path }}
         run: |
           [ -z "$AWS_ENDPOINT_URL" ] && unset AWS_ENDPOINT_URL
@@ -503,6 +517,7 @@ jobs:
             ${{ github.event.inputs.query_overrides != '' && format('--query-overrides {0}', github.event.inputs.query_overrides) || '' }} \
             --ready-wait ${{ github.event.inputs.ready_wait }} \
             --disable-progress-bars \
+            --disable-caching=${{ github.event.inputs.disable_caching }} \
             --validate=${{ github.event.inputs.validate_results }} \
             --metrics \
             --scale-factor ${{ github.event.inputs.scale_factor }}

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -372,7 +372,8 @@ impl SpiceTestQueryWorker {
                         let warmup_start = std::time::Instant::now();
 
                         let QueryRunResult {
-                            connection_failed, ..
+                            connection_failed,
+                            query_failure,
                         } = self
                             .run_single_query(
                                 query,
@@ -382,6 +383,13 @@ impl SpiceTestQueryWorker {
                                 false,
                             )
                             .await?;
+
+                        // The warmup's timing is thrown away; its verdict is not. This is the
+                        // only run of the query that compares results against their snapshot —
+                        // the timed iterations below pass `false` for `results_snapshot` so they
+                        // do not re-assert it — so dropping this failure is what would let a
+                        // wrong answer, or a missing baseline, finish the benchmark green.
+                        query_status = status_after_run(query_status, query_failure);
 
                         println!(
                             "Worker {} - Query '{}' - Warmup query completed in {:?}",
@@ -438,9 +446,7 @@ impl SpiceTestQueryWorker {
                                 ));
                             }
 
-                            if let Some(query_failure) = query_failure {
-                                query_status = QueryStatus::Failed(Some(query_failure.into()));
-                            }
+                            query_status = status_after_run(query_status, query_failure);
 
                             current_query_count += 1;
                         }
@@ -850,6 +856,25 @@ impl SpiceTestQueryWorker {
     }
 }
 
+/// Fold one run of a query into the status the benchmark reports for it.
+///
+/// Every run funnels through here — the warmup and each timed iteration alike — so
+/// the two cannot drift about what a failure is worth. A failure is sticky: once a
+/// run has failed, a later one that succeeds does not clear it.
+///
+/// The warmup is the reason this is a named function rather than an `if` at each
+/// site. Its *timing* is discarded by design, which makes it tempting to discard
+/// its verdict too, but it is the only run that asserts the result snapshot — the
+/// timed iterations pass `false` for `results_snapshot` so they never re-assert it.
+/// A status that skipped the warmup would let a wrong answer, or a missing
+/// baseline, finish the benchmark green.
+fn status_after_run(current: QueryStatus, query_failure: Option<String>) -> QueryStatus {
+    match query_failure {
+        Some(failure) => QueryStatus::Failed(Some(failure.into())),
+        None => current,
+    }
+}
+
 fn validation_result_after_reference_validation(
     validation_result: QueryValidationResult,
     reference_validation_passed: bool,
@@ -934,6 +959,36 @@ mod tests {
 
     use super::*;
     use std::sync::Arc;
+
+    /// The warmup is the only run that asserts a result snapshot, so its failure has
+    /// to reach the reported status. Regression test for a benchmark that logged
+    /// `FAIL` for a mismatched or missing snapshot and still finished green.
+    #[test]
+    fn a_failed_run_fails_the_query() {
+        let status = status_after_run(
+            QueryStatus::Passed,
+            Some(
+                "Query `s3[parquet]-cayenne[file]` `clickbench_q1` snapshot assertion failed"
+                    .to_string(),
+            ),
+        );
+
+        assert!(matches!(status, QueryStatus::Failed(Some(_))));
+    }
+
+    #[test]
+    fn a_successful_run_leaves_the_status_alone() {
+        assert!(status_after_run(QueryStatus::Passed, None) == QueryStatus::Passed);
+    }
+
+    /// A failure is sticky: the timed iterations run after the warmup, and a passing
+    /// one must not clear a warmup that already failed its snapshot.
+    #[test]
+    fn a_successful_run_does_not_clear_an_earlier_failure() {
+        let failed = QueryStatus::Failed(Some("snapshot assertion failed".into()));
+
+        assert!(status_after_run(failed.clone(), None) == failed);
+    }
 
     #[test]
     fn test_reference_validation_does_not_skip_static_validation_failures() {

--- a/tools/testoperator/README.md
+++ b/tools/testoperator/README.md
@@ -44,9 +44,9 @@ Run standard benchmarks using the `testoperator run bench [OPTIONS]` command. In
 - `--scale-factor <SCALE_FACTOR>`: The expected scale factor for the test, used in metrics calculation.
 - `--validate`: A boolean flag to specify whether results should be validated against their expected results. Supported for `tpch`, `tpch[parameterized]` (scale factor 1 only), and `scenario` query sets (when expected results are defined in the scenario file).
 - `--metrics`: Whether to upload metrics to the Spice OSS benchmarks dashboards. By default, submits to the Production metrics endpoint using the API key specified in the `SPICEAI_BENCHMARK_METRICS_KEY` environment variable. If specified, the metrics delivery endpoint can be overridden with the `SPICEAI_TELEMETRY_ENDPOINT` environment variable.
-- `--disable-caching`: Whether to disable results cache by supplying a `Cache-Control: no-cache` header over the Flight request. Allows disabling results cache separately from spicepod configuration.
+- `--disable-caching`: Whether to disable results cache by supplying a `Cache-Control: no-cache` header over the Flight request. Allows disabling results cache separately from spicepod configuration. A benchmark should almost always pass this: `runtime.caching.sql_results` is on by default with a one-second `item_ttl`, and a benchmark runs one warmup query followed by its timed iterations of the same SQL back-to-back, so without it the timed iterations read the cache the warmup filled. The `bench` workflow passes it by default; turn it off only for a spicepod that is benchmarking the cache itself, such as those under `test/spicepods/tpch/sf5/cache`.
 
-Running a benchmark test will always generate snapshots for the query explain plan and results for `tpch` and `tpcds` queries. Only explain plans will be generated for `clickbench` queries.
+Running a benchmark test will always generate snapshots for the query explain plan, and result snapshots for the `tpch` and `tpcds` queries. `clickbench` records result snapshots for the subset of its queries whose rows do not depend on how the engine breaks ties — see `SNAPSHOTTED_CLICKBENCH_QUERIES` in `src/commands/bench/mod.rs` — and explain plans for all of them.
 
 Snapshots can be automatically re-generated using the [`INSTA_UPDATE`](https://docs.rs/insta/latest/insta/#updating-snapshots) environment variable.
 

--- a/tools/testoperator/README.md
+++ b/tools/testoperator/README.md
@@ -48,6 +48,8 @@ Run standard benchmarks using the `testoperator run bench [OPTIONS]` command. In
 
 Running a benchmark test will always generate snapshots for the query explain plan, and result snapshots for the `tpch` and `tpcds` queries. `clickbench` records result snapshots for the subset of its queries whose rows do not depend on how the engine breaks ties — see `SNAPSHOTTED_CLICKBENCH_QUERIES` in `src/commands/bench/mod.rs` — and explain plans for all of them.
 
+A snapshot that does not match, or that does not exist yet, fails the benchmark. Result snapshots are asserted on the warmup run — the only run that takes them — so that verdict comes from the warmup rather than from a timed iteration.
+
 Snapshots can be automatically re-generated using the [`INSTA_UPDATE`](https://docs.rs/insta/latest/insta/#updating-snapshots) environment variable.
 
 `testoperator run bench [OPTIONS]`

--- a/tools/testoperator/dispatch/clickbench/sf1/accelerated/s3[parquet]-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/clickbench/sf1/accelerated/s3[parquet]-cayenne[file].yaml
@@ -1,7 +1,10 @@
+# No query_overrides: the `duckdb` set rewrites 16 of the 43 queries to
+# `CAST(col AS TEXT) <> ''` for the DuckDB accelerator, whose unparser cannot emit
+# binary scalar literals. Cayenne reads those columns as strings, so the cast folds
+# away and the arm gains nothing but a deviation from the published ClickBench SQL.
 tests:
   bench:
     spicepod_path: accelerated/s3[parquet]-cayenne[file].yaml
     query_set: clickbench
-    query_overrides: duckdb
     runner_type: spiceai-dev-large-runners
     ready_wait: 1800

--- a/tools/testoperator/src/args/dataset.rs
+++ b/tools/testoperator/src/args/dataset.rs
@@ -48,7 +48,7 @@ pub struct QueryArgs {
     pub(crate) reference_schema: Option<String>,
 
     /// Whether to disable results caching, by supplying the cache control header through flight
-    #[arg(long)]
+    #[arg(long, action = ArgAction::Set, default_value_t = false, default_missing_value = "true", num_args = 0..=1, require_equals = false)]
     pub(crate) disable_caching: bool,
 
     /// Whether to add HTTP clients for the test
@@ -94,7 +94,7 @@ pub struct DatasetTestArgs {
     pub(crate) reference_schema: Option<String>,
 
     /// Whether to disable results caching, by supplying the cache control header through flight
-    #[arg(long)]
+    #[arg(long, action = ArgAction::Set, default_value_t = false, default_missing_value = "true", num_args = 0..=1, require_equals = false)]
     pub(crate) disable_caching: bool,
 
     /// Whether to add HTTP clients for the test

--- a/tools/testoperator/src/commands/bench/mod.rs
+++ b/tools/testoperator/src/commands/bench/mod.rs
@@ -309,8 +309,47 @@ const DISABLED_SNAPSHOT_QUERIES: &[&str] = &[
     "tpcds_q77", // The ORDER BY clause specifies columns that have multiple matches, so the order is unspecified between those rows
 ];
 
-/// Only snapshot the official TPCH and TPCDS queries, not the "simple" extensions as they don't return consistent results
+/// The `ClickBench` queries whose recorded rows are the same however the engine
+/// breaks ties, so they can be snapshotted.
+///
+/// `ClickBench` needs an allow-list where TPC-H and TPC-DS need a deny-list. Most of
+/// its set ranks by a metric with no unique tiebreaker (`ORDER BY COUNT(*) DESC
+/// LIMIT 10`), and q18 has no `ORDER BY` at all, so which rows reach the top N —
+/// and in what order — follows partitioning and aggregation order rather than the
+/// query. The snapshot keeps the first ten rows as returned, so those queries would
+/// record a plan detail rather than an answer.
+///
+/// `AVG` rules out two more. `avg` coerces its integer argument to `Float64` before
+/// aggregating — the plan for q4 is `avg(CAST(hits.UserID AS Float64))` — so the
+/// partial sums are floats combined in partition-completion order, and float
+/// addition is not associative. Repartitioning the scan moves the low bits, and the
+/// partition count follows the runner's cores, so q3 and q4 would record the shape
+/// of the machine that ran them.
+///
+/// What is left still answers the question a result snapshot is here to ask — did
+/// the table load, and do the aggregates over it come out right. Every query below
+/// returns one exactly-computed aggregate row, except q20 and q26, which project a
+/// column holding the same value in every row that could be selected.
+const SNAPSHOTTED_CLICKBENCH_QUERIES: &[&str] = &[
+    "clickbench_q1",  // COUNT(*)
+    "clickbench_q2",  // COUNT(*) with a filter
+    "clickbench_q5",  // COUNT(DISTINCT)
+    "clickbench_q6",  // COUNT(DISTINCT)
+    "clickbench_q7",  // MIN and MAX over a timestamp conversion
+    "clickbench_q20", // Projects only the literal the filter pins
+    "clickbench_q21", // COUNT(*) over a LIKE filter
+    "clickbench_q26", // Ordered by the only projected column
+    "clickbench_q30", // 90 integer SUMs
+];
+
+/// Only snapshot query sets whose recorded rows are reproducible: the official TPC-H
+/// and TPC-DS queries — not the "simple" extensions, which don't return consistent
+/// results — and the `ClickBench` queries listed in [`SNAPSHOTTED_CLICKBENCH_QUERIES`].
 fn snapshot_predicate(query_name: &str) -> bool {
+    if query_name.starts_with("clickbench_q") {
+        return SNAPSHOTTED_CLICKBENCH_QUERIES.contains(&query_name);
+    }
+
     (query_name.starts_with("tpch_q") || query_name.starts_with("tpcds_q"))
         && !DISABLED_SNAPSHOT_QUERIES.contains(&query_name)
 }
@@ -448,4 +487,49 @@ pub(crate) async fn prepare_chbench_source(
 
     println!("CH-benCHmark source is ready");
     Ok(driver)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SNAPSHOTTED_CLICKBENCH_QUERIES, snapshot_predicate};
+
+    #[test]
+    fn snapshots_the_official_tpch_and_tpcds_queries() {
+        assert!(snapshot_predicate("tpch_q1"));
+        assert!(snapshot_predicate("tpcds_q1"));
+        // The "simple" extensions are not part of either spec.
+        assert!(!snapshot_predicate("tpch_simple_q4"));
+        // Deny-listed for an unspecified order between equal rows.
+        assert!(!snapshot_predicate("tpcds_q77"));
+    }
+
+    #[test]
+    fn snapshots_only_the_reproducible_clickbench_queries() {
+        for query in SNAPSHOTTED_CLICKBENCH_QUERIES {
+            assert!(snapshot_predicate(query), "{query} should be snapshotted");
+        }
+        // Ranks by a metric with no unique tiebreaker.
+        assert!(!snapshot_predicate("clickbench_q13"));
+        // No ORDER BY at all.
+        assert!(!snapshot_predicate("clickbench_q18"));
+        // Averages in Float64, so the low bits follow the partition count.
+        assert!(!snapshot_predicate("clickbench_q3"));
+        assert!(!snapshot_predicate("clickbench_q4"));
+    }
+
+    /// The allow-list matches whole names, so a listed query must not also enable
+    /// the queries it is a prefix of.
+    #[test]
+    fn clickbench_allow_list_matches_whole_query_names() {
+        assert!(snapshot_predicate("clickbench_q1"));
+        assert!(!snapshot_predicate("clickbench_q11"));
+        assert!(snapshot_predicate("clickbench_q2"));
+        assert!(!snapshot_predicate("clickbench_q22"));
+    }
+
+    #[test]
+    fn does_not_snapshot_other_query_sets() {
+        assert!(!snapshot_predicate("chbench_q1"));
+        assert!(!snapshot_predicate("scenario_q1"));
+    }
 }


### PR DESCRIPTION
## What was wrong

### The benchmark suite timed the results cache, not the engine

`runtime.caching.sql_results` is enabled by default with a one-second `item_ttl`. The bench harness runs one warmup query, then five timed iterations of the identical SQL back-to-back — all comfortably inside that TTL — and the workflow never passed `--disable-caching`. So the warmup was the only real execution and every recorded duration was a cache read.

From the runs on 2026-08-15:

| arm | real work (sum of warmups) | published (sum of medians) | ratio |
|---|---|---|---|
| TPC-H SF100 `s3[parquet]-cayenne[file]` | 74.7 s | 42 ms | ~1780x |
| ClickBench `s3[parquet]-cayenne[file]` | 25.7 s | 46 ms | ~559x |

The clearest single case is TPC-H SF100 `tpch_q21`: warmup **13.845 s**, then all five timed iterations completed in **9 ms total**, published as a 2 ms median. Every engine was affected equally — the DuckDB ClickBench arm reported 0-1 ms on all 43 queries too — so the arms stayed comparable to each other while the absolute numbers described the cache.

This is not a measurement artifact: the executor drains the full result stream (`crates/test-framework/src/execution/mod.rs`).

### A result snapshot was recorded but never enforced

`results_snapshot` is passed only to the warmup run — the timed iterations pass `false` so they never re-assert it — and the warmup destructured `QueryRunResult { connection_failed, .. }`, dropping `query_failure`. Only a timed iteration's failure reached `query_status`, which is what `test_succeeded` and the exit code are built from. A snapshot that did not match, or did not exist, printed `FAIL` on stdout and the benchmark still finished green.

This was never ClickBench-specific. It covers every result snapshot the harness takes: the 2415 TPC-H and 4988 TPC-DS baselines have only ever been written, never enforced.

### ClickBench never checked its answers at all

`snapshot_predicate` matched only `tpch_q*` and `tpcds_q*`. ClickBench queries are named `clickbench_q*`, so no ClickBench result was ever recorded or compared — **0** result snapshots on disk against 2415 for TPC-H and 4988 for TPC-DS — and no ClickBench dispatch config sets `validate_results`. A ClickBench arm passed on any values it returned, as long as no query errored and none returned zero rows.

### The ClickBench Cayenne arm ran DuckDB's rewritten queries

Its dispatch config set `query_overrides: duckdb`, which swaps 16 of the 43 queries for `CAST(col AS TEXT) <> ''` variants. That rewrite exists for DuckDB's unparser, which cannot emit binary scalar literals.

### The daily dispatch failed every night on `release/2.1`

`build_and_release.yml` triggered on pushes to `trunk` only, so no release-branch commit ever produced a spiced artifact in MinIO — the sole source the daily `testoperator dispatch` has for a branch's binary. Once `release/2.1` grew past the ten commits `setup-spiced` walks back, its leg failed with ten consecutive `Unable to stat .../spiced_linux_x86_64.tar.gz. Object does not exist.`, and the branch lost benchmark coverage. Its `trunk` leg was green throughout, so the red was easy to misread as a broad benchmark failure.

## What changed

**Pass `--disable-caching` from the bench workflow.** It is a workflow input defaulting to on, not a hard-coded flag, because the 19 spicepods under `test/spicepods/tpch/sf5/cache` exist to benchmark the cache and still need it off. `--disable-caching` now takes an explicit value, matching `--validate` beside it in the same struct.

**Make a result-snapshot failure fail the benchmark.** The warmup's `query_failure` now reaches `query_status`. Both call sites fold through one `status_after_run`, so the warmup and the timed iterations cannot drift about what a failure is worth, and a failure is sticky — a later passing iteration cannot clear a warmup that failed its snapshot.

**Snapshot the nine ClickBench queries whose rows are reproducible.** Not all 43: most of the set ranks by a metric with no unique tiebreaker (`ORDER BY COUNT(*) DESC LIMIT 10`) and q18 has no `ORDER BY` at all, so recording its first ten rows would capture partitioning rather than an answer. q3 and q4 are out for a second reason — `avg` coerces to `Float64` before aggregating (`avg(CAST(hits.UserID AS Float64))`), so partial sums combine in partition-completion order, float addition is not associative, and the partition count follows the runner's cores. What is left is exact: `COUNT(*)`, both `COUNT(DISTINCT)`s, `MIN`/`MAX`, 90 integer `SUM`s, and two queries projecting a column that is constant across every selectable row. Between them they answer whether the table loaded and whether aggregates over it are right.

**Drop `query_overrides: duckdb` from the ClickBench Cayenne arm.** Cayenne reads those columns as strings, so the cast folds away — the recorded plans already show `Filter: hits.URL != LargeUtf8("")` with no cast — meaning the arm ran non-standard ClickBench SQL for no benefit, and removing it changes no plan and no result. The existing explain snapshots stay valid.

**Build spiced on pushes to release branches.** `setup-matrix` already branches on `isReleaseBranch` to select self-hosted runners, enable the MinIO upload, and add the Windows and Linux-ARM targets — only the trigger was missing, so none of that code could run. Publishing stays gated on `refs/tags/v*`, so a branch push builds without releasing, and there is no concurrency group that could cancel a trunk build. `release-*` is deliberately not matched: it would sweep in the `release-notes-*` and `release-finalization-*` branches.

## Expect red on the first scheduled run after this lands

Two changes here turn previously-inert checks into gating ones, and both should be landed expecting triage rather than silence.

1. **ClickBench baselines must be seeded before this merges.** With snapshot failures now gating, every ClickBench arm fails on missing baselines. Dispatching `testoperator_run_bench.yml` against this branch generates them (non-release branches default to `INSTA_UPDATE=always`) and uploads them for commit here. Previously this would have passed silently, which is exactly the bug.
2. **TPC-H and TPC-DS result snapshots become enforced for the first time.** Any drift accumulated while the comparison was inert surfaces at once. This could not be sized locally: the runs with logs available used `INSTA_UPDATE=always`, which rewrites instead of asserting, and the last `no` run failed on explain plans first, which masks what the results would have done.

Benchmark timings will also step up sharply and permanently — roughly three orders of magnitude on the large arms — because they now measure query execution. Historical series are not comparable across this change.

## Not changed

`testoperator_run_throughput.yml` and `testoperator_run_load.yml` have the same latent cache problem: neither passes `--disable-caching`, and throughput runs one query set across 25 concurrent workers, so nearly all of it is cache hits. Left alone deliberately — "throughput of a serving system with its cache on" is a defensible thing to measure, and there is QPS history riding on it. Worth a follow-up decision.

## Testing

- `status_after_run` gets three unit tests: a failed run fails the query, a successful run leaves the status alone, and a successful run does not clear an earlier failure.
- `snapshot_predicate` and the ClickBench allow-list get unit tests, including that `clickbench_q1` does not also enable `clickbench_q11`.
- `check_workflow_yaml.py` passes on both edited workflows.

No end-to-end test covers the snapshot-failure path. Failing a snapshot on purpose means driving the insta assertion, whose verdict depends on `INSTA_UPDATE` — `always` rewrites and passes, `auto` writes a `.snap.new` into the tree — so such a test would change outcome with the environment and litter snapshot files. Testing it properly means putting the assertion behind a seam a fake can fail, a larger change to the snapshot path than belongs here. The unit tests cover the defect itself, and the assertion already returns `Err` through `catch_unwind`.

Related: #12560, which asks the per-config "is this check wanted?" question for benchmarks that never pass. The ClickBench arms here are the inverse case — always green, never checking anything.
