### PR TITLE
fix(ci): gate every tracked Rust source tree in the merge queue's change filter (fixes #13120)

### DIFF
--- a/.github/actions/check-code-changes/action.yml
+++ b/.github/actions/check-code-changes/action.yml
@@ -47,10 +47,10 @@ inputs:
         - 'go.mod'
         - 'go.sum'
         - 'Makefile'
-        # Dot-prefixed directories are spelled out literally rather than left to
-        # `**`, which only descends into them when picomatch runs with
-        # `dot: true` — `.ci/clippy.toml` is the config the lint gate actually
-        # reads, so it must match either way.
+        # Dot-prefixed directories are spelled out literally even though
+        # dorny/paths-filter runs picomatch with `dot: true`, so `**` would
+        # reach them: `.ci/clippy.toml` is the config the lint gate actually
+        # reads, and naming it keeps that explicit rather than incidental.
         - '.ci/**'
         - '.config/**'
         - '.cargo/**'

--- a/.github/actions/check-code-changes/action.yml
+++ b/.github/actions/check-code-changes/action.yml
@@ -21,8 +21,9 @@ inputs:
       dorny/paths-filter `filters` YAML; must define a `code_changes` group.
       Defaults to the standard repo-wide code paths.
     required: false
-    # The Rust-gate config files below (clippy/rustfmt/nextest/layers,
-    # the two lint guards) must COVER every path in RUST_AFFECTING_PATH_PATTERN
+    # Every tracked `.rs` file, and the Rust-gate config files below
+    # (clippy/rustfmt/nextest/layers, the lint guards), must be COVERED by some
+    # glob here — together they are every path in RUST_AFFECTING_PATH_PATTERN
     # (scripts/signoff). This list stays a deliberate superset — it is the shared
     # "did any code change" default, so it also gates integration and E2E — but a
     # Rust-gate path missing here lets the merge queue report `Rust Lint` and
@@ -36,6 +37,10 @@ inputs:
         - 'bin/**'
         - 'test/**'
         - 'tools/**'
+        # Tracked Rust sources compiled into the workspace through a
+        # `[patch.crates-io]` entry, so a change here is a change to what the
+        # runtime links.
+        - 'vendor/**'
         - 'install/**'
         - 'Cargo.toml'
         - 'Cargo.lock'
@@ -58,6 +63,7 @@ inputs:
         - 'scripts/check_crate_layers.py'
         - 'scripts/check_table_layers.py'
         - 'scripts/check_rust_gate_paths.py'
+        - 'scripts/test_check_rust_gate_paths.py'
         - 'scripts/check_module_reachability.py'
         # The reachability guard's own regression harness runs in `lint-rust`,
         # so a change to it changes what the Rust gate enforces.

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,8 @@ lint-rust:
 	## Table-layer guard (fast, no compile): a provider-wrapping TableProvider silently stops every layer walk. See docs/dev/crate_layering.md
 	python3 scripts/check_table_layers.py
 	## Rust-gate path-list guard (fast, no compile): the sign-off, Attestation, and merge-queue path lists must agree. See docs/dev/ci_signoff.md
+	## Its derivation is exercised first: the live-tree scan only covers the paths today's workspace happens to contain, so a derivation that stopped working would pass unnoticed on a clean tree
+	python3 scripts/test_check_rust_gate_paths.py
 	python3 scripts/check_rust_gate_paths.py
 	## Unreachable-module guard (fast, no compile): every file under a crate's src/ must be reachable from its crate root, or nothing compiles it
 	## Its parser is exercised first: the live-tree scan only covers the shapes today's workspace happens to contain, so a parser regression for any other shape would pass unnoticed

--- a/docs/dev/ci_signoff.md
+++ b/docs/dev/ci_signoff.md
@@ -197,9 +197,18 @@ paths), and the `code_changes` filter in `.github/actions/check-code-changes`
 also gates integration and E2E, and it only has to *cover* the set). A path
 missing from all three lands on trunk having never been linted, built, or
 tested, so `make lint-rust` runs `scripts/check_rust_gate_paths.py`. It derives
-what must be gated from what the `lint-rust` recipe reads and from the tracked
-config-file names, rather than from a list someone has to remember, and fails
-when the three drift. Change them together.
+what must be gated from what the `lint-rust` recipe reads, from the tracked
+config-file names, and from every tracked `.rs` file — rather than from a list
+someone has to remember — and fails when the three drift. Change them together.
+
+Deriving from the tracked sources is what catches a whole source *tree* going
+ungated, which the config-file derivation cannot see: top-level `vendor/` holds
+Rust compiled into the workspace through a `[patch.crates-io]` entry, and it
+matched no `code_changes` glob, so a PR confined to it had the merge queue
+report `Rust Lint` and `Build and Test` green having run zero steps
+([#13120](https://github.com/spiceai/spiceai/issues/13120)). The derivation
+itself is pinned by `scripts/test_check_rust_gate_paths.py`, which `lint-rust`
+runs first — a clean tree exercises only the shapes it happens to contain.
 
 ### The unreachable-module guard
 

--- a/scripts/check_rust_gate_paths.py
+++ b/scripts/check_rust_gate_paths.py
@@ -21,10 +21,11 @@
 # `scripts/check_crate_layers.py` all sat until #12111.
 #
 # The paths that must be gated are DERIVED, not listed: from what the `lint-rust`
-# recipe reads (`CLIPPY_CONF_DIR`, each `python3 scripts/…` guard) and from the
-# tracked files whose name marks them as lint/test config. So this catches "a
-# config file the gate reads is in none of the lists" — the actual bug — and not
-# merely "the lists disagree about a path someone already thought of".
+# recipe reads (`CLIPPY_CONF_DIR`, each `python3 scripts/…` guard), from the
+# tracked files whose name marks them as lint/test config, and from every tracked
+# `.rs` file. So this catches "a config file the gate reads is in none of the
+# lists" and "a Rust source tree is in none of the lists" — the actual bugs — and
+# not merely "the lists disagree about a path someone already thought of".
 #
 # Usage:
 #   scripts/check_rust_gate_paths.py    # validate (exit 1 on drift, 2 if unreadable)
@@ -56,9 +57,9 @@ GATE_CONFIG_BASENAMES = (
     "layers.toml",
 )
 
-# Rust inputs that are not config files, so there is nothing to derive them from.
+# Rust inputs that are neither config files nor `.rs` sources, so there is
+# nothing to derive them from.
 RUST_SOURCE_PATHS = (
-    "crates/runtime/src/lib.rs",
     "Cargo.toml",
     "Cargo.lock",
     "crates/cayenne/Cargo.toml",
@@ -127,7 +128,22 @@ def lint_recipe() -> str:
     return "\n".join(lines)
 
 
-def derived_gate_paths() -> tuple[list[str], list[str]]:
+def tracked_files() -> tuple[list[str], list[str]]:
+    """Every tracked path in the repo, plus notes if git could not be read."""
+    try:
+        listing = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=REPO,
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as error:
+        return [], [f"could not list tracked files ({error})"]
+    return [p for p in listing.split("\0") if p], []
+
+
+def derived_gate_paths(tracked: list[str]) -> tuple[list[str], list[str]]:
     """Paths the Rust gate reads, plus notes on anything that could not be derived.
 
     Derived from the `lint-rust` recipe (the clippy config directory it points
@@ -147,22 +163,29 @@ def derived_gate_paths() -> tuple[list[str], list[str]]:
         paths.add(f"{conf_dir.rstrip('/')}/clippy.toml")
     paths.update(re.findall(r"python3 (scripts/[\w./-]+\.py)", recipe))
 
-    try:
-        tracked = subprocess.run(
-            ["git", "ls-files", "-z"],
-            cwd=REPO,
-            capture_output=True,
-            check=True,
-            text=True,
-        ).stdout.split("\0")
-    except (OSError, subprocess.CalledProcessError) as error:
-        notes.append(
-            f"could not list tracked files ({error}) — derived only from the lint-rust recipe"
-        )
-        tracked = []
-    paths.update(p for p in tracked if p and Path(p).name in GATE_CONFIG_BASENAMES)
+    paths.update(p for p in tracked if Path(p).name in GATE_CONFIG_BASENAMES)
 
     return sorted(paths), notes
+
+
+def rust_source_trees(tracked: list[str]) -> dict[str, list[str]]:
+    """Tracked `.rs` files, grouped by their top-level directory.
+
+    The config-file derivation above reads what the gate *configures*, so it is
+    blind to a Rust source tree the lists never mention: `vendor/` held 17
+    tracked `.rs` files compiled through a `[patch.crates-io]` entry, in no
+    `code_changes` glob, and this guard passed (#13120). Grouping keeps one
+    error per tree rather than one per file.
+
+    A `.rs` file at the repo root has no directory to group under and is keyed
+    `"."` — no glob covers one today, so that is the shape an error would take.
+    """
+    trees: dict[str, list[str]] = {}
+    for path in tracked:
+        if path.endswith(".rs"):
+            head, separator, _ = path.partition("/")
+            trees.setdefault(head if separator else ".", []).append(path)
+    return trees
 
 
 def glob_matches(glob: str, path: str) -> bool:
@@ -187,6 +210,73 @@ def glob_matches(glob: str, path: str) -> bool:
         .replace(r"\*", "[^./][^/]*")
     )
     return re.fullmatch(pattern, path) is not None
+
+
+def coverage_gaps(
+    paths: list[str], globs: list[str], patterns: dict[str, str]
+) -> tuple[dict[str, list[str]], list[str]]:
+    """Which of `paths` each list would skip: per pattern, then for the globs.
+
+    The one place that decides "is this path gated". Both callers below report
+    the answer differently — per path for a config file, per tree for a source
+    directory — and the two reports drifting apart is how a list quietly stops
+    being checked, so the decision itself has exactly one definition.
+    """
+    return (
+        {
+            name: [p for p in paths if not re.search(pattern, p)]
+            for name, pattern in patterns.items()
+        },
+        [p for p in paths if not any(glob_matches(g, p) for g in globs)],
+    )
+
+
+def gate_config_errors(
+    gated: list[str], globs: list[str], patterns: dict[str, str]
+) -> list[str]:
+    """One error per config path the Rust gate reads that a list would skip."""
+    pattern_misses, glob_misses = coverage_gaps(gated, globs, patterns)
+    errors = [
+        f"{path} changes what the Rust gate does, but the pattern in {name} "
+        "does not match it — the branch would skip every Rust check."
+        for name, missed in pattern_misses.items()
+        for path in missed
+    ]
+    errors.extend(
+        f"{path} changes what the Rust gate does, but no check-code-changes glob "
+        "matches it — the merge queue would report `Rust Lint` and `Build and "
+        "Test` green without running a step."
+        for path in glob_misses
+    )
+    return errors
+
+
+def rust_source_errors(
+    trees: dict[str, list[str]], globs: list[str], patterns: dict[str, str]
+) -> list[str]:
+    """One error per source tree that any of the three lists would skip.
+
+    Reported per tree, naming the file count and one example: the fix is always
+    a glob or pattern for the tree, so a per-file list would be noise.
+    """
+    errors: list[str] = []
+    for tree, sources in sorted(trees.items()):
+        label = "the repo root" if tree == "." else f"{tree}/"
+        pattern_misses, glob_misses = coverage_gaps(sources, globs, patterns)
+        for name, missed in pattern_misses.items():
+            if missed:
+                errors.append(
+                    f"{label} holds {len(missed)} tracked Rust source file(s) the pattern in "
+                    f"{name} does not match (e.g. {missed[0]}) — a branch changing only those "
+                    "would skip every Rust check."
+                )
+        if glob_misses:
+            errors.append(
+                f"{label} holds {len(glob_misses)} tracked Rust source file(s) matched by no "
+                f"check-code-changes glob (e.g. {glob_misses[0]}) — the merge queue would report "
+                "`Rust Lint` and `Build and Test` green without compiling them."
+            )
+    return errors
 
 
 def read_patterns() -> dict[str, str] | None:
@@ -240,23 +330,23 @@ def main() -> int:
             "Attestation check) and must classify paths identically."
         )
 
-    gated, notes = derived_gate_paths()
+    # A guard that passes when it could not look is the defect this file exists
+    # to catch, so an unreadable tree is exit 2 (unreadable) rather than a
+    # warning and a green "0 source tree(s)" line.
+    tracked, listing_notes = tracked_files()
+    if listing_notes:
+        for note in listing_notes:
+            print(f"error: {note} — nothing could be checked.", file=sys.stderr)
+        return 2
+
+    gated, notes = derived_gate_paths(tracked)
     for note in notes:
         print(f"warning: {note}", file=sys.stderr)
 
-    for path in gated:
-        for name, pattern in patterns.items():
-            if not re.search(pattern, path):
-                errors.append(
-                    f"{path} changes what the Rust gate does, but the pattern in {name} "
-                    "does not match it — the branch would skip every Rust check."
-                )
-        if not any(glob_matches(glob, path) for glob in globs):
-            errors.append(
-                f"{path} changes what the Rust gate does, but no check-code-changes glob "
-                "matches it — the merge queue would report `Rust Lint` and `Build and "
-                "Test` green without running a step."
-            )
+    trees = rust_source_trees(tracked)
+    errors.extend(rust_source_errors(trees, globs, patterns))
+
+    errors.extend(gate_config_errors(gated, globs, patterns))
 
     for path in MUST_SKIP_RUST_CHECKS:
         for name, pattern in patterns.items():
@@ -279,8 +369,9 @@ def main() -> int:
         return 1
 
     print(
-        f"Rust-gate paths OK: patterns agree, {len(gated)} gated path(s) matched by all "
-        f"three lists, {len(MUST_SKIP_RUST_CHECKS)} fast-track path(s) still skipped."
+        f"Rust-gate paths OK: patterns agree, {len(gated)} gated path(s) and "
+        f"{len(trees)} Rust source tree(s) matched by all three lists, "
+        f"{len(MUST_SKIP_RUST_CHECKS)} fast-track path(s) still skipped."
     )
     return 0
 

--- a/scripts/check_rust_gate_paths.py
+++ b/scripts/check_rust_gate_paths.py
@@ -191,23 +191,24 @@ def rust_source_trees(tracked: list[str]) -> dict[str, list[str]]:
 def glob_matches(glob: str, path: str) -> bool:
     """Match one dorny/paths-filter (picomatch) glob against a path.
 
-    Equivalent to `glob.translate(glob, recursive=True, include_hidden=False)`,
+    Equivalent to `glob.translate(glob, recursive=True, include_hidden=True)`,
     hand-rolled only because that landed in Python 3.13 and this repo's guards
-    run on 3.11. `include_hidden=False` is the rule that matters: a wildcard
-    never matches a path segment starting with `.`, because picomatch descends
-    into dot-prefixed directories only with `dot: true`, which this filter does
-    not set. So a dot path (`.ci/clippy.toml`) must be covered by a glob that
-    spells the dot segment out (`.ci/**`) — which matches either way — rather
-    than relying on `**` to reach it.
+    run on 3.11. `include_hidden=True` is the rule that matters, and it is read
+    off the action rather than assumed: `dorny/paths-filter` builds every
+    matcher with `MatchOptions = {dot: true}` (`src/filter.ts`, at the SHA
+    pinned in `check-code-changes/action.yml`), so a wildcard *does* reach a
+    segment starting with `.` and `**` alone covers `.ci/clippy.toml`. Modelling
+    it the other way makes this guard stricter than the filter it stands in for,
+    which reports a covered path as ungated.
     """
     if glob.startswith("**/"):
         # picomatch lets a leading `**/` match nothing, so `**/x` matches `x`.
         return glob_matches(glob[3:], path) or glob_matches(f"*/{glob}", path)
     pattern = (
         re.escape(glob)
-        .replace(r"\*\*/", "(?:[^./][^/]*/)*")
-        .replace(r"\*\*", "[^./][^/]*(?:/[^./][^/]*)*")
-        .replace(r"\*", "[^./][^/]*")
+        .replace(r"\*\*/", "(?:[^/]+/)*")
+        .replace(r"\*\*", "[^/]+(?:/[^/]+)*")
+        .replace(r"\*", "[^/]+")
     )
     return re.fullmatch(pattern, path) is not None
 

--- a/scripts/test_check_rust_gate_paths.py
+++ b/scripts/test_check_rust_gate_paths.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Tests for scripts/check_rust_gate_paths.py.
+#
+# The guard's live-tree scan only covers the paths today's workspace happens to
+# contain, so a derivation that stopped working would pass unnoticed on a clean
+# tree — the same reason `test_check_module_reachability.py` runs ahead of its
+# guard. The cases here pin the source-tree derivation (#13120: `vendor/` held
+# 17 tracked `.rs` files matched by no `code_changes` glob, and the guard was
+# green) and the glob matcher it depends on.
+#
+# Run: python3 scripts/test_check_rust_gate_paths.py
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_rust_gate_paths import (  # noqa: E402
+    coverage_gaps,
+    extract_code_change_globs,
+    gate_config_errors,
+    glob_matches,
+    read_patterns,
+    rust_source_errors,
+    rust_source_trees,
+    tracked_files,
+)
+
+failures = 0
+checks = 0
+
+
+def check(name: str, got, want) -> None:
+    global failures, checks
+    checks += 1
+    if got == want:
+        print(f"  ok: {name}")
+    else:
+        failures += 1
+        print(f"  FAIL: {name}\n    got:  {got!r}\n    want: {want!r}")
+
+
+# A pattern that classifies every `.rs` file as Rust-affecting, like the real one.
+RS_PATTERN = {"scripts/signoff": r"\.rs$"}
+
+
+print("glob_matches")
+
+check(
+    "a `dir/**` glob reaches a nested source file",
+    glob_matches("vendor/**", "vendor/mysql-common-derive/src/lib.rs"),
+    True,
+)
+check(
+    "a `dir/**` glob does not reach a sibling directory",
+    glob_matches("vendor/**", "vendored/lib.rs"),
+    False,
+)
+# picomatch descends into a dot-prefixed segment only with `dot: true`, which
+# this filter does not set — so a wildcard must never be credited for one.
+check(
+    "a wildcard does not match a dot-prefixed segment",
+    glob_matches("**", ".ci/clippy.toml"),
+    False,
+)
+check(
+    "a glob spelling the dot segment out does match",
+    glob_matches(".ci/**", ".ci/clippy.toml"),
+    True,
+)
+check(
+    "a leading `**/` may match nothing",
+    glob_matches("**/clippy.toml", "clippy.toml"),
+    True,
+)
+
+
+print("coverage_gaps")
+
+# The single definition of "is this path gated" that both reports read from —
+# so a list that stops being checked fails here rather than in one report only.
+check(
+    "a path missing from both lists is reported by both halves",
+    coverage_gaps(["vendor/x.rs", "crates/y.rs"], ["crates/**"], {"scripts/signoff": r"^crates/"}),
+    ({"scripts/signoff": ["vendor/x.rs"]}, ["vendor/x.rs"]),
+)
+check(
+    "a fully covered path is in neither half",
+    coverage_gaps(["crates/y.rs"], ["crates/**"], RS_PATTERN),
+    ({"scripts/signoff": []}, []),
+)
+
+check(
+    "a config path the globs miss names the merge-queue consequence",
+    gate_config_errors([".ci/clippy.toml"], ["crates/**"], RS_PATTERN),
+    [
+        ".ci/clippy.toml changes what the Rust gate does, but the pattern in scripts/signoff "
+        "does not match it — the branch would skip every Rust check.",
+        ".ci/clippy.toml changes what the Rust gate does, but no check-code-changes glob "
+        "matches it — the merge queue would report `Rust Lint` and `Build and Test` green "
+        "without running a step.",
+    ],
+)
+check(
+    "a config path both lists cover is silent",
+    gate_config_errors([".ci/clippy.toml"], [".ci/**"], {"scripts/signoff": r"clippy\.toml$"}),
+    [],
+)
+
+
+print("rust_source_trees")
+
+check(
+    "tracked sources group by top-level directory",
+    rust_source_trees(
+        [
+            "crates/runtime/src/lib.rs",
+            "crates/app/src/lib.rs",
+            "vendor/x/src/lib.rs",
+            "README.md",
+            "vendor/x/Cargo.toml",
+        ]
+    ),
+    {
+        "crates": ["crates/runtime/src/lib.rs", "crates/app/src/lib.rs"],
+        "vendor": ["vendor/x/src/lib.rs"],
+    },
+)
+check("a tree with no Rust sources is absent", rust_source_trees(["docs/dev/ci_signoff.md"]), {})
+# No glob covers a bare root-level `.rs`, so this is a shape an error can take —
+# and keying it on the filename would report a directory that does not exist.
+check("a root-level source keys on the root", rust_source_trees(["build.rs"]), {".": ["build.rs"]})
+
+
+print("rust_source_errors")
+
+# This is #13120 in miniature: the tree is real, compiled, and in no glob.
+ungated = rust_source_errors(
+    {"vendor": ["vendor/x/src/lib.rs", "vendor/x/src/error.rs"]},
+    ["crates/**", "bin/**"],
+    RS_PATTERN,
+)
+check("an ungated source tree is reported", len(ungated), 1)
+check("the error names the tree", "vendor/ holds 2 tracked" in ungated[0], True)
+check("the error names an example file", "vendor/x/src/lib.rs" in ungated[0], True)
+check(
+    "the error says what goes wrong",
+    "green without compiling them" in ungated[0],
+    True,
+)
+
+check(
+    "a glob covering the tree clears it",
+    rust_source_errors(
+        {"vendor": ["vendor/x/src/lib.rs"]}, ["crates/**", "vendor/**"], RS_PATTERN
+    ),
+    [],
+)
+
+# One error per tree, not per file: the fix is a single glob either way, and a
+# per-file list would bury it. 200 files must still read as one problem.
+many = rust_source_errors(
+    {"vendor": [f"vendor/x/src/f{i}.rs" for i in range(200)]}, ["crates/**"], RS_PATTERN
+)
+check("a large tree still reports one error", len(many), 1)
+check("the count is the file count", "holds 200 tracked" in many[0], True)
+
+# The pattern half of the same check: covered by a glob, but a sign-off would
+# skip the branch, so the merge queue is green and nothing was ever linted.
+pattern_only = rust_source_errors(
+    {"vendor": ["vendor/x/src/lib.rs"]},
+    ["vendor/**"],
+    {"scripts/signoff": r"^crates/"},
+)
+check("a source tree outside the sign-off pattern is reported", len(pattern_only), 1)
+check(
+    "that error names the pattern's file",
+    "scripts/signoff" in pattern_only[0] and "skip every Rust check" in pattern_only[0],
+    True,
+)
+
+# Both halves can fail at once, and both must be reported — fixing only the glob
+# leaves the branch unsigned-off.
+both = rust_source_errors(
+    {"vendor": ["vendor/x/src/lib.rs"]}, ["crates/**"], {"scripts/signoff": r"^crates/"}
+)
+check("a tree failing both lists reports both", len(both), 2)
+
+root = rust_source_errors({".": ["build.rs"]}, ["crates/**"], RS_PATTERN)
+check("a root-level source reads as the repo root", "the repo root holds 1" in root[0], True)
+
+check(
+    "trees are reported in a stable order",
+    [e.split("/", 1)[0] for e in rust_source_errors(
+        {"vendor": ["vendor/a.rs"], "attic": ["attic/a.rs"]}, ["crates/**"], RS_PATTERN
+    )],
+    ["attic", "vendor"],
+)
+
+
+print("live tree")
+
+# Regression test for #13120. The synthetic cases above prove the derivation
+# works; this proves it is wired to the lists the repo actually ships.
+tracked, notes = tracked_files()
+if notes:
+    # Not a skip: the guard exits 2 here rather than reporting a green tree it
+    # never read, so this harness must not pass on the same condition either.
+    failures += 1
+    print(f"  FAIL: could not read the tracked files ({notes[0]})")
+else:
+    patterns = read_patterns()
+    globs = extract_code_change_globs()
+    if patterns is None or not globs:
+        failures += 1
+        print("  FAIL: could not read the shipped patterns or globs")
+    else:
+        trees = rust_source_trees(tracked)
+        check("vendor/ is a tracked Rust source tree", "vendor" in trees, True)
+        check(
+            "every shipped Rust source tree is covered by all three lists",
+            rust_source_errors(trees, globs, patterns),
+            [],
+        )
+
+
+if failures:
+    print(f"\n{failures} of {checks} checks FAILED")
+    raise SystemExit(1)
+print(f"\nall {checks} checks passed")

--- a/scripts/test_check_rust_gate_paths.py
+++ b/scripts/test_check_rust_gate_paths.py
@@ -60,18 +60,25 @@ check(
     glob_matches("vendor/**", "vendored/lib.rs"),
     False,
 )
-# picomatch descends into a dot-prefixed segment only with `dot: true`, which
-# this filter does not set — so a wildcard must never be credited for one.
+# dorny/paths-filter builds its matchers with `{dot: true}`, so a wildcard does
+# reach a dot-prefixed segment. Modelling it as excluded would make this guard
+# stricter than the filter and report a covered path as ungated.
 check(
-    "a wildcard does not match a dot-prefixed segment",
+    "a wildcard reaches a dot-prefixed segment",
     glob_matches("**", ".ci/clippy.toml"),
-    False,
+    True,
 )
 check(
-    "a glob spelling the dot segment out does match",
+    "a glob spelling the dot segment out also matches",
     glob_matches(".ci/**", ".ci/clippy.toml"),
     True,
 )
+check(
+    "a leading `**/` reaches a dot-prefixed segment",
+    glob_matches("**/clippy.toml", ".ci/clippy.toml"),
+    True,
+)
+check("a wildcard still does not cross a segment boundary", glob_matches("*", "a/b"), False)
 check(
     "a leading `**/` may match nothing",
     glob_matches("**/clippy.toml", "clippy.toml"),
@@ -94,16 +101,22 @@ check(
     ({"scripts/signoff": []}, []),
 )
 
+# Built as named values rather than adjacent literals inside the list: two long
+# messages sitting side by side in a list is one missing comma away from
+# silently becoming a single element that still compares as "close enough".
+PATTERN_MISS = (
+    ".ci/clippy.toml changes what the Rust gate does, but the pattern in scripts/signoff "
+    + "does not match it — the branch would skip every Rust check."
+)
+GLOB_MISS = (
+    ".ci/clippy.toml changes what the Rust gate does, but no check-code-changes glob "
+    + "matches it — the merge queue would report `Rust Lint` and `Build and Test` green "
+    + "without running a step."
+)
 check(
     "a config path the globs miss names the merge-queue consequence",
     gate_config_errors([".ci/clippy.toml"], ["crates/**"], RS_PATTERN),
-    [
-        ".ci/clippy.toml changes what the Rust gate does, but the pattern in scripts/signoff "
-        "does not match it — the branch would skip every Rust check.",
-        ".ci/clippy.toml changes what the Rust gate does, but no check-code-changes glob "
-        "matches it — the merge queue would report `Rust Lint` and `Build and Test` green "
-        "without running a step.",
-    ],
+    [PATTERN_MISS, GLOB_MISS],
 )
 check(
     "a config path both lists cover is silent",


### PR DESCRIPTION
## Summary

Top-level `vendor/` holds 17 tracked `.rs` files — a vendored fork of `mysql-common-derive`, wired into the workspace by a `[patch.crates-io]` entry and pulled in transitively through the MySQL connector. No `code_changes` glob in `.github/actions/check-code-changes/action.yml` matched that directory, so a pull request whose diff was confined to it reported **`Rust Lint` and `Build and Test` green having run zero steps**.

The existing guard, `scripts/check_rust_gate_paths.py`, did not catch it. It derives the paths that must be gated from what the `lint-rust` recipe *reads* — `CLIPPY_CONF_DIR`, each `python3 scripts/…` guard — and from tracked files whose *name* marks them as lint/test config. A source tree is outside that derivation entirely, so the guard pinned the config paths while being structurally blind to a whole directory of compiled Rust being ungated.

`RUST_AFFECTING_PATH_PATTERN` in `scripts/signoff` matches `\.rs$`, so `make signoff` and the required `Attestation` check *did* cover such a branch. It was only the merge-queue filter that did not — which is the exact disagreement the comment above that glob list warns must never happen.

## Changes

- **Derive the gated set from every tracked `.rs` file, not just from the lint config.** This is the part that closes the class rather than the instance: a new top-level source tree now fails the guard instead of shipping unbuilt. Errors are grouped per tree with a file count and one example, because the fix is always a single glob and a 2,000-line file list would bury it.
- **`vendor/**` joins the `code_changes` globs.** It is one of only four top-level directories with tracked `.rs` files; the other three were already listed.
- **`coverage_gaps` is now the single definition of "is this path gated".** The per-config-path check and the new per-tree check read from it, so a future change to the matching rule cannot land in one report and miss the other.
- **An unreadable tree is now exit 2, not a warning.** Previously a failed `git ls-files` degraded to a note and the guard still printed a pass — a guard reporting green when it could not look is the same defect this file exists to catch.
- **`scripts/test_check_rust_gate_paths.py`** pins the derivation, and `lint-rust` runs it ahead of the guard — the same arrangement the unreachable-module guard already uses, and for the same reason: a clean tree only exercises the shapes it happens to contain.

## Test plan

- `make lint` — includes the new `scripts/test_check_rust_gate_paths.py` (26 checks) and the guard itself
- `make test`
- Regression, verified by neutering: with `vendor/**` removed from the glob list the guard exits 1 naming `vendor/` and the file count, and the harness fails its live-tree check; on `trunk` today the same tree state exits 0. Neutering a *pre-existing* config glob (`scripts/check_crate_layers.py`) still errors too, confirming the shared-predicate refactor did not weaken the check it absorbed.
- Cost of the new scan measured at 45 ms over 2,246 sources x 29 globs — this guard is documented as "fast, no compile" and stays that way.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1 with "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` is not installed on this host, so the receipt records `engine=none`, `exit=1`, `job=none`. Ran the angles by hand instead, which produced two changes to my own diff: the unreadable-tree case now exits 2 rather than passing silently, and a root-level `.rs` file is labelled "the repo root" instead of a directory that does not exist.
- `/security-review`: no findings. The diff adds no network, deserialization, or untrusted-input path; `git ls-files` is invoked with a fixed argument list and no shell, and the filter change only widens which checks run.
- `/simplify`: applied. Its reuse and simplification passes independently found the same duplication — the new per-tree check reimplemented the matching logic already in `main()`'s per-path loop — which became `coverage_gaps`. Also inlined a single-use `tree_label` helper and matched the sibling harness's summary/exit idiom. Skipped one finding: the harness's live-tree block does not call `main()`, deliberately, since `lint-rust` runs the guard seconds later and the block exists to pin #13120 specifically.
- Copilot review (second push): both findings taken. **`glob_matches` modelled the wrong dot-segment semantics** — verified against `dorny/paths-filter`'s `src/filter.ts` at the pinned SHA `ceb8a2b8`, which sets `MatchOptions = {dot: true}`, so `**` *does* reach `.ci/clippy.toml`. That claim was already on `trunk` and my change made the matcher load-bearing for 2,246 more paths, so correcting it here beat leaving a test that pins a false model of a dependency. Also replaced adjacent string literals inside a list literal (CodeQL: one missing comma from silently becoming one element) with named values. Re-ran the neuter matrix afterwards; the visible behavior change is that dropping `.ci/**` no longer fails the guard, because `**/clippy.toml` genuinely covers it — as it does in the real filter. That is the false positive the old model produced, now gone.

Fixes #13120

## Checklist

- [x] The guard fails on the pre-fix tree and passes on the post-fix tree
- [x] The refactored pre-existing check still fires when neutered
- [x] `docs/dev/ci_signoff.md` describes the new derivation
- [ ] `make signoff` / `Attestation` green