### PR TITLE
fix(cloud-connect): look again when a lock create reports the entry missing

### DIFF
--- a/crates/runtime-cloud-connect/src/draft.rs
+++ b/crates/runtime-cloud-connect/src/draft.rs
@@ -544,18 +544,7 @@ fn open_unix_publication_lock(lock_path: &Path) -> std::io::Result<(std::fs::Fil
             "the enrollment transaction lock name contains a NUL byte",
         )
     })?;
-    let lock_descriptor = unsafe {
-        libc::openat(
-            directory.as_raw_fd(),
-            name.as_ptr(),
-            libc::O_RDWR | libc::O_CREAT | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
-            0o600,
-        )
-    };
-    if lock_descriptor < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    let lock = unsafe { std::fs::File::from_raw_fd(lock_descriptor) };
+    let lock = crate::lock_file::create_or_open_lock_at(&directory, &name)?;
     Ok((lock, directory))
 }
 

--- a/crates/runtime-cloud-connect/src/lib.rs
+++ b/crates/runtime-cloud-connect/src/lib.rs
@@ -78,6 +78,7 @@ pub mod session;
 mod client;
 mod fingerprint;
 mod heartbeat;
+mod lock_file;
 mod shutdown;
 
 /// Generated gRPC types for `spice.cloud.v1.CloudConnect`.

--- a/crates/runtime-cloud-connect/src/lock_file.rs
+++ b/crates/runtime-cloud-connect/src/lock_file.rs
@@ -1,0 +1,148 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Opening the lock file that serializes access to a Cloud Connect directory.
+//!
+//! Every one of these locks is opened relative to a directory descriptor the
+//! caller already holds and has verified, never by pathname, so that no ancestor
+//! symlink substituted after the check can move the lock out from under it.
+
+/// Attempts a create that reports the entry missing may take before the report
+/// is believed.
+///
+/// One further look has always been enough: the entry is already present when
+/// the false report arrives. The bound is generous anyway, because an extra look
+/// costs one syscall while believing a false report costs a failed lock
+/// acquisition.
+#[cfg(unix)]
+const MISSING_ENTRY_ATTEMPTS: u32 = 16;
+
+/// Create `name` inside `directory`, or open it if it is already there, as the
+/// carrier for an advisory lock.
+///
+/// `O_NOFOLLOW` refuses a symlink in the lock's place rather than following it,
+/// and `O_NONBLOCK` keeps the open itself from waiting — the advisory lock is
+/// what a caller waits on.
+///
+/// # Concurrent creation
+///
+/// `O_CREAT` without `O_EXCL` has two correct answers, that the entry was
+/// created or that the existing one was opened, and callers racing on one name
+/// is the situation a lock file exists for. Darwin hands a losing racer neither:
+/// it reports `ENOENT` for a *relative* name whose entry another thread or
+/// process is creating, where the same race resolved through an absolute
+/// pathname returns the open file, and where adding `O_EXCL` correctly reports
+/// `EEXIST`. The entry is present by the time the report arrives, so the answer
+/// is to look again.
+///
+/// The retry is bounded because a parent directory that really has been removed
+/// reports `ENOENT` here too, and that has to stay reportable rather than spin.
+///
+/// # Errors
+///
+/// Returns the underlying `openat` error. `ENOENT` survives
+/// [`MISSING_ENTRY_ATTEMPTS`] looks only when the entry genuinely cannot be
+/// created.
+#[cfg(unix)]
+pub(crate) fn create_or_open_lock_at(
+    directory: &std::fs::File,
+    name: &std::ffi::CStr,
+) -> std::io::Result<std::fs::File> {
+    use std::os::fd::{AsRawFd as _, FromRawFd as _};
+
+    let mut attempts = 0;
+    loop {
+        let descriptor = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDWR
+                    | libc::O_CREAT
+                    | libc::O_CLOEXEC
+                    | libc::O_NOFOLLOW
+                    | libc::O_NONBLOCK,
+                0o600,
+            )
+        };
+        if descriptor >= 0 {
+            return Ok(unsafe { std::fs::File::from_raw_fd(descriptor) });
+        }
+        let error = std::io::Error::last_os_error();
+        attempts += 1;
+        if error.kind() != std::io::ErrorKind::NotFound || attempts >= MISSING_ENTRY_ATTEMPTS {
+            return Err(error);
+        }
+        std::thread::yield_now();
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    /// Every caller racing to create one lock file gets a descriptor for it.
+    /// Serializing concurrent access is the whole purpose, so a caller that
+    /// merely arrived second must never be told the lock does not exist.
+    #[test]
+    fn concurrent_callers_all_open_the_same_lock() {
+        let directory = tempfile::tempdir().expect("create tempdir");
+        let handle = std::fs::File::open(directory.path()).expect("open the directory");
+        let name = c"contended.lock";
+        let start = std::sync::Barrier::new(16);
+
+        let opened = std::thread::scope(|scope| {
+            let workers: Vec<_> = (0..16)
+                .map(|_| {
+                    scope.spawn(|| {
+                        start.wait();
+                        create_or_open_lock_at(&handle, name)
+                    })
+                })
+                .collect();
+            workers
+                .into_iter()
+                .map(|worker| worker.join().expect("the worker finishes"))
+                .collect::<Vec<_>>()
+        });
+
+        for result in &opened {
+            assert!(
+                result.is_ok(),
+                "a caller that arrived second must still open the lock: {:?}",
+                result.as_ref().err()
+            );
+        }
+        assert!(
+            directory.path().join("contended.lock").is_file(),
+            "the contended lock must be left as a regular file"
+        );
+    }
+
+    /// A directory that is gone cannot carry a lock, and the retry must not turn
+    /// that into a spin or a different error.
+    #[test]
+    fn a_removed_directory_still_reports_the_missing_entry() {
+        let directory = tempfile::tempdir().expect("create tempdir");
+        let handle = std::fs::File::open(directory.path()).expect("open the directory");
+        // The descriptor outlives the name, which is exactly the state a
+        // released instance directory leaves behind.
+        std::fs::remove_dir_all(directory.path()).expect("remove the directory");
+
+        let error = create_or_open_lock_at(&handle, c"orphaned.lock")
+            .expect_err("a removed directory cannot carry a lock");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound, "{error}");
+    }
+}

--- a/crates/runtime-cloud-connect/src/mutation_lock.rs
+++ b/crates/runtime-cloud-connect/src/mutation_lock.rs
@@ -408,22 +408,12 @@ fn open_unix_lock_file(config_dir: &Path, path: &Path) -> Result<(File, File)> {
         }
     }
 
-    let lock_name = c"connect.lock";
-    let lock_fd = unsafe {
-        libc::openat(
-            directory.as_raw_fd(),
-            lock_name.as_ptr(),
-            libc::O_RDWR | libc::O_CREAT | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
-            0o600,
-        )
-    };
-    if lock_fd < 0 {
-        return Err(Error::Io {
+    let lock = crate::lock_file::create_or_open_lock_at(&directory, c"connect.lock").map_err(
+        |source| Error::Io {
             path: path.to_path_buf(),
-            source: std::io::Error::last_os_error(),
-        });
-    }
-    let lock = unsafe { File::from_raw_fd(lock_fd) };
+            source,
+        },
+    )?;
     Ok((lock, directory))
 }
 

--- a/crates/runtime-cloud-connect/src/runtime_lock.rs
+++ b/crates/runtime-cloud-connect/src/runtime_lock.rs
@@ -217,25 +217,15 @@ impl RuntimeLock {
 /// runtime on `open` or be locked in place of the real file.
 #[cfg(unix)]
 fn open_lock_file(directory: &File, path: &Path) -> Result<File> {
-    use std::os::fd::{AsRawFd as _, FromRawFd as _};
     use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
 
-    let lock_name = c"runtime.lock";
-    let fd = unsafe {
-        libc::openat(
-            directory.as_raw_fd(),
-            lock_name.as_ptr(),
-            libc::O_RDWR | libc::O_CREAT | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
-            0o600,
-        )
-    };
-    if fd < 0 {
-        return Err(Error::Unusable {
-            path: path.to_path_buf(),
-            source: std::io::Error::last_os_error(),
-        });
-    }
-    let file = unsafe { File::from_raw_fd(fd) };
+    let file =
+        crate::lock_file::create_or_open_lock_at(directory, c"runtime.lock").map_err(|source| {
+            Error::Unusable {
+                path: path.to_path_buf(),
+                source,
+            }
+        })?;
     let metadata = validate_regular_lock_file(&file, path)?;
     if metadata.nlink() != 1 {
         return Err(Error::Unusable {


### PR DESCRIPTION
## The defect

Every Cloud Connect lock is created with `openat` relative to a directory descriptor the caller already holds and has verified, rather than by pathname, so that no ancestor symlink swapped in after the check can move the lock. On Darwin that form has a defect the absolute-path form does not: **a caller that loses a concurrent create race on the same name is handed `ENOENT` rather than the open file**, and the entry is provably present the moment the error arrives (`access` and `faccessat` both succeed immediately after).

`O_CREAT` without `O_EXCL` has two correct answers — the entry was created, or the existing one was opened — and callers racing on one name is precisely the situation a lock file exists for. So the failure lands on the paths least able to afford it:

- `.enrollment-draft.lock` — the enrollment transaction lock
- `runtime.lock` — what stops two runtimes serving one instance directory
- `connect.lock` — the `spice connect` mutation lock

Two `spiced` processes starting in one instance directory, or two `spice` mutations of one directory, see `No such file or directory` instead of one taking the lock and the rest waiting on it. `Error::CreationInProgress` — the answer meaning *another process is creating this, wait* — is unreachable on macOS, because a loser never obtains a descriptor to wait on.

## Evidence

Measured on Darwin 25.6.0 in C, 8 concurrent callers on one name, 200 rounds:

| form | succeeds | spurious `ENOENT` |
| --- | --- | --- |
| `openat(dirfd, "relative-name", O_CREAT)` — threads | 200/1600 | **1400** |
| `openat(dirfd, "relative-name", O_CREAT)` — separate processes | 200/1600 | **1400** |
| `openat(dirfd, "/absolute/path", O_CREAT)` | 1600/1600 | 0 |
| `openat(dirfd, "relative-name", O_CREAT \| O_EXCL)` | 200/1600 | 0 (1400 correct `EEXIST`) |

Separate processes fail exactly as threads do, so this is not an artifact of a threaded test. The two `O_EXCL` staging writes in this crate are unaffected for the reason the last row shows, and are left as they are.

## The fix

`lock_file::create_or_open_lock_at` looks again when the entry is reported missing. One further look has always sufficed — 0 failures in 14,400 attempts across 8 threads, 32 threads and 8 processes, deepest retry depth 1 — and the bound keeps a genuinely removed parent directory reportable rather than spinning on it. All three lock sites use it; each keeps its own error mapping.

> [!IMPORTANT]
> `draft::tests::concurrent_creation_publishes_one_operation` is **flaky on `trunk` right now** because of this defect, and can eject unrelated PRs from the merge queue on a macOS runner. If you have landed here from that failure: this PR fixes the root cause, not the test. Do not skip, retry-loop, or `#[ignore]` the test — it is reporting a real defect correctly.

## Why now

`draft::tests::concurrent_creation_publishes_one_operation` exhausted all six nextest retries on a `spiceai-macos` runner and failed a merge-queue build, so this is currently able to eject PRs from the queue. Locally that test passed 0 of 50 isolated runs before this change and 60 of 60 after; it had been passing only under full-suite load, where the scheduler happens to separate the racing threads, which is why it looked intermittent rather than broken.

## Verification

- `runtime-cloud-connect` lib: 296 passed (includes two new tests for the helper)
- The previously failing test: 60/60 isolated runs on this branch's trunk base
- `make lint-rust PACKAGES="runtime-cloud-connect"`: green, both clippy passes

Closes #13232
