### PR TITLE
fix(cloud-connect): heartbeat restart-required, attachment by app id, and this crate's integration tests in the gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,15 @@ endif
 # Shared so `nextest` and `verify-cli` cannot drift onto different selections:
 # a different selection resolves different features, which would make verify-cli
 # recompile instead of reading the build nextest just did.
+#
+# `runtime-cloud-connect`'s integration tests are selected for the same reason
+# cayenne's are: they stand their whole control plane up in-process — a TLS
+# enroll mock and a tonic gateway on ephemeral ports — so unlike the suites in
+# `integration*.yml` they need no credentials and no external service. They are
+# also the only coverage of the enrollment, reconnect, command-dispatch and
+# heartbeat wire paths; `--lib` cannot reach a running client at all.
 NEXTEST_SELECTION := --all --exclude libnfs
-NEXTEST_FILTER := kind(=lib) + kind(=proc-macro) + (package(=cayenne) & kind(=test)) + binary(=metrics)
+NEXTEST_FILTER := kind(=lib) + kind(=proc-macro) + (package(=cayenne) & kind(=test)) + (package(=runtime-cloud-connect) & kind(=test)) + binary(=metrics)
 # Extra narrowing for callers that can't run everything (CI lacks credentials
 # for some tests). It has to *intersect* the expression above rather than sit
 # beside it: nextest unions repeated `-E` flags, so a second `-E 'not (…)'` would

--- a/bin/spice/src/commands/connect/snapshots/spice__commands__connect__status__tests__connect_status_schema.snap
+++ b/bin/spice/src/commands/connect/snapshots/spice__commands__connect__status__tests__connect_status_schema.snap
@@ -11,6 +11,7 @@ expression: json
     "endpoint": "https://api.spice.ai",
     "identifier": "inst_0123456789",
     "org_name": "acme",
+    "app_id": "14034",
     "app_name": "edge-analytics",
     "monitor_url": "https://spice.ai/acme/edge-analytics/monitor",
     "gateway_addr": "connect.aws.spiceai.io:443",

--- a/bin/spice/src/commands/connect/status.rs
+++ b/bin/spice/src/commands/connect/status.rs
@@ -109,8 +109,13 @@ pub(crate) struct ConnectionStatus {
     /// Cloud-assigned instance identifier.
     pub(crate) identifier: Option<String>,
     pub(crate) org_name: Option<String>,
+    /// The attached project's cloud id. This is the attachment itself, so an
+    /// instance holding one is attached whether or not the control plane also
+    /// supplied the name and monitor URL below.
+    pub(crate) app_id: Option<String>,
     pub(crate) app_name: Option<String>,
-    /// Cloud-constructed portal monitor URL, when the instance is attached.
+    /// Cloud-constructed portal monitor URL, when the instance is attached and
+    /// the control plane supplied one.
     pub(crate) monitor_url: Option<String>,
     /// The gateway the control stream dials.
     pub(crate) gateway_addr: Option<String>,
@@ -225,6 +230,7 @@ impl ConnectStatus {
             endpoint: endpoint.to_string(),
             identifier: None,
             org_name: None,
+            app_id: None,
             app_name: None,
             monitor_url: None,
             gateway_addr: None,
@@ -265,6 +271,7 @@ impl ConnectStatus {
                 (!id.gateway_addr.is_empty()).then(|| id.gateway_addr.clone());
             connection.identifier = Some(id.identifier.clone());
             connection.org_name.clone_from(&id.org_name);
+            connection.app_id.clone_from(&id.app_id);
             connection.app_name.clone_from(&id.app_name);
             connection.monitor_url.clone_from(&id.monitor_url);
 
@@ -520,8 +527,14 @@ fn render_connection(connection: &ConnectionStatus) {
         ConnectionState::Enrolled => {
             println!(
                 "Spice Cloud Connect: connected{}",
-                match (&connection.org_name, &connection.app_name) {
-                    (Some(org), Some(app)) => format!(" — {org} / {app}"),
+                // The attachment is `app_id`; the name only labels it. An
+                // instance holding a project it has no name for is still
+                // attached, and saying otherwise is wrong.
+                match (&connection.org_name, &connection.app_id) {
+                    (Some(org), Some(_)) => format!(
+                        " — {org} / {}",
+                        connection.app_name.as_deref().unwrap_or("attached project")
+                    ),
                     (Some(org), None) => format!(" — {org} (no app attached)"),
                     _ => String::new(),
                 }
@@ -897,6 +910,7 @@ mod tests {
                 endpoint: "https://api.spice.ai".to_string(),
                 identifier: Some("inst_0123456789".to_string()),
                 org_name: Some("acme".to_string()),
+                app_id: Some("14034".to_string()),
                 app_name: Some("edge-analytics".to_string()),
                 monitor_url: Some("https://spice.ai/acme/edge-analytics/monitor".to_string()),
                 gateway_addr: Some("connect.aws.spiceai.io:443".to_string()),

--- a/bin/spiced/src/cloud_connect.rs
+++ b/bin/spiced/src/cloud_connect.rs
@@ -1911,6 +1911,15 @@ impl RuntimeHandle for SpicedRuntimeHandle {
         )
     }
 
+    /// Always `Some`: this handle holds the pending set, so an empty answer
+    /// means nothing is pending rather than nothing known.
+    ///
+    /// Read from the same place [`SpicedRuntimeHandle::status`] reads it, so the
+    /// heartbeat and the status document cannot report different sets.
+    async fn restart_required(&self) -> Option<Vec<String>> {
+        Some(self.pending.read().restart_required())
+    }
+
     async fn collect_metrics(&self) -> Result<Option<Vec<u8>>, CommandError> {
         let Some(reader) = &self.metrics else {
             return Ok(None);
@@ -4502,14 +4511,19 @@ tools:
     }
 
     /// What is pending is what `GetStatus` reports, so a caller that asked
-    /// after the deploy reads the same answer as one that watched it.
+    /// after the deploy reads the same answer as one that watched it — and the
+    /// heartbeat carries that same set, from the same source, so a caller
+    /// watching only the heartbeat is not told something else.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn status_reports_what_the_last_deployment_left_pending() {
+    async fn status_and_heartbeat_report_what_the_last_deployment_left_pending() {
         let dir = scratch_dir("status-pending");
         let handle = handle_serving(&dir, SERVING).await;
 
         let status = handle.status().await.expect("status is reported");
         assert_eq!(status.detail["restart_required"], serde_json::json!([]));
+        // Present and empty, never absent: this handle holds the pending set,
+        // so an empty answer means nothing is pending, not nothing known.
+        assert_eq!(handle.restart_required().await, Some(Vec::new()));
 
         let deployed = format!("{SERVING}runtime:\n  dataset_load_parallelism: 2\n");
         handle
@@ -4521,6 +4535,10 @@ tools:
         assert_eq!(
             status.detail["restart_required"],
             serde_json::json!(["runtime"])
+        );
+        assert_eq!(
+            handle.restart_required().await,
+            Some(vec!["runtime".to_string()])
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/bin/spiced/src/connection_report.rs
+++ b/bin/spiced/src/connection_report.rs
@@ -59,18 +59,24 @@ impl CompletionReport {
             |org| terminal_text(org).into_owned(),
         );
 
-        match session.app_name.as_deref() {
-            Some(app) => Self {
-                headline: format!(
-                    "Spice Cloud Connect: connected to {org} / {}",
-                    terminal_text(app)
-                ),
+        // `app_id` is the attachment; the name only labels it, and an
+        // attachment can arrive without one. So the name falls back the way
+        // `org` does, rather than an instance that holds a project being told it
+        // has none and offered a link to create the one it already has.
+        if session.app_id.is_some() {
+            let app = session
+                .app_name
+                .as_deref()
+                .map_or(Cow::Borrowed("attached project"), terminal_text);
+            Self {
+                headline: format!("Spice Cloud Connect: connected to {org} / {app}"),
                 link: session
                     .monitor_url
                     .as_deref()
                     .map(|url| format!("Monitor: {url}")),
-            },
-            None => Self {
+            }
+        } else {
+            Self {
                 headline: format!(
                     "Spice Cloud Connect: connected to {org} — not yet attached to a project"
                 ),
@@ -78,7 +84,7 @@ impl CompletionReport {
                     .new_project_url
                     .as_deref()
                     .map(|url| format!("Create one: {url}")),
-            },
+            }
         }
     }
 
@@ -189,13 +195,17 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
-    fn session(app_name: Option<&str>) -> AcknowledgedSession {
+    /// `app_id` is what makes the instance attached; `app_name` only labels the
+    /// attachment, and the two are supplied separately because the control plane
+    /// can deliver the first without the second.
+    fn session(app_id: Option<&str>, app_name: Option<&str>) -> AcknowledgedSession {
         AcknowledgedSession {
             identifier: "inst_abc".to_string(),
             // No identity on disk: `refreshed` then falls back to this
             // snapshot, which is what these cases are about.
             identity_path: std::path::PathBuf::from("/nonexistent/identity.json"),
             org_name: Some("acme".to_string()),
+            app_id: app_id.map(str::to_string),
             app_name: app_name.map(str::to_string),
             monitor_url: Some("https://spice.ai/acme/edge/monitor".to_string()),
             new_project_url: Some("https://spice.ai/acme/new?instance=inst_abc".to_string()),
@@ -204,7 +214,7 @@ mod tests {
 
     #[test]
     fn an_attached_instance_is_reported_with_its_project_and_monitor_page() {
-        let report = CompletionReport::of(&session(Some("edge")));
+        let report = CompletionReport::of(&session(Some("14034"), Some("edge")));
         assert_eq!(
             report.headline,
             "Spice Cloud Connect: connected to acme / edge"
@@ -217,7 +227,7 @@ mod tests {
 
     #[test]
     fn a_detached_instance_is_sent_to_create_a_project() {
-        let report = CompletionReport::of(&session(None));
+        let report = CompletionReport::of(&session(None, None));
         assert_eq!(
             report.headline,
             "Spice Cloud Connect: connected to acme — not yet attached to a project"
@@ -236,9 +246,34 @@ mod tests {
         );
     }
 
+    /// An attachment the control plane delivered without its display metadata.
+    /// The instance holds a project, so reporting it as unattached — and
+    /// offering to create the project it already has — is the failure this
+    /// guards. `monitor_url` is absent here because it arrives with the name it
+    /// is missing.
+    #[test]
+    fn an_attachment_the_cloud_named_nothing_for_is_still_reported_as_attached() {
+        let mut unlabelled = session(Some("14034"), None);
+        unlabelled.monitor_url = None;
+        let report = CompletionReport::of(&unlabelled);
+
+        assert_eq!(
+            report.headline,
+            "Spice Cloud Connect: connected to acme / attached project"
+        );
+        assert!(
+            !report.headline.contains("not yet attached"),
+            "an instance holding a project must never be told it has none: {}",
+            report.headline
+        );
+        // No monitor page was supplied, and the create-a-project link is for an
+        // instance without one — so there is nothing honest to offer.
+        assert_eq!(report.link, None);
+    }
+
     #[test]
     fn control_plane_names_cannot_inject_terminal_lines_or_escapes() {
-        let mut acknowledged = session(Some("edge\n\u{1b}[31m"));
+        let mut acknowledged = session(Some("14034"), Some("edge\n\u{1b}[31m"));
         acknowledged.org_name = Some("acme\radmin".to_string());
         let report = CompletionReport::of(&acknowledged);
 
@@ -253,18 +288,18 @@ mod tests {
 
     #[test]
     fn a_destination_is_never_invented_when_the_cloud_supplied_none() {
-        let mut detached = session(None);
+        let mut detached = session(None, None);
         detached.new_project_url = None;
         assert!(CompletionReport::of(&detached).link.is_none());
 
-        let mut attached = session(Some("edge"));
+        let mut attached = session(Some("14034"), Some("edge"));
         attached.monitor_url = None;
         assert!(CompletionReport::of(&attached).link.is_none());
     }
 
     #[test]
     fn an_instance_whose_org_was_never_named_is_still_identified() {
-        let mut anonymous = session(None);
+        let mut anonymous = session(None, None);
         anonymous.org_name = None;
         assert_eq!(
             CompletionReport::of(&anonymous).headline,
@@ -296,19 +331,19 @@ mod tests {
 
         match order {
             Order::AcknowledgedThenServing => {
-                ack.record(session(Some("edge")));
+                ack.record(session(Some("14034"), Some("edge")));
                 tokio::task::yield_now().await;
                 serving.cancel();
             }
             Order::ServingThenAcknowledged => {
                 serving.cancel();
                 tokio::task::yield_now().await;
-                ack.record(session(Some("edge")));
+                ack.record(session(Some("14034"), Some("edge")));
             }
             // Each half alone is not a completion: the process goes down with
             // one of the two facts never established.
             Order::AcknowledgedOnly => {
-                ack.record(session(Some("edge")));
+                ack.record(session(Some("14034"), Some("edge")));
                 tokio::task::yield_now().await;
                 shutdown.cancel();
             }
@@ -354,7 +389,7 @@ mod tests {
         let ack = SessionAck::new();
         let serving = CancellationToken::new();
         let withdrawn = CancellationToken::new();
-        ack.record(session(Some("edge")));
+        ack.record(session(Some("14034"), Some("edge")));
         serving.cancel();
         withdrawn.cancel();
 

--- a/crates/runtime-cloud-connect/src/handlers.rs
+++ b/crates/runtime-cloud-connect/src/handlers.rs
@@ -486,6 +486,27 @@ pub trait RuntimeHandle: Send + Sync + 'static {
         ))
     }
 
+    /// The configuration sections whose deployed value is not the one this
+    /// process is running with, sorted and deduplicated: what a restart would
+    /// put into effect. Stamped on every heartbeat.
+    ///
+    /// Not a [`Capability`]: the client pushes it with the heartbeat rather than
+    /// answering a command, so there is nothing to advertise or dispatch.
+    ///
+    /// `None` and `Some` of an empty set are different answers, and the control
+    /// plane reads them as different states: `None` means this instance has no
+    /// restart-state source of truth and claims nothing, an empty `Some` means
+    /// it looked and nothing is pending. The default is `None` for that reason —
+    /// a handle with nothing to read must never send an empty set as a stand-in
+    /// for "unknown".
+    ///
+    /// An implementation answers from the same place its [`Self::status`]
+    /// document does, so the heartbeat and that document cannot disagree about
+    /// what is pending.
+    async fn restart_required(&self) -> Option<Vec<String>> {
+        None
+    }
+
     /// The instance's current metrics, as a serialized OTLP
     /// `ExportMetricsServiceRequest`.
     ///

--- a/crates/runtime-cloud-connect/src/heartbeat.rs
+++ b/crates/runtime-cloud-connect/src/heartbeat.rs
@@ -32,6 +32,10 @@ use crate::proto;
 /// instance. They are deliberately *not* mirrored into
 /// [`build_telemetry`]'s open metrics map: one datum, one channel, so the
 /// two can never disagree about the same number.
+///
+/// `standalone_runtime` follows the same rule: its restart-pending set comes
+/// from [`RuntimeHandle::restart_required`], the same place the `GetStatus`
+/// document reads it, and it is present only when the handle reports one.
 pub(crate) async fn build_heartbeat(
     identifier: &str,
     sequence: u64,
@@ -39,6 +43,13 @@ pub(crate) async fn build_heartbeat(
 ) -> proto::Heartbeat {
     let active_datasets = runtime.active_datasets().await;
     let active_models = runtime.active_models().await;
+    // Presence carries the answer: a handle with no restart-state source of
+    // truth reports nothing, which the control plane reads differently from a
+    // reported empty set.
+    let standalone_runtime = runtime
+        .restart_required()
+        .await
+        .map(|restart_required| proto::StandaloneRuntimeStatus { restart_required });
 
     proto::Heartbeat {
         identifier: identifier.to_string(),
@@ -49,7 +60,7 @@ pub(crate) async fn build_heartbeat(
         active_models,
         active_spicepods: 0,
         runtime_versions: std::collections::HashMap::new(),
-        standalone_runtime: None,
+        standalone_runtime,
     }
 }
 
@@ -156,6 +167,59 @@ mod tests {
         let runtime: Arc<dyn RuntimeHandle> = Arc::new(ReadyHandle);
         let hb = build_heartbeat("inst_test", 1, &runtime).await;
         assert_eq!(hb.phase, proto::RuntimePhase::Ready as i32);
+    }
+
+    /// The runtime's own answer rides on the heartbeat verbatim, and the three
+    /// states stay three: absent claims nothing, a present empty set says
+    /// nothing is pending, a populated one names what is. The control plane acts
+    /// differently on each, so none may collapse into another.
+    #[tokio::test]
+    async fn heartbeat_carries_the_restart_set_the_runtime_reports() {
+        use crate::handlers::Capability;
+        use async_trait::async_trait;
+
+        struct ReportingHandle(Option<Vec<String>>);
+
+        #[async_trait]
+        impl RuntimeHandle for ReportingHandle {
+            fn supports(&self, _capability: Capability) -> bool {
+                false
+            }
+            // This restart-state test handle holds no delivered secrets.
+            async fn clear_cloud_delivered_secrets(&self) {}
+            async fn restart_required(&self) -> Option<Vec<String>> {
+                self.0.clone()
+            }
+        }
+
+        let settled: Arc<dyn RuntimeHandle> = Arc::new(ReportingHandle(Some(Vec::new())));
+        let detail = build_heartbeat("inst_test", 1, &settled)
+            .await
+            .standalone_runtime
+            .expect("a reported empty set is still a reported set");
+        assert!(
+            detail.restart_required.is_empty(),
+            "a runtime that looked and found nothing pending reports an empty set"
+        );
+
+        let pending: Arc<dyn RuntimeHandle> = Arc::new(ReportingHandle(Some(vec![
+            "runtime".to_string(),
+            "secrets".to_string(),
+        ])));
+        let detail = build_heartbeat("inst_test", 2, &pending)
+            .await
+            .standalone_runtime
+            .expect("a populated set is reported");
+        assert_eq!(detail.restart_required, ["runtime", "secrets"]);
+
+        let unclaimed: Arc<dyn RuntimeHandle> = Arc::new(ReportingHandle(None));
+        assert_eq!(
+            build_heartbeat("inst_test", 3, &unclaimed)
+                .await
+                .standalone_runtime,
+            None,
+            "a runtime with no restart-state source of truth claims nothing"
+        );
     }
 
     #[test]

--- a/crates/runtime-cloud-connect/src/session.rs
+++ b/crates/runtime-cloud-connect/src/session.rs
@@ -60,7 +60,14 @@ pub struct AcknowledgedSession {
     pub identity_path: PathBuf,
     /// The organization this instance is enrolled in, when one is recorded.
     pub org_name: Option<String>,
-    /// The attached project, when this instance is attached to one.
+    /// The attached project's cloud id, when this instance is attached to one.
+    ///
+    /// This is the attachment itself. [`Self::app_name`] and
+    /// [`Self::monitor_url`] label it, and the control plane can deliver an
+    /// attachment without either, so absent metadata says nothing about whether
+    /// the instance is attached — only this field does.
+    pub app_id: Option<String>,
+    /// The attached project's display name, when the control plane supplied one.
     pub app_name: Option<String>,
     /// The portal page for the attached project. Cloud-constructed; never
     /// derived locally.
@@ -78,6 +85,7 @@ impl AcknowledgedSession {
             identifier: identity.identifier.clone(),
             identity_path: identity_path.to_path_buf(),
             org_name: identity.org_name.clone(),
+            app_id: identity.app_id.clone(),
             app_name: identity.app_name.clone(),
             monitor_url: identity.monitor_url.clone(),
             new_project_url: identity.new_project_url.clone(),
@@ -196,6 +204,7 @@ mod tests {
             identifier: identifier.to_string(),
             identity_path: PathBuf::from("/nonexistent/identity.json"),
             org_name: Some("acme".to_string()),
+            app_id: None,
             app_name: None,
             monitor_url: None,
             new_project_url: None,
@@ -294,6 +303,7 @@ mod tests {
             identifier: "inst_old".to_string(),
             identity_path: path.clone(),
             org_name: Some("acme".to_string()),
+            app_id: None,
             app_name: None,
             monitor_url: None,
             new_project_url: None,

--- a/crates/runtime-cloud-connect/tests/enrollment_flow.rs
+++ b/crates/runtime-cloud-connect/tests/enrollment_flow.rs
@@ -40,7 +40,7 @@ limitations under the License.
     reason = "integration-test harness — readability over lint strictness"
 )]
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -48,8 +48,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
 use rcgen::{
-    BasicConstraints, CertificateParams, CertificateSigningRequestParams, DnType, IsCa, Issuer,
-    KeyPair, KeyUsagePurpose,
+    BasicConstraints, CertificateParams, CertificateSigningRequestParams, DnType,
+    ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType,
 };
 use runtime_cloud_connect::config::CloudConnectConfig;
 use runtime_cloud_connect::handlers::{
@@ -107,6 +107,7 @@ async fn start_rejects_a_persisted_public_key_that_does_not_match_the_mtls_ident
 
     let config = enroll_config(
         "127.0.0.1:9".parse().expect("parse unused endpoint"),
+        None,
         dir.path(),
     );
     let runtime: Arc<dyn RuntimeHandle> =
@@ -303,8 +304,10 @@ async fn spawn_server(mock: MockServer) -> SocketAddr {
 }
 
 // --------------------------------------------------------------------------
-// Mock cloud enroll endpoint (plain HTTP; the enroll contract is HTTPS in
-// production, which is reqwest's standard path and not under test here).
+// Mock cloud enroll endpoint, served over TLS by the same throwaway CA that
+// signs the client CSRs. `EnrollClient::new` normalizes the configured endpoint
+// through an HTTPS-only policy, so a plaintext mock is unreachable by
+// construction and the client is handed this CA to verify the listener.
 // --------------------------------------------------------------------------
 
 #[derive(Clone)]
@@ -321,6 +324,9 @@ struct EnrollMockState {
 
 struct EnrollCa {
     certificate_pem: String,
+    /// Leaf the mock's own listener presents, signed by this CA.
+    server_cert_der: rustls::pki_types::CertificateDer<'static>,
+    server_key_der: rustls::pki_types::PrivateKeyDer<'static>,
     issuer: Issuer<'static, KeyPair>,
 }
 
@@ -339,9 +345,35 @@ impl EnrollCa {
         let certificate = parameters
             .self_signed(&key)
             .expect("self-sign enrollment test CA");
+        // The issuer owns the CA parameters and key, and signs both the
+        // listener's leaf below and the client CSRs that arrive later.
+        let issuer = Issuer::new(parameters, key);
+
+        let server_key = KeyPair::generate().expect("generate enrollment mock listener key");
+        let mut server_parameters = CertificateParams::default();
+        server_parameters
+            .distinguished_name
+            .push(DnType::CommonName, "spice-test-enroll-endpoint");
+        server_parameters.subject_alt_names = vec![
+            SanType::IpAddress(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            SanType::DnsName(
+                "localhost"
+                    .try_into()
+                    .expect("localhost is a valid DNS SAN"),
+            ),
+        ];
+        server_parameters.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+        let server_certificate = server_parameters
+            .signed_by(&server_key, &issuer)
+            .expect("sign enrollment mock listener leaf");
+
         Self {
             certificate_pem: certificate.pem(),
-            issuer: Issuer::new(parameters, key),
+            server_cert_der: server_certificate.der().clone(),
+            server_key_der: rustls::pki_types::PrivateKeyDer::Pkcs8(
+                rustls::pki_types::PrivatePkcs8KeyDer::from(server_key.serialize_der()),
+            ),
+            issuer,
         }
     }
 
@@ -397,39 +429,111 @@ async fn enroll_handler(
     )
 }
 
-/// Serve the mock enroll endpoint on an ephemeral port; returns its address
-/// and the captured request log.
+/// A TCP listener that hands `axum::serve` TLS streams. A handshake that fails
+/// drops that connection and the listener keeps serving, because a test client
+/// that mistrusts the CA must see a TLS error rather than a hung accept loop.
+struct TlsListener {
+    tcp: TcpListener,
+    acceptor: tokio_rustls::TlsAcceptor,
+}
+
+impl axum::serve::Listener for TlsListener {
+    type Io = tokio_rustls::server::TlsStream<tokio::net::TcpStream>;
+    type Addr = SocketAddr;
+
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        loop {
+            let (stream, address) = self.tcp.accept().await.expect("accept enroll connection");
+            if let Ok(stream) = self.acceptor.accept(stream).await {
+                return (stream, address);
+            }
+        }
+    }
+
+    fn local_addr(&self) -> std::io::Result<Self::Addr> {
+        self.tcp.local_addr()
+    }
+}
+
+/// The running mock: where it listens, what it captured, and the CA a client
+/// has to trust to reach it.
+struct EnrollMock {
+    addr: SocketAddr,
+    /// Captured request bodies, in arrival order.
+    requests: Arc<Mutex<Vec<Value>>>,
+    /// The `not_after` the mock reported for each certificate it issued.
+    reported_not_after: Arc<Mutex<Vec<String>>>,
+    /// PEM of the CA that signed the listener's certificate.
+    ca_cert_pem: String,
+}
+
+/// Serve the mock enroll endpoint over HTTPS on an ephemeral port.
 async fn spawn_enroll_server(
     gateway_addr: String,
     reject: Option<(u16, &'static str, &'static str)>,
-) -> (SocketAddr, Arc<Mutex<Vec<Value>>>, Arc<Mutex<Vec<String>>>) {
+) -> EnrollMock {
+    // `rustls::ServerConfig` is built from the process-default crypto provider
+    // and panics when none is installed. Idempotent, so every mock can ask.
+    let _ = rustls::crypto::CryptoProvider::install_default(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    );
+
     let requests = Arc::new(Mutex::new(Vec::new()));
     let reported_not_after = Arc::new(Mutex::new(Vec::new()));
+    let ca = Arc::new(EnrollCa::new());
+    let ca_cert_pem = ca.certificate_pem.clone();
+    let tls = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![ca.server_cert_der.clone()],
+            ca.server_key_der.clone_key(),
+        )
+        .expect("build the enroll mock's TLS configuration");
     let state = EnrollMockState {
         requests: Arc::clone(&requests),
         gateway_addr,
         reject,
-        ca: Arc::new(EnrollCa::new()),
+        ca,
         reported_not_after: Arc::clone(&reported_not_after),
     };
     let app = Router::new()
         .route("/v1/cloud-connect/enroll", post(enroll_handler))
         .with_state(state);
-    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind http");
-    let addr = listener.local_addr().expect("local_addr");
+    let tcp = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind the enroll mock");
+    let addr = tcp.local_addr().expect("local_addr");
+    let listener = TlsListener {
+        tcp,
+        acceptor: tokio_rustls::TlsAcceptor::from(Arc::new(tls)),
+    };
     tokio::spawn(async move {
         let _ = axum::serve(listener, app).await;
     });
-    (addr, requests, reported_not_after)
+    EnrollMock {
+        addr,
+        requests,
+        reported_not_after,
+        ca_cert_pem,
+    }
 }
 
-fn enroll_config(enroll_addr: SocketAddr, dir: &std::path::Path) -> CloudConnectConfig {
+/// `ca_cert_pem` is the CA of the endpoint being addressed, or `None` for an
+/// address nothing listens on — the endpoint is still normalized at startup, so
+/// even an unused one has to satisfy the HTTPS-only policy.
+fn enroll_config(
+    enroll_addr: SocketAddr,
+    ca_cert_pem: Option<String>,
+    dir: &std::path::Path,
+) -> CloudConnectConfig {
     CloudConnectConfig {
-        enroll_endpoint: format!("http://{enroll_addr}"),
-        // No override: the stream must connect to the gateway_addr issued
-        // by the enroll response (http:// scheme because insecure=true).
+        enroll_endpoint: format!("https://{enroll_addr}"),
+        // No override: the stream must connect to the gateway_addr issued by the
+        // enroll response, over h2c because insecure=true. `insecure` selects
+        // the control-stream scheme only — it never relaxes the enroll
+        // endpoint's, which is HTTPS in every configuration.
         gateway_endpoint: None,
-        ca_cert_pem: None,
+        ca_cert_pem,
         insecure: true,
         identity_path: dir.join("identity.json"),
         config_dir: dir.to_path_buf(),
@@ -475,10 +579,9 @@ async fn pre_runtime_enroll_persists_identity_and_connects() {
     let mock_state = Arc::clone(&mock.state);
     let gateway_addr = spawn_server(mock).await;
 
-    let (enroll_addr, enroll_requests, reported_not_after) =
-        spawn_enroll_server(gateway_addr.to_string(), None).await;
+    let enroll = spawn_enroll_server(gateway_addr.to_string(), None).await;
 
-    let config = enroll_config(enroll_addr, dir.path());
+    let config = enroll_config(enroll.addr, Some(enroll.ca_cert_pem.clone()), dir.path());
 
     // Enrollment happens BEFORE the client exists — the `spiced --token`
     // sequence — and its return means the identity is durable.
@@ -519,7 +622,7 @@ async fn pre_runtime_enroll_persists_identity_and_connects() {
         1,
         "enroll ca_bundle_pem should be persisted into identity.json"
     );
-    let reported_not_after = reported_not_after.lock().await;
+    let reported_not_after = enroll.reported_not_after.lock().await;
     let reported_not_after = chrono::DateTime::parse_from_rfc3339(
         reported_not_after
             .first()
@@ -535,7 +638,7 @@ async fn pre_runtime_enroll_persists_identity_and_connects() {
 
     // The enroll request carried the canonical contract shape: kind + token
     // + csr_pem + host facts nested under `instance`.
-    let requests = enroll_requests.lock().await.clone();
+    let requests = enroll.requests.lock().await.clone();
     assert_eq!(requests.len(), 1, "exactly one enroll request");
     let body = &requests[0];
     assert_eq!(body["kind"], "standalone");
@@ -608,13 +711,13 @@ async fn a_terminal_rejection_creates_no_identity_and_stops_immediately() {
 
     // The cloud terminally rejects the key (unknown/consumed). No gateway
     // is involved.
-    let (enroll_addr, enroll_requests, _reported_not_after) = spawn_enroll_server(
+    let enroll = spawn_enroll_server(
         String::new(),
         Some((401, "invalid_token", "unknown enrollment key")),
     )
     .await;
 
-    let config = enroll_config(enroll_addr, dir.path());
+    let config = enroll_config(enroll.addr, Some(enroll.ca_cert_pem.clone()), dir.path());
     let err = runtime_cloud_connect::enroll_now(&config, &token_authority(), quick_retry())
         .await
         .expect_err("a terminal rejection fails the bootstrap");
@@ -628,7 +731,7 @@ async fn a_terminal_rejection_creates_no_identity_and_stops_immediately() {
     // afterwards finds no identity and stays disabled.
     assert!(!identity_path.exists(), "no identity on rejection");
     assert_eq!(
-        enroll_requests.lock().await.len(),
+        enroll.requests.lock().await.len(),
         1,
         "a terminal rejection must not be retried"
     );
@@ -679,8 +782,9 @@ async fn apply_spicepod_writes_file_and_acks() {
     });
 
     let config = CloudConnectConfig {
-        // Never contacted: the identity is pre-seeded and unbounded.
-        enroll_endpoint: "http://127.0.0.1:9".to_string(),
+        // Never contacted: the identity is pre-seeded and unbounded. It is
+        // still normalized at startup, and that policy is HTTPS-only.
+        enroll_endpoint: "https://127.0.0.1:9".to_string(),
         gateway_endpoint: None,
         ca_cert_pem: None,
         insecure: true,
@@ -837,7 +941,9 @@ async fn attach_app_applies_complete_state_and_rejects_empty_ids() {
         identity_path: identity_path.clone(),
     });
     let config = CloudConnectConfig {
-        enroll_endpoint: "http://127.0.0.1:9".to_string(),
+        // Never contacted, but normalized at startup, and that policy is
+        // HTTPS-only.
+        enroll_endpoint: "https://127.0.0.1:9".to_string(),
         gateway_endpoint: None,
         ca_cert_pem: None,
         insecure: true,
@@ -999,7 +1105,9 @@ async fn unknown_command_is_nacked_rather_than_dropped() {
     IdentityStore::store(&identity_path, &identity).unwrap();
 
     let config = CloudConnectConfig {
-        enroll_endpoint: "http://127.0.0.1:9".to_string(),
+        // Never contacted, but normalized at startup, and that policy is
+        // HTTPS-only.
+        enroll_endpoint: "https://127.0.0.1:9".to_string(),
         gateway_endpoint: None,
         ca_cert_pem: None,
         insecure: true,

--- a/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
@@ -2431,8 +2431,21 @@ async fn authenticated_enrollment_carries_the_session_and_no_key() {
     // The server side of the exclusivity contract: a hand-crafted request
     // carrying BOTH a login authorization and a token is rejected before
     // anything is consumed. (The typed client cannot even represent it.)
-    let both = reqwest::Client::new()
-        .post(format!("http://{}/v1/cloud-connect/enroll", harness.cloud_addr))
+    // The mock serves TLS, so the raw request has to as well, trusting the
+    // harness CA the way the typed client does.
+    let mut raw = reqwest::Client::builder();
+    for certificate in reqwest::Certificate::from_pem_bundle(harness.ca.ca_cert_pem.as_bytes())
+        .expect("the harness CA is a PEM bundle")
+    {
+        raw = raw.add_root_certificate(certificate);
+    }
+    let both = raw
+        .build()
+        .expect("build a client trusting the harness CA")
+        .post(format!(
+            "https://{}/v1/cloud-connect/enroll",
+            harness.cloud_addr
+        ))
         .header("Idempotency-Key", "op-carrying-both-authorities")
         .bearer_auth(SESSION_BEARER)
         .header("X-Org-Name", ORG_NAME)

--- a/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
+++ b/crates/runtime-cloud-connect/tests/standalone_enrollment_e2e.rs
@@ -3060,6 +3060,10 @@ async fn heartbeat_and_telemetry_cadence() {
                 // This handle cannot report status, so it must leave the phase
                 // unspecified rather than inventing an "online".
                 && h.phase == proto::RuntimePhase::Unspecified as i32
+                // Nor does it have a restart-state source of truth, so it
+                // claims nothing: absent on the wire, not a present-but-empty
+                // set, which the control plane would read as "nothing pending".
+                && h.standalone_runtime.is_none()
         });
         let tel_ok = c.telemetry.iter().any(|t| {
             t.identifier == ASSIGNED_ID


### PR DESCRIPTION
Three independent changes to the Cloud Connect standalone surface — review the commits separately. Part of #12867.

- **Report restart-required on the heartbeat.** `build_heartbeat` hardcoded `standalone_runtime: None`, so an instance reporting `restart_required: ["runtime"]` on its `GetStatus` document showed as *not reported* in the portal at the same moment; the wire contract, gateway and portal already carried the field. The new `RuntimeHandle::restart_required` defaults to `None` because absent ("no restart-state source of truth") and present-but-empty ("looked, nothing pending") are different states the control plane acts on differently. `SpicedRuntimeHandle` answers from `Pending::restart_required()` — the same set `GetStatus` reads, from the same place, so the two channels cannot drift.
- **Judge attachment by `app_id`, not its display name.** Both display sites branched on `app_name`, a label the control plane may omit, so an instance that *was* attached printed `connected to {org} — not yet attached to a project` and offered a "Create one:" link for the project it already had. They now read `app_id` — the attachment fact — and fall back on the label the way `org_name` beside them already does. No link is offered when the metadata is absent, and no portal URL is ever derived locally. `AcknowledgedSession` and the `spice connect status` document both gain `app_id`.
- **Run this crate's integration tests in the gate.** `make nextest`'s filterset admits `kind(=test)` only for `cayenne`, so `runtime-cloud-connect`'s three integration binaries were compiled by every sign-off and executed by none of it — `cargo nextest list` selected **0 of 52**. Six had been failing unseen: the enroll mock served plaintext against an HTTPS-only `EnrollClient` policy whose test escape hatch is unreachable from a separate test crate, and the e2e dual-authority request spoke HTTP to a TLS mock. The fixtures now speak TLS from the CA that already signs the client CSRs; the production endpoint policy is untouched.

Verified on this branch: `enrollment_flow` 6, `standalone_enrollment_e2e` 37, `contract` 9, `spice` lib 572, `spiced` lib 112, `runtime-cloud-connect` lib 294 — plus one unrelated failure, the `draft` lock-create flake that #13231 fixes.
