### PR TITLE
fix(snowflake): keep NUMBER precision and scale during schema discovery

### DIFF
--- a/crates/data_components/src/snowflake/mod.rs
+++ b/crates/data_components/src/snowflake/mod.rs
@@ -20,7 +20,7 @@ mod write;
 
 use crate::function_support::FunctionSupport;
 use arrow::array::Array;
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit, i256};
 use async_trait::async_trait;
 use datafusion::{
     datasource::TableProvider,
@@ -508,9 +508,7 @@ fn arrow_information_schema_integer(
         }
         DataType::Decimal256(_, scale) => {
             let unscaled = array.as_primitive::<Decimal256Type>().value(row);
-            unscaled
-                .to_i128()
-                .and_then(|unscaled| integer_from_decimal(unscaled, *scale))
+            integer_from_wide_decimal(unscaled, *scale)
                 .ok_or_else(|| unusable(&decimal_rendering(unscaled, *scale)))?
         }
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
@@ -578,6 +576,27 @@ fn integer_from_decimal(unscaled: i128, scale: i8) -> Option<i128> {
         std::cmp::Ordering::Equal => Some(unscaled),
         std::cmp::Ordering::Greater => (unscaled % power == 0).then_some(unscaled / power),
         std::cmp::Ordering::Less => unscaled.checked_mul(power),
+    }
+}
+
+/// Converts a 256-bit decimal metadata value into the whole number it stands
+/// for.
+///
+/// The rescaling happens at full width and only the result is narrowed: a
+/// `Decimal256(76, 38)` cell holding `12` carries a coefficient of 12 followed
+/// by 38 zeros, which no [`i128`] can hold even though the number it represents
+/// is small.
+fn integer_from_wide_decimal(unscaled: i256, scale: i8) -> Option<i128> {
+    let power = i256::from(10_i64).checked_pow(u32::from(scale.unsigned_abs()))?;
+    match scale.cmp(&0) {
+        std::cmp::Ordering::Equal => unscaled.to_i128(),
+        std::cmp::Ordering::Greater => {
+            if unscaled.checked_rem(power)? != i256::ZERO {
+                return None;
+            }
+            unscaled.checked_div(power)?.to_i128()
+        }
+        std::cmp::Ordering::Less => unscaled.checked_mul(power)?.to_i128(),
     }
 }
 
@@ -995,8 +1014,9 @@ impl SnowflakeTableFactory {
 mod tests {
     use super::*;
     use arrow::array::{
-        ArrayRef, BooleanArray, Decimal128Array, Int8Array, Int16Array, Int32Array, Int64Array,
-        NullArray, RecordBatch, StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int8Array, Int16Array,
+        Int32Array, Int64Array, NullArray, RecordBatch, StringArray, UInt8Array, UInt16Array,
+        UInt32Array, UInt64Array,
     };
 
     #[test]
@@ -1434,6 +1454,54 @@ mod tests {
             .expect("information_schema Arrow response should parse");
 
         assert_lineitem_schema(&schema);
+    }
+
+    /// A metadata cell wide enough to need 256 bits has to be rescaled before it
+    /// is narrowed: a `Decimal256(76, 38)` cell holding 12 carries a coefficient
+    /// of 12 followed by 38 zeros, which overruns an `i128` even though the
+    /// number it represents is small.
+    #[test]
+    fn information_schema_arrow_keeps_scale_from_wide_decimal_metadata_columns() {
+        let wide = |digits: &str| {
+            Arc::new(
+                Decimal256Array::from(vec![Some(
+                    i256::from_string(digits).expect("wide decimal literal"),
+                )])
+                .with_precision_and_scale(76, 38)
+                .expect("Decimal256(76,38) metadata column should build"),
+            ) as ArrayRef
+        };
+        let scaled = |value: &str| wide(&format!("{value}{}", "0".repeat(38)));
+
+        let batch = information_schema_batch(
+            &["AMOUNT"],
+            &["NUMBER"],
+            &["YES"],
+            scaled("12"),
+            scaled("2"),
+        );
+
+        let schema = parse_information_schema_arrow(&[batch], "SALES.ORDERS")
+            .expect("a wide decimal metadata column should parse");
+
+        assert_eq!(schema.field(0).data_type(), &DataType::Decimal128(12, 2));
+
+        // 12.5 is not the whole number `numeric_precision` declares, and must
+        // not be truncated into one.
+        let fractional = information_schema_batch(
+            &["AMOUNT"],
+            &["NUMBER"],
+            &["YES"],
+            wide(&format!("125{}", "0".repeat(37))),
+            scaled("2"),
+        );
+
+        let error = parse_information_schema_arrow(&[fractional], "SALES.ORDERS")
+            .expect_err("a fractional wide decimal must not register a schema");
+        assert!(
+            error.contains("numeric_precision") && error.contains("'AMOUNT'"),
+            "error must name the metadata column and the column: {error}"
+        );
     }
 
     /// Snowflake sizes an integer metadata column to the values it holds, so

--- a/crates/data_components/src/snowflake/mod.rs
+++ b/crates/data_components/src/snowflake/mod.rs
@@ -327,6 +327,8 @@ fn parse_information_schema_json(
                 .map(|raw| decimal_scale(raw, precision, col_name, table_name))
                 .transpose()?;
 
+        ensure_fixed_point_metadata(data_type_str, precision, scale, col_name, table_name)?;
+
         let data_type = map_snowflake_sql_type(data_type_str, precision, scale);
         let source_type = snowflake_source_type(data_type_str, precision, scale);
 
@@ -433,6 +435,8 @@ fn parse_information_schema_arrow(
                 arrow_information_schema_integer(scales, i, "numeric_scale", col_name, table_name)?
                     .map(|raw| decimal_scale(raw, precision, col_name, table_name))
                     .transpose()?;
+
+            ensure_fixed_point_metadata(data_type_str, precision, scale, col_name, table_name)?;
 
             let data_type = map_snowflake_sql_type(data_type_str, precision, scale);
             let source_type = snowflake_source_type(data_type_str, precision, scale);
@@ -613,6 +617,54 @@ fn integer_from_text(text: &str) -> Option<i128> {
         return None;
     }
     integer.parse::<i128>().ok()
+}
+
+/// Whether a Snowflake `information_schema` `DATA_TYPE` is fixed-point, i.e. a
+/// type whose Arrow mapping is a decimal and therefore carries `NUMBER`'s
+/// precision and scale.
+fn is_fixed_point_snowflake_type(sql_type: &str) -> bool {
+    matches!(
+        sql_type.to_uppercase().as_str(),
+        "NUMBER"
+            | "DECIMAL"
+            | "NUMERIC"
+            | "INT"
+            | "INTEGER"
+            | "BIGINT"
+            | "SMALLINT"
+            | "TINYINT"
+            | "BYTEINT"
+    )
+}
+
+/// Rejects a fixed-point column whose precision or scale `information_schema`
+/// did not report.
+///
+/// Without both, [`map_snowflake_sql_type`] falls back to `Decimal128(38, 0)` —
+/// the scale-zero mapping that rounds every fraction away. Failing the probe
+/// hands discovery to `SHOW COLUMNS`, whose type descriptor carries the real
+/// precision and scale. Columns that are not fixed-point never report either
+/// value and are left alone.
+fn ensure_fixed_point_metadata(
+    sql_type: &str,
+    precision: Option<u8>,
+    scale: Option<i8>,
+    column_name: &str,
+    table_name: &str,
+) -> std::result::Result<(), String> {
+    let missing = match (precision, scale) {
+        (Some(_), Some(_)) => return Ok(()),
+        (None, Some(_)) => "`numeric_precision`",
+        (Some(_), None) => "`numeric_scale`",
+        (None, None) => "`numeric_precision` and `numeric_scale`",
+    };
+    if !is_fixed_point_snowflake_type(sql_type) {
+        return Ok(());
+    }
+
+    Err(format!(
+        "column '{column_name}' of table '{table_name}' is a {sql_type} column, but Snowflake reported no {missing} for it, so the digits it stores after the decimal point are unknown"
+    ))
 }
 
 /// Validates a Snowflake `NUMERIC_PRECISION` as an Arrow decimal precision.
@@ -807,28 +859,19 @@ fn simple_snowflake_identifier(value: &str) -> Option<String> {
 fn map_snowflake_sql_type(sql_type: &str, precision: Option<u8>, scale: Option<i8>) -> DataType {
     let upper = sql_type.to_uppercase();
     match upper.as_str() {
-        "NUMBER" | "DECIMAL" | "NUMERIC" | "INT" | "INTEGER" | "BIGINT" | "SMALLINT"
-        | "TINYINT" | "BYTEINT" | "FLOAT" | "FLOAT4" | "FLOAT8" | "DOUBLE" | "DOUBLE PRECISION"
-        | "REAL" => {
-            let p = precision.unwrap_or(38);
-            let s = scale.unwrap_or(0);
-            if s == 0 && upper != "NUMBER" {
-                match upper.as_str() {
-                    // Snowflake documents that FLOAT, FLOAT4, FLOAT8, REAL, DOUBLE,
-                    // and DOUBLE PRECISION are all stored internally as 64-bit
-                    // double-precision floats (see "Summary of data types"
-                    // footnote [1]). Mapping any of these to Float32 would be
-                    // lossy and would also disagree with the `SHOW COLUMNS` path
-                    // that maps "REAL" to Float64. Use Float64 for the entire
-                    // float family to keep both discovery paths consistent.
-                    "FLOAT" | "FLOAT4" | "FLOAT8" | "DOUBLE" | "DOUBLE PRECISION" | "REAL" => {
-                        DataType::Float64
-                    }
-                    _ => DataType::Decimal128(p, s),
-                }
-            } else {
-                DataType::Decimal128(p, s)
-            }
+        fixed_point if is_fixed_point_snowflake_type(fixed_point) => DataType::Decimal128(
+            precision.unwrap_or(MAX_DECIMAL_PRECISION),
+            scale.unwrap_or(0),
+        ),
+        // Snowflake documents that FLOAT, FLOAT4, FLOAT8, REAL, DOUBLE, and
+        // DOUBLE PRECISION are all stored internally as 64-bit
+        // double-precision floats (see "Summary of data types" footnote [1]).
+        // Mapping any of these to Float32 would be lossy and would also
+        // disagree with the `SHOW COLUMNS` path that maps "REAL" to Float64.
+        // Use Float64 for the entire float family to keep both discovery paths
+        // consistent.
+        "FLOAT" | "FLOAT4" | "FLOAT8" | "DOUBLE" | "DOUBLE PRECISION" | "REAL" => {
+            DataType::Float64
         }
         "VARCHAR" | "CHAR" | "CHARACTER" | "STRING" | "TEXT" | "VARIANT" | "OBJECT" | "ARRAY"
         // Structured MAP collapses to JSON text here because
@@ -1585,6 +1628,96 @@ mod tests {
         assert!(
             error.contains("numeric_precision") && error.contains("'A'"),
             "error must name the metadata column and the column: {error}"
+        );
+    }
+
+    /// A fixed-point column Snowflake reported no precision or scale for cannot
+    /// be mapped without inventing a scale, so the probe must fail and let
+    /// discovery fall back to `SHOW COLUMNS` instead of registering
+    /// `Decimal128(38, 0)` and rounding every fraction away.
+    #[test]
+    fn information_schema_arrow_rejects_a_fixed_point_column_without_precision_or_scale() {
+        let cases: Vec<(&str, ArrayRef, ArrayRef, &str)> = vec![
+            (
+                "neither reported",
+                Arc::new(Int64Array::from(vec![None::<i64>])),
+                Arc::new(Int64Array::from(vec![None::<i64>])),
+                "`numeric_precision` and `numeric_scale`",
+            ),
+            (
+                "no scale",
+                Arc::new(Int64Array::from(vec![Some(12)])),
+                Arc::new(Int64Array::from(vec![None::<i64>])),
+                "`numeric_scale`",
+            ),
+            (
+                "no precision",
+                Arc::new(Int64Array::from(vec![None::<i64>])),
+                Arc::new(Int64Array::from(vec![Some(2)])),
+                "`numeric_precision`",
+            ),
+            (
+                "empty text",
+                Arc::new(StringArray::from(vec![Some("")])),
+                Arc::new(StringArray::from(vec![Some("  ")])),
+                "`numeric_precision` and `numeric_scale`",
+            ),
+        ];
+
+        for (case, precision, scale, expected) in cases {
+            let batch =
+                information_schema_batch(&["AMOUNT"], &["NUMBER"], &["YES"], precision, scale);
+
+            let error = parse_information_schema_arrow(&[batch], "SALES.ORDERS")
+                .expect_err(&format!("{case} must not register a schema"));
+
+            assert!(
+                error.contains(expected),
+                "{case}: error must name the missing metadata: {error}"
+            );
+            assert!(
+                error.contains("'AMOUNT'") && error.contains("'SALES.ORDERS'"),
+                "{case}: error must name the column and table: {error}"
+            );
+        }
+    }
+
+    /// Snowflake reports no numeric precision or scale for a float, a string, or
+    /// a timestamp, so the fixed-point requirement must not reject them.
+    #[test]
+    fn information_schema_arrow_accepts_non_fixed_point_columns_without_precision() {
+        let columns = &["RATING", "NAME", "CREATED_AT", "PRICE"];
+        let batch = information_schema_batch(
+            columns,
+            &["FLOAT", "VARCHAR", "TIMESTAMP_NTZ", "DOUBLE"],
+            &["YES", "YES", "YES", "YES"],
+            Arc::new(Int64Array::from(vec![None::<i64>; 4])),
+            Arc::new(Int64Array::from(vec![None::<i64>; 4])),
+        );
+
+        let schema = parse_information_schema_arrow(&[batch], "SALES.ORDERS")
+            .expect("columns without numeric metadata should parse");
+
+        assert_eq!(schema.field(0).data_type(), &DataType::Float64);
+        assert_eq!(schema.field(1).data_type(), &DataType::Utf8);
+        assert_eq!(
+            schema.field(2).data_type(),
+            &DataType::Timestamp(TimeUnit::Nanosecond, None)
+        );
+        assert_eq!(schema.field(3).data_type(), &DataType::Float64);
+    }
+
+    /// The JSON path applies the same requirement.
+    #[test]
+    fn information_schema_json_rejects_a_fixed_point_column_without_scale() {
+        let rows = serde_json::json!([["AMOUNT", "NUMBER", "NO", 12, null, null, null, null]]);
+
+        let error = parse_information_schema_json(&rows, "SALES.ORDERS")
+            .expect_err("a fixed-point column without a scale must not register a schema");
+
+        assert!(
+            error.contains("`numeric_scale`") && error.contains("'AMOUNT'"),
+            "error must name the missing metadata and the column: {error}"
         );
     }
 }

--- a/crates/data_components/src/snowflake/mod.rs
+++ b/crates/data_components/src/snowflake/mod.rs
@@ -318,16 +318,14 @@ fn parse_information_schema_json(
             .ok_or_else(|| format!("information_schema row {i}: invalid data type"))?;
         let is_nullable = row[2].as_str().is_none_or(|s| s.to_uppercase() == "YES");
 
-        let precision = row.get(3).and_then(|v| {
-            v.as_u64()
-                .and_then(|n| u8::try_from(n).ok())
-                .or_else(|| v.as_str().and_then(|s| s.parse::<u8>().ok()))
-        });
-        let scale = row.get(4).and_then(|v| {
-            v.as_i64()
-                .and_then(|n| i8::try_from(n).ok())
-                .or_else(|| v.as_str().and_then(|s| s.parse::<i8>().ok()))
-        });
+        let precision =
+            json_information_schema_integer(row.get(3), "numeric_precision", col_name, table_name)?
+                .map(|raw| decimal_precision(raw, col_name, table_name))
+                .transpose()?;
+        let scale =
+            json_information_schema_integer(row.get(4), "numeric_scale", col_name, table_name)?
+                .map(|raw| decimal_scale(raw, precision, col_name, table_name))
+                .transpose()?;
 
         let data_type = map_snowflake_sql_type(data_type_str, precision, scale);
         let source_type = snowflake_source_type(data_type_str, precision, scale);
@@ -389,13 +387,16 @@ fn parse_information_schema_arrow(
             .downcast_ref::<arrow::array::StringArray>()
             .ok_or("is_nullable column is not StringArray")?;
 
-        let precisions: Option<&arrow::array::StringArray> = if batch.num_columns() > 3 {
-            batch.column(3).as_string_opt()
+        // `numeric_precision` and `numeric_scale` are read out of whatever
+        // numeric or text Arrow type Snowflake encoded them as, so keep the
+        // erased array rather than committing to one representation.
+        let precisions: Option<&dyn Array> = if batch.num_columns() > 3 {
+            Some(batch.column(3).as_ref())
         } else {
             None
         };
-        let scales: Option<&arrow::array::StringArray> = if batch.num_columns() > 4 {
-            batch.column(4).as_string_opt()
+        let scales: Option<&dyn Array> = if batch.num_columns() > 4 {
+            Some(batch.column(4).as_ref())
         } else {
             None
         };
@@ -419,12 +420,19 @@ fn parse_information_schema_arrow(
             let col_name = col_names.value(i);
             let data_type_str = data_types.value(i);
             let is_nullable = nullables.value(i).to_uppercase() == "YES";
-            let precision = precisions
-                .and_then(|p| if p.is_null(i) { None } else { Some(p.value(i)) })
-                .and_then(|s| s.parse::<u8>().ok());
-            let scale = scales
-                .and_then(|s| if s.is_null(i) { None } else { Some(s.value(i)) })
-                .and_then(|s| s.parse::<i8>().ok());
+            let precision = arrow_information_schema_integer(
+                precisions,
+                i,
+                "numeric_precision",
+                col_name,
+                table_name,
+            )?
+            .map(|raw| decimal_precision(raw, col_name, table_name))
+            .transpose()?;
+            let scale =
+                arrow_information_schema_integer(scales, i, "numeric_scale", col_name, table_name)?
+                    .map(|raw| decimal_scale(raw, precision, col_name, table_name))
+                    .transpose()?;
 
             let data_type = map_snowflake_sql_type(data_type_str, precision, scale);
             let source_type = snowflake_source_type(data_type_str, precision, scale);
@@ -461,6 +469,185 @@ fn parse_information_schema_arrow(
     );
 
     Ok(Arc::new(Schema::new_with_metadata(fields, schema_metadata)))
+}
+
+/// The widest precision an Arrow `Decimal128` — and a Snowflake `NUMBER` — can
+/// represent.
+const MAX_DECIMAL_PRECISION: u8 = 38;
+
+/// Reads one `information_schema.columns` integer cell out of a Snowflake Arrow
+/// response, whatever type Snowflake encoded it as.
+///
+/// `NUMERIC_PRECISION` and `NUMERIC_SCALE` are declared `NUMBER(38,0)`, and
+/// Snowflake picks the Arrow encoding per result chunk: an integer of whichever
+/// width fits, a decimal, or text. Reading a single representation drops the
+/// precision and scale of every column, registering a `NUMBER(12,2)` measure as
+/// `Decimal128(38, 0)` so its fraction is rounded away — permanently, once the
+/// table is accelerated. A cell that cannot be read exactly is an error rather
+/// than an absent value, so discovery falls back to `SHOW COLUMNS` instead of
+/// registering a scale the source never declared.
+fn arrow_information_schema_integer(
+    array: Option<&dyn Array>,
+    row: usize,
+    metadata_column: &str,
+    column_name: &str,
+    table_name: &str,
+) -> std::result::Result<Option<i128>, String> {
+    use arrow::array::AsArray;
+    use arrow::datatypes::{
+        Decimal128Type, Decimal256Type, Int8Type, Int16Type, Int32Type, Int64Type, UInt8Type,
+        UInt16Type, UInt32Type, UInt64Type,
+    };
+
+    let Some(array) = array else {
+        return Ok(None);
+    };
+    if row >= array.len() || array.is_null(row) {
+        return Ok(None);
+    }
+
+    let unusable = |rendered: &str| {
+        format!(
+            "column '{column_name}' of table '{table_name}' reported `{metadata_column}` as {rendered}, which is not a whole number"
+        )
+    };
+
+    let value = match array.data_type() {
+        DataType::Int8 => i128::from(array.as_primitive::<Int8Type>().value(row)),
+        DataType::Int16 => i128::from(array.as_primitive::<Int16Type>().value(row)),
+        DataType::Int32 => i128::from(array.as_primitive::<Int32Type>().value(row)),
+        DataType::Int64 => i128::from(array.as_primitive::<Int64Type>().value(row)),
+        DataType::UInt8 => i128::from(array.as_primitive::<UInt8Type>().value(row)),
+        DataType::UInt16 => i128::from(array.as_primitive::<UInt16Type>().value(row)),
+        DataType::UInt32 => i128::from(array.as_primitive::<UInt32Type>().value(row)),
+        DataType::UInt64 => i128::from(array.as_primitive::<UInt64Type>().value(row)),
+        DataType::Decimal128(_, scale) => {
+            let unscaled = array.as_primitive::<Decimal128Type>().value(row);
+            integer_from_decimal(unscaled, *scale)
+                .ok_or_else(|| unusable(&decimal_rendering(unscaled, *scale)))?
+        }
+        DataType::Decimal256(_, scale) => {
+            let unscaled = array.as_primitive::<Decimal256Type>().value(row);
+            unscaled
+                .to_i128()
+                .and_then(|unscaled| integer_from_decimal(unscaled, *scale))
+                .ok_or_else(|| unusable(&decimal_rendering(unscaled, *scale)))?
+        }
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+            let text = match array.data_type() {
+                DataType::Utf8 => array.as_string::<i32>().value(row),
+                DataType::LargeUtf8 => array.as_string::<i64>().value(row),
+                _ => array.as_string_view().value(row),
+            }
+            .trim();
+            if text.is_empty() {
+                return Ok(None);
+            }
+            integer_from_text(text).ok_or_else(|| unusable(&format!("'{text}'")))?
+        }
+        // A metadata column that is null in every row can arrive as an Arrow
+        // `Null` array, which carries no null buffer for `is_null` to read.
+        DataType::Null => return Ok(None),
+        other => return Err(unusable(&format!("Arrow type {other}"))),
+    };
+
+    Ok(Some(value))
+}
+
+/// Reads one `information_schema.columns` integer cell out of a Snowflake JSON
+/// response, which renders the value as a JSON number or as text.
+fn json_information_schema_integer(
+    value: Option<&serde_json::Value>,
+    metadata_column: &str,
+    column_name: &str,
+    table_name: &str,
+) -> std::result::Result<Option<i128>, String> {
+    let rendered = match value {
+        None | Some(serde_json::Value::Null) => return Ok(None),
+        Some(serde_json::Value::String(text)) => text.trim().to_string(),
+        Some(serde_json::Value::Number(number)) => number.to_string(),
+        Some(other) => {
+            return Err(format!(
+                "column '{column_name}' of table '{table_name}' reported `{metadata_column}` as {other}, which is not a whole number"
+            ));
+        }
+    };
+    if rendered.is_empty() {
+        return Ok(None);
+    }
+
+    integer_from_text(&rendered).map(Some).ok_or_else(|| {
+        format!(
+            "column '{column_name}' of table '{table_name}' reported `{metadata_column}` as '{rendered}', which is not a whole number"
+        )
+    })
+}
+
+/// Describes a decimal metadata cell for an error message, keeping the unscaled
+/// value and the scale separate so a negative scale still reads clearly.
+fn decimal_rendering(unscaled: impl std::fmt::Display, scale: i8) -> String {
+    format!("the decimal value {unscaled} with scale {scale}")
+}
+
+/// Converts a decimal-encoded metadata value into the whole number it stands
+/// for, or `None` when it carries a fraction and so is not the integer
+/// `information_schema` declares.
+fn integer_from_decimal(unscaled: i128, scale: i8) -> Option<i128> {
+    let power = 10_i128.checked_pow(u32::from(scale.unsigned_abs()))?;
+    match scale.cmp(&0) {
+        std::cmp::Ordering::Equal => Some(unscaled),
+        std::cmp::Ordering::Greater => (unscaled % power == 0).then_some(unscaled / power),
+        std::cmp::Ordering::Less => unscaled.checked_mul(power),
+    }
+}
+
+/// Parses a whole number Snowflake rendered as text, accepting the zero
+/// fraction a decimal rendering carries (`12`, `12.`, `12.00`).
+fn integer_from_text(text: &str) -> Option<i128> {
+    if let Ok(value) = text.parse::<i128>() {
+        return Some(value);
+    }
+
+    let (integer, fraction) = text.split_once('.')?;
+    if fraction.bytes().any(|digit| digit != b'0') {
+        return None;
+    }
+    integer.parse::<i128>().ok()
+}
+
+/// Validates a Snowflake `NUMERIC_PRECISION` as an Arrow decimal precision.
+fn decimal_precision(
+    raw: i128,
+    column_name: &str,
+    table_name: &str,
+) -> std::result::Result<u8, String> {
+    u8::try_from(raw)
+        .ok()
+        .filter(|precision| (1..=MAX_DECIMAL_PRECISION).contains(precision))
+        .ok_or_else(|| {
+            format!(
+                "column '{column_name}' of table '{table_name}' reported `numeric_precision` {raw}, outside the 1 to {MAX_DECIMAL_PRECISION} digits a decimal column can hold"
+            )
+        })
+}
+
+/// Validates a Snowflake `NUMERIC_SCALE` as an Arrow decimal scale, which the
+/// column's own precision bounds.
+fn decimal_scale(
+    raw: i128,
+    precision: Option<u8>,
+    column_name: &str,
+    table_name: &str,
+) -> std::result::Result<i8, String> {
+    let limit = i128::from(precision.unwrap_or(MAX_DECIMAL_PRECISION));
+    i8::try_from(raw)
+        .ok()
+        .filter(|_| (0..=limit).contains(&raw))
+        .ok_or_else(|| {
+            format!(
+                "column '{column_name}' of table '{table_name}' reported `numeric_scale` {raw}, outside the 0 to {limit} digits its `numeric_precision` allows"
+            )
+        })
 }
 
 fn optional_json_string(value: Option<&serde_json::Value>) -> Option<&str> {
@@ -770,6 +957,10 @@ impl SnowflakeTableFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::{
+        ArrayRef, BooleanArray, Decimal128Array, Int8Array, Int16Array, Int32Array, Int64Array,
+        NullArray, RecordBatch, StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+    };
 
     #[test]
     fn snowflake_dialect_unparses_at_time_zone_as_convert_timezone() {
@@ -1060,5 +1251,340 @@ mod tests {
                 "Mismatch for {sql_type}"
             );
         }
+    }
+
+    /// Builds the eight-column `information_schema.columns` Arrow response that
+    /// `probe_snowflake_information_schema` selects, with caller-supplied
+    /// precision and scale arrays so each Snowflake encoding can be exercised.
+    fn information_schema_batch(
+        names: &[&str],
+        data_types: &[&str],
+        nullables: &[&str],
+        precisions: ArrayRef,
+        scales: ArrayRef,
+    ) -> RecordBatch {
+        let rows = names.len();
+        let empty = || Arc::new(StringArray::from(vec![None::<&str>; rows])) as ArrayRef;
+
+        RecordBatch::try_from_iter(vec![
+            (
+                "COLUMN_NAME",
+                Arc::new(StringArray::from(names.to_vec())) as ArrayRef,
+            ),
+            (
+                "DATA_TYPE",
+                Arc::new(StringArray::from(data_types.to_vec())) as ArrayRef,
+            ),
+            (
+                "IS_NULLABLE",
+                Arc::new(StringArray::from(nullables.to_vec())) as ArrayRef,
+            ),
+            ("NUMERIC_PRECISION", precisions),
+            ("NUMERIC_SCALE", scales),
+            ("COMMENT", empty()),
+            ("TABLE_COMMENT", empty()),
+            ("CLUSTERING_KEY", empty()),
+        ])
+        .expect("information_schema Arrow batch should build")
+    }
+
+    /// A `NUMBER(38,0)` metadata column carrying `values`, which is how
+    /// Snowflake encodes `NUMERIC_PRECISION` and `NUMERIC_SCALE` when the
+    /// result chunk uses a decimal representation.
+    fn metadata_decimal(values: &[Option<i128>]) -> ArrayRef {
+        Arc::new(
+            Decimal128Array::from(values.to_vec())
+                .with_precision_and_scale(38, 0)
+                .expect("NUMBER(38,0) metadata column should build"),
+        )
+    }
+
+    /// The `LINEITEM` columns from #13271: a scale-zero key, three
+    /// `NUMBER(12,2)` measures, and a text column with no numeric metadata.
+    const LINEITEM_COLUMNS: &[&str] = &[
+        "L_ORDERKEY",
+        "L_QUANTITY",
+        "L_DISCOUNT",
+        "L_TAX",
+        "L_SHIPMODE",
+    ];
+    const LINEITEM_TYPES: &[&str] = &["NUMBER", "NUMBER", "NUMBER", "NUMBER", "TEXT"];
+    const LINEITEM_NULLABLE: &[&str] = &["NO", "NO", "NO", "NO", "YES"];
+
+    fn assert_lineitem_schema(schema: &Schema) {
+        assert_eq!(
+            schema.field(0).data_type(),
+            &DataType::Decimal128(38, 0),
+            "L_ORDERKEY is NUMBER(38,0)"
+        );
+        for index in 1..=3 {
+            let field = schema.field(index);
+            assert_eq!(
+                field.data_type(),
+                &DataType::Decimal128(12, 2),
+                "{} must keep Snowflake's scale, or every fraction is rounded away",
+                field.name()
+            );
+            assert_eq!(
+                field
+                    .metadata()
+                    .get(SOURCE_TYPE_METADATA_KEY)
+                    .map(String::as_str),
+                Some("NUMBER(12,2)"),
+                "{} source type",
+                field.name()
+            );
+        }
+        assert_eq!(
+            schema.field(4).data_type(),
+            &DataType::Utf8,
+            "L_SHIPMODE has no numeric precision or scale"
+        );
+        assert!(
+            !schema.field(0).is_nullable(),
+            "L_ORDERKEY is declared NOT NULL"
+        );
+        assert!(schema.field(4).is_nullable(), "L_SHIPMODE is nullable");
+    }
+
+    /// Regression test for #13271: Snowflake returns `NUMERIC_PRECISION` and
+    /// `NUMERIC_SCALE` as Arrow integers, and reading them as text only
+    /// registered every `NUMBER(12,2)` column as `Decimal128(38, 0)` —
+    /// rounding away the fraction the source stores, and permanently
+    /// materializing zeros once the table is accelerated.
+    #[test]
+    fn information_schema_arrow_keeps_scale_from_integer_metadata_columns() {
+        let batch = information_schema_batch(
+            LINEITEM_COLUMNS,
+            LINEITEM_TYPES,
+            LINEITEM_NULLABLE,
+            Arc::new(Int64Array::from(vec![
+                Some(38),
+                Some(12),
+                Some(12),
+                Some(12),
+                None,
+            ])),
+            Arc::new(Int64Array::from(vec![
+                Some(0),
+                Some(2),
+                Some(2),
+                Some(2),
+                None,
+            ])),
+        );
+
+        let schema = parse_information_schema_arrow(&[batch], "TPCH_SF1.LINEITEM")
+            .expect("information_schema Arrow response should parse");
+
+        assert_lineitem_schema(&schema);
+    }
+
+    /// The same metadata delivered as decimals, which is how Snowflake encodes
+    /// the `NUMBER(38,0)` `information_schema` columns when the result chunk
+    /// exceeds the width of an Arrow integer.
+    #[test]
+    fn information_schema_arrow_keeps_scale_from_decimal_metadata_columns() {
+        let batch = information_schema_batch(
+            LINEITEM_COLUMNS,
+            LINEITEM_TYPES,
+            LINEITEM_NULLABLE,
+            metadata_decimal(&[Some(38), Some(12), Some(12), Some(12), None]),
+            metadata_decimal(&[Some(0), Some(2), Some(2), Some(2), None]),
+        );
+
+        let schema = parse_information_schema_arrow(&[batch], "TPCH_SF1.LINEITEM")
+            .expect("information_schema Arrow response should parse");
+
+        assert_lineitem_schema(&schema);
+    }
+
+    /// Snowflake sizes an integer metadata column to the values it holds, so
+    /// the same response can arrive as any Arrow integer width, signed or
+    /// unsigned.
+    #[test]
+    fn information_schema_arrow_keeps_scale_from_every_integer_width() {
+        let precisions: Vec<ArrayRef> = vec![
+            Arc::new(Int8Array::from(vec![Some(12)])),
+            Arc::new(Int16Array::from(vec![Some(12)])),
+            Arc::new(Int32Array::from(vec![Some(12)])),
+            Arc::new(Int64Array::from(vec![Some(12)])),
+            Arc::new(UInt8Array::from(vec![Some(12)])),
+            Arc::new(UInt16Array::from(vec![Some(12)])),
+            Arc::new(UInt32Array::from(vec![Some(12)])),
+            Arc::new(UInt64Array::from(vec![Some(12)])),
+        ];
+
+        for precision in precisions {
+            let arrow_type = precision.data_type().clone();
+            let batch = information_schema_batch(
+                &["AMOUNT"],
+                &["NUMBER"],
+                &["YES"],
+                precision,
+                Arc::new(Int32Array::from(vec![Some(2)])),
+            );
+
+            let schema = parse_information_schema_arrow(&[batch], "SALES.ORDERS")
+                .unwrap_or_else(|e| panic!("{arrow_type} precision should parse: {e}"));
+
+            assert_eq!(
+                schema.field(0).data_type(),
+                &DataType::Decimal128(12, 2),
+                "{arrow_type} precision dropped"
+            );
+        }
+    }
+
+    /// The text representation Snowflake uses in its JSON result format still
+    /// has to be read, including a decimal-rendered integer such as `12.00`.
+    #[test]
+    fn information_schema_arrow_keeps_scale_from_string_metadata_columns() {
+        let batch = information_schema_batch(
+            &["AMOUNT", "TOTAL", "NAME"],
+            &["NUMBER", "NUMBER", "VARCHAR"],
+            &["YES", "YES", "YES"],
+            Arc::new(StringArray::from(vec![Some("12"), Some("12.00"), None])),
+            Arc::new(StringArray::from(vec![Some("2"), Some(" 2 "), None])),
+        );
+
+        let schema = parse_information_schema_arrow(&[batch], "SALES.ORDERS")
+            .expect("string metadata should still parse");
+
+        assert_eq!(schema.field(0).data_type(), &DataType::Decimal128(12, 2));
+        assert_eq!(schema.field(1).data_type(), &DataType::Decimal128(12, 2));
+        assert_eq!(schema.field(2).data_type(), &DataType::Utf8);
+    }
+
+    /// An all-null metadata column arrives as an Arrow `Null` array, which
+    /// carries no integers to read and must not be mistaken for unreadable
+    /// metadata.
+    #[test]
+    fn information_schema_arrow_accepts_all_null_metadata_columns() {
+        let batch = information_schema_batch(
+            &["NAME"],
+            &["VARCHAR"],
+            &["YES"],
+            Arc::new(NullArray::new(1)),
+            Arc::new(NullArray::new(1)),
+        );
+
+        let schema = parse_information_schema_arrow(&[batch], "SALES.ORDERS")
+            .expect("absent numeric metadata should parse");
+
+        assert_eq!(schema.field(0).data_type(), &DataType::Utf8);
+    }
+
+    /// Metadata Spice cannot turn into a precision and scale must fail the
+    /// probe so discovery falls back to `SHOW COLUMNS`, rather than register a
+    /// silently wrong scale. Each case names the column and the table so the
+    /// fallback warning identifies what to look at.
+    #[test]
+    fn information_schema_arrow_rejects_unusable_precision_and_scale() {
+        let cases: Vec<(&str, ArrayRef, ArrayRef, &str)> = vec![
+            (
+                "precision above the Decimal128 maximum",
+                Arc::new(Int64Array::from(vec![Some(99)])),
+                Arc::new(Int64Array::from(vec![Some(2)])),
+                "numeric_precision",
+            ),
+            (
+                "zero precision",
+                Arc::new(Int64Array::from(vec![Some(0)])),
+                Arc::new(Int64Array::from(vec![Some(0)])),
+                "numeric_precision",
+            ),
+            (
+                "negative precision",
+                Arc::new(Int64Array::from(vec![Some(-12)])),
+                Arc::new(Int64Array::from(vec![Some(2)])),
+                "numeric_precision",
+            ),
+            (
+                "scale wider than the precision",
+                Arc::new(Int64Array::from(vec![Some(12)])),
+                Arc::new(Int64Array::from(vec![Some(20)])),
+                "numeric_scale",
+            ),
+            (
+                "negative scale",
+                Arc::new(Int64Array::from(vec![Some(12)])),
+                Arc::new(Int64Array::from(vec![Some(-2)])),
+                "numeric_scale",
+            ),
+            (
+                "unreadable Arrow type",
+                Arc::new(BooleanArray::from(vec![Some(true)])),
+                Arc::new(Int64Array::from(vec![Some(2)])),
+                "numeric_precision",
+            ),
+            (
+                "text that is not a number",
+                Arc::new(StringArray::from(vec![Some("twelve")])),
+                Arc::new(Int64Array::from(vec![Some(2)])),
+                "numeric_precision",
+            ),
+            (
+                "fractional decimal",
+                Arc::new(
+                    Decimal128Array::from(vec![Some(1250_i128)])
+                        .with_precision_and_scale(38, 2)
+                        .expect("fractional metadata column should build"),
+                ),
+                Arc::new(Int64Array::from(vec![Some(2)])),
+                "numeric_precision",
+            ),
+        ];
+
+        for (case, precision, scale, expected_column) in cases {
+            let batch =
+                information_schema_batch(&["AMOUNT"], &["NUMBER"], &["YES"], precision, scale);
+
+            let error = parse_information_schema_arrow(&[batch], "SALES.ORDERS")
+                .expect_err(&format!("{case} must not register a schema"));
+
+            assert!(
+                error.contains(expected_column),
+                "{case}: error must name the metadata column it could not read: {error}"
+            );
+            assert!(
+                error.contains("'AMOUNT'") && error.contains("'SALES.ORDERS'"),
+                "{case}: error must name the column and table: {error}"
+            );
+        }
+    }
+
+    /// The JSON result format reaches the same conversion, so a precision and
+    /// scale it renders as text, or as a whole number with a decimal point,
+    /// must survive, and unusable metadata must fail there too.
+    #[test]
+    fn information_schema_json_reads_every_precision_representation() {
+        let rows = serde_json::json!([
+            ["A", "NUMBER", "NO", 12, 2, null, null, null],
+            ["B", "NUMBER", "NO", "12", "2", null, null, null],
+            ["C", "NUMBER", "NO", 12.0, 2.0, null, null, null],
+            ["D", "VARCHAR", "YES", null, null, null, null, null]
+        ]);
+
+        let schema = parse_information_schema_json(&rows, "SALES.ORDERS")
+            .expect("every precision representation should parse");
+
+        for index in 0..3 {
+            assert_eq!(
+                schema.field(index).data_type(),
+                &DataType::Decimal128(12, 2),
+                "{} lost its scale",
+                schema.field(index).name()
+            );
+        }
+        assert_eq!(schema.field(3).data_type(), &DataType::Utf8);
+
+        let invalid = serde_json::json!([["A", "NUMBER", "NO", 99, 2, null, null, null]]);
+        let error = parse_information_schema_json(&invalid, "SALES.ORDERS")
+            .expect_err("an out-of-range precision must not register a schema");
+        assert!(
+            error.contains("numeric_precision") && error.contains("'A'"),
+            "error must name the metadata column and the column: {error}"
+        );
     }
 }

--- a/crates/data_components/src/snowflake/mod.rs
+++ b/crates/data_components/src/snowflake/mod.rs
@@ -318,16 +318,10 @@ fn parse_information_schema_json(
             .ok_or_else(|| format!("information_schema row {i}: invalid data type"))?;
         let is_nullable = row[2].as_str().is_none_or(|s| s.to_uppercase() == "YES");
 
-        let precision =
-            json_information_schema_integer(row.get(3), "numeric_precision", col_name, table_name)?
-                .map(|raw| decimal_precision(raw, col_name, table_name))
-                .transpose()?;
-        let scale =
-            json_information_schema_integer(row.get(4), "numeric_scale", col_name, table_name)?
-                .map(|raw| decimal_scale(raw, precision, col_name, table_name))
-                .transpose()?;
-
-        ensure_fixed_point_metadata(data_type_str, precision, scale, col_name, table_name)?;
+        let (precision, scale) =
+            precision_and_scale(data_type_str, col_name, table_name, |column, metadata| {
+                json_information_schema_integer(row.get(column), metadata, col_name, table_name)
+            })?;
 
         let data_type = map_snowflake_sql_type(data_type_str, precision, scale);
         let source_type = snowflake_source_type(data_type_str, precision, scale);
@@ -389,19 +383,6 @@ fn parse_information_schema_arrow(
             .downcast_ref::<arrow::array::StringArray>()
             .ok_or("is_nullable column is not StringArray")?;
 
-        // `numeric_precision` and `numeric_scale` are read out of whatever
-        // numeric or text Arrow type Snowflake encoded them as, so keep the
-        // erased array rather than committing to one representation.
-        let precisions: Option<&dyn Array> = if batch.num_columns() > 3 {
-            Some(batch.column(3).as_ref())
-        } else {
-            None
-        };
-        let scales: Option<&dyn Array> = if batch.num_columns() > 4 {
-            Some(batch.column(4).as_ref())
-        } else {
-            None
-        };
         let comments: Option<&arrow::array::StringArray> = if batch.num_columns() > 5 {
             batch.column(5).as_string_opt()
         } else {
@@ -422,21 +403,16 @@ fn parse_information_schema_arrow(
             let col_name = col_names.value(i);
             let data_type_str = data_types.value(i);
             let is_nullable = nullables.value(i).to_uppercase() == "YES";
-            let precision = arrow_information_schema_integer(
-                precisions,
-                i,
-                "numeric_precision",
-                col_name,
-                table_name,
-            )?
-            .map(|raw| decimal_precision(raw, col_name, table_name))
-            .transpose()?;
-            let scale =
-                arrow_information_schema_integer(scales, i, "numeric_scale", col_name, table_name)?
-                    .map(|raw| decimal_scale(raw, precision, col_name, table_name))
-                    .transpose()?;
-
-            ensure_fixed_point_metadata(data_type_str, precision, scale, col_name, table_name)?;
+            let (precision, scale) =
+                precision_and_scale(data_type_str, col_name, table_name, |column, metadata| {
+                    // `numeric_precision` and `numeric_scale` arrive in whatever
+                    // numeric or text Arrow type Snowflake encoded them as, so
+                    // hand the reader the erased array rather than committing to
+                    // one representation.
+                    let array =
+                        (batch.num_columns() > column).then(|| batch.column(column).as_ref());
+                    arrow_information_schema_integer(array, i, metadata, col_name, table_name)
+                })?;
 
             let data_type = map_snowflake_sql_type(data_type_str, precision, scale);
             let source_type = snowflake_source_type(data_type_str, precision, scale);
@@ -637,30 +613,48 @@ fn is_fixed_point_snowflake_type(sql_type: &str) -> bool {
     )
 }
 
-/// Rejects a fixed-point column whose precision or scale `information_schema`
-/// did not report.
+/// Position of `NUMERIC_PRECISION` in the `information_schema.columns` row
+/// [`probe_snowflake_information_schema`] selects.
+const PRECISION_COLUMN: usize = 3;
+/// Position of `NUMERIC_SCALE` in that same row.
+const SCALE_COLUMN: usize = 4;
+
+/// Reads the precision and scale a column's Arrow mapping needs out of one
+/// `information_schema.columns` row, where `read` fetches a raw metadata cell by
+/// its position in the row.
 ///
-/// Without both, [`map_snowflake_sql_type`] falls back to `Decimal128(38, 0)` —
-/// the scale-zero mapping that rounds every fraction away. Failing the probe
-/// hands discovery to `SHOW COLUMNS`, whose type descriptor carries the real
-/// precision and scale. Columns that are not fixed-point never report either
-/// value and are left alone.
-fn ensure_fixed_point_metadata(
+/// Only a fixed-point type consults these two columns, so they are left unread
+/// for every other type. Snowflake does not report a decimal's digits there for
+/// a float, a string, or a timestamp, and rejecting whatever it does report
+/// would fail the preferred probe over metadata that nothing goes on to use.
+///
+/// A fixed-point column must report both. Without them [`map_snowflake_sql_type`]
+/// falls back to `Decimal128(38, 0)`, the scale-zero mapping that rounds every
+/// fraction away; failing the probe instead hands discovery to `SHOW COLUMNS`,
+/// whose type descriptor carries the real precision and scale.
+fn precision_and_scale(
     sql_type: &str,
-    precision: Option<u8>,
-    scale: Option<i8>,
     column_name: &str,
     table_name: &str,
-) -> std::result::Result<(), String> {
+    read: impl Fn(usize, &str) -> std::result::Result<Option<i128>, String>,
+) -> std::result::Result<(Option<u8>, Option<i8>), String> {
+    if !is_fixed_point_snowflake_type(sql_type) {
+        return Ok((None, None));
+    }
+
+    let precision = read(PRECISION_COLUMN, "numeric_precision")?
+        .map(|raw| decimal_precision(raw, column_name, table_name))
+        .transpose()?;
+    let scale = read(SCALE_COLUMN, "numeric_scale")?
+        .map(|raw| decimal_scale(raw, precision, column_name, table_name))
+        .transpose()?;
+
     let missing = match (precision, scale) {
-        (Some(_), Some(_)) => return Ok(()),
+        (Some(_), Some(_)) => return Ok((precision, scale)),
         (None, Some(_)) => "`numeric_precision`",
         (Some(_), None) => "`numeric_scale`",
         (None, None) => "`numeric_precision` and `numeric_scale`",
     };
-    if !is_fixed_point_snowflake_type(sql_type) {
-        return Ok(());
-    }
 
     Err(format!(
         "column '{column_name}' of table '{table_name}' is a {sql_type} column, but Snowflake reported no {missing} for it, so the digits it stores after the decimal point are unknown"
@@ -1682,29 +1676,104 @@ mod tests {
         }
     }
 
-    /// Snowflake reports no numeric precision or scale for a float, a string, or
-    /// a timestamp, so the fixed-point requirement must not reject them.
+    /// A float, string, or timestamp column carries no decimal digits, so
+    /// whatever `information_schema` reports in the numeric columns for it must
+    /// neither be required nor rejected.
+    ///
+    /// Snowflake does not report a decimal's precision for these types, and what
+    /// it does report is not one: holding those values to the 1-38 digits a
+    /// decimal can hold would fail the preferred probe for any table with a
+    /// `FLOAT` column and silently drop to `SHOW COLUMNS`, losing the
+    /// nullability, comments, and clustering metadata this probe exists to read.
     #[test]
-    fn information_schema_arrow_accepts_non_fixed_point_columns_without_precision() {
-        let columns = &["RATING", "NAME", "CREATED_AT", "PRICE"];
-        let batch = information_schema_batch(
-            columns,
-            &["FLOAT", "VARCHAR", "TIMESTAMP_NTZ", "DOUBLE"],
-            &["YES", "YES", "YES", "YES"],
-            Arc::new(Int64Array::from(vec![None::<i64>; 4])),
-            Arc::new(Int64Array::from(vec![None::<i64>; 4])),
-        );
+    fn information_schema_arrow_accepts_non_fixed_point_columns_whatever_the_numeric_columns_say() {
+        let columns = &["RATING", "NAME", "CREATED_AT", "PRICE", "ACTIVE", "SHIPPED"];
+        let types = &[
+            "FLOAT",
+            "VARCHAR",
+            "TIMESTAMP_NTZ",
+            "DOUBLE",
+            "BOOLEAN",
+            "DATE",
+        ];
+        let nullable = &["YES", "YES", "YES", "YES", "YES", "YES"];
+        // A zero precision, a binary-radix precision that overruns a decimal's
+        // 38 digits, and an absent one — none of which describe these types.
+        let precisions: Vec<Option<i64>> = vec![Some(0), Some(99), None, Some(53), Some(0), None];
+        let scales: Vec<Option<i64>> = vec![None, None, Some(9), Some(-2), None, None];
 
-        let schema = parse_information_schema_arrow(&[batch], "SALES.ORDERS")
-            .expect("columns without numeric metadata should parse");
+        for precision_kind in ["integer", "text"] {
+            let (precision, scale): (ArrayRef, ArrayRef) = if precision_kind == "integer" {
+                (
+                    Arc::new(Int64Array::from(precisions.clone())),
+                    Arc::new(Int64Array::from(scales.clone())),
+                )
+            } else {
+                let render = |values: &Vec<Option<i64>>| {
+                    Arc::new(StringArray::from(
+                        values
+                            .iter()
+                            .map(|value| value.map(|value| value.to_string()))
+                            .collect::<Vec<_>>(),
+                    )) as ArrayRef
+                };
+                (render(&precisions), render(&scales))
+            };
+            let batch = information_schema_batch(columns, types, nullable, precision, scale);
+
+            let schema =
+                parse_information_schema_arrow(&[batch], "SALES.ORDERS").unwrap_or_else(|e| {
+                    panic!("{precision_kind} metadata on non-fixed-point columns should parse: {e}")
+                });
+
+            assert_eq!(schema.field(0).data_type(), &DataType::Float64);
+            assert_eq!(schema.field(1).data_type(), &DataType::Utf8);
+            assert_eq!(
+                schema.field(2).data_type(),
+                &DataType::Timestamp(TimeUnit::Nanosecond, None)
+            );
+            assert_eq!(schema.field(3).data_type(), &DataType::Float64);
+            assert_eq!(schema.field(4).data_type(), &DataType::Boolean);
+            assert_eq!(schema.field(5).data_type(), &DataType::Date32);
+            for field in schema.fields() {
+                assert_eq!(
+                    field
+                        .metadata()
+                        .get(SOURCE_TYPE_METADATA_KEY)
+                        .map(String::as_str),
+                    Some(types[schema.index_of(field.name()).expect("field present")]),
+                    "{} source type must not gain decimal digits",
+                    field.name()
+                );
+            }
+        }
+    }
+
+    /// The same rule on the JSON path: a `FLOAT` column's numeric metadata is
+    /// not a decimal's, so it cannot fail the probe.
+    #[test]
+    fn information_schema_json_accepts_non_fixed_point_columns_whatever_the_numeric_columns_say() {
+        let rows = serde_json::json!([
+            ["RATING", "FLOAT", "YES", 0, null, null, null, null],
+            ["PRICE", "DOUBLE", "YES", 53, -2, null, null, null],
+            [
+                "NAME",
+                "VARCHAR",
+                "YES",
+                "not a number",
+                "",
+                null,
+                null,
+                null
+            ]
+        ]);
+
+        let schema = parse_information_schema_json(&rows, "SALES.ORDERS")
+            .expect("non-fixed-point numeric metadata should parse");
 
         assert_eq!(schema.field(0).data_type(), &DataType::Float64);
-        assert_eq!(schema.field(1).data_type(), &DataType::Utf8);
-        assert_eq!(
-            schema.field(2).data_type(),
-            &DataType::Timestamp(TimeUnit::Nanosecond, None)
-        );
-        assert_eq!(schema.field(3).data_type(), &DataType::Float64);
+        assert_eq!(schema.field(1).data_type(), &DataType::Float64);
+        assert_eq!(schema.field(2).data_type(), &DataType::Utf8);
     }
 
     /// The JSON path applies the same requirement.


### PR DESCRIPTION
## What

Snowflake schema discovery prefers `information_schema.columns` over `SHOW COLUMNS`, and read `NUMERIC_PRECISION` and `NUMERIC_SCALE` out of the Arrow response only when those two result columns downcast to a `StringArray`:

```rust
let precisions: Option<&arrow::array::StringArray> = batch.column(3).as_string_opt();
```

Snowflake encodes them as Arrow numbers, so the downcast yielded `None`, both values were treated as absent, and every decimal column fell back to the `precision.unwrap_or(38)` / `scale.unwrap_or(0)` default — `Decimal128(38, 0)`.

That registered a `NUMBER(12,2)` measure with scale zero while the query path still decoded the values at scale two (`snowflake_schema_cast` reads the per-column `precision`/`scale` Snowflake sends as field metadata), so the cast to the registered schema rounded the fraction away. For TPC-H `LINEITEM`, `L_DISCOUNT` and `L_TAX` read as `0`, `SUM(L_EXTENDEDPRICE * (1 - L_DISCOUNT))` collapsed to `SUM(L_EXTENDEDPRICE)`, and Arrow acceleration materialized those zeros permanently.

## How

- Read the two metadata columns out of whichever representation Snowflake sent: any Arrow integer width (signed or unsigned), `Decimal128`/`Decimal256` (rescaled at full width before narrowing, so a wide coefficient still reads exactly), text (including a `12.00` decimal rendering), or an all-null `Null` column.
- Validate what comes back — precision within the 1–38 digits a decimal column can hold, scale within the digits its own precision allows.
- Require both values for a fixed-point column. Reading the metadata is not sufficient on its own: with either value absent, the mapping still defaults to `Decimal128(38, 0)` and rounds the fraction away, silently.
- Read and validate the two columns **only where a decimal mapping consumes them**. Snowflake does not report a decimal's digits there for a float, a string, or a timestamp, so holding every column's values to the 1–38 digits a decimal can hold would fail the probe for a whole table over metadata nothing goes on to use.
- Metadata that cannot be read exactly, or is missing where it is required, fails the probe, so discovery falls back to `SHOW COLUMNS` (whose type descriptor carries precision and scale) rather than registering a scale the source never declared. The warning names the column and the table.
- The fixed-point type set has one definition, shared by the requirement and the Arrow mapping, so the two cannot drift. This collapses the mapper's float family to `Float64` unconditionally; a stray scale on a `FLOAT` column had mapped it to a decimal, contradicting the `Float64` values the query path decodes.
- Both response paths share one function for reading precision and scale, so the JSON and Arrow formats accept the same representations and reject the same unusable metadata.

## Tests

`cargo test -p data_components --features snowflake --lib` — 521 passed, 12 ignored. `cargo clippy -p data_components --features snowflake --all-targets` — clean.

New coverage in `crates/data_components/src/snowflake/mod.rs`:

| Test | Covers |
| --- | --- |
| `information_schema_arrow_keeps_scale_from_integer_metadata_columns` | the reported `LINEITEM` shape — `NUMBER(12,2)` measures, a `NUMBER(38,0)` key, and a text column with no numeric metadata |
| `information_schema_arrow_keeps_scale_from_decimal_metadata_columns` | the same metadata delivered as `Decimal128` |
| `information_schema_arrow_keeps_scale_from_wide_decimal_metadata_columns` | a `Decimal256(76, 38)` cell whose coefficient overruns an `i128`, and its fractional counterpart |
| `information_schema_arrow_keeps_scale_from_every_integer_width` | `Int8`…`Int64`, `UInt8`…`UInt64` |
| `information_schema_arrow_keeps_scale_from_string_metadata_columns` | the existing text behavior, plus a `12.00` rendering |
| `information_schema_arrow_accepts_all_null_metadata_columns` | an all-null column arriving as an Arrow `Null` array |
| `information_schema_arrow_rejects_unusable_precision_and_scale` | precision above 38, zero, negative; scale wider than the precision, negative; an unreadable Arrow type; non-numeric text; a fractional decimal — each error naming the column and table |
| `information_schema_arrow_rejects_a_fixed_point_column_without_precision_or_scale` | a fixed-point column with either value absent or empty |
| `information_schema_arrow_accepts_non_fixed_point_columns_whatever_the_numeric_columns_say` | `FLOAT`, `VARCHAR`, `TIMESTAMP_NTZ`, `DOUBLE`, `BOOLEAN`, `DATE` against a zero precision, a precision past 38, a negative scale, and absent values — as integers and as text |
| `information_schema_json_accepts_non_fixed_point_columns_whatever_the_numeric_columns_say` | the same rule on the JSON path, including unparseable text |
| `information_schema_json_reads_every_precision_representation` | the JSON path across number, text, and `12.0` renderings, and its rejection of an out-of-range precision |
| `information_schema_json_rejects_a_fixed_point_column_without_scale` | the same fixed-point requirement on the JSON path |

Non-vacuity, by mutation:

| Mutation | Tests killed |
| --- | --- |
| the fix reverted entirely (trunk's reader, new tests in place) | 6, the primary with `left: Decimal128(38, 0)` / `right: Decimal128(12, 2)` |
| numeric metadata columns read as text only | 3 |
| …and the fixed-point requirement disabled | 6, reproducing the silent `Decimal128(38, 0)` |
| validation applied to every type, not only fixed-point ones | 2 |
| a wide decimal narrowed before it is rescaled | 1 |

## Live validation

Against the TPC-H SF1 sample `LINEITEM` table, federated and Arrow-accelerated:

```text
L_QUANTITY       Decimal128(12, 2)      (was Decimal128(38, 0))
L_EXTENDEDPRICE  Decimal128(12, 2)
L_DISCOUNT       Decimal128(12, 2)
L_TAX            Decimal128(12, 2)
```

- Keyed row `L_ORDERKEY=1, L_LINENUMBER=1`: `17.00, 21168.23, 0.04, 0.02` — the source values, both federated and accelerated.
- Q1 `A/F`: `sum_base_price = 56586554400.73` (the issue reported `56586554401`), `sum_disc_price = 53758257134.87`, `avg_disc = 0.049985`.
- Accelerated `MIN`/`MAX`/`AVG` of `L_DISCOUNT` and `L_TAX` are no longer all zero: `max_disc = 0.1`, `avg_disc = 0.05309`, `max_tax = 0.08`, `avg_tax = 0.042636`.
- Over the same 110 accelerated rows, the federated and accelerated aggregates agree exactly on row count, `SUM(L_QUANTITY)`, `SUM(L_EXTENDEDPRICE)`, `SUM(L_EXTENDEDPRICE * (1 - L_DISCOUNT))`, and `SUM(L_TAX)`.
- No schema-discovery warning or metadata fallback was logged on either run.

Fixes #13271
