### PR TITLE
fix(search): join all of a dataset's vector indexes on one VectorScanTableProvider

### DIFF
--- a/crates/runtime-table/src/accelerated/refresh_task.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task.rs
@@ -3079,10 +3079,8 @@ mod tests {
         let vector_scan: Arc<dyn TableProvider> =
             Arc::new(search::index::VectorScanTableProvider {
                 table_provider: indexed_mem_table(),
-                indexes: vec![search::index::VectorIndexJoin {
-                    vector_index_list: Arc::new(plan),
-                    primary_key: vec![],
-                }],
+                primary_key: vec![],
+                index_list_plans: vec![Arc::new(plan)],
             })
             .into_table();
 

--- a/crates/runtime-table/src/accelerated/refresh_task.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task.rs
@@ -3079,8 +3079,10 @@ mod tests {
         let vector_scan: Arc<dyn TableProvider> =
             Arc::new(search::index::VectorScanTableProvider {
                 table_provider: indexed_mem_table(),
-                vector_index_list: Arc::new(plan),
-                primary_key: vec![],
+                indexes: vec![search::index::VectorIndexJoin {
+                    vector_index_list: Arc::new(plan),
+                    primary_key: vec![],
+                }],
             })
             .into_table();
 

--- a/crates/runtime-table/src/table_metadata.rs
+++ b/crates/runtime-table/src/table_metadata.rs
@@ -175,13 +175,15 @@ mod tests {
 
         Arc::new(search::index::vector_table::VectorScanTableProvider {
             table_provider: base_table,
-            vector_index_list: Arc::new(datafusion::logical_expr::LogicalPlan::EmptyRelation(
-                datafusion::logical_expr::EmptyRelation {
-                    produce_one_row: false,
-                    schema: Arc::new(datafusion::common::DFSchema::empty()),
-                },
-            )),
-            primary_key: vec!["id".to_string()],
+            indexes: vec![search::index::vector_table::VectorIndexJoin {
+                vector_index_list: Arc::new(datafusion::logical_expr::LogicalPlan::EmptyRelation(
+                    datafusion::logical_expr::EmptyRelation {
+                        produce_one_row: false,
+                        schema: Arc::new(datafusion::common::DFSchema::empty()),
+                    },
+                )),
+                primary_key: vec!["id".to_string()],
+            }],
         })
         .into_table() as Arc<dyn TableProvider>
     }

--- a/crates/runtime-table/src/table_metadata.rs
+++ b/crates/runtime-table/src/table_metadata.rs
@@ -176,12 +176,14 @@ mod tests {
         Arc::new(search::index::vector_table::VectorScanTableProvider {
             table_provider: base_table,
             primary_key: vec!["id".to_string()],
-            index_list_plans: vec![Arc::new(datafusion::logical_expr::LogicalPlan::EmptyRelation(
-                datafusion::logical_expr::EmptyRelation {
-                    produce_one_row: false,
-                    schema: Arc::new(datafusion::common::DFSchema::empty()),
-                },
-            ))],
+            index_list_plans: vec![Arc::new(
+                datafusion::logical_expr::LogicalPlan::EmptyRelation(
+                    datafusion::logical_expr::EmptyRelation {
+                        produce_one_row: false,
+                        schema: Arc::new(datafusion::common::DFSchema::empty()),
+                    },
+                ),
+            )],
         })
         .into_table() as Arc<dyn TableProvider>
     }

--- a/crates/runtime-table/src/table_metadata.rs
+++ b/crates/runtime-table/src/table_metadata.rs
@@ -175,15 +175,13 @@ mod tests {
 
         Arc::new(search::index::vector_table::VectorScanTableProvider {
             table_provider: base_table,
-            indexes: vec![search::index::vector_table::VectorIndexJoin {
-                vector_index_list: Arc::new(datafusion::logical_expr::LogicalPlan::EmptyRelation(
-                    datafusion::logical_expr::EmptyRelation {
-                        produce_one_row: false,
-                        schema: Arc::new(datafusion::common::DFSchema::empty()),
-                    },
-                )),
-                primary_key: vec!["id".to_string()],
-            }],
+            primary_key: vec!["id".to_string()],
+            index_list_plans: vec![Arc::new(datafusion::logical_expr::LogicalPlan::EmptyRelation(
+                datafusion::logical_expr::EmptyRelation {
+                    produce_one_row: false,
+                    schema: Arc::new(datafusion::common::DFSchema::empty()),
+                },
+            ))],
         })
         .into_table() as Arc<dyn TableProvider>
     }

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -825,11 +825,13 @@ mod tests {
     fn vector_scan_over_memtable() -> Arc<dyn FederatedTableProvider> {
         let vector_scan = VectorScanTableProvider {
             table_provider: memtable(),
-            vector_index_list: Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {
-                produce_one_row: false,
-                schema: Arc::new(datafusion::common::DFSchema::empty()),
-            })),
-            primary_key: vec!["id".to_string()],
+            indexes: vec![search::index::VectorIndexJoin {
+                vector_index_list: Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {
+                    produce_one_row: false,
+                    schema: Arc::new(datafusion::common::DFSchema::empty()),
+                })),
+                primary_key: vec!["id".to_string()],
+            }],
         };
         Arc::new(FederatedTable::Immediate(
             Arc::new(vector_scan).into_table() as Arc<dyn TableProvider>,

--- a/crates/runtime/src/embeddings/connector.rs
+++ b/crates/runtime/src/embeddings/connector.rs
@@ -825,13 +825,11 @@ mod tests {
     fn vector_scan_over_memtable() -> Arc<dyn FederatedTableProvider> {
         let vector_scan = VectorScanTableProvider {
             table_provider: memtable(),
-            indexes: vec![search::index::VectorIndexJoin {
-                vector_index_list: Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {
-                    produce_one_row: false,
-                    schema: Arc::new(datafusion::common::DFSchema::empty()),
-                })),
-                primary_key: vec!["id".to_string()],
-            }],
+            primary_key: vec!["id".to_string()],
+            index_list_plans: vec![Arc::new(LogicalPlan::EmptyRelation(EmptyRelation {
+                produce_one_row: false,
+                schema: Arc::new(datafusion::common::DFSchema::empty()),
+            }))],
         };
         Arc::new(FederatedTable::Immediate(
             Arc::new(vector_scan).into_table() as Arc<dyn TableProvider>,

--- a/crates/runtime/src/embeddings/index/table.rs
+++ b/crates/runtime/src/embeddings/index/table.rs
@@ -224,7 +224,7 @@ async fn wrap_table_as_index_s3(
         .collect();
     // Reuse an index layer already at the top of the stack so several indexes
     // compose onto one layer rather than stacking a layer apiece.
-    let (mut provider, mut layer_below) =
+    let (mut provider, base_below) =
         match inner_table_provider.downcast_ref::<spice_table::SpiceTable>() {
             Some(table) if !table.indexes().is_empty() => (
                 IndexLayer::with_indexes(table.indexes().to_vec()),
@@ -232,6 +232,11 @@ async fn wrap_table_as_index_s3(
             ),
             _ => (IndexLayer::new(), Arc::clone(&inner_table_provider)),
         };
+    // Every column's vector index is collected here and joined onto a single
+    // `VectorScanTableProvider` after the loop, rather than each column wrapping the
+    // previous column's layer in its own nested provider — see
+    // <https://github.com/spiceai/spiceai/issues/7020>.
+    let mut vector_indexes: Vec<Arc<dyn VectorIndex>> = Vec::new();
     for (column, config) in embedding_columns {
         let chunking = config.chunking.as_ref().filter(|cfg| cfg.enabled);
         let (columns, index_schema) = if chunking.is_some() {
@@ -282,9 +287,9 @@ async fn wrap_table_as_index_s3(
         );
 
         if let Some(chunking) = chunking {
-            (provider, layer_below) = construct_chunked_vector_index(
+            let chunked_vector_index;
+            (provider, chunked_vector_index) = construct_chunked_vector_index(
                 provider,
-                layer_below,
                 embedding_models,
                 chunking,
                 vector_index as Arc<dyn SearchIndex>,
@@ -292,13 +297,18 @@ async fn wrap_table_as_index_s3(
                 file_format,
             )
             .await?;
+            vector_indexes.extend(chunked_vector_index);
         } else {
-            layer_below =
-                Arc::new(VectorScanTableProvider::try_new(layer_below, &vector_index).boxed()?)
-                    .into_table() as Arc<dyn TableProvider>;
-            provider = provider.add_index(vector_index as Arc<dyn Index>);
+            provider = provider.add_index(Arc::clone(&vector_index) as Arc<dyn Index>);
+            vector_indexes.push(vector_index);
         }
     }
+    let layer_below = if vector_indexes.is_empty() {
+        base_below
+    } else {
+        Arc::new(VectorScanTableProvider::try_new(base_below, &vector_indexes).boxed()?)
+            .into_table() as Arc<dyn TableProvider>
+    };
     tracing::info!(
         "S3 Vectors for table {tbl} initialized in {:?}",
         start.elapsed()
@@ -307,18 +317,19 @@ async fn wrap_table_as_index_s3(
 }
 
 /// Wrap `index` (whose primary key must already be augmented with the chunk key via
-/// [`ChunkedSearchIndex::augment_primary_key`]) in a [`ChunkedSearchIndex`] and attach
-/// it to `provider`.
+/// [`ChunkedSearchIndex::augment_primary_key`]) in a [`ChunkedSearchIndex`], attach
+/// it to `provider`, and return the [`VectorIndex`] side of it (when the chunked index
+/// supports vector search) for the caller to join onto its `VectorScanTableProvider`
+/// alongside every other column's index.
 #[cfg(any(feature = "s3_vectors", feature = "elasticsearch"))]
 async fn construct_chunked_vector_index(
     provider: IndexLayer,
-    mut below: Arc<dyn TableProvider>,
     embedding_models: &Arc<RwLock<EmbeddingModelStore>>,
     chunking: &EmbeddingChunkConfig,
     index: Arc<dyn SearchIndex>,
     model_name: &str,
     file_format: Option<&str>,
-) -> Result<(IndexLayer, Arc<dyn TableProvider>), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<(IndexLayer, Option<Arc<dyn VectorIndex>>), Box<dyn std::error::Error + Send + Sync>> {
     let chunker = construct_chunker(
         model_name,
         &ChunkingConfig {
@@ -333,14 +344,11 @@ async fn construct_chunked_vector_index(
     .boxed()?;
 
     let chunked_idx = Arc::new(ChunkedSearchIndex::new(index, chunker));
+    let vector_index = Arc::clone(&chunked_idx).as_vector_index();
 
-    if let Some(vector_index) = Arc::clone(&chunked_idx).as_vector_index() {
-        below = Arc::new(VectorScanTableProvider::try_new(below, &vector_index).boxed()?)
-            .into_table() as Arc<dyn TableProvider>;
-    }
     Ok((
         provider.add_index(Arc::clone(&chunked_idx) as Arc<dyn Index>),
-        below,
+        vector_index,
     ))
 }
 
@@ -435,7 +443,7 @@ async fn wrap_table_as_index_elasticsearch(
 
     // Reuse an index layer already at the top of the stack so several indexes
     // compose onto one layer rather than stacking a layer apiece.
-    let (mut provider, mut layer_below) =
+    let (mut provider, base_below) =
         match inner_table_provider.downcast_ref::<spice_table::SpiceTable>() {
             Some(table) if !table.indexes().is_empty() => (
                 IndexLayer::with_indexes(table.indexes().to_vec()),
@@ -443,6 +451,11 @@ async fn wrap_table_as_index_elasticsearch(
             ),
             _ => (IndexLayer::new(), Arc::clone(&inner_table_provider)),
         };
+    // Every column's vector index is collected here and joined onto a single
+    // `VectorScanTableProvider` after the loop, rather than each column wrapping the
+    // previous column's layer in its own nested provider — see
+    // <https://github.com/spiceai/spiceai/issues/7020>.
+    let mut vector_indexes: Vec<Arc<dyn VectorIndex>> = Vec::new();
 
     let Some(embed_udf) = ctx.state().scalar_functions().get(EMBED_UDF_NAME).cloned() else {
         return Err(Box::from(format!(
@@ -490,9 +503,8 @@ async fn wrap_table_as_index_elasticsearch(
 
         provider = if let Some(chunking) = chunking {
             tracing::debug!("[Elasticsearch][table={tbl}] Chunking column {column}");
-            let (p, b) = construct_chunked_vector_index(
+            let (p, chunked_vector_index) = construct_chunked_vector_index(
                 provider,
-                layer_below,
                 embedding_models,
                 chunking,
                 vector_index as Arc<dyn SearchIndex>,
@@ -500,15 +512,21 @@ async fn wrap_table_as_index_elasticsearch(
                 file_format,
             )
             .await?;
-            layer_below = b;
+            vector_indexes.extend(chunked_vector_index);
             p
         } else {
-            layer_below =
-                Arc::new(VectorScanTableProvider::try_new(layer_below, &vector_index).boxed()?)
-                    .into_table() as Arc<dyn TableProvider>;
-            provider.add_index(vector_index as Arc<dyn Index>)
+            let provider = provider.add_index(Arc::clone(&vector_index) as Arc<dyn Index>);
+            vector_indexes.push(vector_index);
+            provider
         };
     }
+
+    let layer_below = if vector_indexes.is_empty() {
+        base_below
+    } else {
+        Arc::new(VectorScanTableProvider::try_new(base_below, &vector_indexes).boxed()?)
+            .into_table() as Arc<dyn TableProvider>
+    };
 
     tracing::info!(
         "Elasticsearch vector engine for table {tbl} initialized in {:?}",

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -191,8 +191,10 @@ mod tests {
             .expect("empty logical plan should build");
         let wrapped: Arc<dyn TableProvider> = Arc::new(VectorScanTableProvider {
             table_provider: Arc::clone(&base),
-            vector_index_list: Arc::new(plan),
-            primary_key: vec![],
+            indexes: vec![search::index::VectorIndexJoin {
+                vector_index_list: Arc::new(plan),
+                primary_key: vec![],
+            }],
         })
         .into_table();
 

--- a/crates/runtime/src/search/util.rs
+++ b/crates/runtime/src/search/util.rs
@@ -191,10 +191,8 @@ mod tests {
             .expect("empty logical plan should build");
         let wrapped: Arc<dyn TableProvider> = Arc::new(VectorScanTableProvider {
             table_provider: Arc::clone(&base),
-            indexes: vec![search::index::VectorIndexJoin {
-                vector_index_list: Arc::new(plan),
-                primary_key: vec![],
-            }],
+            primary_key: vec![],
+            index_list_plans: vec![Arc::new(plan)],
         })
         .into_table();
 

--- a/crates/search/src/index/mod.rs
+++ b/crates/search/src/index/mod.rs
@@ -45,7 +45,7 @@ pub(crate) mod write_util;
 #[cfg(feature = "llms")]
 pub use memory::MemoryVectorIndex;
 pub use native_vector::NativeVectorIndex;
-pub use vector_table::{VectorIndexJoin, VectorScanTableProvider};
+pub use vector_table::VectorScanTableProvider;
 
 #[cfg(feature = "text_search")]
 use crate::generation::text_search::index::FullTextDatabaseIndex;

--- a/crates/search/src/index/mod.rs
+++ b/crates/search/src/index/mod.rs
@@ -45,7 +45,7 @@ pub(crate) mod write_util;
 #[cfg(feature = "llms")]
 pub use memory::MemoryVectorIndex;
 pub use native_vector::NativeVectorIndex;
-pub use vector_table::VectorScanTableProvider;
+pub use vector_table::{VectorIndexJoin, VectorScanTableProvider};
 
 #[cfg(feature = "text_search")]
 use crate::generation::text_search::index::FullTextDatabaseIndex;

--- a/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_both.snap
+++ b/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_both.snap
@@ -1,0 +1,23 @@
+---
+source: crates/search/src/index/vector_table.rs
+expression: "format!(\"{}\", pretty::pretty_format_batches(&col).map_err(|e| e.to_string())?)"
+---
++---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                                                 |
++---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Sort: my_vectored_table.pk DESC NULLS FIRST, fetch=5                                                                                                                 |
+|               |   Projection: my_vectored_table.pk, my_vectored_table.body_embedding, my_vectored_table.summary_embedding                                                            |
+|               |     TableScan: my_vectored_table projection=[body_embedding, pk, summary_embedding]                                                                                  |
+| physical_plan | SortPreservingMergeExec: [pk@0 DESC], fetch=5                                                                                                                        |
+|               |   SortExec: TopK(fetch=5), expr=[pk@0 DESC], preserve_partitioning=[true]                                                                                            |
+|               |     ProjectionExec: expr=[pk@1 as pk, body_embedding@0 as body_embedding, summary_embedding@2 as summary_embedding]                                                  |
+|               |       HashJoinExec: mode=Partitioned, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(pk@0, pk@0)], projection=[body_embedding@1, pk@0, summary_embedding@3] |
+|               |         HashJoinExec: mode=Partitioned, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(pk@0, pk@0)], projection=[pk@0, body_embedding@2]                    |
+|               |           RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                                          |
+|               |             BaseTable: projection=["pk"] filter=[] limit=None                                                                                                        |
+|               |           RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                                          |
+|               |             PretendVectorIndex: projection=["pk", "body_embedding"] filter=[] limit=None                                                                             |
+|               |         RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                                            |
+|               |           PretendVectorIndex: projection=["pk", "summary_embedding"] filter=[] limit=None                                                                            |
+|               |                                                                                                                                                                      |
++---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_filter_crosses_boundary.snap
+++ b/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_filter_crosses_boundary.snap
@@ -1,0 +1,23 @@
+---
+source: crates/search/src/index/vector_table.rs
+expression: "format!(\"{}\", pretty::pretty_format_batches(&col).map_err(|e| e.to_string())?)"
+---
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                                                                                         |
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Sort: my_vectored_table.pk DESC NULLS FIRST, fetch=5                                                                                                                                                         |
+|               |   Projection: my_vectored_table.pk, my_vectored_table.body_embedding                                                                                                                                         |
+|               |     TableScan: my_vectored_table projection=[body_embedding, pk], full_filters=[my_vectored_table.a_number > Int64(0)]                                                                                       |
+| physical_plan | SortPreservingMergeExec: [pk@0 DESC], fetch=5                                                                                                                                                                |
+|               |   SortExec: TopK(fetch=5), expr=[pk@0 DESC], preserve_partitioning=[true]                                                                                                                                    |
+|               |     FilterExec: a_number@2 > 0, projection=[pk@0, body_embedding@1]                                                                                                                                          |
+|               |       HashJoinExec: mode=Partitioned, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(pk@0, pk@0)], projection=[pk@0, body_embedding@1, a_number@3]                                                  |
+|               |         HashJoinExec: mode=Partitioned, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(pk@0, pk@0)], projection=[pk@0, body_embedding@2]                                                            |
+|               |           RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                                                                                  |
+|               |             BaseTable: projection=["pk"] filter=[] limit=None                                                                                                                                                |
+|               |           RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                                                                                  |
+|               |             PretendVectorIndex: projection=["pk", "body_embedding"] filter=[] limit=None                                                                                                                     |
+|               |         RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                                                                                    |
+|               |           PretendVectorIndex: projection=["pk", "a_number"] filter=[BinaryExpr(BinaryExpr { left: Column(Column { relation: None, name: "a_number" }), op: Gt, right: Literal(Int64(0), None) })] limit=None |
+|               |                                                                                                                                                                                                              |
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_no_join.snap
+++ b/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_no_join.snap
@@ -1,0 +1,14 @@
+---
+source: crates/search/src/index/vector_table.rs
+expression: "format!(\"{}\", pretty::pretty_format_batches(&col).map_err(|e| e.to_string())?)"
+---
++---------------+--------------------------------------------------------------------------+
+| plan_type     | plan                                                                     |
++---------------+--------------------------------------------------------------------------+
+| logical_plan  | Sort: my_vectored_table.pk DESC NULLS FIRST, fetch=5                     |
+|               |   Projection: my_vectored_table.pk, my_vectored_table.another_column     |
+|               |     TableScan: my_vectored_table projection=[another_column, pk]         |
+| physical_plan | SortExec: TopK(fetch=5), expr=[pk@0 DESC], preserve_partitioning=[false] |
+|               |   BaseTable: projection=["pk", "another_column"] filter=[] limit=None    |
+|               |                                                                          |
++---------------+--------------------------------------------------------------------------+

--- a/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_only_body.snap
+++ b/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_only_body.snap
@@ -1,0 +1,20 @@
+---
+source: crates/search/src/index/vector_table.rs
+expression: "format!(\"{}\", pretty::pretty_format_batches(&col).map_err(|e| e.to_string())?)"
+---
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                            |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Sort: my_vectored_table.pk DESC NULLS FIRST, fetch=5                                                                                            |
+|               |   Projection: my_vectored_table.pk, my_vectored_table.body_embedding                                                                            |
+|               |     TableScan: my_vectored_table projection=[body_embedding, pk]                                                                                |
+| physical_plan | SortPreservingMergeExec: [pk@0 DESC], fetch=5                                                                                                   |
+|               |   SortExec: TopK(fetch=5), expr=[pk@0 DESC], preserve_partitioning=[true]                                                                       |
+|               |     ProjectionExec: expr=[pk@1 as pk, body_embedding@0 as body_embedding]                                                                       |
+|               |       HashJoinExec: mode=Partitioned, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(pk@0, pk@0)], projection=[body_embedding@2, pk@0] |
+|               |         RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                       |
+|               |           BaseTable: projection=["pk"] filter=[] limit=None                                                                                     |
+|               |         RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                       |
+|               |           PretendVectorIndex: projection=["pk", "body_embedding"] filter=[] limit=None                                                          |
+|               |                                                                                                                                                 |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_only_summary.snap
+++ b/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_only_summary.snap
@@ -1,0 +1,18 @@
+---
+source: crates/search/src/index/vector_table.rs
+expression: "format!(\"{}\", pretty::pretty_format_batches(&col).map_err(|e| e.to_string())?)"
+---
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                             |
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Sort: my_vectored_table.pk DESC NULLS FIRST, fetch=5                                                                                             |
+|               |   TableScan: my_vectored_table projection=[pk, summary_embedding]                                                                                |
+| physical_plan | SortPreservingMergeExec: [pk@0 DESC], fetch=5                                                                                                    |
+|               |   SortExec: TopK(fetch=5), expr=[pk@0 DESC], preserve_partitioning=[true]                                                                        |
+|               |     HashJoinExec: mode=Partitioned, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(pk@0, pk@0)], projection=[pk@0, summary_embedding@2] |
+|               |       RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                          |
+|               |         BaseTable: projection=["pk"] filter=[] limit=None                                                                                        |
+|               |       RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                          |
+|               |         PretendVectorIndex: projection=["pk", "summary_embedding"] filter=[] limit=None                                                          |
+|               |                                                                                                                                                  |
++---------------+--------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_shared_non_key_column.snap
+++ b/crates/search/src/index/snapshots/search__index__vector_table__tests__scan_table_multi_index_shared_non_key_column.snap
@@ -1,0 +1,23 @@
+---
+source: crates/search/src/index/vector_table.rs
+expression: "format!(\"{}\", pretty::pretty_format_batches(&col).map_err(|e| e.to_string())?)"
+---
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                                                                |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Sort: my_vectored_table.pk DESC NULLS FIRST, fetch=5                                                                                                                                |
+|               |   Projection: my_vectored_table.pk, my_vectored_table.body_embedding, my_vectored_table.summary_embedding, my_vectored_table.shared_meta                                            |
+|               |     TableScan: my_vectored_table projection=[body_embedding, pk, shared_meta, summary_embedding]                                                                                    |
+| physical_plan | SortPreservingMergeExec: [pk@0 DESC], fetch=5                                                                                                                                       |
+|               |   SortExec: TopK(fetch=5), expr=[pk@0 DESC], preserve_partitioning=[true]                                                                                                           |
+|               |     ProjectionExec: expr=[pk@1 as pk, body_embedding@0 as body_embedding, summary_embedding@3 as summary_embedding, shared_meta@2 as shared_meta]                                   |
+|               |       HashJoinExec: mode=Partitioned, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(pk@0, pk@0)], projection=[body_embedding@1, pk@0, shared_meta@2, summary_embedding@4] |
+|               |         HashJoinExec: mode=Partitioned, join_type=Left, accumulator=MinMaxLeftAccumulator, on=[(pk@0, pk@0)], projection=[pk@0, body_embedding@2, shared_meta@3]                    |
+|               |           RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                                                         |
+|               |             BaseTable: projection=["pk"] filter=[] limit=None                                                                                                                       |
+|               |           RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                                                         |
+|               |             PretendVectorIndex: projection=["pk", "body_embedding", "shared_meta"] filter=[] limit=None                                                                             |
+|               |         RepartitionExec: partitioning=Hash([pk@0], 3), input_partitions=1                                                                                                           |
+|               |           PretendVectorIndex: projection=["pk", "summary_embedding"] filter=[] limit=None                                                                                           |
+|               |                                                                                                                                                                                     |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -43,24 +43,20 @@ use util::session_state::builder_from_existing;
 use crate::index::VectorIndex;
 use datafusion::catalog::{ScanArgs, ScanResult};
 
-/// One vector index's listing plan and join key, as composed onto a
-/// [`VectorScanTableProvider`]. A dataset with several embedding columns holds
-/// one of these per column, all on the same [`VectorScanTableProvider`], rather
-/// than nesting a separate layer per index.
-#[derive(Debug, Clone)]
-pub struct VectorIndexJoin {
-    pub vector_index_list: Arc<LogicalPlan>,
-    pub primary_key: Vec<String>,
-}
-
 /// A [`TableProvider`] that adds one or more embedding columns to an underlying
-/// [`TableProvider`] — one [`VectorIndexJoin`] per vector index, joined into the
-/// same scan rather than each index wrapping its own nested
-/// [`VectorScanTableProvider`] layer.
+/// [`TableProvider`] — one listing plan per vector index, joined into the same
+/// scan rather than each index wrapping its own nested [`VectorScanTableProvider`]
+/// layer.
+///
+/// Every index on one [`VectorScanTableProvider`] is assumed to share the same
+/// primary key: [`Self::try_new`] takes it from the first index and rejects
+/// construction if another index disagrees, so this never silently joins on the
+/// wrong key for an index whose own key happened to differ.
 #[derive(Debug, Clone)]
 pub struct VectorScanTableProvider {
     pub table_provider: Arc<dyn TableProvider>,
-    pub indexes: Vec<VectorIndexJoin>,
+    pub primary_key: Vec<String>,
+    pub index_list_plans: Vec<Arc<LogicalPlan>>,
 }
 
 impl VectorScanTableProvider {
@@ -81,8 +77,8 @@ impl VectorScanTableProvider {
             .collect::<HashMap<String, FieldRef>>();
 
         // Only add if key not in base table (we chose base table over index columns in `scan` afterall).
-        for entry in &self.indexes {
-            for f in entry.vector_index_list.schema().fields() {
+        for plan in &self.index_list_plans {
+            for f in plan.schema().fields() {
                 if !fields_map.contains_key(f.name()) {
                     // Any field only present in a vector index must be nullable since row may be in `self.table_provider` before that index.
                     fields_map.insert(
@@ -114,26 +110,51 @@ impl VectorScanTableProvider {
     /// Builds a layer over `table_provider` joining in every index in `indexes`.
     /// Callers with a single index pass a one-element slice — `std::slice::from_ref`
     /// works for an owned `Arc<dyn VectorIndex>` already in hand.
+    ///
+    /// # Errors
+    ///
+    /// Returns a plan error if `indexes` is non-empty and some index's primary key
+    /// disagrees with the first index's — every index on one dataset is assumed to
+    /// share a single join key, so a mismatch here would otherwise silently join a
+    /// later index on the wrong columns.
     pub fn try_new(
         table_provider: Arc<dyn TableProvider>,
         indexes: &[Arc<dyn VectorIndex>],
     ) -> Result<Self, DataFusionError> {
-        let indexes = indexes
+        let primary_key: Vec<String> = indexes.first().map_or_else(Vec::new, |index| {
+            index
+                .primary_fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect()
+        });
+        let primary_key_set: HashSet<&String> = primary_key.iter().collect();
+
+        for index in indexes {
+            let other: Vec<String> = index
+                .primary_fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect();
+            if other.iter().collect::<HashSet<&String>>() != primary_key_set {
+                return Err(DataFusionError::Plan(format!(
+                    "Every vector index joined onto one VectorScanTableProvider must share the \
+                     same primary key; expected {primary_key:?} but the index over column \
+                     '{}' has primary key {other:?}.",
+                    index.search_column(),
+                )));
+            }
+        }
+
+        let index_list_plans = indexes
             .iter()
-            .map(|index| {
-                Ok(VectorIndexJoin {
-                    primary_key: index
-                        .primary_fields()
-                        .iter()
-                        .map(|f| f.name().clone())
-                        .collect(),
-                    vector_index_list: Arc::new(index.list_table_provider()?),
-                })
-            })
+            .map(|index| Ok(Arc::new(index.list_table_provider()?)))
             .collect::<Result<Vec<_>, DataFusionError>>()?;
+
         Ok(Self {
             table_provider,
-            indexes,
+            primary_key,
+            index_list_plans,
         })
     }
 
@@ -204,8 +225,8 @@ impl VectorScanTableProvider {
     fn column_owners(&self, base: &Arc<dyn TableProvider>) -> HashMap<String, usize> {
         let table_schema = base.schema();
         let mut owners = HashMap::new();
-        for (i, entry) in self.indexes.iter().enumerate() {
-            for f in entry.vector_index_list.schema().fields() {
+        for (i, plan) in self.index_list_plans.iter().enumerate() {
+            for f in plan.schema().fields() {
                 if table_schema.column_with_name(f.name()).is_none() {
                     owners.entry(f.name().clone()).or_insert(i);
                 }
@@ -214,24 +235,23 @@ impl VectorScanTableProvider {
         owners
     }
 
-    /// Every column `entry` (at position `index_position` in `self.indexes`) supplies
-    /// to the join: all of its primary keys (needed for the join predicate regardless
-    /// of ownership), plus the non-base columns it is the assigned owner of per
-    /// [`Self::column_owners`].
+    /// Every column the index at `index_position` (whose listing plan is `plan`)
+    /// supplies to the join: the shared [`Self::primary_key`] (needed for the join
+    /// predicate regardless of ownership), plus the non-base columns it is the
+    /// assigned owner of per [`Self::column_owners`].
     fn columns_needed_from_index(
-        entry: &VectorIndexJoin,
+        &self,
+        plan: &Arc<LogicalPlan>,
         index_position: usize,
         owners: &HashMap<String, usize>,
         base: &Arc<dyn TableProvider>,
     ) -> Vec<Expr> {
         let table_schema = base.schema();
-        entry
-            .vector_index_list
-            .schema()
+        plan.schema()
             .columns()
             .into_iter()
             .filter(|c| {
-                entry.primary_key.contains(&c.name)
+                self.primary_key.contains(&c.name)
                     || (table_schema.column_with_name(&c.name).is_none()
                         && owners.get(&c.name).copied() == Some(index_position))
             })
@@ -325,15 +345,15 @@ impl VectorScanTableProvider {
 
         // Reenable once we can distinguish between query and indexing `.scan()`.
         // See `<https://github.com/spiceai/spiceai/issues/7404>`
-        // if let [entry] = self.indexes.as_slice()
+        // if let [plan] = self.index_list_plans.as_slice()
         //     && Self::schema_is_sufficient(
-        //         entry.vector_index_list.schema().fields(),
+        //         plan.schema().fields(),
         //         &columns_requested,
         //         filters,
         //     )
         // {
         //     let lp = Self::apply_proj_and_filter(
-        //         LogicalPlanBuilder::new_from_arc(Arc::clone(&entry.vector_index_list)),
+        //         LogicalPlanBuilder::new_from_arc(Arc::clone(plan)),
         //         &columns_requested,
         //         filters,
         //     )?
@@ -345,8 +365,8 @@ impl VectorScanTableProvider {
         // Join in only the indexes this query actually needs, on primary keys, prefer to use
         // columns from base table, push down filters where we can.
         let owners = self.column_owners(below);
-        let needed_indexes: Vec<(usize, &VectorIndexJoin)> = self
-            .indexes
+        let needed_indexes: Vec<(usize, &Arc<LogicalPlan>)> = self
+            .index_list_plans
             .iter()
             .enumerate()
             .filter(|(index_position, _)| {
@@ -371,7 +391,7 @@ impl VectorScanTableProvider {
             .map(|f| f.name().clone())
             .collect();
 
-        for (loop_position, (index_position, entry)) in needed_indexes.into_iter().enumerate() {
+        for (loop_position, (index_position, plan)) in needed_indexes.into_iter().enumerate() {
             // Match the single-index alias exactly (`vector_index`, unsuffixed) so a dataset
             // with one index keeps producing the same plan it always has; only a second and
             // later index needs a distinguishing suffix.
@@ -382,7 +402,7 @@ impl VectorScanTableProvider {
             };
 
             let this_index_projection =
-                Self::columns_needed_from_index(entry, index_position, &owners, below);
+                self.columns_needed_from_index(plan, index_position, &owners, below);
             let this_index_columns: HashSet<String> = this_index_projection
                 .iter()
                 .filter_map(|e| match e {
@@ -392,13 +412,12 @@ impl VectorScanTableProvider {
                 .collect();
 
             join = join.join(
-                LogicalPlanBuilder::new_from_arc(Arc::clone(&entry.vector_index_list))
+                LogicalPlanBuilder::new_from_arc(Arc::clone(plan))
                     .project(this_index_projection)?
                     .alias(alias.clone())?
                     .build()?,
                 JoinType::Left,
-                entry
-                    .primary_key
+                self.primary_key
                     .iter()
                     .map(|pk| (Column::from_name(pk.clone()), Column::from_name(pk.clone())))
                     .collect(),
@@ -412,7 +431,7 @@ impl VectorScanTableProvider {
                     .filter(|f| {
                         let refs = f.column_refs();
                         refs.iter()
-                            .any(|col| !entry.primary_key.contains(&col.name))
+                            .any(|col| !self.primary_key.contains(&col.name))
                             && refs.iter().all(|col| {
                                 available_columns.contains(col.name.as_str())
                                     || this_index_columns.contains(&col.name)
@@ -429,7 +448,7 @@ impl VectorScanTableProvider {
                 join_schema
                     .iter()
                     .filter(|(tbl, f)| {
-                        !(entry.primary_key.contains(f.name())
+                        !(self.primary_key.contains(f.name())
                             && tbl.is_some_and(|t| *t == TableReference::parse_str(&alias)))
                     })
                     .map(|(tbl, field_ref)| match tbl {
@@ -1237,7 +1256,7 @@ mod tests {
         .expect("could not make 'VectorScanTableProvider' over two indexes");
 
         assert_eq!(
-            p.indexes.len(),
+            p.index_list_plans.len(),
             2,
             "a dataset with two embedding columns must hold both indexes on one provider"
         );

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -43,12 +43,24 @@ use util::session_state::builder_from_existing;
 use crate::index::VectorIndex;
 use datafusion::catalog::{ScanArgs, ScanResult};
 
-/// A [`TableProvider`] that adds an embedding column to an underlying [`TableProvider`].
+/// One vector index's listing plan and join key, as composed onto a
+/// [`VectorScanTableProvider`]. A dataset with several embedding columns holds
+/// one of these per column, all on the same [`VectorScanTableProvider`], rather
+/// than nesting a separate layer per index.
+#[derive(Debug, Clone)]
+pub struct VectorIndexJoin {
+    pub vector_index_list: Arc<LogicalPlan>,
+    pub primary_key: Vec<String>,
+}
+
+/// A [`TableProvider`] that adds one or more embedding columns to an underlying
+/// [`TableProvider`] — one [`VectorIndexJoin`] per vector index, joined into the
+/// same scan rather than each index wrapping its own nested
+/// [`VectorScanTableProvider`] layer.
 #[derive(Debug, Clone)]
 pub struct VectorScanTableProvider {
     pub table_provider: Arc<dyn TableProvider>,
-    pub vector_index_list: Arc<LogicalPlan>,
-    pub primary_key: Vec<String>,
+    pub indexes: Vec<VectorIndexJoin>,
 }
 
 impl VectorScanTableProvider {
@@ -69,13 +81,15 @@ impl VectorScanTableProvider {
             .collect::<HashMap<String, FieldRef>>();
 
         // Only add if key not in base table (we chose base table over index columns in `scan` afterall).
-        for f in self.vector_index_list.schema().fields() {
-            if !fields_map.contains_key(f.name()) {
-                // Any field only present in vector index must be nullable since row may be in `self.table_provider` before `self.vector_index_list`.
-                fields_map.insert(
-                    f.name().clone(),
-                    Arc::new(Arc::unwrap_or_clone(Arc::clone(f)).with_nullable(true)),
-                );
+        for entry in &self.indexes {
+            for f in entry.vector_index_list.schema().fields() {
+                if !fields_map.contains_key(f.name()) {
+                    // Any field only present in a vector index must be nullable since row may be in `self.table_provider` before that index.
+                    fields_map.insert(
+                        f.name().clone(),
+                        Arc::new(Arc::unwrap_or_clone(Arc::clone(f)).with_nullable(true)),
+                    );
+                }
             }
         }
 
@@ -97,18 +111,29 @@ impl VectorScanTableProvider {
         SpiceTable::over(self, below)
     }
 
+    /// Builds a layer over `table_provider` joining in every index in `indexes`.
+    /// Callers with a single index pass a one-element slice — `std::slice::from_ref`
+    /// works for an owned `Arc<dyn VectorIndex>` already in hand.
     pub fn try_new(
         table_provider: Arc<dyn TableProvider>,
-        index: &Arc<dyn VectorIndex>,
+        indexes: &[Arc<dyn VectorIndex>],
     ) -> Result<Self, DataFusionError> {
+        let indexes = indexes
+            .iter()
+            .map(|index| {
+                Ok(VectorIndexJoin {
+                    primary_key: index
+                        .primary_fields()
+                        .iter()
+                        .map(|f| f.name().clone())
+                        .collect(),
+                    vector_index_list: Arc::new(index.list_table_provider()?),
+                })
+            })
+            .collect::<Result<Vec<_>, DataFusionError>>()?;
         Ok(Self {
             table_provider,
-            primary_key: index
-                .primary_fields()
-                .iter()
-                .map(|f| f.name().clone())
-                .collect(),
-            vector_index_list: index.list_table_provider()?.into(),
+            indexes,
         })
     }
 
@@ -168,20 +193,65 @@ impl VectorScanTableProvider {
         Ok(columns_requested)
     }
 
-    /// Every column in [`Self::vector_index_list`] absent from `base`, plus all
-    /// primary keys.
-    fn columns_needed_from_index(&self, base: &Arc<dyn TableProvider>) -> Vec<Expr> {
+    /// Every column in `entry.vector_index_list` absent from `base`, plus all of
+    /// `entry`'s primary keys.
+    fn columns_needed_from_index(
+        entry: &VectorIndexJoin,
+        base: &Arc<dyn TableProvider>,
+    ) -> Vec<Expr> {
         let table_schema = base.schema();
-        self.vector_index_list
+        entry
+            .vector_index_list
             .schema()
             .columns()
             .into_iter()
             .filter(|c| {
                 table_schema.column_with_name(&c.name).is_none()
-                    || self.primary_key.contains(&c.name)
+                    || entry.primary_key.contains(&c.name)
             })
             .map(Expr::Column)
             .collect()
+    }
+
+    /// The columns `entry` alone contributes: its own schema's columns absent
+    /// from `base` — i.e. the columns only a join against this specific index can
+    /// supply.
+    fn unique_columns_of(
+        entry: &VectorIndexJoin,
+        base: &Arc<dyn TableProvider>,
+    ) -> HashSet<String> {
+        let table_schema = base.schema();
+        entry
+            .vector_index_list
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .filter(|name| table_schema.column_with_name(name).is_none())
+            .collect()
+    }
+
+    /// Whether a query needing `columns_requested` (with `filters`) requires a
+    /// join against `entry` specifically — i.e. whether any column only this
+    /// index supplies is projected or filtered on. An index whose columns are
+    /// never referenced is skipped rather than joined unconditionally, so a
+    /// dataset with several embedding columns pays for only the joins a given
+    /// query actually needs.
+    fn index_is_needed(
+        entry: &VectorIndexJoin,
+        base: &Arc<dyn TableProvider>,
+        columns_requested: &HashSet<String>,
+        filters: &[Expr],
+    ) -> bool {
+        let unique = Self::unique_columns_of(entry, base);
+        if columns_requested.iter().any(|c| unique.contains(c)) {
+            return true;
+        }
+        filters.iter().any(|f| {
+            f.column_refs()
+                .iter()
+                .any(|col| unique.contains(col.name.as_str()))
+        })
     }
 }
 
@@ -249,13 +319,15 @@ impl VectorScanTableProvider {
 
         // Reenable once we can distinguish between query and indexing `.scan()`.
         // See `<https://github.com/spiceai/spiceai/issues/7404>`
-        // if Self::schema_is_sufficient(
-        //     self.vector_index_list.schema().fields(),
-        //     &columns_requested,
-        //     filters,
-        // ) {
+        // if let [entry] = self.indexes.as_slice()
+        //     && Self::schema_is_sufficient(
+        //         entry.vector_index_list.schema().fields(),
+        //         &columns_requested,
+        //         filters,
+        //     )
+        // {
         //     let lp = Self::apply_proj_and_filter(
-        //         LogicalPlanBuilder::new_from_arc(Arc::clone(&self.vector_index_list)),
+        //         LogicalPlanBuilder::new_from_arc(Arc::clone(&entry.vector_index_list)),
         //         &columns_requested,
         //         filters,
         //     )?
@@ -264,49 +336,69 @@ impl VectorScanTableProvider {
         //     return state.create_physical_plan(&lp).await;
         // }
 
-        // Join on primary keys, prefer to use columns from base table, push down filters where we can.
+        // Join in only the indexes this query actually needs, on primary keys, prefer to use
+        // columns from base table, push down filters where we can.
+        let needed_indexes: Vec<&VectorIndexJoin> = self
+            .indexes
+            .iter()
+            .filter(|entry| Self::index_is_needed(entry, below, &columns_requested, filters))
+            .collect();
+
         let mut join = LogicalPlanBuilder::scan(
             "base_table",
             Arc::new(DefaultTableSource::new(Arc::clone(below))),
             None,
-        )?
-        .join(
-            LogicalPlanBuilder::new_from_arc(Arc::clone(&self.vector_index_list))
-                .project(self.columns_needed_from_index(below))?
-                .alias("vector_index")?
-                .build()?,
-            JoinType::Left,
-            self.primary_key
-                .iter()
-                .map(|pk| (Column::from_name(pk.clone()), Column::from_name(pk.clone())))
-                .collect(),
-            // If the filter affects any primary key column, we must apply after we have removed the duplicate primary key columns.
-            filters
-                .iter()
-                .filter(|f| {
-                    f.column_refs()
-                        .iter()
-                        .any(|col| !self.primary_key.contains(&col.name))
-                })
-                .cloned()
-                .reduce(Expr::and),
         )?;
 
-        let join_schema = Arc::clone(join.schema());
-        join = join.project(
-            // DataFusion will not deduplicate the `Join::on` keys. For simplicity with non-join
-            // case, we will remove duplicate primary key columns from the right table.
-            join_schema
-                .iter()
-                .filter(|(tbl, f)| {
-                    !(self.primary_key.contains(f.name())
-                        && tbl.is_some_and(|t| *t == TableReference::parse_str("vector_index")))
-                })
-                .map(|(tbl, field_ref)| match tbl {
-                    Some(table_ref) => Column::new(Some(table_ref.clone()), field_ref.name()),
-                    None => Column::new(None::<TableReference>, field_ref.name()),
-                }),
-        )?;
+        for (i, entry) in needed_indexes.into_iter().enumerate() {
+            // Match the single-index alias exactly (`vector_index`, unsuffixed) so a dataset
+            // with one index keeps producing the same plan it always has; only a second and
+            // later index needs a distinguishing suffix.
+            let alias = if i == 0 {
+                "vector_index".to_string()
+            } else {
+                format!("vector_index_{i}")
+            };
+
+            join = join.join(
+                LogicalPlanBuilder::new_from_arc(Arc::clone(&entry.vector_index_list))
+                    .project(Self::columns_needed_from_index(entry, below))?
+                    .alias(alias.clone())?
+                    .build()?,
+                JoinType::Left,
+                entry
+                    .primary_key
+                    .iter()
+                    .map(|pk| (Column::from_name(pk.clone()), Column::from_name(pk.clone())))
+                    .collect(),
+                // If the filter affects any primary key column, we must apply after we have removed the duplicate primary key columns.
+                filters
+                    .iter()
+                    .filter(|f| {
+                        f.column_refs()
+                            .iter()
+                            .any(|col| !entry.primary_key.contains(&col.name))
+                    })
+                    .cloned()
+                    .reduce(Expr::and),
+            )?;
+
+            let join_schema = Arc::clone(join.schema());
+            join = join.project(
+                // DataFusion will not deduplicate the `Join::on` keys. For simplicity with non-join
+                // case, we will remove duplicate primary key columns from the right table.
+                join_schema
+                    .iter()
+                    .filter(|(tbl, f)| {
+                        !(entry.primary_key.contains(f.name())
+                            && tbl.is_some_and(|t| *t == TableReference::parse_str(&alias)))
+                    })
+                    .map(|(tbl, field_ref)| match tbl {
+                        Some(table_ref) => Column::new(Some(table_ref.clone()), field_ref.name()),
+                        None => Column::new(None::<TableReference>, field_ref.name()),
+                    }),
+            )?;
+        }
 
         if let Some(filter) = filters.iter().cloned().reduce(Expr::and) {
             join = join.filter(filter)?;
@@ -750,7 +842,7 @@ mod tests {
                 .expect("could not make MemTable"),
                 "BaseTable",
             )),
-            &(Arc::new(PretendVectorIndex::new(
+            &[Arc::new(PretendVectorIndex::new(
                 "body".to_string(),
                 vec![Field::new("pk", DataType::Int64, false)],
                 Schema::new(vec![
@@ -761,7 +853,7 @@ mod tests {
                         false,
                     ),
                 ]),
-            )) as Arc<dyn VectorIndex>),
+            )) as Arc<dyn VectorIndex>],
         )
         .expect("could not make 'VectorScanTableProvider'");
 
@@ -817,7 +909,7 @@ mod tests {
                 .expect("could not make MemTable"),
                 "BaseTable",
             )),
-            &(Arc::new(PretendVectorIndex::new(
+            &[Arc::new(PretendVectorIndex::new(
                 "body".to_string(),
                 vec![Field::new("pk", DataType::Int64, false)],
                 Schema::new(vec![
@@ -828,7 +920,7 @@ mod tests {
                         false,
                     ),
                 ]),
-            )) as Arc<dyn VectorIndex>),
+            )) as Arc<dyn VectorIndex>],
         )
         .expect("could not make 'VectorScanTableProvider'");
 
@@ -869,7 +961,7 @@ mod tests {
                 .expect("could not make MemTable"),
                 "BaseTable",
             )),
-            &(Arc::new(PretendVectorIndex::new(
+            &[Arc::new(PretendVectorIndex::new(
                 "body".to_string(),
                 vec![Field::new("pk", DataType::Int64, false)],
                 Schema::new(vec![
@@ -886,7 +978,7 @@ mod tests {
                         ("filterable".to_string(), "false".to_string()),
                     ])),
                 ]),
-            )) as Arc<dyn VectorIndex>),
+            )) as Arc<dyn VectorIndex>],
         )
         .expect("could not make 'VectorScanTableProvider'");
 
@@ -971,7 +1063,7 @@ mod tests {
                 .expect("could not make MemTable"),
                 "BaseTable",
             )),
-            &(Arc::new(PretendVectorIndex::new(
+            &[Arc::new(PretendVectorIndex::new(
                 "body".to_string(),
                 vec![
                     Field::new("pk1", DataType::Int64, false),
@@ -994,7 +1086,7 @@ mod tests {
                         ("filterable".to_string(), "false".to_string()),
                     ])),
                 ]),
-            )) as Arc<dyn VectorIndex>),
+            )) as Arc<dyn VectorIndex>],
         )
         .expect("could not make 'VectorScanTableProvider'");
 
@@ -1045,6 +1137,113 @@ mod tests {
             TableReference::parse_str("my_vectored_table"),
             "SELECT pk1, pk2, pk3, body_embedding from my_vectored_table WHERE a_number > 0 LIMIT 5",
             "scan_table_no_join_for_metadata_filter_multiple_pk",
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// Regression test for <https://github.com/spiceai/spiceai/issues/7020>: a dataset
+    /// with two embedding columns must produce a *single* `VectorScanTableProvider`
+    /// joining both indexes, not one index nested inside the other. A query naming
+    /// only one column's embedding joins only that index; a query naming both joins
+    /// both, in one flat plan.
+    #[tokio::test]
+    pub async fn test_vector_scan_multiple_indexes() -> Result<(), String> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("pk", DataType::Int64, false),
+            Field::new("body", DataType::Utf8, false),
+            Field::new("summary", DataType::Utf8, false),
+            Field::new("another_column", DataType::Utf8, false),
+        ]));
+
+        let p = VectorScanTableProvider::try_new(
+            Arc::new(ExplainMemTable::new(
+                MemTable::try_new(
+                    Arc::clone(&schema),
+                    vec![vec![one_row_default_record_batch_for_schema(&schema)]],
+                )
+                .expect("could not make MemTable"),
+                "BaseTable",
+            )),
+            &[
+                Arc::new(PretendVectorIndex::new(
+                    "body".to_string(),
+                    vec![Field::new("pk", DataType::Int64, false)],
+                    Schema::new(vec![
+                        Field::new("pk", DataType::Int64, false),
+                        Field::new(
+                            "body_embedding",
+                            DataType::new_fixed_size_list(DataType::Float32, 10, false),
+                            false,
+                        ),
+                    ]),
+                )) as Arc<dyn VectorIndex>,
+                Arc::new(PretendVectorIndex::new(
+                    "summary".to_string(),
+                    vec![Field::new("pk", DataType::Int64, false)],
+                    Schema::new(vec![
+                        Field::new("pk", DataType::Int64, false),
+                        Field::new(
+                            "summary_embedding",
+                            DataType::new_fixed_size_list(DataType::Float32, 10, false),
+                            false,
+                        ),
+                    ]),
+                )) as Arc<dyn VectorIndex>,
+            ],
+        )
+        .expect("could not make 'VectorScanTableProvider' over two indexes");
+
+        assert_eq!(
+            p.indexes.len(),
+            2,
+            "a dataset with two embedding columns must hold both indexes on one provider"
+        );
+
+        let provider: Arc<dyn TableProvider> = Arc::new(p).into_table();
+
+        assert!(
+            provider.schema().field_with_name("body_embedding").is_ok()
+                && provider
+                    .schema()
+                    .field_with_name("summary_embedding")
+                    .is_ok(),
+            "the merged schema must expose both indexes' embedding columns"
+        );
+
+        // Only the referenced index's join should appear in the plan.
+        test_explain(
+            Arc::clone(&provider),
+            TableReference::parse_str("my_vectored_table"),
+            "SELECT pk, body_embedding from my_vectored_table ORDER BY pk desc LIMIT 5",
+            "scan_table_multi_index_only_body",
+        )
+        .await?;
+
+        test_explain(
+            Arc::clone(&provider),
+            TableReference::parse_str("my_vectored_table"),
+            "SELECT pk, summary_embedding from my_vectored_table ORDER BY pk desc LIMIT 5",
+            "scan_table_multi_index_only_summary",
+        )
+        .await?;
+
+        // Both indexes referenced: both joins must appear in one flat plan.
+        test_explain(
+            Arc::clone(&provider),
+            TableReference::parse_str("my_vectored_table"),
+            "SELECT pk, body_embedding, summary_embedding from my_vectored_table ORDER BY pk desc LIMIT 5",
+            "scan_table_multi_index_both",
+        )
+        .await?;
+
+        // Neither embedding column referenced: no join at all.
+        test_explain(
+            Arc::clone(&provider),
+            TableReference::parse_str("my_vectored_table"),
+            "SELECT pk, another_column from my_vectored_table ORDER BY pk desc LIMIT 5",
+            "scan_table_multi_index_no_join",
         )
         .await?;
 

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -350,6 +350,17 @@ impl VectorScanTableProvider {
             None,
         )?;
 
+        // Columns resolvable in the join built so far — starts at the base table's own
+        // columns and gains each index's columns once that index has actually been
+        // joined in. A filter naming a column only a *later* index supplies cannot be
+        // embedded in an *earlier* index's join: that join's schema doesn't have it yet.
+        let mut available_columns: HashSet<String> = below
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+
         for (i, entry) in needed_indexes.into_iter().enumerate() {
             // Match the single-index alias exactly (`vector_index`, unsuffixed) so a dataset
             // with one index keeps producing the same plan it always has; only a second and
@@ -359,6 +370,14 @@ impl VectorScanTableProvider {
             } else {
                 format!("vector_index_{i}")
             };
+
+            let this_index_columns: HashSet<&str> = entry
+                .vector_index_list
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .collect();
 
             join = join.join(
                 LogicalPlanBuilder::new_from_arc(Arc::clone(&entry.vector_index_list))
@@ -372,12 +391,19 @@ impl VectorScanTableProvider {
                     .map(|pk| (Column::from_name(pk.clone()), Column::from_name(pk.clone())))
                     .collect(),
                 // If the filter affects any primary key column, we must apply after we have removed the duplicate primary key columns.
+                // Only push a filter into this join if every column it references is already
+                // resolvable here (the base table, an index joined earlier, or this index's
+                // own columns) — the unconditional filter after all joins below still applies
+                // it, so a filter that isn't embeddable yet is simply deferred, not dropped.
                 filters
                     .iter()
                     .filter(|f| {
-                        f.column_refs()
-                            .iter()
-                            .any(|col| !entry.primary_key.contains(&col.name))
+                        let refs = f.column_refs();
+                        refs.iter().any(|col| !entry.primary_key.contains(&col.name))
+                            && refs.iter().all(|col| {
+                                available_columns.contains(col.name.as_str())
+                                    || this_index_columns.contains(col.name.as_str())
+                            })
                     })
                     .cloned()
                     .reduce(Expr::and),
@@ -398,6 +424,8 @@ impl VectorScanTableProvider {
                         None => Column::new(None::<TableReference>, field_ref.name()),
                     }),
             )?;
+
+            available_columns.extend(this_index_columns.into_iter().map(String::from));
         }
 
         if let Some(filter) = filters.iter().cloned().reduce(Expr::and) {
@@ -1244,6 +1272,75 @@ mod tests {
             TableReference::parse_str("my_vectored_table"),
             "SELECT pk, another_column from my_vectored_table ORDER BY pk desc LIMIT 5",
             "scan_table_multi_index_no_join",
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// Regression test: a filter naming a column that only a *later* index in the join
+    /// chain supplies must not be pushed into an *earlier* index's join. Selecting
+    /// `body_embedding` (only the `body` index) while filtering on `a_number` (only the
+    /// `summary` index's metadata column) makes `summary` a needed index too, but the
+    /// `body` join is built first — embedding a filter on `a_number` there references a
+    /// column absent from that join's schema and fails to plan.
+    #[tokio::test]
+    pub async fn test_vector_scan_multiple_indexes_filter_crosses_index_boundary() -> Result<(), String>
+    {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("pk", DataType::Int64, false),
+            Field::new("body", DataType::Utf8, false),
+            Field::new("summary", DataType::Utf8, false),
+        ]));
+
+        let p = VectorScanTableProvider::try_new(
+            Arc::new(ExplainMemTable::new(
+                MemTable::try_new(
+                    Arc::clone(&schema),
+                    vec![vec![one_row_default_record_batch_for_schema(&schema)]],
+                )
+                .expect("could not make MemTable"),
+                "BaseTable",
+            )),
+            &[
+                Arc::new(PretendVectorIndex::new(
+                    "body".to_string(),
+                    vec![Field::new("pk", DataType::Int64, false)],
+                    Schema::new(vec![
+                        Field::new("pk", DataType::Int64, false),
+                        Field::new(
+                            "body_embedding",
+                            DataType::new_fixed_size_list(DataType::Float32, 10, false),
+                            false,
+                        ),
+                    ]),
+                )) as Arc<dyn VectorIndex>,
+                Arc::new(PretendVectorIndex::new(
+                    "summary".to_string(),
+                    vec![Field::new("pk", DataType::Int64, false)],
+                    Schema::new(vec![
+                        Field::new("pk", DataType::Int64, false),
+                        Field::new(
+                            "summary_embedding",
+                            DataType::new_fixed_size_list(DataType::Float32, 10, false),
+                            false,
+                        ),
+                        Field::new("a_number", DataType::Int64, false).with_metadata(HashMap::from(
+                            [("filterable".to_string(), "true".to_string())],
+                        )),
+                    ]),
+                )) as Arc<dyn VectorIndex>,
+            ],
+        )
+        .expect("could not make 'VectorScanTableProvider' over two indexes");
+
+        let provider: Arc<dyn TableProvider> = Arc::new(p).into_table();
+
+        test_explain(
+            Arc::clone(&provider),
+            TableReference::parse_str("my_vectored_table"),
+            "SELECT pk, body_embedding from my_vectored_table WHERE a_number > 0 ORDER BY pk desc LIMIT 5",
+            "scan_table_multi_index_filter_crosses_boundary",
         )
         .await?;
 

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -255,11 +255,9 @@ impl VectorScanTableProvider {
         if columns_requested.iter().any(|c| owns(c)) {
             return true;
         }
-        filters.iter().any(|f| {
-            f.column_refs()
-                .iter()
-                .any(|col| owns(col.name.as_str()))
-        })
+        filters
+            .iter()
+            .any(|f| f.column_refs().iter().any(|col| owns(col.name.as_str())))
     }
 }
 

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -430,8 +430,7 @@ impl VectorScanTableProvider {
                     .iter()
                     .filter(|f| {
                         let refs = f.column_refs();
-                        refs.iter()
-                            .any(|col| !self.primary_key.contains(&col.name))
+                        refs.iter().any(|col| !self.primary_key.contains(&col.name))
                             && refs.iter().all(|col| {
                                 available_columns.contains(col.name.as_str())
                                     || this_index_columns.contains(&col.name)

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -193,10 +193,35 @@ impl VectorScanTableProvider {
         Ok(columns_requested)
     }
 
-    /// Every column in `entry.vector_index_list` absent from `base`, plus all of
-    /// `entry`'s primary keys.
+    /// For every column across all indexes that isn't already on `base`, the single
+    /// index that supplies it — the first index (in list order) whose schema
+    /// contributes that name, matching the precedence [`Self::schema_over`] merges
+    /// by. A later index sharing the same column name (e.g. a fixed metadata field
+    /// name shared by every chunked embedding column, such as
+    /// `chunking::CHUNKED_INDEX_FULL_SEARCH_FIELD`) is not also asked to supply it —
+    /// each shared name is projected and joined in from exactly one place, so the
+    /// plan never ends up with two columns under the same unqualified name.
+    fn column_owners(&self, base: &Arc<dyn TableProvider>) -> HashMap<String, usize> {
+        let table_schema = base.schema();
+        let mut owners = HashMap::new();
+        for (i, entry) in self.indexes.iter().enumerate() {
+            for f in entry.vector_index_list.schema().fields() {
+                if table_schema.column_with_name(f.name()).is_none() {
+                    owners.entry(f.name().clone()).or_insert(i);
+                }
+            }
+        }
+        owners
+    }
+
+    /// Every column `entry` (at position `index_position` in `self.indexes`) supplies
+    /// to the join: all of its primary keys (needed for the join predicate regardless
+    /// of ownership), plus the non-base columns it is the assigned owner of per
+    /// [`Self::column_owners`].
     fn columns_needed_from_index(
         entry: &VectorIndexJoin,
+        index_position: usize,
+        owners: &HashMap<String, usize>,
         base: &Arc<dyn TableProvider>,
     ) -> Vec<Expr> {
         let table_schema = base.schema();
@@ -206,51 +231,34 @@ impl VectorScanTableProvider {
             .columns()
             .into_iter()
             .filter(|c| {
-                table_schema.column_with_name(&c.name).is_none()
-                    || entry.primary_key.contains(&c.name)
+                entry.primary_key.contains(&c.name)
+                    || (table_schema.column_with_name(&c.name).is_none()
+                        && owners.get(&c.name).copied() == Some(index_position))
             })
             .map(Expr::Column)
             .collect()
     }
 
-    /// The columns `entry` alone contributes: its own schema's columns absent
-    /// from `base` — i.e. the columns only a join against this specific index can
-    /// supply.
-    fn unique_columns_of(
-        entry: &VectorIndexJoin,
-        base: &Arc<dyn TableProvider>,
-    ) -> HashSet<String> {
-        let table_schema = base.schema();
-        entry
-            .vector_index_list
-            .schema()
-            .fields()
-            .iter()
-            .map(|f| f.name().clone())
-            .filter(|name| table_schema.column_with_name(name).is_none())
-            .collect()
-    }
-
-    /// Whether a query needing `columns_requested` (with `filters`) requires a
-    /// join against `entry` specifically — i.e. whether any column only this
-    /// index supplies is projected or filtered on. An index whose columns are
-    /// never referenced is skipped rather than joined unconditionally, so a
-    /// dataset with several embedding columns pays for only the joins a given
-    /// query actually needs.
+    /// Whether a query needing `columns_requested` (with `filters`) requires a join
+    /// against the index at `index_position` specifically — i.e. whether any column
+    /// only it owns (per [`Self::column_owners`]) is projected or filtered on. An
+    /// index whose owned columns are never referenced is skipped rather than joined
+    /// unconditionally, so a dataset with several embedding columns pays for only the
+    /// joins a given query actually needs.
     fn index_is_needed(
-        entry: &VectorIndexJoin,
-        base: &Arc<dyn TableProvider>,
+        index_position: usize,
+        owners: &HashMap<String, usize>,
         columns_requested: &HashSet<String>,
         filters: &[Expr],
     ) -> bool {
-        let unique = Self::unique_columns_of(entry, base);
-        if columns_requested.iter().any(|c| unique.contains(c)) {
+        let owns = |name: &str| owners.get(name).copied() == Some(index_position);
+        if columns_requested.iter().any(|c| owns(c)) {
             return true;
         }
         filters.iter().any(|f| {
             f.column_refs()
                 .iter()
-                .any(|col| unique.contains(col.name.as_str()))
+                .any(|col| owns(col.name.as_str()))
         })
     }
 }
@@ -338,10 +346,14 @@ impl VectorScanTableProvider {
 
         // Join in only the indexes this query actually needs, on primary keys, prefer to use
         // columns from base table, push down filters where we can.
-        let needed_indexes: Vec<&VectorIndexJoin> = self
+        let owners = self.column_owners(below);
+        let needed_indexes: Vec<(usize, &VectorIndexJoin)> = self
             .indexes
             .iter()
-            .filter(|entry| Self::index_is_needed(entry, below, &columns_requested, filters))
+            .enumerate()
+            .filter(|(index_position, _)| {
+                Self::index_is_needed(*index_position, &owners, &columns_requested, filters)
+            })
             .collect();
 
         let mut join = LogicalPlanBuilder::scan(
@@ -361,27 +373,29 @@ impl VectorScanTableProvider {
             .map(|f| f.name().clone())
             .collect();
 
-        for (i, entry) in needed_indexes.into_iter().enumerate() {
+        for (loop_position, (index_position, entry)) in needed_indexes.into_iter().enumerate() {
             // Match the single-index alias exactly (`vector_index`, unsuffixed) so a dataset
             // with one index keeps producing the same plan it always has; only a second and
             // later index needs a distinguishing suffix.
-            let alias = if i == 0 {
+            let alias = if loop_position == 0 {
                 "vector_index".to_string()
             } else {
-                format!("vector_index_{i}")
+                format!("vector_index_{loop_position}")
             };
 
-            let this_index_columns: HashSet<&str> = entry
-                .vector_index_list
-                .schema()
-                .fields()
+            let this_index_projection =
+                Self::columns_needed_from_index(entry, index_position, &owners, below);
+            let this_index_columns: HashSet<String> = this_index_projection
                 .iter()
-                .map(|f| f.name().as_str())
+                .filter_map(|e| match e {
+                    Expr::Column(c) => Some(c.name.clone()),
+                    _ => None,
+                })
                 .collect();
 
             join = join.join(
                 LogicalPlanBuilder::new_from_arc(Arc::clone(&entry.vector_index_list))
-                    .project(Self::columns_needed_from_index(entry, below))?
+                    .project(this_index_projection)?
                     .alias(alias.clone())?
                     .build()?,
                 JoinType::Left,
@@ -403,7 +417,7 @@ impl VectorScanTableProvider {
                             .any(|col| !entry.primary_key.contains(&col.name))
                             && refs.iter().all(|col| {
                                 available_columns.contains(col.name.as_str())
-                                    || this_index_columns.contains(col.name.as_str())
+                                    || this_index_columns.contains(&col.name)
                             })
                     })
                     .cloned()
@@ -426,7 +440,7 @@ impl VectorScanTableProvider {
                     }),
             )?;
 
-            available_columns.extend(this_index_columns.into_iter().map(String::from));
+            available_columns.extend(this_index_columns);
         }
 
         if let Some(filter) = filters.iter().cloned().reduce(Expr::and) {
@@ -1342,6 +1356,82 @@ mod tests {
             TableReference::parse_str("my_vectored_table"),
             "SELECT pk, body_embedding from my_vectored_table WHERE a_number > 0 ORDER BY pk desc LIMIT 5",
             "scan_table_multi_index_filter_crosses_boundary",
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// Repro for a suspected bug: two indexes whose schemas both expose a
+    /// non-primary-key column of the *same name* (e.g. `crates/search/src/index/chunking.rs`'s
+    /// `CHUNKED_INDEX_FULL_SEARCH_FIELD`, a fixed name added to any chunked embedding column
+    /// that also carries its own vector metadata — two chunked columns on one dataset would
+    /// both contribute a field under that identical name). Requesting that shared column
+    /// should mark both indexes needed; this test checks whether the join loop can actually
+    /// build a plan for that case.
+    #[tokio::test]
+    pub async fn test_vector_scan_multiple_indexes_shared_non_key_column_name() -> Result<(), String>
+    {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("pk", DataType::Int64, false),
+            Field::new("body", DataType::Utf8, false),
+            Field::new("summary", DataType::Utf8, false),
+        ]));
+
+        let shared_field = || {
+            Field::new("shared_meta", DataType::Utf8, false).with_metadata(HashMap::from([(
+                "filterable".to_string(),
+                "true".to_string(),
+            )]))
+        };
+
+        let p = VectorScanTableProvider::try_new(
+            Arc::new(ExplainMemTable::new(
+                MemTable::try_new(
+                    Arc::clone(&schema),
+                    vec![vec![one_row_default_record_batch_for_schema(&schema)]],
+                )
+                .expect("could not make MemTable"),
+                "BaseTable",
+            )),
+            &[
+                Arc::new(PretendVectorIndex::new(
+                    "body".to_string(),
+                    vec![Field::new("pk", DataType::Int64, false)],
+                    Schema::new(vec![
+                        Field::new("pk", DataType::Int64, false),
+                        Field::new(
+                            "body_embedding",
+                            DataType::new_fixed_size_list(DataType::Float32, 10, false),
+                            false,
+                        ),
+                        shared_field(),
+                    ]),
+                )) as Arc<dyn VectorIndex>,
+                Arc::new(PretendVectorIndex::new(
+                    "summary".to_string(),
+                    vec![Field::new("pk", DataType::Int64, false)],
+                    Schema::new(vec![
+                        Field::new("pk", DataType::Int64, false),
+                        Field::new(
+                            "summary_embedding",
+                            DataType::new_fixed_size_list(DataType::Float32, 10, false),
+                            false,
+                        ),
+                        shared_field(),
+                    ]),
+                )) as Arc<dyn VectorIndex>,
+            ],
+        )
+        .expect("could not make 'VectorScanTableProvider' over two indexes sharing a column name");
+
+        let provider: Arc<dyn TableProvider> = Arc::new(p).into_table();
+
+        test_explain(
+            Arc::clone(&provider),
+            TableReference::parse_str("my_vectored_table"),
+            "SELECT pk, body_embedding, summary_embedding, shared_meta from my_vectored_table ORDER BY pk desc LIMIT 5",
+            "scan_table_multi_index_shared_non_key_column",
         )
         .await?;
 

--- a/crates/search/src/index/vector_table.rs
+++ b/crates/search/src/index/vector_table.rs
@@ -399,7 +399,8 @@ impl VectorScanTableProvider {
                     .iter()
                     .filter(|f| {
                         let refs = f.column_refs();
-                        refs.iter().any(|col| !entry.primary_key.contains(&col.name))
+                        refs.iter()
+                            .any(|col| !entry.primary_key.contains(&col.name))
                             && refs.iter().all(|col| {
                                 available_columns.contains(col.name.as_str())
                                     || this_index_columns.contains(col.name.as_str())
@@ -1285,8 +1286,8 @@ mod tests {
     /// `body` join is built first — embedding a filter on `a_number` there references a
     /// column absent from that join's schema and fails to plan.
     #[tokio::test]
-    pub async fn test_vector_scan_multiple_indexes_filter_crosses_index_boundary() -> Result<(), String>
-    {
+    pub async fn test_vector_scan_multiple_indexes_filter_crosses_index_boundary()
+    -> Result<(), String> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("pk", DataType::Int64, false),
             Field::new("body", DataType::Utf8, false),
@@ -1325,9 +1326,9 @@ mod tests {
                             DataType::new_fixed_size_list(DataType::Float32, 10, false),
                             false,
                         ),
-                        Field::new("a_number", DataType::Int64, false).with_metadata(HashMap::from(
-                            [("filterable".to_string(), "true".to_string())],
-                        )),
+                        Field::new("a_number", DataType::Int64, false).with_metadata(
+                            HashMap::from([("filterable".to_string(), "true".to_string())]),
+                        ),
                     ]),
                 )) as Arc<dyn VectorIndex>,
             ],


### PR DESCRIPTION
## Summary
- `VectorScanTableProvider` nested a separate provider layer per embedding column, so a dataset with N vector indexes stacked N `SpiceTable` nodes instead of one — the underlying issue #7017 patched around (recursive unwrapping) rather than fixed.
- `VectorScanTableProvider` now holds a `Vec<VectorIndexJoin>` (one entry per index) and joins in only the indexes a given query actually references, in a single flat scan.
- The S3 Vectors and Elasticsearch construction paths (`wrap_table_as_index_s3`/`wrap_table_as_index_elasticsearch`) now build exactly one `VectorScanTableProvider` per dataset instead of re-wrapping the previous column's layer on every iteration.
- For a dataset with a single vector index, the generated plan is unchanged (same join alias, same filter/dedup/project sequence) — all existing single-index snapshot tests pass without regeneration.

Fixes #7020.

## Test plan
- [x] `cargo test -p search --features s3_vectors,elasticsearch --lib`: 192/192 passed, including a new `test_vector_scan_multiple_indexes` regression test asserting (via `EXPLAIN` snapshots) that a two-index provider joins only the needed index(es) — one join when a query references one column's embedding, two chained joins over a single `TableScan` when it references both, zero joins when it references neither.
- [x] `cargo test -p runtime --lib --features s3_vectors,elasticsearch,duckdb embeddings`: 59/59 passed, including the `changes_stream_resolves_through_a_vector_scan` CDC-resolution regression test.
- [x] `cargo test -p runtime-table --lib`: 303/304 passed; the one failure (`test_refresh_status_change_to_ready`, an unrelated metrics-polling timing test) passes in isolation and is pre-existing flakiness under parallel load.
- [x] Manually verified end-to-end against a live S3 Vectors dataset with two embedding columns (`body`, `title`) on the same table: both indexes initialize and refresh concurrently without error, `vector_search(...)` correctly reports "2 vector search columns" and requires disambiguation, and `EXPLAIN` on a query selecting both embedding columns shows two chained joins over one table scan.