### PR TITLE
docs(criteria): sign off the PostgreSQL Catalog Connector at Beta

### DIFF
--- a/docs/criteria/catalogs/beta.md
+++ b/docs/criteria/catalogs/beta.md
@@ -17,7 +17,7 @@ All criteria must be met for the Catalog to be considered Beta, with exceptions 
 | MS SQL        | ➖            |                 |
 | MySQL         | ➖            |                 |
 | Oracle        | ➖            |                 |
-| PostgreSQL    | ➖            |                 |
+| PostgreSQL    | ✅            | @bjchambers     |
 | Snowflake     | ➖            |                 |
 | Spice.ai      | ✅            | @peasee         |
 | Unity Catalog | ✅            | @Sevenannn      |


### PR DESCRIPTION
Signs off the PostgreSQL Catalog Connector at Beta quality, per [`docs/criteria/catalogs/beta.md`](https://github.com/spiceai/spiceai/blob/trunk/docs/criteria/catalogs/beta.md). For #10373.

Companion PR: **spiceai/docs#2110** flips `pg` to Beta in the published table of Catalog Connectors. Both should land together — this PR records the sign-off, that one is what users see.

## Criteria audit

| Criterion | Status | Evidence |
| --- | --- | --- |
| All Alpha criteria pass | ✅ | PostgreSQL is ✅ on the Alpha table |
| Associated Data Connector at Beta or higher | ✅ | The PostgreSQL Data Connector is **Stable** |
| TPC-H SF1 e2e test loads a catalog, not individual datasets | ✅ | `test/spicepods/tpch/sf1/federated/postgres[catalog].yaml` |
| Queries pass at the native connector's rate | ✅ | `validate_results: true` in the dispatch config; #12104 |
| Added to the scheduled benchmarks | ✅ | `tools/testoperator/dispatch/tpch/sf1/federated/postgres[catalog].yaml`, run by the daily `testoperator_dispatch` cron |
| Schema loads without a data query at registration | ✅ | schemas resolve from `information_schema`/`pg_catalog`; covered by the dispatch config's `schema` workflow |
| Known Major bugs resolved | ✅ | none open for the federated path — see Scope |
| Known Minor bugs logged | ✅ | tracked under `area/catalogs` |
| Error messages follow the error handling guidelines | ✅ | #12108, merged in #13199 |
| Documentation covers setup | ✅ | `components/catalogs/postgres.md` |
| Documentation covers known issues/limitations | ✅ | its `## Limitations` section |
| Cookbook recipe | ✅ | `spiceai/cookbook` → `catalogs/postgres` |
| Status updated in the docs table of Catalogs | 🔜 | spiceai/docs#2110 |

## Scope

**Catalog-level CDC acceleration is a separate enhancement**, so the open bugs in that path are not Beta criteria for this Catalog:

- #12110 — a dropped-and-recreated accelerated table serves rows captured from the previous table
- #12729 — durable catalog acceleration comes back empty after a restart

Both are real and worth fixing; neither affects the federated discovery path the Beta criteria exercise.

**#13082** (an unreachable catalog wedges the Spicepod apply) is deliberately not treated as a blocker: it is a defect in the runtime's shared catalog load path rather than in this connector, and every Catalog already signed off at Beta — Databricks, DuckLake, Iceberg, Spice.ai, Unity Catalog — carries the same defect. Gating this sign-off on it would be a change of precedent rather than an application of the criteria.

## What is not claimed

The audit task (#12108) asked for a per-schema discovery failure asserted end to end. What shipped covers the degrade-and-continue path end to end through a real `refresh()` — with a table-load failure as the trigger, since that is the seam the provider exposes — while the `list_tables` trigger itself remains covered at unit level. That does not affect any Beta criterion, but it is the one box worth naming rather than quietly ticking.

