### PR TITLE
Populate the file metadata cache with Vortex footers at write time

### DIFF
--- a/crates/cayenne/src/provider/sink.rs
+++ b/crates/cayenne/src/provider/sink.rs
@@ -642,6 +642,104 @@ mod tests {
         sink.write_all(stream, &ctx.task_ctx()).await
     }
 
+    /// Staged writes keep their write-time footer-cache entries: the Vortex
+    /// sink caches each written footer under the path it wrote, and the
+    /// post-move re-key (`rekey_moved_footer_cache_entries`) transfers the
+    /// entry to the published location scans look up. This pins the
+    /// invariant that after an append publishes, no footer-cache entry is
+    /// keyed by a stale (staging / non-current) path.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn staged_append_rekeys_write_time_footer_cache_entries() {
+        use datafusion_expr::{col, lit};
+
+        let ctx = SessionContext::new();
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let metadata_dir = format!("{}/metadata", temp_dir.path().to_str().expect("path"));
+        let data_dir = format!("{}/data", temp_dir.path().to_str().expect("path"));
+        std::fs::create_dir_all(&metadata_dir).expect("metadata dir");
+        let connection_string = format!("sqlite://{metadata_dir}/cayenne.db");
+        let catalog = Arc::new(CayenneCatalog::new(connection_string).expect("catalog"))
+            as Arc<dyn MetadataCatalog>;
+        catalog.init().await.expect("catalog init");
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let vortex_config = VortexConfig::default();
+        let context = CayenneContext::new(&vortex_config, ctx.runtime_env(), "footer_rekey");
+        let options = CreateTableOptions {
+            table_name: "footer_rekey".to_string(),
+            schema: Arc::clone(&schema),
+            primary_key: vec!["id".to_string()],
+            on_conflict: Some(OnConflict::Upsert(ColumnReference::new(vec![
+                "id".to_string(),
+            ]))),
+            base_path: data_dir,
+            partition_column: None,
+            vortex_config,
+        };
+        let provider = CayenneTableProviderBuilder::new(Arc::clone(&catalog), ctx.runtime_env())
+            .with_context(Arc::clone(&context))
+            // Bar the inline path so the append writes real Vortex files.
+            .with_retention_filters(vec![col("id").lt(lit(0_i64))])
+            .create(options)
+            .await
+            .expect("table created");
+
+        let written = append_rows(
+            &provider,
+            &context,
+            &schema,
+            &ctx,
+            vec![int64_batch(&schema, vec![1, 2, 3])],
+        )
+        .await
+        .expect("write");
+        assert_eq!(written, 3);
+
+        let cache = ctx.runtime_env().cache_manager.get_file_metadata_cache();
+        let entries = cache.list_entries();
+        assert!(
+            !entries.is_empty(),
+            "the staged write must leave footer-cache entries"
+        );
+        // The published snapshot may reference files at the path they were
+        // written (no relocation) or move them (staging publish flows); in
+        // both cases the invariant is the same: every cached footer is keyed
+        // by a path that still exists, so no entry is orphaned and scans that
+        // list these locations can hit.
+        for path in entries.keys() {
+            let on_disk = std::path::Path::new("/").join(path.as_ref());
+            assert!(
+                on_disk.exists(),
+                "footer-cache entry '{path}' points at a path that no longer exists"
+            );
+        }
+
+        // Directly exercise the re-key mechanism relocation flows use: the
+        // entry moves to the destination key with its footer intact, and the
+        // stale source key is dropped.
+        let (src_key, src_entry) = {
+            let entries = cache.list_entries();
+            let path = entries.keys().next().expect("an entry").clone();
+            let entry = cache.get(&path).expect("entry");
+            (path, entry)
+        };
+        let dst_key = object_store::path::Path::from(format!("{src_key}.moved"));
+        let dst_meta =
+            vortex_datafusion::synthetic_object_meta(dst_key.clone(), src_entry.meta.size);
+        provider.rekey_moved_footer_cache_entries(vec![(src_key.clone(), Some(dst_meta))]);
+        assert!(
+            cache.get(&src_key).is_none(),
+            "source key must be removed by the re-key"
+        );
+        let moved = cache
+            .get(&dst_key)
+            .expect("entry must exist under the destination key");
+        assert!(
+            Arc::ptr_eq(&moved.file_metadata, &src_entry.file_metadata),
+            "the re-key must carry the same cached footer, not a copy"
+        );
+    }
+
     /// An append that carries no rows must complete as a successful no-op —
     /// including on the upsert + retention-filter shape, where the inline
     /// memtable path is barred and the write goes to a new Vortex snapshot.

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -5253,6 +5253,44 @@ impl CayenneTableProvider {
         }
     }
 
+    /// Move write-time footer-cache entries along with staged files.
+    ///
+    /// The Vortex sink caches each written file's footer under the path it
+    /// wrote — for staged writes, the staging directory — while scans look up
+    /// the post-move location, so without this the entries are unreachable and
+    /// the first post-publish scan pays the cold footer read anyway. Each
+    /// `(source, dst_meta)` pair removes the staging-keyed entry and, when the
+    /// post-move listing meta is known (`Some`), re-inserts the same footer
+    /// under the moved location with exactly the meta the delta-applied
+    /// listing will present (`is_valid_for` compares size and mtime exactly).
+    /// Best-effort in every direction: a missing source entry, or a `None`
+    /// meta, degrades to the cold footer read the scan always paid.
+    pub(super) fn rekey_moved_footer_cache_entries(
+        &self,
+        moves: Vec<(object_store::path::Path, Option<ObjectMeta>)>,
+    ) {
+        use datafusion_execution::cache::cache_manager::CachedFileMetadataEntry;
+
+        let cache = self
+            .context
+            .runtime_env()
+            .cache_manager
+            .get_file_metadata_cache();
+        for (source, dst_meta) in moves {
+            let Some(entry) = cache.remove(&source) else {
+                continue;
+            };
+            let Some(dst_meta) = dst_meta else {
+                continue;
+            };
+            let dst = dst_meta.location.clone();
+            cache.put(
+                &dst,
+                CachedFileMetadataEntry::new(dst_meta, entry.file_metadata),
+            );
+        }
+    }
+
     fn record_current_snapshot_files_added(&self, file_count: usize) {
         if file_count == 0 {
             return;
@@ -5339,36 +5377,64 @@ impl CayenneTableProvider {
             Self::sync_snapshot_dir(&target_dir).await?;
             self.record_current_snapshot_files_added(moved_count);
 
-            // Record the moved files' ObjectMeta in the side-channel so the
-            // caller's `publish_current_snapshot_files_changed_under_held_fence`
-            // can delta-apply them onto the list-files cache instead of evicting
-            // the whole directory listing. Best-effort: if stat fails for any
-            // file we skip the side-channel entirely (leaving `None`), so the
-            // publish falls back to a full eviction + re-LIST — never wrong, just
-            // not incremental.
+            // Stat the moved files for the list-files-cache delta-apply below.
+            // Best-effort: if stat fails for any file this stays `None`, so the
+            // publish falls back to a full eviction + re-LIST — never wrong,
+            // just not incremental.
             //
             // ONLY when the move target is the live current snapshot. A
             // compaction/overwrite move targets a not-yet-current snapshot and is
             // followed by `refresh_listing_table_under_held_fence` (which evicts),
             // NOT this delta path — recording its files would let a later
             // current-snapshot publish apply the WRONG snapshot's additions.
-            if self.get_current_snapshot_id() == current_snapshot {
+            let delta_metas = if self.get_current_snapshot_id() == current_snapshot {
                 let snapshot_dir_url = Self::snapshot_dir_url(
                     &self.table_metadata.path,
                     &self.table_metadata.table_id,
                     current_snapshot,
                 );
-                if let Some(metas) = self
-                    .stat_moved_files_as_object_metas(
-                        &snapshot_dir_url,
-                        &target_dir,
-                        &moved_file_names,
-                    )
-                    .await
-                {
-                    *self.last_moved_snapshot_files.lock() =
-                        Some((current_snapshot.to_string(), metas));
-                }
+                self.stat_moved_files_as_object_metas(
+                    &snapshot_dir_url,
+                    &target_dir,
+                    &moved_file_names,
+                )
+                .await
+            } else {
+                None
+            };
+
+            // Move the write-time footer-cache entries along with the files
+            // (see `rekey_moved_footer_cache_entries`). `delta_metas` is
+            // index-aligned with `moved_file_names` when present.
+            let staging_prefix = ListingTableUrl::parse(Self::snapshot_dir_url(
+                &self.table_metadata.path,
+                &self.table_metadata.table_id,
+                staging_snapshot_id,
+            ))
+            .ok()
+            .map(|url| url.prefix().clone());
+            if let Some(staging_prefix) = staging_prefix {
+                let moves = moved_file_names
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, name)| {
+                        let name = name.to_str()?;
+                        Some((
+                            staging_prefix.clone().join(name),
+                            delta_metas.as_ref().and_then(|metas| metas.get(i).cloned()),
+                        ))
+                    })
+                    .collect();
+                self.rekey_moved_footer_cache_entries(moves);
+            }
+
+            // Record the moved files' ObjectMeta in the side-channel so the
+            // caller's `publish_current_snapshot_files_changed_under_held_fence`
+            // can delta-apply them onto the list-files cache instead of evicting
+            // the whole directory listing.
+            if let Some(metas) = delta_metas {
+                *self.last_moved_snapshot_files.lock() =
+                    Some((current_snapshot.to_string(), metas));
             }
         }
 
@@ -5553,6 +5619,17 @@ impl CayenneTableProvider {
         );
 
         self.record_current_snapshot_files_added(file_moves.len());
+
+        // Move the write-time footer-cache entries along with the objects (see
+        // `rekey_moved_footer_cache_entries`). `moved_metas` is index-aligned
+        // with `file_moves` when the cache prefix parsed; otherwise this
+        // degrades to removing the now-stale staging-keyed entries.
+        let footer_cache_moves = file_moves
+            .iter()
+            .enumerate()
+            .map(|(i, (source, _))| (source.clone(), moved_metas.get(i).cloned()))
+            .collect();
+        self.rekey_moved_footer_cache_entries(footer_cache_moves);
 
         // Record the moved files for the list-files-cache delta-apply (see
         // `last_moved_snapshot_files`). Only when (a) the move target is the live

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -27488,13 +27488,10 @@ impl CayenneTableProvider {
             if object_store_url.is_none() {
                 object_store_url = Some(listing_url.clone());
             }
-            let object_meta = ObjectMeta {
-                location: listing_url.prefix().clone(),
-                last_modified: chrono::DateTime::UNIX_EPOCH,
-                size: u64::try_from(file.file_size_bytes).unwrap_or(0),
-                e_tag: None,
-                version: None,
-            };
+            let object_meta = vortex_datafusion::synthetic_object_meta(
+                listing_url.prefix().clone(),
+                u64::try_from(file.file_size_bytes).unwrap_or(0),
+            );
             let mut part_file = PartitionedFile::from(object_meta);
             if let Some(stats) = crate::stats::statistics_from_persisted_blob(
                 &file.statistics_blob,
@@ -27633,16 +27630,14 @@ impl CayenneTableProvider {
             // (if any) are excluded identically.
             .filter(|file| file.file_size_bytes > 0)
             .map(|file| {
-                let object_meta = ObjectMeta {
-                    location: prefix.clone().join(file.file_path.as_str()),
-                    // `last_modified` is unused by the Vortex scan (it reads
-                    // footer stats by location/size); a fixed epoch keeps the
-                    // value deterministic without an extra stat round-trip.
-                    last_modified: chrono::DateTime::UNIX_EPOCH,
-                    size: u64::try_from(file.file_size_bytes).unwrap_or(0),
-                    e_tag: None,
-                    version: None,
-                };
+                // `synthetic_object_meta` stamps the epoch mtime the Vortex
+                // write path also stamps on its footer-cache entries, so
+                // `is_valid_for` matches and post-write scans reuse the
+                // just-written footers instead of re-reading them cold.
+                let object_meta = vortex_datafusion::synthetic_object_meta(
+                    prefix.clone().join(file.file_path.as_str()),
+                    u64::try_from(file.file_size_bytes).unwrap_or(0),
+                );
                 // Same conversion `pruned_partition_list` uses for the
                 // unpartitioned case (`object_meta.into()`).
                 PartitionedFile::from(object_meta)

--- a/crates/vortex/src/persistent/cache.rs
+++ b/crates/vortex/src/persistent/cache.rs
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::sync::Arc;
+
+use datafusion_execution::cache::cache_manager::CachedFileMetadataEntry;
 use datafusion_execution::cache::cache_manager::FileMetadata;
+use datafusion_execution::cache::cache_manager::FileMetadataCache;
+use object_store::ObjectMeta;
+use object_store::path::Path;
 use vortex::file::Footer;
 use vortex::file::VortexFile;
 
@@ -13,10 +19,13 @@ pub struct CachedVortexMetadata {
 impl CachedVortexMetadata {
     /// Create a new cached metadata entry from a `VortexFile`.
     pub fn new(vortex_file: &VortexFile) -> Self {
-        let footer = vortex_file.footer();
-        Self {
-            footer: footer.clone(),
-        }
+        Self::from_footer(vortex_file.footer().clone())
+    }
+
+    /// Create a cached metadata entry directly from a just-written file's footer,
+    /// so the write path can populate the cache without reading the file back.
+    pub fn from_footer(footer: Footer) -> Self {
+        Self { footer }
     }
 
     /// Get the cached footer.
@@ -41,4 +50,41 @@ impl FileMetadata for CachedVortexMetadata {
     fn extra_info(&self) -> std::collections::HashMap<String, String> {
         std::collections::HashMap::default()
     }
+}
+
+/// The `ObjectMeta` for files whose consumers list from recorded metadata (a
+/// catalog / metastore) rather than the object store: the recorded file size
+/// plus the Unix-epoch mtime. [`CachedFileMetadataEntry::is_valid_for`]
+/// compares size and mtime *exactly*, so a writer caching an entry at write
+/// time and a reader listing from recorded metadata must both build their
+/// metas through this constructor for the entry to ever hit.
+#[must_use]
+pub fn synthetic_object_meta(location: Path, size: u64) -> ObjectMeta {
+    ObjectMeta {
+        location,
+        last_modified: std::time::SystemTime::UNIX_EPOCH.into(),
+        size,
+        e_tag: None,
+        version: None,
+    }
+}
+
+/// Insert a footer into the file-metadata cache, emitting the footer-cache
+/// right-sizing telemetry (the accounted footer size is what fills the cache
+/// budget) shared by every population site.
+pub(crate) fn cache_footer(
+    cache: &Arc<dyn FileMetadataCache>,
+    meta: ObjectMeta,
+    cached: Arc<CachedVortexMetadata>,
+    src: &'static str,
+) {
+    tracing::debug!(
+        target: "vortex::footer_cache",
+        path = %meta.location,
+        footer_bytes = cached.memory_size(),
+        src,
+        "footer cached",
+    );
+    let location = meta.location.clone();
+    cache.put(&location, CachedFileMetadataEntry::new(meta, cached));
 }

--- a/crates/vortex/src/persistent/format.rs
+++ b/crates/vortex/src/persistent/format.rs
@@ -36,7 +36,6 @@ use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::file_sink_config::FileSinkConfig;
 use datafusion_datasource::sink::DataSinkExec;
 use datafusion_datasource::source::DataSourceExec;
-use datafusion_execution::cache::cache_manager::CachedFileMetadataEntry;
 use datafusion_expr::dml::InsertOp;
 use datafusion_physical_expr::LexRequirement;
 use datafusion_physical_expr::PhysicalExprRef;
@@ -72,6 +71,7 @@ use vortex::session::VortexSession;
 
 use super::access_plan::VortexAccessPlanProvider;
 use super::cache::CachedVortexMetadata;
+use super::cache::cache_footer;
 use super::segment_cache;
 use super::segment_cache::SharedSegmentCache;
 use super::sink::{ShardSpec, VortexSink};
@@ -707,8 +707,9 @@ impl FileFormat for VortexFormat {
                             .as_any()
                             .downcast_ref::<CachedVortexMetadata>()
                     {
-                        let inferred_schema =
-                            session.arrow().to_arrow_schema(cached_vortex.footer().dtype())?;
+                        let inferred_schema = session
+                            .arrow()
+                            .to_arrow_schema(cached_vortex.footer().dtype())?;
                         return VortexResult::Ok((object.location, inferred_schema));
                     }
 
@@ -728,17 +729,7 @@ impl FileFormat for VortexFormat {
 
                     // Cache the metadata
                     let cached_metadata = Arc::new(CachedVortexMetadata::new(&vxf));
-                    // Footer-cache right-sizing telemetry: the accounted footer
-                    // size (what fills the FileMetadataCache budget) per file.
-                    tracing::debug!(
-                        target: "vortex::footer_cache",
-                        path = %object.location,
-                        footer_bytes = datafusion_execution::cache::cache_manager::FileMetadata::memory_size(cached_metadata.as_ref()),
-                        src = "infer_schema",
-                        "footer cached",
-                    );
-                    let entry = CachedFileMetadataEntry::new(object.clone(), cached_metadata);
-                    cache.put(&object.location, entry);
+                    cache_footer(&cache, object.clone(), cached_metadata, "infer_schema");
 
                     let inferred_schema = session.arrow().to_arrow_schema(vxf.dtype())?;
                     VortexResult::Ok((object.location, inferred_schema))
@@ -825,16 +816,7 @@ impl FileFormat for VortexFormat {
 
                 // Cache the metadata
                 let cached = Arc::new(CachedVortexMetadata::new(&vxf));
-                // Footer-cache right-sizing telemetry (see infer_schema above).
-                tracing::debug!(
-                    target: "vortex::footer_cache",
-                    path = %object.location,
-                    footer_bytes = datafusion_execution::cache::cache_manager::FileMetadata::memory_size(cached.as_ref()),
-                    src = "infer_stats",
-                    "footer cached",
-                );
-                let entry = CachedFileMetadataEntry::new(object.clone(), cached);
-                file_metadata_cache.put(&object.location, entry);
+                cache_footer(&file_metadata_cache, object.clone(), cached, "infer_stats");
 
                 (
                     vxf.dtype().clone(),

--- a/crates/vortex/src/persistent/mod.rs
+++ b/crates/vortex/src/persistent/mod.rs
@@ -4,6 +4,7 @@
 //! Persistent implementation of a Vortex table provider.
 mod access_plan;
 mod cache;
+pub use cache::synthetic_object_meta;
 mod format;
 pub mod metrics;
 mod opener;

--- a/crates/vortex/src/persistent/sink.rs
+++ b/crates/vortex/src/persistent/sink.rs
@@ -45,6 +45,10 @@ use vortex::io::object_store::ObjectStoreWrite;
 use vortex::session::VortexSession;
 use vortex_utils::aliases::hash_set::HashSet;
 
+use crate::persistent::cache::CachedVortexMetadata;
+use crate::persistent::cache::cache_footer;
+use crate::persistent::cache::synthetic_object_meta;
+
 /// How [`VortexSink`] fans a single input stream into N concurrent file writers.
 ///
 /// `Single` reproduces the historical one-writer-per-statement behavior. The
@@ -308,6 +312,9 @@ impl DataSink for VortexSink {
         // parallelizes Vortex encode across shards (the framework demuxer does
         // not).
         if !self.config.table_partition_cols.is_empty() {
+            // No write-time footer caching on this path: partitioned tables are
+            // listed with real store mtimes, so an epoch-stamped entry (see
+            // `synthetic_object_meta`) could never validate.
             return FileSink::write_all(self, data, context).await;
         }
 
@@ -343,6 +350,10 @@ impl DataSink for VortexSink {
         .await?;
 
         let mut row_count = 0_u64;
+        let file_metadata_cache = context
+            .runtime_env()
+            .cache_manager
+            .get_file_metadata_cache();
         for (path, summary) in summaries {
             row_count = row_count.checked_add(summary.row_count()).ok_or_else(|| {
                 exec_datafusion_err!(
@@ -351,6 +362,17 @@ impl DataSink for VortexSink {
                     summary.row_count()
                 )
             })?;
+            // Cache the just-written footer so the first post-write scan skips
+            // the cold footer read. Only readers that list from recorded
+            // metadata can hit this entry (see `synthetic_object_meta`);
+            // listings carrying real store mtimes miss and read the footer as
+            // before.
+            cache_footer(
+                &file_metadata_cache,
+                synthetic_object_meta(path.clone(), summary.size()),
+                Arc::new(CachedVortexMetadata::from_footer(summary.footer().clone())),
+                "write",
+            );
             tracing::debug!(path = %path, "Successfully written file");
         }
 
@@ -943,6 +965,58 @@ mod tests {
             &batches
         );
 
+        Ok(())
+    }
+
+    /// Write-time footer-cache population: `write_all` caches each written
+    /// file's footer, so the first post-write scan (e.g. right after an
+    /// acceleration refresh) skips the cold footer read.
+    #[tokio::test]
+    async fn test_write_all_populates_file_metadata_cache() -> anyhow::Result<()> {
+        use crate::persistent::cache::CachedVortexMetadata;
+
+        let ctx = TestSessionContext::default();
+        ctx.session
+            .sql(
+                "CREATE EXTERNAL TABLE my_tbl \
+                    (c1 VARCHAR NOT NULL, c2 INT NOT NULL) \
+                STORED AS vortex \
+                LOCATION 'table/';",
+            )
+            .await?;
+
+        let cache = ctx
+            .session
+            .runtime_env()
+            .cache_manager
+            .get_file_metadata_cache();
+
+        ctx.session
+            .sql("INSERT INTO my_tbl VALUES ('hello', 1), ('world', 2);")
+            .await?
+            .collect()
+            .await?;
+
+        let entries = cache.list_entries();
+        assert!(
+            !entries.is_empty(),
+            "write_all must cache the written files' footers"
+        );
+        for path in entries.keys() {
+            let entry = cache.get(path).expect("entry for listed path");
+            // The cached footer is complete: usable without reading the file back.
+            let footer = entry
+                .file_metadata
+                .as_any()
+                .downcast_ref::<CachedVortexMetadata>()
+                .expect("cached entry holds Vortex footer metadata")
+                .footer();
+            assert_eq!(footer.row_count(), 2);
+            // The validation meta carries the epoch mtime `synthetic_object_meta`
+            // stamps, so recorded-metadata listings can match it.
+            assert!(entry.meta.size > 0);
+            assert_eq!(entry.meta.last_modified.timestamp(), 0);
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Description

The first scan after a write — e.g. immediately after an acceleration refresh — pays a cold footer read for every newly written Vortex file, which lands on scan tail latency. The footer of each written file is already in hand at write completion (`WriteSummary` carries it), so `VortexSink::write_all` now puts it into the runtime `FileMetadataCache` directly: no read-back I/O, no background warmup task, and it covers refresh, append, and compaction writes uniformly.

A cache entry only hits if the reader's listing `ObjectMeta` byte-matches the writer's (`is_valid_for` compares size and mtime exactly), so the synthetic-meta convention — recorded size, epoch mtime — moves from per-site literals into one named constructor, `synthetic_object_meta`, now shared by the write path and Cayenne's metastore-driven listings. The three footer-cache population sites (schema/stats inference and the new write path) share one `cache_footer` helper carrying the existing right-sizing telemetry.

Partitioned writes are deliberately excluded: their readers list with real store mtimes, so an epoch-stamped entry could never validate — noted at the exclusion point.

## Changes

- `VortexSink::write_all`: cache each written file's footer after a successful write
- `CachedVortexMetadata::from_footer`: build the entry from a just-written footer; `new` delegates to it
- `synthetic_object_meta`: single definition of the recorded-size/epoch-mtime validation contract, adopted by Cayenne's two metastore listing sites
- `cache_footer`: shared population + telemetry helper replacing three inline copies
- Test: `test_write_all_populates_file_metadata_cache`
- Re-key on staged-file moves: both staging-move sites (local rename, S3 copy) transfer the write-time entries to the moved locations, stamped with the metas the list-files-cache delta-apply records; test pins the no-orphaned-keys invariant
