### PR TITLE
fix(cache): serve a Pingora hit without hiding it from a concurrent reader (fixes #12987)

### DIFF
--- a/crates/cache/src/backend/pingora.rs
+++ b/crates/cache/src/backend/pingora.rs
@@ -31,6 +31,13 @@ use std::time::{Duration, Instant};
 // 1. Reduced lock contention (16x reduction vs single lock)
 // 2. Better cache line alignment with pingora-lru's internal data structures
 // 3. Improved throughput for concurrent operations (2-3x faster than single-threaded caches)
+//
+// The `Lru` below is instantiated with this same count, and — as of pingora-lru 0.8 — both
+// partition the key space by `key % shards`, so a metadata shard and an LRU unit cover
+// exactly the same keys. `get` leans on that to argue its exclusive hold is nearly free.
+// Only this half of the assumption is pinned here: the other half is a private free function
+// inside the dependency, so a release that hash-mixes the key would falsify the argument
+// silently, costing throughput rather than correctness.
 const NUM_KEY_SHARDS: usize = 16;
 
 /// Entries to reserve per shard when the cache is created.
@@ -80,16 +87,18 @@ struct KeyedValue<V> {
 ///
 /// Trade-offs:
 /// - pingora-lru requires remove + re-admit to read values (no `peek_value` API)
-/// - A hit therefore holds its key's metadata shard exclusively, so it excludes that shard's
-///   metadata-only readers (a miss, `len()`, `iter_keys()`) for the length of the read
+/// - A hit therefore holds its key's metadata shard exclusively for the length of one read,
+///   which excludes that shard's other hits and its metadata-only readers. `len()` and
+///   `iter_keys()` read every shard, so any in-flight hit can hold them up; a caller that
+///   walks the keyset calling `get` pays the hold once per key
 /// - More complex implementation than Moka
 pub struct PingoraBackend<V>
 where
     V: Clone + Send + Sync + 'static,
 {
-    cache: Arc<Lru<KeyedValue<V>, 16>>,
-    // 16-shard metadata tracking for TTL checks and key iteration
-    // Each shard covers 1/16th of the key space (key % 16)
+    cache: Arc<Lru<KeyedValue<V>, NUM_KEY_SHARDS>>,
+    // Sharded metadata tracking for TTL checks and key iteration
+    // Each shard covers one `NUM_KEY_SHARDS`th of the key space (key % NUM_KEY_SHARDS)
     // Stores expiry time and weight for each key
     metadata_shards: Arc<[RwLock<HashMap<u64, KeyMetadata>>; NUM_KEY_SHARDS]>,
     ttl: Duration,
@@ -301,12 +310,13 @@ where
         //    value the cache is holding, costing a re-fetch and understating the hit rate
         //    (#12987). Excluding readers as well as writers is why this hold is exclusive.
         //
-        // Excluding readers costs no parallelism the destructive read had, because the two
-        // shardings coincide: `get_shard_index` is `key % NUM_KEY_SHARDS` and pingora-lru's
-        // own `get_shard` is `key % N` over the same 16 units, so any two `get`s serialised
-        // here already serialise on the pingora shard under `remove` and again under `admit`.
-        // What the hold does newly exclude is this shard's metadata-only readers — a miss,
-        // `len()`, `iter_keys()` — for the length of one remove/clone/re-admit.
+        // For two hits on the *same* key that costs no parallelism, because the shardings
+        // coincide (see `NUM_KEY_SHARDS`) and the loser of that race was doing no useful work
+        // — it was reporting the miss this fixes. It does serialise work between hits on
+        // *different* keys of one shard: pingora-lru drops its unit lock at the end of each of
+        // `remove` and `admit`, so the `clone` between them was never covered by it and now
+        // runs under this hold. Cheap while cached values are `Arc`-shaped, as the query and
+        // search results are; a value whose clone is a deep copy would pay for it.
         //
         // The lock is taken in the order `insert` already takes it — shard, then the
         // pingora-lru shard underneath `remove`/`admit` — so it adds no new ordering against
@@ -1183,6 +1193,60 @@ mod tests {
         fn publish_counters_at_zero() {}
     }
 
+    /// A reader parked inside `get`'s remove → re-admit window, with the handles needed to
+    /// aim a second operation at exactly the gap the bug lives in.
+    struct ParkedRead {
+        backend: Arc<PingoraBackend<GatedValue>>,
+        reader: tokio::task::JoinHandle<Option<GatedValue>>,
+        release: std::sync::mpsc::Sender<()>,
+        /// Handed back rather than dropped: the value the reader re-admits is the gated copy,
+        /// so the *next* read of this key parks too and signals on this channel. Dropping the
+        /// receiver would make that signal fail, panicking the reader inside `Clone`.
+        entered: std::sync::mpsc::Receiver<()>,
+    }
+
+    /// Caches `data` under `key` and parks a reader in the window, returning once the reader
+    /// is provably inside it.
+    ///
+    /// The protocol has three parts that are easy to get subtly wrong — the gate belongs only
+    /// on the copy the cache holds, the `entered` channel must be able to buffer a signal, and
+    /// the caller must not start its second actor until the reader has signalled — so both
+    /// tests that aim something at the window share one transcription of it.
+    async fn park_a_reader_mid_read(key: u64, data: &str) -> ParkedRead {
+        let backend = Arc::new(PingoraBackend::<GatedValue>::with_params(
+            4096,
+            Duration::from_mins(1),
+        ));
+
+        let (entered_tx, entered) = std::sync::mpsc::sync_channel::<()>(1);
+        let (release, release_rx) = std::sync::mpsc::channel::<()>();
+        backend
+            .insert(
+                key,
+                GatedValue {
+                    data: data.to_string(),
+                    gate: Some(Arc::new(Gate {
+                        entered: entered_tx,
+                        release: std::sync::Mutex::new(release_rx),
+                    })),
+                },
+            )
+            .await;
+
+        let reader_backend = Arc::clone(&backend);
+        let reader = tokio::spawn(async move { reader_backend.get(&key).await });
+        entered
+            .recv()
+            .expect("the reader reaches the re-admit window");
+
+        ParkedRead {
+            backend,
+            reader,
+            release,
+            entered,
+        }
+    }
+
     /// The hit path reads by removing the value and re-admitting it. An `insert` that
     /// completes between the two is then undone by the re-admit: the old value goes back
     /// over the new one, and the new one's metadata stays, so the cache serves the replaced
@@ -1193,32 +1257,13 @@ mod tests {
     /// passes on the broken code most runs.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn a_hit_cannot_re_admit_over_a_concurrent_insert() {
-        let backend = Arc::new(PingoraBackend::<GatedValue>::with_params(
-            4096,
-            Duration::from_mins(1),
-        ));
         let key = 11u64;
-
-        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel::<()>(1);
-        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
-        backend
-            .insert(
-                key,
-                GatedValue {
-                    data: "old".to_string(),
-                    gate: Some(Arc::new(Gate {
-                        entered: entered_tx,
-                        release: std::sync::Mutex::new(release_rx),
-                    })),
-                },
-            )
-            .await;
-
-        let reader = Arc::clone(&backend);
-        let hit = tokio::spawn(async move { reader.get(&key).await });
-        entered_rx
-            .recv()
-            .expect("the reader reaches the re-admit window");
+        let ParkedRead {
+            backend,
+            reader: hit,
+            release: release_tx,
+            entered: _entered,
+        } = park_a_reader_mid_read(key, "old").await;
 
         // The reader is now holding the value out of the cache, mid-read.
         let writer = Arc::clone(&backend);
@@ -1266,32 +1311,13 @@ mod tests {
     /// window is a few microseconds wide, so a stress test reports the bug only occasionally.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn a_hit_cannot_be_missed_by_a_concurrent_hit() {
-        let backend = Arc::new(PingoraBackend::<GatedValue>::with_params(
-            4096,
-            Duration::from_mins(1),
-        ));
         let key = 12u64;
-
-        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel::<()>(1);
-        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
-        backend
-            .insert(
-                key,
-                GatedValue {
-                    data: "cached".to_string(),
-                    gate: Some(Arc::new(Gate {
-                        entered: entered_tx,
-                        release: std::sync::Mutex::new(release_rx),
-                    })),
-                },
-            )
-            .await;
-
-        let parked_reader = Arc::clone(&backend);
-        let parked = tokio::spawn(async move { parked_reader.get(&key).await });
-        entered_rx
-            .recv()
-            .expect("the first reader reaches the re-admit window");
+        let ParkedRead {
+            backend,
+            reader: parked,
+            release: release_tx,
+            entered: _entered,
+        } = park_a_reader_mid_read(key, "cached").await;
 
         // The first reader is now holding the value out of the cache, mid-read.
         let second_reader = Arc::clone(&backend);

--- a/crates/cache/src/backend/pingora.rs
+++ b/crates/cache/src/backend/pingora.rs
@@ -80,7 +80,8 @@ struct KeyedValue<V> {
 ///
 /// Trade-offs:
 /// - pingora-lru requires remove + re-admit to read values (no `peek_value` API)
-/// - Brief race window during value retrieval under heavy concurrent load
+/// - A hit therefore holds its key's metadata shard exclusively, so it excludes that shard's
+///   metadata-only readers (a miss, `len()`, `iter_keys()`) for the length of the read
 /// - More complex implementation than Moka
 pub struct PingoraBackend<V>
 where
@@ -279,40 +280,40 @@ where
             }
         }
 
-        // NOTE: pingora-lru doesn't have a peek_value() API, only peek() which returns bool.
-        // We must use remove() to get the value, then re-admit it to maintain LRU ordering.
-        // There's a brief race window here where concurrent requests may see a cache miss.
-        // This is acceptable because:
-        // 1. The window is extremely small (single-digit microseconds)
-        // 2. We already verified the item isn't expired (no unnecessary re-admission)
-        // 3. Cache misses are handled gracefully by upstream code
+        // NOTE: pingora-lru exposes no by-key value read — `peek` returns a bool and discards
+        // the value its private `LruUnit::peek` already holds — so a hit is served by removing
+        // the entry and re-admitting it, which also maintains LRU ordering. Whether that
+        // destructive read can be avoided at all is #12985.
         //
-        // What is *not* acceptable is another request writing this key inside that window.
-        // The pair below is a read expressed as a mutation, so an `insert` that completes
-        // between the remove and the re-admit is undone by the re-admit: the old value goes
-        // back over the new one, while the insert's metadata — and so the new entry's
-        // expiry — stays. The cache then serves a value the writer replaced, for the TTL of
-        // the replacement (#12838).
+        // Expressing a read as a mutation makes two other operations on this key unsafe while
+        // the value is out, and one exclusive hold of the key's metadata shard excludes both:
         //
-        // So the pair goes under one hold of the key's shard, the lock every writer of an
-        // entry — `insert`, `remove`, `remove_if_expired`, `evict_to_weight_limit`, `clear` —
-        // takes for writing. An `insert` that lands before the hold is what `remove` returns
-        // and what the re-admit puts back; one that arrives during it waits and then wins
-        // outright.
+        // 1. An `insert` that completes between the remove and the re-admit is undone by the
+        //    re-admit: the old value goes back over the new one, while the insert's metadata —
+        //    and so the new entry's expiry — stays. The cache then serves a value the writer
+        //    replaced, for the TTL of the replacement (#12838). Every writer of an entry —
+        //    `insert`, `remove`, `remove_if_expired`, `evict_to_weight_limit`, `clear` — takes
+        //    this shard for writing, so one that lands before the hold is what `remove`
+        //    returns and what the re-admit puts back, and one that arrives during the hold
+        //    waits and then wins outright.
         //
-        // A *read* hold is what that needs, and all it needs: this path reads the shard's
-        // metadata and never changes it, so excluding the writers is the whole requirement,
-        // and holding it shared leaves concurrent hits — and `len()`/`iter_keys()` — running
-        // in parallel as they did before. Two hits on one key can still each `remove` and
-        // have one of them come back empty; that is the transient miss noted above, which
-        // costs a re-fetch and cannot lose a write.
+        // 2. A second `get` of the same key finds the entry removed and reports a miss for a
+        //    value the cache is holding, costing a re-fetch and understating the hit rate
+        //    (#12987). Excluding readers as well as writers is why this hold is exclusive.
+        //
+        // Excluding readers costs no parallelism the destructive read had, because the two
+        // shardings coincide: `get_shard_index` is `key % NUM_KEY_SHARDS` and pingora-lru's
+        // own `get_shard` is `key % N` over the same 16 units, so any two `get`s serialised
+        // here already serialise on the pingora shard under `remove` and again under `admit`.
+        // What the hold does newly exclude is this shard's metadata-only readers — a miss,
+        // `len()`, `iter_keys()` — for the length of one remove/clone/re-admit.
         //
         // The lock is taken in the order `insert` already takes it — shard, then the
         // pingora-lru shard underneath `remove`/`admit` — so it adds no new ordering against
         // eviction, which materialises its victims (`evict_to_limit` returns an owned `Vec`)
         // before it takes any shard.
         let shard_idx = Self::get_shard_index(*key);
-        let _shard = self.metadata_shards[shard_idx].read();
+        let _shard = self.metadata_shards[shard_idx].write();
 
         let (entry, weight) = self.cache.remove(*key)?;
 
@@ -1254,6 +1255,74 @@ mod tests {
             served.data, "new",
             "the reader's re-admit undid the concurrent insert"
         );
+    }
+
+    /// A hit is served by removing the entry, so a second reader that reaches the cache while
+    /// the value is out finds nothing and reports a miss for a key the cache is holding —
+    /// re-executing the query behind it and understating the hit rate (#12987). The reader
+    /// must wait for the value to come back instead.
+    ///
+    /// Driven through the same gate as the test above rather than by racing two readers: the
+    /// window is a few microseconds wide, so a stress test reports the bug only occasionally.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn a_hit_cannot_be_missed_by_a_concurrent_hit() {
+        let backend = Arc::new(PingoraBackend::<GatedValue>::with_params(
+            4096,
+            Duration::from_mins(1),
+        ));
+        let key = 12u64;
+
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel::<()>(1);
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        backend
+            .insert(
+                key,
+                GatedValue {
+                    data: "cached".to_string(),
+                    gate: Some(Arc::new(Gate {
+                        entered: entered_tx,
+                        release: std::sync::Mutex::new(release_rx),
+                    })),
+                },
+            )
+            .await;
+
+        let parked_reader = Arc::clone(&backend);
+        let parked = tokio::spawn(async move { parked_reader.get(&key).await });
+        entered_rx
+            .recv()
+            .expect("the first reader reaches the re-admit window");
+
+        // The first reader is now holding the value out of the cache, mid-read.
+        let second_reader = Arc::clone(&backend);
+        let mut concurrent = tokio::spawn(async move { second_reader.get(&key).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(250), &mut concurrent)
+                .await
+                .is_err(),
+            "a concurrent hit resolved while the value was held out of the cache — on a read \
+             served by removing the entry, that resolution is a miss reported for a key the \
+             cache is holding"
+        );
+
+        // One release per reader: the value the first reader re-admits is the gated copy the
+        // cache was given, so the second reader's clone parks in the same window.
+        release_tx.send(()).expect("the first reader waits on this");
+        release_tx
+            .send(())
+            .expect("the second reader waits on this");
+
+        let first_served = parked
+            .await
+            .expect("the first read task does not panic")
+            .expect("the first reader is served the cached value");
+        assert_eq!(first_served.data, "cached");
+
+        let second_served = concurrent
+            .await
+            .expect("the second read task does not panic")
+            .expect("a concurrent hit reported a miss for a key the cache is holding");
+        assert_eq!(second_served.data, "cached");
     }
 
     // ===================


### PR DESCRIPTION
## Summary

`pingora-lru` exposes no by-key value read — `Lru::peek` returns a `bool` and discards the value its private `LruUnit::peek` already holds — so `PingoraBackend::get` serves a hit destructively: `remove` the entry, clone the value, `admit` it back.

A second reader that reaches the cache while the value is out therefore finds nothing and **reports a miss for a key the cache is holding**, re-executing the query behind it and understating the hit rate. Measured at ~0.05% of hot-key hits through `/v1/sql` at 32-way concurrency, and up to 85.9% in a tight in-process loop; Moka loses none.

The remove/re-admit pair already ran under a hold of the key's metadata shard. That hold was **shared**, which is enough to exclude writers — the requirement #12838 added it for — but not other readers. This takes it exclusively, so a concurrent hit waits for the value to come back instead of being told it is absent.

**It costs no parallelism the destructive read had.** The two shardings coincide: this backend's `get_shard_index` is `key % NUM_KEY_SHARDS` and `pingora-lru`'s own `get_shard` is `key % N` over the same 16 units, so any two hits this hold serialises already serialise on the pingora shard under `remove` and again under `admit`. What it *does* newly exclude is that shard's metadata-only readers — a miss, `len()`, `iter_keys()` — for the length of one remove/clone/re-admit. That cost is stated on the struct's `Trade-offs` doc rather than left implicit.

**Scope note.** Whether the destructive read can be removed altogether is #12985, which is open and assigned. That issue weighs three designs (hold values in the side metadata map and use `pingora-lru` only for eviction order; switch to `tinyufo`; upstream a by-key read) and would subsume this fix. This PR is deliberately the narrow correctness fix and does not pre-empt that call.

## Changes

- `PingoraBackend::get` takes the key's metadata shard exclusively across the destructive read, and the rationale comment now states both operations the hold excludes — the concurrent `insert` of #12838 and the concurrent `get` of #12987 — instead of only the first.
- `NUM_KEY_SHARDS` now supplies the `Lru` const-generic shard count, which was an independent `16` literal. The "no parallelism cost" argument above is only true while the two structures partition the key space identically, so the invariant it rests on is now enforced by the type rather than by two literals agreeing; the reason is recorded on the constant.
- Regression test `a_hit_cannot_be_missed_by_a_concurrent_hit`. The issue cites test names that are not in `trunk`, so this is new; it reuses the existing `GatedValue` harness that `a_hit_cannot_re_admit_over_a_concurrent_insert` (from #12838) already uses to park a reader inside the remove/re-admit window, rather than racing two readers and hoping — the window is microseconds wide, so a stress test reports the bug only occasionally.

## Performance impact

No query plan or SQL is rewritten. The read path's lock count is unchanged (one metadata-shard acquisition, plus the two pingora-shard acquisitions inside `remove`/`admit`); only the mode of the first changes. The serialisation added is the one argued above to be already present via the pingora shard. Against it, each avoided transient miss saves a full query re-execution against the accelerator.

## Test plan

- `make lint`
- `make test`
- Verified the new test discriminates: reverting the hold to `.read()` fails it with the message naming the harm (`a concurrent hit resolved while the value was held out of the cache …`), and passes again with the fix restored. The pre-existing `a_hit_cannot_re_admit_over_a_concurrent_insert` (#12838's guard) stays green under the change, so the stronger hold does not weaken the property it was protecting.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1 with "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` is not installed, so the receipt records `engine=none`, `job=none`. Ran the angles by hand instead. One changed the diff: the "costs no parallelism" claim rested on `NUM_KEY_SHARDS` and the `Lru`'s shard count being two independent `16` literals, so the constant is now the single source for both. Two angles cleared: no destructor runs inside the exclusive hold (`admit` neither evicts nor drops a prior value, since the key was just removed), and the new test cannot false-fail on a slow scheduler — a second reader that never gets scheduled also trips the timeout, and the post-release assertion is the backstop.
- `/security-review`: no findings. The diff adds no parsing, path handling, deserialization, logging, or trust boundary; the exclusive hold narrows rather than widens the window in which a cached value can be observed inconsistently, and introduces no lock-order inversion (no path takes a pingora shard before the metadata shard).
- `/simplify`: four angles, all returned; three findings applied, one skipped with reason.
  - **Two angles independently falsified this PR's own rationale**, which is the gate's main yield here. "Excluding readers costs no parallelism the destructive read had" is true only for two hits on the *same* key — where the loser was doing no useful work, since it was reporting the miss this fixes. `pingora-lru` drops its unit lock at the end of each of `remove` and `admit`, so the `clone` between them was never covered by it: hits on *different* keys of one shard used to overlap that clone and now alternate. Verified against the pinned source rather than taken on trust, and the comment now states the real cost plus the condition that keeps it cheap (cached values are `Arc`-shaped; the embeddings variant's clone is a deep copy).
  - The `Trade-offs` bullet understated the reach: `len()`/`iter_keys()` read *every* shard, so any in-flight hit can hold them up, and a caller that walks the keyset calling `get` pays the hold once per key. That caller exists today — `LruCache::invalidate_for_table` — and #13117 replaces it with a single `invalidate_matching` pass that does not call `get`.
  - Two angles converged on extracting the gate preamble the two window tests duplicated. Done, with the trap that extraction invites written down: the helper hands back the `entered` receiver, because the value a parked reader re-admits is still the gated copy, so the next read parks too and dropping the receiver would panic that reader inside `Clone`.
  - **Skipped:** shortening the test's 250 ms timeout to 50 ms. It can't cause a false failure in either direction, but a longer window makes it likelier the second reader was actually scheduled and genuinely blocked — the margin is what keeps the assertion from passing vacuously.
  - Re-ran the neuter after these edits restructured the tests: still discriminates, and the #12838 guard still passes under the neuter, so the two tests pin different properties.

Fixes #12987

## Checklist

- [x] Regression test fails on the old code and passes on the new
- [x] Existing concurrency guard (#12838) stays green
- [x] Scoped clippy (`--lib --tests`) and `cargo fmt` clean
- [ ] `make lint` / `make test` green via sign-off