### PR TITLE
Add MS MARCO and StackOverflowQA search benchmark datasets

### DIFF
--- a/.github/workflows/testoperator_run_search.yml
+++ b/.github/workflows/testoperator_run_search.yml
@@ -36,6 +36,8 @@ on:
           - 'scifact_retrieval'
           - 'nfcorpus_retrieval'
           - 'touche2020_retrieval'
+          - 'msmarco_retrieval'
+          - 'stackoverflow_qa_retrieval'
       ready_wait:
         description: 'Seconds to wait for the spiced instance to become ready'
         required: false

--- a/test/spicepods/search/mteb/msmarco/full_text_search-cayenne[file].yaml
+++ b/test/spicepods/search/mteb/msmarco/full_text_search-cayenne[file].yaml
@@ -1,0 +1,30 @@
+version: v1
+kind: Spicepod
+name: full_text_search-cayenne[file]
+datasets:
+
+  # MTEB MSMARCO Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/msmarco
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+    columns:
+      - name: text
+        full_text_search:
+          enabled: true
+          row_id:
+            - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true

--- a/test/spicepods/search/mteb/msmarco/full_text_search-duckdb[file].yaml
+++ b/test/spicepods/search/mteb/msmarco/full_text_search-duckdb[file].yaml
@@ -1,0 +1,29 @@
+version: v1
+kind: Spicepod
+name: full_text_search-duckdb[file]
+datasets:
+
+  # MTEB MSMARCO Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/msmarco
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+    columns:
+      - name: text
+        full_text_search:
+          enabled: true
+          row_id:
+            - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:

--- a/test/spicepods/search/mteb/msmarco/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/msmarco/hf[all-minilm-l6-v2]-arrow.yaml
@@ -1,0 +1,34 @@
+version: v1
+kind: Spicepod
+name: hf[all-minilm-l6-v2]-arrow
+datasets:
+
+  # MTEB MSMARCO Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/msmarco
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+    columns:
+      - name: text
+        embeddings:
+          - from: minilm_embed
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+    name: minilm_embed
+    params:
+      truncate: END

--- a/test/spicepods/search/mteb/msmarco/hybrid[model2vec[potion-multilingual-128M]]-duckdb[file].yaml
+++ b/test/spicepods/search/mteb/msmarco/hybrid[model2vec[potion-multilingual-128M]]-duckdb[file].yaml
@@ -1,0 +1,38 @@
+version: v1
+kind: Spicepod
+name: hybrid[model2vec[potion-multilingual-128M]]-duckdb[file]
+datasets:
+
+  # MTEB MSMARCO Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/msmarco
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+    columns:
+      - name: text
+        full_text_search:
+          enabled: true
+          row_id:
+            - _id
+        embeddings:
+          - from: potion
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: model2vec:minishlab/potion-multilingual-128M
+    name: potion

--- a/test/spicepods/search/mteb/msmarco/model2vec[potion-multilingual-128M]-cayenne[file].yaml
+++ b/test/spicepods/search/mteb/msmarco/model2vec[potion-multilingual-128M]-cayenne[file].yaml
@@ -1,0 +1,34 @@
+version: v1
+kind: Spicepod
+name: model2vec[potion-multilingual-128M]-cayenne[file]
+datasets:
+
+  # MTEB MSMARCO Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/msmarco
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+    columns:
+      - name: text
+        embeddings:
+          - from: potion
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: model2vec:minishlab/potion-multilingual-128M
+    name: potion

--- a/test/spicepods/search/mteb/msmarco/model2vec[potion-multilingual-128M]-duckdb[file].yaml
+++ b/test/spicepods/search/mteb/msmarco/model2vec[potion-multilingual-128M]-duckdb[file].yaml
@@ -1,0 +1,34 @@
+version: v1
+kind: Spicepod
+name: model2vec[potion-multilingual-128M]-duckdb[file]
+datasets:
+
+  # MTEB MSMARCO Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/msmarco
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+    columns:
+      - name: text
+        embeddings:
+          - from: potion
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: model2vec:minishlab/potion-multilingual-128M
+    name: potion

--- a/test/spicepods/search/mteb/msmarco/model2vec[potion-multilingual-128M]-s3_vectors.yaml
+++ b/test/spicepods/search/mteb/msmarco/model2vec[potion-multilingual-128M]-s3_vectors.yaml
@@ -1,0 +1,41 @@
+version: v1
+kind: Spicepod
+name: model2vec[potion-multilingual-128M]-s3_vectors
+datasets:
+
+  # MTEB MSMARCO Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/msmarco
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+    vectors:
+      enabled: true
+      engine: s3_vectors
+      params:
+        s3_vectors_bucket: spice-ci-search-benchmarks-variant-001
+        s3_vectors_index: msmarco
+        s3_vectors_aws_region: us-east-2
+        s3_vectors_aws_access_key_id: ${env:AWS_S3_VECTORS_KEY}
+        s3_vectors_aws_secret_access_key: ${env:AWS_S3_VECTORS_SECRET}
+    columns:
+      - name: text
+        embeddings:
+          - from: potion
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: model2vec:minishlab/potion-multilingual-128M
+    name: potion

--- a/test/spicepods/search/mteb/stackoverflow_qa/full_text_search-cayenne[file].yaml
+++ b/test/spicepods/search/mteb/stackoverflow_qa/full_text_search-cayenne[file].yaml
@@ -1,0 +1,30 @@
+version: v1
+kind: Spicepod
+name: full_text_search-cayenne[file]
+datasets:
+
+  # MTEB StackOverflowQA Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/stackoverflow-qa
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+    columns:
+      - name: text
+        full_text_search:
+          enabled: true
+          row_id:
+            - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true

--- a/test/spicepods/search/mteb/stackoverflow_qa/full_text_search-duckdb[file].yaml
+++ b/test/spicepods/search/mteb/stackoverflow_qa/full_text_search-duckdb[file].yaml
@@ -1,0 +1,29 @@
+version: v1
+kind: Spicepod
+name: full_text_search-duckdb[file]
+datasets:
+
+  # MTEB StackOverflowQA Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/stackoverflow-qa
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+    columns:
+      - name: text
+        full_text_search:
+          enabled: true
+          row_id:
+            - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:

--- a/test/spicepods/search/mteb/stackoverflow_qa/hf[all-minilm-l6-v2]-arrow.yaml
+++ b/test/spicepods/search/mteb/stackoverflow_qa/hf[all-minilm-l6-v2]-arrow.yaml
@@ -1,0 +1,34 @@
+version: v1
+kind: Spicepod
+name: hf[all-minilm-l6-v2]-arrow
+datasets:
+
+  # MTEB StackOverflowQA Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/stackoverflow-qa
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+    columns:
+      - name: text
+        embeddings:
+          - from: minilm_embed
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+    name: minilm_embed
+    params:
+      truncate: END

--- a/test/spicepods/search/mteb/stackoverflow_qa/hybrid[model2vec[potion-multilingual-128M]]-duckdb[file].yaml
+++ b/test/spicepods/search/mteb/stackoverflow_qa/hybrid[model2vec[potion-multilingual-128M]]-duckdb[file].yaml
@@ -1,0 +1,38 @@
+version: v1
+kind: Spicepod
+name: hybrid[model2vec[potion-multilingual-128M]]-duckdb[file]
+datasets:
+
+  # MTEB StackOverflowQA Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/stackoverflow-qa
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+    columns:
+      - name: text
+        full_text_search:
+          enabled: true
+          row_id:
+            - _id
+        embeddings:
+          - from: potion
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: model2vec:minishlab/potion-multilingual-128M
+    name: potion

--- a/test/spicepods/search/mteb/stackoverflow_qa/model2vec[potion-multilingual-128M]-cayenne[file].yaml
+++ b/test/spicepods/search/mteb/stackoverflow_qa/model2vec[potion-multilingual-128M]-cayenne[file].yaml
@@ -1,0 +1,34 @@
+version: v1
+kind: Spicepod
+name: model2vec[potion-multilingual-128M]-cayenne[file]
+datasets:
+
+  # MTEB StackOverflowQA Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/stackoverflow-qa
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: cayenne
+      mode: file
+    columns:
+      - name: text
+        embeddings:
+          - from: potion
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: model2vec:minishlab/potion-multilingual-128M
+    name: potion

--- a/test/spicepods/search/mteb/stackoverflow_qa/model2vec[potion-multilingual-128M]-duckdb[file].yaml
+++ b/test/spicepods/search/mteb/stackoverflow_qa/model2vec[potion-multilingual-128M]-duckdb[file].yaml
@@ -1,0 +1,34 @@
+version: v1
+kind: Spicepod
+name: model2vec[potion-multilingual-128M]-duckdb[file]
+datasets:
+
+  # MTEB StackOverflowQA Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/stackoverflow-qa
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+    columns:
+      - name: text
+        embeddings:
+          - from: potion
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: model2vec:minishlab/potion-multilingual-128M
+    name: potion

--- a/test/spicepods/search/mteb/stackoverflow_qa/model2vec[potion-multilingual-128M]-s3_vectors.yaml
+++ b/test/spicepods/search/mteb/stackoverflow_qa/model2vec[potion-multilingual-128M]-s3_vectors.yaml
@@ -1,0 +1,41 @@
+version: v1
+kind: Spicepod
+name: model2vec[potion-multilingual-128M]-s3_vectors
+datasets:
+
+  # MTEB StackOverflowQA Retrieval dataset files (*.parquet) are automatically downloaded by the test operator.
+  # https://huggingface.co/datasets/mteb/stackoverflow-qa
+
+  - from: file:./corpus.parquet
+    name: corpus
+    acceleration:
+      enabled: true
+    vectors:
+      enabled: true
+      engine: s3_vectors
+      params:
+        s3_vectors_bucket: spice-ci-search-benchmarks-variant-001
+        s3_vectors_index: stackoverflow-qa
+        s3_vectors_aws_region: us-east-2
+        s3_vectors_aws_access_key_id: ${env:AWS_S3_VECTORS_KEY}
+        s3_vectors_aws_secret_access_key: ${env:AWS_S3_VECTORS_SECRET}
+    columns:
+      - name: text
+        embeddings:
+          - from: potion
+            row_id:
+              - _id
+
+  - from: file:./queries.parquet
+    name: test_queries
+    acceleration:
+      enabled: true
+
+  - from: file:./data.parquet
+    name: relevance_data
+    acceleration:
+      enabled: true
+
+embeddings:
+  - from: model2vec:minishlab/potion-multilingual-128M
+    name: potion

--- a/tools/testoperator/dispatch/search/msmarco.yaml
+++ b/tools/testoperator/dispatch/search/msmarco.yaml
@@ -1,0 +1,30 @@
+tests:
+  search:
+    - spicepod_path: test/spicepods/search/mteb/msmarco/full_text_search-duckdb[file].yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: msmarco_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/msmarco/full_text_search-cayenne[file].yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: msmarco_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/msmarco/hf[all-minilm-l6-v2]-arrow.yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: msmarco_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/msmarco/hybrid[model2vec[potion-multilingual-128M]]-duckdb[file].yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: msmarco_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/msmarco/model2vec[potion-multilingual-128M]-duckdb[file].yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: msmarco_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/msmarco/model2vec[potion-multilingual-128M]-cayenne[file].yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: msmarco_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/msmarco/model2vec[potion-multilingual-128M]-s3_vectors.yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: msmarco_retrieval
+      ready_wait: 1800

--- a/tools/testoperator/dispatch/search/stackoverflow_qa.yaml
+++ b/tools/testoperator/dispatch/search/stackoverflow_qa.yaml
@@ -1,0 +1,30 @@
+tests:
+  search:
+    - spicepod_path: test/spicepods/search/mteb/stackoverflow_qa/full_text_search-duckdb[file].yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: stackoverflow_qa_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/stackoverflow_qa/full_text_search-cayenne[file].yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: stackoverflow_qa_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/stackoverflow_qa/hf[all-minilm-l6-v2]-arrow.yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: stackoverflow_qa_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/stackoverflow_qa/hybrid[model2vec[potion-multilingual-128M]]-duckdb[file].yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: stackoverflow_qa_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/stackoverflow_qa/model2vec[potion-multilingual-128M]-duckdb[file].yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: stackoverflow_qa_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/stackoverflow_qa/model2vec[potion-multilingual-128M]-cayenne[file].yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: stackoverflow_qa_retrieval
+      ready_wait: 1800
+    - spicepod_path: test/spicepods/search/mteb/stackoverflow_qa/model2vec[potion-multilingual-128M]-s3_vectors.yaml
+      runner_type: spiceai-dev-runners
+      benchmark_dataset: stackoverflow_qa_retrieval
+      ready_wait: 1800

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -963,6 +963,53 @@ tests:
     }
 
     #[test]
+    fn test_msmarco_search_section_deserialization() {
+        let yaml = "
+tests:
+  search:
+    spicepod_path: test/spicepods/search/mteb/msmarco/full_text_search-duckdb[file].yaml
+    runner_type: spiceai-dev-runners
+    benchmark_dataset: msmarco_retrieval
+    ready_wait: 1800
+";
+
+        let test_file: DispatchTestFile = yaml::from_str(yaml).expect("Failed to deserialize");
+
+        assert!(matches!(
+            test_file.tests.search[0].benchmark_dataset,
+            Some(SearchDatasetArg::MsmarcoRetrieval)
+        ));
+        let serialized =
+            serde_json::to_value(&test_file.tests.search[0]).expect("Failed to serialize");
+        assert_eq!(serialized["benchmark_dataset"], "msmarco_retrieval");
+    }
+
+    #[test]
+    fn test_stackoverflow_qa_search_section_deserialization() {
+        let yaml = "
+tests:
+  search:
+    spicepod_path: test/spicepods/search/mteb/stackoverflow_qa/full_text_search-duckdb[file].yaml
+    runner_type: spiceai-dev-runners
+    benchmark_dataset: stackoverflow_qa_retrieval
+    ready_wait: 1800
+";
+
+        let test_file: DispatchTestFile = yaml::from_str(yaml).expect("Failed to deserialize");
+
+        assert!(matches!(
+            test_file.tests.search[0].benchmark_dataset,
+            Some(SearchDatasetArg::StackoverflowQaRetrieval)
+        ));
+        let serialized =
+            serde_json::to_value(&test_file.tests.search[0]).expect("Failed to serialize");
+        assert_eq!(
+            serialized["benchmark_dataset"],
+            "stackoverflow_qa_retrieval"
+        );
+    }
+
+    #[test]
     fn test_custom_search_section_omits_benchmark_dataset() {
         // A custom run leaves `benchmark_dataset` unset. It must deserialize to `None` and, so the
         // dispatch workflow input stays absent (letting the workflow default to a custom run), it

--- a/tools/testoperator/src/args/search.rs
+++ b/tools/testoperator/src/args/search.rs
@@ -74,6 +74,14 @@ pub enum SearchDatasetArg {
     #[value(name = "touche2020_retrieval")]
     #[serde(rename = "touche2020_retrieval")]
     Touche2020Retrieval,
+    /// MTEB `MSMARCO` (`https://huggingface.co/datasets/mteb/msmarco`).
+    #[value(name = "msmarco_retrieval")]
+    #[serde(rename = "msmarco_retrieval")]
+    MsmarcoRetrieval,
+    /// MTEB `StackOverflowQA` (`https://huggingface.co/datasets/mteb/stackoverflow-qa`).
+    #[value(name = "stackoverflow_qa_retrieval")]
+    #[serde(rename = "stackoverflow_qa_retrieval")]
+    StackoverflowQaRetrieval,
 }
 
 impl std::fmt::Display for SearchDatasetArg {
@@ -88,6 +96,8 @@ impl std::fmt::Display for SearchDatasetArg {
             SearchDatasetArg::ScifactRetrieval => write!(f, "scifact_retrieval"),
             SearchDatasetArg::NfcorpusRetrieval => write!(f, "nfcorpus_retrieval"),
             SearchDatasetArg::Touche2020Retrieval => write!(f, "touche2020_retrieval"),
+            SearchDatasetArg::MsmarcoRetrieval => write!(f, "msmarco_retrieval"),
+            SearchDatasetArg::StackoverflowQaRetrieval => write!(f, "stackoverflow_qa_retrieval"),
         }
     }
 }

--- a/tools/testoperator/src/commands/search/dataset.rs
+++ b/tools/testoperator/src/commands/search/dataset.rs
@@ -43,6 +43,19 @@ const TOUCHE2020_RETRIEVAL_REPOSITORY: MtebRepo = MtebRepo::standard_sharded(
     "mteb/touche2020",
     &["corpus/corpus/0000.parquet", "corpus/corpus/0001.parquet"],
 );
+const MSMARCO_RETRIEVAL_REPOSITORY: MtebRepo = MtebRepo::standard_sharded(
+    "mteb/msmarco",
+    &[
+        "corpus/corpus/0000.parquet",
+        "corpus/corpus/0001.parquet",
+        "corpus/corpus/0002.parquet",
+        "corpus/corpus/0003.parquet",
+        "corpus/corpus/0004.parquet",
+        "corpus/corpus/0005.parquet",
+        "corpus/corpus/0006.parquet",
+    ],
+);
+const STACKOVERFLOW_QA_RETRIEVAL_REPOSITORY: MtebRepo = MtebRepo::standard("mteb/stackoverflow-qa");
 
 /// The search dataset to run against. Each built-in variant owns its own MTEB data preparation,
 /// while `Custom` tests a customer-supplied spicepod as-is. Search-config construction,
@@ -70,6 +83,8 @@ pub(crate) enum BuiltinDataset {
     ScifactRetrieval,
     NfcorpusRetrieval,
     Touche2020Retrieval,
+    MsmarcoRetrieval,
+    StackoverflowQaRetrieval,
 }
 
 impl From<Option<SearchDatasetArg>> for SearchDataset {
@@ -93,6 +108,8 @@ impl From<SearchDatasetArg> for BuiltinDataset {
             SearchDatasetArg::ScifactRetrieval => BuiltinDataset::ScifactRetrieval,
             SearchDatasetArg::NfcorpusRetrieval => BuiltinDataset::NfcorpusRetrieval,
             SearchDatasetArg::Touche2020Retrieval => BuiltinDataset::Touche2020Retrieval,
+            SearchDatasetArg::MsmarcoRetrieval => BuiltinDataset::MsmarcoRetrieval,
+            SearchDatasetArg::StackoverflowQaRetrieval => BuiltinDataset::StackoverflowQaRetrieval,
         }
     }
 }
@@ -109,6 +126,8 @@ impl BuiltinDataset {
             BuiltinDataset::ScifactRetrieval => &SCIFACT_RETRIEVAL_REPOSITORY,
             BuiltinDataset::NfcorpusRetrieval => &NFCORPUS_RETRIEVAL_REPOSITORY,
             BuiltinDataset::Touche2020Retrieval => &TOUCHE2020_RETRIEVAL_REPOSITORY,
+            BuiltinDataset::MsmarcoRetrieval => &MSMARCO_RETRIEVAL_REPOSITORY,
+            BuiltinDataset::StackoverflowQaRetrieval => &STACKOVERFLOW_QA_RETRIEVAL_REPOSITORY,
         }
     }
 
@@ -123,6 +142,8 @@ impl BuiltinDataset {
             BuiltinDataset::ScifactRetrieval => "scifact_retrieval",
             BuiltinDataset::NfcorpusRetrieval => "nfcorpus_retrieval",
             BuiltinDataset::Touche2020Retrieval => "touche2020_retrieval",
+            BuiltinDataset::MsmarcoRetrieval => "msmarco_retrieval",
+            BuiltinDataset::StackoverflowQaRetrieval => "stackoverflow_qa_retrieval",
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds two new MTEB retrieval benchmark datasets to the search test suite: MS MARCO (`mteb/msmarco`, 7-shard corpus) and StackOverflowQA (`mteb/stackoverflow-qa`), following the existing `MtebRepo` standard-layout loader pattern used by the other datasets in the suite.
- Adds `test/spicepods/search/mteb/msmarco/` and `test/spicepods/search/mteb/stackoverflow_qa/` with the same 7 spicepod variants (HF+Arrow, full-text search on DuckDB/Cayenne, vector search on DuckDB/Cayenne/S3 Vectors, hybrid) used by the other datasets.
- Adds matching `tools/testoperator/dispatch/search/{msmarco,stackoverflow_qa}.yaml` dispatch configs, picked up automatically by the scheduled `testoperator dispatch search` workflow.
- Relates to https://github.com/spiceai/spiceai/issues/12223 (candidate benchmark dataset list). BioASQ from that issue is intentionally excluded: its MTEB source is gated on Hugging Face and its only ungated alternative isn't retrieval-shaped (no corpus/queries/qrels).

## Test plan
- [x] `cargo check -p testoperator`
- [x] `cargo clippy -p testoperator --no-deps`
- [x] `cargo fmt -p testoperator -- --check`
- [x] `cargo test -p testoperator` (added `test_msmarco_search_section_deserialization` / `test_stackoverflow_qa_search_section_deserialization`, all existing dispatch tests still pass)
- [ ] Scheduled `testoperator dispatch search` CI run (validates the spicepods end-to-end by downloading the real datasets and running the search harness)