### PR TITLE
fix(secrets): check secret references where the components resolve them

### DIFF
--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -587,30 +587,22 @@ impl RuntimeBuilder {
         let resource_monitor = crate::resource_monitor::ResourceMonitor::new();
         let loaded_secrets = Self::load_secrets(self.app.as_ref()).await;
 
-        // Diagnostics-only: resolve every `${ store:key }` reference in the
-        // app up front so secret problems surface as one consolidated report
-        // instead of scattered per-component errors. Skipped on cluster
-        // executors, where secrets resolve via scheduler RPC and the
-        // scheduler has already validated them. Never changes component
-        // loading; never logs secret values.
-        //
-        // Runs on the owned `Secrets` before it is wrapped in the shared
-        // `RwLock` below, so no lock guard is held across the lookups' awaits.
-        // Wrapped in `in_tracing_context_async` for the same reason as
-        // `load_secrets`: this runs before `spiced::init_tracing` installs the
-        // global subscriber, so without a temporary subscriber the summary
-        // would be dropped on the floor.
+        // The secret preflight runs at the start of `Runtime::load_components`,
+        // not here: stores the runtime owns rather than the spicepod — the
+        // Cloud Connect delivered-secrets store, restored from its local cache
+        // — are registered on the built runtime, between this point and the
+        // load that resolves the references.
+        let secrets = Arc::new(RwLock::new(loaded_secrets));
+
+        // Read here because `self.resolved_cluster_config` is moved into the
+        // DataFusion builder below, and the executor's cluster status is
+        // registered once the runtime is constructed.
         let is_cluster_executor = matches!(
             self.resolved_cluster_config
                 .as_ref()
                 .and_then(ResolvedClusterConfig::effective_role),
             Some(ClusterRole::Executor)
         );
-        if !is_cluster_executor && let Some(app) = self.app.as_ref() {
-            in_tracing_context_async(crate::secrets_preflight::run(app, &loaded_secrets)).await;
-        }
-
-        let secrets = Arc::new(RwLock::new(loaded_secrets));
 
         // Create the shared app reference early so DataFusion, Runtime, and PartitionService share it.
         let shared_app: Arc<RwLock<Option<Arc<App>>>> = Arc::new(RwLock::new(self.app));

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1789,6 +1789,38 @@ impl Runtime {
         self.initial_load.in_flight.load(Ordering::SeqCst)
     }
 
+    /// Reports every `${ store:key }` reference the app cannot resolve, as one
+    /// consolidated block, before any component is loaded.
+    ///
+    /// Runs at the start of the load rather than when the runtime is built,
+    /// because the two are not the same moment for the stores the runtime owns
+    /// rather than the spicepod: Cloud Connect registers its delivered-secrets
+    /// store on the built runtime and fills it from the local cache, and a
+    /// preflight that ran before that reported every delivered secret as
+    /// missing while the components that referenced them went on to load
+    /// perfectly well.
+    ///
+    /// Diagnostics only: it never changes whether or how components load, and
+    /// it never logs secret values.
+    async fn secrets_preflight(&self) {
+        // A cluster executor resolves every reference over the scheduler RPC
+        // store, one round trip each, and the scheduler has already checked
+        // them — so checking here re-reports the scheduler's own findings at
+        // the cost of a round trip per reference.
+        if matches!(self.distributed, Some(DistributedNode::Executor { .. })) {
+            return;
+        }
+
+        let Some(app) = self.app.read().await.clone() else {
+            return;
+        };
+        // A snapshot rather than the read guard: a lookup can be a network
+        // round trip, and holding the guard across it stalls a writer (and
+        // risks the write-preferring deadlock `Secrets::snapshot` documents).
+        let secrets = secrets::Secrets::snapshot(&self.secrets).await;
+        secrets_preflight::run(&app, &secrets).await;
+    }
+
     /// Will load all of the components of the Runtime, including `secret_stores`, `catalogs`, `datasets`, `models`, and `embeddings`.
     ///
     /// The future returned by this function will not resolve until all components have been loaded and marked as ready.
@@ -1804,6 +1836,8 @@ impl Runtime {
             );
             return;
         }
+
+        self.secrets_preflight().await;
 
         Arc::clone(&self).set_components_initializing().await;
 

--- a/crates/runtime/src/secrets_preflight.rs
+++ b/crates/runtime/src/secrets_preflight.rs
@@ -22,6 +22,12 @@ limitations under the License.
 //! store surfaces as one consolidated, root-caused report up front instead of
 //! as scattered per-component "missing required parameter" errors later.
 //!
+//! Driven from the start of [`Runtime::load_components`](crate::Runtime::load_components)
+//! so it sees the same stores a component will: the built-in stores the runtime
+//! registers on itself after it is built — Cloud Connect's delivered secrets,
+//! restored from their local cache — are in place by then, and a check that ran
+//! any earlier would report them all as missing.
+//!
 //! This is diagnostics only: it never changes whether or how components load,
 //! and it never logs secret values (it consumes [`RefStatus`], which carries
 //! store/key names and error text only).
@@ -60,15 +66,39 @@ impl LocatedRef {
     }
 }
 
+/// What the preflight found, as the summary it will be logged as.
+#[derive(Debug, PartialEq, Eq)]
+enum Outcome {
+    /// The app declares no secret references, so nothing is logged.
+    NoReferences,
+    /// Every reference resolved.
+    AllResolved { total: usize },
+    /// At least one reference did not resolve; `report` is the `WARN` block,
+    /// carrying store/key names and error text only.
+    Unresolved { report: String },
+}
+
 /// Runs the preflight against the app's components and logs a single summary.
 ///
 /// On success: one `INFO` line (or nothing when there are no references). On
 /// problems: one `WARN` block listing each unresolved reference with its
 /// provenance and root cause. Never aborts; never logs secret values.
 pub(crate) async fn run(app: &App, secrets: &Secrets) {
+    match evaluate(app, secrets).await {
+        Outcome::NoReferences => {}
+        Outcome::AllResolved { total } => {
+            tracing::info!("Secrets: all {total} secret reference(s) resolved.");
+        }
+        Outcome::Unresolved { report } => tracing::warn!("{report}"),
+    }
+}
+
+/// Resolves every reference and builds the summary, so what the operator reads
+/// can be asserted without a subscriber.
+async fn evaluate(app: &App, secrets: &Secrets) -> Outcome {
     let refs = collect_references(app);
     if refs.is_empty() {
-        return;
+        return Outcome::NoReferences;
     }
 
     // Resolve each distinct (store, key) once — components loading right after
@@ -92,8 +122,7 @@ pub(crate) async fn run(app: &App, secrets: &Secrets) {
     }
 
     if problems.is_empty() {
-        tracing::info!("Secrets: all {} secret reference(s) resolved.", refs.len());
-        return;
+        return Outcome::AllResolved { total: refs.len() };
     }
 
     let mut report = format!(
@@ -112,7 +141,7 @@ pub(crate) async fn run(app: &App, secrets: &Secrets) {
         );
     }
     let _ = write!(report, "\nDocs: {DOCS_URL}");
-    tracing::warn!("{report}");
+    Outcome::Unresolved { report }
 }
 
 /// Human-readable explanation of a [`RefStatus`]. Carries only store/key
@@ -334,6 +363,83 @@ mod tests {
             .with_dataset(dataset_with_params("plain", &[("host", "localhost")]))
             .build();
         assert!(collect_references(&app).is_empty());
+    }
+
+    /// A key no environment (and no `.env`) is expected to hold, so `env`
+    /// cannot answer for the store under test. Unprefixed on purpose: the
+    /// `env` store also looks a key up as `SPICE_<key>`.
+    const DELIVERED_KEY: &str = "PREFLIGHT_TEST_UNSET_SECRET";
+
+    /// Stands in for Cloud Connect's delivered-secrets store: registered on the
+    /// runtime itself, after the spicepod's `secrets:` section was loaded.
+    struct FixedStore {
+        key: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl runtime_secrets::SecretStore for FixedStore {
+        async fn get_secret(
+            &self,
+            key: &str,
+        ) -> runtime_secrets::AnyErrorResult<Option<secrecy::SecretString>> {
+            Ok((key == self.key).then(|| secrecy::SecretString::from("delivered")))
+        }
+    }
+
+    fn app_referencing(key: &str) -> app::App {
+        let reference = format!("${{ secrets:{key} }}");
+        AppBuilder::new("test")
+            .with_dataset(dataset_with_params(
+                "orders",
+                &[("pg_pass", reference.as_str())],
+            ))
+            .build()
+    }
+
+    /// A spicepod with only the default `env` store: the reference is named,
+    /// located, and root-caused in one block.
+    #[tokio::test]
+    async fn unresolved_reference_is_reported_with_provenance_and_cause() {
+        let mut secrets = Secrets::new();
+        secrets.load_from(&[]).await.expect("env store loads");
+
+        let Outcome::Unresolved { report } =
+            evaluate(&app_referencing(DELIVERED_KEY), &secrets).await
+        else {
+            panic!("expected the reference to be reported as unresolved");
+        };
+        assert!(
+            report.contains("Secrets: 1 of 1 secret reference(s) could not be resolved:"),
+            "{report}"
+        );
+        assert!(
+            report.contains(&format!(
+                "✗ ${{ secrets:{DELIVERED_KEY} }}  dataset 'orders' (pg_pass) — not found in [env]"
+            )),
+            "{report}"
+        );
+        assert!(report.contains(DOCS_URL), "{report}");
+    }
+
+    /// The preflight runs at the start of the component load, so the built-in
+    /// stores the runtime registers on itself after the spicepod's `secrets:`
+    /// section — Cloud Connect's delivered secrets, restored from their local
+    /// cache — answer for it, the same as they do for the components that load
+    /// next. Checking any earlier reported every delivered secret as missing
+    /// while the dataset referencing it went on to register.
+    #[tokio::test]
+    async fn reference_served_by_a_builtin_store_resolves() {
+        let mut secrets = Secrets::new();
+        secrets.load_from(&[]).await.expect("env store loads");
+        secrets.register_builtin_store(
+            "cloud",
+            std::sync::Arc::new(FixedStore { key: DELIVERED_KEY }),
+        );
+
+        assert_eq!(
+            evaluate(&app_referencing(DELIVERED_KEY), &secrets).await,
+            Outcome::AllResolved { total: 1 }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 📝 Summary

<!-- What does this PR change? Why is it necessary? Keep it concise. -->

The startup preflight resolved every `${ store:key }` reference while the runtime was being built, against the spicepod-declared stores plus the `env` fallback. The stores the runtime owns rather than the spicepod are registered later, on the built runtime: Spice Cloud Connect installs its delivered-secrets store and fills it from the local encrypted cache after the build and before the component load. So an instance restarting on secrets a deployment had delivered reported every one of them unresolved — `not found in [env]` — and then registered the datasets referencing them without trouble. A report whose problems are routinely spurious is one an operator learns to skip.

Run the check at the start of `Runtime::load_components` instead, which is after every store is registered and still before any component resolves anything, so the preflight sees exactly the stores its components will. It resolves against a `Secrets` snapshot rather than the shared lock's read guard, since a lookup can be a network round trip.

The report's construction is now separate from its logging so the text an operator reads can be asserted: one test pins the unresolved wording, and one covers a reference only a built-in store can answer.