### PR TITLE
Declare the CPU entitlement to Vortex at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22706,7 +22706,7 @@ dependencies = [
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "vortex-alp",
  "vortex-array",
@@ -22741,7 +22741,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -22759,7 +22759,7 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "arc-swap",
  "arcref",
@@ -22806,7 +22806,7 @@ dependencies = [
 [[package]]
 name = "vortex-array-macros"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -22816,7 +22816,7 @@ dependencies = [
 [[package]]
 name = "vortex-arrow"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -22838,7 +22838,7 @@ dependencies = [
 [[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "itertools 0.14.0",
  "pco",
@@ -22864,7 +22864,7 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "arrow-buffer",
  "bitvec",
@@ -22877,7 +22877,7 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "num-traits",
  "vortex-array",
@@ -22889,7 +22889,7 @@ dependencies = [
 [[package]]
 name = "vortex-compressor"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -22907,7 +22907,7 @@ dependencies = [
 [[package]]
 name = "vortex-compute"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "vortex-buffer",
 ]
@@ -22959,7 +22959,7 @@ dependencies = [
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "num-traits",
  "prost",
@@ -22973,7 +22973,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "num-traits",
  "prost",
@@ -22987,7 +22987,7 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -23000,7 +23000,7 @@ dependencies = [
 [[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "fastlanes",
  "itertools 0.14.0",
@@ -23017,7 +23017,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -23061,7 +23061,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -23071,7 +23071,7 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "fsst-rs",
  "num-traits",
@@ -23086,7 +23086,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "async-fs",
  "async-stream",
@@ -23116,7 +23116,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -23133,7 +23133,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "arcref",
  "arrow-array",
@@ -23176,7 +23176,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer",
@@ -23186,7 +23186,7 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "parking_lot",
  "sketches-ddsketch",
@@ -23195,7 +23195,7 @@ dependencies = [
 [[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "pco",
  "prost",
@@ -23209,7 +23209,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "prost",
  "prost-types",
@@ -23218,7 +23218,7 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -23233,7 +23233,7 @@ dependencies = [
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "async-trait",
  "futures",
@@ -23249,7 +23249,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "num-traits",
  "prost",
@@ -23265,7 +23265,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "arc-swap",
  "lasso",
@@ -23277,7 +23277,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -23292,7 +23292,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "dashmap",
  "hashbrown 0.17.1",
@@ -23301,7 +23301,7 @@ dependencies = [
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "vortex-array",
  "vortex-buffer",
@@ -23314,7 +23314,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
+source = "git+https://github.com/spiceai/vortex.git?rev=633c1dc4ad0d4a5b38f291a391da08519068519a#633c1dc4ad0d4a5b38f291a391da08519068519a"
 dependencies = [
  "itertools 0.14.0",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19527,6 +19527,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "util",
+ "vortex-utils",
  "yaml",
 ]
 
@@ -22645,7 +22646,7 @@ dependencies = [
 [[package]]
 name = "vortex"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "vortex-alp",
  "vortex-array",
@@ -22680,7 +22681,7 @@ dependencies = [
 [[package]]
 name = "vortex-alp"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -22698,7 +22699,7 @@ dependencies = [
 [[package]]
 name = "vortex-array"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "arc-swap",
  "arcref",
@@ -22745,7 +22746,7 @@ dependencies = [
 [[package]]
 name = "vortex-array-macros"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -22755,7 +22756,7 @@ dependencies = [
 [[package]]
 name = "vortex-arrow"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -22777,7 +22778,7 @@ dependencies = [
 [[package]]
 name = "vortex-btrblocks"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "itertools 0.14.0",
  "pco",
@@ -22803,7 +22804,7 @@ dependencies = [
 [[package]]
 name = "vortex-buffer"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "arrow-buffer",
  "bitvec",
@@ -22816,7 +22817,7 @@ dependencies = [
 [[package]]
 name = "vortex-bytebool"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "num-traits",
  "vortex-array",
@@ -22828,7 +22829,7 @@ dependencies = [
 [[package]]
 name = "vortex-compressor"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -22846,7 +22847,7 @@ dependencies = [
 [[package]]
 name = "vortex-compute"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "vortex-buffer",
 ]
@@ -22898,7 +22899,7 @@ dependencies = [
 [[package]]
 name = "vortex-datetime-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "num-traits",
  "prost",
@@ -22912,7 +22913,7 @@ dependencies = [
 [[package]]
 name = "vortex-decimal-byte-parts"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "num-traits",
  "prost",
@@ -22926,7 +22927,7 @@ dependencies = [
 [[package]]
 name = "vortex-error"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "arrow-schema",
  "flatbuffers",
@@ -22939,7 +22940,7 @@ dependencies = [
 [[package]]
 name = "vortex-fastlanes"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "fastlanes",
  "itertools 0.14.0",
@@ -22956,7 +22957,7 @@ dependencies = [
 [[package]]
 name = "vortex-file"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "async-trait",
  "bytes",
@@ -23000,7 +23001,7 @@ dependencies = [
 [[package]]
 name = "vortex-flatbuffers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "flatbuffers",
  "vortex-buffer",
@@ -23010,7 +23011,7 @@ dependencies = [
 [[package]]
 name = "vortex-fsst"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "fsst-rs",
  "num-traits",
@@ -23025,7 +23026,7 @@ dependencies = [
 [[package]]
 name = "vortex-io"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "async-fs",
  "async-stream",
@@ -23055,7 +23056,7 @@ dependencies = [
 [[package]]
 name = "vortex-ipc"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "bytes",
  "flatbuffers",
@@ -23072,7 +23073,7 @@ dependencies = [
 [[package]]
 name = "vortex-layout"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "arcref",
  "arrow-array",
@@ -23115,7 +23116,7 @@ dependencies = [
 [[package]]
 name = "vortex-mask"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "itertools 0.14.0",
  "vortex-buffer",
@@ -23125,7 +23126,7 @@ dependencies = [
 [[package]]
 name = "vortex-metrics"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "parking_lot",
  "sketches-ddsketch",
@@ -23134,7 +23135,7 @@ dependencies = [
 [[package]]
 name = "vortex-pco"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "pco",
  "prost",
@@ -23148,7 +23149,7 @@ dependencies = [
 [[package]]
 name = "vortex-proto"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "prost",
  "prost-types",
@@ -23157,7 +23158,7 @@ dependencies = [
 [[package]]
 name = "vortex-runend"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -23172,7 +23173,7 @@ dependencies = [
 [[package]]
 name = "vortex-scan"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "async-trait",
  "futures",
@@ -23188,7 +23189,7 @@ dependencies = [
 [[package]]
 name = "vortex-sequence"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "num-traits",
  "prost",
@@ -23204,7 +23205,7 @@ dependencies = [
 [[package]]
 name = "vortex-session"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "arc-swap",
  "lasso",
@@ -23216,7 +23217,7 @@ dependencies = [
 [[package]]
 name = "vortex-sparse"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "itertools 0.14.0",
  "num-traits",
@@ -23231,7 +23232,7 @@ dependencies = [
 [[package]]
 name = "vortex-utils"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "dashmap",
  "hashbrown 0.17.1",
@@ -23240,7 +23241,7 @@ dependencies = [
 [[package]]
 name = "vortex-zigzag"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "vortex-array",
  "vortex-buffer",
@@ -23253,7 +23254,7 @@ dependencies = [
 [[package]]
 name = "vortex-zstd"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/vortex.git?rev=4e2d626544b1317f5a1f65f081419e19f8a79462#4e2d626544b1317f5a1f65f081419e19f8a79462"
+source = "git+https://github.com/spiceai/vortex.git?rev=92284354f74dfbb1f0ff604bd346cd66cbfee9da#92284354f74dfbb1f0ff604bd346cd66cbfee9da"
 dependencies = [
  "itertools 0.14.0",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -445,14 +445,14 @@ flatbuffers = "25.2.10"
 # Vortex tagged releases publish version 0.1.0 in their Cargo.toml, not the actual release version,
 # so we specify git deps here directly. The [patch.crates-io] entries below exist to override
 # transitive vortex dependencies pulled in by other patched crates.
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
-vortex-btrblocks = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)
+vortex-btrblocks = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)
 vortex-datafusion = { path = "crates/vortex" }
-vortex-io = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da", features = ["tokio"] } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex-io = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a", features = ["tokio"] } # branch: spiceai-54 (vortex 0.79.0)
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)
 
 x509-certificate = "0.25.0"
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "93b75c3c7d1a812b23d00b45adf537d7a2415496" } # spiceai/spice-rs#77
@@ -584,9 +584,9 @@ arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a4037
 arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a40370d014a0f8eed12ee0d5a914e8cb2070d8" } # branch: lukim/spiceai-58.3.0
 parquet = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a40370d014a0f8eed12ee0d5a914e8cb2070d8" }      # branch: lukim/spiceai-58.3.0
 
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)
 vortex-datafusion = { path = "crates/vortex" }
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "633c1dc4ad0d4a5b38f291a391da08519068519a" } # branch: spiceai-54 (vortex 0.79.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -444,14 +444,14 @@ flatbuffers = "25.2.10"
 # Vortex tagged releases publish version 0.1.0 in their Cargo.toml, not the actual release version,
 # so we specify git deps here directly. The [patch.crates-io] entries below exist to override
 # transitive vortex dependencies pulled in by other patched crates.
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
-vortex-btrblocks = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex-btrblocks = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
 vortex-datafusion = { path = "crates/vortex" }
-vortex-io = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462", features = ["tokio"] } # branch: spiceai-54 (vortex 0.79.0)
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
+vortex-io = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da", features = ["tokio"] } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
 
 x509-certificate = "0.25.0"
 spiceai = { git = "https://github.com/spiceai/spice-rs.git", rev = "93b75c3c7d1a812b23d00b45adf537d7a2415496" } # spiceai/spice-rs#77
@@ -583,9 +583,9 @@ arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a4037
 arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a40370d014a0f8eed12ee0d5a914e8cb2070d8" } # branch: lukim/spiceai-58.3.0
 parquet = { git = "https://github.com/spiceai/arrow-rs.git", rev = "18a40370d014a0f8eed12ee0d5a914e8cb2070d8" }      # branch: lukim/spiceai-58.3.0
 
-vortex = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
-vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
+vortex = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex-array = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
 vortex-datafusion = { path = "crates/vortex" }
-vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
-vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
-vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "4e2d626544b1317f5a1f65f081419e19f8a79462" } # branch: spiceai-54 (vortex 0.79.0)
+vortex-scan = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex-session = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)
+vortex-utils = { git = "https://github.com/spiceai/vortex.git", rev = "92284354f74dfbb1f0ff604bd346cd66cbfee9da" } # branch: sgrebnov/12328-declare-available-parallelism (vortex 0.79.0)

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -96,6 +96,11 @@ tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 util = { path = "../../crates/util"}
 
+# Vortex ships on non-Windows targets only (matching `runtime`'s gate on
+# Cayenne), so the startup parallelism declaration is gated the same way.
+[target.'cfg(not(windows))'.dependencies]
+vortex-utils.workspace = true
+
 # Non-default features should be added to `lint-rust` make target.
 [dev-dependencies]
 # Builds the `RequestContext` the trace-span test needs; `spiced` itself only

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -532,7 +532,29 @@ pub fn install_cpu_budget(args: &Args, app: Option<&App>) -> Result<(), cpu_budg
     if let Err(err) = budget.install() {
         tracing::warn!("{err}");
     }
+    #[cfg(not(windows))]
+    declare_vortex_parallelism();
     Ok(())
+}
+
+/// Declare the effective CPU entitlement to Vortex, so its host-derived
+/// concurrency defaults (encode fan-out, per-worker scan lookahead) size
+/// against the budget rather than the machine's core count.
+///
+/// Reads [`cpu_budget::cpu_budget`] so it declares whatever is actually in
+/// effect. The declaration is first-write-wins on the Vortex side: a call
+/// arriving after anything read the parallelism fails, and the warning names
+/// the value that stayed in effect.
+#[cfg(not(windows))]
+fn declare_vortex_parallelism() {
+    let Some(cores) = std::num::NonZeroUsize::new(cpu_budget::cpu_budget().vortex_parallelism())
+    else {
+        // `CpuBudget::cores` is documented as at least 1.
+        return;
+    };
+    if let Err(err) = vortex_utils::parallelism::set_available_parallelism(cores) {
+        tracing::warn!("Failed to declare the CPU entitlement to Vortex: {err}");
+    }
 }
 
 pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -499,7 +499,8 @@ pub struct AppBundle {
 }
 
 /// Resolve the CPU entitlement from all three configuration surfaces plus host
-/// detection, log it, and install it as the process-wide budget.
+/// detection, install it as the process-wide budget, and log the budget in
+/// effect.
 ///
 /// Must run before any thread pool, `DataFusion` session, or accelerator is
 /// created: [`cpu_budget::cpu_budget`] lazily detects into the same cell, so a
@@ -528,10 +529,13 @@ pub fn install_cpu_budget(args: &Args, app: Option<&App>) -> Result<(), cpu_budg
     );
 
     let budget = cpu_budget::CpuBudget::resolve(&config, &cpu_budget::HostReadings::detect())?;
-    budget.log_summary();
     if let Err(err) = budget.install() {
         tracing::warn!("{err}");
     }
+    // Log the budget in effect, not the resolved candidate: when the install
+    // lost to an earlier one, the summary and the Vortex declaration below must
+    // still report the same numbers.
+    cpu_budget::cpu_budget().log_summary();
     #[cfg(not(windows))]
     declare_vortex_parallelism();
     Ok(())

--- a/bin/spiced/tests/cpu_budget.rs
+++ b/bin/spiced/tests/cpu_budget.rs
@@ -87,6 +87,15 @@ fn spicepod_cores_size_the_runtime_pools() {
     // reports for each of them.
     let dedicated = runtime_async::ManagedTokioRuntime::try_new().expect("builds a pool");
     assert_eq!(dedicated.handle().metrics().num_workers(), 1);
+
+    // Installing the budget also declares it to Vortex. Like the budget, the
+    // declaration resolves once per process, so only the test that installs
+    // the budget can assert it.
+    #[cfg(not(windows))]
+    assert_eq!(
+        vortex_utils::parallelism::get_available_parallelism(),
+        Some(2)
+    );
 }
 
 /// `--set-runtime cpu.cores=4` reaches the typed field, so the override surface

--- a/crates/cpu-budget/src/lib.rs
+++ b/crates/cpu-budget/src/lib.rs
@@ -720,6 +720,8 @@ impl CpuBudget {
                 self.dedicated_runtime_worker_threads(),
             ),
             ("target_partitions", self.target_partitions()),
+            ("scan_split_concurrency", self.scan_split_concurrency()),
+            ("vortex_parallelism", self.vortex_parallelism()),
             ("max_concurrent_queries", self.max_concurrent_queries()),
             ("cayenne_encode_permits", self.cayenne_encode_permits()),
             (
@@ -1007,6 +1009,18 @@ impl CpuBudget {
     /// default.
     #[must_use]
     pub const fn scan_split_concurrency(&self) -> usize {
+        self.cores
+    }
+
+    /// The parallelism spiced declares to Vortex at startup
+    /// (`vortex_utils::parallelism::set_available_parallelism`).
+    ///
+    /// Vortex sizes its remaining concurrency defaults — encode fan-out and
+    /// per-worker scan lookahead — from that declaration; undeclared, it reads
+    /// the machine's core count instead of the entitlement. This is a default
+    /// Vortex derives fan-outs from, not an enforced ceiling.
+    #[must_use]
+    pub const fn vortex_parallelism(&self) -> usize {
         self.cores
     }
 

--- a/crates/cpu-budget/src/snapshots/cpu_budget__tests__derived_sizing.snap
+++ b/crates/cpu-budget/src/snapshots/cpu_budget__tests__derived_sizing.snap
@@ -2,4 +2,4 @@
 source: crates/cpu-budget/src/lib.rs
 expression: budget.derived_sizing_line()
 ---
-CPU budget derived sizing: main_runtime_worker_threads=4, dedicated_runtime_worker_threads=3, target_partitions=4, max_concurrent_queries=16, cayenne_encode_permits=2, cayenne_write_concurrency_ceiling=4, cayenne_compaction_permits=4, cayenne_upload_concurrency=4, cayenne_max_concurrent_file_scans=4, metastore_pool_connections=4, embedding_pool_threads=4, duckdb_threads=4, cluster_executor_concurrent_tasks=4
+CPU budget derived sizing: main_runtime_worker_threads=4, dedicated_runtime_worker_threads=3, target_partitions=4, scan_split_concurrency=4, vortex_parallelism=4, max_concurrent_queries=16, cayenne_encode_permits=2, cayenne_write_concurrency_ceiling=4, cayenne_compaction_permits=4, cayenne_upload_concurrency=4, cayenne_max_concurrent_file_scans=4, metastore_pool_connections=4, embedding_pool_threads=4, duckdb_threads=4, cluster_executor_concurrent_tasks=4


### PR DESCRIPTION
## Why

Vortex sizes its remaining concurrency defaults — encode-side compression and zone-statistics fan-out, per-worker scan lookahead — from `available_parallelism()`, which reports the machine's cores rather than the process's entitlement. A pod with `requests.cpu` and no `limits.cpu` therefore fans out for the whole node. (The scan path was already fixed by spiceai/vortex#87 + #12940.)

Closes #12328

## What

- Bump the Vortex pin to the branch carrying `set_available_parallelism` (spiceai/vortex#88); re-pin to the merged `spiceai-54` SHA once it lands, before this merges.
- Declare `cpu_budget().vortex_parallelism()` in `install_cpu_budget`, right after the budget installs and before anything reads the parallelism. The declaration is first-write-wins on the Vortex side; a late call fails and is logged with the value that stayed in effect.
- The cpu-budget integration test now asserts Vortex reports the declared value.

The declaration follows the same shape as the existing process-wide installs (`CpuBudget::install`, the process segment cache): one cell, first write wins, a late set is an observable error, the caller logs and continues.

## Review

Adversarial review of the Vortex half (Codex): **approve**, no material findings — "the setter/getter latch behavior is explicit, tested in both ordering directions, and preserves the old detection path when unset."

## Testing

`cargo check -p spiced`, `cargo test -p spiced --test cpu_budget` (4/4, including the new declaration assertion), `cargo test -p cpu-budget`, clippy with the gate's flag set.