### PR TITLE
fix(docker): install ARM64 linker toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM rust:${RUST_VERSION}-slim-trixie as build
 USER root
 
 RUN apt update \
-    && apt install --yes pkg-config libssl-dev build-essential libsqlite3-dev cmake protobuf-compiler unixodbc-dev libclang-dev \
+    && apt install --yes pkg-config libssl-dev build-essential libsqlite3-dev cmake protobuf-compiler unixodbc-dev clang lld libclang-dev \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
 COPY . /build


### PR DESCRIPTION
## Summary
- Install clang and lld in the Docker build stage.
- Satisfy the ARM64 Cargo linker configuration that selects clang with lld.

## Validation
- git diff --check
- ARM64 spiced_docker_dev image build will validate the fix.

Fixes the ARM64 development-image build failure: linker clang not found.