### PR TITLE
Fix runtime lint with zero features

### DIFF
--- a/crates/runtime/src/dataaccelerator/spice_sys.rs
+++ b/crates/runtime/src/dataaccelerator/spice_sys.rs
@@ -450,6 +450,10 @@ pub async fn checkpoint_store(
     feature = "postgres-accel",
     feature = "turso"
 )))]
+#[expect(
+    clippy::unused_async,
+    reason = "async for signature parity with the accelerator-backed variant"
+)]
 pub async fn checkpoint_store(
     dataset: &crate::component::dataset::Dataset,
     table_name: &'static str,

--- a/crates/runtime/src/dataconnector/schema_projection.rs
+++ b/crates/runtime/src/dataconnector/schema_projection.rs
@@ -22,6 +22,7 @@ limitations under the License.
 //! The tests stay on this side because building a `DatasetSpec` by hand is a
 //! 20-plus-field literal, while `DatasetBuilder` is right here.
 
+#[cfg(any(feature = "debezium", test))]
 pub use data_connector_api::schema_projection::{ProjectionPolicy, parse_schema_projection};
 
 #[cfg(test)]

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -138,6 +138,7 @@ pub use runtime_datafusion::composed_catalog;
 // through these aliases, but they belong to `runtime-datafusion`. Crate-visible
 // so a crate outside the runtime has to depend on `runtime-datafusion` directly
 // rather than route through here.
+#[cfg(any(feature = "duckdb", test))]
 pub(crate) use runtime_datafusion::dialect;
 pub(crate) use runtime_datafusion::error;
 pub use runtime_table::filter_converter;


### PR DESCRIPTION
## Summary

Had issues running `make signoff` locally for https://github.com/spiceai/spiceai/pull/13136 - an edge case when the change was only in `data-connectors/connector-adbc`, which resulted in `runtime` being built with no features.

- Makes `runtime` lint clean when built with zero features (its documented baseline, since it has no `default`).
- Gates two re-exports whose only real consumer is feature-gated, and marks an intentionally-async stub function's lint expectation.