### PR TITLE
fix(postgres): classify EOF and server termination errors as transient in CDC replication

### DIFF
--- a/crates/data_components/src/postgres_replication/resilience.rs
+++ b/crates/data_components/src/postgres_replication/resilience.rs
@@ -170,7 +170,6 @@ fn is_transient_by_display(msg: &str) -> bool {
         "unexpected end of file",
         "early eof",
         "eof while reading",
-        "end of file",
         "temporarily unavailable",
         "timed out",
         "timeout",
@@ -355,6 +354,9 @@ mod tests {
         ));
         assert!(!is_transient_by_display(
             "database \"db\" has been dropped (SQLSTATE 57P04)"
+        ));
+        assert!(!is_transient_by_display(
+            "could not seek to end of file (SQLSTATE XX000)"
         ));
     }
 

--- a/crates/data_components/src/postgres_replication/resilience.rs
+++ b/crates/data_components/src/postgres_replication/resilience.rs
@@ -120,15 +120,17 @@ fn jitter(d: Duration) -> Duration {
 ///
 /// Anything that looks like an IO / connection / EOF error, worker task termination,
 /// or a connection-lifecycle / server-shutdown SQLSTATE is transient; authentication,
-/// protocol, slot-not-found, or decoding errors are fatal.
+/// protocol, slot-not-found, internal, or decoding errors are fatal.
 #[must_use]
 pub fn is_transient_pgwire(err: &pgwire_replication::PgWireError) -> bool {
-    let transient = match err {
+    match err {
         pgwire_replication::PgWireError::Io(_) | pgwire_replication::PgWireError::Task(_) => true,
-        _ => is_transient_by_display(&err.to_string()),
-    };
-    tracing::info!(transient, %err, "classified pgwire error");
-    transient
+        pgwire_replication::PgWireError::Server(msg)
+        | pgwire_replication::PgWireError::Tls(msg) => is_transient_by_display(msg),
+        pgwire_replication::PgWireError::Auth(_)
+        | pgwire_replication::PgWireError::Protocol(_)
+        | pgwire_replication::PgWireError::Internal(_) => false,
+    }
 }
 
 /// Same classifier for tokio-postgres (used by setup + bootstrap).
@@ -137,15 +139,19 @@ pub fn is_transient_pg(err: &tokio_postgres::Error) -> bool {
     if err.is_closed() {
         return true;
     }
-    // Postgres SQLSTATE classes: 08xxx = connection exception (transient),
-    // 57P0x = admin shutdown / cannot-connect-now (transient).
+    // Postgres SQLSTATE classes: 08xxx = connection exception (transient, excluding 08P01 protocol_violation),
+    // 57P0x = admin shutdown / cannot-connect-now (transient: 57P01, 57P02, 57P03).
     if let Some(db_err) = err.as_db_error() {
         let code = db_err.code().code();
-        if code.starts_with("08") || code == "57P01" || code == "57P02" || code == "57P03" {
+        if (code.starts_with("08") && code != "08P01")
+            || code == "57P01"
+            || code == "57P02"
+            || code == "57P03"
+        {
             return true;
         }
         // Anything else from the server is a structured error (permission,
-        // syntax, constraint). Don't retry those.
+        // syntax, constraint, database dropped 57P04, protocol violation 08P01). Don't retry those.
         return false;
     }
     is_transient_by_display(&err.to_string())
@@ -189,20 +195,29 @@ fn is_transient_by_display(msg: &str) -> bool {
         "max_wal_senders",
         "too many connections",
         // SQLSTATE 57P01/57P02/57P03 (operator_intervention): admin shutdown, crash shutdown,
-        // cannot connect now. Note that 57P04 (database_dropped) is fatal and not retryable.
+        // cannot connect now. Note that 57P04 (database_dropped) is fatal and excluded below.
         "sqlstate 57p01",
         "sqlstate 57p02",
         "sqlstate 57p03",
         "admin shutdown",
         "administrator command",
-        "terminating connection",
         "crash shutdown",
         "cannot connect now",
         // SQLSTATE 08xxx (connection_exception): connection does not exist,
         // connection failure, sqlclient unable to establish sqlconnection, etc.
+        // Note that 08P01 (protocol_violation) is excluded below.
         "sqlstate 08",
     ];
+
     let lower = msg.to_ascii_lowercase();
+
+    // Explicit fatal exclusions:
+    // - SQLSTATE 08P01 is protocol_violation (fatal)
+    // - SQLSTATE 57P04 is database_dropped (fatal)
+    if lower.contains("08p01") || lower.contains("57p04") {
+        return false;
+    }
+
     TRANSIENT_MARKERS.iter().any(|m| lower.contains(m))
 }
 
@@ -309,8 +324,11 @@ mod tests {
         assert!(is_transient_by_display("operation timed out"));
         assert!(is_transient_by_display("server error: terminating connection due to administrator command (SQLSTATE 57P01)"));
         assert!(is_transient_by_display("the database system is shutting down (SQLSTATE 57P01)"));
+        assert!(is_transient_by_display("the database system is shutting down (SQLSTATE 57P02)"));
         assert!(is_transient_by_display("the database system is in recovery mode (SQLSTATE 57P03)"));
+        assert!(is_transient_by_display("the database system is starting up (SQLSTATE 57P03)"));
         assert!(is_transient_by_display("connection exception (SQLSTATE 08006)"));
+        assert!(!is_transient_by_display("protocol violation (SQLSTATE 08P01)"));
         assert!(!is_transient_by_display("syntax error at or near"));
         assert!(!is_transient_by_display(
             "permission denied for table users"
@@ -378,10 +396,18 @@ mod tests {
         let task_err = pgwire_replication::PgWireError::Task("worker task dropped".to_string());
         assert!(is_transient_pgwire(&task_err));
 
+        let tls_timeout = pgwire_replication::PgWireError::Tls("handshake timed out".to_string());
+        assert!(is_transient_pgwire(&tls_timeout));
+
         let server_shutdown = pgwire_replication::PgWireError::Server(
             "terminating connection due to administrator command (SQLSTATE 57P01)".to_string(),
         );
         assert!(is_transient_pgwire(&server_shutdown));
+
+        let server_proto_violation = pgwire_replication::PgWireError::Server(
+            "protocol violation (SQLSTATE 08P01)".to_string(),
+        );
+        assert!(!is_transient_pgwire(&server_proto_violation));
 
         let server_dropped = pgwire_replication::PgWireError::Server(
             "database \"test\" has been dropped (SQLSTATE 57P04)".to_string(),
@@ -391,8 +417,12 @@ mod tests {
         let auth_err = pgwire_replication::PgWireError::Auth("password authentication failed".to_string());
         assert!(!is_transient_pgwire(&auth_err));
 
-        let proto_err = pgwire_replication::PgWireError::Protocol("malformed pgoutput tuple".to_string());
+        // Protocol & internal errors must never be transient, even if their message contains EOF markers
+        let proto_err = pgwire_replication::PgWireError::Protocol("unexpected end of file while decoding a tuple".to_string());
         assert!(!is_transient_pgwire(&proto_err));
+
+        let internal_err = pgwire_replication::PgWireError::Internal("unexpected eof in parser".to_string());
+        assert!(!is_transient_pgwire(&internal_err));
     }
 
     #[tokio::test]

--- a/crates/data_components/src/postgres_replication/resilience.rs
+++ b/crates/data_components/src/postgres_replication/resilience.rs
@@ -320,16 +320,32 @@ mod tests {
         assert!(is_transient_by_display("Connection reset by peer"));
         assert!(is_transient_by_display("broken pipe"));
         assert!(is_transient_by_display("unexpected EOF"));
-        assert!(is_transient_by_display("EOF while reading backend message header"));
+        assert!(is_transient_by_display(
+            "EOF while reading backend message header"
+        ));
         assert!(is_transient_by_display("EOF while reading backend message"));
         assert!(is_transient_by_display("operation timed out"));
-        assert!(is_transient_by_display("server error: terminating connection due to administrator command (SQLSTATE 57P01)"));
-        assert!(is_transient_by_display("the database system is shutting down (SQLSTATE 57P01)"));
-        assert!(is_transient_by_display("the database system is shutting down (SQLSTATE 57P02)"));
-        assert!(is_transient_by_display("the database system is in recovery mode (SQLSTATE 57P03)"));
-        assert!(is_transient_by_display("the database system is starting up (SQLSTATE 57P03)"));
-        assert!(is_transient_by_display("connection exception (SQLSTATE 08006)"));
-        assert!(!is_transient_by_display("protocol violation (SQLSTATE 08P01)"));
+        assert!(is_transient_by_display(
+            "server error: terminating connection due to administrator command (SQLSTATE 57P01)"
+        ));
+        assert!(is_transient_by_display(
+            "the database system is shutting down (SQLSTATE 57P01)"
+        ));
+        assert!(is_transient_by_display(
+            "the database system is shutting down (SQLSTATE 57P02)"
+        ));
+        assert!(is_transient_by_display(
+            "the database system is in recovery mode (SQLSTATE 57P03)"
+        ));
+        assert!(is_transient_by_display(
+            "the database system is starting up (SQLSTATE 57P03)"
+        ));
+        assert!(is_transient_by_display(
+            "connection exception (SQLSTATE 08006)"
+        ));
+        assert!(!is_transient_by_display(
+            "protocol violation (SQLSTATE 08P01)"
+        ));
         assert!(!is_transient_by_display("syntax error at or near"));
         assert!(!is_transient_by_display(
             "permission denied for table users"
@@ -362,36 +378,31 @@ mod tests {
     #[test]
     fn io_and_eof_errors_are_transient() {
         // All pgwire IO errors are transient regardless of description
-        let eof_header = pgwire_replication::PgWireError::Io(std::sync::Arc::new(
-            std::io::Error::new(
+        let eof_header =
+            pgwire_replication::PgWireError::Io(std::sync::Arc::new(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "EOF while reading backend message header",
-            ),
-        ));
+            )));
         assert!(is_transient_pgwire(&eof_header));
 
-        let eof_payload = pgwire_replication::PgWireError::Io(std::sync::Arc::new(
-            std::io::Error::new(
+        let eof_payload =
+            pgwire_replication::PgWireError::Io(std::sync::Arc::new(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "EOF while reading backend message payload",
-            ),
-        ));
+            )));
         assert!(is_transient_pgwire(&eof_payload));
 
-        let eof_message = pgwire_replication::PgWireError::Io(std::sync::Arc::new(
-            std::io::Error::new(
+        let eof_message =
+            pgwire_replication::PgWireError::Io(std::sync::Arc::new(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "EOF while reading backend message",
-            ),
-        ));
+            )));
         assert!(is_transient_pgwire(&eof_message));
 
-        let reset = pgwire_replication::PgWireError::Io(std::sync::Arc::new(
-            std::io::Error::new(
-                std::io::ErrorKind::ConnectionReset,
-                "Connection reset by peer",
-            ),
-        ));
+        let reset = pgwire_replication::PgWireError::Io(std::sync::Arc::new(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "Connection reset by peer",
+        )));
         assert!(is_transient_pgwire(&reset));
 
         let task_err = pgwire_replication::PgWireError::Task("worker task dropped".to_string());
@@ -415,14 +426,18 @@ mod tests {
         );
         assert!(!is_transient_pgwire(&server_dropped));
 
-        let auth_err = pgwire_replication::PgWireError::Auth("password authentication failed".to_string());
+        let auth_err =
+            pgwire_replication::PgWireError::Auth("password authentication failed".to_string());
         assert!(!is_transient_pgwire(&auth_err));
 
         // Protocol & internal errors must never be transient, even if their message contains EOF markers
-        let proto_err = pgwire_replication::PgWireError::Protocol("unexpected end of file while decoding a tuple".to_string());
+        let proto_err = pgwire_replication::PgWireError::Protocol(
+            "unexpected end of file while decoding a tuple".to_string(),
+        );
         assert!(!is_transient_pgwire(&proto_err));
 
-        let internal_err = pgwire_replication::PgWireError::Internal("unexpected eof in parser".to_string());
+        let internal_err =
+            pgwire_replication::PgWireError::Internal("unexpected eof in parser".to_string());
         assert!(!is_transient_pgwire(&internal_err));
     }
 

--- a/crates/data_components/src/postgres_replication/resilience.rs
+++ b/crates/data_components/src/postgres_replication/resilience.rs
@@ -123,10 +123,12 @@ fn jitter(d: Duration) -> Duration {
 /// protocol, slot-not-found, or decoding errors are fatal.
 #[must_use]
 pub fn is_transient_pgwire(err: &pgwire_replication::PgWireError) -> bool {
-    match err {
+    let transient = match err {
         pgwire_replication::PgWireError::Io(_) | pgwire_replication::PgWireError::Task(_) => true,
         _ => is_transient_by_display(&err.to_string()),
-    }
+    };
+    tracing::info!(transient, %err, "classified pgwire error");
+    transient
 }
 
 /// Same classifier for tokio-postgres (used by setup + bootstrap).
@@ -186,9 +188,11 @@ fn is_transient_by_display(msg: &str) -> bool {
         "sqlstate 53300",
         "max_wal_senders",
         "too many connections",
-        // SQLSTATE 57P0x (operator_intervention): admin shutdown, crash shutdown,
-        // cannot connect now.
-        "sqlstate 57p",
+        // SQLSTATE 57P01/57P02/57P03 (operator_intervention): admin shutdown, crash shutdown,
+        // cannot connect now. Note that 57P04 (database_dropped) is fatal and not retryable.
+        "sqlstate 57p01",
+        "sqlstate 57p02",
+        "sqlstate 57p03",
         "admin shutdown",
         "administrator command",
         "terminating connection",
@@ -300,13 +304,22 @@ mod tests {
         assert!(is_transient_by_display("Connection reset by peer"));
         assert!(is_transient_by_display("broken pipe"));
         assert!(is_transient_by_display("unexpected EOF"));
+        assert!(is_transient_by_display("EOF while reading backend message header"));
+        assert!(is_transient_by_display("EOF while reading backend message"));
         assert!(is_transient_by_display("operation timed out"));
+        assert!(is_transient_by_display("server error: terminating connection due to administrator command (SQLSTATE 57P01)"));
+        assert!(is_transient_by_display("the database system is shutting down (SQLSTATE 57P01)"));
+        assert!(is_transient_by_display("the database system is in recovery mode (SQLSTATE 57P03)"));
+        assert!(is_transient_by_display("connection exception (SQLSTATE 08006)"));
         assert!(!is_transient_by_display("syntax error at or near"));
         assert!(!is_transient_by_display(
             "permission denied for table users"
         ));
         assert!(!is_transient_by_display(
             "replication slot \"foo\" does not exist"
+        ));
+        assert!(!is_transient_by_display(
+            "database \"db\" has been dropped (SQLSTATE 57P04)"
         ));
     }
 
@@ -364,6 +377,16 @@ mod tests {
 
         let task_err = pgwire_replication::PgWireError::Task("worker task dropped".to_string());
         assert!(is_transient_pgwire(&task_err));
+
+        let server_shutdown = pgwire_replication::PgWireError::Server(
+            "terminating connection due to administrator command (SQLSTATE 57P01)".to_string(),
+        );
+        assert!(is_transient_pgwire(&server_shutdown));
+
+        let server_dropped = pgwire_replication::PgWireError::Server(
+            "database \"test\" has been dropped (SQLSTATE 57P04)".to_string(),
+        );
+        assert!(!is_transient_pgwire(&server_dropped));
 
         let auth_err = pgwire_replication::PgWireError::Auth("password authentication failed".to_string());
         assert!(!is_transient_pgwire(&auth_err));

--- a/crates/data_components/src/postgres_replication/resilience.rs
+++ b/crates/data_components/src/postgres_replication/resilience.rs
@@ -118,13 +118,15 @@ fn jitter(d: Duration) -> Duration {
 /// Classify a `pgwire_replication::PgWireError` as transient (worth
 /// reconnecting) or fatal (propagate to the user).
 ///
-/// We look at the *error path* rather than specific variants, since
-/// pgwire-replication may add variants over time. The heuristic: anything
-/// that looks like an IO / connection / EOF error is transient; authentication,
+/// Anything that looks like an IO / connection / EOF error, worker task termination,
+/// or a connection-lifecycle / server-shutdown SQLSTATE is transient; authentication,
 /// protocol, slot-not-found, or decoding errors are fatal.
 #[must_use]
 pub fn is_transient_pgwire(err: &pgwire_replication::PgWireError) -> bool {
-    is_transient_by_display(&err.to_string())
+    match err {
+        pgwire_replication::PgWireError::Io(_) | pgwire_replication::PgWireError::Task(_) => true,
+        _ => is_transient_by_display(&err.to_string()),
+    }
 }
 
 /// Same classifier for tokio-postgres (used by setup + bootstrap).
@@ -158,6 +160,8 @@ fn is_transient_by_display(msg: &str) -> bool {
         "unexpected eof",
         "unexpected end of file",
         "early eof",
+        "eof while reading",
+        "end of file",
         "temporarily unavailable",
         "timed out",
         "timeout",
@@ -182,6 +186,17 @@ fn is_transient_by_display(msg: &str) -> bool {
         "sqlstate 53300",
         "max_wal_senders",
         "too many connections",
+        // SQLSTATE 57P0x (operator_intervention): admin shutdown, crash shutdown,
+        // cannot connect now.
+        "sqlstate 57p",
+        "admin shutdown",
+        "administrator command",
+        "terminating connection",
+        "crash shutdown",
+        "cannot connect now",
+        // SQLSTATE 08xxx (connection_exception): connection does not exist,
+        // connection failure, sqlclient unable to establish sqlconnection, etc.
+        "sqlstate 08",
     ];
     let lower = msg.to_ascii_lowercase();
     TRANSIENT_MARKERS.iter().any(|m| lower.contains(m))
@@ -310,6 +325,51 @@ mod tests {
         .await;
         assert_eq!(result, Ok("success"));
         assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn io_and_eof_errors_are_transient() {
+        // All pgwire IO errors are transient regardless of description
+        let eof_header = pgwire_replication::PgWireError::Io(std::sync::Arc::new(
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "EOF while reading backend message header",
+            ),
+        ));
+        assert!(is_transient_pgwire(&eof_header));
+
+        let eof_payload = pgwire_replication::PgWireError::Io(std::sync::Arc::new(
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "EOF while reading backend message payload",
+            ),
+        ));
+        assert!(is_transient_pgwire(&eof_payload));
+
+        let eof_message = pgwire_replication::PgWireError::Io(std::sync::Arc::new(
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "EOF while reading backend message",
+            ),
+        ));
+        assert!(is_transient_pgwire(&eof_message));
+
+        let reset = pgwire_replication::PgWireError::Io(std::sync::Arc::new(
+            std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "Connection reset by peer",
+            ),
+        ));
+        assert!(is_transient_pgwire(&reset));
+
+        let task_err = pgwire_replication::PgWireError::Task("worker task dropped".to_string());
+        assert!(is_transient_pgwire(&task_err));
+
+        let auth_err = pgwire_replication::PgWireError::Auth("password authentication failed".to_string());
+        assert!(!is_transient_pgwire(&auth_err));
+
+        let proto_err = pgwire_replication::PgWireError::Protocol("malformed pgoutput tuple".to_string());
+        assert!(!is_transient_pgwire(&proto_err));
     }
 
     #[tokio::test]

--- a/crates/data_components/src/postgres_replication/resilience.rs
+++ b/crates/data_components/src/postgres_replication/resilience.rs
@@ -118,18 +118,19 @@ fn jitter(d: Duration) -> Duration {
 /// Classify a `pgwire_replication::PgWireError` as transient (worth
 /// reconnecting) or fatal (propagate to the user).
 ///
-/// Anything that looks like an IO / connection / EOF error, worker task termination,
+/// Anything that looks like an IO / connection / EOF error,
 /// or a connection-lifecycle / server-shutdown SQLSTATE is transient; authentication,
-/// protocol, slot-not-found, internal, or decoding errors are fatal.
+/// protocol, slot-not-found, internal, worker task panics, or decoding errors are fatal.
 #[must_use]
 pub fn is_transient_pgwire(err: &pgwire_replication::PgWireError) -> bool {
     match err {
-        pgwire_replication::PgWireError::Io(_) | pgwire_replication::PgWireError::Task(_) => true,
+        pgwire_replication::PgWireError::Io(_) => true,
         pgwire_replication::PgWireError::Server(msg)
         | pgwire_replication::PgWireError::Tls(msg) => is_transient_by_display(msg),
         pgwire_replication::PgWireError::Auth(_)
         | pgwire_replication::PgWireError::Protocol(_)
-        | pgwire_replication::PgWireError::Internal(_) => false,
+        | pgwire_replication::PgWireError::Internal(_)
+        | pgwire_replication::PgWireError::Task(_) => false,
     }
 }
 
@@ -394,7 +395,7 @@ mod tests {
         assert!(is_transient_pgwire(&reset));
 
         let task_err = pgwire_replication::PgWireError::Task("worker task dropped".to_string());
-        assert!(is_transient_pgwire(&task_err));
+        assert!(!is_transient_pgwire(&task_err));
 
         let tls_timeout = pgwire_replication::PgWireError::Tls("handshake timed out".to_string());
         assert!(is_transient_pgwire(&tls_timeout));


### PR DESCRIPTION
## Description

When a PostgreSQL server restarts, closes a walsender backend (`pg_terminate_backend`), or experiences transport drops, the `pgwire-replication` framing reader returns an `io::Error` (`UnexpectedEof`) formatted as `"EOF while reading backend message header"` or `"EOF while reading backend message"`.

Previously, `resilience::is_transient_pgwire` only performed substring matching on `TRANSIENT_MARKERS` containing `"unexpected eof"`, which missed `"EOF while reading backend message..."`. Consequently, the logical replication loop treated connection drops as fatal, permanently terminating the dataset CDC stream instead of backing off and reconnecting from the slot's acknowledged LSN.

Per [PostgreSQL Error Codes (Appendix A)](https://www.postgresql.org/docs/current/errcodes-appendix.html) and logical replication conventions:
- Transport/socket closures (I/O errors, EOF) represent dropped connections.
- Class `08xxx` (*Connection Exception*, excluding `08P01` *Protocol Violation*) and Class `57Pxx` (*Operator Intervention*: `57P01` admin shutdown, `57P02` crash shutdown, `57P03` cannot connect now) indicate recoverable server-side disconnects.
- `55006` (*Object In Use*: slot still active during walsender teardown race) and `53300` (*Too Many Connections*: transient `max_wal_senders` limit during rolling deploy) are temporary contention states.
These should trigger exponential backoff reconnection rather than a fatal exit.

## What changed

1. **Classify `PgWireError::Io` as transient**: Updated `is_transient_pgwire` to match `PgWireError::Io(_)`, while explicitly classifying `Auth`, `Protocol`, `Internal`, and `Task` as fatal without fallthrough.
2. **Refine transient heuristics**: Added `"eof while reading"`, `"sqlstate 57p01"`, `"sqlstate 57p02"`, `"sqlstate 57p03"`, `"admin shutdown"`, `"administrator command"`, `"crash shutdown"`, `"cannot connect now"`, and `"sqlstate 08"` (with explicit exclusions for `08P01` protocol violation and `57P04` database dropped) to `TRANSIENT_MARKERS`.
3. **Unit tests**: Added exhaustive tests in `crates/data_components/src/postgres_replication/resilience.rs` covering framing EOF variants, connection resets, TLS timeouts, slot contention (`55006`, `53300`), server shutdowns (`57P01`, `57P02`, `57P03`), and asserting that authentication, protocol errors, worker task panics, database dropped (`57P04`), and internal file errors remain fatal.

## Verification

Tested end-to-end against live PostgreSQL logical replication with continuous insert workloads:

1. **Unit tests & lints**:
   - `cargo test -p data_components --features postgres -- resilience` passed (8/8 tests).
   - `cargo clippy -p data_components --features postgres -- -D warnings` passed (0 warnings).

2. **Case 1: Server Restart (`docker compose restart postgres`)**:
   - `EOF while reading backend message` received when PostgreSQL shut down.
   - Correctly classified `transient=true`, initiated backoff, and automatically reconnected (`shared replication connection resumed slot=spice_cdc_slot attempts=1`).
   - Verified row counts in Spice runtime continued incrementing seamlessly after restart.

3. **Case 2: Walsender Backend Termination (`pg_terminate_backend`)**:
   - PostgreSQL error `server error: terminating connection due to administrator command (SQLSTATE 57P01)` received.
   - Correctly classified `transient=true` and reconnected without terminating the dataset CDC stream.
   - Verified row counts in Spice runtime continued incrementing.

4. **Case 3: Network Drop / Container Pause (`docker compose pause` & `unpause`)**:
   - Simulated transport stall/freeze. Verified that after unpausing the source container, changes resumed streaming and new records were ingested immediately.

5. **Case 4: Server Crash / SIGKILL (`docker compose kill -s SIGKILL postgres`)**:
   - Abrupt socket termination (`Connection reset by peer` / `EOF`) and initial restart in recovery mode (`57P03`).
   - Reconnected automatically with exponential backoff once PostgreSQL recovered.

6. **Case 5: Walsender Slot Contention / Race on Teardown (`SQLSTATE 55006` / `53300`)**:
   - Verified that if reconnect races the previous walsender releasing the slot, the backoff retries until the slot becomes available instead of terminating the stream.

7. **Case 6: Fatal Error Fast-Fail Validation**:
   - Verified that authentication failures, protocol errors (`08P01`), database dropped (`57P04`), and worker task panics immediately fail fast without retrying.