### PR TITLE
feat(helm): support customizing Deployment strategy and StatefulSet updateStrategy

### DIFF
--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -17,6 +17,13 @@ spec:
   {{- end }}
   {{- if .Values.stateful.enabled }}
   serviceName: {{ template "spiceai.fullname" .  }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  {{- with .Values.strategy }}
+  strategy: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -6,6 +6,17 @@ image:
   tag: latest-models # 2.2.0-unstable
 replicaCount: 1
 
+# Update strategy for the Deployment (used when stateful.enabled is false).
+# Defaults to the Kubernetes RollingUpdate strategy when unset.
+# Example — fully terminate the old pod before starting the new one
+# (e.g. for single-replica deployments with file-based acceleration):
+# strategy:
+#   type: Recreate
+
+# Update strategy for the StatefulSet (used when stateful.enabled is true).
+# updateStrategy:
+#   type: RollingUpdate
+
 service:
   # type can be null, ClusterIP, NodePort, or LoadBalancer
   type: null

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -7,9 +7,6 @@ image:
 replicaCount: 1
 
 # Update strategy for the Deployment (used when stateful.enabled is false).
-# Defaults to the Kubernetes RollingUpdate strategy when unset.
-# Example — fully terminate the old pod before starting the new one
-# (e.g. for single-replica deployments with file-based acceleration):
 # strategy:
 #   type: Recreate
 


### PR DESCRIPTION
Fixes #5828

The Helm chart does not render `spec.strategy`, so a `strategy` block in values is silently ignored and Deployments always use the default `RollingUpdate` (`maxSurge: 25%`, `maxUnavailable: 25%`). This blocks e.g. `type: Recreate` for single-replica deployments with file-based acceleration (DuckDB on hostPath/local NVMe), where the old pod must release file locks before the replacement starts.

## Changes

- `templates/deployment.yaml`: pass through `.Values.strategy` (Deployment) and `.Values.updateStrategy` (StatefulSet, `stateful.enabled: true`).
- `values.yaml`: document both keys (commented out; unset by default).

Usage:

```yaml
strategy:
  type: Recreate
```

## Verification

- `helm lint`: pass.
- `helm template --set strategy.type=Recreate` renders `spec.strategy.type: Recreate`; `--set stateful.enabled=true --set updateStrategy.type=OnDelete` renders `updateStrategy` on the StatefulSet.
- With neither value set, rendered output is byte-identical to trunk (keys are omitted entirely).

Follows the pattern of Grafana (`deploymentStrategy`) and ingress-nginx (`controller.strategy`).
