### PR TITLE
ci: build the runtime integration archives with one feature set

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -174,11 +174,16 @@ jobs:
           # previous one built and recompiles the graph from data_components up (the same
           # reason `make nextest` uses a single selection -- spiceai/spiceai#12337).
           #
-          # Widening the set cannot change which tests are built: `integration_aws_sdk` and
-          # `integration_snapshot_refresh` contain no `cfg(feature)` at all, and the only
-          # `turso` gate in `integration.rs` is inside an `any(...)` already satisfied by
-          # `postgres`/`duckdb`/`sqlite`. `turso` is the one feature the narrower sets needed
-          # that this set lacked; it is the combination `make test-integration` already runs.
+          # Widening the set preserves each target's test selection because this set is a
+          # superset of what that target was already built with -- not because the targets
+          # are ungated. They are gated: `integration_aws_sdk` gates on
+          # `all(databricks, delta_lake)`, and `snapshot_refresh` gates each backend on
+          # `duckdb`/`sqlite`/`turso`. Every one of those features is in this set, so every
+          # gate that was satisfied before is still satisfied, and `turso` is the only one
+          # this set previously lacked. `integration` itself is unaffected: its lone `turso`
+          # gate sits inside an `any(...)` that `postgres`/`duckdb`/`sqlite` already satisfy.
+          # `turso` alongside `postgres`/`mysql`/`delta_lake`/`duckdb`/`sqlite` is the
+          # combination `make test-integration` runs.
           FEATURES="postgres,mysql,delta_lake,duckdb,sqlite,spark,databricks,dynamodb,oracle,kafka,iceberg-write,snapshots,mongodb,turso"
           if [[ "${{ github.event.inputs.run_all_tests }}" == "true" ]]; then
             FEATURES="${FEATURES},extended_tests"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -153,6 +153,21 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Records one `ARCHIVE_TIMING <label> <seconds>` line per archive so the cost of
+          # each `nextest archive` invocation can be read straight from the job log instead
+          # of inferred from the gaps between cargo's own output.
+          archive() {
+            local label="$1"; shift
+            local t0 rc
+            t0=$(date +%s)
+            # Capture the status rather than letting `set -e` abort at `"$@"`, so the timing
+            # line is emitted even for the invocation that failed -- then re-raise it, so a
+            # failed build still fails the step instead of inheriting `echo`'s success.
+            "$@" && rc=0 || rc=$?
+            echo "ARCHIVE_TIMING ${label} $(( $(date +%s) - t0 )) rc=${rc}"
+            return "$rc"
+          }
+
           FEATURES="postgres,mysql,delta_lake,duckdb,sqlite,spark,databricks,dynamodb,oracle,kafka,iceberg-write,snapshots,mongodb"
           if [[ "${{ github.event.inputs.run_all_tests }}" == "true" ]]; then
             FEATURES="${FEATURES},extended_tests"
@@ -161,13 +176,18 @@ jobs:
             echo "Excluding extended_tests"
           fi
 
-          cargo nextest archive -p runtime --test integration --features ${FEATURES} --archive-file integration.tar.zst
-          cargo nextest archive -p runtime --test retention_oom --features ${FEATURES} --archive-file retention_oom.tar.zst
-          cargo nextest archive -p runtime --test integration_aws_sdk --features databricks,delta_lake --archive-file integration_aws_sdk.tar.zst
-          cargo nextest archive -p runtime --test integration_snapshot_refresh --features duckdb,sqlite,turso,snapshots --archive-file integration_snapshot_refresh.tar.zst
-          cargo nextest archive -p aws-sdk-credential-bridge --test credential_provider --archive-file integration_aws_sdk_credential_bridge.tar.zst
-          cargo nextest archive -p runtime-table-partition --test partition_table_provider --archive-file partition_table_test.tar.zst
-          cargo nextest archive -p data_components --test hadoop_catalog_test --archive-file data_components_hadoop.tar.zst
+          archive integration cargo nextest archive -p runtime --test integration --features ${FEATURES} --archive-file integration.tar.zst
+          archive retention_oom cargo nextest archive -p runtime --test retention_oom --features ${FEATURES} --archive-file retention_oom.tar.zst
+          archive integration_aws_sdk cargo nextest archive -p runtime --test integration_aws_sdk --features databricks,delta_lake --archive-file integration_aws_sdk.tar.zst
+          archive integration_snapshot_refresh cargo nextest archive -p runtime --test integration_snapshot_refresh --features duckdb,sqlite,turso,snapshots --archive-file integration_snapshot_refresh.tar.zst
+          archive credential_provider cargo nextest archive -p aws-sdk-credential-bridge --test credential_provider --archive-file integration_aws_sdk_credential_bridge.tar.zst
+          archive partition_table_provider cargo nextest archive -p runtime-table-partition --test partition_table_provider --archive-file partition_table_test.tar.zst
+          archive hadoop_catalog_test cargo nextest archive -p data_components --test hadoop_catalog_test --archive-file data_components_hadoop.tar.zst
+
+          echo "--- archive sizes ---"
+          ls -l *.tar.zst
+          echo "--- compiler cache stats ---"
+          if command -v sccache >/dev/null 2>&1; then sccache --show-stats || true; fi
 
       - name: Set up MinIO client
         if: needs.check_changes.outputs.relevant_changes == 'true' && env.HAS_TEST_MINIO_SECRET == 'true'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -168,7 +168,18 @@ jobs:
             return "$rc"
           }
 
-          FEATURES="postgres,mysql,delta_lake,duckdb,sqlite,spark,databricks,dynamodb,oracle,kafka,iceberg-write,snapshots,mongodb"
+          # All four `-p runtime` archives below build with this one feature set. Under
+          # resolver = "2" the resolved features of every crate in the graph depend on the
+          # feature flags given, so an invocation that changes them cannot reuse anything the
+          # previous one built and recompiles the graph from data_components up (the same
+          # reason `make nextest` uses a single selection -- spiceai/spiceai#12337).
+          #
+          # Widening the set cannot change which tests are built: `integration_aws_sdk` and
+          # `integration_snapshot_refresh` contain no `cfg(feature)` at all, and the only
+          # `turso` gate in `integration.rs` is inside an `any(...)` already satisfied by
+          # `postgres`/`duckdb`/`sqlite`. `turso` is the one feature the narrower sets needed
+          # that this set lacked; it is the combination `make test-integration` already runs.
+          FEATURES="postgres,mysql,delta_lake,duckdb,sqlite,spark,databricks,dynamodb,oracle,kafka,iceberg-write,snapshots,mongodb,turso"
           if [[ "${{ github.event.inputs.run_all_tests }}" == "true" ]]; then
             FEATURES="${FEATURES},extended_tests"
             echo "Including extended_tests"
@@ -178,8 +189,8 @@ jobs:
 
           archive integration cargo nextest archive -p runtime --test integration --features ${FEATURES} --archive-file integration.tar.zst
           archive retention_oom cargo nextest archive -p runtime --test retention_oom --features ${FEATURES} --archive-file retention_oom.tar.zst
-          archive integration_aws_sdk cargo nextest archive -p runtime --test integration_aws_sdk --features databricks,delta_lake --archive-file integration_aws_sdk.tar.zst
-          archive integration_snapshot_refresh cargo nextest archive -p runtime --test integration_snapshot_refresh --features duckdb,sqlite,turso,snapshots --archive-file integration_snapshot_refresh.tar.zst
+          archive integration_aws_sdk cargo nextest archive -p runtime --test integration_aws_sdk --features ${FEATURES} --archive-file integration_aws_sdk.tar.zst
+          archive integration_snapshot_refresh cargo nextest archive -p runtime --test integration_snapshot_refresh --features ${FEATURES} --archive-file integration_snapshot_refresh.tar.zst
           archive credential_provider cargo nextest archive -p aws-sdk-credential-bridge --test credential_provider --archive-file integration_aws_sdk_credential_bridge.tar.zst
           archive partition_table_provider cargo nextest archive -p runtime-table-partition --test partition_table_provider --archive-file partition_table_test.tar.zst
           archive hadoop_catalog_test cargo nextest archive -p data_components --test hadoop_catalog_test --archive-file data_components_hadoop.tar.zst


### PR DESCRIPTION
## What was wrong

The `Build integration test archives` step runs seven `cargo nextest archive`
invocations back to back, across **four different `--features` sets**. Under
`resolver = "2"` the resolved feature set of every crate in the graph is a
function of the flags given, so each change of flags invalidated everything the
previous invocation built and recompiled the graph from `data_components` up. In
one trunk run `object_store` compiled 8 times, `data_components` 5 and `runtime` 4.

That step was ~86 of the ~98 minute run. Actual test execution is ~8 minutes of
wall clock across the parallel test jobs, so the workflow was roughly 90% build.

## The measurement

This adds an `ARCHIVE_TIMING` line per invocation, which is what made the cost
attributable. On a control run the seven archives sum to exactly the measured
step duration:

| # | archive | `--features` | build |
|---|---|---|---|
| 1 | `integration` | the shared set | 28.8 min |
| 2 | `retention_oom` | **same as #1** | **0.5 min** |
| 3 | `integration_aws_sdk` | different | 22.2 min |
| 4 | `integration_snapshot_refresh` | different | 22.9 min |
| 5 | `credential_provider` | default | 0.6 min |
| 6 | `partition_table_provider` | default | 6.0 min |
| 7 | `hadoop_catalog_test` | default | 5.3 min |

Row 2 is the control: reusing the preceding feature set, a full extra ~1.2 GB
test binary costs **28 seconds**. Rows 3 and 4 cost 45.1 minutes between them for
no other reason than differing flags.

## The change

All four `-p runtime` archives now build with one feature set. `turso` is the only
feature the narrower sets needed that the shared set lacked.

**This preserves each target's test selection**, because the shared set is a
*superset* of what each target was already built with. Both targets are gated:
`integration_aws_sdk` gates on `all(databricks, delta_lake)` and `snapshot_refresh`
gates each backend on `duckdb`/`sqlite`/`turso`. Every one of those features is in
the shared set, so every gate satisfied before is still satisfied, and `turso` is
the only one the set previously lacked. `integration` itself is unaffected: its lone
`turso` gate sits inside an `any(...)` that `postgres`/`duckdb`/`sqlite` already
satisfy.

(An earlier revision of this description claimed the two targets contained no
`cfg(feature)` at all. That was wrong — the grep behind it did not match
`cfg(all(feature = ...))`. Corrected in 8cfa3fc; the conclusion is unchanged but it
rests on the superset property, not on the absence of gates.)

## Result

Reproduced over two runs, against a control on the same commit:

| | control | with the change |
|---|---|---|
| build step | 86.3 min | **53.1 / 53.8 min** |
| build job | 88.4 min | 56.0 / 56.0 min |
| run wall | 97.9 min | 65.8 / 65.3 min |
| test jobs green | 8/8 | 8/8 / 8/8 |

Archives 3 and 4 drop to 0.5 min each, matching the control's own 28 s marginal
archive. Net **~33 minutes (−38%)** off every integration run. `integration`
itself grows ~8 min from the wider feature set, which the 45 min recovered
dwarfs.

## Variant measured and rejected

Sharing one *package* selection across all seven invocations — so a newly added
target could not diverge on either axis — was built and run. It is worse: every
archive then carries the whole selection's non-test binaries, so
`data_components_hadoop` grows 0.25 → 1.70 GiB and `partition_table_test`
0.28 → 1.72 GiB, inflating compression (`credential_provider` 0.7 → 3.5 min) plus
upload and per-job download. Build step 58.6 min, i.e. ~5 min *slower*. Recorded
here so it does not get retried.

## Notes

- The timing wrapper captures each invocation's exit status and re-raises it.
  Returning the trailing `echo`'s status instead would let a failed archive pass
  as success — the step would go green on a broken build.
- The same divergence exists in `make signoff`'s phases (its lint and test phases
  differ on both features and the exclude list, and 35 unit tests behind `models`
  and `elasticsearch` are linted but never run). Deliberately **not** in this PR.
