### PR TITLE
Cloud Connect: interactive spice connect workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19437,7 +19437,6 @@ dependencies = [
  "flate2",
  "fundu",
  "futures",
- "gethostname",
  "http 1.4.1",
  "humantime",
  "insta",
@@ -19475,6 +19474,7 @@ dependencies = [
  "uuid 1.23.2",
  "wiremock",
  "yaml",
+ "zeroize",
  "zip 7.2.0",
 ]
 
@@ -19498,6 +19498,7 @@ dependencies = [
 name = "spice-cloud-client"
 version = "2.2.0-unstable"
 dependencies = [
+ "futures",
  "reqwest 0.13.4",
  "serde",
  "serde_json",

--- a/bin/spice/Cargo.toml
+++ b/bin/spice/Cargo.toml
@@ -37,6 +37,7 @@ reqwest = { workspace = true, features = ["stream"] }
 serde.workspace = true
 serde_json.workspace = true
 secrecy.workspace = true
+zeroize = "1.8"
 
 # Environment files
 dotenv.workspace = true
@@ -44,14 +45,12 @@ dotenv.workspace = true
 # Cross-platform directories
 dirs = "6"
 
-# Deterministic per-instance-directory service names (`spice connect --install`)
+# Deterministic per-instance-directory service names (`spice connect service`)
 sha2.workspace = true
-
-# Host name for the adoption-code mint label (`spice connect` codeless path)
-gethostname.workspace = true
 
 # Semver comparison
 semver = "1"
+uuid = { workspace = true, features = ["v4"] }
 
 # Date/time formatting
 chrono = { workspace = true, features = ["serde"] }
@@ -114,9 +113,10 @@ test-framework = { path = "../../crates/test-framework" }
 # Tracing/opentelemetry for trace ID handling
 opentelemetry.workspace = true
 
-# Unix signal handling, and the effective-uid check `spice connect --install` gates on
+# Unix signal handling, terminal tests, and local account inspection.
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["signal", "process", "user"] }
+nix = { version = "0.29", features = ["signal", "process", "term", "user"] }
+
 [build-dependencies]
 # None needed - we use include_str! for version
 
@@ -131,7 +131,6 @@ predicates = "3"
 rstest = "0.26.1"
 serde_json.workspace = true
 tempfile.workspace = true
-uuid = { workspace = true, features = ["v4"] }
 wiremock = "0.6"
 
 [lints]

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -27,10 +27,9 @@ use crate::error::{CloudErrorCode, Error, InvalidResponseSnafu, Result};
 pub use spice_cloud_client::CloudClient as InnerCloudClient;
 use spice_cloud_client::types::{
     ApiKeysResponse, AuthContext, AuthExchangeResponse, ContainerImagesResponse,
-    CreateDeploymentRequest, CreateProjectRequest, Deployment, LogsResponse, MetricsResponse,
-    MintAdoptionCodeRequest, MintAdoptionCodeResponse, Org, Project, ProjectExecutor, ProjectKind,
-    ProjectResourceLimits, ProjectResources, RegenerateApiKeyResponse, RegionsResponse, Secret,
-    UpdateChannel, UpdateProjectRequest,
+    CreateDeploymentRequest, CreateProjectRequest, Deployment, LogsResponse, MetricsResponse, Org,
+    Project, ProjectExecutor, ProjectKind, ProjectResourceLimits, ProjectResources,
+    RegenerateApiKeyResponse, RegionsResponse, Secret, UpdateChannel, UpdateProjectRequest,
 };
 
 use super::org;
@@ -157,7 +156,19 @@ impl CloudClient {
     /// Create a new authenticated cloud client with an explicit bearer token,
     /// acting on `org`.
     pub fn with_token_for_org(token: impl Into<String>, org: Option<&str>) -> Result<Self> {
-        let mut inner = InnerCloudClient::new(&get_base_url())
+        Self::with_token_for_org_at(token, org, &get_base_url())
+    }
+
+    /// Create an authenticated client against an explicit Cloud API base URL.
+    ///
+    /// Cloud Connect uses this for `--endpoint` and local HTTP fixtures; every
+    /// other Cloud command continues to use [`Self::with_token_for_org`].
+    pub fn with_token_for_org_at(
+        token: impl Into<String>,
+        org: Option<&str>,
+        base_url: &str,
+    ) -> Result<Self> {
+        let mut inner = InnerCloudClient::new(base_url)
             .map_err(map_cloud_error(None))?
             .with_token(token);
         if let Some(org) = org {
@@ -221,31 +232,6 @@ impl CloudClient {
             }
             .fail()
         }
-    }
-
-    /// Mint a single-use standalone-instance adoption code for
-    /// `spice connect`'s codeless path.
-    pub async fn mint_instance_adoption_code(
-        &self,
-        request: &MintAdoptionCodeRequest,
-    ) -> Result<MintAdoptionCodeResponse> {
-        self.inner
-            .mint_instance_adoption_code(request)
-            .await
-            .map_err(|error| self.err(error))
-    }
-
-    /// `true` when a `spice login` credential [`Self::connect`] would accept for
-    /// `org` is available in this environment.
-    ///
-    /// Lets `spice connect` tell "no code and no login" (which must name both
-    /// fixes) apart from "logged in, so mint a code" — without making a
-    /// network request to find out. It resolves credentials the same way
-    /// [`Self::connect`] does, so an operator with a credential for the named
-    /// org alone is never told to log in again.
-    #[must_use]
-    pub fn is_authenticated(org: Option<&str>) -> bool {
-        org.is_some_and(org::has_org_token) || org::default_token().is_some()
     }
 
     /// Get the auth context for the current user.
@@ -875,6 +861,9 @@ fn map_cloud_error(org: Option<&str>) -> impl Fn(spice_cloud_client::error::Erro
                 format!("Spice Cloud request failed with status {status}: {message}"),
             ),
             CloudError::HttpRequest { source } => Error::HttpRequestFailed { source },
+            CloudError::ResponseTooLarge { limit } => Error::InvalidResponse {
+                message: format!("Spice Cloud response exceeded the {limit} byte limit"),
+            },
             CloudError::JsonParse { source } => Error::InvalidResponse {
                 message: format!("Failed to parse response: {source}"),
             },

--- a/bin/spice/src/commands/connect/mod.rs
+++ b/bin/spice/src/commands/connect/mod.rs
@@ -14,178 +14,159 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! `spice connect` — Spice Cloud Connect enrollment flow.
+//! `spice connect` — enroll this directory with Spice Cloud, create its
+//! project transactionally, and manage the resulting instance.
 //!
 //! Two distinct use cases share this command:
 //!
-//! 1. **Cloud Connect enrollment** (remote management of `spiced` from
-//!    Spice Cloud). This foundation accepts a one-shot key created in the
-//!    Spice Cloud portal:
-//!
-//!    ```text
-//!    spice connect spice-enroll-abcdefghijklmnopqrstuvwxyz012345
-//!    ```
-//!
-//!    The command **enrolls and exits**: it installs the runtime if missing,
-//!    completes the HTTPS enroll (identity issued and
-//!    persisted, registry row created), prints the next steps, and returns.
-//!    It starts `spiced` only when `--install` asks for a persistent
-//!    service. `status`/`remove` inspect and clear the local state.
+//! 1. **Cloud Connect interactive setup** (remote management of `spiced` from
+//!    Spice Cloud). Bare `spice connect` authenticates the user, enrolls this
+//!    directory, creates and attaches a project, then starts the instance in
+//!    the foreground. Unattended enrollment belongs to the runtime itself via
+//!    `spiced --token <enrollment-key>` and does not create a project.
 //!
 //! 2. **Deprecated pod-add behavior**: when the argument is a Spicepod
 //!    path on Spice.ai Cloud (e.g. `spiceai/quickstart`), this prints a
 //!    deprecation notice and behaves like `spice add <pod>` with Spice.ai
 //!    Cloud authentication headers.
 
+mod naming;
+mod project;
+#[cfg(test)]
+#[expect(
+    dead_code,
+    reason = "the stacked Linux service PR wires these lifecycle entry points"
+)]
 mod service;
+mod state;
+mod transaction;
 
+use std::io::IsTerminal as _;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::commands::add::{AddArgs, execute_add_or_connect};
 use crate::context::RuntimeContext;
 use crate::error::{Error, Result};
 use clap::{Args, Subcommand};
-use runtime_cloud_connect::config::{CloudConnectConfig, IDENTITY_FILE};
-use runtime_cloud_connect::enrollment_key::looks_like_enrollment_key;
+use runtime_cloud_connect::config::{
+    CLOUD_MANAGED_SPICEPOD_FILE, CloudConnectConfig, DEPLOYMENT_TRANSACTION_FILE,
+    DEPLOYMENT_TRANSACTION_INCOMING_FILE, IDENTITY_FILE, INCOMING_SECRET_CACHE_FILE,
+    PREVIOUS_CLOUD_MANAGED_SPICEPOD_FILE, PREVIOUS_SECRET_CACHE_FILE,
+};
 use secrecy::{ExposeSecret as _, SecretString};
-
-/// Legacy file (relative to the config dir) holding an endpoint override.
-/// Fresh enrollment stores its canonical control-plane binding in the identity;
-/// this path remains only for compatibility and cleanup.
-const CLOUD_ENDPOINT_FILE: &str = "cloud-endpoint";
 
 /// Arguments for the `spice connect` command.
 #[derive(Args, Debug)]
 #[command(
-    about = "Enroll this host with Spice Cloud (or add a cloud-hosted Spicepod)",
-    long_about = r#"`spice connect` enrolls this host with Spice Cloud and exits.
+    about = "Connect this directory to Spice Cloud and start its instance",
+    long_about = r#"`spice connect` enrolls this directory with Spice Cloud and manages its instance.
 
-  spice connect spice-enroll-<32 base64url characters>
-                                          Enroll with a one-shot key from the
-                                          Spice Cloud portal, for hosts with no
-                                          login: the identity is issued and
-                                          stored locally, the instance appears
-                                          in the portal registry, and the
-                                          command exits.
-  sudo spice connect --install            For a previously enrolled directory,
-                                          install
-                                          `spiced --cloud-connect` as a
-                                          persistent systemd service on Linux.
-                                          Re-run to upgrade in place: latest
-                                          binary, rewritten service definition,
-                                          service restarted, staged identity
-                                          untouched.
-  spice connect status                    Show the current enrollment state.
-  spice connect remove                    Release this instance: report the
-                                          release to Spice Cloud, uninstall the
-                                          service when one was installed, and
-                                          clear the local identity on disk.
-                                          A running `spiced` keeps its
-                                          in-memory identity until it is
-                                          restarted or the cloud sends a Remove
-                                          command (a mere stream drop just
-                                          reconnects with the same identity),
-                                          so restart spiced to stop remote
-                                          management immediately.
+This is an interactive setup flow. It authenticates a user, resolves an
+owner/admin organization, enrolls the local instance, and atomically creates
+and attaches a new project. Without a login, it offers inline login
+(recommended) or secure enrollment-key entry.
 
-Nothing is left running unless `--install` is passed — otherwise start the
-runtime with `spiced --cloud-connect` to bring the instance online.
+The transaction is retry-safe: an interrupted enrollment reuses its durable
+operation and key material, while project creation uses the enrolled instance's
+single attachment as its exact replay key. Existing identities always win and
+are never duplicated. A re-run continues the pending enrollment in the mode that
+started it — it never asks which authentication to use again, and an enrollment
+key is asked for again only because keys are never stored.
 
-Use `--dir <path>` to enroll an instance rooted at a different directory:
+For unattended enrollment, run `spiced --token <enrollment-key>`. The runtime
+enrolls into the organization authorized by the key; project creation and
+attachment happen separately in Spice Cloud.
+
+`spice connect remove --force --yes` is the explicit recovery path for an
+unusable identity or an enrollment transaction that must be abandoned. It
+clears only this directory's local Cloud state; delete any Cloud project
+separately.
+
+Use `--dir <path>` to manage an instance rooted at a different directory:
 per-instance state lives under `<dir>/.spice`, so multiple instances on one
 host enroll independently. `SPICE_CONFIG_DIR` overrides the derived location
 entirely and wins over `--dir`.
-
-`--install` requires root and Linux with systemd. Containers use
-`spiced --token <enrollment-key>` for unattended enrollment under the
-container runtime's restart policy. This layer does not provide service
-lifecycle management on macOS or Windows.
 
 DEPRECATED POD-ADD BEHAVIOR:
   spice connect <org>/<pod>               Deprecated; use `spice add <org>/<pod>`.
 
 EXAMPLES
-  sudo spice connect --install
-  spice connect spice-enroll-abcdefghijklmnopqrstuvwxyz012345
-  spice connect spice-enroll-abcdefghijklmnopqrstuvwxyz012345 --dir /opt/edge-1
-  spice connect status
-  sudo spice connect remove
+  spice connect
+  spice connect --dir /srv/edge --region us-west-2
+  spice connect remove --force --yes
 
 Docs: https://spiceai.org/docs"#
 )]
 pub struct ConnectArgs {
-    /// Optional explicit subcommand. If absent, the first positional
-    /// argument (`target`) is inspected to decide between enrollment flow
-    /// and the deprecated pod-add behavior.
+    /// Explicit state-recovery command. Setup remains the default when absent.
     #[command(subcommand)]
     pub command: Option<ConnectCommand>,
 
-    /// First positional argument: either a Spice Cloud enrollment key
-    /// (`spice-enroll-...`) or a Spicepod path (`<org>/<pod>`). Omit it only
-    /// to inspect/install an already-enrolled directory in this layer.
+    /// A Spicepod path (`<org>/<pod>`) for the deprecated pod-add behavior.
+    /// Secrets are never accepted positionally: enrollment keys go to the
+    /// runtime as `spiced --token <enrollment-key>`.
     #[arg(value_name = "TARGET")]
     pub target: Option<ConnectTarget>,
 
-    /// Override the Spice Cloud enroll endpoint the enrollment authority is
-    /// presented to. Defaults to `https://api.spice.ai`. Also
-    /// configurable via `SPICE_CLOUD_ENDPOINT`. The gateway (stream)
-    /// address is issued by the enroll response, not configured here.
-    #[arg(long, value_name = "URL")]
+    /// Declared location label for the enrolled instance.
+    #[arg(long, value_name = "LABEL", global = true)]
+    pub region: Option<String>,
+
+    /// Override the Spice Cloud endpoint used for enrollment. Defaults to
+    /// `https://api.spice.ai`. Also
+    /// configurable via `SPICE_CLOUD_ENDPOINT`.
+    #[arg(long, value_name = "URL", global = true)]
     pub endpoint: Option<String>,
 
     /// The instance directory: per-instance Cloud Connect state (the
-    /// identity and retry-safe enrollment draft) lives under `<dir>/.spice`.
-    /// Defaults to the current directory; resolved to an absolute path at
-    /// enroll time. `SPICE_CONFIG_DIR` overrides the derived `.spice`
-    /// location entirely. Applies to enrollment, `status`, and `remove`.
+    /// enrolled identity) lives under `<dir>/.spice`. Defaults to the
+    /// current directory. `SPICE_CONFIG_DIR` overrides the derived `.spice`
+    /// location entirely.
     #[arg(long, value_name = "PATH", global = true)]
     pub dir: Option<PathBuf>,
 
-    /// Where this instance runs, e.g. `us-west-2` or `on-prem-syd`. A
-    /// customer-declared label, not a probed fact.
-    ///
-    /// Spice Cloud displays it on the registry row and resolves this instance's
-    /// gateway from it, by ranking the stamps it actually runs a gateway in and
-    /// returning the nearest as `gateway_addr` in the enroll response — the same
-    /// nearest-stamp mapping a BYOC cluster's region gets. A label it cannot
-    /// rank falls back to the deployment's home stamp, so every enrollment gets
-    /// a gateway that resolves.
-    ///
-    /// Any syntactically valid label is therefore accepted, including one no
-    /// region catalog knows: a standalone host need not be in a cloud region at
-    /// all. Also configurable via `SPICE_CONNECT_ADOPT_REGION`. Omitted on a
-    /// re-enroll leaves an existing region untouched.
-    #[arg(long, value_name = "REGION")]
-    pub region: Option<String>,
-
-    /// Install and start `spiced --cloud-connect` as a persistent system
-    /// service running from the instance directory, so the instance survives
-    /// reboots and closed terminals. Requires Linux with systemd and root.
-    /// Combinable with a code, or run on its own after a prior enroll.
-    /// Re-running is the idempotent in-place upgrade path.
-    #[arg(long, global = true)]
-    pub install: bool,
-
-    /// Skip the confirmation prompt. Applies to `remove`, which otherwise
-    /// asks before stopping and uninstalling a service.
+    /// Confirm local state abandonment without another prompt.
     #[arg(long, short = 'y', global = true)]
     pub yes: bool,
+
+    /// Abandon only this directory's local Cloud state. This does not delete a
+    /// Cloud project; clean up that project separately.
+    #[arg(long, global = true)]
+    pub force: bool,
+
+    /// The global `-v` count, forwarded by the dispatcher for the same reason
+    /// as [`ConnectArgs::cloud_region`] below: the flag is global and clap
+    /// would reject a second definition of it here.
+    ///
+    /// A foreground runtime this command starts is the command's own output,
+    /// so `spice -v connect` has to reach it exactly as `spice run -v` does.
+    #[arg(skip)]
+    pub verbosity: u8,
 
     /// The global `--cloud-region`, forwarded by the dispatcher rather than
     /// declared here (the flag is global; clap would reject a second definition
     /// of the same name).
     ///
-    /// Carried only so the adoption path can *refuse* it with a message naming
-    /// `--region` and `--endpoint` — see [`reject_cloud_region`]. It stays
+    /// Carried so state-management commands can reject it explicitly rather
+    /// than silently implying that it changes the enrolled instance. It stays
     /// honoured on the deprecated pod-add fallthrough, where it always meant
     /// the Spice.ai Cloud data region.
     #[arg(skip)]
     pub cloud_region: Option<String>,
 }
 
-/// A positional connect target. It may be a deprecated Spicepod path, but it
-/// may also be a one-shot enrollment authority, so its storage is zeroizing
-/// and its `Debug` representation never exposes the value.
+/// Cloud Connect state-recovery commands available with interactive setup.
+#[derive(Subcommand, Debug)]
+pub enum ConnectCommand {
+    /// Abandon this directory's local Cloud identity and retry state. Requires
+    /// `--force --yes`; Cloud project cleanup remains a separate operation.
+    Remove,
+}
+
+/// A positional value may be a deprecated Spicepod path, but operators can
+/// accidentally paste an enrollment authority here. Keep it zeroizing and
+/// permanently redacted from derived CLI diagnostics either way.
 #[derive(Clone)]
 pub struct ConnectTarget(SecretString);
 
@@ -193,6 +174,13 @@ impl ConnectTarget {
     fn expose(&self) -> &str {
         self.0.expose_secret()
     }
+}
+
+fn is_deprecated_spicepod_target(target: &str) -> bool {
+    let Some((org, pod)) = target.split_once('/') else {
+        return false;
+    };
+    !org.is_empty() && !pod.is_empty() && !pod.contains('/')
 }
 
 impl std::str::FromStr for ConnectTarget {
@@ -209,931 +197,571 @@ impl std::fmt::Debug for ConnectTarget {
     }
 }
 
-/// Cloud-connect subcommands.
-#[derive(Subcommand, Debug)]
-pub enum ConnectCommand {
-    /// Show the current Spice Cloud Connect adoption state.
-    Status,
+impl ConnectArgs {
+    /// Whether this invocation writes JSON to stdout, so the dispatcher can
+    /// suppress the version banner that would otherwise foul it.
+    #[must_use]
+    pub fn produces_json(&self) -> bool {
+        false
+    }
 
-    /// Release this instance: report the release to Spice Cloud, uninstall an
-    /// installed service, and clear the local identity. spiced will continue
-    /// running unmanaged after the next restart.
-    Remove,
+    /// Select JSON output wherever this command has a structured form.
+    pub fn apply_machine_mode(&mut self) {
+        // Interactive setup has no structured output mode.
+    }
 }
 
 /// Execute the `spice connect` command.
 ///
 /// # Errors
 ///
-/// Returns an error if I/O fails, the enrollment is rejected, or the
-/// deprecated pod-add path errors.
+/// Returns an error if I/O fails, this directory holds no Cloud Connect
+/// state to act on, or the deprecated pod-add path errors.
 pub async fn execute(ctx: &RuntimeContext, args: ConnectArgs) -> Result<()> {
     let config_dir = CloudConnectConfig::resolve_config_dir(args.dir.as_deref());
 
-    if let Some(cmd) = args.command {
+    if matches!(args.command, Some(ConnectCommand::Remove)) {
         reject_cloud_region(args.cloud_region.as_deref())?;
-        return match cmd {
-            ConnectCommand::Status => print_status(&config_dir, args.endpoint.as_deref()).await,
-            ConnectCommand::Remove => {
-                remove_identity(&config_dir, args.endpoint.as_deref(), args.yes).await
-            }
-        };
-    }
-
-    // A region typo must be caught before any authority is presented: the
-    // cloud rejects it too, but failing here keeps the diagnosis local and a
-    // one-shot key unspent.
-    let region = validate_region(args.region.as_deref())?;
-
-    let enroll = EnrollOptions {
-        region,
-        install: args.install,
-        endpoint: args.endpoint,
-    };
-
-    // Rejected on the adoption branches only. The deprecated pod-add
-    // fallthrough below is a Spice.ai Cloud fetch, where `--cloud-region` has
-    // always been meaningful, so refusing it there would be a regression.
-    let Some(target) = args.target.as_ref().map(ConnectTarget::expose) else {
-        reject_cloud_region(args.cloud_region.as_deref())?;
-        return connect_without_code(ctx, &config_dir, enroll).await;
-    };
-
-    if let Ok(key) = runtime_cloud_connect::EnrollmentKey::parse(target) {
-        reject_cloud_region(args.cloud_region.as_deref())?;
-        return enroll_instance(ctx, key, &config_dir, enroll).await;
-    }
-
-    // An input that clearly looks like an adoption code but fails validation
-    // is a malformed code, not a Spicepod path. Treating it as a pod path
-    // produces a misleading cloud-Spicepod error and may fire a cloud pod-add
-    // request for what was plainly meant to be an adoption code, so reject it
-    // explicitly instead of falling through to the pod-add path.
-    if looks_like_enrollment_key(target) {
-        return Err(Error::InvalidArgument {
-            message:
-                "The supplied value looks like a Spice Cloud enrollment key but is malformed. \
-                 Expected spice-enroll- followed by exactly 32 base64url characters. \
-                 Copy a fresh key from your Spice Cloud portal and retry."
+        if args.endpoint.is_some() {
+            return Err(Error::InvalidUsage {
+                message: "--endpoint does not apply to `connect remove`; --force abandons local state only, and Cloud project cleanup is separate."
                     .to_string(),
+            });
+        }
+        if args.region.is_some() {
+            return Err(Error::InvalidUsage {
+                message: "--region applies to enrollment, not to `connect remove`.".to_string(),
+            });
+        }
+        return abandon_local_state(&config_dir, args.yes, args.force).await;
+    }
+
+    if args.force || args.yes {
+        return Err(Error::InvalidUsage {
+            message: "--force and --yes apply only to `spice connect remove`; interactive setup and the deprecated pod-add form do not consume them."
+                .to_string(),
         });
     }
 
-    // Deprecated pod-add behavior, forwarded to `spice add`.
-    eprintln!(
-        "warning: `spice connect <org>/<pod>` is deprecated and will be removed in a future release; use `spice add {target}` instead."
-    );
-    let add_args = AddArgs {
-        pod_path: target.to_string(),
+    // The deprecated pod-add fallthrough is a Spice.ai Cloud fetch, where
+    // `--cloud-region` has always been meaningful, so it is not rejected here.
+    if let Some(target) = args.target.as_ref().map(ConnectTarget::expose) {
+        if args.region.is_some() {
+            return Err(Error::InvalidUsage {
+                message:
+                    "--region cannot be combined with the deprecated `connect <org>/<pod>` form."
+                        .to_string(),
+            });
+        }
+
+        // A secret must never ride a positional argument. Reject canonical keys
+        // and close near misses without echoing either.
+        if runtime_cloud_connect::enrollment_key::looks_like_enrollment_key(target) {
+            return Err(Error::InvalidUsage {
+                message: "An enrollment key is not accepted as a positional argument. For unattended enrollment, run `spiced --token <enrollment-key>` from the instance directory. See: https://spiceai.org/docs".to_string(),
+            });
+        }
+        if !is_deprecated_spicepod_target(target) {
+            return Err(Error::InvalidUsage {
+                message: "`spice connect` accepts only interactive setup, `connect remove`, or the deprecated `<org>/<pod>` Spicepod form. Lifecycle words such as `status`, `start`, and `stop` are not remote Spicepod targets."
+                    .to_string(),
+            });
+        }
+        if args.endpoint.is_some() {
+            return Err(Error::InvalidUsage {
+                message: "--endpoint applies to Cloud Connect setup, not to the deprecated `connect <org>/<pod>` form; use `spice add <org>/<pod>`."
+                    .to_string(),
+            });
+        }
+
+        eprintln!(
+            "warning: `spice connect <org>/<pod>` is deprecated and will be removed in a future release; use `spice add {target}` instead."
+        );
+        return execute_add_or_connect(
+            ctx,
+            AddArgs {
+                pod_path: target.to_string(),
+            },
+            true,
+        )
+        .await;
+    }
+
+    reject_cloud_region(args.cloud_region.as_deref())?;
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return Err(Error::InvalidUsage {
+            message: "`spice connect` is an interactive setup flow and requires a terminal. For unattended enrollment, run `spiced --token <enrollment-key>`; create and attach the project separately in Spice Cloud.".to_string(),
+        });
+    }
+    // The command promises to finish by running the instance in this terminal.
+    // Refuse a platform that cannot launch the local runtime before enrollment
+    // or project creation commits any remote state.
+    ctx.ensure_local_runtime_supported()?;
+
+    let Some(directory) = transaction::execute(
+        ctx,
+        transaction::ConnectRequest {
+            org: None,
+            project: None,
+            token: None,
+            region: args.region,
+            dir: args.dir,
+            endpoint: args.endpoint,
+        },
+    )
+    .await?
+    else {
+        return Ok(());
     };
-    execute_add_or_connect(ctx, add_args, true).await
+
+    // The transaction has committed this directory's durable state, so the
+    // command ends where the operator asked it to: at a running instance.
+    start_foreground_instance(ctx, Some(&directory), args.verbosity).await
 }
 
-/// Reject `--cloud-region` on the adoption path, naming the two flags that do
-/// what the caller was reaching for.
+/// Explicitly abandon local transaction and credential state.
 ///
-/// Neither half of an enrollment is chosen by a region code on this side:
-///
-/// - The **control plane** the enroll and renew requests go to comes from
-///   `--endpoint`, then `SPICE_CLOUD_ENDPOINT`, then the `cloud-endpoint` file
-///   staged by an earlier connect, then
-///   [`runtime_cloud_connect::config::DEFAULT_ENDPOINT`].
-/// - The **gateway** the control stream dials comes back in the enroll response
-///   as `gateway_addr`. Spice Cloud resolves it from `--region` — the instance's
-///   declared location — by ranking the stamps it actually runs a gateway in and
-///   picking the nearest, falling back to the deployment's home stamp for a
-///   location it cannot rank. Deriving a gateway host from a region code
-///   CLI-side is the conflation that hands out hostnames with nothing behind
-///   them, so the CLI sends the location and never interprets it.
-///
-/// Erroring beats accepting-and-ignoring: `--cloud-region` silently doing
-/// nothing would look like a working region selection right up until someone
-/// checked which gateway the instance dialled.
+/// This is the recovery half of removal: it is intentionally force-only and
+/// makes no claim about Cloud-side project cleanup. The shared mutation lock
+/// is outer to the runtime lease, matching enrollment's lock order, so removal
+/// cannot win a gap and have enrollment recreate the state it just cleared.
+async fn abandon_local_state(config_dir: &Path, yes: bool, force: bool) -> Result<()> {
+    if !force || !yes {
+        return Err(Error::InvalidUsage {
+            message: "Local Cloud Connect recovery requires `spice connect remove --force --yes`. This abandons only local identity and retry state; delete any Cloud project separately.".to_string(),
+        });
+    }
+
+    let mutation_lock = runtime_cloud_connect::MutationLock::acquire(config_dir, "remove")
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("acquire Cloud Connect state for local recovery: {source}"),
+        })?;
+    let display_config_dir = mutation_lock
+        .config_dir()
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("validate locked Cloud Connect state: {source}"),
+        })?
+        .to_path_buf();
+    abandon_local_state_locked(&mutation_lock, &display_config_dir).await
+}
+
+async fn abandon_local_state_locked(
+    mutation_lock: &runtime_cloud_connect::MutationLock,
+    display_config_dir: &Path,
+) -> Result<()> {
+    let config_dir = mutation_lock
+        .descriptor_relative_config_dir()
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("pin locked Cloud Connect state for local recovery: {source}"),
+        })?;
+    let _runtime_lock =
+        runtime_cloud_connect::RuntimeLock::acquire(&config_dir).map_err(|source| {
+            Error::CloudConnectIo {
+                message: format!(
+                    "{source} Stop the running instance before using `spice connect remove`."
+                ),
+            }
+        })?;
+
+    // One enrollment transaction spans the entire cleanup. Taking it once is
+    // what prevents `spiced --token` from publishing a new draft or identity
+    // between two individually locked deletes while this command still reports
+    // that the directory was cleared.
+    let enrollment_transaction = Arc::new(
+        runtime_cloud_connect::EnrollmentTransactionLock::try_acquire_async(&config_dir)
+            .await
+            .map_err(|source| Error::CloudConnectIo {
+                message: format!("acquire the enrollment transaction for local recovery: {source}"),
+            })?,
+    );
+    let identity_path = config_dir.join(IDENTITY_FILE);
+    let blocking_transaction = Arc::clone(&enrollment_transaction);
+    tokio::task::spawn_blocking(move || {
+        // Carry a guard into the uncancellable blocking task. If the async
+        // caller is dropped, cleanup cannot continue after releasing the
+        // enrollment exclusion.
+        let _enrollment_transaction = blocking_transaction;
+        clear_local_cloud_state(&config_dir)
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("local Cloud Connect cleanup task failed: {source}"),
+    })??;
+    enrollment_transaction
+        .delete_draft_async()
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("remove enrollment draft: {source}"),
+        })?;
+    runtime_cloud_connect::identity::IdentityStore::clear_with_transaction_async(
+        identity_path,
+        Arc::clone(&enrollment_transaction),
+    )
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("remove Cloud Connect identity: {source}"),
+    })?;
+
+    println!(
+        "Removed local Spice Cloud Connect state from {}. Cloud project cleanup, if any, must be completed separately.",
+        display_config_dir.display()
+    );
+    Ok(())
+}
+
+/// Remove the auxiliary files of one local Cloud generation on the blocking
+/// pool. The caller retains the mutation, runtime, and enrollment leases, and
+/// removes the draft and identity through that same enrollment transaction
+/// after this returns. `config_dir` is rooted at the locked directory
+/// descriptor, so no pathname replacement can redirect these deletes.
+fn clear_local_cloud_state(config_dir: &Path) -> Result<()> {
+    state::remove_durable_file(
+        &config_dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE),
+    )
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("remove delivered-secret cache: {source}"),
+    })?;
+
+    for file in [
+        CLOUD_MANAGED_SPICEPOD_FILE,
+        "spicepod-cloud-managed.incoming.yml",
+        "spicepod-cloud-managed.bak",
+        DEPLOYMENT_TRANSACTION_FILE,
+        DEPLOYMENT_TRANSACTION_INCOMING_FILE,
+        PREVIOUS_CLOUD_MANAGED_SPICEPOD_FILE,
+        PREVIOUS_SECRET_CACHE_FILE,
+        INCOMING_SECRET_CACHE_FILE,
+    ] {
+        state::remove_durable_file(&config_dir.join(file)).map_err(|source| {
+            Error::CloudConnectIo {
+                message: format!("remove Cloud Connect deployment state {file}: {source}"),
+            }
+        })?;
+    }
+
+    remove_local_credential_debris(config_dir)?;
+    state::ConnectOperation::delete(config_dir).map_err(|source| Error::CloudConnectIo {
+        message: format!("remove enrollment journal: {source}"),
+    })?;
+    state::ProjectOperation::delete(config_dir).map_err(|source| Error::CloudConnectIo {
+        message: format!("remove project journal: {source}"),
+    })?;
+    state::remove_durable_file(&config_dir.join(CloudConnectConfig::ENDPOINT_OVERRIDE_FILE))
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("remove endpoint override: {source}"),
+        })?;
+    Ok(())
+}
+
+/// Remove secret-bearing crash/recovery files whose names are created by the
+/// enrollment and identity writers. The caller owns the mutation, runtime, and
+/// enrollment exclusion needed to treat every matching temp/backup as dead.
+/// Match only exact generated name families; never recurse or follow links.
+fn remove_local_credential_debris(config_dir: &Path) -> Result<()> {
+    let entries = match std::fs::read_dir(config_dir) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => {
+            return Err(Error::CloudConnectIo {
+                message: format!(
+                    "inspect local Cloud credential debris in {}: {source}",
+                    config_dir.display()
+                ),
+            });
+        }
+    };
+    for entry in entries {
+        let entry = entry.map_err(|source| Error::CloudConnectIo {
+            message: format!(
+                "inspect local Cloud credential debris in {}: {source}",
+                config_dir.display()
+            ),
+        })?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let extension = Path::new(&name)
+            .extension()
+            .and_then(std::ffi::OsStr::to_str);
+        let generated_draft_quarantine =
+            name.starts_with("enrollment-draft.quarantine.") && extension == Some("json");
+        let generated_draft_temp =
+            name.starts_with(".enrollment-draft.json.") && matches!(extension, Some("tmp" | "bak"));
+        let generated_identity_temp =
+            name.starts_with(".identity.json.") && matches!(extension, Some("tmp" | "bak"));
+        let fixed_identity_backup = name == "identity.bak" || name == "identity.json.bak";
+        if generated_draft_quarantine
+            || generated_draft_temp
+            || generated_identity_temp
+            || fixed_identity_backup
+        {
+            state::remove_durable_file(&entry.path()).map_err(|source| Error::CloudConnectIo {
+                message: format!(
+                    "remove local Cloud credential debris at {}: {source}",
+                    entry.path().display()
+                ),
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Reject the legacy global Cloud data-region flag on Cloud Connect setup.
+/// Interactive setup has its own instance-location and control-plane options;
+/// local recovery has neither.
 fn reject_cloud_region(cloud_region: Option<&str>) -> Result<()> {
     let Some(region) = cloud_region.filter(|r| !r.is_empty()) else {
         return Ok(());
     };
-    Err(Error::InvalidArgument {
+    Err(Error::InvalidUsage {
         message: format!(
-            "--cloud-region {region} does not apply to `spice connect`. Spice Cloud selects this \
-             instance's gateway from --region (where the instance runs) and returns it in the \
-             enroll response, falling back to the home stamp for a location it does not \
-             recognise. Use --region <region> to record the location, or --endpoint <url> to \
-             enroll against a different Spice Cloud control plane. \
-             See: https://spiceai.org/docs"
+            "--cloud-region {region} selects a Spice.ai Cloud data region and does not apply to \
+             `spice connect`. For interactive setup, use --region <location> for the instance \
+             label and --endpoint <url> for the enrollment control plane. `connect remove` is \
+             local-only and accepts neither option. See: https://spiceai.org/docs"
         ),
     })
 }
 
-/// Validate an explicit `--region` label, mirroring the cloud's own rule.
-fn validate_region(region: Option<&str>) -> Result<Option<String>> {
-    let Some(region) = region.map(str::trim).filter(|r| !r.is_empty()) else {
-        return Ok(None);
-    };
-    if !runtime_cloud_connect::is_valid_instance_region(region) {
-        return Err(Error::InvalidArgument {
-            message: format!(
-                "Invalid --region '{region}': expected 2-64 lowercase letters, digits, and \
-                 hyphens, starting and ending with a letter or digit (for example 'us-west-2' or \
-                 'on-prem-syd'). Any such label is accepted — it need not be a cloud region. \
-                 See: https://spiceai.org/docs"
-            ),
-        });
-    }
-    Ok(Some(region.to_string()))
-}
-
-/// The enrollment options gathered from flags, distinct from the credential.
-struct EnrollOptions {
-    region: Option<String>,
-    install: bool,
-    endpoint: Option<String>,
-}
-
-/// `spice connect` with no enrollment key.
-///
-/// An already-enrolled directory is never re-enrolled: that could create a second
-/// registry row for a host that already has one. The authenticated interactive
-/// setup flow is deliberately owned by the later interactive layer in this
-/// stack; this foundation accepts only the one-shot positional authority.
-async fn connect_without_code(
+async fn start_foreground_instance(
     ctx: &RuntimeContext,
-    config_dir: &Path,
-    enroll: EnrollOptions,
+    dir: Option<&Path>,
+    verbosity: u8,
 ) -> Result<()> {
-    if config_dir.join(IDENTITY_FILE).exists() {
-        if enroll.install {
-            // The `--install`-after-a-prior-enroll path, and the in-place
-            // upgrade path when a service is already installed.
-            return install_service(ctx, config_dir);
-        }
-        println!("This host is already enrolled with Spice Cloud.");
-        println!();
-        return print_status(config_dir, enroll.endpoint.as_deref()).await;
-    }
-
-    Err(Error::InvalidArgument {
-        message: "Interactive `spice connect` setup is introduced by the interactive workflow layer. In this foundation layer, supply a one-shot `spice-enroll-…` key or use `spiced --token <enrollment-key>` for unattended enrollment."
-            .to_string(),
-    })
-}
-
-/// Enroll this host with Spice Cloud and exit.
-///
-/// Sequence: preflight the service install (so a host that cannot be installed
-/// on fails with the code unspent), stage the code when it is stageable,
-/// install the runtime if missing, complete the HTTPS enroll (identity issued
-/// and persisted, registry row created cloud-side, and region recorded when
-/// requested), optionally install the service, and print the next steps.
-async fn enroll_instance(
-    ctx: &RuntimeContext,
-    token: runtime_cloud_connect::EnrollmentKey,
-    config_dir: &Path,
-    enroll: EnrollOptions,
-) -> Result<()> {
-    // Preflight BEFORE the enroll: a host with no supervisor or without root
-    // must fail with nothing installed and the adoption code still redeemable.
-    if enroll.install {
-        service::preflight()?;
-    }
-
-    std::fs::create_dir_all(config_dir).map_err(|e| Error::CloudConnectIo {
-        message: format!("create config dir {}: {e}", config_dir.display()),
-    })?;
-
-    println!("Enrolling this host with Spice Cloud...");
-
+    // The same preflight runs before the transaction; retain the error here as
+    // a defensive boundary for callers that invoke this helper directly.
     ctx.ensure_local_runtime_supported()?;
 
-    // Auto-install runtime if not present, so the printed next step
-    // (`spiced --cloud-connect`) works immediately after this command.
-    if !ctx.is_runtime_installed() {
-        tracing::info!("Spice.ai runtime is not installed. Installing now...");
-        crate::commands::install::execute(ctx, &crate::commands::install::InstallArgs::default())
-            .await?;
-    }
-
-    // Complete the HTTPS enroll right here — `spiced` is never started.
-    //
-    // Report the version of the runtime that will actually run, probed from the
-    // binary itself, so the registry row never shows a version the host is not
-    // running. The CLI's own version is only a fallback for when `spiced` cannot
-    // be executed; the two agree in shipped builds, where the CLI and the
-    // runtime move in lockstep.
-    let runtime_version = ctx
-        .runtime_version()
-        .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
-    let mut config = CloudConnectConfig::from_env_at(runtime_version, config_dir.to_path_buf());
-    if let Some(ref ep) = enroll.endpoint {
-        // The explicit flag wins over `SPICE_CLOUD_ENDPOINT` for this
-        // process. A successful fresh enrollment persists the canonical
-        // control-plane binding in the identity used by later starts.
-        config.enroll_endpoint = ep.clone();
-    }
-    if enroll.region.is_some() {
-        config.instance_region = enroll.region.clone();
-    }
-
-    let retry_hint = "re-run `spice connect <spice-enroll-key>`";
-    let outcome = runtime_cloud_connect::enroll_now_with_token(
-        &config,
-        token.expose_secret(),
-        None,
-        runtime_cloud_connect::RetryPolicy::INTERACTIVE,
-    )
-    .await;
-    let outcome = match outcome {
-        Ok(outcome) => outcome,
-        Err(err) if err.is_credential_rejection() => {
-            return Err(Error::CloudConnectEnroll {
-                message: format!(
-                    "{err}. Obtain a fresh enrollment key in the Spice Cloud portal and re-run `spice connect <spice-enroll-key>`."
-                ),
-            });
-        }
-        Err(err) if err.is_authoritative_rejection() => {
-            return Err(Error::CloudConnectEnroll {
-                message: format!("{err}. Fix the reported problem and {retry_hint}."),
-            });
-        }
-        Err(err @ runtime_cloud_connect::enroll::EnrollNowError::Persist { .. }) => {
-            // The identity was issued but could not be written; the message
-            // carries the recovery steps (the code is already consumed).
-            return Err(Error::CloudConnectEnroll {
-                message: err.to_string(),
-            });
-        }
-        Err(err) => {
-            return Err(Error::CloudConnectEnroll {
-                message: format!("{err}. {retry_hint} to retry."),
-            });
-        }
-    };
-
-    let (identity, metadata) = match outcome {
-        runtime_cloud_connect::EnrollNowOutcome::AlreadyEnrolled { identity } => (identity, None),
-        runtime_cloud_connect::EnrollNowOutcome::Enrolled { identity, metadata } => {
-            (identity, Some(metadata))
-        }
-    };
-    // The canonical identity now carries the control-plane binding. A legacy
-    // endpoint file is removed only after a fresh enrollment has committed;
-    // an existing identity short-circuit leaves every byte of its local state
-    // untouched, including a self-hosted binding used by older runtimes.
-    if metadata.is_some() {
-        let endpoint_path = config_dir.join(CLOUD_ENDPOINT_FILE);
-        if let Err(error) = std::fs::remove_file(&endpoint_path)
-            && error.kind() != std::io::ErrorKind::NotFound
-        {
-            tracing::warn!(
-                "The enrolled identity is durable, but the legacy endpoint override at {} could not be removed: {error}",
-                endpoint_path.display()
-            );
-        }
-    }
-    println!("Enrolled with Spice Cloud.");
-    // Display only the organization reported by the issuing control plane.
-    if let Some(org) = metadata
-        .as_ref()
-        .map(|metadata| &metadata.organization.name)
-        .filter(|org| !org.is_empty())
-    {
-        println!("  org:         {org}");
-    }
-    println!("  instance id: {}", identity.identifier);
-    println!("  identity:    {}", config.identity_path.display());
-    if !identity.gateway_addr.is_empty() {
-        println!("  gateway:     {}", identity.gateway_addr);
-    }
-    if let Some(region) = metadata
-        .as_ref()
-        .and_then(|metadata| metadata.region.as_ref())
-        .or(enroll.region.as_ref())
-    {
-        println!("  region:      {region}");
-    }
-    println!("  app:         unattached — attach to an app in the Spice Cloud portal");
-    println!();
-
-    if enroll.install {
-        // Any failure here is post-enroll: the identity is staged and the
-        // install resumes with `sudo spice connect --install`, so say so
-        // rather than leaving the operator to guess whether to re-enroll.
-        return install_service(ctx, config_dir).map_err(|err| Error::CloudConnectEnroll {
-            message: format!(
-                "The host is enrolled and its identity is staged at {}, but the service could not \
-                 be installed: {err} Fix the problem and run `sudo spice connect --install` to \
-                 finish — do not re-enroll.",
-                config_dir.display()
-            ),
-        });
-    }
-
-    println!("Nothing is running yet. Choose how this instance runs:");
-    println!("  sudo spice connect --install   Install a persistent service (Linux/systemd)");
-    println!("  spiced --cloud-connect         Run it in the foreground from this directory");
-    println!("The instance shows as connected in the Spice Cloud portal once the runtime is up.");
-
-    Ok(())
-}
-
-/// Install (or reinstall) the service for this instance directory and report
-/// its name and how to manage it.
-fn install_service(ctx: &RuntimeContext, config_dir: &Path) -> Result<()> {
-    service::preflight()?;
-
-    // The service runs from the *instance* directory, not the `.spice` config
-    // dir beneath it: that directory is the spicepod root the runtime loads
-    // from.
-    let instance_dir = instance_dir_for(config_dir);
-    // Resolved, not derived from `$HOME`: `sudo` rewrites `HOME` to `/root`, and
-    // the runtime the operator installed is normally under their own home.
-    let spiced_path = ctx.resolve_spiced_path().ok_or_else(|| Error::InvalidArgument {
-        message: format!(
-            "Failed to install the Spice Cloud Connect service: no Spice runtime was found at {}. \
-             Install it with `spice install` and re-run `sudo spice connect --install`. \
-             See: https://spiceai.org/docs",
-            ctx.spiced_path().display()
-        ),
-    })?;
-
-    let installed = service::install(&instance_dir, config_dir, &spiced_path)?;
-
-    println!("Installed the Spice Cloud Connect service.");
-    println!("  service:   {}", installed.name);
-    println!("  file:      {}", installed.path.display());
-    println!("  directory: {}", instance_dir.display());
-    // Name both paths: the operator needs to know which build was installed and
-    // that the service runs a root-owned copy of it, not the original.
-    println!("  runtime:   {}", installed.runtime.display());
-    if installed.runtime != spiced_path {
-        println!("             staged from {}", spiced_path.display());
-    }
-    if let Ok(version) = ctx.runtime_version() {
-        println!("  version:   {version}");
-    }
-    if let Some(state) = service::is_active(&installed.name) {
-        println!("  state:     {state}");
-    }
-    println!();
-    println!("Manage it with:");
-    for hint in service::manage_hints(&installed.name) {
-        println!("  {hint}");
-    }
-    println!(
-        "Re-run `sudo spice connect --install` to upgrade the runtime in place; \
-         `sudo spice connect remove` to release this instance and uninstall the service."
-    );
-    Ok(())
-}
-
-/// The instance directory a config dir belongs to: `<dir>/.spice` → `<dir>`.
-///
-/// `SPICE_CONFIG_DIR` can point anywhere, so a config dir that is not named
-/// `.spice` has no instance directory above it — in that case the config dir
-/// itself is the best available answer for `WorkingDirectory`.
-fn instance_dir_for(config_dir: &Path) -> PathBuf {
-    if config_dir.file_name() == Some(std::ffi::OsStr::new(".spice"))
-        && let Some(parent) = config_dir.parent().filter(|p| !p.as_os_str().is_empty())
-    {
-        return parent.to_path_buf();
-    }
-    config_dir.to_path_buf()
-}
-
-async fn print_status(config_dir: &Path, endpoint: Option<&str>) -> Result<()> {
-    let identity_path = config_dir.join(IDENTITY_FILE);
-    let draft_path = runtime_cloud_connect::EnrollmentDraft::path_in(config_dir);
-
-    let identity = runtime_cloud_connect::identity::IdentityStore::load_optional(&identity_path)
-        .map_err(|e| Error::CloudConnectIo {
-            message: format!("load identity: {e}"),
-        })?;
-
-    if let Some(id) = identity {
-        let expiry = id.not_after_unix.map_or_else(
-            || "unbounded".to_string(),
-            |secs| format!("unix={secs} (expired={})", id.is_expired()),
-        );
-        println!("Spice Cloud Connect: adopted");
-        println!("  identifier:  {}", id.identifier);
-        println!("  identity:    {}", identity_path.display());
-        if !id.gateway_addr.is_empty() {
-            println!("  gateway:     {}", id.gateway_addr);
-        }
-        println!("  expiry:      {expiry}");
-        print_deployed_spicepod(config_dir);
-        print_delivered_secrets(config_dir);
-        print_service_for_dir(config_dir);
-        // An identity that reads as expired on a host whose clock is wrong is
-        // not actually expired — measure before the operator goes chasing a
-        // renewal problem that does not exist. A live identity needs no probe,
-        // which keeps the common `status` offline and instant.
-        if id.is_expired() {
-            report_clock_skew(&resolved_endpoint(config_dir, endpoint)).await;
-        }
-        return Ok(());
-    }
-
-    if draft_path.exists() {
-        println!("Spice Cloud Connect: pending enrollment");
-        println!("  enrollment draft: {}", draft_path.display());
-        println!(
-            "  present a fresh enrollment key to resume this retry-safe operation, or run `spice connect remove --yes` to abandon it"
-        );
-        print_service_for_dir(config_dir);
-        report_clock_skew(&resolved_endpoint(config_dir, endpoint)).await;
-        return Ok(());
-    }
-
-    // No state in this directory. A host can still be connected from another
-    // instance directory, so report the installed services rather than a
-    // misleading "not connected".
-    let installed = service::discover_all();
-    if !installed.is_empty() {
-        println!(
-            "Spice Cloud Connect: no instance in this directory ({}).",
-            instance_dir_for(config_dir).display()
-        );
-        println!("Installed services on this host:");
-        for service in &installed {
-            let state = service::is_active(&service.name).unwrap_or_else(|| "unknown".to_string());
-            println!(
-                "  {} (dir {}) — {state}",
-                service.name,
-                service.working_dir.display()
-            );
-        }
-        println!();
-        println!(
-            "Run `spice connect status --dir <directory>` to inspect one of them, or \
-             present a fresh enrollment key with `spice connect <spice-enroll-key>` here."
-        );
-        return Ok(());
-    }
-
-    println!("Spice Cloud Connect: not connected");
-    println!(
-        "Run `spice connect <spice-enroll-key>` with a fresh key from your Spice Cloud portal, \
-         or use `spiced --token <enrollment-key>` for unattended enrollment."
-    );
-    Ok(())
-}
-
-/// Report whether a deployed spicepod is what this instance comes up on.
-///
-/// Reads the config dir only, so it answers on a host with no network.
-fn print_deployed_spicepod(config_dir: &Path) {
-    let spicepod = config_dir.join(runtime_cloud_connect::config::CLOUD_MANAGED_SPICEPOD_FILE);
-    if spicepod.exists() {
-        println!("  deployment:  {}", spicepod.display());
-    } else {
-        println!(
-            "  deployment:  none yet — this instance runs its local spicepod until an app is deployed to it"
-        );
-    }
-}
-
-/// Report the delivered secrets held in the local cache.
-///
-/// Reads only the cache's plaintext header, so this works without the key and
-/// **cannot** print a value. Names are what diagnose the common failure: a
-/// component referencing a secret the last deployment did not deliver.
-fn print_delivered_secrets(config_dir: &Path) {
-    let path = config_dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE);
-    let Some(header) = runtime_cloud_connect::secret_cache::read_header(&path) else {
-        if path.exists() {
-            println!(
-                "  secrets:     cache present but unreadable — deploy the app to re-deliver them"
-            );
-        } else {
-            println!("  secrets:     none delivered yet — deploy the app to deliver them");
-        }
-        return;
-    };
-    if header.names.is_empty() {
-        println!("  secrets:     none (the last deployment delivered no secrets)");
-        return;
-    }
-    println!(
-        "  secrets:     {} delivered: {}",
-        header.names.len(),
-        header.names.join(", ")
-    );
-}
-
-/// Report the service installed for this instance directory, when there is one.
-fn print_service_for_dir(config_dir: &Path) {
-    let instance_dir = instance_dir_for(config_dir);
-    let Some(installed) = service::find_for_dir(&instance_dir) else {
-        // Not an error: containers and foreground runs are supported ways to
-        // run, and `--install` needs a supported supervisor.
-        return;
-    };
-    let state = service::is_active(&installed.name).unwrap_or_else(|| "unknown".to_string());
-    println!("  service:     {} — {state}", installed.name);
-}
-
-/// Measure the host clock against Spice Cloud and report a significant skew.
-///
-/// Called only from the states a wrong clock explains — an identity that reads
-/// as expired, or an enrollment stuck pending — so a healthy `status` makes no
-/// network request at all. Best-effort and silent on failure: `status` must
-/// stay usable on a host with no network.
-async fn report_clock_skew(endpoint: &str) {
-    if let Some(skew) = runtime_cloud_connect::clock_skew::diagnose(endpoint, None).await
-        && skew.is_significant()
-    {
-        println!("  clock:       {}", skew.advice());
-    }
-}
-
-/// Release this instance: report the release to Spice Cloud, uninstall an
-/// installed service, and clear the local identity and staged state.
-///
-/// Local state is cleared whether or not the cloud could be reached — the host
-/// is being decommissioned, and a `remove` that failed because the network was
-/// down would leave a credential behind. Unreachable, the registry row reads
-/// `disconnected` until it is deleted in the portal; the portal-side delete is
-/// authoritative either way.
-async fn remove_identity(
-    config_dir: &Path,
-    endpoint: Option<&str>,
-    assume_yes: bool,
-) -> Result<()> {
-    // Inventory and cleanup are one enrollment transaction. An enrollment may
-    // already be promoting its identity when removal starts; acquiring this
-    // boundary first makes removal observe and clear that winner instead of
-    // sampling an old draft-only state and returning with a new identity.
-    let enrollment_transaction = std::sync::Arc::new(
-        runtime_cloud_connect::EnrollmentTransactionLock::try_acquire_async(config_dir)
-            .await
-            .map_err(|e| Error::CloudConnectIo {
-                message: format!("acquire the enrollment transaction before removal: {e}"),
-            })?,
-    );
-    let identity_path = config_dir.join(IDENTITY_FILE);
-    let draft_path = runtime_cloud_connect::EnrollmentDraft::path_in(config_dir);
-    let endpoint_path = config_dir.join(CLOUD_ENDPOINT_FILE);
-    let cache_path = config_dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE);
-    let instance_dir = instance_dir_for(config_dir);
-
-    let identity =
-        runtime_cloud_connect::identity::IdentityStore::load_optional_async(identity_path.clone())
-            .await
-            .map_err(|e| Error::CloudConnectIo {
-                message: format!("load identity: {e}"),
-            })?;
-    let installed = service::find_for_dir(&instance_dir);
-
-    let had_identity = identity.is_some();
-    let had_draft = draft_path.exists();
-    let had_endpoint = endpoint_path.exists();
-    let had_cache = cache_path.exists();
-
-    if !had_identity && !had_draft && !had_endpoint && !had_cache && installed.is_none() {
-        println!("Spice Cloud Connect: nothing to remove.");
-        return Ok(());
-    }
-
-    // Confirm before touching a running service: stopping it takes the
-    // instance offline, and an operator who ran this in the wrong directory
-    // needs the chance to say no. Name what will be affected.
-    if let Some(ref installed) = installed
-        && !assume_yes
-    {
-        println!("This will release this instance from Spice Cloud and remove it from this host:");
-        println!("  service:   {} (stopped and uninstalled)", installed.name);
-        println!("  directory: {}", instance_dir.display());
-        if had_identity {
-            println!("  identity:  {} (deleted)", identity_path.display());
-        }
-        if had_draft {
-            println!("  draft:     {} (deleted)", draft_path.display());
-        }
-        if had_cache {
-            println!(
-                "  secrets:   {} (deleted — the app's delivered secrets)",
-                cache_path.display()
-            );
-        }
-        if !confirm("Continue?")? {
-            println!(
-                "Nothing was removed — the service is still running and the local state is intact."
-            );
-            return Ok(());
-        }
-    }
-
-    // Report the release before clearing anything: the identity leaf is the
-    // credential that authorises it, so it has to still exist.
-    if let Some(ref identity) = identity {
-        report_release(config_dir, endpoint, identity).await;
-    }
-
-    // A service left running against a released identity restarts forever, so
-    // this is the step that most needs to happen — but a failure must not abort
-    // the command before the identity is cleared. The cloud has already
-    // released the instance by this point, so keeping a dead credential on disk
-    // is strictly worse than reporting the uninstall failure at the end.
-    let uninstall_failure = match installed {
-        Some(ref installed) => match service::uninstall(&instance_dir) {
-            Ok(_) => {
-                println!("Stopped and uninstalled {}.", installed.name);
-                None
-            }
-            Err(err) => Some(err),
+    println!("Starting the Spice runtime. Press Ctrl-C to stop it.");
+    // The transaction's block reports durable enrollment/attachment only. It
+    // deliberately does not claim the process is connected or serving; the
+    // runtime prints that distinct completion after both its listener is bound
+    // and Cloud acknowledges this session. `AlreadyReported` is reserved for a
+    // launcher that already emitted that final runtime claim.
+    crate::runtime_launcher::run_runtime(
+        ctx,
+        &crate::runtime_launcher::RunConfig {
+            working_dir: dir.map(Path::to_path_buf),
+            verbosity,
+            connection_report: crate::runtime_launcher::ConnectionReport::Runtime,
+            ..crate::runtime_launcher::RunConfig::default()
         },
-        None => None,
-    };
-
-    // Before the identity: the cache holds the app's secrets and the identity
-    // holds the only key that opens them, so deleting the key first would leave
-    // an unopenable file that still has to be removed. Deleting the secrets
-    // first means an interrupted `remove` never leaves them behind.
-    if had_cache {
-        runtime_cloud_connect::secret_cache::remove(&cache_path).map_err(|e| {
-            Error::CloudConnectIo {
-                message: format!("remove the delivered-secrets cache: {e}"),
-            }
-        })?;
-    }
-
-    if had_identity {
-        // Clearing this also destroys the cache key, which is only in this file.
-        runtime_cloud_connect::identity::IdentityStore::clear_async(&identity_path)
-            .await
-            .map_err(|e| Error::CloudConnectIo {
-                message: format!("clear identity: {e}"),
-            })?;
-    }
-
-    if had_draft {
-        enrollment_transaction
-            .delete_draft_async()
-            .await
-            .map_err(|e| Error::CloudConnectIo {
-                message: format!("remove enrollment draft: {e}"),
-            })?;
-    }
-
-    // Also clear any `cloud-endpoint` override so a later
-    // `spice connect <code>` without `--endpoint` doesn't silently keep
-    // using the stale endpoint.
-    if had_endpoint
-        && let Err(e) = std::fs::remove_file(&endpoint_path)
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        return Err(Error::CloudConnectIo {
-            message: format!("remove endpoint override: {e}"),
-        });
-    }
-
-    println!(
-        "Spice Cloud Connect identity cleared. Present a fresh enrollment key with `spice connect <spice-enroll-key>` to enroll this directory again."
-    );
-
-    // Surfaced last so the exit status still reports it: the local state is
-    // gone, but a service left behind would keep restarting a runtime with no
-    // identity until someone removes it.
-    match uninstall_failure {
-        Some(err) => Err(err),
-        None => Ok(()),
-    }
-}
-
-/// Tell Spice Cloud this instance is released, and report what happened.
-///
-/// Never fails the command: the release moves the registry row to `removed`
-/// immediately when it lands. Unreachable, the row reads `disconnected` until it
-/// is deleted in the portal, and the operator is told so.
-async fn report_release(
-    config_dir: &Path,
-    endpoint: Option<&str>,
-    identity: &runtime_cloud_connect::Identity,
-) {
-    let endpoint = resolved_endpoint(config_dir, endpoint);
-    let ca = (!identity.ca_bundle_pem.is_empty()).then_some(identity.ca_bundle_pem.as_str());
-
-    match runtime_cloud_connect::release::release(&endpoint, identity, ca).await {
-        Ok(outcome) => {
-            println!("Released this instance in Spice Cloud.");
-            if !outcome.status.is_empty() {
-                println!("  registry status: {}", outcome.status);
-            }
-            if let Some(app) = outcome.app_name {
-                println!(
-                    "  app {app} is paused — its deploy target was removed. Move it to another \
-                     instance, or delete it, in the Spice Cloud portal."
-                );
-            }
-        }
-        Err(err) => {
-            println!(
-                "Could not report the release to Spice Cloud at {endpoint}: {err} \
-                 Clearing local state anyway. The instance reads as disconnected in the portal \
-                 until you delete it there."
-            );
-        }
-    }
-}
-
-/// Ask the operator to confirm a destructive step.
-///
-/// A non-interactive stdin (a script, a pipe) cannot answer, so rather than
-/// assuming yes — which would let an unattended run stop a service nobody asked
-/// it to — this errors and names `--yes` as the way scripts opt in.
-fn confirm(prompt: &str) -> Result<bool> {
-    use std::io::{BufRead as _, IsTerminal as _, Write as _};
-
-    if !std::io::stdin().is_terminal() {
-        return Err(Error::InvalidArgument {
-            message: format!(
-                "{prompt} — stdin is not a terminal, so the confirmation cannot be asked. \
-                 Pass --yes to confirm non-interactively. Nothing was removed."
-            ),
-        });
-    }
-
-    print!("{prompt} [y/N] ");
-    std::io::stdout()
-        .flush()
-        .map_err(|e| Error::CloudConnectIo {
-            message: format!("write prompt: {e}"),
-        })?;
-
-    let mut answer = String::new();
-    std::io::stdin()
-        .lock()
-        .read_line(&mut answer)
-        .map_err(|e| Error::CloudConnectIo {
-            message: format!("read confirmation: {e}"),
-        })?;
-    Ok(matches!(
-        answer.trim().to_ascii_lowercase().as_str(),
-        "y" | "yes"
-    ))
-}
-
-/// Resolve the endpoint `spiced` will actually contact, mirroring the
-/// precedence used at runtime: an explicit `--endpoint` first, then the
-/// `SPICE_CLOUD_ENDPOINT` env var, then the on-disk `cloud-endpoint` override
-/// in the config dir, then the built-in default.
-fn resolved_endpoint(config_dir: &Path, explicit: Option<&str>) -> String {
-    if let Some(endpoint) = explicit.filter(|e| !e.is_empty()) {
-        return endpoint.to_string();
-    }
-    if let Ok(env) = std::env::var("SPICE_CLOUD_ENDPOINT")
-        && !env.is_empty()
-    {
-        return env;
-    }
-    if let Ok(s) = std::fs::read_to_string(config_dir.join(CLOUD_ENDPOINT_FILE)) {
-        let trimmed = s.trim();
-        if !trimmed.is_empty() {
-            return trimmed.to_string();
-        }
-    }
-    runtime_cloud_connect::config::DEFAULT_ENDPOINT.to_string()
+    )
+    .await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser as _;
+
+    #[derive(clap::Parser, Debug)]
+    #[command(name = "spice")]
+    struct Harness {
+        #[command(subcommand)]
+        command: HarnessCommand,
+    }
+
+    #[derive(clap::Subcommand, Debug)]
+    enum HarnessCommand {
+        Connect(ConnectArgs),
+    }
+
+    fn parse(args: &[&str]) -> std::result::Result<ConnectArgs, clap::Error> {
+        let harness = Harness::try_parse_from(args)?;
+        let HarnessCommand::Connect(connect) = harness.command;
+        Ok(connect)
+    }
 
     #[test]
-    fn connect_target_debug_never_exposes_an_enrollment_authority() {
+    fn positional_target_debug_never_exposes_an_enrollment_authority() {
         let authority = "spice-enroll-abcdefghijklmnopqrstuvwxyz012345";
-        let target: ConnectTarget = authority.parse().expect("infallible parse");
-        let debug = format!("{target:?}");
-        assert_eq!(debug, "ConnectTarget([REDACTED])");
+        let args = parse(&["spice", "connect", authority]).expect("target parses");
+        let debug = format!("{args:?}");
         assert!(!debug.contains(authority));
+        assert!(debug.contains("[REDACTED]"));
     }
 
     #[test]
-    fn enrollment_key_near_misses_stay_on_the_redacted_path() {
-        assert!(looks_like_enrollment_key(
-            "spice-enroll-abcdefghijklmnopqrstuvwxyz012345"
-        ));
-        let secret = "A".repeat(32);
-        assert!(looks_like_enrollment_key(&format!("SPICE-ENROLL-{secret}")));
-        assert!(looks_like_enrollment_key(&format!("spcie-enroll-{secret}")));
-        assert!(looks_like_enrollment_key(&format!(
-            "prefix/spice-enroll-{secret}"
-        )));
-    }
-
-    #[test]
-    fn looks_like_enrollment_key_rejects_pod_paths() {
-        assert!(!looks_like_enrollment_key("spiceai/quickstart"));
-        assert!(!looks_like_enrollment_key("org/pod"));
-        assert!(!looks_like_enrollment_key("ordinary-local-path"));
-    }
-
-    #[test]
-    fn validate_region_accepts_labels_no_catalog_knows() {
-        // A standalone host need not be in a cloud region at all, and a brand
-        // new AWS region must not need a CLI release to be usable.
-        for region in ["us-west-2", "on-prem-syd", "ap-southeast-7"] {
-            assert_eq!(
-                validate_region(Some(region)).expect("valid").as_deref(),
-                Some(region)
+    fn only_an_org_and_pod_pair_can_use_deprecated_fallthrough() {
+        assert!(is_deprecated_spicepod_target("spiceai/quickstart"));
+        for target in [
+            "status",
+            "start",
+            "stop",
+            "restart",
+            "logs",
+            "spiceai/quickstart/extra",
+            "/quickstart",
+            "spiceai/",
+        ] {
+            assert!(
+                !is_deprecated_spicepod_target(target),
+                "{target} must not reach the deprecated pod-add path"
             );
         }
     }
 
     #[test]
-    fn validate_region_trims_and_treats_blank_as_absent() {
-        assert_eq!(
-            validate_region(Some("  us-west-2 "))
-                .expect("valid")
-                .as_deref(),
-            Some("us-west-2")
-        );
-        assert_eq!(validate_region(Some("   ")).expect("blank is absent"), None);
-        assert_eq!(validate_region(None).expect("absent"), None);
+    fn connect_exposes_only_interactive_setup_options() {
+        let args = parse(&[
+            "spice",
+            "connect",
+            "--dir",
+            "/srv/edge",
+            "--region",
+            "us-west-2",
+        ])
+        .expect("interactive setup options parse");
+        assert_eq!(args.dir.as_deref(), Some(Path::new("/srv/edge")));
+        assert_eq!(args.region.as_deref(), Some("us-west-2"));
+
+        for flag in ["--org", "--project", "--token"] {
+            assert!(
+                parse(&["spice", "connect", flag, "value"]).is_err(),
+                "{flag} must not be accepted by spice connect"
+            );
+        }
     }
 
     #[test]
-    fn validate_region_rejects_malformed_labels_with_an_actionable_message() {
-        let err = validate_region(Some("US_WEST_2")).expect_err("must reject");
-        let message = err.to_string();
-        assert!(message.contains("--region"), "{message}");
+    fn force_remove_is_an_explicit_local_recovery_command() {
+        let args = parse(&[
+            "spice",
+            "connect",
+            "remove",
+            "--force",
+            "--yes",
+            "--dir",
+            "/srv/edge",
+        ])
+        .expect("local recovery parses");
+        assert!(matches!(args.command, Some(ConnectCommand::Remove)));
+        assert!(args.force);
+        assert!(args.yes);
+        assert_eq!(args.dir.as_deref(), Some(Path::new("/srv/edge")));
+    }
+
+    #[test]
+    fn connect_has_no_machine_output_mode() {
+        let mut args = parse(&["spice", "connect"]).expect("parse bare connect");
+        args.apply_machine_mode();
+        assert!(!args.produces_json());
+    }
+
+    #[tokio::test]
+    async fn local_recovery_durably_removes_the_previous_cloud_generation() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let config_dir = dir.path().join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config directory");
+        let artifacts = [
+            IDENTITY_FILE,
+            "enrollment-draft.json",
+            "enrollment-draft.quarantine.1.2.json",
+            ".enrollment-draft.json.abandoned.tmp",
+            ".identity.json.interrupted.bak",
+            "identity.bak",
+            runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE,
+            CLOUD_MANAGED_SPICEPOD_FILE,
+            "spicepod-cloud-managed.incoming.yml",
+            "spicepod-cloud-managed.bak",
+            DEPLOYMENT_TRANSACTION_FILE,
+            DEPLOYMENT_TRANSACTION_INCOMING_FILE,
+            PREVIOUS_CLOUD_MANAGED_SPICEPOD_FILE,
+            PREVIOUS_SECRET_CACHE_FILE,
+            INCOMING_SECRET_CACHE_FILE,
+        ]
+        .map(|file| config_dir.join(file));
+        for artifact in &artifacts {
+            std::fs::write(artifact, b"previous Cloud generation")
+                .expect("write previous Cloud artifact");
+        }
+
+        abandon_local_state(&config_dir, true, true)
+            .await
+            .expect("local recovery succeeds");
+
+        for artifact in artifacts {
+            assert!(
+                !artifact.exists(),
+                "local recovery must remove {}",
+                artifact.display()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn local_recovery_deletes_nothing_without_enrollment_transaction_ownership() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let config_dir = dir.path().join(".spice");
+        let active =
+            runtime_cloud_connect::EnrollmentTransactionLock::try_acquire_async(&config_dir)
+                .await
+                .expect("hold the enrollment transaction");
+        let identity = config_dir.join(IDENTITY_FILE);
+        let draft = runtime_cloud_connect::EnrollmentDraft::path_in(&config_dir);
+        let cache = config_dir.join(runtime_cloud_connect::secret_cache::SECRET_CACHE_FILE);
+        for (path, contents) in [
+            (&identity, b"active identity".as_slice()),
+            (&draft, b"active draft".as_slice()),
+            (&cache, b"active cache".as_slice()),
+        ] {
+            std::fs::write(path, contents).expect("write active Cloud state");
+        }
+
+        let error = abandon_local_state(&config_dir, true, true)
+            .await
+            .expect_err("another enrollment transaction must exclude local recovery");
+
         assert!(
-            message.contains("us-west-2") && message.contains("on-prem-syd"),
-            "the message must show both an AWS and a non-AWS example: {message}"
+            error.to_string().contains("Another live process"),
+            "the refusal must explain that enrollment still owns the state: {error}"
         );
+        for path in [&identity, &draft, &cache] {
+            assert!(
+                path.exists(),
+                "recovery must delete nothing before it owns the enrollment transaction: {}",
+                path.display()
+            );
+        }
+        drop(active);
     }
 
-    #[test]
-    fn instance_dir_is_the_parent_of_a_dot_spice_config_dir() {
-        assert_eq!(
-            instance_dir_for(Path::new("/opt/edge-1/.spice")),
-            PathBuf::from("/opt/edge-1")
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_recovery_clears_the_locked_directory_after_path_replacement() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let config_dir = dir.path().join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config directory");
+        std::fs::write(config_dir.join(IDENTITY_FILE), b"locked identity")
+            .expect("write locked identity");
+
+        let mutation_lock = runtime_cloud_connect::MutationLock::acquire(
+            &config_dir,
+            "local-recovery-path-replacement-test",
+        )
+        .await
+        .expect("acquire mutation lock");
+        let moved_config_dir = dir.path().join("locked-spice");
+        std::fs::rename(&config_dir, &moved_config_dir).expect("rename locked directory");
+        std::fs::create_dir_all(&config_dir).expect("create replacement directory");
+        let replacement_identity = config_dir.join(IDENTITY_FILE);
+        std::fs::write(&replacement_identity, b"replacement identity")
+            .expect("write replacement identity");
+
+        abandon_local_state_locked(&mutation_lock, &config_dir)
+            .await
+            .expect("descriptor-rooted recovery succeeds");
+
+        assert!(
+            !moved_config_dir.join(IDENTITY_FILE).exists(),
+            "the identity in the locked directory must be removed"
         );
-    }
-
-    #[test]
-    fn instance_dir_falls_back_to_a_custom_config_dir() {
-        // SPICE_CONFIG_DIR can point anywhere; a directory not named `.spice`
-        // has no instance directory above it to infer.
         assert_eq!(
-            instance_dir_for(Path::new("/var/lib/spice-state")),
-            PathBuf::from("/var/lib/spice-state")
-        );
-    }
-
-    #[test]
-    fn resolved_endpoint_prefers_the_explicit_flag() {
-        let dir = std::env::temp_dir().join(format!("spice-connect-ep-{}", std::process::id()));
-        let _ = std::fs::create_dir_all(&dir);
-        assert_eq!(
-            resolved_endpoint(&dir, Some("https://explicit.example")),
-            "https://explicit.example"
-        );
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn resolved_endpoint_reads_the_on_disk_override_then_the_default() {
-        let dir = std::env::temp_dir().join(format!("spice-connect-ep2-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("create scratch dir");
-
-        // Nothing on disk: the built-in default.
-        assert_eq!(
-            resolved_endpoint(&dir, None),
-            runtime_cloud_connect::config::DEFAULT_ENDPOINT
-        );
-
-        // The override file wins over the default.
-        std::fs::write(dir.join(CLOUD_ENDPOINT_FILE), "https://override.example\n")
-            .expect("write override");
-        assert_eq!(resolved_endpoint(&dir, None), "https://override.example");
-
-        // A blank override is not an endpoint.
-        std::fs::write(dir.join(CLOUD_ENDPOINT_FILE), "  \n").expect("write blank override");
-        assert_eq!(
-            resolved_endpoint(&dir, None),
-            runtime_cloud_connect::config::DEFAULT_ENDPOINT
-        );
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn cloud_region_and_region_are_distinct_flags() {
-        // The pair a customer is most likely to transpose: `--region` records
-        // where the instance runs and is validated as a label, while
-        // `--cloud-region` names a Spice Cloud and is not a label on the row.
-        // Guard that the instance-region validator does not silently accept a
-        // Spice Cloud *data* region suffix as an instance location.
-        assert_eq!(
-            validate_region(Some("us-west-2-prod-aws-data"))
-                .expect("charset-valid")
-                .as_deref(),
-            Some("us-west-2-prod-aws-data"),
-            "the CLI validates charset only — the cloud stores the label verbatim"
+            std::fs::read(&replacement_identity).expect("read replacement identity"),
+            b"replacement identity",
+            "path replacement must not redirect destructive cleanup"
         );
     }
 }

--- a/bin/spice/src/commands/connect/naming.rs
+++ b/bin/spice/src/commands/connect/naming.rs
@@ -1,0 +1,168 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Project-name suggestions for the interactive Cloud Connect flow.
+
+use std::path::Path;
+
+use rand::RngExt as _;
+
+pub(super) const PROJECT_NAME_MIN_LEN: usize = 4;
+pub(super) const PROJECT_NAME_MAX_LEN: usize = 38;
+
+const FALLBACK_ADJECTIVES: &[&str] = &[
+    "amber", "bright", "calm", "clever", "crisp", "eager", "gentle", "lively", "rapid", "steady",
+    "vivid", "warm",
+];
+
+/// Validate a project name exactly as the connect contract accepts it.
+pub(super) fn validate_project_name(name: &str) -> std::result::Result<(), &'static str> {
+    if !(PROJECT_NAME_MIN_LEN..=PROJECT_NAME_MAX_LEN).contains(&name.len()) {
+        return Err("must be between 4 and 38 characters");
+    }
+    if !name
+        .bytes()
+        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err("must contain only lowercase letters, digits, and dashes");
+    }
+    if name.starts_with('-') || name.ends_with('-') {
+        return Err("must start and end with a letter or digit");
+    }
+    Ok(())
+}
+
+/// Derive the editable first suggestion from a canonical instance directory.
+///
+/// The result uses the directory basename when it can produce a valid name.
+/// An unusable basename gets exactly one CLI-local `adjective-spice` fallback.
+pub(super) fn initial_suggestion(directory: &Path) -> String {
+    let derived = directory
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .map(normalize_basename)
+        .unwrap_or_default();
+    if validate_project_name(&derived).is_ok() {
+        return derived;
+    }
+
+    let mut rng = rand::rng();
+    let index = rng.random_range(0..FALLBACK_ADJECTIVES.len());
+    format!("{}-spice", FALLBACK_ADJECTIVES[index])
+}
+
+fn normalize_basename(value: &str) -> String {
+    let mut normalized = String::with_capacity(value.len().min(PROJECT_NAME_MAX_LEN));
+    let mut separator_pending = false;
+
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() {
+            if separator_pending
+                && !normalized.is_empty()
+                && normalized.len() < PROJECT_NAME_MAX_LEN
+            {
+                normalized.push('-');
+            }
+            separator_pending = false;
+            if normalized.len() == PROJECT_NAME_MAX_LEN {
+                break;
+            }
+            normalized.push(byte.to_ascii_lowercase() as char);
+        } else if !normalized.is_empty() {
+            separator_pending = true;
+        }
+    }
+
+    normalized.truncate(PROJECT_NAME_MAX_LEN);
+    while normalized.ends_with('-') {
+        normalized.pop();
+    }
+    normalized
+}
+
+/// Suggest the next editable name after an authoritative create conflict.
+pub(super) fn collision_suggestion(base: &str, number: u32) -> String {
+    let suffix = format!("-{number}");
+    let base_budget = PROJECT_NAME_MAX_LEN.saturating_sub(suffix.len());
+    let mut truncated = base[..base.len().min(base_budget)].trim_end_matches('-');
+    if truncated.len() < PROJECT_NAME_MIN_LEN {
+        truncated = "spice";
+    }
+    format!("{truncated}{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_directory_basename_is_normalized() {
+        assert_eq!(
+            normalize_basename("  Retail__Analytics 2026 "),
+            "retail-analytics-2026"
+        );
+        assert_eq!(normalize_basename("A".repeat(60).as_str()).len(), 38);
+        assert_eq!(normalize_basename("café/東京"), "caf");
+    }
+
+    #[test]
+    fn unusable_basename_gets_one_valid_local_fallback() {
+        let suggestion = initial_suggestion(Path::new("/tmp/---"));
+        validate_project_name(&suggestion).expect("fallback must be valid");
+        assert!(suggestion.ends_with("-spice"));
+    }
+
+    #[test]
+    fn explicit_names_are_validated_without_rewriting() {
+        for invalid in ["ABC", "abc", "-valid", "valid-", "has space", "a_b"] {
+            assert!(validate_project_name(invalid).is_err(), "{invalid}");
+        }
+        validate_project_name("valid-project-2").expect("valid project name");
+    }
+
+    #[test]
+    fn normalization_and_collision_suffixes_preserve_the_name_contract() {
+        let alphabet = [b'a', b'Z', b'0', b'-', b'_', b' ', 0xf0, b'.'];
+        let mut state = 0x5eed_u64;
+        for length in 0..256 {
+            let mut input = Vec::with_capacity(length);
+            for _ in 0..length {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1);
+                input.push(alphabet[usize::from(state.to_le_bytes()[0]) % alphabet.len()]);
+            }
+            let lossy = String::from_utf8_lossy(&input);
+            let normalized = normalize_basename(&lossy);
+            assert!(normalized.len() <= PROJECT_NAME_MAX_LEN);
+            assert!(normalized.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'
+            }));
+            assert!(!normalized.starts_with('-'));
+            assert!(!normalized.ends_with('-'));
+
+            let base = if validate_project_name(&normalized).is_ok() {
+                normalized
+            } else {
+                "steady-spice".to_string()
+            };
+            for number in [2, 9, 10, 999, u32::MAX] {
+                validate_project_name(&collision_suggestion(&base, number))
+                    .expect("collision suggestion must stay valid");
+            }
+        }
+    }
+}

--- a/bin/spice/src/commands/connect/project.rs
+++ b/bin/spice/src/commands/connect/project.rs
@@ -1,0 +1,643 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Narrow client for the atomic Cloud Connect project operation.
+
+use futures::StreamExt as _;
+use reqwest::{StatusCode, redirect::Policy};
+use runtime_cloud_connect::Identity;
+use runtime_cloud_connect::enroll::SessionToken;
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+const PROJECT_PATH: &str = "/v1/cloud-connect/project";
+const MAX_RESPONSE_BYTES: usize = 64 * 1024;
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[derive(Debug, Snafu)]
+pub(super) enum Error {
+    #[snafu(display(
+        "Failed to create and attach the Spice Cloud project: the request could not be sent: {source}"
+    ))]
+    Transport { source: reqwest::Error },
+
+    #[snafu(display(
+        "Failed to create and attach the Spice Cloud project: the response could not be read: {source}"
+    ))]
+    ResponseBody { source: reqwest::Error },
+
+    #[snafu(display(
+        "Failed to create and attach the Spice Cloud project: the response exceeded the 64 KiB limit"
+    ))]
+    ResponseTooLarge,
+
+    #[snafu(display(
+        "Failed to create and attach the Spice Cloud project: the server returned an invalid response ({reason})"
+    ))]
+    InvalidResponse { reason: &'static str },
+
+    #[snafu(display(
+        "Failed to create and attach the Spice Cloud project: the enrolled identity could not sign the request: {reason}"
+    ))]
+    IdentityProof { reason: String },
+
+    #[snafu(display(
+        "Spice Cloud did not create the project ({status}, code={code}, retryable={retryable})"
+    ))]
+    Denied {
+        status: u16,
+        code: ProjectErrorCode,
+        retryable: bool,
+    },
+}
+
+impl Error {
+    #[must_use]
+    pub(super) fn is_name_conflict(&self) -> bool {
+        matches!(
+            self,
+            Self::Denied {
+                status: 409,
+                code: ProjectErrorCode::ProjectNameConflict,
+                retryable: false,
+            }
+        )
+    }
+
+    #[must_use]
+    pub(super) fn is_already_attached(&self) -> bool {
+        matches!(
+            self,
+            Self::Denied {
+                status: 409,
+                code: ProjectErrorCode::InstanceAlreadyAttached,
+                retryable: false,
+            }
+        )
+    }
+
+    /// A response that may have followed a committed mutation but did not
+    /// prove the authoritative result. Exact replay is the only safe recovery.
+    ///
+    /// The complement is exactly the non-retryable structured denial, which
+    /// proves the requested mutation did not commit — so a negated call is how
+    /// a caller asks "is it accurate to report this identity as unattached?".
+    #[must_use]
+    pub(super) fn is_attachment_ambiguous(&self) -> bool {
+        !matches!(
+            self,
+            Self::Denied {
+                retryable: false,
+                ..
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProjectErrorCode {
+    InvalidProjectName,
+    Unauthenticated,
+    Forbidden,
+    InstanceNotFound,
+    ProjectNameConflict,
+    InstanceNotEnrolled,
+    InstanceAlreadyAttached,
+    RateLimited,
+    Internal,
+    Unknown,
+}
+
+impl ProjectErrorCode {
+    fn parse(value: Option<&str>) -> Self {
+        match value {
+            Some("invalid_project_name") => Self::InvalidProjectName,
+            Some("unauthenticated") => Self::Unauthenticated,
+            Some("forbidden") => Self::Forbidden,
+            Some("instance_not_found") => Self::InstanceNotFound,
+            Some("project_name_conflict") => Self::ProjectNameConflict,
+            Some("instance_not_enrolled") => Self::InstanceNotEnrolled,
+            Some("instance_already_attached") => Self::InstanceAlreadyAttached,
+            Some("rate_limited") => Self::RateLimited,
+            Some("internal") => Self::Internal,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl std::fmt::Display for ProjectErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::InvalidProjectName => "invalid_project_name",
+            Self::Unauthenticated => "unauthenticated",
+            Self::Forbidden => "forbidden",
+            Self::InstanceNotFound => "instance_not_found",
+            Self::ProjectNameConflict => "project_name_conflict",
+            Self::InstanceNotEnrolled => "instance_not_enrolled",
+            Self::InstanceAlreadyAttached => "instance_already_attached",
+            Self::RateLimited => "rate_limited",
+            Self::Internal => "internal",
+            Self::Unknown => "unknown",
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct ProjectAttachment {
+    pub instance_id: String,
+    pub organization: String,
+    pub project_id: i64,
+    pub project_name: String,
+    pub monitor_url: String,
+}
+
+pub(super) struct ProjectClient {
+    http: reqwest::Client,
+    url: String,
+}
+
+impl std::fmt::Debug for ProjectClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProjectClient").finish_non_exhaustive()
+    }
+}
+
+impl ProjectClient {
+    pub(super) fn new(endpoint: &str) -> std::result::Result<Self, Error> {
+        Self::build(endpoint, true)
+    }
+
+    /// Build against Wiremock's plaintext listener without weakening the
+    /// production constructor's HTTPS-only transport.
+    #[cfg(test)]
+    fn new_allowing_http_for_test(endpoint: &str) -> std::result::Result<Self, Error> {
+        Self::build(endpoint, false)
+    }
+
+    fn build(endpoint: &str, https_only: bool) -> std::result::Result<Self, Error> {
+        reqwest::Url::parse(endpoint).map_err(|_| Error::InvalidResponse {
+            reason: "the Cloud endpoint was not an absolute URL",
+        })?;
+        let http = reqwest::Client::builder()
+            // Shorter than the transaction's replay window so a single lost
+            // response cannot consume the entire exact-replay opportunity.
+            .timeout(REQUEST_TIMEOUT)
+            .connect_timeout(std::time::Duration::from_secs(10))
+            // A redirect must never carry the user bearer to another origin.
+            .redirect(Policy::none())
+            .https_only(https_only)
+            .build()
+            .map_err(|source| Error::Transport { source })?;
+        Ok(Self {
+            http,
+            url: format!("{}{PROJECT_PATH}", endpoint.trim_end_matches('/')),
+        })
+    }
+
+    pub(super) async fn create(
+        &self,
+        token: &SessionToken,
+        organization: &str,
+        mutation: &ProjectMutation,
+    ) -> std::result::Result<ProjectAttachment, Error> {
+        let response = self
+            .http
+            .post(&self.url)
+            .bearer_auth(token.expose_secret())
+            .header("X-Org-Name", organization)
+            .json(mutation)
+            .send()
+            .await
+            .map_err(|source| Error::Transport { source })?;
+        let status = response.status();
+        if status.is_redirection() {
+            return Err(Error::InvalidResponse {
+                reason: "redirect responses are not allowed",
+            });
+        }
+        let body = bounded_body(response).await?;
+
+        if !matches!(status, StatusCode::OK | StatusCode::CREATED) {
+            return Err(parse_denial(status, &body)?);
+        }
+
+        let result = serde_json::from_slice::<ProjectResponse>(&body).map_err(|_| {
+            Error::InvalidResponse {
+                reason: "response was not the documented JSON object",
+            }
+        })?;
+        let monitor_url =
+            validate_response(&result, organization, &mutation.instance_id, &mutation.name)?;
+
+        Ok(ProjectAttachment {
+            instance_id: result.instance_id,
+            organization: result.organization.name,
+            project_id: result.project.id,
+            project_name: result.project.name,
+            monitor_url,
+        })
+    }
+}
+
+fn parse_denial(status: StatusCode, body: &[u8]) -> std::result::Result<Error, Error> {
+    let wire = serde_json::from_slice::<ErrorWire>(body).map_err(|_| Error::InvalidResponse {
+        reason: "non-success response was not the documented JSON object",
+    })?;
+    let code = ProjectErrorCode::parse(wire.code.as_deref());
+    let documented = matches!(
+        (status, code),
+        (
+            StatusCode::BAD_REQUEST,
+            ProjectErrorCode::InvalidProjectName
+        ) | (StatusCode::UNAUTHORIZED, ProjectErrorCode::Unauthenticated)
+            | (StatusCode::FORBIDDEN, ProjectErrorCode::Forbidden)
+            | (
+                StatusCode::NOT_FOUND,
+                ProjectErrorCode::InstanceNotFound | ProjectErrorCode::InstanceNotEnrolled
+            )
+            | (
+                StatusCode::CONFLICT,
+                ProjectErrorCode::ProjectNameConflict | ProjectErrorCode::InstanceAlreadyAttached
+            )
+            | (StatusCode::TOO_MANY_REQUESTS, ProjectErrorCode::RateLimited)
+            | (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ProjectErrorCode::Internal
+            )
+    );
+    if !documented {
+        return Err(Error::InvalidResponse {
+            reason: "non-success response status and code did not match the documented contract",
+        });
+    }
+    let transport_retryable = matches!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS | StatusCode::REQUEST_TIMEOUT
+    ) || status.is_server_error();
+    if wire.retryable != transport_retryable {
+        return Err(Error::InvalidResponse {
+            reason: "non-success response retryability did not match its status",
+        });
+    }
+    Ok(Error::Denied {
+        status: status.as_u16(),
+        code,
+        retryable: transport_retryable,
+    })
+}
+
+async fn bounded_body(response: reqwest::Response) -> std::result::Result<Vec<u8>, Error> {
+    let mut stream = response.bytes_stream();
+    let mut body = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|source| Error::ResponseBody { source })?;
+        if body.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
+            return Err(Error::ResponseTooLarge);
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn validate_response(
+    response: &ProjectResponse,
+    expected_org: &str,
+    expected_instance: &str,
+    expected_name: &str,
+) -> std::result::Result<String, Error> {
+    if response.instance_id != expected_instance {
+        return Err(Error::InvalidResponse {
+            reason: "instance_id did not match the request",
+        });
+    }
+    if !response
+        .organization
+        .name
+        .eq_ignore_ascii_case(expected_org)
+    {
+        return Err(Error::InvalidResponse {
+            reason: "organization did not match the request",
+        });
+    }
+    if response.project.name != expected_name {
+        return Err(Error::InvalidResponse {
+            reason: "project name did not match the request",
+        });
+    }
+    if response.project.id <= 0 {
+        return Err(Error::InvalidResponse {
+            reason: "project id was not positive",
+        });
+    }
+    if response
+        .organization
+        .name
+        .chars()
+        .chain(response.project.name.chars())
+        .any(char::is_control)
+    {
+        return Err(Error::InvalidResponse {
+            reason: "project metadata contained control characters",
+        });
+    }
+    // The same rule every Cloud-delivered link is held to, applied in one place:
+    // a second copy of it here is a second thing to keep in step, and the two
+    // would sooner or later accept different links.
+    runtime_cloud_connect::config::safe_portal_url(&response.monitor_url).ok_or(
+        Error::InvalidResponse {
+            reason: "monitor_url was not a safe HTTP URL",
+        },
+    )
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct ProjectMutation {
+    pub(super) instance_id: String,
+    pub(super) name: String,
+    pub(super) cert_pem: String,
+    pub(super) pop_sig: String,
+}
+
+impl ProjectMutation {
+    pub(super) fn signed(
+        identity: &Identity,
+        organization: &str,
+        name: &str,
+    ) -> std::result::Result<Self, Error> {
+        let proof_payload = format!(
+            "spice-cloud-connect/project/v1\n{organization}\n{}\n{name}",
+            identity.identifier
+        );
+        let pop_sig = runtime_cloud_connect::sign_identity_proof(
+            &identity.private_key_pem,
+            proof_payload.as_bytes(),
+        )
+        .map_err(|reason| Error::IdentityProof { reason })?;
+        Ok(Self {
+            instance_id: identity.identifier.clone(),
+            name: name.to_string(),
+            cert_pem: identity.identity_cert_pem.clone(),
+            pop_sig,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct ProjectResponse {
+    instance_id: String,
+    organization: NamedResource,
+    project: NamedResource,
+    monitor_url: String,
+}
+
+#[derive(Deserialize)]
+struct NamedResource {
+    id: i64,
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct ErrorWire {
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    retryable: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const TOKEN: &str = "login-secret-that-must-not-leak";
+
+    fn test_identity() -> Identity {
+        let key_pair = rcgen::KeyPair::generate().expect("generate project proof key");
+        let certificate = rcgen::CertificateParams::new(Vec::<String>::new())
+            .expect("build project proof certificate parameters")
+            .self_signed(&key_pair)
+            .expect("sign project proof certificate");
+        Identity {
+            identifier: "inst_8fa21c".to_string(),
+            identity_cert_pem: certificate.pem(),
+            private_key_pem: key_pair.serialize_pem(),
+            public_key_pem: key_pair.public_key_pem(),
+            ca_bundle_pem: String::new(),
+            gateway_addr: String::new(),
+            not_after_unix: None,
+            enc_private_key_pem: String::new(),
+            enc_public_key_pem: String::new(),
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+            app_id: None,
+            org_name: None,
+            app_name: None,
+            monitor_url: None,
+            new_project_url: None,
+            control_plane_endpoint: None,
+        }
+    }
+
+    fn test_mutation(identity: &Identity) -> ProjectMutation {
+        ProjectMutation::signed(identity, "acme", "retail-analytics")
+            .expect("sign project mutation")
+    }
+
+    fn success_body() -> serde_json::Value {
+        serde_json::json!({
+            "instance_id": "inst_8fa21c",
+            "organization": {"id": 42, "name": "acme"},
+            "project": {"id": 314, "name": "retail-analytics"},
+            "monitor_url": "https://spice.ai/acme/retail-analytics/monitor"
+        })
+    }
+
+    #[tokio::test]
+    async fn first_create_sends_the_exact_atomic_project_contract() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(PROJECT_PATH))
+            .and(header("Authorization", format!("Bearer {TOKEN}")))
+            .and(header("X-Org-Name", "acme"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(success_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+        let result = ProjectClient::new_allowing_http_for_test(&server.uri())
+            .expect("client")
+            .create(&SessionToken::new(TOKEN.to_string()), "acme", &mutation)
+            .await
+            .expect("project created");
+        assert_eq!(result.project_id, 314);
+        assert_eq!(result.project_name, "retail-analytics");
+        let requests = server
+            .received_requests()
+            .await
+            .expect("read received project request");
+        let request: serde_json::Value =
+            serde_json::from_slice(&requests[0].body).expect("parse project request body");
+        assert_eq!(request["instance_id"], "inst_8fa21c");
+        assert_eq!(request["name"], "retail-analytics");
+        assert_eq!(request["cert_pem"], identity.identity_cert_pem);
+        assert!(
+            request["pop_sig"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty()),
+            "project request must carry a proof-of-possession signature"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_replay_accepts_the_same_project_with_status_200() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(PROJECT_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+            .expect(2)
+            .mount(&server)
+            .await;
+        let client = ProjectClient::new_allowing_http_for_test(&server.uri()).expect("client");
+        let token = SessionToken::new(TOKEN.to_string());
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+
+        for _ in 0..2 {
+            client
+                .create(&token, "acme", &mutation)
+                .await
+                .expect("exact replay succeeds");
+        }
+    }
+
+    #[tokio::test]
+    async fn project_conflicts_are_typed_and_server_detail_is_redacted() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                "code": "project_name_conflict",
+                "error": format!("{TOKEN} acme retail-analytics https://private.example"),
+                "retryable": false
+            })))
+            .mount(&server)
+            .await;
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+        let err = ProjectClient::new_allowing_http_for_test(&server.uri())
+            .expect("client")
+            .create(&SessionToken::new(TOKEN.to_string()), "acme", &mutation)
+            .await
+            .expect_err("conflict");
+
+        assert!(err.is_name_conflict());
+        let rendered = format!("{err:?} {err}");
+        for secret in [TOKEN, "acme", "retail-analytics", "private.example"] {
+            assert!(!rendered.contains(secret), "leaked {secret}: {rendered}");
+        }
+    }
+
+    #[tokio::test]
+    async fn mismatched_success_is_not_persistable_attachment_state() {
+        let server = MockServer::start().await;
+        let mut body = success_body();
+        body["instance_id"] = serde_json::Value::String("inst_other".to_string());
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(body))
+            .mount(&server)
+            .await;
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+        let err = ProjectClient::new_allowing_http_for_test(&server.uri())
+            .expect("client")
+            .create(&SessionToken::new(TOKEN.to_string()), "acme", &mutation)
+            .await
+            .expect_err("mismatch must fail closed");
+        assert!(matches!(err, Error::InvalidResponse { .. }));
+    }
+
+    #[tokio::test]
+    async fn plaintext_remote_monitor_url_is_rejected() {
+        let server = MockServer::start().await;
+        let mut body = success_body();
+        body["monitor_url"] =
+            serde_json::Value::String("http://example.invalid/monitor".to_string());
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(body))
+            .mount(&server)
+            .await;
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+        let err = ProjectClient::new_allowing_http_for_test(&server.uri())
+            .expect("client")
+            .create(&SessionToken::new(TOKEN.to_string()), "acme", &mutation)
+            .await
+            .expect_err("plaintext remote monitor URL must fail closed");
+        assert!(matches!(err, Error::InvalidResponse { .. }));
+    }
+
+    #[tokio::test]
+    async fn project_redirect_is_rejected_without_forwarding_the_bearer() {
+        let source = MockServer::start().await;
+        let target = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/stolen"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&target)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(PROJECT_PATH))
+            .respond_with(
+                ResponseTemplate::new(307)
+                    .insert_header("Location", format!("{}/stolen", target.uri())),
+            )
+            .expect(1)
+            .mount(&source)
+            .await;
+
+        let identity = test_identity();
+        let mutation = test_mutation(&identity);
+        let err = ProjectClient::new_allowing_http_for_test(&source.uri())
+            .expect("client")
+            .create(&SessionToken::new(TOKEN.to_string()), "acme", &mutation)
+            .await
+            .expect_err("redirect must fail closed");
+        assert!(matches!(err, Error::InvalidResponse { .. }), "{err}");
+        target.verify().await;
+    }
+
+    #[test]
+    fn only_authoritative_denials_are_safe_to_report_as_unattached() {
+        let denied = Error::Denied {
+            status: 409,
+            code: ProjectErrorCode::ProjectNameConflict,
+            retryable: false,
+        };
+        assert!(!denied.is_attachment_ambiguous());
+
+        for ambiguous in [
+            Error::ResponseTooLarge,
+            Error::InvalidResponse {
+                reason: "invalid success body",
+            },
+        ] {
+            assert!(ambiguous.is_attachment_ambiguous());
+        }
+    }
+}

--- a/bin/spice/src/commands/connect/state.rs
+++ b/bin/spice/src/commands/connect/state.rs
@@ -1,0 +1,1023 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Per-directory serialization and the non-secret enrollment journal.
+
+use std::fs::OpenOptions;
+use std::io::{Read as _, Write as _};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use runtime_cloud_connect::EnrollmentDraft;
+use runtime_cloud_connect::identity::Identity;
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt as _, Snafu};
+
+use super::project::ProjectMutation;
+
+pub(super) const CONNECT_OPERATION_FILE: &str = "connect-operation.json";
+pub(super) const PROJECT_OPERATION_FILE: &str = "connect-project-operation.json";
+
+const CONNECT_OPERATION_SCHEMA_VERSION: u32 = 3;
+const PROJECT_OPERATION_SCHEMA_VERSION: u32 = 3;
+const MAX_JOURNAL_BYTES: u64 = 256 * 1024;
+
+#[derive(Debug, Snafu)]
+pub(super) enum Error {
+    #[snafu(display("Failed to access Cloud Connect state at {}: {source}", path.display()))]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to parse the Cloud Connect enrollment journal at {}: {source}", path.display()))]
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("Failed to serialize the Cloud Connect enrollment journal: {source}"))]
+    Serialize { source: serde_json::Error },
+
+    #[snafu(display(
+        "Cloud Connect state for this directory is already being changed{owner}. Wait for that command to finish, then retry."
+    ))]
+    LockTimeout { owner: String },
+
+    #[snafu(display("The Cloud Connect enrollment journal did not match this directory or identity. It was quarantined at {} and was not replayed.", journal.display()))]
+    Quarantined { journal: PathBuf },
+
+    #[snafu(display(
+        "A retry-safe Cloud Connect enrollment is already pending for different parameters ({reason}). Retry with the original organization and endpoint, or run `spice connect remove --force --yes` to explicitly abandon it. The exact-replay state was preserved."
+    ))]
+    PendingRequestMismatch { reason: String },
+
+    #[snafu(display(
+        "A retry-safe Cloud Connect project assignment is already pending for different parameters ({reason}). Retry the original command or run `spice connect remove --force --yes` to explicitly abandon it. The exact-replay state was preserved."
+    ))]
+    PendingProjectMismatch { reason: String },
+
+    #[snafu(display("The Cloud Connect enrollment journal at {} uses unsupported schema {found}; expected schema {expected}.", path.display()))]
+    UnsupportedSchema {
+        path: PathBuf,
+        found: u32,
+        expected: u32,
+    },
+}
+
+pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// The non-secret identity fields journal reconciliation compares against.
+///
+/// Reconciliation runs on a blocking task, so handing it the whole [`Identity`]
+/// would copy the PEM-encoded certificate and both private keys onto the heap —
+/// where nothing zeroizes them — to perform four string comparisons.
+#[derive(Debug, Clone)]
+pub(super) struct IdentityFacts {
+    identifier: String,
+    org_name: Option<String>,
+    app_id: Option<String>,
+    app_name: Option<String>,
+    control_plane_endpoint: Option<String>,
+}
+
+impl From<&Identity> for IdentityFacts {
+    fn from(identity: &Identity) -> Self {
+        Self {
+            identifier: identity.identifier.clone(),
+            org_name: identity.org_name.clone(),
+            app_id: identity.app_id.clone(),
+            app_name: identity.app_name.clone(),
+            control_plane_endpoint: identity.control_plane_endpoint.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum EnrollmentPhase {
+    Prepared,
+    Enrolled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ConnectOperation {
+    pub schema_version: u32,
+    pub directory: PathBuf,
+    pub enrollment_operation_id: String,
+    pub organization: String,
+    pub endpoint: String,
+    pub region: Option<String>,
+    pub phase: EnrollmentPhase,
+    pub instance_id: Option<String>,
+}
+
+/// How firmly an operation is tied to the organization recorded for it.
+///
+/// The two enrollment authorities differ here, and the journal has to match them
+/// or it refuses a retry the enrollment itself would accept.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OrganizationBinding {
+    /// A login-session operation is bound to one organization for its lifetime:
+    /// the session was issued for it, and another organization is another
+    /// operation.
+    Fixed,
+    /// An enrollment key asserts the organization it expects, and Spice Cloud
+    /// checks the assertion *before* consuming the key — so a mismatch leaves the
+    /// key unspent and the operation replayable with the assertion corrected.
+    Assertion,
+}
+
+impl ConnectOperation {
+    pub(super) fn prepare(
+        config_dir: &Path,
+        directory: &Path,
+        enrollment_operation_id: &str,
+        organization: &str,
+        binding: OrganizationBinding,
+        endpoint: &str,
+        region: Option<&str>,
+    ) -> Result<Self> {
+        if let Some(mut existing) = Self::load_optional(config_dir)? {
+            let same_organization = existing.organization.eq_ignore_ascii_case(organization);
+            if existing.schema_version == CONNECT_OPERATION_SCHEMA_VERSION
+                && existing.directory == directory
+                && existing.enrollment_operation_id == enrollment_operation_id
+                && (same_organization || binding == OrganizationBinding::Assertion)
+                && existing.endpoint == endpoint
+                && region.is_none_or(|region| existing.region.as_deref() == Some(region))
+                && existing.phase == EnrollmentPhase::Prepared
+            {
+                if !same_organization {
+                    // The corrected assertion, replaying the same operation. It is
+                    // recorded now so that the identity this run enrolls is checked
+                    // against what was asked for, not against what was mistyped.
+                    existing.organization = organization.to_string();
+                    existing.store(config_dir)?;
+                }
+                return Ok(existing);
+            }
+            return Err(Error::PendingRequestMismatch {
+                reason: format!(
+                    "journal operation {}, organization {}, endpoint {}, region {}",
+                    existing.enrollment_operation_id,
+                    existing.organization,
+                    existing.endpoint,
+                    existing.region.as_deref().unwrap_or("unspecified")
+                ),
+            });
+        }
+
+        let operation = Self {
+            schema_version: CONNECT_OPERATION_SCHEMA_VERSION,
+            directory: directory.to_path_buf(),
+            enrollment_operation_id: enrollment_operation_id.to_string(),
+            organization: organization.to_string(),
+            endpoint: endpoint.to_string(),
+            region: region.map(ToString::to_string),
+            phase: EnrollmentPhase::Prepared,
+            instance_id: None,
+        };
+        operation.store(config_dir)?;
+        Ok(operation)
+    }
+
+    pub(super) fn mark_enrolled(&mut self, config_dir: &Path, identity: &Identity) -> Result<()> {
+        self.phase = EnrollmentPhase::Enrolled;
+        self.instance_id = Some(identity.identifier.clone());
+        if !self.organization.is_empty()
+            && !identity
+                .org_name
+                .as_deref()
+                .is_some_and(|org| org.eq_ignore_ascii_case(&self.organization))
+        {
+            return Err(Error::PendingRequestMismatch {
+                reason: format!(
+                    "the enrolled identity organization did not match requested organization {}",
+                    self.organization
+                ),
+            });
+        }
+        self.store(config_dir)
+    }
+
+    pub(super) fn delete(config_dir: &Path) -> Result<()> {
+        remove_if_exists(&config_dir.join(CONNECT_OPERATION_FILE))
+    }
+
+    pub(super) fn load_optional(config_dir: &Path) -> Result<Option<Self>> {
+        let path = config_dir.join(CONNECT_OPERATION_FILE);
+        let raw = match read_bounded_regular_file(&path, MAX_JOURNAL_BYTES) {
+            Ok(raw) => String::from_utf8(raw).map_err(|source| Error::Io {
+                path: path.clone(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, source),
+            })?,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(Error::Io { path, source }),
+        };
+        let operation =
+            serde_json::from_str::<Self>(&raw).context(ParseSnafu { path: path.clone() })?;
+        if operation.schema_version != CONNECT_OPERATION_SCHEMA_VERSION {
+            return Err(Error::UnsupportedSchema {
+                path,
+                found: operation.schema_version,
+                expected: CONNECT_OPERATION_SCHEMA_VERSION,
+            });
+        }
+        Ok(Some(operation))
+    }
+
+    /// Reconcile a leftover enrollment journal before any new mutation.
+    ///
+    /// A matching durable identity makes the journal obsolete. Any positive
+    /// mismatch is quarantined together with the provisional draft so it can
+    /// never be replayed under this directory by accident.
+    pub(super) fn reconcile(
+        config_dir: &Path,
+        directory: &Path,
+        endpoint: &str,
+        identity: Option<&IdentityFacts>,
+    ) -> Result<()> {
+        let Some(operation) = Self::load_optional(config_dir)? else {
+            return Ok(());
+        };
+        let directory_matches = operation.directory == directory;
+        if identity.is_none() && (!directory_matches || operation.endpoint != endpoint) {
+            return Err(Error::PendingRequestMismatch {
+                reason: format!(
+                    "directory {}, endpoint {}",
+                    operation.directory.display(),
+                    operation.endpoint
+                ),
+            });
+        }
+        let identity_matches = identity.is_none_or(|identity| {
+            operation
+                .instance_id
+                .as_deref()
+                .is_none_or(|instance_id| instance_id == identity.identifier)
+                && (operation.organization.is_empty()
+                    || identity
+                        .org_name
+                        .as_deref()
+                        .is_some_and(|org| org.eq_ignore_ascii_case(&operation.organization)))
+                && identity.control_plane_endpoint.as_deref() == Some(operation.endpoint.as_str())
+        });
+        let missing_identity_after_enroll =
+            identity.is_none() && operation.phase == EnrollmentPhase::Enrolled;
+
+        if !directory_matches || !identity_matches || missing_identity_after_enroll {
+            let path = config_dir.join(CONNECT_OPERATION_FILE);
+            let draft = EnrollmentDraft::path_in(config_dir);
+            // The replay material goes first. If either rename fails, the
+            // mismatched journal remains as a fail-closed guard; moving the
+            // journal first could strand a live draft that the next run pairs
+            // with fresh local authority.
+            if draft.exists() {
+                let _ = quarantine(config_dir, &draft)?;
+            }
+            let journal = quarantine(config_dir, &path)?;
+            return Err(Error::Quarantined { journal });
+        }
+
+        if identity.is_some() {
+            // Identity promotion is authoritative, but a crash can leave the
+            // draft (and both private keys it contains) beside that identity.
+            // Retire it under the enrollment transaction before removing the
+            // journal, otherwise every later run takes the existing-identity
+            // path and the credential debris becomes permanent.
+            EnrollmentDraft::delete(config_dir).map_err(|source| Error::Io {
+                path: EnrollmentDraft::path_in(config_dir),
+                source: std::io::Error::other(source),
+            })?;
+            Self::delete(config_dir)?;
+        }
+        Ok(())
+    }
+
+    fn store(&self, config_dir: &Path) -> Result<()> {
+        let path = config_dir.join(CONNECT_OPERATION_FILE);
+        let body = serde_json::to_vec_pretty(self).context(SerializeSnafu)?;
+        atomic_write_owner_only(&path, &body)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ProjectOperation {
+    pub schema_version: u32,
+    pub directory: PathBuf,
+    pub endpoint: String,
+    pub organization: String,
+    pub request: ProjectMutation,
+}
+
+impl ProjectOperation {
+    pub(super) fn prepare(
+        config_dir: &Path,
+        directory: &Path,
+        endpoint: &str,
+        organization: &str,
+        request: ProjectMutation,
+    ) -> Result<Self> {
+        if let Some(existing) = Self::load_optional(config_dir)? {
+            if existing.directory == directory
+                && existing.endpoint == endpoint
+                && existing.organization.eq_ignore_ascii_case(organization)
+                && existing.request.instance_id == request.instance_id
+                && existing.request.name == request.name
+            {
+                return Ok(existing);
+            }
+            return Err(Error::PendingProjectMismatch {
+                reason: format!(
+                    "organization {}, endpoint {}, instance {}, project {}",
+                    existing.organization,
+                    existing.endpoint,
+                    existing.request.instance_id,
+                    existing.request.name
+                ),
+            });
+        }
+        let operation = Self {
+            schema_version: PROJECT_OPERATION_SCHEMA_VERSION,
+            directory: directory.to_path_buf(),
+            endpoint: endpoint.to_string(),
+            organization: organization.to_string(),
+            request,
+        };
+        operation.store(config_dir)?;
+        Ok(operation)
+    }
+
+    pub(super) fn reconcile(
+        config_dir: &Path,
+        directory: &Path,
+        endpoint: &str,
+        identity: Option<&IdentityFacts>,
+    ) -> Result<Option<Self>> {
+        let Some(operation) = Self::load_optional(config_dir)? else {
+            return Ok(None);
+        };
+        let matches_identity = identity.is_some_and(|identity| {
+            identity.identifier == operation.request.instance_id
+                && identity
+                    .org_name
+                    .as_deref()
+                    .is_some_and(|org| org.eq_ignore_ascii_case(&operation.organization))
+        });
+        if operation.directory != directory || operation.endpoint != endpoint || !matches_identity {
+            return Err(Error::PendingProjectMismatch {
+                reason: format!(
+                    "organization {}, endpoint {}, instance {}, project {}",
+                    operation.organization,
+                    operation.endpoint,
+                    operation.request.instance_id,
+                    operation.request.name
+                ),
+            });
+        }
+        let Some(identity) = identity else {
+            return Err(Error::PendingProjectMismatch {
+                reason: "the enrolled identity is missing".to_string(),
+            });
+        };
+        if identity.app_id.is_some() {
+            let matches_attachment = identity
+                .org_name
+                .as_deref()
+                .is_some_and(|org| org.eq_ignore_ascii_case(&operation.organization))
+                && identity.app_name.as_deref() == Some(operation.request.name.as_str());
+            if matches_attachment {
+                Self::delete(config_dir)?;
+                return Ok(None);
+            }
+            return Err(Error::PendingProjectMismatch {
+                reason: "the durable identity has a different project attachment".to_string(),
+            });
+        }
+        Ok(Some(operation))
+    }
+
+    pub(super) fn load_optional(config_dir: &Path) -> Result<Option<Self>> {
+        let path = config_dir.join(PROJECT_OPERATION_FILE);
+        let raw = match read_bounded_regular_file(&path, MAX_JOURNAL_BYTES) {
+            Ok(raw) => String::from_utf8(raw).map_err(|source| Error::Io {
+                path: path.clone(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, source),
+            })?,
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(Error::Io { path, source }),
+        };
+        let operation =
+            serde_json::from_str::<Self>(&raw).context(ParseSnafu { path: path.clone() })?;
+        if operation.schema_version != PROJECT_OPERATION_SCHEMA_VERSION {
+            return Err(Error::UnsupportedSchema {
+                path,
+                found: operation.schema_version,
+                expected: PROJECT_OPERATION_SCHEMA_VERSION,
+            });
+        }
+        Ok(Some(operation))
+    }
+
+    pub(super) fn delete(config_dir: &Path) -> Result<()> {
+        remove_if_exists(&config_dir.join(PROJECT_OPERATION_FILE))
+    }
+
+    fn store(&self, config_dir: &Path) -> Result<()> {
+        let path = config_dir.join(PROJECT_OPERATION_FILE);
+        let body = serde_json::to_vec_pretty(self).context(SerializeSnafu)?;
+        atomic_write_owner_only(&path, &body)
+    }
+}
+
+fn read_bounded_regular_file(path: &Path, max_bytes: u64) -> std::io::Result<Vec<u8>> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK);
+    }
+    let file = options.open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.len() > max_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the Cloud Connect state file was not a bounded regular file",
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        if metadata.nlink() != 1 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "the Cloud Connect state file must not be hard-linked",
+            ));
+        }
+    }
+    let mut bytes = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
+    file.take(max_bytes.saturating_add(1))
+        .read_to_end(&mut bytes)?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > max_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the Cloud Connect state file exceeded its size limit",
+        ));
+    }
+    Ok(bytes)
+}
+
+pub(super) fn atomic_write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context(IoSnafu {
+            path: parent.to_path_buf(),
+        })?;
+    }
+    let candidate = path.with_file_name(format!(
+        ".{}.{}.candidate",
+        path.file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or(CONNECT_OPERATION_FILE),
+        rand::random::<u64>()
+    ));
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&candidate).context(IoSnafu {
+        path: candidate.clone(),
+    })?;
+    file.write_all(bytes).context(IoSnafu {
+        path: candidate.clone(),
+    })?;
+    file.sync_all().context(IoSnafu {
+        path: candidate.clone(),
+    })?;
+    drop(file);
+    if let Err(source) = promote_candidate(&candidate, path) {
+        let _ = std::fs::remove_file(&candidate);
+        return Err(Error::Io {
+            path: path.to_path_buf(),
+            source,
+        });
+    }
+    sync_parent_directory(path).context(IoSnafu {
+        path: path.to_path_buf(),
+    })
+}
+
+#[cfg(unix)]
+fn promote_candidate(candidate: &Path, path: &Path) -> std::io::Result<()> {
+    std::fs::rename(candidate, path)
+}
+
+#[cfg(not(unix))]
+fn promote_candidate(candidate: &Path, path: &Path) -> std::io::Result<()> {
+    std::fs::rename(candidate, path)
+}
+
+#[cfg(all(not(unix), not(windows)))]
+fn promote_candidate(candidate: &Path, path: &Path) -> std::io::Result<()> {
+    std::fs::rename(candidate, path)
+}
+
+/// Exercise the legacy non-replacing-filesystem rollback behavior in tests.
+/// Production Windows builds use `ReplaceFileW`, which is atomic and requires
+/// no backup window.
+#[cfg(test)]
+fn promote_candidate_without_replace(candidate: &Path, path: &Path) -> std::io::Result<()> {
+    if path.exists() {
+        let file_name = path
+            .file_name()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or(CONNECT_OPERATION_FILE);
+        let backup = path.with_file_name(format!(".{file_name}.{}.backup", rand::random::<u64>()));
+        std::fs::rename(path, &backup)?;
+        match std::fs::rename(candidate, path) {
+            Ok(()) => std::fs::remove_file(backup),
+            Err(promote_source) => {
+                std::fs::rename(&backup, path).map_err(|rollback_source| {
+                    std::io::Error::other(format!(
+                        "replacement failed ({promote_source}); rollback from {} also failed ({rollback_source})",
+                        backup.display()
+                    ))
+                })?;
+                Err(promote_source)
+            }
+        }
+    } else {
+        std::fs::rename(candidate, path)
+    }
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> std::io::Result<()> {
+    std::fs::File::open(path.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+fn quarantine(config_dir: &Path, path: &Path) -> Result<PathBuf> {
+    let epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let stem = path
+        .file_stem()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("connect-state");
+    let extension = path
+        .extension()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or("json");
+    let quarantined = config_dir.join(format!(
+        "{stem}.quarantine.{epoch}.{}.{extension}",
+        std::process::id()
+    ));
+    std::fs::rename(path, &quarantined).context(IoSnafu {
+        path: path.to_path_buf(),
+    })?;
+    // The quarantine is an authority transition: after success, the old live
+    // name must not reappear after a crash and become replayable again.
+    sync_parent(&quarantined)?;
+    Ok(quarantined)
+}
+
+pub(super) fn remove_durable_file(path: &Path) -> Result<()> {
+    remove_if_exists(path)
+}
+
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => sync_parent(path),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => sync_parent(path),
+        Err(source) => Err(Error::Io {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+#[cfg(unix)]
+fn sync_parent(path: &Path) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|source| Error::Io {
+            path: parent.to_path_buf(),
+            source,
+        })
+}
+
+#[cfg(not(unix))]
+fn sync_parent(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity(instance: &str, org: &str) -> Identity {
+        Identity {
+            identifier: instance.to_string(),
+            identity_cert_pem: "CERT".to_string(),
+            private_key_pem: "KEY".to_string(),
+            public_key_pem: "PUB".to_string(),
+            ca_bundle_pem: String::new(),
+            gateway_addr: "gateway.test:443".to_string(),
+            not_after_unix: None,
+            enc_private_key_pem: String::new(),
+            enc_public_key_pem: String::new(),
+            enc_previous_private_key_pem: String::new(),
+            cache_key_b64: String::new(),
+            app_id: None,
+            org_name: Some(org.to_string()),
+            app_name: None,
+            monitor_url: None,
+            new_project_url: None,
+            control_plane_endpoint: Some("https://api.spice.ai".to_string()),
+        }
+    }
+
+    #[test]
+    fn enrolled_identity_retires_the_matching_enrollment_journal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            EnrollmentDraft::path_in(dir.path()),
+            b"private enrollment material left after identity promotion",
+        )
+        .expect("write interrupted draft");
+        let mut operation = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            OrganizationBinding::Fixed,
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("prepare");
+        operation
+            .mark_enrolled(dir.path(), &identity("inst_1", "acme"))
+            .expect("mark enrolled");
+        ConnectOperation::reconcile(
+            dir.path(),
+            dir.path(),
+            "https://api.spice.ai",
+            Some(&IdentityFacts::from(&identity("inst_1", "acme"))),
+        )
+        .expect("reconcile");
+        assert!(!dir.path().join(CONNECT_OPERATION_FILE).exists());
+        assert!(
+            !EnrollmentDraft::path_in(dir.path()).exists(),
+            "the authoritative identity must retire its matching draft"
+        );
+    }
+
+    #[test]
+    fn mismatched_identity_is_quarantined_and_never_replayed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut operation = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            OrganizationBinding::Fixed,
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("prepare");
+        operation
+            .mark_enrolled(dir.path(), &identity("inst_1", "acme"))
+            .expect("mark enrolled");
+        let err = ConnectOperation::reconcile(
+            dir.path(),
+            dir.path(),
+            "https://api.spice.ai",
+            Some(&IdentityFacts::from(&identity("inst_other", "acme"))),
+        )
+        .expect_err("mismatch must quarantine");
+        assert!(matches!(err, Error::Quarantined { .. }));
+        assert!(!dir.path().join(CONNECT_OPERATION_FILE).exists());
+        assert!(
+            std::fs::read_dir(dir.path())
+                .expect("read dir")
+                .flatten()
+                .any(|entry| entry.file_name().to_string_lossy().contains("quarantine"))
+        );
+    }
+
+    #[test]
+    fn identity_from_another_control_plane_cannot_retire_the_journal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut operation = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            OrganizationBinding::Fixed,
+            "https://control-a.example",
+            None,
+        )
+        .expect("prepare");
+        let mut enrolled = identity("inst_1", "acme");
+        enrolled.control_plane_endpoint = Some("https://control-b.example".to_string());
+        operation
+            .mark_enrolled(dir.path(), &enrolled)
+            .expect("record enrolled phase");
+
+        let error = ConnectOperation::reconcile(
+            dir.path(),
+            dir.path(),
+            "https://control-b.example",
+            Some(&IdentityFacts::from(&enrolled)),
+        )
+        .expect_err("another control plane must not consume exact-replay state");
+
+        assert!(matches!(error, Error::Quarantined { .. }));
+        assert!(!dir.path().join(CONNECT_OPERATION_FILE).exists());
+    }
+
+    #[test]
+    fn missing_identity_organization_cannot_retire_an_org_bound_journal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            OrganizationBinding::Fixed,
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("prepare");
+        let mut recovered = IdentityFacts::from(&identity("inst_1", "acme"));
+        recovered.org_name = None;
+
+        let error = ConnectOperation::reconcile(
+            dir.path(),
+            dir.path(),
+            "https://api.spice.ai",
+            Some(&recovered),
+        )
+        .expect_err("missing organization must not bypass journal authority");
+
+        assert!(matches!(error, Error::Quarantined { .. }));
+        assert!(!dir.path().join(CONNECT_OPERATION_FILE).exists());
+    }
+
+    /// An enrollment key asserts the organization it expects and Spice Cloud
+    /// checks the assertion before consuming the key, so a mismatch leaves the
+    /// operation replayable with the assertion corrected. The journal has to
+    /// accept that correction, or the draft it preserved can never be finished.
+    #[test]
+    fn a_corrected_assertion_replays_the_same_token_operation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme-typo",
+            OrganizationBinding::Assertion,
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("prepare the operation that asserted the wrong organization");
+
+        let corrected = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            OrganizationBinding::Assertion,
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("the corrected assertion replays the same operation");
+        assert_eq!(
+            corrected.enrollment_operation_id, "operation-1",
+            "the operation is replayed, not replaced"
+        );
+        assert_eq!(
+            corrected.organization, "acme",
+            "and the journal records what was asked for"
+        );
+
+        // Persisted, so the identity this run enrolls is checked against the
+        // corrected organization rather than the mistyped one.
+        let reloaded = ConnectOperation::load_optional(dir.path())
+            .expect("load")
+            .expect("the journal is still there");
+        assert_eq!(reloaded.organization, "acme");
+
+        // A login-bound operation is not an assertion and does not move.
+        let fixed = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "globex",
+            OrganizationBinding::Fixed,
+            "https://api.spice.ai",
+            None,
+        )
+        .expect_err("a session is issued for one organization");
+        assert!(matches!(fixed, Error::PendingRequestMismatch { .. }));
+    }
+
+    #[test]
+    fn changed_pending_request_preserves_exact_replay_state() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let draft = EnrollmentDraft::path_in(dir.path());
+        std::fs::write(&draft, "exact replay material").expect("write draft sentinel");
+        ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            OrganizationBinding::Fixed,
+            "https://control-a.example",
+            None,
+        )
+        .expect("prepare");
+
+        let endpoint_error =
+            ConnectOperation::reconcile(dir.path(), dir.path(), "https://control-b.example", None)
+                .expect_err("changed endpoint must fail closed");
+        assert!(matches!(
+            endpoint_error,
+            Error::PendingRequestMismatch { .. }
+        ));
+        let org_error = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "globex",
+            OrganizationBinding::Fixed,
+            "https://control-a.example",
+            None,
+        )
+        .expect_err("changed organization must fail closed");
+        assert!(matches!(org_error, Error::PendingRequestMismatch { .. }));
+        assert_eq!(
+            std::fs::read_to_string(draft).expect("draft remains"),
+            "exact replay material"
+        );
+        let operation = ConnectOperation::load_optional(dir.path())
+            .expect("load journal")
+            .expect("journal remains");
+        assert_eq!(operation.enrollment_operation_id, "operation-1");
+        assert_eq!(operation.organization, "acme");
+        assert_eq!(operation.endpoint, "https://control-a.example");
+    }
+
+    #[test]
+    fn changed_pending_region_preserves_exact_replay_state() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            OrganizationBinding::Fixed,
+            "https://api.spice.ai",
+            Some("us-east-1"),
+        )
+        .expect("prepare");
+        let error = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            OrganizationBinding::Fixed,
+            "https://api.spice.ai",
+            Some("eu-west-1"),
+        )
+        .expect_err("changed region must fail closed");
+        assert!(matches!(error, Error::PendingRequestMismatch { .. }));
+        let operation = ConnectOperation::load_optional(dir.path())
+            .expect("load operation")
+            .expect("operation remains");
+        assert_eq!(operation.region.as_deref(), Some("us-east-1"));
+    }
+
+    #[test]
+    fn enrolled_organization_cannot_replace_the_requested_organization() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut operation = ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            OrganizationBinding::Fixed,
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("prepare");
+        let error = operation
+            .mark_enrolled(dir.path(), &identity("inst_1", "globex"))
+            .expect_err("response org must not rewrite request authority");
+        assert!(matches!(error, Error::PendingRequestMismatch { .. }));
+        assert_eq!(operation.organization, "acme");
+    }
+
+    #[test]
+    fn project_operation_persists_only_the_exact_request_for_server_replay() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let request = ProjectMutation {
+            instance_id: "inst_1".to_string(),
+            name: "retail".to_string(),
+            cert_pem: "certificate".to_string(),
+            pop_sig: "signature".to_string(),
+        };
+        let operation = ProjectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "https://api.spice.ai",
+            "acme",
+            request.clone(),
+        )
+        .expect("prepare project operation");
+        let recovered = ProjectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "https://api.spice.ai",
+            "acme",
+            request,
+        )
+        .expect("recover exact operation");
+        assert_eq!(recovered, operation);
+    }
+
+    #[test]
+    fn non_replacing_promotion_replaces_an_existing_journal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join(CONNECT_OPERATION_FILE);
+        let candidate = dir.path().join("candidate");
+        std::fs::write(&target, "prepared").expect("write old journal");
+        std::fs::write(&candidate, "enrolled").expect("write new journal");
+
+        promote_candidate_without_replace(&candidate, &target).expect("promote replacement");
+        assert_eq!(
+            std::fs::read_to_string(&target).expect("read promoted journal"),
+            "enrolled"
+        );
+        assert!(!candidate.exists());
+        assert!(
+            std::fs::read_dir(dir.path())
+                .expect("read directory")
+                .flatten()
+                .all(|entry| !entry.file_name().to_string_lossy().ends_with(".backup"))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_is_owner_only_and_contains_no_credentials() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().expect("tempdir");
+        ConnectOperation::prepare(
+            dir.path(),
+            dir.path(),
+            "operation-1",
+            "acme",
+            OrganizationBinding::Fixed,
+            "https://api.spice.ai",
+            None,
+        )
+        .expect("prepare");
+        let path = dir.path().join(CONNECT_OPERATION_FILE);
+        let mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+        let raw = std::fs::read_to_string(path).expect("journal");
+        assert!(!raw.contains("token"));
+        assert!(!raw.contains("private_key"));
+    }
+}

--- a/bin/spice/src/commands/connect/transaction.rs
+++ b/bin/spice/src/commands/connect/transaction.rs
@@ -1,0 +1,2798 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! The resumable `spice connect` enrollment and project transaction.
+
+use std::cell::Cell;
+use std::io::IsTerminal as _;
+use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::{Duration, Instant};
+
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::{Confirm, Input, Password, Select};
+use runtime_cloud_connect::enroll::{
+    EnrollNowOutcome, EnrollmentAuthority, InstanceFacts, RetryPolicy, SessionToken,
+};
+use runtime_cloud_connect::enrollment_key::EnrollmentKey;
+use runtime_cloud_connect::identity::{AppAttachment, Identity, IdentityStore};
+use runtime_cloud_connect::{CloudConnectConfig, EnrollmentTransactionLock};
+use zeroize::Zeroizing;
+
+use crate::commands::cloud::{CloudClient, org as cloud_org};
+use crate::commands::login::connect_org::{
+    OrgResolution, resolve_connect_organization_with_client,
+};
+use crate::commands::login::session::{CredentialStore, LoginContinuation, login_inline};
+use crate::context::RuntimeContext;
+use crate::error::{CloudErrorCode, Error, Result};
+
+use super::naming::{collision_suggestion, initial_suggestion, validate_project_name};
+use super::project::{ProjectAttachment, ProjectClient, ProjectMutation};
+use super::state::{ConnectOperation, IdentityFacts, OrganizationBinding, ProjectOperation};
+
+pub(super) struct ConnectRequest {
+    pub org: Option<String>,
+    pub project: Option<String>,
+    pub token: Option<EnrollmentKey>,
+    pub region: Option<String>,
+    pub dir: Option<PathBuf>,
+    pub endpoint: Option<String>,
+}
+
+struct EnrollmentResult {
+    identity: Identity,
+    recovery_url: Option<String>,
+    already_enrolled: bool,
+}
+
+/// How the control plane for this transaction was chosen. Both downstream
+/// rules are functions of this, so the source is carried instead of the
+/// derived flags — that keeps "persist a file we were never given" and
+/// "withhold a credential we are allowed to send" unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EndpointSource {
+    /// `--endpoint` or `SPICE_CLOUD_ENDPOINT`.
+    Explicit,
+    /// The durable identity or pending draft binding.
+    Bound,
+    /// The operator-authored instance-local `cloud-endpoint` file.
+    LegacyFile,
+    /// No binding, no override: the compiled-in public control plane.
+    CompiledDefault,
+}
+
+#[derive(Debug)]
+struct TransactionEndpoint {
+    value: String,
+    source: EndpointSource,
+}
+
+impl TransactionEndpoint {
+    /// Only an explicit request or a durable binding is eligible to create or
+    /// replace the endpoint file: the legacy file already holds its own value,
+    /// and the compiled default needs no state file at all.
+    fn persist_file(&self) -> bool {
+        matches!(
+            self.source,
+            EndpointSource::Explicit | EndpointSource::Bound
+        )
+    }
+
+    /// A repo-local `cloud-endpoint` file selects a destination but does not
+    /// authorize sending any bearer credential to it.
+    fn permits_credentials(&self) -> bool {
+        !matches!(self.source, EndpointSource::LegacyFile)
+    }
+}
+
+const PROJECT_RETRY_DEADLINE: Duration = Duration::from_secs(30);
+const PROJECT_MAX_ATTEMPTS: u32 = 5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthChoice {
+    Login,
+    EnrollmentKey,
+}
+
+trait Prompter {
+    fn interactive(&self) -> bool;
+    async fn choose_auth(&mut self) -> Result<Option<AuthChoice>>;
+    async fn read_enrollment_key(&mut self, portal_url: &str) -> Result<Option<Zeroizing<String>>>;
+    async fn confirm_project_assignment(&mut self) -> Result<Option<bool>>;
+    async fn project_name(&mut self, suggestion: &str) -> Result<Option<String>>;
+}
+
+struct TerminalPrompter {
+    interactive: bool,
+}
+
+impl TerminalPrompter {
+    fn new() -> Self {
+        Self {
+            interactive: std::io::stdin().is_terminal(),
+        }
+    }
+}
+
+impl Prompter for TerminalPrompter {
+    fn interactive(&self) -> bool {
+        self.interactive
+    }
+
+    async fn choose_auth(&mut self) -> Result<Option<AuthChoice>> {
+        let result = tokio::task::spawn_blocking(|| {
+            Select::with_theme(&ColorfulTheme::default())
+                .with_prompt("Connect this directory to Spice Cloud")
+                .items([
+                    "Log in to Spice Cloud (recommended)",
+                    "Use an enrollment key",
+                ])
+                .default(0)
+                .interact_opt()
+        })
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("authentication-choice task panicked: {source}"),
+        })?;
+        map_optional_prompt(result, "authentication choice").map(|choice| {
+            choice.map(|index| {
+                if index == 0 {
+                    AuthChoice::Login
+                } else {
+                    AuthChoice::EnrollmentKey
+                }
+            })
+        })
+    }
+
+    async fn read_enrollment_key(&mut self, portal_url: &str) -> Result<Option<Zeroizing<String>>> {
+        println!("Open this URL to create or copy an enrollment key:");
+        println!("{portal_url}");
+        println!();
+        let open_url = portal_url.to_string();
+        tokio::task::spawn_blocking(move || {
+            // The printed URL is authoritative recovery when the platform has
+            // no opener or the opener fails.
+            let _ = system_open::that(open_url);
+        });
+        let result = tokio::task::spawn_blocking(|| {
+            Password::with_theme(&ColorfulTheme::default())
+                .with_prompt("Enrollment key")
+                .interact()
+        })
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("enrollment-key prompt task panicked: {source}"),
+        })?;
+        map_required_prompt(result, "enrollment key").map(|value| value.map(Zeroizing::new))
+    }
+
+    async fn confirm_project_assignment(&mut self) -> Result<Option<bool>> {
+        let result = tokio::task::spawn_blocking(|| {
+            Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt("Create a project for this instance now?")
+                .default(false)
+                .interact_opt()
+        })
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("project confirmation task panicked: {source}"),
+        })?;
+        map_optional_prompt(result, "project confirmation")
+    }
+
+    async fn project_name(&mut self, suggestion: &str) -> Result<Option<String>> {
+        let suggestion = suggestion.to_string();
+        let result = tokio::task::spawn_blocking(move || {
+            Input::<String>::with_theme(&ColorfulTheme::default())
+                .with_prompt("Project name")
+                .default(suggestion)
+                .allow_empty(false)
+                .interact_text()
+        })
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("project-name prompt task panicked: {source}"),
+        })?;
+        map_required_prompt(result, "project name")
+    }
+}
+
+fn map_optional_prompt<T>(result: dialoguer::Result<Option<T>>, what: &str) -> Result<Option<T>> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(dialoguer::Error::IO(source))
+            if matches!(
+                source.kind(),
+                std::io::ErrorKind::Interrupted | std::io::ErrorKind::UnexpectedEof
+            ) =>
+        {
+            Ok(None)
+        }
+        Err(source) => Err(Error::CloudConnectIo {
+            message: format!("read {what}: {source}"),
+        }),
+    }
+}
+
+/// The same interrupt/EOF-to-cancellation mapping for a prompt whose success
+/// value is unconditional.
+fn map_required_prompt<T>(result: dialoguer::Result<T>, what: &str) -> Result<Option<T>> {
+    map_optional_prompt(result.map(Some), what)
+}
+
+struct LoginCredential {
+    token: SessionToken,
+    credential_org: Option<String>,
+}
+
+struct FlowTelemetry {
+    auth_path: Cell<&'static str>,
+    completion: Cell<&'static str>,
+    failure_stage: Cell<&'static str>,
+    cancelled: Option<Arc<AtomicBool>>,
+}
+
+impl FlowTelemetry {
+    fn new(cancelled: Option<Arc<AtomicBool>>) -> Self {
+        Self {
+            auth_path: Cell::new("unknown"),
+            completion: Cell::new("failed"),
+            failure_stage: Cell::new("initialization"),
+            cancelled,
+        }
+    }
+
+    fn auth(&self, path: &'static str) {
+        self.auth_path.set(path);
+    }
+
+    fn stage(&self, stage: &'static str) {
+        self.failure_stage.set(stage);
+    }
+
+    fn complete(&self, outcome: &'static str) {
+        self.completion.set(outcome);
+        self.failure_stage.set("none");
+        if outcome == "cancelled"
+            && let Some(cancelled) = self.cancelled.as_ref()
+        {
+            cancelled.store(true, Ordering::Release);
+        }
+    }
+}
+
+impl Drop for FlowTelemetry {
+    fn drop(&mut self) {
+        tracing::debug!(
+            target: "spice_cli::connect",
+            auth_path = self.auth_path.get(),
+            completion = self.completion.get(),
+            failure_stage = self.failure_stage.get(),
+            "Spice Connect flow completed"
+        );
+    }
+}
+
+pub(super) async fn execute(
+    ctx: &RuntimeContext,
+    mut request: ConnectRequest,
+) -> Result<Option<PathBuf>> {
+    // Resolve the instance directory once, before the transaction, and pass
+    // that same stable path through to the foreground launcher. A caller may
+    // spell `--dir` through a symlink, but retargeting it after enrollment must
+    // never start spiced in a different directory.
+    let directory = canonical_instance_directory(request.dir.as_deref()).await?;
+    request.dir = Some(directory.clone());
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let result = execute_with_inner(
+        ctx,
+        request,
+        &mut TerminalPrompter::new(),
+        Some(Arc::clone(&cancelled)),
+    )
+    .await;
+    result?;
+    Ok((!cancelled.load(Ordering::Acquire)).then_some(directory))
+}
+
+#[cfg(test)]
+async fn execute_with<P: Prompter>(
+    ctx: &RuntimeContext,
+    request: ConnectRequest,
+    prompter: &mut P,
+) -> Result<()> {
+    execute_with_inner(ctx, request, prompter, None).await
+}
+
+async fn execute_with_inner<P: Prompter>(
+    ctx: &RuntimeContext,
+    mut request: ConnectRequest,
+    prompter: &mut P,
+    cancelled: Option<Arc<AtomicBool>>,
+) -> Result<()> {
+    let telemetry = FlowTelemetry::new(cancelled);
+    preflight_request(&request)?;
+    telemetry.stage("local_state");
+    let directory = canonical_instance_directory(request.dir.as_deref()).await?;
+    let config_dir = CloudConnectConfig::resolve_config_dir(Some(&directory));
+    let identity_path = config_dir.join(runtime_cloud_connect::config::IDENTITY_FILE);
+    // A pending draft names the authority its operation already committed to,
+    // so it decides what a resumed run needs — and says so in terms of that
+    // operation. This guard stays a cheap pre-lock probe and defers to
+    // [`resumable_authority`] once the draft can be read under the lock.
+    //
+    // Only a *definitive* absence takes the shortcut. A probe that cannot answer
+    // — a permission or metadata failure — must not be read as "nothing is
+    // pending": that would answer a protected retry state with generic
+    // fresh-enrollment guidance. Deferring instead reaches the draft loader under
+    // the lock, which is the layer that reports the real I/O failure.
+    let draft_pending = !matches!(
+        tokio::fs::try_exists(runtime_cloud_connect::EnrollmentDraft::path_in(&config_dir)).await,
+        Ok(false)
+    );
+    let identity_present = tokio::fs::try_exists(&identity_path).await.unwrap_or(true);
+    if !prompter.interactive()
+        && request.token.is_none()
+        && (request.org.is_none() || request.project.is_none())
+        && !identity_present
+        && !draft_pending
+    {
+        return Err(invalid_usage(
+            "non-interactive Cloud Connect requires either a login with --org <org> --project <name>, or --token <enrollment-key>.",
+        ));
+    }
+    // Serialize the complete CLI mutation with service lifecycle actions,
+    // cloud-dispatched removal, and delivered-secret cache writes. This is the
+    // outer lock; the runtime lease and enrollment transaction are acquired
+    // only after it, preserving the shared lock order.
+    let mutation_lock = runtime_cloud_connect::MutationLock::acquire(&config_dir, "connect")
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("acquire Cloud Connect state for enrollment: {source}"),
+        })?;
+    // The guard pins the directory that was actually locked. From here on,
+    // derive every state path from it so retargeting a symlink used by the
+    // caller cannot redirect the operation after acquisition.
+    mutation_lock
+        .ensure_directory_stable()
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("validate locked Cloud Connect state: {source}"),
+        })?;
+    let config_dir = mutation_lock
+        .descriptor_relative_config_dir()
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("pin locked Cloud Connect state: {source}"),
+        })?;
+    let identity_path = config_dir.join(runtime_cloud_connect::config::IDENTITY_FILE);
+    let _runtime_lock =
+        runtime_cloud_connect::RuntimeLock::acquire(&config_dir).map_err(|source| {
+            Error::CloudConnectIo {
+                message: format!(
+                    "{source} Stop the running instance before using `spice connect`."
+                ),
+            }
+        })?;
+    let identity = load_identity(&identity_path).await?;
+    if let Some(identity) = identity.as_ref() {
+        validate_existing_identity(&identity_path, identity)?;
+    }
+    let (draft, _, _) = load_operations(&config_dir).await?;
+    let resolved_endpoint = resolve_transaction_endpoint(
+        &config_dir,
+        request.endpoint.as_deref(),
+        identity.as_ref(),
+        draft.as_ref(),
+    )?;
+    let endpoint = resolved_endpoint.value.clone();
+    reconcile_journal(&config_dir, &directory, &endpoint, identity.as_ref()).await?;
+    let project_operation =
+        reconcile_project_journal(&config_dir, &directory, &endpoint, identity.as_ref()).await?;
+
+    if let Some(identity) = identity {
+        telemetry.auth("existing");
+        return existing_identity_flow(
+            &request,
+            prompter,
+            ExistingIdentityContext {
+                config_dir: &config_dir,
+                directory: &directory,
+                identity_path: &identity_path,
+                endpoint: &endpoint,
+                persist_endpoint_file: resolved_endpoint.persist_file(),
+                permits_stored_credentials: resolved_endpoint.permits_credentials(),
+                identity,
+                pending_project: project_operation,
+            },
+            &telemetry,
+        )
+        .await;
+    }
+
+    // The pending draft, if any, decides the authority: the cloud may already
+    // hold its operation, so only the mode that published it can replay the
+    // operation ID and key material instead of creating a sibling instance.
+    //
+    // This read is not under [`EnrollmentTransactionLock`], and deliberately so:
+    // what follows it is a credential prompt, and holding the enrollment
+    // transaction across unbounded human input would block every other
+    // enrollment in this directory — including a `spiced --token` bootstrap — for
+    // as long as an operator leaves a prompt open. The decision is therefore a
+    // *routing* decision, never the safety boundary. Another process may finish,
+    // replace, or abandon the operation while this one is prompting; the
+    // authoritative re-check happens under the transaction lock inside
+    // `enroll`, where a durable identity answers `AlreadyEnrolled` and a changed
+    // binding fails closed with `RequestBindingMismatch`, leaving the state the
+    // other process wrote intact. The cost of losing that race is a prompt
+    // answered for nothing, not a wrong enrollment.
+    let resumable = draft
+        .as_ref()
+        .map(|draft| resumable_authority(draft, &request, prompter.interactive()))
+        .transpose()?;
+    // The operation the decision above was made for. Carried so the enrollment
+    // transaction can refuse an operation this run never routed on.
+    let resumed_operation = resumable
+        .as_ref()
+        .and(draft.as_ref())
+        .map(|draft| draft.enrollment_operation_id.clone());
+    // A resumed operation replays the location recorded when it was published:
+    // the enrollment request is built from the draft, and the draft deliberately
+    // keeps its region so a differing `--region` on a retry cannot invalidate
+    // exact-replay state. The journal has to record that same value or it
+    // describes a request that was never sent — and then rejects the retry that
+    // names the region the operation actually carries.
+    let region = match resumable.as_ref().and(draft.as_ref()) {
+        Some(pending) => {
+            if let Some(requested) = request.region.as_deref()
+                && pending.region.as_deref() != Some(requested)
+            {
+                println!(
+                    "The pending enrollment declares location {}, which is what it replays; --region {requested} applies to a new enrollment.",
+                    pending.region.as_deref().unwrap_or("(none)")
+                );
+            }
+            pending.region.clone()
+        }
+        None => request.region.clone(),
+    };
+    let token = request.token.take();
+
+    let key_enrollment =
+        |expected_org: Option<String>, resumed_operation: Option<String>| KeyEnrollment {
+            ctx,
+            config_dir: &config_dir,
+            directory: &directory,
+            endpoint: &resolved_endpoint,
+            region: region.clone(),
+            expected_org,
+            resumed_operation,
+        };
+
+    match resumable {
+        Some(ResumableAuthority::EnrollmentKey { expected_org }) => {
+            // The enrollment key is bearer material that is deliberately never
+            // persisted, so resuming asks for a current one — and only for
+            // that. Offering the authentication chooser here would offer an
+            // authority this operation cannot be finished under.
+            if !resolved_endpoint.permits_credentials() {
+                return Err(legacy_endpoint_requires_explicit_authority(&endpoint));
+            }
+            telemetry.auth("token");
+            let key = if let Some(key) = token {
+                key
+            } else {
+                println!(
+                    "Resuming the pending enrollment for this directory. Enrollment keys are never stored, so this needs a current one."
+                );
+                let Some(raw) = prompter.read_enrollment_key(&connect_portal_url()).await? else {
+                    telemetry.complete("cancelled");
+                    return Ok(());
+                };
+                EnrollmentKey::parse(raw.as_str()).map_err(|source| Error::InvalidUsage {
+                    message: source.to_string(),
+                })?
+            };
+            return enroll_with_key(
+                key_enrollment(expected_org, resumed_operation),
+                key,
+                &telemetry,
+            )
+            .await;
+        }
+        Some(ResumableAuthority::Login { organization }) => {
+            return resume_pending_login(
+                PendingLogin {
+                    ctx,
+                    config_dir: &config_dir,
+                    directory: &directory,
+                    endpoint: &resolved_endpoint,
+                    region,
+                    organization,
+                    resumed_operation,
+                },
+                &request,
+                prompter,
+                &telemetry,
+            )
+            .await;
+        }
+        None => {}
+    }
+
+    if let Some(key) = token {
+        // A key cannot create a project, in any mode. This sits below the draft
+        // decision so that a pending operation answers first: a login-mode
+        // operation asked to finish with a key names the command that finishes it
+        // and the one that abandons it, which is more use than a rule about two
+        // flags.
+        if request.project.is_some() {
+            return Err(invalid_usage(
+                "--project cannot be used with --token; an enrollment key can enroll an instance but cannot create a project.",
+            ));
+        }
+        if !resolved_endpoint.permits_credentials() {
+            return Err(legacy_endpoint_requires_explicit_authority(&endpoint));
+        }
+        return enroll_with_key(key_enrollment(request.org.clone(), None), key, &telemetry).await;
+    }
+
+    if !prompter.interactive() && (request.org.is_none() || request.project.is_none()) {
+        return Err(invalid_usage(
+            "non-interactive Cloud Connect requires either a login with --org <org> --project <name>, or --token <enrollment-key>.",
+        ));
+    }
+
+    telemetry.stage("authentication");
+    let login = match if resolved_endpoint.permits_credentials() {
+        stored_user_login(&endpoint, request.org.as_deref()).await?
+    } else {
+        None
+    } {
+        Some(login) => login,
+        None if !prompter.interactive() => {
+            if !resolved_endpoint.permits_credentials() {
+                return Err(legacy_endpoint_requires_explicit_authority(&endpoint));
+            }
+            return Err(invalid_usage(
+                "non-interactive Cloud Connect requires either a login with --org <org> --project <name>, or --token <enrollment-key>.",
+            ));
+        }
+        None => match prompter.choose_auth().await? {
+            Some(AuthChoice::Login) => {
+                if !resolved_endpoint.permits_credentials() {
+                    return Err(legacy_endpoint_requires_explicit_authority(&endpoint));
+                }
+                match login_inline(CredentialStore::EnvFile).await? {
+                    LoginContinuation::Authenticated(session) => LoginCredential {
+                        token: SessionToken::new(session.access_token().to_string()),
+                        credential_org: Some(session.org_name().to_string()),
+                    },
+                    LoginContinuation::Cancelled => {
+                        telemetry.complete("cancelled");
+                        return Ok(());
+                    }
+                }
+            }
+            Some(AuthChoice::EnrollmentKey) => {
+                if !resolved_endpoint.permits_credentials() {
+                    return Err(legacy_endpoint_requires_explicit_authority(&endpoint));
+                }
+                telemetry.auth("token");
+                let Some(raw) = prompter.read_enrollment_key(&connect_portal_url()).await? else {
+                    telemetry.complete("cancelled");
+                    return Ok(());
+                };
+                let key =
+                    EnrollmentKey::parse(raw.as_str()).map_err(|source| Error::InvalidUsage {
+                        message: source.to_string(),
+                    })?;
+                return enroll_with_key(key_enrollment(request.org.clone(), None), key, &telemetry)
+                    .await;
+            }
+            None => {
+                telemetry.complete("cancelled");
+                return Ok(());
+            }
+        },
+    };
+    telemetry.auth("login");
+
+    let management = CloudClient::with_token_for_org_at(
+        login.token.expose_secret().to_string(),
+        None,
+        &endpoint,
+    )?;
+    telemetry.stage("organization_selection");
+    let selected = match resolve_connect_organization_with_client(
+        &management,
+        request.org.as_deref(),
+        login.credential_org.as_deref(),
+        prompter.interactive(),
+    )
+    .await
+    {
+        Ok(OrgResolution::Selected(org)) => org,
+        Ok(OrgResolution::Cancelled) => {
+            telemetry.complete("cancelled");
+            return Ok(());
+        }
+        Err(error)
+            if request.org.is_none()
+                && prompter.interactive()
+                && error.cloud_code() == Some(CloudErrorCode::Forbidden) =>
+        {
+            eprintln!("{error}");
+            eprintln!(
+                "An owner or admin can supply an enrollment key instead; that path enrolls this instance without creating a project."
+            );
+            if !resolved_endpoint.permits_credentials() {
+                return Err(legacy_endpoint_requires_explicit_authority(&endpoint));
+            }
+            telemetry.auth("token");
+            let Some(raw) = prompter.read_enrollment_key(&connect_portal_url()).await? else {
+                telemetry.complete("cancelled");
+                return Ok(());
+            };
+            let key = EnrollmentKey::parse(raw.as_str()).map_err(|source| Error::InvalidUsage {
+                message: source.to_string(),
+            })?;
+            return enroll_with_key(key_enrollment(request.org.clone(), None), key, &telemetry)
+                .await;
+        }
+        Err(error) => return Err(error),
+    };
+
+    enroll_with_login(
+        LoginEnrollment {
+            ctx,
+            config_dir: &config_dir,
+            directory: &directory,
+            endpoint: &resolved_endpoint,
+            region,
+            organization: selected.name,
+            login,
+            resumed_operation: None,
+        },
+        &request,
+        prompter,
+        &telemetry,
+    )
+    .await
+}
+
+/// The authority a pending enrollment draft already committed to, reconciled
+/// with this invocation's explicit inputs.
+#[derive(Debug, PartialEq, Eq)]
+enum ResumableAuthority {
+    /// An enrollment-key operation. The key itself is bearer material that is
+    /// never persisted, so a resume supplies a current one; the operation ID,
+    /// key material, and organization assertion come from the draft.
+    EnrollmentKey { expected_org: Option<String> },
+    /// A login-session operation, bound to one organization for its lifetime.
+    Login { organization: String },
+}
+
+/// Decide what can finish the pending operation `draft` describes.
+///
+/// The draft is authoritative. Spice Cloud may already hold its operation under
+/// the persisted ID, so the authority that published it is the only one that
+/// can replay it — which is why a resume never asks the operator to choose an
+/// authentication mode again. Explicit inputs that would move the operation to
+/// another authority, or that cannot finish it at all, fail here: before any
+/// prompt, credential, or request, with the draft left on disk so the command
+/// the error names can still replay it exactly.
+fn resumable_authority(
+    draft: &runtime_cloud_connect::EnrollmentDraft,
+    request: &ConnectRequest,
+    interactive: bool,
+) -> Result<ResumableAuthority> {
+    match &draft.binding.authority {
+        runtime_cloud_connect::EnrollmentAuthorityBinding::Token { expected_org } => {
+            if request.project.is_some() {
+                return Err(pending_operation_conflict(
+                    "was authorized by an enrollment key, which cannot create a project",
+                    "--project",
+                    "re-run without --project; attach a project from the Spice Cloud portal, or after the pending enrollment finishes",
+                ));
+            }
+            if !interactive && request.token.is_none() {
+                return Err(invalid_usage(
+                    "this directory has a pending enrollment that was authorized by an enrollment key. Enrollment keys are never stored, so finishing it non-interactively requires --token <enrollment-key>.",
+                ));
+            }
+            // `--org` on a resume corrects the assertion rather than
+            // contradicting it. Spice Cloud checks the assertion before it
+            // consumes the key, so an operation that failed on a mistyped one is
+            // still replayable — and refusing the correction here would strand the
+            // draft with no way to finish it but abandoning it. A flag naming the
+            // organization the draft already asserts is not a correction, and
+            // replays the draft's own value.
+            let expected_org = match (request.org.as_deref(), expected_org.as_deref()) {
+                (Some(requested), Some(pending)) if requested.eq_ignore_ascii_case(pending) => {
+                    expected_org.clone()
+                }
+                (Some(requested), _) => Some(requested.to_string()),
+                (None, _) => expected_org.clone(),
+            };
+            Ok(ResumableAuthority::EnrollmentKey { expected_org })
+        }
+        runtime_cloud_connect::EnrollmentAuthorityBinding::AuthenticatedSession {
+            organization,
+        } => {
+            // The public CLI is interactive-only: a rerun resumes the durable
+            // operation and asks for the missing project choice. The explicit
+            // force command is the only local-abandon path.
+            let finish = "re-run `spice connect` interactively to finish it, or run `spice connect remove --force --yes` to abandon it explicitly";
+            if request.token.is_some() {
+                return Err(pending_operation_conflict(
+                    &format!("was authorized by a login to organization {organization}"),
+                    "--token",
+                    finish,
+                ));
+            }
+            if let Some(requested) = request.org.as_deref()
+                && !requested.eq_ignore_ascii_case(organization)
+            {
+                return Err(pending_operation_conflict(
+                    &format!("is bound to organization {organization}"),
+                    &format!("--org {requested}"),
+                    finish,
+                ));
+            }
+            if !interactive && request.project.is_none() {
+                return Err(invalid_usage(format!(
+                    "this directory has a pending enrollment for organization {organization}. Finishing it non-interactively requires --project <name>."
+                )));
+            }
+            Ok(ResumableAuthority::Login {
+                organization: organization.clone(),
+            })
+        }
+    }
+}
+
+/// One message shape for every way an explicit input contradicts the pending
+/// operation: what the operation is, what contradicts it, and what to do —
+/// never a silent switch to the requested authority, and never a discarded
+/// draft.
+fn pending_operation_conflict(pending: &str, requested: &str, remedy: &str) -> Error {
+    invalid_usage(format!(
+        "this directory has a pending enrollment that {pending}, so {requested} cannot be applied to it. The exact-replay state was preserved: {remedy}."
+    ))
+}
+
+/// Everything an enrollment-key attempt needs beyond the key itself.
+struct KeyEnrollment<'a> {
+    ctx: &'a RuntimeContext,
+    config_dir: &'a Path,
+    directory: &'a Path,
+    endpoint: &'a TransactionEndpoint,
+    region: Option<String>,
+    /// The operation a resumed run routed on, verified under the enrollment
+    /// transaction before the key is spent. `None` for a fresh enrollment,
+    /// which has no operation to hold to.
+    resumed_operation: Option<String>,
+    /// The organization this attempt asserts the key belongs to, checked
+    /// against the enrollment response. `None` asserts nothing.
+    expected_org: Option<String>,
+}
+
+/// Enroll with an enrollment key and report the outcome.
+async fn enroll_with_key(
+    context: KeyEnrollment<'_>,
+    key: EnrollmentKey,
+    telemetry: &FlowTelemetry,
+) -> Result<()> {
+    telemetry.auth("token");
+    telemetry.stage("enrollment");
+    let expected_org = context.expected_org;
+    let enrolled = enroll(EnrollAttempt {
+        ctx: context.ctx,
+        config_dir: context.config_dir,
+        directory: context.directory,
+        endpoint: context.endpoint,
+        region: context.region,
+        journal_org: expected_org.clone().unwrap_or_default(),
+        authority: EnrollmentAuthority::Token { key, expected_org },
+        resumed_operation: context.resumed_operation,
+    })
+    .await?;
+    print_enrollment_result(&enrolled);
+    telemetry.complete(if enrolled.identity.app_id.is_some() {
+        "already_attached"
+    } else {
+        "unattached"
+    });
+    Ok(())
+}
+
+/// A login-authorized enrollment and the project assignment that follows it.
+struct LoginEnrollment<'a> {
+    ctx: &'a RuntimeContext,
+    config_dir: &'a Path,
+    directory: &'a Path,
+    endpoint: &'a TransactionEndpoint,
+    /// The location this enrollment declares. A resumed operation carries the
+    /// one its draft recorded, not this invocation's flag.
+    region: Option<String>,
+    organization: String,
+    login: LoginCredential,
+    /// As [`KeyEnrollment::resumed_operation`].
+    resumed_operation: Option<String>,
+}
+
+/// Enroll under a login session, then attach a project when one is named.
+async fn enroll_with_login<P: Prompter>(
+    context: LoginEnrollment<'_>,
+    request: &ConnectRequest,
+    prompter: &mut P,
+    telemetry: &FlowTelemetry,
+) -> Result<()> {
+    telemetry.stage("enrollment");
+    let enrolled = enroll(EnrollAttempt {
+        ctx: context.ctx,
+        config_dir: context.config_dir,
+        directory: context.directory,
+        endpoint: context.endpoint,
+        region: context.region,
+        journal_org: context.organization.clone(),
+        authority: EnrollmentAuthority::AuthenticatedSession {
+            access_token: context.login.token.clone(),
+            org: context.organization.clone(),
+        },
+        resumed_operation: context.resumed_operation,
+    })
+    .await?;
+
+    if enrolled.already_enrolled && enrolled.identity.app_id.is_some() {
+        print_attached(&enrolled.identity);
+        telemetry.complete("already_attached");
+        return Ok(());
+    }
+
+    telemetry.stage("project_assignment");
+    let project =
+        project_name_after_enrollment(request.project.as_deref(), context.directory, prompter)
+            .await?;
+    let Some(project) = project else {
+        print_unattached(&enrolled.identity, enrolled.recovery_url.as_deref());
+        telemetry.complete("cancelled");
+        return Ok(());
+    };
+    let assignment = assign_project(
+        ProjectAssignmentContext {
+            endpoint: &context.endpoint.value,
+            config_dir: context.config_dir,
+            directory: context.directory,
+            token: &context.login.token,
+            organization: &context.organization,
+            identity: &enrolled.identity,
+            recovery_url: enrolled.recovery_url.as_deref(),
+        },
+        project,
+        prompter,
+    )
+    .await?;
+    telemetry.complete(match assignment {
+        ProjectAssignment::Attached => "attached",
+        ProjectAssignment::Cancelled => "cancelled",
+    });
+    Ok(())
+}
+
+/// The pending login-mode operation this directory must finish.
+struct PendingLogin<'a> {
+    ctx: &'a RuntimeContext,
+    config_dir: &'a Path,
+    directory: &'a Path,
+    endpoint: &'a TransactionEndpoint,
+    /// As [`LoginEnrollment::region`].
+    region: Option<String>,
+    organization: String,
+    /// As [`KeyEnrollment::resumed_operation`].
+    resumed_operation: Option<String>,
+}
+
+/// The credential a resumed login operation presents.
+///
+/// The organization-bound credential is preferred; a default credential is used
+/// as it is, without asking the control plane which organization it belongs to.
+/// That identification is the `/api/spice-cli/auth` route, which a split-origin
+/// deployment serves from the portal rather than the control plane — requesting
+/// it against the pending operation's enrollment endpoint answers 404 there and
+/// is not needed anywhere: the enroll request names the bound organization, so
+/// Spice Cloud refuses a credential that is not entitled to it, and the
+/// response organization is checked against the binding before any identity is
+/// promoted. A wrong-organization credential therefore fails closed rather than
+/// enrolling somewhere the operator did not ask for.
+fn stored_resume_credential(organization: &str) -> Option<LoginCredential> {
+    cloud_org::token_for_org(organization)
+        .or_else(cloud_org::default_token)
+        .map(|token| LoginCredential {
+            token: SessionToken::new(token),
+            // Which organization a default credential belongs to is exactly
+            // what this path declines to ask, so it is not claimed here.
+            credential_org: None,
+        })
+}
+
+/// Finish a pending login-mode operation under the organization it is bound to.
+///
+/// The authentication chooser is deliberately absent: an enrollment key would
+/// publish a different authority than the operation Spice Cloud may already
+/// hold. Organization discovery is equally absent — the binding already chose
+/// the organization, so there is nothing to resolve and no way for a listing to
+/// retarget the pending operation. Spice Cloud re-validates the owner/admin role
+/// before the enrollment commits, as it does for the run that published the
+/// draft.
+async fn resume_pending_login<P: Prompter>(
+    context: PendingLogin<'_>,
+    request: &ConnectRequest,
+    prompter: &mut P,
+    telemetry: &FlowTelemetry,
+) -> Result<()> {
+    let endpoint = context.endpoint.value.as_str();
+    if !context.endpoint.permits_credentials() {
+        return Err(legacy_endpoint_requires_explicit_authority(endpoint));
+    }
+    // Nothing else would explain the absent chooser or where this run is going.
+    println!(
+        "Resuming the pending enrollment for organization {}.",
+        context.organization
+    );
+    telemetry.stage("authentication");
+    let login = match stored_resume_credential(&context.organization) {
+        Some(login) => login,
+        None if !prompter.interactive() => {
+            return Err(org_credential_missing(&context.organization));
+        }
+        None => match login_inline(CredentialStore::EnvFile).await? {
+            LoginContinuation::Authenticated(session) => LoginCredential {
+                token: SessionToken::new(session.access_token().to_string()),
+                credential_org: Some(session.org_name().to_string()),
+            },
+            LoginContinuation::Cancelled => {
+                telemetry.complete("cancelled");
+                return Ok(());
+            }
+        },
+    };
+    telemetry.auth("login");
+
+    enroll_with_login(
+        LoginEnrollment {
+            ctx: context.ctx,
+            config_dir: context.config_dir,
+            directory: context.directory,
+            endpoint: context.endpoint,
+            region: context.region,
+            organization: context.organization,
+            login,
+            resumed_operation: context.resumed_operation,
+        },
+        request,
+        prompter,
+        telemetry,
+    )
+    .await
+}
+
+struct ExistingIdentityContext<'a> {
+    config_dir: &'a Path,
+    directory: &'a Path,
+    identity_path: &'a Path,
+    endpoint: &'a str,
+    persist_endpoint_file: bool,
+    permits_stored_credentials: bool,
+    identity: Identity,
+    pending_project: Option<ProjectOperation>,
+}
+
+async fn existing_identity_flow<P: Prompter>(
+    request: &ConnectRequest,
+    prompter: &mut P,
+    context: ExistingIdentityContext<'_>,
+    telemetry: &FlowTelemetry,
+) -> Result<()> {
+    // An enrolled instance ignores an enrollment key — the identity wins — so
+    // accepting one here would take a secret from the operator, drop it, and then
+    // attach the project with a stored login credential instead. Moving the flag
+    // rule below the draft decision left this path unguarded; it is invalid in
+    // every mode, so it is refused wherever it is reachable.
+    if request.token.is_some() && request.project.is_some() {
+        return Err(invalid_usage(
+            "--project cannot be used with --token; an enrollment key can enroll an instance but cannot create a project.",
+        ));
+    }
+
+    let ExistingIdentityContext {
+        config_dir,
+        directory,
+        identity_path,
+        endpoint,
+        persist_endpoint_file,
+        permits_stored_credentials,
+        identity,
+        pending_project,
+    } = context;
+
+    if identity.is_expired() {
+        // The host clock is not the authority on whether this credential may
+        // renew. Hand the retained runtime locks back to the launcher and let
+        // spiced present the existing key to the control plane, which supports
+        // renewal of an expired leaf within its server-side grace period.
+        // Project mutation remains deferred until a later connect observes the
+        // renewed identity, so this path cannot attach using a credential whose
+        // renewal the control plane has not accepted.
+        println!(
+            "The local clock places this instance identity outside its validity period. Starting the runtime so Spice Cloud can decide whether to renew it; run `spice connect` again after renewal to make project changes."
+        );
+        telemetry.complete("renewal_required");
+        return Ok(());
+    }
+
+    if identity.app_id.is_some() {
+        if let Some(asserted) = request.org.as_deref() {
+            let stored = identity.org_name.as_deref().ok_or_else(|| {
+                invalid_usage(
+                    "the stored attachment has no organization metadata, so --org cannot be verified.",
+                )
+            })?;
+            if !stored.eq_ignore_ascii_case(asserted) {
+                return Err(invalid_usage(format!(
+                    "this instance is already attached in organization {stored}; --org {asserted} does not match."
+                )));
+            }
+        }
+        if let Some(asserted) = request.project.as_deref() {
+            let stored = identity.app_name.as_deref().ok_or_else(|| {
+                invalid_usage(
+                    "the stored attachment has no project metadata, so --project cannot be verified.",
+                )
+            })?;
+            if stored != asserted {
+                return Err(invalid_usage(format!(
+                    "this instance is already attached to project {stored}; --project {asserted} does not match."
+                )));
+            }
+        }
+        if persist_endpoint_file {
+            persist_endpoint(config_dir, endpoint).await?;
+        }
+        print_attached(&identity);
+        telemetry.complete("already_attached");
+        return Ok(());
+    }
+
+    let fixed_org = identity
+        .org_name
+        .as_deref()
+        .filter(|org| !org.is_empty())
+        .ok_or_else(|| Error::CloudConnectIo {
+            message: format!(
+                "the existing unattached identity at {} has no Cloud-provided organization metadata; update the runtime and reconnect before assigning a project",
+                identity_path.display()
+            ),
+        })?;
+    if let Some(asserted) = request.org.as_deref()
+        && !asserted.eq_ignore_ascii_case(fixed_org)
+    {
+        return Err(invalid_usage(format!(
+            "this instance is enrolled in organization {fixed_org}, not {asserted}. Run `spice connect remove --force --yes` before enrolling it into another organization."
+        )));
+    }
+
+    if let Some(pending) = pending_project.as_ref() {
+        if !pending.organization.eq_ignore_ascii_case(fixed_org)
+            || pending.request.instance_id != identity.identifier
+        {
+            return Err(Error::CloudConnectIo {
+                message: "the pending project transaction does not match the enrolled identity"
+                    .to_string(),
+            });
+        }
+        if let Some(asserted) = request.project.as_deref()
+            && asserted != pending.request.name
+        {
+            return Err(invalid_usage(format!(
+                "project attachment for {} is already pending; retry that exact project name.",
+                pending.request.name
+            )));
+        }
+    }
+
+    let explicit_project = pending_project
+        .as_ref()
+        .map(|operation| operation.request.name.as_str())
+        .or(request.project.as_deref());
+    if !prompter.interactive() {
+        if explicit_project.is_none() {
+            print_unattached(&identity, identity.new_project_url.as_deref());
+            telemetry.complete("unattached");
+            return Ok(());
+        }
+        if request.org.is_none() && pending_project.is_none() {
+            return Err(invalid_usage(
+                "non-interactive project setup requires both --org <org> and --project <name>.",
+            ));
+        }
+    }
+
+    if persist_endpoint_file {
+        persist_endpoint(config_dir, endpoint).await?;
+    }
+
+    telemetry.stage("authentication");
+    if !permits_stored_credentials {
+        return Err(legacy_endpoint_requires_explicit_authority(endpoint));
+    }
+    let mut login = stored_user_login(endpoint, Some(fixed_org)).await?;
+    if login.is_none() && prompter.interactive() {
+        login = match login_inline(CredentialStore::EnvFile).await? {
+            LoginContinuation::Authenticated(session) => Some(LoginCredential {
+                token: SessionToken::new(session.access_token().to_string()),
+                credential_org: Some(session.org_name().to_string()),
+            }),
+            LoginContinuation::Cancelled => {
+                print_unattached(&identity, identity.new_project_url.as_deref());
+                telemetry.complete("cancelled");
+                return Ok(());
+            }
+        };
+    }
+    let Some(login) = login else {
+        return Err(org_credential_missing(fixed_org));
+    };
+    if let Some(credential_org) = login.credential_org.as_deref()
+        && !credential_org.eq_ignore_ascii_case(fixed_org)
+    {
+        return Err(org_credential_wrong_org(fixed_org, credential_org));
+    }
+    let token = login.token;
+    telemetry.auth("login");
+    if explicit_project.is_none() {
+        let confirmed = prompter.confirm_project_assignment().await?;
+        if confirmed != Some(true) {
+            print_unattached(&identity, identity.new_project_url.as_deref());
+            telemetry.complete(if confirmed.is_none() {
+                "cancelled"
+            } else {
+                "unattached"
+            });
+            return Ok(());
+        }
+    }
+
+    telemetry.stage("project_assignment");
+    let project = project_name_after_enrollment(explicit_project, directory, prompter).await?;
+    let Some(project) = project else {
+        print_unattached(&identity, identity.new_project_url.as_deref());
+        telemetry.complete("cancelled");
+        return Ok(());
+    };
+    let assignment = assign_project(
+        ProjectAssignmentContext {
+            endpoint,
+            config_dir,
+            directory,
+            token: &token,
+            organization: fixed_org,
+            identity: &identity,
+            recovery_url: None,
+        },
+        project,
+        prompter,
+    )
+    .await?;
+    telemetry.complete(match assignment {
+        ProjectAssignment::Attached => "attached",
+        ProjectAssignment::Cancelled => "cancelled",
+    });
+    Ok(())
+}
+
+async fn stored_user_login(
+    endpoint: &str,
+    org_hint: Option<&str>,
+) -> Result<Option<LoginCredential>> {
+    if let Some(org) = org_hint
+        && let Some(token) = cloud_org::token_for_org(org)
+    {
+        return Ok(Some(LoginCredential {
+            token: SessionToken::new(token),
+            credential_org: Some(org.to_string()),
+        }));
+    }
+    let token = cloud_org::default_token();
+    let Some(token) = token else {
+        return Ok(None);
+    };
+    let client = CloudClient::with_token_for_org_at(token.clone(), None, endpoint)?;
+    let Some(context) = client.optional_user_auth_context().await? else {
+        // Service-account credentials have no user auth context. Their
+        // organization is fixed by the issuer and remains server-authorized.
+        return Ok(Some(LoginCredential {
+            token: SessionToken::new(token),
+            credential_org: None,
+        }));
+    };
+    if let Some(org) = org_hint
+        && !context.org_name.eq_ignore_ascii_case(org)
+    {
+        return Err(org_credential_wrong_org(org, &context.org_name));
+    }
+    Ok(Some(LoginCredential {
+        token: SessionToken::new(token),
+        credential_org: (!context.org_name.is_empty()).then_some(context.org_name),
+    }))
+}
+
+fn org_credential_wrong_org(requested: &str, actual: &str) -> Error {
+    Error::cloud_with_hint(
+        CloudErrorCode::OrgCredentialMissing,
+        format!(
+            "No Spice Cloud credential is stored for organization '{requested}'; your selected credential belongs to '{actual}'."
+        ),
+        format!(
+            "Authenticate for it with 'spice cloud login pat --org {requested}' (or 'spice cloud login api --org {requested}' for automation)."
+        ),
+    )
+}
+
+fn org_credential_missing(org: &str) -> Error {
+    Error::cloud_with_hint(
+        CloudErrorCode::OrgCredentialMissing,
+        format!("No Spice Cloud credential is stored for organization '{org}'."),
+        format!(
+            "Authenticate for it with 'spice cloud login pat --org {org}' (or 'spice cloud login api --org {org}' for automation), or set {}.",
+            cloud_org::org_token_var(org)
+        ),
+    )
+}
+
+fn legacy_endpoint_requires_explicit_authority(endpoint: &str) -> Error {
+    invalid_usage(format!(
+        "the repository-local cloud-endpoint file selects {endpoint}, so Spice will not send a login or enrollment-key credential there without explicit authority. Re-run with --endpoint {endpoint} or set SPICE_CLOUD_ENDPOINT."
+    ))
+}
+
+/// One enrollment attempt: where it goes, what authorizes it, and what it has to
+/// stay faithful to.
+struct EnrollAttempt<'a> {
+    ctx: &'a RuntimeContext,
+    config_dir: &'a Path,
+    directory: &'a Path,
+    endpoint: &'a TransactionEndpoint,
+    region: Option<String>,
+    /// The organization recorded in the enrollment journal, which is compared
+    /// case-insensitively on every replay.
+    journal_org: String,
+    authority: EnrollmentAuthority,
+    /// The operation a resumed run routed on, verified under the enrollment
+    /// transaction before the credential is spent. `None` for a fresh
+    /// enrollment, which has no operation to hold to.
+    resumed_operation: Option<String>,
+}
+
+async fn enroll(attempt: EnrollAttempt<'_>) -> Result<EnrollmentResult> {
+    let EnrollAttempt {
+        ctx,
+        config_dir,
+        directory,
+        endpoint,
+        region,
+        journal_org,
+        authority,
+        resumed_operation,
+    } = attempt;
+    // Which authority is enrolling decides whether the organization recorded for
+    // this operation can still be corrected: an enrollment key asserts one and is
+    // checked before it is spent, a session is issued for one.
+    let organization_binding = match &authority {
+        EnrollmentAuthority::Token { .. } => OrganizationBinding::Assertion,
+        EnrollmentAuthority::AuthenticatedSession { .. } => OrganizationBinding::Fixed,
+    };
+    let runtime_version = ctx
+        .runtime_version()
+        .unwrap_or_else(|_| crate::commands::version::cli_version());
+    let mut config =
+        CloudConnectConfig::from_env_at(runtime_version.clone(), config_dir.to_path_buf());
+    config.enroll_endpoint.clone_from(&endpoint.value);
+    if endpoint.persist_file() {
+        persist_endpoint(config_dir, &endpoint.value).await?;
+    }
+    let endpoint = endpoint.value.as_str();
+
+    let enrollment_transaction = EnrollmentTransactionLock::acquire_async(config_dir)
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("acquire retry-safe enrollment transaction: {source}"),
+        })?;
+
+    let prepare_dir = config_dir.to_path_buf();
+    let canonical_dir = directory.to_path_buf();
+    let journal_endpoint = endpoint.to_string();
+    let draft_binding = runtime_cloud_connect::EnrollmentRequestBinding {
+        endpoint: endpoint.to_string(),
+        authority: match &authority {
+            EnrollmentAuthority::Token { expected_org, .. } => {
+                runtime_cloud_connect::EnrollmentAuthorityBinding::Token {
+                    expected_org: expected_org.clone(),
+                }
+            }
+            EnrollmentAuthority::AuthenticatedSession { org, .. } => {
+                runtime_cloud_connect::EnrollmentAuthorityBinding::AuthenticatedSession {
+                    organization: org.clone(),
+                }
+            }
+        },
+    };
+    let (enrollment_transaction, mut operation) = tokio::task::spawn_blocking(move || {
+        let facts = InstanceFacts::gather(&runtime_version);
+        // A resumed run exists to finish one operation, so it settles that
+        // question before anything can publish a new one. `load_or_create`
+        // creates when the draft is absent, and creating here would answer a
+        // vanished operation by leaving a phantom one on disk for the next run to
+        // resume — so the resumed case is decided first, from what the
+        // transaction can now see, and refuses instead.
+        //
+        // The binding check inside `load_or_create` cannot stand in for this: it
+        // admits a corrected organization assertion, which is what lets a
+        // mistyped `--org` recover, and therefore cannot tell a replay from a
+        // different operation published under the same binding.
+        if let Some(resumed) = resumed_operation.as_deref() {
+            match runtime_cloud_connect::EnrollmentDraft::load_optional(&prepare_dir)
+                .map_err(|source| Error::CloudConnectIo {
+                    message: format!("read the pending enrollment: {source}"),
+                })?
+            {
+                Some(pending) if pending.enrollment_operation_id == resumed => {}
+                Some(_) => {
+                    return Err(invalid_usage(
+                        "the pending enrollment for this directory changed while this run was preparing: it now holds a different operation. Nothing was sent. Re-run `spice connect` to continue the operation that is pending now, or run `spice connect remove --force --yes` to abandon it explicitly.",
+                    ));
+                }
+                None if prepare_dir
+                    .join(runtime_cloud_connect::config::IDENTITY_FILE)
+                    .exists() =>
+                {
+                    return Err(invalid_usage(
+                        "this directory finished enrolling while this run was preparing, so the pending operation is gone. Nothing was sent, and the enrollment key was not redeemed. Re-run `spice connect` to start the instance.",
+                    ));
+                }
+                None => {
+                    return Err(invalid_usage(
+                        "the pending enrollment for this directory was removed while this run was preparing. Nothing was sent, and the enrollment key was not redeemed. Re-run `spice connect` to enroll this directory again.",
+                    ));
+                }
+            }
+        }
+        let draft = enrollment_transaction
+            .load_or_create(&facts, region.as_deref(), &draft_binding)
+            .map_err(|source| Error::CloudConnectIo {
+                message: format!("prepare retry-safe enrollment: {source}"),
+            })?;
+        let operation = ConnectOperation::prepare(
+            &prepare_dir,
+            &canonical_dir,
+            &draft.enrollment_operation_id,
+            &journal_org,
+            organization_binding,
+            &journal_endpoint,
+            region.as_deref(),
+        )
+        .map_err(|error| state_error(&error))?;
+        Ok::<_, Error>((enrollment_transaction, operation))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("enrollment preparation task panicked: {source}"),
+    })??;
+
+    config.instance_region = operation.region.clone();
+    let (identity, recovery_url, already_enrolled) =
+        match runtime_cloud_connect::enroll::enroll_now_with_transaction(
+            &config,
+            &authority,
+            RetryPolicy::INTERACTIVE,
+            enrollment_transaction,
+        )
+        .await
+        .map_err(|source| Error::CloudConnectEnroll {
+            message: source.to_string(),
+        })? {
+            EnrollNowOutcome::AlreadyEnrolled { identity } => (identity, None, true),
+            EnrollNowOutcome::Enrolled { identity, metadata } => {
+                (identity, metadata.new_project_url, false)
+            }
+        };
+
+    let finish_dir = config_dir.to_path_buf();
+    let finish_identity = identity.clone();
+    tokio::task::spawn_blocking(move || {
+        operation
+            .mark_enrolled(&finish_dir, &finish_identity)
+            .map_err(|error| state_error(&error))?;
+        ConnectOperation::delete(&finish_dir).map_err(|error| state_error(&error))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("enrollment journal finalization task panicked: {source}"),
+    })??;
+    Ok(EnrollmentResult {
+        identity,
+        recovery_url,
+        already_enrolled,
+    })
+}
+
+async fn project_name_after_enrollment<P: Prompter>(
+    explicit: Option<&str>,
+    directory: &Path,
+    prompter: &mut P,
+) -> Result<Option<String>> {
+    if let Some(name) = explicit {
+        validate_project_name(name)
+            .map_err(|reason| invalid_usage(format!("invalid --project value: {reason}.")))?;
+        return Ok(Some(name.to_string()));
+    }
+    if !prompter.interactive() {
+        return Err(invalid_usage(
+            "non-interactive project setup requires both --org <org> and --project <name>.",
+        ));
+    }
+
+    let suggestion = initial_suggestion(directory);
+    loop {
+        let Some(name) = prompter.project_name(&suggestion).await? else {
+            return Ok(None);
+        };
+        match validate_project_name(&name) {
+            Ok(()) => return Ok(Some(name)),
+            Err(reason) => eprintln!("Project name {reason}."),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectAssignment {
+    Attached,
+    Cancelled,
+}
+
+struct ProjectAssignmentContext<'a> {
+    endpoint: &'a str,
+    config_dir: &'a Path,
+    directory: &'a Path,
+    token: &'a SessionToken,
+    organization: &'a str,
+    identity: &'a Identity,
+    recovery_url: Option<&'a str>,
+}
+
+async fn assign_project<P: Prompter>(
+    context: ProjectAssignmentContext<'_>,
+    first_name: String,
+    prompter: &mut P,
+) -> Result<ProjectAssignment> {
+    let client = ProjectClient::new(context.endpoint).map_err(|error| project_error(&error))?;
+    let base = first_name.clone();
+    let mut name = first_name;
+    let mut collision_number = 2_u32;
+    let started = Instant::now();
+    let mut retry_attempt = 0_u32;
+
+    loop {
+        let operation = prepare_project_operation(&context, &name).await?;
+        match client
+            .create(context.token, context.organization, &operation.request)
+            .await
+        {
+            Ok(attachment) => {
+                persist_attachment(context.config_dir, &attachment).await?;
+                delete_project_operation(context.config_dir).await?;
+                println!(
+                    "Spice Cloud Connect: enrollment complete; attached to {} / {}",
+                    attachment.organization, attachment.project_name
+                );
+                println!("Monitor: {}", attachment.monitor_url);
+                return Ok(ProjectAssignment::Attached);
+            }
+            Err(error) if error.is_name_conflict() && prompter.interactive() => {
+                delete_project_operation(context.config_dir).await?;
+                eprintln!(
+                    "A project named '{name}' already exists. Choose a new name; the existing project was not linked."
+                );
+                let suggestion = collision_suggestion(&base, collision_number);
+                collision_number = collision_number.saturating_add(1);
+                loop {
+                    let Some(next) = prompter.project_name(&suggestion).await? else {
+                        print_unattached(context.identity, context.recovery_url);
+                        return Ok(ProjectAssignment::Cancelled);
+                    };
+                    match validate_project_name(&next) {
+                        Ok(()) => {
+                            name = next;
+                            break;
+                        }
+                        Err(reason) => eprintln!("Project name {reason}."),
+                    }
+                }
+                retry_attempt = 0;
+            }
+            Err(error) if error.is_name_conflict() => {
+                delete_project_operation(context.config_dir).await?;
+                print_unattached(context.identity, context.recovery_url);
+                return Err(project_error(&error));
+            }
+            // The control plane knows this instance has an attachment, but
+            // does not return enough state in this denial to persist it
+            // locally. Never tell the operator it is unattached.
+            Err(error) if error.is_already_attached() => return Err(project_error(&error)),
+            Err(error)
+                if error.is_attachment_ambiguous()
+                    && retry_attempt + 1 < PROJECT_MAX_ATTEMPTS
+                    && started.elapsed() < PROJECT_RETRY_DEADLINE =>
+            {
+                let exponential = 200_u64
+                    .saturating_mul(1_u64.checked_shl(retry_attempt.min(4)).unwrap_or(u64::MAX));
+                let window_ms = exponential.min(2_000);
+                retry_attempt = retry_attempt.saturating_add(1);
+                let delay = Duration::from_millis(rand::random_range(1..=window_ms));
+                tokio::time::sleep(delay).await;
+            }
+            Err(error) if !error.is_attachment_ambiguous() => {
+                delete_project_operation(context.config_dir).await?;
+                print_unattached(context.identity, context.recovery_url);
+                return Err(project_error(&error));
+            }
+            Err(error) => return Err(ambiguous_project_error(&error)),
+        }
+    }
+}
+
+async fn prepare_project_operation(
+    context: &ProjectAssignmentContext<'_>,
+    project_name: &str,
+) -> Result<ProjectOperation> {
+    let config_dir = context.config_dir.to_path_buf();
+    let directory = context.directory.to_path_buf();
+    let endpoint = context.endpoint.to_string();
+    let organization = context.organization.to_string();
+    let project_name = project_name.to_string();
+    let request = ProjectMutation::signed(context.identity, context.organization, &project_name)
+        .map_err(|error| project_error(&error))?;
+    tokio::task::spawn_blocking(move || {
+        ProjectOperation::prepare(&config_dir, &directory, &endpoint, &organization, request)
+            .map_err(|error| state_error(&error))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("project journal preparation task panicked: {source}"),
+    })?
+}
+
+async fn delete_project_operation(config_dir: &Path) -> Result<()> {
+    let config_dir = config_dir.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        ProjectOperation::delete(&config_dir).map_err(|error| state_error(&error))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("project journal cleanup task panicked: {source}"),
+    })?
+}
+
+async fn persist_attachment(config_dir: &Path, attachment: &ProjectAttachment) -> Result<()> {
+    let config_dir = config_dir.to_path_buf();
+    let identity_path = config_dir.join(runtime_cloud_connect::config::IDENTITY_FILE);
+    let attachment = AppAttachment {
+        app_id: attachment.project_id.to_string(),
+        org_name: Some(attachment.organization.clone()),
+        app_name: Some(attachment.project_name.clone()),
+        monitor_url: Some(attachment.monitor_url.clone()),
+    };
+    tokio::task::spawn_blocking(move || {
+        IdentityStore::set_attachment(&config_dir, &identity_path, Some(&attachment)).map_err(
+            |source| Error::CloudConnectIo {
+                message: format!("persist project attachment: {source}"),
+            },
+        )
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("project attachment persistence task panicked: {source}"),
+    })??
+    .ok_or_else(|| Error::CloudConnectIo {
+        message: "the enrolled identity disappeared before project attachment was persisted"
+            .to_string(),
+    })?;
+    Ok(())
+}
+
+async fn load_identity(path: &Path) -> Result<Option<Identity>> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking({
+        let path = path.clone();
+        move || IdentityStore::load_optional(&path)
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("identity load task panicked: {source}"),
+    })?
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("load identity at {}: {source}", path.display()),
+    })
+}
+
+fn validate_existing_identity(path: &Path, identity: &Identity) -> Result<()> {
+    if let Some(reason) = identity.reconnect_validation_error() {
+        return Err(Error::CloudConnectIo {
+            message: format!(
+                "the Cloud Connect identity at {} is unusable ({reason}); run `spice connect remove --force --yes` before enrolling again",
+                path.display()
+            ),
+        });
+    }
+    for (field, value) in [
+        ("organization", identity.org_name.as_deref()),
+        ("project", identity.app_name.as_deref()),
+    ] {
+        if value.is_some_and(|value| value.chars().any(char::is_control)) {
+            return Err(Error::CloudConnectIo {
+                message: format!(
+                    "the Cloud Connect identity at {} has unsafe {field} metadata",
+                    path.display()
+                ),
+            });
+        }
+    }
+    if identity
+        .monitor_url
+        .as_deref()
+        .is_some_and(|url| safe_recovery_url(url).is_none())
+    {
+        return Err(Error::CloudConnectIo {
+            message: format!(
+                "the Cloud Connect identity at {} has an unsafe monitor URL",
+                path.display()
+            ),
+        });
+    }
+    Ok(())
+}
+
+async fn load_operations(
+    config_dir: &Path,
+) -> Result<(
+    Option<runtime_cloud_connect::EnrollmentDraft>,
+    Option<ConnectOperation>,
+    Option<ProjectOperation>,
+)> {
+    let config_dir = config_dir.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let draft = runtime_cloud_connect::EnrollmentDraft::load_optional(&config_dir).map_err(
+            |source| Error::CloudConnectIo {
+                message: format!("load enrollment draft: {source}"),
+            },
+        )?;
+        let enrollment =
+            ConnectOperation::load_optional(&config_dir).map_err(|error| state_error(&error))?;
+        let project =
+            ProjectOperation::load_optional(&config_dir).map_err(|error| state_error(&error))?;
+        Ok::<_, Error>((draft, enrollment, project))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("Cloud Connect journal load task panicked: {source}"),
+    })?
+}
+
+fn resolve_transaction_endpoint(
+    config_dir: &Path,
+    explicit: Option<&str>,
+    identity: Option<&Identity>,
+    draft: Option<&runtime_cloud_connect::EnrollmentDraft>,
+) -> Result<TransactionEndpoint> {
+    let environment = std::env::var("SPICE_CLOUD_ENDPOINT").ok();
+    resolve_transaction_endpoint_with_env(
+        config_dir,
+        explicit,
+        environment.as_deref(),
+        identity,
+        draft,
+    )
+}
+
+fn resolve_transaction_endpoint_with_env(
+    config_dir: &Path,
+    explicit: Option<&str>,
+    environment: Option<&str>,
+    identity: Option<&Identity>,
+    draft: Option<&runtime_cloud_connect::EnrollmentDraft>,
+) -> Result<TransactionEndpoint> {
+    let requested = explicit
+        .filter(|endpoint| !endpoint.is_empty())
+        .or_else(|| environment.filter(|endpoint| !endpoint.is_empty()))
+        .map(normalize_control_plane_endpoint)
+        .transpose()?;
+    let bound = identity
+        .and_then(|identity| identity.control_plane_endpoint.as_deref())
+        .or_else(|| draft.map(|draft| draft.binding.endpoint.as_str()))
+        .map(normalize_control_plane_endpoint)
+        .transpose()?;
+    if let (Some(requested), Some(bound)) = (requested.as_deref(), bound.as_deref())
+        && requested != bound
+    {
+        return Err(invalid_usage(format!(
+            "--endpoint {requested} does not match this pending or enrolled instance's control plane {bound}."
+        )));
+    }
+    if let Some(value) = requested {
+        return Ok(TransactionEndpoint {
+            value,
+            source: EndpointSource::Explicit,
+        });
+    }
+    if let Some(value) = bound {
+        return Ok(TransactionEndpoint {
+            value,
+            source: EndpointSource::Bound,
+        });
+    }
+
+    let legacy = CloudConnectConfig::read_normalized_enroll_endpoint_override(config_dir).map_err(
+        |source| Error::CloudConnectIo {
+            message: source.to_string(),
+        },
+    )?;
+    Ok(match legacy {
+        Some(value) => TransactionEndpoint {
+            value,
+            source: EndpointSource::LegacyFile,
+        },
+        None => TransactionEndpoint {
+            value: runtime_cloud_connect::config::DEFAULT_ENDPOINT.to_string(),
+            source: EndpointSource::CompiledDefault,
+        },
+    })
+}
+
+async fn reconcile_journal(
+    config_dir: &Path,
+    directory: &Path,
+    endpoint: &str,
+    identity: Option<&Identity>,
+) -> Result<()> {
+    let config_dir = config_dir.to_path_buf();
+    let directory = directory.to_path_buf();
+    let endpoint = endpoint.to_string();
+    let identity = identity.map(IdentityFacts::from);
+    tokio::task::spawn_blocking(move || {
+        ConnectOperation::reconcile(&config_dir, &directory, &endpoint, identity.as_ref())
+            .map_err(|error| state_error(&error))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("enrollment journal reconciliation task panicked: {source}"),
+    })?
+}
+
+async fn reconcile_project_journal(
+    config_dir: &Path,
+    directory: &Path,
+    endpoint: &str,
+    identity: Option<&Identity>,
+) -> Result<Option<ProjectOperation>> {
+    let config_dir = config_dir.to_path_buf();
+    let directory = directory.to_path_buf();
+    let endpoint = endpoint.to_string();
+    let identity = identity.map(IdentityFacts::from);
+    tokio::task::spawn_blocking(move || {
+        ProjectOperation::reconcile(&config_dir, &directory, &endpoint, identity.as_ref())
+            .map_err(|error| state_error(&error))
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("project journal reconciliation task panicked: {source}"),
+    })?
+}
+
+async fn persist_endpoint(config_dir: &Path, endpoint: &str) -> Result<()> {
+    let path = config_dir.join(CloudConnectConfig::ENDPOINT_OVERRIDE_FILE);
+    let endpoint = endpoint.to_string();
+    tokio::task::spawn_blocking(move || {
+        super::state::atomic_write_owner_only(&path, format!("{endpoint}\n").as_bytes())
+    })
+    .await
+    .map_err(|source| Error::CloudConnectIo {
+        message: format!("endpoint persistence task panicked: {source}"),
+    })?
+    .map_err(|error| state_error(&error))
+}
+
+async fn canonical_instance_directory(explicit: Option<&Path>) -> Result<PathBuf> {
+    let directory = match explicit {
+        Some(directory) => directory.to_path_buf(),
+        None => std::env::current_dir().map_err(|source| Error::CloudConnectIo {
+            message: format!("resolve current instance directory: {source}"),
+        })?,
+    };
+    let reported = directory.clone();
+    tokio::task::spawn_blocking(move || std::fs::canonicalize(directory))
+        .await
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!("directory canonicalization task panicked: {source}"),
+        })?
+        .map_err(|source| Error::CloudConnectIo {
+            message: format!(
+                "canonicalize instance directory {}: {source}",
+                reported.display()
+            ),
+        })
+}
+
+fn connect_portal_url() -> String {
+    format!(
+        "{}/connect",
+        crate::commands::login::spice_base_url().trim_end_matches('/')
+    )
+}
+
+fn normalize_control_plane_endpoint(endpoint: &str) -> Result<String> {
+    runtime_cloud_connect::config::normalize_control_plane_endpoint(endpoint)
+        .map_err(|source| invalid_usage(format!("invalid --endpoint: {source}.")))
+}
+
+#[cfg(test)]
+fn validate_control_plane_endpoint(endpoint: &str) -> Result<()> {
+    normalize_control_plane_endpoint(endpoint).map(|_| ())
+}
+
+fn print_unattached(identity: &Identity, recovery_url: Option<&str>) {
+    let org = identity.org_name.as_deref().unwrap_or("Spice Cloud");
+    println!("Spice Cloud Connect: enrolled in {org} — not yet attached to a project");
+    let recovery_url = recovery_url
+        .and_then(safe_recovery_url)
+        .unwrap_or_else(connect_portal_url);
+    println!("Create one: {recovery_url}");
+}
+
+fn print_enrollment_result(enrolled: &EnrollmentResult) {
+    if enrolled.identity.app_id.is_some() {
+        print_attached(&enrolled.identity);
+    } else {
+        print_unattached(&enrolled.identity, enrolled.recovery_url.as_deref());
+    }
+}
+
+/// One rule decides which Cloud-provided link may be printed or opened, and it
+/// lives with the identity that persists them.
+fn safe_recovery_url(candidate: &str) -> Option<String> {
+    runtime_cloud_connect::config::safe_portal_url(candidate)
+}
+
+/// Validate what this invocation asks for on its own terms, before any state is
+/// read or any lock is taken.
+///
+/// Everything here is wrong whatever is on disk — a malformed project name, an
+/// impossible region, an unusable endpoint — so rejecting it costs no I/O and
+/// touches nothing. Rules that a pending operation can answer better are not
+/// here: those wait until the draft has been read, so an operator with an
+/// operation in flight is always told about *that* operation rather than about
+/// the flags in the abstract.
+fn preflight_request(request: &ConnectRequest) -> Result<()> {
+    if let Some(project) = request.project.as_deref() {
+        validate_project_name(project)
+            .map_err(|reason| invalid_usage(format!("invalid --project value: {reason}.")))?;
+    }
+    if let Some(org) = request.org.as_deref() {
+        cloud_org::validate_org_name(org)?;
+    }
+    if let Some(region) = request.region.as_deref()
+        && !runtime_cloud_connect::is_valid_instance_region(region)
+    {
+        return Err(invalid_usage(format!(
+            "invalid --region value '{region}': expected 2-64 lowercase letters, digits, and hyphens, starting and ending with a letter or digit."
+        )));
+    }
+    if let Some(endpoint) = request.endpoint.as_deref() {
+        normalize_control_plane_endpoint(endpoint)?;
+    }
+    if request.endpoint.is_none()
+        && let Ok(endpoint) = std::env::var("SPICE_CLOUD_ENDPOINT")
+        && !endpoint.is_empty()
+    {
+        normalize_control_plane_endpoint(&endpoint)?;
+    }
+    Ok(())
+}
+
+fn print_attached(identity: &Identity) {
+    let org = identity.org_name.as_deref().unwrap_or("Spice Cloud");
+    let project = identity.app_name.as_deref().unwrap_or("attached project");
+    println!("Spice Cloud Connect: enrollment complete; attached to {org} / {project}");
+    if let Some(url) = identity.monitor_url.as_deref() {
+        println!("Monitor: {url}");
+    }
+}
+
+fn invalid_usage(message: impl Into<String>) -> Error {
+    Error::InvalidUsage {
+        message: message.into(),
+    }
+}
+
+fn state_error(source: &super::state::Error) -> Error {
+    Error::CloudConnectIo {
+        message: source.to_string(),
+    }
+}
+
+fn project_error(source: &super::project::Error) -> Error {
+    Error::CloudConnectProject {
+        message: source.to_string(),
+    }
+}
+
+fn ambiguous_project_error(source: &super::project::Error) -> Error {
+    Error::CloudConnectProject {
+        message: format!(
+            "{source}. The attachment result is unknown because the server may have committed the request before the response failed. Retry the exact same command to reconcile it; do not create another project."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use runtime_cloud_connect::{
+        EnrollmentAuthorityBinding, EnrollmentDraft, EnrollmentRequestBinding,
+    };
+
+    use super::*;
+
+    struct ScriptedPrompter {
+        interactive: bool,
+        auth: Option<AuthChoice>,
+        key: Option<String>,
+        confirm: Option<bool>,
+        names: std::collections::VecDeque<Option<String>>,
+    }
+
+    impl Prompter for ScriptedPrompter {
+        fn interactive(&self) -> bool {
+            self.interactive
+        }
+
+        async fn choose_auth(&mut self) -> Result<Option<AuthChoice>> {
+            Ok(self.auth.take())
+        }
+
+        async fn read_enrollment_key(
+            &mut self,
+            _portal_url: &str,
+        ) -> Result<Option<Zeroizing<String>>> {
+            Ok(self.key.take().map(Zeroizing::new))
+        }
+
+        async fn confirm_project_assignment(&mut self) -> Result<Option<bool>> {
+            Ok(self.confirm.take())
+        }
+
+        async fn project_name(&mut self, _suggestion: &str) -> Result<Option<String>> {
+            Ok(self.names.pop_front().flatten())
+        }
+    }
+
+    #[tokio::test]
+    async fn scripted_auth_choice_has_exact_two_paths() {
+        let mut prompt = ScriptedPrompter {
+            interactive: true,
+            auth: Some(AuthChoice::Login),
+            key: None,
+            confirm: None,
+            names: std::collections::VecDeque::new(),
+        };
+        assert_eq!(
+            prompt.choose_auth().await.expect("choice"),
+            Some(AuthChoice::Login)
+        );
+        prompt.auth = Some(AuthChoice::EnrollmentKey);
+        assert_eq!(
+            prompt.choose_auth().await.expect("choice"),
+            Some(AuthChoice::EnrollmentKey)
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_and_eof_are_clean_prompt_outcomes() {
+        let mut prompt = ScriptedPrompter {
+            interactive: true,
+            auth: None,
+            key: None,
+            confirm: None,
+            names: std::collections::VecDeque::from([None]),
+        };
+        assert_eq!(prompt.choose_auth().await.expect("cancel"), None);
+        assert_eq!(
+            prompt.project_name("steady-spice").await.expect("eof"),
+            None
+        );
+    }
+
+    #[test]
+    fn terminal_prompt_interrupt_and_eof_map_to_clean_cancellation() {
+        for kind in [
+            std::io::ErrorKind::Interrupted,
+            std::io::ErrorKind::UnexpectedEof,
+        ] {
+            let optional = map_optional_prompt::<usize>(
+                Err(dialoguer::Error::IO(std::io::Error::from(kind))),
+                "test prompt",
+            )
+            .expect("cancellation is not an error");
+            assert_eq!(optional, None);
+            let required = map_required_prompt::<String>(
+                Err(dialoguer::Error::IO(std::io::Error::from(kind))),
+                "test prompt",
+            )
+            .expect("cancellation is not an error");
+            assert_eq!(required, None);
+        }
+    }
+
+    #[test]
+    fn telemetry_vocabulary_contains_no_customer_values() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let telemetry = FlowTelemetry::new(Some(Arc::clone(&cancelled)));
+        telemetry.auth("login");
+        telemetry.stage("project_assignment");
+        assert_eq!(telemetry.auth_path.get(), "login");
+        assert_eq!(telemetry.failure_stage.get(), "project_assignment");
+        telemetry.complete("cancelled");
+        assert!(cancelled.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn control_plane_endpoint_requires_https() {
+        for valid in ["https://api.spice.ai", "https://cloud.example.test/api"] {
+            validate_control_plane_endpoint(valid).expect("valid control-plane URL");
+        }
+        for invalid in [
+            "not-a-url",
+            "http://localhost:8090",
+            "http://cloud.example.test",
+            "ftp://127.0.0.1/file",
+            "https://user:secret@cloud.example.test",
+            "https://cloud.example.test?token=secret",
+            "https://cloud.example.test#fragment",
+        ] {
+            validate_control_plane_endpoint(invalid).expect_err("unsafe URL must fail");
+        }
+    }
+
+    #[test]
+    fn explicit_project_and_region_are_validated_before_mutation() {
+        let request = ConnectRequest {
+            org: Some("acme".to_string()),
+            project: Some("INVALID PROJECT".to_string()),
+            token: None,
+            region: Some("lab-seoul".to_string()),
+            dir: None,
+            endpoint: None,
+        };
+        assert!(preflight_request(&request).is_err());
+
+        let request = ConnectRequest {
+            project: Some("valid-project".to_string()),
+            region: Some("INVALID_REGION".to_string()),
+            ..request
+        };
+        assert!(preflight_request(&request).is_err());
+    }
+
+    #[test]
+    fn fresh_transactions_use_the_compiled_endpoint_without_a_binding() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fresh = resolve_transaction_endpoint_with_env(dir.path(), None, None, None, None)
+            .expect("resolve fresh endpoint");
+        assert_eq!(fresh.value, runtime_cloud_connect::config::DEFAULT_ENDPOINT);
+        assert_eq!(fresh.source, EndpointSource::CompiledDefault);
+        assert!(!fresh.persist_file());
+        assert!(fresh.permits_credentials());
+    }
+
+    #[test]
+    fn fresh_transactions_honor_but_do_not_rewrite_the_legacy_endpoint() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        std::fs::write(
+            dir.path().join("cloud-endpoint"),
+            "https://private.example/\n",
+        )
+        .expect("write endpoint override");
+        let resolved = resolve_transaction_endpoint_with_env(dir.path(), None, None, None, None)
+            .expect("resolve legacy endpoint");
+        assert_eq!(resolved.value, "https://private.example");
+        assert_eq!(resolved.source, EndpointSource::LegacyFile);
+        assert!(!resolved.persist_file());
+        assert!(!resolved.permits_credentials());
+    }
+
+    /// A prompter that answers only the enrollment-key prompt and fails the
+    /// test if the authentication chooser — or anything past enrollment — is
+    /// ever reached. Offering a mode the pending operation cannot be finished
+    /// under is the regression this guards.
+    struct ResumePrompter {
+        interactive: bool,
+        key: Option<String>,
+        key_prompts: usize,
+    }
+
+    impl Prompter for ResumePrompter {
+        fn interactive(&self) -> bool {
+            self.interactive
+        }
+
+        async fn choose_auth(&mut self) -> Result<Option<AuthChoice>> {
+            panic!("a pending draft must resume its own authority without a chooser");
+        }
+
+        async fn read_enrollment_key(
+            &mut self,
+            _portal_url: &str,
+        ) -> Result<Option<Zeroizing<String>>> {
+            self.key_prompts += 1;
+            Ok(self.key.take().map(Zeroizing::new))
+        }
+
+        async fn confirm_project_assignment(&mut self) -> Result<Option<bool>> {
+            panic!("a resumed enrollment-key operation never assigns a project");
+        }
+
+        async fn project_name(&mut self, _suggestion: &str) -> Result<Option<String>> {
+            panic!("a resumed enrollment-key operation never assigns a project");
+        }
+    }
+
+    /// A prompter that replaces the pending draft while the key prompt is open —
+    /// the one place a resumed run waits on a human, and so the widest window a
+    /// concurrent enrollment has to change the operation under it.
+    struct RacingPrompter {
+        key: Option<String>,
+        config_dir: std::path::PathBuf,
+        replacement: Option<EnrollmentRequestBinding>,
+        /// Remove the pending draft without publishing another, the way a
+        /// release does.
+        remove: bool,
+    }
+
+    impl Prompter for RacingPrompter {
+        fn interactive(&self) -> bool {
+            true
+        }
+
+        async fn choose_auth(&mut self) -> Result<Option<AuthChoice>> {
+            panic!("a pending draft must resume its own authority without a chooser");
+        }
+
+        async fn read_enrollment_key(
+            &mut self,
+            _portal_url: &str,
+        ) -> Result<Option<Zeroizing<String>>> {
+            // What another process does when it takes the transaction: the
+            // operation this run routed on is gone, and either a different one is
+            // pending in its place or nothing is.
+            if self.remove || self.replacement.is_some() {
+                std::fs::remove_file(EnrollmentDraft::path_in(&self.config_dir))
+                    .expect("remove the pending draft");
+            }
+            if let Some(binding) = self.replacement.take() {
+                EnrollmentDraft::load_or_create(
+                    &self.config_dir,
+                    &InstanceFacts::gather("v0.0.0-racing-test"),
+                    Some("lab-seoul"),
+                    &binding,
+                )
+                .expect("publish the replacement draft");
+            }
+            Ok(self.key.take().map(Zeroizing::new))
+        }
+
+        async fn confirm_project_assignment(&mut self) -> Result<Option<bool>> {
+            panic!("a resumed enrollment-key operation never assigns a project");
+        }
+
+        async fn project_name(&mut self, _suggestion: &str) -> Result<Option<String>> {
+            panic!("a resumed enrollment-key operation never assigns a project");
+        }
+    }
+
+    fn connect_request() -> ConnectRequest {
+        ConnectRequest {
+            org: None,
+            project: None,
+            token: None,
+            region: None,
+            dir: None,
+            endpoint: None,
+        }
+    }
+
+    fn pending_draft(config_dir: &Path, authority: EnrollmentAuthorityBinding) -> EnrollmentDraft {
+        EnrollmentDraft::load_or_create(
+            config_dir,
+            &InstanceFacts::gather("v0.0.0-resume-test"),
+            Some("lab-seoul"),
+            &EnrollmentRequestBinding {
+                endpoint: "https://api.spice.ai".to_string(),
+                authority,
+            },
+        )
+        .expect("publish a pending enrollment draft")
+    }
+
+    fn token_draft(config_dir: &Path, expected_org: Option<&str>) -> EnrollmentDraft {
+        pending_draft(
+            config_dir,
+            EnrollmentAuthorityBinding::Token {
+                expected_org: expected_org.map(str::to_string),
+            },
+        )
+    }
+
+    fn login_draft(config_dir: &Path, organization: &str) -> EnrollmentDraft {
+        pending_draft(
+            config_dir,
+            EnrollmentAuthorityBinding::AuthenticatedSession {
+                organization: organization.to_string(),
+            },
+        )
+    }
+
+    /// A loopback address nothing listens on: an enrollment attempt against it
+    /// fails without reaching a control plane.
+    fn closed_endpoint() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve a loopback port");
+        let address = listener.local_addr().expect("reserved port");
+        drop(listener);
+        format!("https://{address}")
+    }
+
+    /// A pending enrollment-key operation resumes token mode: the key prompt is
+    /// the only question, the chooser is never opened, and the persisted
+    /// organization assertion rides the replay even though no flag named it.
+    #[test]
+    fn a_token_draft_resumes_the_key_path_under_its_persisted_assertion() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let draft = token_draft(dir.path(), Some("acme"));
+
+        for requested in [None, Some("ACME")] {
+            let request = ConnectRequest {
+                org: requested.map(str::to_string),
+                ..connect_request()
+            };
+            let resumed = resumable_authority(&draft, &request, true).expect("resume token mode");
+            assert_eq!(
+                resumed,
+                ResumableAuthority::EnrollmentKey {
+                    expected_org: Some("acme".to_string())
+                },
+                "the draft's own assertion is what a resume replays"
+            );
+        }
+    }
+
+    /// An explicit input an enrollment-key operation cannot replay — a project it
+    /// has no authority to create, a key it cannot be given — fails before
+    /// anything is prompted for or sent, and says what finishes it instead.
+    #[test]
+    fn a_token_draft_rejects_inputs_it_cannot_replay() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let draft = token_draft(dir.path(), Some("acme"));
+
+        let with_project = resumable_authority(
+            &draft,
+            &ConnectRequest {
+                project: Some("retail".to_string()),
+                ..connect_request()
+            },
+            true,
+        )
+        .expect_err("an enrollment-key operation cannot create a project");
+        assert!(
+            with_project.to_string().contains("--project"),
+            "{with_project}"
+        );
+
+        let headless = resumable_authority(&draft, &connect_request(), false)
+            .expect_err("a key cannot be prompted for without a terminal");
+        assert!(
+            headless.to_string().contains("--token <enrollment-key>"),
+            "{headless}"
+        );
+
+        // The unasserted case still resumes token mode rather than the chooser.
+        let unasserted = token_draft(tempfile::tempdir().expect("create tempdir").path(), None);
+        assert_eq!(
+            resumable_authority(&unasserted, &connect_request(), true).expect("resume token mode"),
+            ResumableAuthority::EnrollmentKey { expected_org: None }
+        );
+    }
+
+    /// `--org` on a pending token operation corrects the assertion rather than
+    /// contradicting it.
+    ///
+    /// Spice Cloud checks `expected_org` before it consumes the key, so an
+    /// operation that failed on a mistyped organization still holds an unspent
+    /// key and is replayable with the right one. Refusing the correction would
+    /// leave abandoning the draft as the only way forward.
+    #[test]
+    fn a_token_draft_takes_a_corrected_organization_assertion() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let draft = token_draft(dir.path(), Some("acme-typo"));
+
+        let corrected = resumable_authority(
+            &draft,
+            &ConnectRequest {
+                org: Some("acme".to_string()),
+                ..connect_request()
+            },
+            true,
+        )
+        .expect("a corrected assertion replays the pending operation");
+        assert_eq!(
+            corrected,
+            ResumableAuthority::EnrollmentKey {
+                expected_org: Some("acme".to_string())
+            },
+            "the corrected organization is what the replay asserts"
+        );
+
+        // And one is supplied where the draft asserted nothing at all.
+        let unasserted = token_draft(tempfile::tempdir().expect("create tempdir").path(), None);
+        assert_eq!(
+            resumable_authority(
+                &unasserted,
+                &ConnectRequest {
+                    org: Some("acme".to_string()),
+                    ..connect_request()
+                },
+                true,
+            )
+            .expect("resume token mode"),
+            ResumableAuthority::EnrollmentKey {
+                expected_org: Some("acme".to_string())
+            }
+        );
+    }
+
+    /// A pending login operation resumes login mode for the organization its
+    /// binding names, with or without a matching `--org`.
+    #[test]
+    fn a_login_draft_resumes_the_organization_it_is_bound_to() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let draft = login_draft(dir.path(), "acme");
+
+        for requested in [None, Some("acme"), Some("ACME")] {
+            let request = ConnectRequest {
+                org: requested.map(str::to_string),
+                project: Some("retail".to_string()),
+                ..connect_request()
+            };
+            assert_eq!(
+                resumable_authority(&draft, &request, true).expect("resume login mode"),
+                ResumableAuthority::Login {
+                    organization: "acme".to_string()
+                }
+            );
+        }
+    }
+
+    /// A login-mode operation cannot be finished with an enrollment key or
+    /// under another organization: both fail closed, naming the command that
+    /// finishes it and the one that abandons it explicitly.
+    #[test]
+    fn a_login_draft_rejects_a_key_or_another_organization() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let draft = login_draft(dir.path(), "acme");
+
+        let with_key = resumable_authority(
+            &draft,
+            &ConnectRequest {
+                token: Some(
+                    EnrollmentKey::parse("spice-enroll-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+                        .expect("fixture enrollment key"),
+                ),
+                project: Some("retail".to_string()),
+                ..connect_request()
+            },
+            true,
+        )
+        .expect_err("a key must not replace the pending login authority");
+        let rendered = with_key.to_string();
+        assert!(
+            rendered.contains("--token")
+                && rendered.contains("re-run `spice connect` interactively")
+                && rendered.contains("spice connect remove --force --yes"),
+            "{rendered}"
+        );
+        // The advertised command has to work in the mode the operator is in. A
+        // login-mode resume needs a project name off a terminal and accepts one
+        // on it, while the organization comes from the binding either way — so
+        // naming --org instead would fail the caller it was written for.
+        assert!(
+            !rendered.contains("spice connect --org"),
+            "the remedy must not advertise a command a non-interactive caller cannot finish: {rendered}"
+        );
+
+        let another_org = resumable_authority(
+            &draft,
+            &ConnectRequest {
+                org: Some("globex".to_string()),
+                project: Some("retail".to_string()),
+                ..connect_request()
+            },
+            true,
+        )
+        .expect_err("another organization must not redirect the pending operation");
+        assert!(
+            another_org
+                .to_string()
+                .contains("bound to organization acme"),
+            "{another_org}"
+        );
+
+        let headless = resumable_authority(
+            &draft,
+            &ConnectRequest {
+                org: Some("acme".to_string()),
+                ..connect_request()
+            },
+            false,
+        )
+        .expect_err("a project name cannot be prompted for without a terminal");
+        assert!(
+            headless.to_string().contains("--project <name>"),
+            "{headless}"
+        );
+    }
+
+    /// The pending draft binds the control plane: it is used when no flag names
+    /// one, and a flag naming another is refused rather than replayed there.
+    #[test]
+    fn a_pending_draft_binds_the_control_plane() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let draft = token_draft(dir.path(), Some("acme"));
+
+        let bound =
+            resolve_transaction_endpoint_with_env(dir.path(), None, None, None, Some(&draft))
+                .expect("the draft binds the endpoint");
+        assert_eq!(bound.value, "https://api.spice.ai");
+        assert_eq!(bound.source, EndpointSource::Bound);
+
+        resolve_transaction_endpoint_with_env(
+            dir.path(),
+            Some("https://other.example"),
+            None,
+            None,
+            Some(&draft),
+        )
+        .expect_err("a pending operation must not be replayed to another control plane");
+    }
+
+    /// The end-to-end resume: a plain interactive `spice connect` over a pending
+    /// enrollment-key draft asks for a key exactly once, never opens the
+    /// chooser, and leaves the retry-safe state intact when the control plane
+    /// cannot be reached.
+    #[tokio::test(start_paused = true)]
+    async fn a_pending_token_draft_resumes_without_the_chooser() {
+        let instance = tempfile::tempdir().expect("create instance directory");
+        let directory = instance.path().canonicalize().expect("canonical tempdir");
+        let config_dir = CloudConnectConfig::resolve_config_dir(Some(&directory));
+        let endpoint = closed_endpoint();
+        let published = EnrollmentDraft::load_or_create(
+            &config_dir,
+            &InstanceFacts::gather("v0.0.0-resume-test"),
+            Some("lab-seoul"),
+            &EnrollmentRequestBinding {
+                endpoint: endpoint.clone(),
+                authority: EnrollmentAuthorityBinding::Token {
+                    expected_org: Some("acme".to_string()),
+                },
+            },
+        )
+        .expect("publish a pending enrollment draft");
+
+        let mut prompter = ResumePrompter {
+            interactive: true,
+            key: Some("spice-enroll-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string()),
+            key_prompts: 0,
+        };
+        let error = execute_with(
+            &RuntimeContext::new().expect("runtime context"),
+            ConnectRequest {
+                dir: Some(directory.clone()),
+                // Named explicitly so an ambient SPICE_CLOUD_ENDPOINT cannot
+                // decide what this exercise resumes against.
+                endpoint: Some(endpoint.clone()),
+                ..connect_request()
+            },
+            &mut prompter,
+        )
+        .await
+        .expect_err("a closed control plane cannot complete an enrollment");
+
+        assert_eq!(
+            prompter.key_prompts, 1,
+            "resuming a key operation asks for exactly one key"
+        );
+        assert!(
+            matches!(error, Error::CloudConnectEnroll { .. }),
+            "the resume must reach the enrollment request: {error}"
+        );
+        let preserved = EnrollmentDraft::load_optional(&config_dir)
+            .expect("read the preserved draft")
+            .expect("a failed attempt keeps the retry-safe state");
+        assert_eq!(
+            preserved.enrollment_operation_id, published.enrollment_operation_id,
+            "a resume replays the durable operation ID"
+        );
+        assert_eq!(preserved.public_key_pem, published.public_key_pem);
+        assert_eq!(preserved.binding, published.binding);
+        let contents =
+            std::fs::read_to_string(EnrollmentDraft::path_in(&config_dir)).expect("read draft");
+        assert!(
+            !contents.contains("spice-enroll-"),
+            "the enrollment key must never be persisted"
+        );
+    }
+
+    /// The authority is routed from a draft read before the enrollment
+    /// transaction is held, so another process can replace the operation while
+    /// the key prompt is open — the one place a resumed run waits on a human.
+    ///
+    /// What refuses is the operation's identity, whatever else the replacement
+    /// changed. The binding cannot stand in for it: every token binding matches
+    /// every other so a corrected organization assertion can still recover its
+    /// operation, which leaves a *different* operation under the same binding
+    /// indistinguishable. Both replacements below are therefore refused the same
+    /// way, with nothing sent, nothing enrolled, and the operation the other
+    /// process published left exactly as it wrote it.
+    #[tokio::test(start_paused = true)]
+    async fn an_operation_replaced_while_prompting_fails_closed() {
+        let endpoint = closed_endpoint();
+        let routed_binding = EnrollmentRequestBinding {
+            endpoint: endpoint.clone(),
+            authority: EnrollmentAuthorityBinding::Token {
+                expected_org: Some("acme".to_string()),
+            },
+        };
+        let replacements = [
+            // Indistinguishable by binding: only the operation ID differs.
+            routed_binding.clone(),
+            // A different authority entirely.
+            EnrollmentRequestBinding {
+                endpoint: endpoint.clone(),
+                authority: EnrollmentAuthorityBinding::AuthenticatedSession {
+                    organization: "globex".to_string(),
+                },
+            },
+        ];
+
+        for replacement in replacements {
+            let instance = tempfile::tempdir().expect("create instance directory");
+            let directory = instance.path().canonicalize().expect("canonical tempdir");
+            let config_dir = CloudConnectConfig::resolve_config_dir(Some(&directory));
+            let routed = EnrollmentDraft::load_or_create(
+                &config_dir,
+                &InstanceFacts::gather("v0.0.0-racing-test"),
+                Some("lab-seoul"),
+                &routed_binding,
+            )
+            .expect("publish a pending enrollment draft");
+
+            let mut prompter = RacingPrompter {
+                key: Some("spice-enroll-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string()),
+                config_dir: config_dir.clone(),
+                replacement: Some(replacement.clone()),
+                remove: false,
+            };
+            let error = execute_with(
+                &RuntimeContext::new().expect("runtime context"),
+                ConnectRequest {
+                    dir: Some(directory.clone()),
+                    endpoint: Some(endpoint.clone()),
+                    ..connect_request()
+                },
+                &mut prompter,
+            )
+            .await
+            .expect_err("an operation this run never routed on must not be enrolled");
+            let rendered = error.to_string();
+            assert!(
+                rendered.contains("changed while this run was preparing")
+                    && rendered.contains("Nothing was sent"),
+                "the transaction must refuse the replaced operation: {rendered}"
+            );
+
+            let surviving = EnrollmentDraft::load_optional(&config_dir)
+                .expect("read the draft state")
+                .expect("the replacement is still pending");
+            assert_eq!(
+                surviving.binding, replacement,
+                "the operation the other process published must be left exactly as written"
+            );
+            assert_ne!(
+                surviving.enrollment_operation_id, routed.enrollment_operation_id,
+                "the replacement is a different operation, which is what refuses"
+            );
+            assert!(
+                !config_dir
+                    .join(runtime_cloud_connect::config::IDENTITY_FILE)
+                    .exists(),
+                "a refused resume must enroll nothing"
+            );
+        }
+    }
+
+    /// The conflict rules are asserted through the command, not only through the
+    /// decision function, because their value is which message an operator
+    /// actually gets — and that depends on the order the command applies them in.
+    ///
+    /// `--token` with `--project` is invalid in every mode, but over a pending
+    /// login-mode operation the useful answer is the one about that operation, so
+    /// the flag rule must not pre-empt it.
+    #[tokio::test(start_paused = true)]
+    async fn a_pending_login_draft_answers_before_the_flag_rules_do() {
+        let instance = tempfile::tempdir().expect("create instance directory");
+        let directory = instance.path().canonicalize().expect("canonical tempdir");
+        let config_dir = CloudConnectConfig::resolve_config_dir(Some(&directory));
+        let endpoint = closed_endpoint();
+        let published = EnrollmentDraft::load_or_create(
+            &config_dir,
+            &InstanceFacts::gather("v0.0.0-ordering-test"),
+            Some("lab-seoul"),
+            &EnrollmentRequestBinding {
+                endpoint: endpoint.clone(),
+                authority: EnrollmentAuthorityBinding::AuthenticatedSession {
+                    organization: "acme".to_string(),
+                },
+            },
+        )
+        .expect("publish a pending enrollment draft");
+
+        let mut prompter = ResumePrompter {
+            interactive: true,
+            key: None,
+            key_prompts: 0,
+        };
+        let error = execute_with(
+            &RuntimeContext::new().expect("runtime context"),
+            ConnectRequest {
+                token: Some(
+                    EnrollmentKey::parse("spice-enroll-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+                        .expect("fixture enrollment key"),
+                ),
+                project: Some("retail".to_string()),
+                dir: Some(directory.clone()),
+                endpoint: Some(endpoint.clone()),
+                ..connect_request()
+            },
+            &mut prompter,
+        )
+        .await
+        .expect_err("a key cannot finish a pending login-mode operation");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("re-run `spice connect` interactively")
+                && rendered.contains("spice connect remove --force --yes"),
+            "the pending operation must answer, naming what finishes and what abandons it: {rendered}"
+        );
+        assert_eq!(
+            prompter.key_prompts, 0,
+            "a refusal must not ask for anything first"
+        );
+        assert_eq!(
+            EnrollmentDraft::load_optional(&config_dir)
+                .expect("read the draft state")
+                .expect("the operation is still pending")
+                .enrollment_operation_id,
+            published.enrollment_operation_id,
+            "a refused invocation leaves the pending operation exactly as it was"
+        );
+    }
+
+    /// A resumed run whose operation is gone refuses and publishes nothing. The
+    /// prepare step creates a draft when none exists, and creating one here would
+    /// answer a vanished operation by leaving a phantom for the next run to
+    /// resume — so it is decided before anything can create.
+    #[tokio::test(start_paused = true)]
+    async fn a_resumed_operation_that_vanished_publishes_nothing() {
+        let instance = tempfile::tempdir().expect("create instance directory");
+        let directory = instance.path().canonicalize().expect("canonical tempdir");
+        let config_dir = CloudConnectConfig::resolve_config_dir(Some(&directory));
+        let endpoint = closed_endpoint();
+        EnrollmentDraft::load_or_create(
+            &config_dir,
+            &InstanceFacts::gather("v0.0.0-racing-test"),
+            Some("lab-seoul"),
+            &EnrollmentRequestBinding {
+                endpoint: endpoint.clone(),
+                authority: EnrollmentAuthorityBinding::Token {
+                    expected_org: Some("acme".to_string()),
+                },
+            },
+        )
+        .expect("publish a pending enrollment draft");
+
+        let mut prompter = RacingPrompter {
+            key: Some("spice-enroll-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string()),
+            config_dir: config_dir.clone(),
+            // No replacement: the operation is simply removed, as a release does.
+            replacement: None,
+            remove: true,
+        };
+        let error = execute_with(
+            &RuntimeContext::new().expect("runtime context"),
+            ConnectRequest {
+                dir: Some(directory.clone()),
+                endpoint: Some(endpoint.clone()),
+                ..connect_request()
+            },
+            &mut prompter,
+        )
+        .await
+        .expect_err("a vanished operation must not be replaced by a new one");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("was removed while this run was preparing")
+                && rendered.contains("was not redeemed"),
+            "the failure must say the operation is gone and the key unspent: {rendered}"
+        );
+        assert!(
+            EnrollmentDraft::load_optional(&config_dir)
+                .expect("read the draft state")
+                .is_none(),
+            "a refused resume must not publish a phantom operation"
+        );
+        assert!(
+            !config_dir
+                .join(runtime_cloud_connect::config::IDENTITY_FILE)
+                .exists(),
+            "a refused resume must enroll nothing"
+        );
+    }
+
+    #[test]
+    fn unsafe_cloud_recovery_urls_are_never_opened_or_printed() {
+        assert_eq!(
+            safe_recovery_url("https://spice.ai/connect").as_deref(),
+            Some("https://spice.ai/connect")
+        );
+        for unsafe_url in [
+            "javascript:alert(1)",
+            "http://127.0.0.1:8080/connect",
+            "http://attacker.example/connect",
+            "https://user:secret@spice.ai/connect",
+        ] {
+            assert_eq!(safe_recovery_url(unsafe_url), None);
+        }
+    }
+}

--- a/bin/spice/src/commands/login/mod.rs
+++ b/bin/spice/src/commands/login/mod.rs
@@ -475,7 +475,7 @@ fn credentialed_client() -> Result<reqwest::Client> {
 }
 
 /// Get the Spice.ai base URL.
-fn get_spice_base_url() -> String {
+pub(crate) fn spice_base_url() -> String {
     if let Ok(url) = std::env::var("SPICE_BASE_URL") {
         return url;
     }

--- a/bin/spice/src/commands/login/session.rs
+++ b/bin/spice/src/commands/login/session.rs
@@ -203,7 +203,7 @@ pub(super) struct BrowserLogin {
 
 impl BrowserLogin {
     pub(super) fn new() -> Self {
-        Self::at(super::get_spice_base_url())
+        Self::at(super::spice_base_url())
     }
 
     /// A flow against an explicit base URL. Tests point this at a mock server;

--- a/bin/spice/src/commands/run.rs
+++ b/bin/spice/src/commands/run.rs
@@ -17,12 +17,9 @@ limitations under the License.
 //! Run command implementation - starts the Spice runtime.
 
 use crate::context::RuntimeContext;
-use crate::error::{
-    ChildProcessIdSnafu, InvalidArgumentSnafu, Result, RuntimeExecutionSnafu, SignalHandlerSnafu,
-};
+use crate::error::Result;
+use crate::runtime_launcher::{ConnectionReport, RunConfig, run_runtime};
 use clap::Args;
-use snafu::{OptionExt, ResultExt, ensure};
-use std::process::Stdio;
 
 /// Arguments for the run command.
 #[derive(Args, Debug)]
@@ -71,152 +68,20 @@ pub struct RunArgs {
 
 /// Execute the run command.
 pub async fn execute(ctx: &RuntimeContext, args: &RunArgs, verbosity: u8) -> Result<()> {
-    ctx.ensure_local_runtime_supported()?;
-
-    // Auto-install runtime if not present
-    if !ctx.is_runtime_installed() {
-        tracing::info!("Spice.ai runtime is not installed. Installing now...");
-        crate::commands::install::execute(ctx, &crate::commands::install::InstallArgs::default())
-            .await?;
-    }
-
-    // Route --endpoint to the appropriate endpoint based on scheme
-    let (http_endpoint, flight_endpoint) = resolve_endpoint(
-        args.endpoint.as_deref(),
-        args.http_endpoint.as_deref(),
-        args.flight_endpoint.as_deref(),
-    )?;
-
-    tracing::info!("Spice.ai runtime starting...");
-
-    let mut spiced_args = args.args.clone();
-
-    // Add verbosity flags
-    if verbosity > 0 {
-        let v_flag = format!("-{}", "v".repeat(verbosity as usize));
-        spiced_args.push(v_flag);
-    }
-
-    // Add endpoint flags if specified
-    if let Some(flight) = &flight_endpoint {
-        spiced_args.push("--flight".to_string());
-        spiced_args.push(flight.clone());
-    }
-
-    if let Some(metrics) = &args.metrics_endpoint {
-        spiced_args.push("--metrics".to_string());
-        spiced_args.push(metrics.clone());
-    }
-
-    let std_cmd = ctx.get_run_cmd(&spiced_args, http_endpoint.as_deref())?;
-
-    // Convert std::process::Command to tokio::process::Command
-    let mut cmd = tokio::process::Command::from(std_cmd);
-
-    cmd.stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-
-    let mut child = cmd.spawn().context(RuntimeExecutionSnafu)?;
-
-    let status = run_with_signal_forwarding(&mut child).await?;
-
-    if !status.success() {
-        std::process::exit(status.code().unwrap_or(1));
-    }
-
-    Ok(())
-}
-
-/// Run the child process and forward signals (SIGTERM, SIGINT) to it.
-///
-/// On Unix systems, this listens for SIGTERM and SIGINT and forwards them
-/// to the child process so it can perform graceful shutdown.
-#[cfg(unix)]
-pub(crate) async fn run_with_signal_forwarding(
-    child: &mut tokio::process::Child,
-) -> Result<std::process::ExitStatus> {
-    use nix::sys::signal::{Signal, kill};
-    use nix::unistd::Pid;
-    use tokio::signal::unix::{SignalKind, signal};
-
-    let pid = child
-        .id()
-        .map(|id| Pid::from_raw(id as i32))
-        .context(ChildProcessIdSnafu)?;
-
-    let mut sigterm = signal(SignalKind::terminate()).context(SignalHandlerSnafu)?;
-    let mut sigint = signal(SignalKind::interrupt()).context(SignalHandlerSnafu)?;
-
-    tokio::select! {
-        status = child.wait() => {
-            status.context(RuntimeExecutionSnafu)
-        }
-        _ = sigterm.recv() => {
-            tracing::debug!("Received SIGTERM, forwarding to child process");
-            let _ = kill(pid, Signal::SIGTERM);
-            child.wait().await.context(RuntimeExecutionSnafu)
-        }
-        _ = sigint.recv() => {
-            tracing::debug!("Received SIGINT, forwarding to child process");
-            let _ = kill(pid, Signal::SIGINT);
-            child.wait().await.context(RuntimeExecutionSnafu)
-        }
-    }
-}
-
-/// On non-Unix systems (Windows), just wait for the child process.
-/// Windows handles Ctrl+C differently and typically propagates it to child processes
-/// in the same console automatically.
-#[cfg(not(unix))]
-pub(crate) async fn run_with_signal_forwarding(
-    child: &mut tokio::process::Child,
-) -> Result<std::process::ExitStatus> {
-    child.wait().await.context(RuntimeExecutionSnafu)
-}
-
-/// Resolve `--endpoint` into the appropriate HTTP or Flight endpoint based on its URL scheme.
-///
-/// Returns `(http_endpoint, flight_endpoint)`. If `--endpoint` is provided, it takes precedence
-/// over the corresponding specific endpoint flag. An error is returned if `--endpoint` has no
-/// recognized scheme or conflicts with an already-specified endpoint.
-fn resolve_endpoint(
-    endpoint: Option<&str>,
-    http_endpoint: Option<&str>,
-    flight_endpoint: Option<&str>,
-) -> Result<(Option<String>, Option<String>)> {
-    let Some(ep) = endpoint else {
-        return Ok((
-            http_endpoint.map(String::from),
-            flight_endpoint.map(String::from),
-        ));
-    };
-
-    if ep.starts_with("http://") || ep.starts_with("https://") {
-        ensure!(
-            http_endpoint.is_none(),
-            InvalidArgumentSnafu {
-                message: "--endpoint with http(s):// scheme cannot be combined with --http-endpoint"
-            }
-        );
-        Ok((Some(ep.to_string()), flight_endpoint.map(String::from)))
-    } else if ep.starts_with("grpc://") || ep.starts_with("grpc+tls://") {
-        ensure!(
-            flight_endpoint.is_none(),
-            InvalidArgumentSnafu {
-                message: "--endpoint with grpc:// scheme cannot be combined with --flight-endpoint"
-            }
-        );
-        let addr = ep
-            .trim_start_matches("grpc+tls://")
-            .trim_start_matches("grpc://");
-        Ok((http_endpoint.map(String::from), Some(addr.to_string())))
-    } else {
-        Err(InvalidArgumentSnafu {
-            message: format!(
-                "Unrecognized scheme in --endpoint '{ep}'. Use http://, https://, grpc://, or grpc+tls://"
-            ),
-        }
-        .build())
-    }
+    run_runtime(
+        ctx,
+        &RunConfig {
+            endpoint: args.endpoint.clone(),
+            http_endpoint: args.http_endpoint.clone(),
+            flight_endpoint: args.flight_endpoint.clone(),
+            metrics_endpoint: args.metrics_endpoint.clone(),
+            verbosity,
+            args: args.args.clone(),
+            working_dir: None,
+            // Nothing precedes this command, so the runtime it starts is the
+            // only process that can report the Cloud connection.
+            connection_report: ConnectionReport::Runtime,
+        },
+    )
+    .await
 }

--- a/bin/spice/src/context.rs
+++ b/bin/spice/src/context.rs
@@ -245,6 +245,25 @@ impl RuntimeContext {
         }
     }
 
+    /// Create a context whose runtime binary is `<spice_bin_dir>/spiced`.
+    ///
+    /// This is how a test drives the parts of the CLI that *run* the runtime —
+    /// the launcher's working directory, exit status, and signal handling —
+    /// against a stub executable, without an installed Spice runtime and
+    /// without mutating this process's environment.
+    #[cfg(test)]
+    pub(crate) fn with_bin_dir_for_test(spice_bin_dir: PathBuf) -> Self {
+        Self {
+            spice_runtime_dir: spice_bin_dir.clone(),
+            spice_bin_dir,
+            ..Self::with_deadlines_for_test(
+                DEFAULT_HTTP_ENDPOINT,
+                CONTROL_PLANE_DEADLINE,
+                INFERENCE_DEADLINE,
+            )
+        }
+    }
+
     /// Create a runtime context from CLI arguments.
     ///
     /// `cloud` is `None` when cloud mode is not enabled, or `Some("region")` with
@@ -584,6 +603,17 @@ impl RuntimeContext {
 
         // Add TLS root certificate file if present
         if let Some(tls_cert) = &self.tls_root_certificate_file {
+            let tls_cert = PathBuf::from(tls_cert);
+            let tls_cert = if tls_cert.is_absolute() {
+                tls_cert
+            } else {
+                // Preserve the CLI caller's path semantics even when a command
+                // such as `spice connect --dir` later changes the child's
+                // working directory before spawn.
+                std::env::current_dir()
+                    .context(RuntimeExecutionSnafu)?
+                    .join(tls_cert)
+            };
             cmd.arg("--tls-root-certificate-file");
             cmd.arg(tls_cert);
         }

--- a/bin/spice/src/error.rs
+++ b/bin/spice/src/error.rs
@@ -192,6 +192,10 @@ pub enum Error {
     #[snafu(display("Invalid argument: {message}"))]
     InvalidArgument { message: String },
 
+    /// Invalid command usage that should use Clap's usage-error exit code.
+    #[snafu(display("Invalid argument: {message}"))]
+    InvalidUsage { message: String },
+
     /// A Spice Cloud operation failed, carrying a stable code scripts can branch on.
     #[snafu(display(
         "{message}{}",
@@ -243,13 +247,44 @@ pub enum Error {
     #[snafu(display("No models found. Please configure a model in your Spicepod."))]
     NoModelsConfigured,
 
-    /// Local I/O failure for the Cloud Connect / adoption flow.
+    /// Local I/O failure for the Cloud Connect flow.
     #[snafu(display("Cloud Connect I/O error: {message}"))]
     CloudConnectIo { message: String },
 
     /// Enrollment against the Spice Cloud control plane failed.
     #[snafu(display("Failed to enroll with Spice Cloud: {message}"))]
     CloudConnectEnroll { message: String },
+
+    /// A `spice connect service` action needs a service that is not installed
+    /// for the selected instance directory.
+    ///
+    /// Distinct from a generic failure because nothing went wrong: the request
+    /// cannot be carried out as asked, which is what exit code
+    /// [`Error::USAGE_EXIT_CODE`] means.
+    #[snafu(display("{message}"))]
+    ServiceNotInstalled { message: String },
+
+    /// The service supervisor could not be asked, or reports the service as
+    /// failed. The status report has already been written; this carries the
+    /// diagnosis and the non-zero exit.
+    #[snafu(display("{message}"))]
+    ServiceUnavailable { message: String },
+
+    /// The viewer was interrupted — `spice connect service logs --follow`
+    /// stopped following. The service is unchanged.
+    #[snafu(display("Interrupted."))]
+    Interrupted,
+
+    /// A callable path that this release does not implement yet.
+    ///
+    /// A typed error rather than a panic, so the CLI exits with a diagnosis and
+    /// a non-zero status instead of aborting.
+    #[snafu(display("{message}"))]
+    NotImplemented { message: String },
+
+    /// Atomic Cloud Connect project creation/attachment failed.
+    #[snafu(display("{message}"))]
+    CloudConnectProject { message: String },
 }
 
 impl Error {
@@ -292,6 +327,55 @@ impl Error {
         match self {
             Self::Cloud { hint, .. } => hint.as_deref(),
             _ => None,
+        }
+    }
+
+    /// The operation failed. The default for anything without a more specific
+    /// meaning.
+    pub const FAILURE_EXIT_CODE: i32 = 1;
+
+    /// The request cannot be carried out as asked and the caller has to change
+    /// something. The same code clap uses for a usage error.
+    pub const USAGE_EXIT_CODE: i32 = 2;
+
+    /// Re-authenticate and retry, matching the convention `gh` uses
+    /// (<https://cli.github.com/manual/gh_help_exit-codes>).
+    pub const AUTH_EXIT_CODE: i32 = 4;
+
+    /// Interrupted by a signal: `128 + SIGINT`, the shell convention.
+    pub const INTERRUPTED_EXIT_CODE: i32 = 130;
+
+    /// The process exit code for this error.
+    ///
+    /// The contract automation branches on:
+    ///
+    /// - `0` — the command did what it was asked (never produced here).
+    /// - `1` — the operation failed.
+    /// - `2` — the request was invalid; change something and retry.
+    /// - `4` — authenticate again and retry.
+    /// - `130` — interrupted; nothing was changed.
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        if matches!(
+            self.cloud_code(),
+            Some(
+                CloudErrorCode::NotAuthenticated
+                    | CloudErrorCode::TokenExpired
+                    | CloudErrorCode::OrgCredentialMissing,
+            )
+        ) {
+            return Self::AUTH_EXIT_CODE;
+        }
+        match self {
+            Self::Unauthorized => Self::AUTH_EXIT_CODE,
+            // These are explicit CLI contract refusals: the caller has to
+            // change the request. Keep the long-standing `InvalidArgument`
+            // behavior on the generic failure code because that variant is
+            // also used for operational validation failures throughout the
+            // existing command surface.
+            Self::InvalidUsage { .. } | Self::ServiceNotInstalled { .. } => Self::USAGE_EXIT_CODE,
+            Self::Interrupted => Self::INTERRUPTED_EXIT_CODE,
+            _ => Self::FAILURE_EXIT_CODE,
         }
     }
 }
@@ -365,6 +449,15 @@ pub async fn read_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn existing_invalid_argument_exit_code_remains_a_generic_failure() {
+        let error = Error::InvalidArgument {
+            message: "bad argument".to_string(),
+        };
+
+        assert_eq!(error.exit_code(), Error::FAILURE_EXIT_CODE);
+    }
 
     /// A response whose body fails part-way through, under the caller's choice of status.
     fn response_with_unreadable_body(status: StatusCode) -> reqwest::Response {

--- a/bin/spice/src/lib.rs
+++ b/bin/spice/src/lib.rs
@@ -31,6 +31,7 @@ pub mod github;
 pub mod manifest;
 pub mod output;
 pub mod registry;
+pub mod runtime_launcher;
 pub(crate) mod sse;
 
 #[cfg(test)]

--- a/bin/spice/src/main.rs
+++ b/bin/spice/src/main.rs
@@ -310,22 +310,37 @@ fn main() {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
     };
 
-    // The subscriber writes to stdout, so stdout's terminal-ness decides colour.
-    // The builder default would honour `NO_COLOR` but still paint a redirected
-    // stdout; this is the same decision the CLI's own painted output already uses.
-    tracing_subscriber::fmt()
+    // Whether stdout is reserved for one JSON document. Decided before the
+    // subscriber is built, because it decides where log output may go.
+    let json_stdout = is_json_output(&mut cli.command);
+
+    // A JSON run must leave stdout parseable, so every log line goes to stderr
+    // instead — including the final error, which a command that has already
+    // written its report would otherwise append to the JSON. Otherwise the
+    // subscriber writes to stdout, so stdout's terminal-ness decides colour:
+    // the builder default would honour `NO_COLOR` but still paint a redirected
+    // stdout, and this is the same decision the CLI's own painted output uses.
+    let subscriber = tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_target(false)
-        .without_time()
-        .with_ansi(ansi_colors::colors_enabled_for(ansi_colors::Target::Stdout))
-        .init();
+        .without_time();
+    if json_stdout {
+        subscriber
+            .with_ansi(ansi_colors::colors_enabled_for(ansi_colors::Target::Stderr))
+            .with_writer(std::io::stderr)
+            .init();
+    } else {
+        subscriber
+            .with_ansi(ansi_colors::colors_enabled_for(ansi_colors::Target::Stdout))
+            .init();
+    }
 
     // Version banner: stderr-only so it doesn't foul pipes, and only for interactive stderr.
     // Suppressed for commands that produce JSON (scripting) or where it's just noise.
     if std::io::stderr().is_terminal()
         && !cli.machine
         && !matches!(cli.command, Commands::Version(_) | Commands::Completions(_))
-        && !is_json_output(&mut cli.command)
+        && !json_stdout
     {
         eprintln!("Spice.ai OSS CLI {}", version::cli_version());
     }
@@ -344,23 +359,11 @@ fn main() {
 
 /// Exit code for a failed command.
 ///
-/// Authentication failures get their own code so automation can re-authenticate
-/// and retry without parsing the message, matching the convention `gh` uses
-/// (<https://cli.github.com/manual/gh_help_exit-codes>).
+/// The mapping lives on the error type so every caller — this dispatcher and
+/// the machine-mode writer — reports the same code. See
+/// [`spice::error::Error::exit_code`] for the contract.
 fn exit_code_for(error: &spice::error::Error) -> i32 {
-    use spice::error::CloudErrorCode;
-
-    match error.cloud_code() {
-        Some(
-            CloudErrorCode::NotAuthenticated
-            | CloudErrorCode::TokenExpired
-            | CloudErrorCode::OrgCredentialMissing,
-        ) => 4,
-        _ => match error {
-            spice::error::Error::Unauthorized => 4,
-            _ => 1,
-        },
-    }
+    error.exit_code()
 }
 
 fn normalize_direct_command_args(args: impl IntoIterator<Item = OsString>) -> Vec<OsString> {
@@ -673,6 +676,7 @@ fn apply_machine_mode(command: &mut Commands) {
         Commands::Chat(args) => args.output = OutputFormat::Json,
         Commands::Refresh(args) => args.output = OutputFormat::Json,
         Commands::Cloud(args) => apply_machine_cloud_mode(&mut args.command),
+        Commands::Connect(args) => args.apply_machine_mode(),
         // `Nsql` is intentionally excluded: it is always an interactive REPL with
         // no one-shot/non-interactive mode, so there is no JSON output format to apply.
         // The remaining commands are lifecycle/manifest-editing commands with no
@@ -683,7 +687,6 @@ fn apply_machine_mode(command: &mut Commands) {
         | Commands::Upgrade(_)
         | Commands::Run(_)
         | Commands::Add(_)
-        | Commands::Connect(_)
         | Commands::Validate(_)
         | Commands::Dataset(_)
         | Commands::Catalog(_)
@@ -810,7 +813,9 @@ fn machine_error_code(error: &spice::error::Error) -> &'static str {
         spice::error::Error::RuntimeExecution { .. } => "runtime_execution",
         spice::error::Error::RuntimeVersion { .. } => "runtime_version",
         spice::error::Error::Environment { .. } => "environment",
-        spice::error::Error::InvalidArgument { .. } => "invalid_argument",
+        spice::error::Error::InvalidArgument { .. } | spice::error::Error::InvalidUsage { .. } => {
+            "invalid_argument"
+        }
         spice::error::Error::Cloud { code, .. } => code.as_str(),
         spice::error::Error::DeviceAuthorizationDenied => "device_authorization_denied",
         spice::error::Error::HomeDirectoryNotFound => "home_directory_not_found",
@@ -821,6 +826,11 @@ fn machine_error_code(error: &spice::error::Error) -> &'static str {
         spice::error::Error::NoModelsConfigured => "no_models_configured",
         spice::error::Error::CloudConnectIo { .. } => "cloud_connect_io",
         spice::error::Error::CloudConnectEnroll { .. } => "cloud_connect_enroll",
+        spice::error::Error::CloudConnectProject { .. } => "cloud_connect_project",
+        spice::error::Error::ServiceNotInstalled { .. } => "service_not_installed",
+        spice::error::Error::ServiceUnavailable { .. } => "service_unavailable",
+        spice::error::Error::Interrupted => "interrupted",
+        spice::error::Error::NotImplemented { .. } => "not_implemented",
     }
 }
 
@@ -850,6 +860,9 @@ fn is_json_output(cmd: &mut Commands) -> bool {
         }) => *output == OutputFormat::Json,
         // Cloud commands answer for themselves, from the one match in cloud::mod.
         Commands::Cloud(a) => a.command.produces_json(),
+        // Connect owns this decision so later structured subcommands do not
+        // duplicate its command parsing here.
+        Commands::Connect(a) => a.produces_json(),
         _ => false,
     }
 }
@@ -911,6 +924,9 @@ fn run_cli(cli: Cli) -> Result<()> {
             // participates in the documented enroll-endpoint precedence
             // instead of being silently accepted and ignored.
             args.cloud_region.clone_from(&cli.cloud_region);
+            // A foreground runtime this command starts is its output, so the
+            // global verbosity has to reach it the way `spice run -v` does.
+            args.verbosity = cli.verbose;
             let rt = tokio::runtime::Runtime::new()
                 .map_err(|e| spice::error::Error::RuntimeExecution { source: e })?;
             rt.block_on(connect::execute(&ctx, args))?;
@@ -1336,13 +1352,7 @@ mod tests {
     /// command's own refusal is covered in `cli_integration`.
     #[test]
     fn cloud_region_is_left_to_connect_to_diagnose() {
-        let cli = parse_normalized(&[
-            "spice",
-            "connect",
-            "spice-enroll-abcdefghijklmnopqrstuvwxyz012345",
-            "--cloud-region",
-            "us-west-2",
-        ]);
+        let cli = parse_normalized(&["spice", "connect", "status", "--cloud-region", "us-west-2"]);
         assert!(!cli.cloud);
         assert_eq!(cli.cloud_region.as_deref(), Some("us-west-2"));
         validate_cloud_region_usage(&cli)

--- a/bin/spice/src/runtime_launcher.rs
+++ b/bin/spice/src/runtime_launcher.rs
@@ -1,0 +1,616 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Starting the runtime in the foreground, from any command that needs to.
+//!
+//! `spice run` is not the only command that ends with a runtime attached to the
+//! terminal — `spice connect` does too, and anything that leaves the user at a
+//! running instance must behave identically: install the runtime if it is
+//! missing, resolve the same endpoint flags, inherit the terminal so the
+//! runtime's own output *is* the command's output, forward the signals that
+//! stop it, and exit with the status the runtime exited with.
+//!
+//! One launcher is what keeps those identical. Re-invoking the `spice run`
+//! subcommand from another command would add a third process to every Ctrl-C
+//! and put the CLI's argument parsing between the caller and the runtime.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use snafu::{OptionExt, ResultExt, ensure};
+
+use crate::context::RuntimeContext;
+use crate::error::{
+    ChildProcessIdSnafu, InvalidArgumentSnafu, Result, RuntimeExecutionSnafu, SignalHandlerSnafu,
+};
+
+/// Who tells the operator that this instance is connected to Spice Cloud.
+///
+/// The runtime is the default reporter, and the only one for a direct `spiced`
+/// or `spice run` start: it is the process that knows when the instance is
+/// actually serving and Spice Cloud has answered it. A caller that has just
+/// completed a connect transaction has already printed that block, so it says
+/// so here rather than letting the same two lines arrive twice.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionReport {
+    /// The runtime reports it, once both facts are true.
+    #[default]
+    Runtime,
+    /// The caller already reported it; the runtime stays quiet.
+    AlreadyReported,
+}
+
+/// The environment variable that carries [`ConnectionReport::AlreadyReported`]
+/// to the runtime.
+///
+/// A private handshake between this launcher and the runtime it starts, not a
+/// configuration surface: it is never documented for operators, never read from
+/// a spicepod, and absent for every start the CLI does not parent.
+const CONNECTION_REPORTED_ENV: &str = "SPICE_CONNECTION_REPORTED";
+const SPICE_CONFIG_DIR_ENV: &str = "SPICE_CONFIG_DIR";
+
+/// How the runtime should be started.
+#[derive(Debug, Default, Clone)]
+pub struct RunConfig {
+    /// `--endpoint`: routed to the HTTP or Flight endpoint by its scheme.
+    pub endpoint: Option<String>,
+    /// `--http-endpoint`, the address the runtime binds its HTTP API on.
+    pub http_endpoint: Option<String>,
+    /// `--flight-endpoint`, the address the runtime binds Flight on.
+    pub flight_endpoint: Option<String>,
+    /// `--metrics-endpoint`, the address the runtime serves Prometheus on.
+    pub metrics_endpoint: Option<String>,
+    /// `-v` count, forwarded to the runtime as its own verbosity flag.
+    pub verbosity: u8,
+    /// Arguments passed through to `spiced` verbatim.
+    pub args: Vec<String>,
+    /// Who reports the Cloud connection once the runtime is serving.
+    pub connection_report: ConnectionReport,
+    /// The directory the runtime runs in. It resolves the spicepod *and* the
+    /// per-instance `.spice` state, so a caller acting on an instance directory
+    /// (`spice connect --dir`) has to set it rather than assume the CLI was
+    /// invoked from there. `None` inherits this process's working directory.
+    pub working_dir: Option<PathBuf>,
+}
+
+/// Start the runtime in the foreground and stay attached to it until it exits.
+///
+/// Installs the runtime first if this host has none. Returns only when the
+/// runtime has exited: a non-zero exit is propagated as this process's own
+/// status, so a caller in a script sees what the runtime reported.
+///
+/// # Errors
+///
+/// Returns an error when the runtime cannot be installed, when the endpoint
+/// flags conflict, or when the child process cannot be started or waited on.
+pub async fn run_runtime(ctx: &RuntimeContext, config: &RunConfig) -> Result<()> {
+    let status = start_runtime_process(ctx, config).await?;
+
+    if !status.success() {
+        // The runtime's status is this command's status: a caller in a script
+        // sees what the runtime reported, not that the CLI managed to run it.
+        #[cfg(unix)]
+        let code = {
+            use std::os::unix::process::ExitStatusExt as _;
+            status
+                .code()
+                .or_else(|| status.signal().map(|signal| 128 + signal))
+                .unwrap_or(1)
+        };
+        #[cfg(not(unix))]
+        let code = status.code().unwrap_or(1);
+        std::process::exit(code);
+    }
+
+    Ok(())
+}
+
+/// [`run_runtime`] up to the point where the runtime has exited, returning the
+/// status it exited with instead of adopting it.
+///
+/// Split out because adopting the status ends the process, which is exactly
+/// what a test of this behavior cannot do.
+#[cfg(test)]
+async fn start_runtime(
+    ctx: &RuntimeContext,
+    config: &RunConfig,
+) -> Result<std::process::ExitStatus> {
+    start_runtime_process(ctx, config).await
+}
+
+async fn start_runtime_process(
+    ctx: &RuntimeContext,
+    config: &RunConfig,
+) -> Result<std::process::ExitStatus> {
+    ctx.ensure_local_runtime_supported()?;
+
+    // Auto-install runtime if not present
+    if !ctx.is_runtime_installed() {
+        tracing::info!("Spice.ai runtime is not installed. Installing now...");
+        crate::commands::install::execute(ctx, &crate::commands::install::InstallArgs::default())
+            .await?;
+    }
+    // Route --endpoint to the appropriate endpoint based on scheme
+    let (http_endpoint, flight_endpoint) = resolve_endpoint(
+        config.endpoint.as_deref(),
+        config.http_endpoint.as_deref(),
+        config.flight_endpoint.as_deref(),
+    )?;
+
+    tracing::info!("Spice.ai runtime starting...");
+
+    let spiced_args = spiced_args(config, flight_endpoint.as_deref());
+    let std_cmd = ctx.get_run_cmd(&spiced_args, http_endpoint.as_deref())?;
+
+    // Convert std::process::Command to tokio::process::Command
+    let mut cmd = tokio::process::Command::from(std_cmd);
+
+    // Environment paths are normally resolved relative to the parent's current
+    // directory. Preserve that meaning when `--dir` gives the child a different
+    // working directory; otherwise the runtime can enroll against a different
+    // `.spice` directory than the CLI just wrote.
+    if let Some(config_dir) = std::env::var_os(SPICE_CONFIG_DIR_ENV) {
+        cmd.env(
+            SPICE_CONFIG_DIR_ENV,
+            absolute_from_parent(PathBuf::from(config_dir))?,
+        );
+    }
+    if let Some(dir) = &config.working_dir {
+        cmd.current_dir(dir);
+    }
+
+    match config.connection_report {
+        ConnectionReport::AlreadyReported => {
+            cmd.env(CONNECTION_REPORTED_ENV, "1");
+        }
+        ConnectionReport::Runtime => {
+            // This is a private parent-child handshake, not an operator
+            // setting. A direct `spice run` must not inherit a stale value and
+            // accidentally suppress the runtime's own connection report.
+            cmd.env_remove(CONNECTION_REPORTED_ENV);
+        }
+    }
+
+    cmd.stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    // Install the handlers before spawning so a signal cannot land before the
+    // launcher is ready to forward it.
+    let mut child_signals = ChildSignals::new()?;
+    let mut child = cmd.spawn().context(RuntimeExecutionSnafu)?;
+
+    run_with_signal_forwarding(&mut child, &mut child_signals).await
+}
+
+/// Resolve a path with the same parent-working-directory semantics environment
+/// variables have before the child changes directory. An empty path remains
+/// empty: `CloudConnectConfig` deliberately treats an explicitly empty
+/// `SPICE_CONFIG_DIR` as unset, so the child must retain that meaning after it
+/// changes to the configured instance directory.
+fn absolute_from_parent(path: PathBuf) -> Result<PathBuf> {
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return Ok(path);
+    }
+    std::env::current_dir()
+        .map(|parent| parent.join(path))
+        .context(RuntimeExecutionSnafu)
+}
+
+/// The `spiced` argument list a [`RunConfig`] resolves to, apart from the
+/// endpoint and defaults [`RuntimeContext::get_run_cmd`] supplies.
+///
+/// Pass-through arguments come first so a flag the caller repeats explicitly is
+/// the one `spiced`'s parser sees last only where that is intended.
+fn spiced_args(config: &RunConfig, flight_endpoint: Option<&str>) -> Vec<String> {
+    let mut args = config.args.clone();
+
+    if config.verbosity > 0 {
+        args.push(format!("-{}", "v".repeat(config.verbosity as usize)));
+    }
+
+    if let Some(flight) = flight_endpoint {
+        args.push("--flight".to_string());
+        args.push(flight.to_string());
+    }
+
+    if let Some(metrics) = &config.metrics_endpoint {
+        args.push("--metrics".to_string());
+        args.push(metrics.clone());
+    }
+
+    args
+}
+
+/// Signal streams installed before the runtime child is spawned and retained
+/// through the final child wait.
+struct ChildSignals {
+    #[cfg(unix)]
+    sigterm: tokio::signal::unix::Signal,
+    #[cfg(unix)]
+    sigint: tokio::signal::unix::Signal,
+}
+
+#[derive(Clone, Copy)]
+enum ChildSignal {
+    #[cfg(unix)]
+    Terminate,
+    #[cfg(unix)]
+    Interrupt,
+    #[cfg(not(unix))]
+    Never,
+}
+
+impl ChildSignals {
+    fn new() -> Result<Self> {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+            Ok(Self {
+                sigterm: signal(SignalKind::terminate()).context(SignalHandlerSnafu)?,
+                sigint: signal(SignalKind::interrupt()).context(SignalHandlerSnafu)?,
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            Ok(Self {})
+        }
+    }
+
+    async fn recv(&mut self) -> ChildSignal {
+        #[cfg(unix)]
+        {
+            tokio::select! {
+                _ = self.sigterm.recv() => ChildSignal::Terminate,
+                _ = self.sigint.recv() => ChildSignal::Interrupt,
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            std::future::pending::<ChildSignal>().await
+        }
+    }
+
+    fn forward(child: &tokio::process::Child, signal: ChildSignal) -> Result<()> {
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{Signal, kill};
+            use nix::unistd::Pid;
+
+            let pid = child
+                .id()
+                .map(|id| Pid::from_raw(id as i32))
+                .context(ChildProcessIdSnafu)?;
+            let signal = match signal {
+                ChildSignal::Terminate => Signal::SIGTERM,
+                ChildSignal::Interrupt => Signal::SIGINT,
+            };
+            tracing::debug!(?signal, "Forwarding signal to runtime child");
+            let _ = kill(pid, signal);
+        }
+        #[cfg(not(unix))]
+        {
+            let ChildSignal::Never = signal;
+            let _ = child;
+        }
+        Ok(())
+    }
+}
+
+/// Run the child process and forward signals (SIGTERM, SIGINT) to it.
+async fn run_with_signal_forwarding(
+    child: &mut tokio::process::Child,
+    signals: &mut ChildSignals,
+) -> Result<std::process::ExitStatus> {
+    tokio::select! {
+        status = child.wait() => {
+            status.context(RuntimeExecutionSnafu)
+        }
+        signal = signals.recv() => {
+            ChildSignals::forward(child, signal)?;
+            child.wait().await.context(RuntimeExecutionSnafu)
+        }
+    }
+}
+
+/// Resolve `--endpoint` into the appropriate HTTP or Flight endpoint based on its URL scheme.
+///
+/// Returns `(http_endpoint, flight_endpoint)`. If `--endpoint` is provided, it takes precedence
+/// over the corresponding specific endpoint flag. An error is returned if `--endpoint` has no
+/// recognized scheme or conflicts with an already-specified endpoint.
+fn resolve_endpoint(
+    endpoint: Option<&str>,
+    http_endpoint: Option<&str>,
+    flight_endpoint: Option<&str>,
+) -> Result<(Option<String>, Option<String>)> {
+    let Some(ep) = endpoint else {
+        return Ok((
+            http_endpoint.map(String::from),
+            flight_endpoint.map(String::from),
+        ));
+    };
+
+    if ep.starts_with("http://") || ep.starts_with("https://") {
+        ensure!(
+            http_endpoint.is_none(),
+            InvalidArgumentSnafu {
+                message: "--endpoint with http(s):// scheme cannot be combined with --http-endpoint"
+            }
+        );
+        Ok((Some(ep.to_string()), flight_endpoint.map(String::from)))
+    } else if ep.starts_with("grpc://") || ep.starts_with("grpc+tls://") {
+        ensure!(
+            flight_endpoint.is_none(),
+            InvalidArgumentSnafu {
+                message: "--endpoint with grpc:// scheme cannot be combined with --flight-endpoint"
+            }
+        );
+        let addr = ep
+            .trim_start_matches("grpc+tls://")
+            .trim_start_matches("grpc://");
+        Ok((http_endpoint.map(String::from), Some(addr.to_string())))
+    } else {
+        Err(InvalidArgumentSnafu {
+            message: format!(
+                "Unrecognized scheme in --endpoint '{ep}'. Use http://, https://, grpc://, or grpc+tls://"
+            ),
+        }
+        .build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_routes_by_scheme() {
+        assert_eq!(
+            resolve_endpoint(Some("http://127.0.0.1:8090"), None, None).expect("http scheme"),
+            (Some("http://127.0.0.1:8090".to_string()), None)
+        );
+        // The Flight address is passed to `spiced` without its scheme.
+        assert_eq!(
+            resolve_endpoint(Some("grpc://127.0.0.1:50051"), None, None).expect("grpc scheme"),
+            (None, Some("127.0.0.1:50051".to_string()))
+        );
+        assert_eq!(
+            resolve_endpoint(Some("grpc+tls://127.0.0.1:50051"), None, None).expect("grpc+tls"),
+            (None, Some("127.0.0.1:50051".to_string()))
+        );
+    }
+
+    #[test]
+    fn endpoint_conflicts_and_unknown_schemes_are_refused() {
+        resolve_endpoint(Some("http://a:1"), Some("http://b:2"), None)
+            .expect_err("two HTTP endpoints must not both be honoured");
+        resolve_endpoint(Some("grpc://a:1"), None, Some("b:2"))
+            .expect_err("two Flight endpoints must not both be honoured");
+        resolve_endpoint(Some("a:1"), None, None).expect_err("a scheme is required");
+    }
+
+    #[test]
+    fn without_an_endpoint_the_specific_flags_pass_through() {
+        assert_eq!(
+            resolve_endpoint(None, Some("http://a:1"), Some("b:2")).expect("pass through"),
+            (Some("http://a:1".to_string()), Some("b:2".to_string()))
+        );
+    }
+
+    #[test]
+    fn verbosity_metrics_and_flight_reach_the_runtime() {
+        let config = RunConfig {
+            metrics_endpoint: Some("127.0.0.1:9090".to_string()),
+            verbosity: 2,
+            args: vec!["--dataset-path".to_string(), "x".to_string()],
+            ..RunConfig::default()
+        };
+        assert_eq!(
+            spiced_args(&config, Some("127.0.0.1:50051")),
+            vec![
+                "--dataset-path",
+                "x",
+                "-vv",
+                "--flight",
+                "127.0.0.1:50051",
+                "--metrics",
+                "127.0.0.1:9090",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_quiet_run_adds_no_flags_of_its_own() {
+        assert!(spiced_args(&RunConfig::default(), None).is_empty());
+    }
+
+    #[test]
+    fn an_empty_config_directory_stays_unset_for_the_child() {
+        assert_eq!(
+            absolute_from_parent(PathBuf::new()).expect("an empty path needs no resolution"),
+            PathBuf::new()
+        );
+    }
+
+    /// The launcher against a stub runtime: what it does with a real child
+    /// process, which is the half no argument assertion can cover.
+    #[cfg(unix)]
+    mod child_process {
+        use super::*;
+        use std::time::{Duration, Instant};
+
+        /// How long a stub is given to reach the state a test waits for. Only
+        /// an upper bound on something that normally happens in milliseconds.
+        const READY_BUDGET: Duration = Duration::from_secs(10);
+        const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+        /// Install `script` as the `spiced` a context resolves, and return that
+        /// context. The directory is the caller's to keep alive.
+        fn context_with_stub_runtime(bin_dir: &std::path::Path, script: &str) -> RuntimeContext {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            std::fs::create_dir_all(bin_dir).expect("create the stub bin directory");
+            let stub = bin_dir.join("spiced");
+            std::fs::write(&stub, script).expect("write the stub runtime");
+            std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
+                .expect("make the stub runtime executable");
+            RuntimeContext::with_bin_dir_for_test(bin_dir.to_path_buf())
+        }
+
+        /// Wait for the stub to report the state a test needs, rather than
+        /// sleeping for a duration that is either flaky or slow.
+        async fn wait_for(path: &std::path::Path) {
+            let deadline = Instant::now() + READY_BUDGET;
+            while !path.exists() {
+                assert!(
+                    Instant::now() < deadline,
+                    "the stub runtime never created {}",
+                    path.display()
+                );
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        }
+
+        #[tokio::test]
+        async fn the_runtime_runs_in_the_configured_working_directory() {
+            // `spice connect --dir` acts on an instance directory, and the
+            // runtime resolves both the spicepod and the `.spice` state from
+            // its working directory — so this is what makes the runtime it
+            // starts the one that directory describes.
+            let dir = tempfile::tempdir().expect("create tempdir");
+            let instance_dir = dir.path().join("instance");
+            std::fs::create_dir_all(&instance_dir).expect("create the instance directory");
+            let observed = dir.path().join("cwd");
+            let ctx = context_with_stub_runtime(
+                &dir.path().join("bin"),
+                &format!("#!/bin/sh\npwd > {}\n", observed.display()),
+            );
+
+            let status = start_runtime(
+                &ctx,
+                &RunConfig {
+                    working_dir: Some(instance_dir.clone()),
+                    ..RunConfig::default()
+                },
+            )
+            .await
+            .expect("the stub runtime runs");
+
+            assert!(status.success());
+            let reported = std::fs::read_to_string(&observed).expect("the stub reported its cwd");
+            assert_eq!(
+                std::fs::canonicalize(reported.trim()).expect("canonicalize the reported cwd"),
+                std::fs::canonicalize(&instance_dir).expect("canonicalize the instance directory"),
+            );
+        }
+
+        #[tokio::test]
+        async fn a_failing_runtime_reports_its_own_status() {
+            // The CLI adopts this as its own exit status, so a script that runs
+            // `spice connect` sees what the runtime reported rather than that
+            // the CLI managed to start it.
+            let dir = tempfile::tempdir().expect("create tempdir");
+            let ctx = context_with_stub_runtime(&dir.path().join("bin"), "#!/bin/sh\nexit 3\n");
+
+            let status = start_runtime(&ctx, &RunConfig::default())
+                .await
+                .expect("a failing runtime is an exit status, not a launcher error");
+
+            assert_eq!(status.code(), Some(3));
+        }
+
+        #[tokio::test]
+        async fn a_termination_signal_reaches_the_runtime() {
+            let status = tokio::process::Command::new(
+                std::env::current_exe().expect("resolve the unit-test executable"),
+            )
+            .args([
+                "--ignored",
+                "--exact",
+                "runtime_launcher::tests::child_process::signal_forwarding_subprocess",
+                "--nocapture",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .await
+            .expect("run the isolated signal-forwarding test");
+
+            assert!(status.success(), "the isolated signal test must pass");
+        }
+
+        /// Signals are process-global. Keep the real raise in a test-harness
+        /// subprocess selected with `--exact`, where no parallel unit test can
+        /// install a listener or receive the broadcast.
+        #[tokio::test]
+        #[ignore = "run by a_termination_signal_reaches_the_runtime in isolation"]
+        async fn signal_forwarding_subprocess() {
+            // Ctrl-C and `systemctl stop` reach the CLI, and the runtime is the
+            // process that has to shut down cleanly — its identity and desired
+            // state are only intact if it gets to do that itself.
+            use tokio::signal::unix::{SignalKind, signal};
+
+            // Registered before the signal is raised: this is what makes the
+            // default terminate action inapplicable, so a raise cannot kill the
+            // test process before the launcher installs its own handler.
+            let mut guard = signal(SignalKind::terminate()).expect("register SIGTERM");
+
+            let dir = tempfile::tempdir().expect("create tempdir");
+            let started = dir.path().join("started");
+            let terminated = dir.path().join("terminated");
+            // `sleep &` + `wait` rather than a foreground sleep: a shell runs a
+            // trap only between commands, so a foreground sleep would swallow
+            // the signal for its whole duration.
+            let ctx = context_with_stub_runtime(
+                &dir.path().join("bin"),
+                &format!(
+                    "#!/bin/sh\ntrap 'echo yes > {terminated}; kill \"$idle\" 2>/dev/null; exit 143' TERM\ntouch {started}\nsleep 30 & idle=$!\nwait\n",
+                    terminated = terminated.display(),
+                    started = started.display(),
+                ),
+            );
+
+            let launched = tokio::spawn(async move {
+                start_runtime(&ctx, &RunConfig::default())
+                    .await
+                    .expect("the stub runtime runs")
+            });
+
+            wait_for(&started).await;
+            nix::sys::signal::raise(nix::sys::signal::Signal::SIGTERM)
+                .expect("raise SIGTERM in this process");
+            // Consumed so the test's own listener does not outlive the raise
+            // with a pending signal.
+            let _ = guard.recv().await;
+
+            let status = tokio::time::timeout(READY_BUDGET, launched)
+                .await
+                .expect("the launcher must return once the runtime exits")
+                .expect("the launcher task must not panic");
+
+            assert_eq!(
+                status.code(),
+                Some(143),
+                "the runtime's own exit status must reach the caller"
+            );
+            assert!(
+                terminated.exists(),
+                "the runtime must receive the signal rather than be killed by it"
+            );
+        }
+    }
+}

--- a/bin/spice/tests/cli_integration.rs
+++ b/bin/spice/tests/cli_integration.rs
@@ -773,6 +773,96 @@ mod add {
     }
 }
 
+// ============================================================================
+// Connect Command Tests
+// ============================================================================
+
+mod connect {
+    use super::*;
+
+    #[test]
+    fn test_connect_help_describes_the_interactive_surface() {
+        spice_cmd()
+            .arg("connect")
+            .arg("--help")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "This is an interactive setup flow",
+            ))
+            .stdout(predicate::str::contains("spiced --token"))
+            .stdout(predicate::str::contains("--dir"))
+            .stdout(predicate::str::contains("--region"))
+            .stdout(predicate::str::contains("SPICE-ADOPT").not())
+            .stdout(predicate::str::contains("--install").not())
+            .stdout(predicate::str::contains("status").not())
+            .stdout(predicate::str::contains("remove --force --yes"));
+    }
+
+    #[test]
+    fn test_connect_rejects_removed_automation_flags() {
+        for flag in ["--token", "--org", "--project", "--install"] {
+            spice_cmd()
+                .arg("connect")
+                .arg(flag)
+                .arg("value")
+                .assert()
+                .failure()
+                .stderr(predicate::str::contains("unexpected argument"));
+        }
+    }
+
+    #[test]
+    fn test_connect_rejects_removal_only_flags_during_setup() {
+        for flag in ["--force", "--yes"] {
+            spice_cmd()
+                .arg("connect")
+                .arg(flag)
+                .assert()
+                .failure()
+                .stderr(predicate::str::contains(
+                    "apply only to `spice connect remove`",
+                ));
+        }
+    }
+
+    #[test]
+    fn test_local_remove_rejects_a_control_plane_endpoint() {
+        spice_cmd()
+            .arg("connect")
+            .arg("remove")
+            .arg("--force")
+            .arg("--yes")
+            .arg("--endpoint")
+            .arg("https://control.example")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "--endpoint does not apply to `connect remove`",
+            ));
+    }
+
+    #[test]
+    fn test_local_remove_rejects_an_enrollment_region() {
+        spice_cmd()
+            .arg("connect")
+            .arg("remove")
+            .arg("--force")
+            .arg("--yes")
+            .arg("--region")
+            .arg("us-west-2")
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(
+                "--region applies to enrollment, not to `connect remove`",
+            ));
+    }
+}
+
+// ============================================================================
+// Acceleration Command Tests
+// ============================================================================
+
 mod acceleration {
     use super::*;
 
@@ -1513,188 +1603,5 @@ mod env_vars {
             .arg("--help")
             .assert()
             .success();
-    }
-}
-
-// ============================================================================
-// Cloud Connect Foundation Tests
-// ============================================================================
-
-#[cfg(unix)]
-mod cloud_connect_foundation {
-    use super::*;
-    use rcgen::{
-        BasicConstraints, CertificateParams, CertificateSigningRequestParams, DnType, IsCa, Issuer,
-        KeyPair, KeyUsagePurpose,
-    };
-    use std::io::{Read as _, Write as _};
-    use std::os::unix::fs::PermissionsExt as _;
-
-    const ENROLLMENT_KEY: &str = "spice-enroll-abcdefghijklmnopqrstuvwxyz012345";
-
-    fn install_fake_spiced(home: &std::path::Path) {
-        let bin_dir = home.join(".spice/bin");
-        fs::create_dir_all(&bin_dir).expect("create fake runtime directory");
-        let spiced = bin_dir.join("spiced");
-        fs::write(
-            &spiced,
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'spiced v0.0.0-test'; exit 0; fi\ntouch \"$(dirname \"$0\")/spiced-ran\"\n",
-        )
-        .expect("write fake spiced");
-        fs::set_permissions(&spiced, fs::Permissions::from_mode(0o755))
-            .expect("make fake spiced executable");
-    }
-
-    fn spawn_enroll_endpoint() -> (String, std::thread::JoinHandle<serde_json::Value>) {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind enroll endpoint");
-        let endpoint = format!(
-            "http://{}",
-            listener.local_addr().expect("endpoint address")
-        );
-        let handle = std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("accept enrollment request");
-            let mut request = Vec::new();
-            let mut chunk = [0_u8; 4096];
-            loop {
-                let read = stream.read(&mut chunk).expect("read enrollment request");
-                if read == 0 {
-                    break;
-                }
-                request.extend_from_slice(&chunk[..read]);
-                let text = String::from_utf8_lossy(&request);
-                if let Some(headers_end) = text.find("\r\n\r\n") {
-                    let content_length = text[..headers_end]
-                        .lines()
-                        .find_map(|line| {
-                            let (name, value) = line.split_once(':')?;
-                            name.eq_ignore_ascii_case("content-length")
-                                .then(|| value.trim().parse::<usize>().ok())
-                                .flatten()
-                        })
-                        .unwrap_or_default();
-                    if request.len() >= headers_end + 4 + content_length {
-                        break;
-                    }
-                }
-            }
-            let request = String::from_utf8(request).expect("request is UTF-8");
-            let (_, request_body) = request.split_once("\r\n\r\n").expect("request has headers");
-            let request_json: serde_json::Value =
-                serde_json::from_str(request_body).expect("request body is JSON");
-
-            let ca_key = KeyPair::generate().expect("generate enrollment CA key");
-            let mut ca_parameters = CertificateParams::default();
-            ca_parameters
-                .distinguished_name
-                .push(DnType::CommonName, "CLI integration enrollment CA");
-            ca_parameters.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-            ca_parameters.key_usages = vec![
-                KeyUsagePurpose::KeyCertSign,
-                KeyUsagePurpose::DigitalSignature,
-            ];
-            let ca_certificate = ca_parameters
-                .self_signed(&ca_key)
-                .expect("self-sign enrollment CA");
-            let issuer = Issuer::new(ca_parameters, ca_key);
-            let identity_certificate = CertificateSigningRequestParams::from_pem(
-                request_json["csr_pem"]
-                    .as_str()
-                    .expect("enrollment request carries a CSR"),
-            )
-            .expect("parse enrollment CSR")
-            .signed_by(&issuer)
-            .expect("sign enrollment CSR")
-            .pem();
-            let response_body = serde_json::json!({
-                "instance_id": "inst_cli_foundation",
-                "identity_cert_pem": identity_certificate,
-                "ca_bundle_pem": ca_certificate.pem(),
-                "gateway_addr": "127.0.0.1:443",
-                "not_after": "2099-01-01T00:00:00Z",
-                "organization": {"id": 7, "name": "cli-test-org"},
-                "portal": {"new_project_url": "https://spice.ai/orgs/cli-test-org/projects/new"}
-            })
-            .to_string();
-            write!(
-                stream,
-                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
-                response_body.len(),
-                response_body
-            )
-            .expect("write enrollment response");
-            request_json
-        });
-        (endpoint, handle)
-    }
-
-    #[test]
-    fn connect_enrolls_the_requested_directory_and_exits_without_starting_spiced() {
-        let instance = TempDir::new().expect("create instance directory");
-        let cwd = TempDir::new().expect("create unrelated working directory");
-        let home = TempDir::new().expect("create isolated home");
-        install_fake_spiced(home.path());
-        let (endpoint, server) = spawn_enroll_endpoint();
-
-        let output = spice_cmd()
-            .env("HOME", home.path())
-            .env_remove("SPICE_CONFIG_DIR")
-            .env_remove("SPICE_CLOUD_ENDPOINT")
-            .current_dir(cwd.path())
-            .arg("connect")
-            .arg(ENROLLMENT_KEY)
-            .arg("--dir")
-            .arg(instance.path())
-            .arg("--endpoint")
-            .arg(&endpoint)
-            .assert()
-            .success()
-            .stdout(predicate::str::contains("Enrolled with Spice Cloud"))
-            .stdout(predicate::str::contains(ENROLLMENT_KEY).not())
-            .stderr(predicate::str::contains(ENROLLMENT_KEY).not())
-            .get_output()
-            .clone();
-        assert!(output.status.success());
-        let request = server.join().expect("enrollment server finishes");
-        assert_eq!(request["token"], ENROLLMENT_KEY);
-
-        let config_dir = instance.path().join(".spice");
-        let identity: serde_json::Value = serde_json::from_slice(
-            &fs::read(config_dir.join("identity.json")).expect("read durable identity"),
-        )
-        .expect("identity is JSON");
-        assert_eq!(identity["identifier"], "inst_cli_foundation");
-        assert_eq!(identity["control_plane_endpoint"], endpoint);
-        assert!(
-            !home.path().join(".spice/bin/spiced-ran").exists(),
-            "foundation enrollment exits without launching the runtime"
-        );
-        assert!(
-            !cwd.path().join(".spice").exists(),
-            "--dir keeps state out of the current working directory"
-        );
-
-        spice_cmd()
-            .env_remove("SPICE_CONFIG_DIR")
-            .current_dir(cwd.path())
-            .arg("connect")
-            .arg("status")
-            .arg("--dir")
-            .arg(instance.path())
-            .assert()
-            .success()
-            .stdout(predicate::str::contains("inst_cli_foundation"));
-    }
-
-    #[test]
-    fn malformed_enrollment_authority_is_not_echoed() {
-        let secret = "abcdefghijklmnopqrstuvwxyz012345";
-        let malformed = format!("spice-enroll-{secret}!");
-        spice_cmd()
-            .arg("connect")
-            .arg(&malformed)
-            .assert()
-            .failure()
-            .stdout(predicate::str::contains(secret).not())
-            .stderr(predicate::str::contains(secret).not());
     }
 }

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -81,9 +81,11 @@ use runtime::Runtime;
 use runtime::datafusion::query::Error as QueryError;
 use runtime::metrics_reader::MetricsReader;
 use runtime::status::ComponentStatus;
+#[cfg(test)]
+use runtime_cloud_connect::config::IDENTITY_FILE;
 use runtime_cloud_connect::config::{
     CLOUD_MANAGED_SPICEPOD_FILE, CloudConnectConfig, DEPLOYMENT_TRANSACTION_FILE,
-    DEPLOYMENT_TRANSACTION_INCOMING_FILE, IDENTITY_FILE, INCOMING_SECRET_CACHE_FILE,
+    DEPLOYMENT_TRANSACTION_INCOMING_FILE, INCOMING_SECRET_CACHE_FILE,
     PREVIOUS_CLOUD_MANAGED_SPICEPOD_FILE, PREVIOUS_SECRET_CACHE_FILE,
 };
 use runtime_cloud_connect::handlers::{
@@ -105,15 +107,6 @@ use crate::log_capture::LogRingBuffer;
 const DEFAULT_LOG_TAIL_LINES: usize = 500;
 
 const DEPLOYMENT_TRANSACTION_FORMAT: u8 = 1;
-
-/// Cheap probe used during tracing initialization, before startup state has
-/// been loaded. Full identity validation still happens during bootstrap.
-pub(crate) fn is_configured(token_supplied: bool) -> bool {
-    token_supplied
-        || CloudConnectConfig::default_config_dir()
-            .join(IDENTITY_FILE)
-            .exists()
-}
 
 /// The one durable-state decision made before the runtime is built.
 ///

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -1589,14 +1589,7 @@ fn init_metrics(
 
     // Case 1: Prometheus scrape
     if let Some(registry) = registry {
-        let prometheus_exporter = opentelemetry_prometheus::exporter()
-            .with_registry(registry)
-            .without_scope_info()
-            .without_units()
-            .without_counter_suffixes()
-            .without_target_info()
-            .build()?;
-        provider_builder = provider_builder.with_reader(prometheus_exporter);
+        provider_builder = provider_builder.with_reader(runtime::prometheus_reader(registry)?);
 
         let spice_metrics_exporter =
             OtelArrowExporter::new(spice_metrics::SpiceMetricsExporter::new(df));

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -121,7 +121,6 @@ fn main() {
         println!("{}", get_version_string());
         return;
     }
-
     // Install the default AWS LC RS crypto provider for rusttls
     let _ = CryptoProvider::install_default(crypto::aws_lc_rs::default_provider());
 
@@ -155,15 +154,26 @@ fn main() {
         }
     });
 
-    if let Err(err) = load_and_run(args) {
-        in_tracing_context(|| {
-            tracing::error!("{err}");
-        });
-    }
+    let runtime_failed = match load_and_run(args) {
+        Ok(()) => false,
+        Err(err) => {
+            in_tracing_context(|| {
+                tracing::error!("{err}");
+            });
+            true
+        }
+    };
 
     // There is no global::shutdown_meter_provider, so we replace currently used meter provider with a noop one to clean up resources
     global::set_meter_provider(NoopMeterProvider::new());
     tracing::info!("Goodbye!");
+    if runtime_failed {
+        // The foreground launcher has already seen the instance-claim ack at
+        // this point. Preserve every later startup/runtime failure in the
+        // process status so it cannot mistake "claimed, then failed" for a
+        // successfully running instance.
+        std::process::exit(1);
+    }
 }
 
 /// Load the spicepod, resolve the CPU budget it configures, and only then build
@@ -192,7 +202,6 @@ fn load_and_run(mut args: spiced::Args) -> Result<(), Box<dyn std::error::Error>
             std::process::exit(1);
         }
     };
-
     // One temporary subscriber for the whole window before `spiced::run` installs the
     // global one, so every line the spicepod load and the CPU budget emit — including
     // any added later — has somewhere to go. Both the bootstrap runtime and

--- a/bin/spiced/src/tracing.rs
+++ b/bin/spiced/src/tracing.rs
@@ -166,12 +166,12 @@ fn should_include_otel_location(is_release_build: bool, verbosity: &LogVerbosity
 /// unchanged. The same `task_history` exclusion as the console layer is
 /// applied so span-only records don't pollute the log tail.
 fn cloud_connect_log_capture_layer<S>(
-    token_supplied: bool,
+    cloud_connect_configured: bool,
 ) -> Option<Box<dyn Layer<S> + Send + Sync>>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    if !crate::cloud_connect::is_configured(token_supplied) {
+    if !cloud_connect_configured {
         return None;
     }
     let ring = crate::log_capture::install(crate::log_capture::DEFAULT_CAPACITY);
@@ -241,7 +241,7 @@ pub(crate) async fn init_tracing(
     config: Option<&TracingConfig>,
     df: Arc<DataFusion>,
     verbosity: LogVerbosity,
-    token_supplied: bool,
+    cloud_connect_configured: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let include_otel_location = should_include_otel_location(!cfg!(debug_assertions), &verbosity);
     let filter: EnvFilter = verbosity.into();
@@ -267,7 +267,7 @@ pub(crate) async fn init_tracing(
         .with(task_history_layer)
         .with(progress_layer())
         .with(console_layer(ansi, std::io::stdout))
-        .with(cloud_connect_log_capture_layer(token_supplied));
+        .with(cloud_connect_log_capture_layer(cloud_connect_configured));
 
     tracing::subscriber::set_global_default(subscriber)?;
     // Routes `log` records — which most of the dependency graph, DataFusion

--- a/crates/spice-cloud-client/Cargo.toml
+++ b/crates/spice-cloud-client/Cargo.toml
@@ -9,7 +9,8 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-reqwest.workspace = true
+futures.workspace = true
+reqwest = { workspace = true, features = ["stream"] }
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true

--- a/crates/spice-cloud-client/src/client.rs
+++ b/crates/spice-cloud-client/src/client.rs
@@ -18,6 +18,7 @@ limitations under the License.
 
 use std::time::Duration;
 
+use futures::StreamExt as _;
 use reqwest::{Client, RequestBuilder};
 use snafu::ResultExt;
 
@@ -26,14 +27,15 @@ use crate::redirect::same_origin_redirect_policy;
 use crate::types::{
     ApiKeysResponse, AuthContext, AuthContextRaw, AuthExchangeRequest, AuthExchangeResponse,
     ContainerImagesResponse, CreateDeploymentRequest, CreateProjectRequest, Deployment,
-    DeploymentsResponse, LogsResponse, MetricsResponse, MintAdoptionCodeRequest,
-    MintAdoptionCodeResponse, OAuthTokenRequest, OAuthTokenResponse, Org, OrgsResponse, Project,
-    ProjectsResponse, RegenerateApiKeyRequest, RegenerateApiKeyResponse, RegionsResponse, Secret,
-    SecretsResponse, SetSecretRequest, UpdateProjectRequest,
+    DeploymentsResponse, LogsResponse, MetricsResponse, OAuthTokenRequest, OAuthTokenResponse, Org,
+    OrgsResponse, Project, ProjectsResponse, RegenerateApiKeyRequest, RegenerateApiKeyResponse,
+    RegionsResponse, Secret, SecretsResponse, SetSecretRequest, UpdateProjectRequest,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.spice.ai";
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_RESPONSE_BYTES: usize = 64 * 1024;
+const MAX_SUCCESS_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 
 /// Header carrying the organization a management request should act on. Tokens
 /// minted for a single org ignore it; the server is the authority on membership.
@@ -44,7 +46,7 @@ const ORG_HEADER: &str = "X-Org-Name";
 /// Both constructors go through here so the settings cannot drift apart — in particular the
 /// same-origin redirect policy, which is what keeps a bearer token, and the auth code that
 /// `exchange_code` puts in a request body, from following a `Location` off origin.
-fn build_http_client(timeout: Duration) -> Result<Client> {
+fn build_http_client(_base_url: &str, timeout: Duration) -> Result<Client> {
     Client::builder()
         .connect_timeout(Duration::from_secs(10))
         .timeout(timeout)
@@ -73,7 +75,24 @@ impl CloudClient {
     /// Use [`Self::with_token`] to set an authentication token, and
     /// [`Self::with_timeout`] to override the default 30-second timeout.
     pub fn new(base_url: &str) -> Result<Self> {
-        let client = build_http_client(DEFAULT_TIMEOUT)?;
+        let client = build_http_client(base_url, DEFAULT_TIMEOUT)?;
+
+        Ok(Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client,
+            token: None,
+            org: None,
+        })
+    }
+
+    #[cfg(test)]
+    fn new_allowing_http_for_test(base_url: &str) -> Result<Self> {
+        let client = Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(DEFAULT_TIMEOUT)
+            .redirect(same_origin_redirect_policy())
+            .build()
+            .context(HttpRequestSnafu)?;
 
         Ok(Self {
             base_url: base_url.trim_end_matches('/').to_string(),
@@ -111,7 +130,7 @@ impl CloudClient {
     ///
     /// Returns an error if the HTTP client cannot be rebuilt with the given timeout.
     pub fn with_timeout(mut self, timeout: Duration) -> Result<Self> {
-        self.client = build_http_client(timeout)?;
+        self.client = build_http_client(&self.base_url, timeout)?;
         Ok(self)
     }
 
@@ -154,14 +173,17 @@ impl CloudClient {
         }
 
         if !status.is_success() {
-            self.handle_empty_response(response).await?;
+            self.handle_empty_response_with_sensitive(response, &[auth_code])
+                .await?;
             return Err(error::Error::Api {
                 status: status.as_u16(),
                 message: "Unexpected non-success status while exchanging auth code".to_string(),
             });
         }
 
-        let body: AuthExchangeResponse = response.json().await.context(HttpRequestSnafu)?;
+        let body: AuthExchangeResponse = self
+            .handle_response_with_sensitive(response, &[auth_code])
+            .await?;
         auth_exchange_result(body)
     }
 
@@ -209,7 +231,8 @@ impl CloudClient {
             .await
             .context(HttpRequestSnafu)?;
 
-        self.handle_response(response).await
+        self.handle_response_with_sensitive(response, &[client_secret])
+            .await
     }
 
     /// Get the authentication context for the current token — the identity and
@@ -503,7 +526,8 @@ impl CloudClient {
             .await
             .context(HttpRequestSnafu)?;
 
-        self.handle_response(response).await
+        self.handle_response_with_sensitive(response, &[value])
+            .await
     }
 
     /// Delete a secret.
@@ -554,37 +578,6 @@ impl CloudClient {
     }
 
     // ========================================================================
-    // Standalone instance adoption codes
-    // ========================================================================
-
-    /// Mint a single-use standalone-instance adoption code.
-    ///
-    /// This is the codeless-connect path: a host already authenticated with
-    /// `spice login` can mint its own code and redeem it in the same command
-    /// rather than sending the customer to the portal.
-    ///
-    /// The code is minted in the client's org context, so a credential that
-    /// spans several orgs adopts the instance into the requested one rather
-    /// than the token's default.
-    ///
-    /// Requires org admin/owner. The plaintext code is returned once and must
-    /// never be printed or persisted — the caller consumes it immediately.
-    pub async fn mint_instance_adoption_code(
-        &self,
-        request: &MintAdoptionCodeRequest,
-    ) -> Result<MintAdoptionCodeResponse> {
-        let url = format!("{}/v1/instance-adoption-codes", self.base_url);
-        let response = self
-            .authed(self.client.post(&url))
-            .json(request)
-            .send()
-            .await
-            .context(HttpRequestSnafu)?;
-
-        self.handle_response(response).await
-    }
-
-    // ========================================================================
     // Metrics
     // ========================================================================
 
@@ -612,12 +605,22 @@ impl CloudClient {
         &self,
         response: reqwest::Response,
     ) -> Result<T> {
+        self.handle_response_with_sensitive(response, &[]).await
+    }
+
+    async fn handle_response_with_sensitive<T: serde::de::DeserializeOwned>(
+        &self,
+        response: reqwest::Response,
+        sensitive: &[&str],
+    ) -> Result<T> {
         let status = response.status();
-        let body = response.text().await.context(HttpRequestSnafu)?;
+        if matches!(status.as_u16(), 200..=202) {
+            let body = bounded_response_body(response, MAX_SUCCESS_RESPONSE_BYTES).await?;
+            return serde_json::from_slice(&body)
+                .map_err(|source| error::Error::JsonParse { source });
+        }
+        let body = self.sanitized_error_body(response, sensitive).await?;
         match status.as_u16() {
-            200..=202 => {
-                serde_json::from_str(&body).map_err(|source| error::Error::JsonParse { source })
-            }
             401 => error::UnauthorizedSnafu {
                 message: body_or("invalid or expired token", &body),
             }
@@ -643,11 +646,23 @@ impl CloudClient {
     }
 
     async fn handle_empty_response(&self, response: reqwest::Response) -> Result<()> {
+        self.handle_empty_response_with_sensitive(response, &[])
+            .await
+    }
+
+    async fn handle_empty_response_with_sensitive(
+        &self,
+        response: reqwest::Response,
+        sensitive: &[&str],
+    ) -> Result<()> {
         let status = response.status();
-        let body = response.text().await.context(HttpRequestSnafu)?;
+        if matches!(status.as_u16(), 200..=204) {
+            let _ = bounded_response_body(response, MAX_SUCCESS_RESPONSE_BYTES).await?;
+            return Ok(());
+        }
+        let body = self.sanitized_error_body(response, sensitive).await?;
 
         match status.as_u16() {
-            200..=204 => Ok(()),
             401 => error::UnauthorizedSnafu {
                 message: body_or("invalid or expired token", &body),
             }
@@ -676,6 +691,27 @@ impl CloudClient {
         self.token.as_deref().unwrap_or("")
     }
 
+    async fn sanitized_error_body(
+        &self,
+        response: reqwest::Response,
+        sensitive: &[&str],
+    ) -> Result<String> {
+        let bytes = match bounded_response_body(response, MAX_RESPONSE_BYTES).await {
+            Ok(bytes) => bytes,
+            // The status is already authoritative. An oversized diagnostic is
+            // equivalent to no diagnostic, not a reason to erase a known
+            // Unauthorized/Forbidden/NotFound/Conflict classification.
+            Err(error::Error::ResponseTooLarge { .. }) => return Ok(String::new()),
+            Err(error) => return Err(error),
+        };
+        let raw = String::from_utf8_lossy(&bytes);
+        let mut redacted = redact_response_body(&raw, self.token.as_deref());
+        for value in sensitive {
+            redacted = redact_response_body(&redacted, Some(value));
+        }
+        Ok(redacted)
+    }
+
     /// Apply the bearer token and, when set, the org context header.
     ///
     /// An org name that cannot be encoded as a header value surfaces as a
@@ -687,6 +723,59 @@ impl CloudClient {
             Some(org) => request.header(ORG_HEADER, org),
             None => request,
         }
+    }
+}
+
+async fn bounded_response_body(response: reqwest::Response, limit: usize) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context(HttpRequestSnafu)?;
+        if bytes.len().saturating_add(chunk.len()) > limit {
+            return error::ResponseTooLargeSnafu { limit }.fail();
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+fn redact_response_body(body: &str, sensitive: Option<&str>) -> String {
+    let Some(sensitive) = sensitive.filter(|value| !value.is_empty()) else {
+        return body.to_string();
+    };
+    let redacted = body.replace(sensitive, "[REDACTED]");
+    let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&redacted) else {
+        // A malformed document can still carry the credential through JSON
+        // escapes that raw replacement cannot recognize. Without a complete
+        // parse there is no sound decoding boundary, so discard the peer's
+        // diagnostic rather than risk returning recoverable authority bytes.
+        return String::new();
+    };
+    redact_json_strings(&mut json, sensitive);
+    serde_json::to_string(&json).unwrap_or(redacted)
+}
+
+fn redact_json_strings(value: &mut serde_json::Value, sensitive: &str) {
+    match value {
+        serde_json::Value::String(value) => *value = value.replace(sensitive, "[REDACTED]"),
+        serde_json::Value::Array(values) => {
+            for value in values {
+                redact_json_strings(value, sensitive);
+            }
+        }
+        serde_json::Value::Object(values) => {
+            // Keys carry the credential just as easily as values, and parsing
+            // decodes an escaped key back to its literal bytes — so a key the
+            // raw replacement above could not match is reconstructed here and
+            // would be re-emitted by the serialization that follows.
+            let mut redacted = serde_json::Map::with_capacity(values.len());
+            for (key, mut value) in std::mem::take(values) {
+                redact_json_strings(&mut value, sensitive);
+                redacted.insert(key.replace(sensitive, "[REDACTED]"), value);
+            }
+            *values = redacted;
+        }
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
     }
 }
 
@@ -744,10 +833,88 @@ fn oauth_host(host: &str) -> Option<String> {
 mod tests {
     use super::{
         CloudClient, DEFAULT_TIMEOUT, auth_exchange_result, auth_exchange_status_is_pending,
-        same_origin_redirect_policy,
+        redact_response_body, same_origin_redirect_policy,
     };
     use crate::types::{AuthContext, AuthContextApp, AuthContextOrg, AuthContextRaw};
     use crate::{error, types::AuthExchangeResponse};
+
+    #[tokio::test]
+    async fn an_oversized_error_body_preserves_the_authoritative_status() {
+        let body = "x".repeat(super::MAX_RESPONSE_BYTES + 1);
+        let stub = crate::test_support::Stub::serve(move |_| {
+            format!(
+                "HTTP/1.1 401 Unauthorized\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+        });
+        let client = CloudClient::new_allowing_http_for_test(&stub.url(""))
+            .expect("construct a loopback client")
+            .with_token("secret-token");
+        let response = client
+            .client
+            .get(stub.url("/oversized"))
+            .send()
+            .await
+            .expect("the stub answers");
+
+        let error = client
+            .handle_empty_response(response)
+            .await
+            .expect_err("HTTP 401 is not success");
+        assert!(
+            matches!(error, error::Error::Unauthorized { .. }),
+            "the known status must win over its oversized diagnostic: {error}"
+        );
+    }
+
+    #[test]
+    fn management_error_bodies_redact_raw_and_json_escaped_bearers() {
+        let token = "secret-token";
+        let raw = redact_response_body("proxy echoed secret-token", Some(token));
+        assert!(!raw.contains(token));
+        let escaped =
+            redact_response_body(r#"{"error":"secret\u002dtoken was rejected"}"#, Some(token));
+        assert!(!escaped.contains(token));
+        assert!(escaped.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn malformed_management_errors_with_authority_are_discarded() {
+        let token = "secret-token";
+        for malformed in [
+            r#"{"error":"secret\u002dtoken was rejected""#,
+            "proxy echoed secret-token but never returned JSON",
+        ] {
+            assert_eq!(
+                redact_response_body(malformed, Some(token)),
+                "",
+                "a malformed peer diagnostic cannot be proven free of escaped authority"
+            );
+        }
+    }
+
+    /// An escaped credential in an object *key* survives the raw replacement,
+    /// and parsing decodes it back to the literal token, so serializing the
+    /// tree again would publish it.
+    #[test]
+    fn management_error_bodies_redact_bearers_hidden_in_object_keys() {
+        let token = "secret-token";
+        for body in [
+            // Escaped in the key, so the raw replacement cannot match it.
+            r#"{"secret\u002dtoken":"rejected"}"#,
+            r#"{"outer":{"secret\u002dtoken":["rejected"]}}"#,
+            // Literal in the key, for the path the raw replacement does cover.
+            r#"{"secret-token":"rejected"}"#,
+        ] {
+            let redacted = redact_response_body(body, Some(token));
+            assert!(
+                !redacted.contains(token),
+                "object key leaked the bearer: {redacted}"
+            );
+            assert!(redacted.contains("[REDACTED]"), "{redacted}");
+        }
+    }
 
     /// Both constructors must install the same-origin redirect policy, or a bearer token —
     /// and the auth code `exchange_code` puts in a request body — could follow a `Location`

--- a/crates/spice-cloud-client/src/error.rs
+++ b/crates/spice-cloud-client/src/error.rs
@@ -29,6 +29,12 @@ pub enum Error {
     #[snafu(display("HTTP request failed: {source}"))]
     HttpRequest { source: reqwest::Error },
 
+    /// The server returned a body larger than the client accepts. The limit
+    /// differs per call site, so it travels with the error rather than being
+    /// named in the message.
+    #[snafu(display("Response body exceeded the {limit} byte limit"))]
+    ResponseTooLarge { limit: usize },
+
     /// The server returned 401 Unauthorized.
     #[snafu(display("Unauthorized: {message}"))]
     Unauthorized { message: String },

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -453,46 +453,6 @@ pub struct RegenerateApiKeyRequest {
 }
 
 // ============================================================================
-// Standalone instance adoption codes
-// ============================================================================
-
-/// Request body for `POST /v1/instance-adoption-codes`, the management-API
-/// mint a logged-in `spice connect` uses instead of making the customer copy a
-/// code out of the portal.
-#[derive(Debug, Default, Serialize)]
-pub struct MintAdoptionCodeRequest {
-    /// Display label for the adoption-codes screen — who minted this and why.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub label: Option<String>,
-    /// Lifetime in seconds. Omitted to take the endpoint's short default,
-    /// which is what a mint-and-redeem-immediately caller wants: a code that
-    /// outlives its own enroll is a live org credential nobody is holding.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ttl_seconds: Option<u32>,
-    /// The org the caller believes it is minting into. An **assertion, not a
-    /// selection** — the org always comes from the token, and a mismatch is a
-    /// not-found. Without it, a token bound to org A plus `--org B` would mint
-    /// quietly into A.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub org: Option<String>,
-}
-
-/// Response from `POST /v1/instance-adoption-codes`. The plaintext code is
-/// returned exactly once, at mint.
-#[derive(Debug, Deserialize)]
-pub struct MintAdoptionCodeResponse {
-    /// The plaintext adoption code. Never logged, never written to disk.
-    pub code: String,
-    /// The org the code is scoped to, as the cloud resolved it from the token.
-    #[serde(default)]
-    pub org: Option<String>,
-    /// RFC 3339 expiry, for an error message that can say how long the code
-    /// was good for.
-    #[serde(default)]
-    pub expires_at: Option<String>,
-}
-
-// ============================================================================
 // Metrics
 // ============================================================================
 


### PR DESCRIPTION
Splits the interactive `spice connect` workflow from #13174.

This layer adds login/enrollment prompts, organization and project selection, transactional instance/project attachment, resumable enrollment state, and foreground runtime launch with a one-time connection report.

The intended CLI experience is interactive. Unattended enrollment remains limited to `spiced --token`; automation flags on `spice connect` are being removed in this stack.

Non-goals: persistent service lifecycle, macOS lifecycle support, Helm, and Docker Compose.

Stack: #13181 → #13182 → **3 of 4** → #13184.