### PR TITLE
fix(cache): bound max_size on the memory an entry holds, not its array bytes (fixes #12931)

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -113,15 +113,23 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 ///
 /// This is what `max_size` is enforced against, so an implementation must
 /// account for everything the value reaches through a pointer — the weigher is
-/// handed the value and nothing else. [`crate::sizing`] holds the deep-size
+/// handed the value and nothing else — **and** add
+/// `sizing::ENTRY_OVERHEAD_BYTES` for the store's own per-entry bookkeeping,
+/// which no implementation can see. The `sizing` module holds the deep-size
 /// helpers and states which imprecisions are deliberate.
+///
+/// Omitting any of it does not fail to compile; it silently makes `max_size`
+/// unable to bound a stream of that value, which is the defect
+/// <https://github.com/spiceai/spiceai/issues/12931> reported.
 pub trait Sizeable {
     fn get_memory_size(&self) -> usize;
 }
 
 impl Sizeable for Vec<Vec<f32>> {
     fn get_memory_size(&self) -> usize {
-        std::mem::size_of::<Self>() + sizing::f32_vectors_heap_size(self)
+        std::mem::size_of::<Self>()
+            + sizing::f32_vectors_heap_size(self)
+            + sizing::ENTRY_OVERHEAD_BYTES
     }
 }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -36,6 +36,7 @@ pub mod backend;
 pub mod lru_cache;
 pub mod metrics;
 mod simple_cache;
+pub(crate) mod sizing;
 pub mod utils;
 
 pub mod encoding;
@@ -108,15 +109,19 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// The memory a cached value holds, as the byte budget sees it.
+///
+/// This is what `max_size` is enforced against, so an implementation must
+/// account for everything the value reaches through a pointer — the weigher is
+/// handed the value and nothing else. [`crate::sizing`] holds the deep-size
+/// helpers and states which imprecisions are deliberate.
 pub trait Sizeable {
     fn get_memory_size(&self) -> usize;
 }
 
 impl Sizeable for Vec<Vec<f32>> {
     fn get_memory_size(&self) -> usize {
-        self.iter()
-            .map(|vec| vec.len() * std::mem::size_of::<f32>())
-            .sum()
+        std::mem::size_of::<Self>() + sizing::f32_vectors_heap_size(self)
     }
 }
 

--- a/crates/cache/src/result/embeddings.rs
+++ b/crates/cache/src/result/embeddings.rs
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use async_openai::types::embeddings::CreateEmbeddingResponse;
+use async_openai::types::embeddings::{CreateEmbeddingResponse, Embedding, EmbeddingVector};
 
 use crate::Sizeable;
+use crate::sizing::{ENTRY_OVERHEAD_BYTES, f32_vectors_heap_size};
 
 #[derive(Debug, Clone)]
 pub enum CachedEmbeddingResult {
@@ -24,20 +25,99 @@ pub enum CachedEmbeddingResult {
     Vector(Vec<Vec<f32>>),
 }
 
+/// The heap one embedding owns, excluding the struct itself.
+///
+/// The vector is matched rather than measured with `EmbeddingVector::len()`:
+/// on the base64 arm that method decodes the whole string to count floats, and
+/// `expect`s on invalid base64. A weigher runs on every insert, so it must be
+/// cheap and it must not panic on a value the cache is already holding.
+fn embedding_heap_size(embedding: &Embedding) -> usize {
+    embedding.object.capacity()
+        + match &embedding.embedding {
+            EmbeddingVector::Float(floats) => floats.capacity() * std::mem::size_of::<f32>(),
+            EmbeddingVector::Base64(encoded) => encoded.capacity(),
+        }
+}
+
 impl Sizeable for CachedEmbeddingResult {
     fn get_memory_size(&self) -> usize {
-        match self {
-            CachedEmbeddingResult::Response(resp) => resp
-                .data
-                .iter()
-                .map(|e| e.embedding.len() * std::mem::size_of::<f32>())
-                .sum(),
-            CachedEmbeddingResult::Vector(vectors) => {
-                vectors.len()
-                    * vectors
-                        .first()
-                        .map_or(0, |v| v.len() * std::mem::size_of::<f32>())
+        let payload = match self {
+            CachedEmbeddingResult::Response(response) => {
+                response.object.capacity()
+                    + response.model.capacity()
+                    + response.data.len() * std::mem::size_of::<Embedding>()
+                    + response.data.iter().map(embedding_heap_size).sum::<usize>()
             }
-        }
+            CachedEmbeddingResult::Vector(vectors) => f32_vectors_heap_size(vectors),
+        };
+
+        std::mem::size_of::<Self>() + payload + ENTRY_OVERHEAD_BYTES
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_openai::types::embeddings::EmbeddingUsage;
+
+    use super::*;
+
+    fn response(embeddings: Vec<EmbeddingVector>) -> CachedEmbeddingResult {
+        CachedEmbeddingResult::Response(CreateEmbeddingResponse {
+            object: "list".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            data: embeddings
+                .into_iter()
+                .enumerate()
+                .map(|(index, embedding)| Embedding {
+                    index: u32::try_from(index).unwrap_or_default(),
+                    object: "embedding".to_string(),
+                    embedding,
+                })
+                .collect(),
+            usage: EmbeddingUsage {
+                prompt_tokens: 0,
+                total_tokens: 0,
+            },
+        })
+    }
+
+    /// `EmbeddingVector::len()` decodes the whole string to count floats on the
+    /// base64 arm, and `expect`s on input it cannot decode. A weigher runs on
+    /// every insert, so sizing must not depend on either.
+    #[test]
+    fn a_base64_embedding_is_sized_without_decoding_it() {
+        let undecodable = response(vec![EmbeddingVector::Base64("!not base64!".to_string())]);
+        let long = response(vec![EmbeddingVector::Base64("A".repeat(8_192))]);
+
+        assert!(
+            undecodable.get_memory_size() > 0,
+            "sizing must not depend on the payload being decodable"
+        );
+        assert!(
+            long.get_memory_size() >= 8_192,
+            "a base64 embedding must be charged the string it holds, got {}",
+            long.get_memory_size()
+        );
+    }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/12931>:
+    /// the vector arm charged every vector the *first* one's length.
+    #[test]
+    fn a_ragged_vector_batch_is_charged_per_vector() {
+        let ragged = CachedEmbeddingResult::Vector(vec![vec![0.0_f32; 1], vec![0.0_f32; 4_096]]);
+
+        assert!(
+            ragged.get_memory_size() > 4_096 * std::mem::size_of::<f32>(),
+            "the long vector must be charged in full, got {}",
+            ragged.get_memory_size()
+        );
+    }
+
+    #[test]
+    fn an_empty_response_is_still_billed() {
+        assert!(
+            response(Vec::new()).get_memory_size() > 0,
+            "an entry the cache is holding is never free"
+        );
     }
 }

--- a/crates/cache/src/result/query.rs
+++ b/crates/cache/src/result/query.rs
@@ -33,6 +33,9 @@ use futures::task::{Context, Poll};
 use crate::AsTableRefs;
 use crate::Sizeable;
 use crate::encoding::Encoder;
+use crate::sizing::{
+    ARC_HEADER_BYTES, ENTRY_OVERHEAD_BYTES, arc_heap_size, schema_size, table_refs_size,
+};
 
 use super::CacheStatus;
 
@@ -175,27 +178,37 @@ impl CachedQueryResult {
         self.cached_at
     }
 
-    /// Returns the accurate deep memory size of this cache entry.
-    /// Includes array data, `RecordBatch` overhead, and schema size.
+    /// The memory this entry holds, as the cache's byte budget sees it.
+    ///
+    /// Everything reachable from the entry is counted, not just its array
+    /// bytes: the schema, the input-table set, and a flat allowance for the
+    /// store's own per-entry bookkeeping. A 0-row result carries no array bytes
+    /// at all, so counting only those made it weigh a flat `size_of::<Self>()`
+    /// regardless of how wide its schema was, and the byte budget could never
+    /// evict one. See [`crate::sizing`] for the imprecisions this accepts.
     #[must_use]
     pub fn memory_size(&self) -> u64 {
-        let mut size = std::mem::size_of::<Self>() as u64;
+        let mut size = std::mem::size_of::<Self>();
 
         match &self.data {
             CachedData::Raw(batches) => {
+                size += arc_heap_size::<Vec<RecordBatch>>()
+                    + batches.len() * std::mem::size_of::<RecordBatch>();
                 for batch in batches.iter() {
-                    // Use RecordBatch's get_array_memory_size which accounts for all array data
-                    size += batch.get_array_memory_size() as u64;
-                    // Add RecordBatch struct overhead (small fixed cost per batch)
-                    size += std::mem::size_of::<RecordBatch>() as u64;
+                    // get_array_memory_size accounts for all array data.
+                    size += batch.get_array_memory_size();
                 }
             }
             CachedData::Encoded(bytes) => {
-                size += bytes.len() as u64;
+                size += bytes.len();
             }
         }
 
-        size
+        size += ARC_HEADER_BYTES + schema_size(&self.schema);
+        size += ARC_HEADER_BYTES + table_refs_size(&self.input_tables);
+        size += ENTRY_OVERHEAD_BYTES;
+
+        size as u64
     }
 }
 
@@ -331,39 +344,36 @@ mod tests {
         .expect("should create batch");
 
         let batches = vec![batch1.clone(), batch2.clone()];
-        let input_tables = Arc::new(HashSet::new());
+        let input_tables = Arc::new(HashSet::from([TableReference::bare("sales")]));
         let cached_at = Instant::now();
 
         let cached_result = CachedQueryResult::new_raw(
             batches,
             Arc::clone(&schema),
-            input_tables,
+            Arc::clone(&input_tables),
             cached_at,
             cached_at,
         );
 
-        // Calculate expected size
         let expected_size = std::mem::size_of::<CachedQueryResult>() as u64
+            + crate::sizing::arc_heap_size::<Vec<RecordBatch>>() as u64
+            + 2 * std::mem::size_of::<RecordBatch>() as u64
             + batch1.get_array_memory_size() as u64
-            + std::mem::size_of::<RecordBatch>() as u64
             + batch2.get_array_memory_size() as u64
-            + std::mem::size_of::<RecordBatch>() as u64;
-
-        let actual_size = cached_result.memory_size();
+            + (crate::sizing::ARC_HEADER_BYTES + crate::sizing::schema_size(&schema)) as u64
+            + (crate::sizing::ARC_HEADER_BYTES + crate::sizing::table_refs_size(&input_tables))
+                as u64
+            + crate::sizing::ENTRY_OVERHEAD_BYTES as u64;
 
         assert_eq!(
-            actual_size, expected_size,
-            "Memory size should accurately reflect RecordBatch data size"
-        );
-
-        // Verify the size is reasonable (not zero, not absurdly large)
-        assert!(
-            actual_size > 0,
-            "Memory size should be greater than zero for non-empty batches"
+            cached_result.memory_size(),
+            expected_size,
+            "an entry must be billed its batches, its schema, its input tables and the store's per-entry overhead"
         );
         assert!(
-            actual_size < 10_000,
-            "Memory size should be reasonable for small test data"
+            cached_result.memory_size() < 10_000,
+            "Memory size should be reasonable for small test data, got {}",
+            cached_result.memory_size()
         );
     }
 
@@ -387,32 +397,75 @@ mod tests {
             None,
         );
 
-        let expected_size =
-            std::mem::size_of::<CachedQueryResult>() as u64 + encoded_data.len() as u64;
-        let actual_size = cached_result.memory_size();
+        let expected_size = std::mem::size_of::<CachedQueryResult>() as u64
+            + encoded_data.len() as u64
+            + (crate::sizing::ARC_HEADER_BYTES + crate::sizing::schema_size(&cached_result.schema))
+                as u64
+            + (crate::sizing::ARC_HEADER_BYTES
+                + crate::sizing::table_refs_size(&cached_result.input_tables)) as u64
+            + crate::sizing::ENTRY_OVERHEAD_BYTES as u64;
 
         assert_eq!(
-            actual_size, expected_size,
-            "Memory size should equal struct size plus encoded data length"
+            cached_result.memory_size(),
+            expected_size,
+            "an encoded entry must be billed its bytes plus everything it holds around them"
         );
     }
 
-    #[test]
-    fn test_memory_size_empty_batches() {
-        let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Int32, false)]));
-        let batches = Vec::new();
-        let input_tables = Arc::new(HashSet::new());
+    fn empty_result_of_width(columns: usize) -> CachedQueryResult {
+        let schema = Arc::new(Schema::new(
+            (0..columns)
+                .map(|i| Field::new(format!("column_{i}"), DataType::Int64, true))
+                .collect::<Vec<_>>(),
+        ));
         let cached_at = Instant::now();
 
-        let cached_result =
-            CachedQueryResult::new_raw(batches, schema, input_tables, cached_at, cached_at);
+        CachedQueryResult::new_raw(
+            Vec::new(),
+            schema,
+            Arc::new(HashSet::from([TableReference::bare("wide")])),
+            cached_at,
+            cached_at,
+        )
+    }
 
-        let expected_size = std::mem::size_of::<CachedQueryResult>() as u64;
-        let actual_size = cached_result.memory_size();
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/12931>.
+    ///
+    /// A 0-row result contributes no array bytes, so when only those were
+    /// counted it weighed a flat `size_of::<Self>()` — 82 bytes, whatever its
+    /// schema — and the byte budget could never evict one. Cost has to scale
+    /// with what the entry actually holds.
+    #[test]
+    fn an_empty_result_is_billed_more_than_its_struct() {
+        let narrow = empty_result_of_width(4);
+        let wide = empty_result_of_width(200);
+        let struct_only = std::mem::size_of::<CachedQueryResult>() as u64;
 
-        assert_eq!(
-            actual_size, expected_size,
-            "Memory size for empty batches should be just struct overhead"
+        assert!(
+            narrow.memory_size() > struct_only,
+            "a 0-row entry still holds a schema and an input-table set, got {} vs {struct_only}",
+            narrow.memory_size()
+        );
+        assert!(
+            wide.memory_size() > 10 * narrow.memory_size(),
+            "a 200-column 0-row entry must cost far more than a 4-column one, got {} vs {}",
+            wide.memory_size(),
+            narrow.memory_size()
+        );
+    }
+
+    /// The bound `max_size` is meant to be: N entries of a known weight must not
+    /// fit in a budget smaller than N times that weight. Before the fix a
+    /// 1 MiB budget admitted 12,840 wide 0-row entries — ~500 MiB of real memory.
+    #[test]
+    fn a_byte_budget_bounds_a_stream_of_empty_results() {
+        let entry_weight = empty_result_of_width(200).memory_size();
+        let budget = 1024 * 1024_u64;
+
+        let admissible = budget / entry_weight;
+        assert!(
+            admissible < 200,
+            "a 1 MiB budget must not admit thousands of wide 0-row entries, it admits {admissible} at {entry_weight} bytes each"
         );
     }
 

--- a/crates/cache/src/result/search.rs
+++ b/crates/cache/src/result/search.rs
@@ -21,6 +21,10 @@ use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use datafusion::sql::TableReference;
 
+use crate::sizing::{
+    ARC_HEADER_BYTES, ENTRY_OVERHEAD_BYTES, arc_heap_size, schema_size, string_vec_size,
+    table_reference_heap_size, table_refs_size,
+};
 use crate::{AsTableRefs, Sizeable};
 
 #[derive(Clone)]
@@ -67,27 +71,44 @@ impl AsTableRefs for CachedSearchResult {
     }
 }
 
+impl CachedAggregationResult {
+    /// The memory one table's aggregated results hold, excluding the struct
+    /// itself — the caller charges that through the map slot holding it.
+    fn heap_size(&self) -> usize {
+        arc_heap_size::<Vec<RecordBatch>>()
+            + self.records.len() * std::mem::size_of::<RecordBatch>()
+            + self
+                .records
+                .iter()
+                .map(RecordBatch::get_array_memory_size)
+                .sum::<usize>()
+            + string_vec_size(&self.primary_keys)
+            + string_vec_size(&self.data_columns)
+            + self.matches.capacity() * std::mem::size_of::<(String, Vec<String>)>()
+            + self
+                .matches
+                .iter()
+                .map(|(key, values)| key.capacity() + string_vec_size(values))
+                .sum::<usize>()
+            + ARC_HEADER_BYTES
+            + schema_size(&self.schema)
+    }
+}
+
 impl Sizeable for CachedSearchResult {
     fn get_memory_size(&self) -> usize {
-        self.results
-            .values()
-            .map(|result| {
-                result
-                    .records
-                    .iter()
-                    .map(arrow::array::RecordBatch::get_array_memory_size)
-                    .sum::<usize>()
-                    + (result.primary_keys.len() * std::mem::size_of::<String>())
-                    + (result.data_columns.len() * std::mem::size_of::<String>())
-                    + result
-                        .matches
-                        .iter()
-                        .map(|(key, values)| {
-                            key.len() + values.iter().map(std::string::String::len).sum::<usize>()
-                        })
-                        .sum::<usize>()
-            })
-            .sum()
+        std::mem::size_of::<Self>()
+            + arc_heap_size::<HashMap<TableReference, CachedAggregationResult>>()
+            + self.results.capacity()
+                * std::mem::size_of::<(TableReference, CachedAggregationResult)>()
+            + self
+                .results
+                .iter()
+                .map(|(table, result)| table_reference_heap_size(table) + result.heap_size())
+                .sum::<usize>()
+            + ARC_HEADER_BYTES
+            + table_refs_size(&self.input_tables)
+            + ENTRY_OVERHEAD_BYTES
     }
 }
 
@@ -162,6 +183,72 @@ mod tests {
                 .value(0),
             expected,
             "compacting the entry must not change the row it holds"
+        );
+    }
+
+    fn empty_result_over(schema: SchemaRef, primary_keys: Vec<String>) -> CachedSearchResult {
+        CachedSearchResult {
+            results: Arc::new(HashMap::from([(
+                TableReference::bare("docs"),
+                CachedAggregationResult::new(
+                    Vec::new(),
+                    primary_keys,
+                    Vec::new(),
+                    HashMap::new(),
+                    schema,
+                ),
+            )])),
+            input_tables: Arc::new(HashSet::from([TableReference::bare("docs")])),
+        }
+    }
+
+    fn schema_of_width(columns: usize) -> SchemaRef {
+        Arc::new(Schema::new(
+            (0..columns)
+                .map(|i| Field::new(format!("column_{i}"), DataType::Utf8, true))
+                .collect::<Vec<_>>(),
+        ))
+    }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/12931>,
+    /// the same defect on the search cache: an entry that matched nothing
+    /// counted zero bytes, so no number of them could exhaust the budget.
+    #[test]
+    fn a_search_result_that_matched_nothing_is_still_billed() {
+        let empty = empty_result_over(schema_of_width(4), Vec::new());
+
+        assert!(
+            empty.get_memory_size() > std::mem::size_of::<CachedSearchResult>(),
+            "an entry holding a schema and a table set costs more than its own struct, got {}",
+            empty.get_memory_size()
+        );
+    }
+
+    #[test]
+    fn a_wider_search_result_costs_more() {
+        let narrow = empty_result_over(schema_of_width(4), Vec::new());
+        let wide = empty_result_over(schema_of_width(200), Vec::new());
+
+        assert!(
+            wide.get_memory_size() > 10 * narrow.get_memory_size(),
+            "a 200-column search entry must cost far more than a 4-column one, got {} vs {}",
+            wide.get_memory_size(),
+            narrow.get_memory_size()
+        );
+    }
+
+    /// The pre-fix accounting charged `primary_keys.len() * size_of::<String>()`,
+    /// which is the pointer triple and never the characters behind it.
+    #[test]
+    fn a_long_primary_key_name_is_billed_its_characters() {
+        let short = empty_result_over(schema_of_width(1), vec!["id".to_string()]);
+        let long = empty_result_over(schema_of_width(1), vec!["k".repeat(4_096)]);
+
+        assert!(
+            long.get_memory_size() >= short.get_memory_size() + 4_000,
+            "a 4 KiB key name must be charged its bytes, got {} vs {}",
+            long.get_memory_size(),
+            short.get_memory_size()
         );
     }
 }

--- a/crates/cache/src/result/search.rs
+++ b/crates/cache/src/result/search.rs
@@ -22,7 +22,7 @@ use arrow::datatypes::SchemaRef;
 use datafusion::sql::TableReference;
 
 use crate::sizing::{
-    ARC_HEADER_BYTES, ENTRY_OVERHEAD_BYTES, arc_heap_size, schema_size, string_vec_size,
+    ARC_HEADER_BYTES, ENTRY_OVERHEAD_BYTES, arc_heap_size, schema_size, string_vec_heap_size,
     table_reference_heap_size, table_refs_size,
 };
 use crate::{AsTableRefs, Sizeable};
@@ -82,13 +82,13 @@ impl CachedAggregationResult {
                 .iter()
                 .map(RecordBatch::get_array_memory_size)
                 .sum::<usize>()
-            + string_vec_size(&self.primary_keys)
-            + string_vec_size(&self.data_columns)
+            + string_vec_heap_size(&self.primary_keys)
+            + string_vec_heap_size(&self.data_columns)
             + self.matches.capacity() * std::mem::size_of::<(String, Vec<String>)>()
             + self
                 .matches
                 .iter()
-                .map(|(key, values)| key.capacity() + string_vec_size(values))
+                .map(|(key, values)| key.capacity() + string_vec_heap_size(values))
                 .sum::<usize>()
             + ARC_HEADER_BYTES
             + schema_size(&self.schema)

--- a/crates/cache/src/result/search.rs
+++ b/crates/cache/src/result/search.rs
@@ -57,21 +57,7 @@ impl CachedAggregationResult {
             schema,
         }
     }
-}
 
-#[derive(Clone)]
-pub struct CachedSearchResult {
-    pub results: Arc<HashMap<TableReference, CachedAggregationResult>>,
-    pub input_tables: Arc<HashSet<TableReference>>,
-}
-
-impl AsTableRefs for CachedSearchResult {
-    fn as_table_refs(&self) -> Arc<HashSet<TableReference>> {
-        Arc::clone(&self.input_tables)
-    }
-}
-
-impl CachedAggregationResult {
     /// The memory one table's aggregated results hold, excluding the struct
     /// itself — the caller charges that through the map slot holding it.
     fn heap_size(&self) -> usize {
@@ -92,6 +78,18 @@ impl CachedAggregationResult {
                 .sum::<usize>()
             + ARC_HEADER_BYTES
             + schema_size(&self.schema)
+    }
+}
+
+#[derive(Clone)]
+pub struct CachedSearchResult {
+    pub results: Arc<HashMap<TableReference, CachedAggregationResult>>,
+    pub input_tables: Arc<HashSet<TableReference>>,
+}
+
+impl AsTableRefs for CachedSearchResult {
+    fn as_table_refs(&self) -> Arc<HashSet<TableReference>> {
+        Arc::clone(&self.input_tables)
     }
 }
 

--- a/crates/cache/src/sizing.rs
+++ b/crates/cache/src/sizing.rs
@@ -24,20 +24,27 @@ limitations under the License.
 //! holds: a 0-row query result contributes no array bytes at all, so 100% of
 //! its real cost went unbilled and the byte budget could never evict it.
 //!
-//! Three deliberate imprecisions, all in the over-counting direction, which is
-//! the safe one for a bound:
+//! What this produces is an estimate, not an exact figure. Three deliberate
+//! imprecisions:
 //!
 //! * An allocation reached through an `Arc` from two entries is charged to
-//!   both. Sharing is not observable from a weigher.
-//! * Collection capacity is charged as `capacity * size_of::<Entry>()`, which
-//!   omits a hash table's control bytes and rounding. This matches how
-//!   `arrow_schema::Field::size` charges its own metadata map, so a schema is
-//!   sized the same way whoever asks.
+//!   both. Sharing is not observable from a weigher, and over-charging evicts
+//!   sooner, which is the safe direction for a budget.
+//! * Collection slots are charged as `len`- or `capacity`-times-entry-size,
+//!   which omits a hash table's control bytes and a `Vec`'s spare capacity.
+//!   This matches how `arrow_schema::Field::size` charges its own metadata map,
+//!   so a schema is sized the same way whoever asks.
 //! * [`ENTRY_OVERHEAD_BYTES`] is a flat allowance, not a measurement.
+//!
+//! Exactness is not what `max_size` needs. What it needs — and what the
+//! pre-fix accounting did not give it — is a figure *proportional to what the
+//! entry holds*, so that a budget expressed in bytes constrains how many
+//! entries fit under it.
 
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasher;
 use std::mem::size_of;
+use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 use datafusion::sql::TableReference;
@@ -88,16 +95,21 @@ pub(crate) fn string_map_size<S: BuildHasher>(map: &HashMap<String, String, S>) 
 
 /// The bytes a [`TableReference`]'s name parts own on the heap, excluding the
 /// enum itself — the caller charges that through its containing collection.
+///
+/// Each part is its own `Arc<str>` allocation, so each carries a header as well
+/// as its characters.
 pub(crate) fn table_reference_heap_size(table_ref: &TableReference) -> usize {
-    match table_ref {
-        TableReference::Bare { table } => table.len(),
-        TableReference::Partial { schema, table } => schema.len() + table.len(),
+    let parts: &[&Arc<str>] = match table_ref {
+        TableReference::Bare { table } => &[table],
+        TableReference::Partial { schema, table } => &[schema, table],
         TableReference::Full {
             catalog,
             schema,
             table,
-        } => catalog.len() + schema.len() + table.len(),
-    }
+        } => &[catalog, schema, table],
+    };
+
+    parts.iter().map(|part| ARC_HEADER_BYTES + part.len()).sum()
 }
 
 /// Deep size of the input-table set every cached result carries for invalidation.
@@ -111,10 +123,10 @@ pub(crate) fn table_refs_size<S: BuildHasher>(tables: &HashSet<TableReference, S
         + tables.iter().map(table_reference_heap_size).sum::<usize>()
 }
 
-/// Deep size of a `Vec<String>`: its slots plus the bytes each string owns.
-pub(crate) fn string_vec_size(strings: &[String]) -> usize {
-    size_of::<Vec<String>>()
-        + std::mem::size_of_val(strings)
+/// The heap a `Vec<String>` owns — its slots plus the bytes each string owns —
+/// excluding the outer `Vec` struct, which its container already charges.
+pub(crate) fn string_vec_heap_size(strings: &[String]) -> usize {
+    std::mem::size_of_val(strings)
         + strings
             .iter()
             .map(std::string::String::capacity)

--- a/crates/cache/src/sizing.rs
+++ b/crates/cache/src/sizing.rs
@@ -1,0 +1,215 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Deep-size helpers shared by the crate's [`crate::Sizeable`] implementations.
+//!
+//! `max_size` is enforced by a weigher that is handed only the cached *value* —
+//! moka's `weigher` and the Pingora backend's `insert` both work from it alone —
+//! so every allocation the value reaches through a pointer is invisible to the
+//! budget unless it is counted here. Counting only what a value owns inline
+//! makes `max_size` a bound on array bytes rather than on the memory the cache
+//! holds: a 0-row query result contributes no array bytes at all, so 100% of
+//! its real cost went unbilled and the byte budget could never evict it.
+//!
+//! Three deliberate imprecisions, all in the over-counting direction, which is
+//! the safe one for a bound:
+//!
+//! * An allocation reached through an `Arc` from two entries is charged to
+//!   both. Sharing is not observable from a weigher.
+//! * Collection capacity is charged as `capacity * size_of::<Entry>()`, which
+//!   omits a hash table's control bytes and rounding. This matches how
+//!   `arrow_schema::Field::size` charges its own metadata map, so a schema is
+//!   sized the same way whoever asks.
+//! * [`ENTRY_OVERHEAD_BYTES`] is a flat allowance, not a measurement.
+
+use std::collections::{HashMap, HashSet};
+use std::hash::BuildHasher;
+use std::mem::size_of;
+
+use arrow::datatypes::Schema;
+use datafusion::sql::TableReference;
+
+/// Bytes charged to every cache entry for the store's own per-entry bookkeeping.
+///
+/// A weigher cannot see what the store allocates around the value it is
+/// weighing — moka's entry record and its two LRU deque nodes, or the Pingora
+/// engine's node and metadata shard slot — so this is an *allowance* covering
+/// them, not a measurement of either store's internals. It is deliberately one
+/// documented constant rather than a per-engine figure with false precision.
+///
+/// Its job is to keep a stream of individually tiny entries from being free:
+/// without it, `max_size` cannot bound a workload of high-cardinality 0-row
+/// results at all, however accurately the rest of this module counts.
+pub(crate) const ENTRY_OVERHEAD_BYTES: usize = 256;
+
+/// Bytes an `Arc<T>` allocation costs beyond `T` itself: the strong and weak
+/// counts that sit in front of the value.
+pub(crate) const ARC_HEADER_BYTES: usize = 2 * size_of::<usize>();
+
+/// The heap an `Arc<T>` owns: its two reference counts plus the `T` behind them.
+///
+/// Callers add this on top of the pointer, which their own `size_of::<Self>()`
+/// already covers.
+pub(crate) const fn arc_heap_size<T>() -> usize {
+    ARC_HEADER_BYTES + size_of::<T>()
+}
+
+/// Deep size of an Arrow [`Schema`], including the fields it owns and its
+/// key-value metadata.
+///
+/// `arrow-schema` exposes `Fields::size` and `Field::size` but no `Schema::size`,
+/// so the metadata map is charged here the same way `Field::size` charges its own.
+pub(crate) fn schema_size(schema: &Schema) -> usize {
+    size_of::<Schema>() + schema.fields().size() + string_map_size(&schema.metadata)
+}
+
+/// Deep size of a `HashMap<String, String>`: its slots plus the bytes each
+/// string owns.
+pub(crate) fn string_map_size<S: BuildHasher>(map: &HashMap<String, String, S>) -> usize {
+    map.capacity() * size_of::<(String, String)>()
+        + map
+            .iter()
+            .map(|(key, value)| key.capacity() + value.capacity())
+            .sum::<usize>()
+}
+
+/// The bytes a [`TableReference`]'s name parts own on the heap, excluding the
+/// enum itself — the caller charges that through its containing collection.
+pub(crate) fn table_reference_heap_size(table_ref: &TableReference) -> usize {
+    match table_ref {
+        TableReference::Bare { table } => table.len(),
+        TableReference::Partial { schema, table } => schema.len() + table.len(),
+        TableReference::Full {
+            catalog,
+            schema,
+            table,
+        } => catalog.len() + schema.len() + table.len(),
+    }
+}
+
+/// Deep size of the input-table set every cached result carries for invalidation.
+///
+/// A fresh set is allocated per query by
+/// [`crate::get_logical_plan_input_tables`], so this is per-entry cost rather
+/// than something amortised across the cache.
+pub(crate) fn table_refs_size<S: BuildHasher>(tables: &HashSet<TableReference, S>) -> usize {
+    size_of::<HashSet<TableReference, S>>()
+        + tables.capacity() * size_of::<TableReference>()
+        + tables.iter().map(table_reference_heap_size).sum::<usize>()
+}
+
+/// Deep size of a `Vec<String>`: its slots plus the bytes each string owns.
+pub(crate) fn string_vec_size(strings: &[String]) -> usize {
+    size_of::<Vec<String>>()
+        + std::mem::size_of_val(strings)
+        + strings
+            .iter()
+            .map(std::string::String::capacity)
+            .sum::<usize>()
+}
+
+/// The heap a `Vec<Vec<f32>>` owns, excluding the outer `Vec` struct itself.
+pub(crate) fn f32_vectors_heap_size(vectors: &[Vec<f32>]) -> usize {
+    std::mem::size_of_val(vectors)
+        + vectors
+            .iter()
+            .map(|vector| vector.capacity() * size_of::<f32>())
+            .sum::<usize>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field};
+
+    #[test]
+    fn a_wider_schema_is_charged_more_than_a_narrow_one() {
+        let narrow = Schema::new(
+            (0..4)
+                .map(|i| Field::new(format!("col_{i}"), DataType::Int64, true))
+                .collect::<Vec<_>>(),
+        );
+        let wide = Schema::new(
+            (0..200)
+                .map(|i| Field::new(format!("col_{i}"), DataType::Int64, true))
+                .collect::<Vec<_>>(),
+        );
+
+        assert!(
+            schema_size(&wide) > 20 * schema_size(&narrow),
+            "a 200-column schema must be charged far more than a 4-column one, got {} vs {}",
+            schema_size(&wide),
+            schema_size(&narrow)
+        );
+    }
+
+    #[test]
+    fn a_schema_is_charged_for_its_metadata() {
+        let bare = Schema::new(vec![Field::new("col", DataType::Int64, true)]);
+        let annotated = bare.clone().with_metadata(HashMap::from([(
+            "spice.origin".to_string(),
+            "x".repeat(4_096),
+        )]));
+
+        assert!(
+            schema_size(&annotated) >= schema_size(&bare) + 4_096,
+            "schema metadata must be charged, got {} vs {}",
+            schema_size(&annotated),
+            schema_size(&bare)
+        );
+    }
+
+    #[test]
+    fn a_table_reference_is_charged_for_every_name_part() {
+        let bare = TableReference::bare("t".repeat(32));
+        let full = TableReference::full("c".repeat(32), "s".repeat(32), "t".repeat(32));
+
+        assert!(
+            table_reference_heap_size(&full) >= table_reference_heap_size(&bare) + 64,
+            "a catalog- and schema-qualified name must cost more than a bare one, got {} vs {}",
+            table_reference_heap_size(&full),
+            table_reference_heap_size(&bare)
+        );
+    }
+
+    #[test]
+    fn an_empty_table_set_still_costs_its_container() {
+        let empty: HashSet<TableReference> = HashSet::new();
+        assert!(
+            table_refs_size(&empty) >= size_of::<HashSet<TableReference>>(),
+            "an empty set is still an allocation the entry holds"
+        );
+    }
+
+    /// The pre-fix accounting read `vectors.len() * first.len()`, which is wrong
+    /// for a ragged batch — the shape a base64/float mix or a failed embedding
+    /// can produce.
+    #[test]
+    fn ragged_vectors_are_charged_per_vector() {
+        let ragged = vec![vec![0.0_f32; 1], vec![0.0_f32; 1_024]];
+        let uniform_by_first = ragged.len() * ragged[0].len() * size_of::<f32>();
+
+        assert!(
+            f32_vectors_heap_size(&ragged) > 1_024 * size_of::<f32>(),
+            "the long vector must be charged in full, got {}",
+            f32_vectors_heap_size(&ragged)
+        );
+        assert!(
+            f32_vectors_heap_size(&ragged) > uniform_by_first,
+            "charging every vector the first one's length under-counts a ragged batch"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`max_size` on the SQL results, search results, and embeddings caches is enforced
by a weigher that is handed only the cached *value*, so everything a value
reaches through a pointer was invisible to the budget. `CachedQueryResult::memory_size`
counted `size_of::<Self>()` plus the batches' array bytes and nothing else, which
made `max_size` a bound on *array bytes* rather than on the memory the cache holds.

The sharpest case is a 0-row result: it contributes no array bytes at all, so it
weighed a flat 82 bytes whatever its schema, and the size budget could never
evict one. #12931 measured 12,840 entries staying resident under a 1 MiB budget —
33x under-accounted for a 4-column table, **500x** for a 200-column one, where
~105,000 cached queries is 4 GB of RSS while the cache reads under 1% full.

The same shape was in both sibling implementations, so this fixes the class:

- `CachedSearchResult` counted array bytes, `primary_keys.len() * size_of::<String>()`
  (the pointer triple, never the characters), and `String::len()` inside `matches`.
  An entry that matched nothing counted **zero** bytes.
- `CachedEmbeddingResult` counted only the float payload — and had two further
  defects in the same expression. It charged every vector the **first** one's
  length, which is wrong for a ragged batch; and it sized a base64 embedding with
  `EmbeddingVector::len()`, which decodes the entire string to count floats and
  `expect`s on input it cannot decode — inside a weigher that runs on every insert.

## Changes

- New `crates/cache/src/sizing.rs`: deep-size helpers the three `Sizeable`
  implementations share (`schema_size`, `table_refs_size`, `string_vec_heap_size`,
  `f32_vectors_heap_size`, …), plus `ENTRY_OVERHEAD_BYTES`, a flat allowance for
  the store's own per-entry bookkeeping. The module doc states which imprecisions
  it accepts and why exactness is not what a budget needs — proportionality is.
- `CachedQueryResult::memory_size` now charges the schema, the input-table set,
  the `Arc<Vec<RecordBatch>>` allocation, and the per-entry allowance.
- `CachedSearchResult` charges its map slots, each table name, each aggregation
  result's schema, and the *characters* behind its key and column names.
- `CachedEmbeddingResult` matches `EmbeddingVector` instead of measuring it, and
  charges each vector its own length.

The direction of the correction is up in every realistic case. One arm can now
report *less* than before: a ragged `Vector` batch whose first vector is the
longest was over-counted by `n * first.len()`, and is now charged what it holds.

**Behavior note.** A wide 0-row entry now weighs ~27 KB instead of 82 bytes, so a
deployment that set `max_size` to a few KiB will cache less than it did — the
`actual_size > cache_max_size` skip in `utils.rs` will refuse entries it used to
admit. That is the bound working; the default budget is 128 MiB.

Related: #12932 (the schema copy each entry allocates) is a distinct fix — this PR
makes that copy *visible* to the budget rather than removing it.

## Test plan

- `make lint`
- `make nextest`
- New regression tests, each verified to fail against the pre-fix implementation
  (the old body restored under the new tests, per arm):
  - `an_empty_result_is_billed_more_than_its_struct` / `a_byte_budget_bounds_a_stream_of_empty_results`
    — a 0-row entry costs more than its struct, and scales with schema width; a
    1 MiB budget must not admit thousands of them (pre-fix: 12,786 admissible).
  - `a_search_result_that_matched_nothing_is_still_billed`, `a_wider_search_result_costs_more`,
    `a_long_primary_key_name_is_billed_its_characters` (pre-fix: 0, 0, and 24 bytes).
  - `a_base64_embedding_is_sized_without_decoding_it` (pre-fix: panics inside the
    weigher), `a_ragged_vector_batch_is_charged_per_vector`, `an_empty_response_is_still_billed`.
  - `sizing.rs` unit tests for each helper, including schema metadata and every
    `TableReference` arm.
- The two existing exact-size assertions were rewritten against the new
  composition rather than deleted.

## Review gate

- Adversarial review: **skipped** — `codex` ran and exited 1: "Your workspace is out of credits. Ask your workspace owner to refill in order to continue." `grok` is not installed in this environment (`result=not-installed`), so the receipt records `engine=none exit=1`. Hand-run adversarial angles were done instead and changed the diff twice: each `TableReference` name part is its own `Arc<str>` allocation and was missing its header, and `string_vec_heap_size` was charging the inline `Vec` struct its container already charges. A third angle corrected the module doc, which claimed every imprecision was in the over-counting direction — `len`-based slot counting is not.
- `/security-review`: no findings. Traced the diff's sinks — it adds no I/O, no `unsafe`, no logging, no error text, and no metric label; the only untrusted values it touches (table names, schema strings, embedding payloads) are read for their length and never emitted. It also *removes* a panic path: the base64 arm no longer calls `EmbeddingVector::len()`, which `expect`s inside the weigher.
- `/simplify`: the four parallel cleanup agents stalled in this session and returned no findings (each was killed after ~45 min having emitted only its opening line), so the cleanup pass was run by hand across the same four angles. Reuse: `Fields::size` is called rather than re-walking fields, and `f32_vectors_heap_size` is shared by both vector call sites; arrow exposes no `Schema::size` to reuse. Simplification: the two `impl CachedAggregationResult` blocks were folded into one. Efficiency: verified `get_memory_size` is called only on insert paths (the moka weigher, `PingoraBackend::insert`, and the pre-store size check) and never on a read, so the new O(columns) walk is not on a hot path. Altitude: the per-entry allowance stays in the value rather than moving to the three consumption sites, because moving it would be three places to forget instead of one — the `Sizeable` doc now states the requirement, and the previously-unused `Vec<Vec<f32>>` impl was brought in line with it. Light checks re-run green.

Fixes #12931
