### PR TITLE
feat(cloud-connect): name the local spicepod a cloud-managed instance serves or ignores

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -1316,21 +1316,20 @@ fn cloud_managed_deployed_note(local: Option<PathBuf>, deployed: PathBuf) -> Dep
 }
 
 /// Which note a cloud-managed instance attaches when no deployment is served
-/// and the local manifest loaded.
+/// and a local filesystem manifest loaded.
+///
+/// A remote `--spicepod` URL is not a local file: there is nothing on this
+/// machine to copy into Spice Cloud, so this note stays off.
 fn local_awaiting_note(
     cloud_managed: bool,
     already_noted: bool,
     local_manifest: Option<&Path>,
-    spicepod_path: &Path,
 ) -> Option<DeploymentNote> {
     if !cloud_managed || already_noted {
         return None;
     }
     Some(DeploymentNote::LocalAwaitingDeployment {
-        path: local_manifest.map_or_else(
-            || spicepod_path.to_path_buf(),
-            Path::to_path_buf,
-        ),
+        path: local_manifest?.to_path_buf(),
     })
 }
 
@@ -1569,7 +1568,6 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
                 cloud_managed_state,
                 deployment_note.is_some(),
                 local_manifest.as_deref(),
-                &spicepod_path,
             ) {
                 deployment_note = Some(note);
             }
@@ -2267,12 +2265,7 @@ mod tests {
 
     #[test]
     fn no_deployment_with_a_local_manifest_awaits() {
-        let note = local_awaiting_note(
-            true,
-            false,
-            Some(Path::new("/tmp/spicepod.yaml")),
-            Path::new("."),
-        );
+        let note = local_awaiting_note(true, false, Some(Path::new("/tmp/spicepod.yaml")));
         assert!(matches!(
             note,
             Some(DeploymentNote::LocalAwaitingDeployment { .. })
@@ -2281,13 +2274,35 @@ mod tests {
 
     #[test]
     fn a_rejected_deployment_does_not_add_awaiting() {
-        let note = local_awaiting_note(
-            true,
-            true,
-            Some(Path::new("/tmp/spicepod.yaml")),
-            Path::new("."),
-        );
+        let note = local_awaiting_note(true, true, Some(Path::new("/tmp/spicepod.yaml")));
         assert!(note.is_none());
+    }
+
+    #[test]
+    fn a_remote_spicepod_url_does_not_get_the_local_awaiting_warning() {
+        assert_eq!(
+            local_spicepod_manifest(Path::new("s3://bucket/spicepod.yaml")),
+            None
+        );
+        assert!(local_awaiting_note(true, false, None).is_none());
+    }
+
+    #[test]
+    fn a_non_cloud_managed_start_does_not_await() {
+        assert!(local_awaiting_note(false, false, Some(Path::new("/tmp/spicepod.yaml"))).is_none());
+    }
+
+    #[test]
+    fn a_path_with_a_newline_stays_on_one_log_line() {
+        let path = Path::new("/tmp/spice\npod.yaml");
+        let awaiting = DeploymentNote::local_awaiting_deployment(path);
+        let ignored = DeploymentNote::local_spicepod_ignored(path, Path::new("/tmp/deployed.yml"));
+        assert!(awaiting.contains("/tmp/spice pod.yaml"));
+        assert!(ignored.contains("/tmp/spice pod.yaml"));
+        assert!(!awaiting.contains('\n'));
+        assert!(!ignored.contains('\n'));
+        assert!(awaiting.contains("'/tmp/spice pod.yaml'"));
+        assert!(ignored.contains("'/tmp/spice pod.yaml'"));
     }
 
     #[test]

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -1302,9 +1302,7 @@ fn local_spicepod_manifest(spicepod_path: &Path) -> Option<PathBuf> {
 /// Render a user-supplied path for a one-line log: `--spicepod` may contain
 /// control characters that would otherwise split the warning.
 fn display_path(path: &Path) -> String {
-    path.display()
-        .to_string()
-        .replace(['\r', '\n'], " ")
+    path.display().to_string().replace(['\r', '\n'], " ")
 }
 
 /// Which note a cloud-managed instance attaches when a deployment loaded.
@@ -1389,10 +1387,7 @@ enum DeploymentNote {
     LocalAwaitingDeployment { path: PathBuf },
     /// A cloud-managed instance serves the deployed spicepod while a local
     /// spicepod.yaml also exists: the local file is on disk but not read.
-    LocalSpicepodIgnored {
-        local: PathBuf,
-        deployed: PathBuf,
-    },
+    LocalSpicepodIgnored { local: PathBuf, deployed: PathBuf },
 }
 
 impl DeploymentNote {
@@ -2238,9 +2233,9 @@ mod tests {
         assert!(message.contains("/tmp/spicepod.yaml"));
         assert!(message.contains("/tmp/config/spicepod-cloud-managed.yml"));
         assert!(message.contains("is ignored"));
-        assert!(message.contains(
-            "Edit the project's Spicepod in Spice Cloud and deploy there instead"
-        ));
+        assert!(
+            message.contains("Edit the project's Spicepod in Spice Cloud and deploy there instead")
+        );
         assert!(message.contains("https://spiceai.org/docs"));
         assert!(!message.contains('\n'));
     }
@@ -2314,7 +2309,10 @@ mod tests {
         assert_eq!(local_spicepod_manifest(dir.path()), Some(manifest.clone()));
 
         // A path that is neither a file nor a directory holds no manifest.
-        assert_eq!(local_spicepod_manifest(dir.path().join("absent").as_ref()), None);
+        assert_eq!(
+            local_spicepod_manifest(dir.path().join("absent").as_ref()),
+            None
+        );
 
         // A manifest file path resolves to itself when it exists.
         assert_eq!(local_spicepod_manifest(&manifest), Some(manifest));

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -20,7 +20,7 @@ limitations under the License.
 use std::collections::HashMap;
 use std::env;
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -1285,6 +1285,20 @@ fn tolerates_missing_spicepod(args: &Args, error: &app::Error, cloud_managed_sta
     tolerates_missing_spicepod_when_cloud_managed(args, error, cloud_managed_state)
 }
 
+/// The local manifest [`AppBuilder::build_from_path`] resolves `spicepod_path`
+/// to: the file itself, or `spicepod.yaml` inside the instance directory.
+///
+/// A remote URL resolves to neither — a manifest that is not on this machine
+/// cannot be pointed at, so the notes that name it fall back to the path
+/// itself.
+fn local_spicepod_manifest(spicepod_path: &Path) -> Option<PathBuf> {
+    if spicepod_path.is_file() {
+        return Some(spicepod_path.to_path_buf());
+    }
+    let manifest = spicepod_path.join("spicepod.yaml");
+    manifest.is_file().then_some(manifest)
+}
+
 /// Pure policy behind [`tolerates_missing_spicepod`]. Configuration provenance
 /// is deliberately separate from credential activation: an unusable identity
 /// still means the instance has no local Spicepod, while it enables no Cloud
@@ -1335,6 +1349,16 @@ enum DeploymentNote {
     /// A cloud-managed instance found no spicepod — neither deployed nor local —
     /// and started on an empty one.
     NoSpicepod,
+    /// A cloud-managed instance whose first deployment has not landed yet
+    /// started on the local spicepod.yaml, which serves until a deployment
+    /// replaces it.
+    LocalAwaitingDeployment { path: PathBuf },
+    /// A cloud-managed instance serves the deployed spicepod while a local
+    /// spicepod.yaml also exists: the local file is on disk but not read.
+    LocalSpicepodIgnored {
+        local: PathBuf,
+        deployed: PathBuf,
+    },
 }
 
 impl DeploymentNote {
@@ -1362,7 +1386,31 @@ impl DeploymentNote {
             Self::NoSpicepod => {
                 tracing::warn!("No existing spicepod was found. Starting Runtime without one.");
             }
+            Self::LocalAwaitingDeployment { path } => {
+                tracing::warn!("{}", Self::local_awaiting_deployment(path));
+            }
+            Self::LocalSpicepodIgnored { local, deployed } => {
+                tracing::warn!("{}", Self::local_spicepod_ignored(local, deployed));
+            }
         }
+    }
+
+    /// The local manifest a cloud-managed instance serves before its first
+    /// deployment, and why a deployment to the portal is what makes it stick.
+    fn local_awaiting_deployment(path: &Path) -> String {
+        format!(
+            "Spice Cloud Connect: this instance is serving the local {} — but that file is not the Spicepod Spice Cloud manages. Copy it into the project's Spicepod in Spice Cloud before you deploy: the first deployment replaces what this instance serves, and anything that exists only in that file stops being served when it lands. See: https://spiceai.org/docs",
+            path.display()
+        )
+    }
+
+    /// A local manifest that coexists with the deployed one is not read.
+    fn local_spicepod_ignored(local: &Path, deployed: &Path) -> String {
+        format!(
+            "Spice Cloud Connect: the local {} is ignored: this instance serves the deployed spicepod at {}. To change this instance, edit the app's Spicepod in Spice Cloud and deploy it instead. See: https://spiceai.org/docs",
+            local.display(),
+            deployed.display()
+        )
     }
 }
 
@@ -1435,16 +1483,29 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
                     Error::UnableToReadCloudManagedSpicepod { path, source }
                 },
             )?;
+    let spicepod_path = args
+        .spicepod
+        .clone()
+        .unwrap_or_else(|| env::current_dir().unwrap_or(PathBuf::from(".")));
+    let local_manifest = local_spicepod_manifest(&spicepod_path);
+
     if let Some(deployed) = cloud_managed_spicepod {
         match AppBuilder::build_from_path(deployed.path.clone()).await {
             Ok(mut app) => {
                 app.runtime = apply_overrides(app.runtime, &args.set_runtime)?;
+                deployment_note = Some(match local_manifest {
+                    Some(local) => DeploymentNote::LocalSpicepodIgnored {
+                        local,
+                        deployed: deployed.path.clone(),
+                    },
+                    None => DeploymentNote::Loaded {
+                        path: deployed.path.clone(),
+                    },
+                });
                 return Ok(AppBundle {
                     app: Some(Arc::new(app)),
                     spicepod_load_error: None,
-                    deployment_note: Some(DeploymentNote::Loaded {
-                        path: deployed.path.clone(),
-                    }),
+                    deployment_note,
                     running_deployment: Some(deployed),
                     cloud_connect_identity,
                 });
@@ -1463,16 +1524,22 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
         }
     }
 
-    let spicepod_path = args
-        .spicepod
-        .clone()
-        .unwrap_or_else(|| env::current_dir().unwrap_or(PathBuf::from(".")));
-
     let mut spicepod_load_error: Option<app::Error> = None;
 
     let app: Option<Arc<App>> = match AppBuilder::build_from_path(spicepod_path.clone()).await {
         Ok(mut app) => {
             app.runtime = apply_overrides(app.runtime, &args.set_runtime)?;
+            // A cloud-managed instance with no deployment yet serves this
+            // manifest only until the first deployment replaces it; the local
+            // file is not part of the app, so it has to be copied into Spice
+            // Cloud to survive the first deployment. A deployment that landed
+            // but did not build (`Rejected`) already says the local manifest
+            // is a fallback, so no second note.
+            if cloud_managed_state && deployment_note.is_none() {
+                deployment_note = Some(DeploymentNote::LocalAwaitingDeployment {
+                    path: local_manifest.clone().unwrap_or(spicepod_path.clone()),
+                });
+            }
             Some(Arc::new(app))
         }
         Err(e) => {
@@ -2119,5 +2186,42 @@ mod tests {
                 .contains("without the anonymous_telemetry feature")
         );
         assert!(TELEMETRY_DISABLED_SETTING_IGNORED_MESSAGE.contains("Spice.ai Enterprise"));
+    }
+
+    #[test]
+    fn the_local_awaiting_deployment_warning_names_the_file_and_how_to_fix_it() {
+        let message = DeploymentNote::local_awaiting_deployment(Path::new("/tmp/spicepod.yaml"));
+        assert!(message.contains("/tmp/spicepod.yaml"));
+        assert!(message.contains("is not the Spicepod Spice Cloud manages"));
+        assert!(message.contains("Copy it into the project's Spicepod in Spice Cloud"));
+        assert!(message.contains("https://spiceai.org/docs"));
+    }
+
+    #[test]
+    fn the_local_spicepod_ignored_warning_names_both_files() {
+        let message = DeploymentNote::local_spicepod_ignored(
+            Path::new("/tmp/spicepod.yaml"),
+            Path::new("/tmp/config/spicepod-cloud-managed.yml"),
+        );
+        assert!(message.contains("/tmp/spicepod.yaml"));
+        assert!(message.contains("/tmp/config/spicepod-cloud-managed.yml"));
+        assert!(message.contains("is ignored"));
+        assert!(message.contains("edit the app's Spicepod in Spice Cloud and deploy it instead"));
+        assert!(message.contains("https://spiceai.org/docs"));
+    }
+
+    #[test]
+    fn local_spicepod_manifest_resolves_a_directory_to_its_spicepod_yaml() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let manifest = dir.path().join("spicepod.yaml");
+        std::fs::write(&manifest, "\n").expect("write spicepod.yaml");
+
+        assert_eq!(local_spicepod_manifest(dir.path()), Some(manifest.clone()));
+
+        // A path that is neither a file nor a directory holds no manifest.
+        assert_eq!(local_spicepod_manifest(dir.path().join("absent").as_ref()), None);
+
+        // A manifest file path resolves to itself when it exists.
+        assert_eq!(local_spicepod_manifest(&manifest), Some(manifest));
     }
 }

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -1399,7 +1399,7 @@ impl DeploymentNote {
     /// deployment, and why a deployment to the portal is what makes it stick.
     fn local_awaiting_deployment(path: &Path) -> String {
         format!(
-            "Spice Cloud Connect: this instance is serving the local {} — but that file is not the Spicepod Spice Cloud manages. Copy it into the project's Spicepod in Spice Cloud before you deploy: the first deployment replaces what this instance serves, and anything that exists only in that file stops being served when it lands. See: https://spiceai.org/docs",
+            "The Spicepod that is loaded will be replaced by Spice Cloud on the next deployment. Copy it to the project's Spicepod in Spice Cloud to avoid being overwritten. See: https://spiceai.org/docs",
             path.display()
         )
     }
@@ -1407,7 +1407,7 @@ impl DeploymentNote {
     /// A local manifest that coexists with the deployed one is not read.
     fn local_spicepod_ignored(local: &Path, deployed: &Path) -> String {
         format!(
-            "Spice Cloud Connect: the local {} is ignored: this instance serves the deployed spicepod at {}. To change this instance, edit the app's Spicepod in Spice Cloud and deploy it instead. See: https://spiceai.org/docs",
+            "The local {} is ignored: this instance serves the deployed spicepod at {}. Edit the project's Spicepod in Spice Cloud and deploy there instead. See: https://spiceai.org/docs",
             local.display(),
             deployed.display()
         )

--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -1299,6 +1299,41 @@ fn local_spicepod_manifest(spicepod_path: &Path) -> Option<PathBuf> {
     manifest.is_file().then_some(manifest)
 }
 
+/// Render a user-supplied path for a one-line log: `--spicepod` may contain
+/// control characters that would otherwise split the warning.
+fn display_path(path: &Path) -> String {
+    path.display()
+        .to_string()
+        .replace(['\r', '\n'], " ")
+}
+
+/// Which note a cloud-managed instance attaches when a deployment loaded.
+fn cloud_managed_deployed_note(local: Option<PathBuf>, deployed: PathBuf) -> DeploymentNote {
+    match local {
+        Some(local) => DeploymentNote::LocalSpicepodIgnored { local, deployed },
+        None => DeploymentNote::Loaded { path: deployed },
+    }
+}
+
+/// Which note a cloud-managed instance attaches when no deployment is served
+/// and the local manifest loaded.
+fn local_awaiting_note(
+    cloud_managed: bool,
+    already_noted: bool,
+    local_manifest: Option<&Path>,
+    spicepod_path: &Path,
+) -> Option<DeploymentNote> {
+    if !cloud_managed || already_noted {
+        return None;
+    }
+    Some(DeploymentNote::LocalAwaitingDeployment {
+        path: local_manifest.map_or_else(
+            || spicepod_path.to_path_buf(),
+            Path::to_path_buf,
+        ),
+    })
+}
+
 /// Pure policy behind [`tolerates_missing_spicepod`]. Configuration provenance
 /// is deliberately separate from credential activation: an unusable identity
 /// still means the instance has no local Spicepod, while it enables no Cloud
@@ -1399,17 +1434,17 @@ impl DeploymentNote {
     /// deployment, and why a deployment to the portal is what makes it stick.
     fn local_awaiting_deployment(path: &Path) -> String {
         format!(
-            "The Spicepod that is loaded will be replaced by Spice Cloud on the next deployment. Copy it to the project's Spicepod in Spice Cloud to avoid being overwritten. See: https://spiceai.org/docs",
-            path.display()
+            "The Spicepod at '{}' will be replaced by Spice Cloud on the next deployment. Copy it to the project's Spicepod in Spice Cloud to avoid being overwritten. See: https://spiceai.org/docs",
+            display_path(path)
         )
     }
 
     /// A local manifest that coexists with the deployed one is not read.
     fn local_spicepod_ignored(local: &Path, deployed: &Path) -> String {
         format!(
-            "The local {} is ignored: this instance serves the deployed spicepod at {}. Edit the project's Spicepod in Spice Cloud and deploy there instead. See: https://spiceai.org/docs",
-            local.display(),
-            deployed.display()
+            "The local '{}' is ignored: this instance serves the deployed spicepod at '{}'. Edit the project's Spicepod in Spice Cloud and deploy there instead. See: https://spiceai.org/docs",
+            display_path(local),
+            display_path(deployed)
         )
     }
 }
@@ -1493,15 +1528,10 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
         match AppBuilder::build_from_path(deployed.path.clone()).await {
             Ok(mut app) => {
                 app.runtime = apply_overrides(app.runtime, &args.set_runtime)?;
-                deployment_note = Some(match local_manifest {
-                    Some(local) => DeploymentNote::LocalSpicepodIgnored {
-                        local,
-                        deployed: deployed.path.clone(),
-                    },
-                    None => DeploymentNote::Loaded {
-                        path: deployed.path.clone(),
-                    },
-                });
+                deployment_note = Some(cloud_managed_deployed_note(
+                    local_manifest,
+                    deployed.path.clone(),
+                ));
                 return Ok(AppBundle {
                     app: Some(Arc::new(app)),
                     spicepod_load_error: None,
@@ -1535,10 +1565,13 @@ pub async fn build_app(args: &Args) -> Result<AppBundle> {
             // Cloud to survive the first deployment. A deployment that landed
             // but did not build (`Rejected`) already says the local manifest
             // is a fallback, so no second note.
-            if cloud_managed_state && deployment_note.is_none() {
-                deployment_note = Some(DeploymentNote::LocalAwaitingDeployment {
-                    path: local_manifest.clone().unwrap_or(spicepod_path.clone()),
-                });
+            if let Some(note) = local_awaiting_note(
+                cloud_managed_state,
+                deployment_note.is_some(),
+                local_manifest.as_deref(),
+                &spicepod_path,
+            ) {
+                deployment_note = Some(note);
             }
             Some(Arc::new(app))
         }
@@ -2192,9 +2225,10 @@ mod tests {
     fn the_local_awaiting_deployment_warning_names_the_file_and_how_to_fix_it() {
         let message = DeploymentNote::local_awaiting_deployment(Path::new("/tmp/spicepod.yaml"));
         assert!(message.contains("/tmp/spicepod.yaml"));
-        assert!(message.contains("is not the Spicepod Spice Cloud manages"));
-        assert!(message.contains("Copy it into the project's Spicepod in Spice Cloud"));
+        assert!(message.contains("will be replaced by Spice Cloud"));
+        assert!(message.contains("Copy it to the project's Spicepod in Spice Cloud"));
         assert!(message.contains("https://spiceai.org/docs"));
+        assert!(!message.contains('\n'));
     }
 
     #[test]
@@ -2206,8 +2240,54 @@ mod tests {
         assert!(message.contains("/tmp/spicepod.yaml"));
         assert!(message.contains("/tmp/config/spicepod-cloud-managed.yml"));
         assert!(message.contains("is ignored"));
-        assert!(message.contains("edit the app's Spicepod in Spice Cloud and deploy it instead"));
+        assert!(message.contains(
+            "Edit the project's Spicepod in Spice Cloud and deploy there instead"
+        ));
         assert!(message.contains("https://spiceai.org/docs"));
+        assert!(!message.contains('\n'));
+    }
+
+    #[test]
+    fn a_loaded_deployment_with_a_local_manifest_is_ignored() {
+        let note = cloud_managed_deployed_note(
+            Some(PathBuf::from("/tmp/spicepod.yaml")),
+            PathBuf::from("/tmp/config/spicepod-cloud-managed.yml"),
+        );
+        assert!(matches!(note, DeploymentNote::LocalSpicepodIgnored { .. }));
+    }
+
+    #[test]
+    fn a_loaded_deployment_without_a_local_manifest_is_loaded() {
+        let note = cloud_managed_deployed_note(
+            None,
+            PathBuf::from("/tmp/config/spicepod-cloud-managed.yml"),
+        );
+        assert!(matches!(note, DeploymentNote::Loaded { .. }));
+    }
+
+    #[test]
+    fn no_deployment_with_a_local_manifest_awaits() {
+        let note = local_awaiting_note(
+            true,
+            false,
+            Some(Path::new("/tmp/spicepod.yaml")),
+            Path::new("."),
+        );
+        assert!(matches!(
+            note,
+            Some(DeploymentNote::LocalAwaitingDeployment { .. })
+        ));
+    }
+
+    #[test]
+    fn a_rejected_deployment_does_not_add_awaiting() {
+        let note = local_awaiting_note(
+            true,
+            true,
+            Some(Path::new("/tmp/spicepod.yaml")),
+            Path::new("."),
+        );
+        assert!(note.is_none());
     }
 
     #[test]


### PR DESCRIPTION
A cloud-managed instance silently decides at startup between the local `spicepod.yaml` and the manifest its last deployment persisted. This makes it say which one it is serving, in the two states where the local file matters.

Two new `DeploymentNote` variants, logged once at startup:

- **`LocalAwaitingDeployment`** — a cloud-managed instance has received no deployment yet and serves the local `spicepod.yaml`. Warns that the file is not the Spicepod Spice Cloud manages, so copy it into the project's Spicepod before deploying: the first deployment replaces what the instance serves.
- **`LocalSpicepodIgnored`** — a local `spicepod.yaml` coexists with a deployed manifest and is not read. Warns to edit the app's Spicepod in Spice Cloud and deploy it instead.

## Scenario

In the Cloud Connect flow, the user's datasets live in the local `spicepod.yaml`. Adding a view that reads a dataset to the project's Spicepod and deploying it fails the view with `Dependent table data for <dataset> does not exist`, because the portal manifest has no dataset. The reason — the local manifest is neither the portal's manifest nor what the instance serves after the first deployment — was invisible at startup; the runtime now states it in both states.

## Evidence

`spiced` started with a Cloud Connect identity and no deployment, local `spicepod.yaml` present:

```
WARN spiced: Spice Cloud Connect: this instance is serving the local /tmp/cc-e2e/manifest/spicepod.yaml — but that file is not the Spicepod Spice Cloud manages. Copy it into the project's Spicepod in Spice Cloud before you deploy: the first deployment replaces what this instance serves, and anything that exists only in that file stops being served when it lands. See: https://spiceai.org/docs
```

Same start with a deployed manifest alongside the local `spicepod.yaml`:

```
WARN spiced: Spice Cloud Connect: the local /tmp/cc-e2e/manifest/spicepod.yaml is ignored: this instance serves the deployed spicepod at /tmp/cc-e2e/config/spicepod-cloud-managed.yml. To change this instance, edit the app's Spicepod in Spice Cloud and deploy it instead. See: https://spiceai.org/docs
```

New unit tests assert the two messages and the manifest resolution.
