### PR TITLE
fix(sql): bump the datafusion pin so a bounded EXISTS refuses instead of returning wrong rows (fixes #13277)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,7 +4146,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6297,7 +6297,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6349,7 +6349,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6373,7 +6373,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6397,7 +6397,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6422,7 +6422,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "futures",
  "log",
@@ -6432,7 +6432,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "async-compression",
@@ -6469,7 +6469,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -6492,7 +6492,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6514,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6536,7 +6536,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6585,12 +6585,12 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6611,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -6633,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6685,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -6716,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6736,7 +6736,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6760,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -6784,7 +6784,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6799,7 +6799,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6815,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -6824,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -6834,7 +6834,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "chrono",
@@ -6885,7 +6885,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6906,7 +6906,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6920,7 +6920,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "chrono",
@@ -6936,7 +6936,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -6956,7 +6956,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "arrow-data",
@@ -6988,7 +6988,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "chrono",
@@ -7017,7 +7017,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -7029,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -7044,7 +7044,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -7085,7 +7085,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -7103,7 +7103,7 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "54.1.0"
-source = "git+https://github.com/spiceai/datafusion.git?rev=b5cb7bb321acbbff749bb9147130f6b47bb36034#b5cb7bb321acbbff749bb9147130f6b47bb36034"
+source = "git+https://github.com/spiceai/datafusion.git?rev=8e881090e862257f4ca4418fb44d2a59e56f147e#8e881090e862257f4ca4418fb44d2a59e56f147e"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9033,8 +9033,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -10167,7 +10167,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -10202,7 +10202,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -14914,7 +14914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6705a26ad89d241a989a5395641931ba37076f5ab5fbd19ee92402414a43af32"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
+ "hashbrown 0.5.0",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -15390,8 +15390,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -15412,7 +15412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15740,7 +15740,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -15779,7 +15779,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -18819,7 +18819,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -19380,7 +19380,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -24144,7 +24144,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,7 +4146,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9033,8 +9033,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -10167,7 +10167,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -10202,7 +10202,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -14914,7 +14914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6705a26ad89d241a989a5395641931ba37076f5ab5fbd19ee92402414a43af32"
 dependencies = [
  "arrayvec",
- "hashbrown 0.5.0",
+ "hashbrown 0.17.1",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -15390,8 +15390,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -15412,7 +15412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15740,7 +15740,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -15779,7 +15779,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -18819,7 +18819,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -19380,7 +19380,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -24144,7 +24144,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -494,41 +494,41 @@ inherits = "dev"
 lto = "off"
 
 [patch.crates-io]
-datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" } # branch: spiceai-54
-datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
-datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "b5cb7bb321acbbff749bb9147130f6b47bb36034" }
+datafusion = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" } # branch: spiceai-54 (merged PR #205)
+datafusion-catalog = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-catalog-listing = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-common = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-common-runtime = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-datasource = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-datasource-arrow = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-datasource-csv = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-datasource-json = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-datasource-parquet = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-doc = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-execution = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-functions = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-functions-aggregate = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-functions-aggregate-common = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-functions-nested = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-functions-table = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-functions-window = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-functions-window-common = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-macros = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-physical-expr = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-physical-expr-adapter = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-physical-expr-common = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-physical-optimizer = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-physical-plan = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-proto = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-proto-common = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-pruning = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-session = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-spark = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-sql = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
+datafusion-substrait = { git = "https://github.com/spiceai/datafusion.git", rev = "8e881090e862257f4ca4418fb44d2a59e56f147e" }
 
 # Local vendored fork of `mysql-common-derive` (path: vendor/mysql-common-derive)
 # that drops the unmaintained `proc-macro-error2` dependency (RUSTSEC-2026-0173).

--- a/crates/data_components/src/federation.rs
+++ b/crates/data_components/src/federation.rs
@@ -321,21 +321,25 @@ mod tests {
         assert_eq!(adaptor.source.schema().as_ref(), schema.as_ref());
     }
 
-    /// The upstream fixes these guard live in the `spiceai/datafusion` fork on
-    /// `spiceai-54`, so nothing here fails if a later pin bump drops them. The
-    /// fork's branch is re-cut per `DataFusion` major and takes its own tests with
-    /// it; these stay. Extend them whenever a pin bump carries another unparser
-    /// fix — #13081 tracks the three this bump left unguarded.
-    ///
-    /// This unparses through the federation executor, which supplies no dialect
-    /// here, so the SQL is the default dialect's rather than any one connector's.
-    /// The plan shapes, not the spelling, are what these assert.
+    /// Unparse a plan the way a federated connector would, and demand it
+    /// succeed. See `federated_sql_result` for what these guards are for.
     fn federated_sql(plan: &LogicalPlan) -> String {
         federated_sql_result(plan).expect("plan should unparse")
     }
 
-    /// Unparse without demanding success, so a guard can pin a refusal as well
-    /// as a rendering.
+    /// The seam every guard below unparses through, fallible so a guard can pin
+    /// a refusal as well as a rendering.
+    ///
+    /// The upstream fixes these guard live in the `spiceai/datafusion` fork on
+    /// `spiceai-54`, so nothing here fails if a later pin bump drops them. The
+    /// fork's branch is re-cut per `DataFusion` major and takes its own tests with
+    /// it; these stay. Extend them whenever a pin bump carries another unparser
+    /// fix — #13081 tracks the three the `edd8861e` → `b5cb7bb3` bump left
+    /// unguarded, and the two below arrived with `b5cb7bb3` → `8e881090`.
+    ///
+    /// This unparses through the federation executor, which supplies no dialect
+    /// here, so the SQL is the default dialect's rather than any one connector's.
+    /// The plan shapes, not the spelling, are what these assert.
     fn federated_sql_result(plan: &LogicalPlan) -> DataFusionResult<String> {
         Unparser::new(test_executor().dialect().as_ref())
             .plan_to_sql(plan)
@@ -464,8 +468,10 @@ mod tests {
                 [col("t2.c").eq(col("t3.c"))],
             )
             .expect("join build inputs");
-        // `limit(0, None)` still inserts a `Limit`, and the unbounded case is
-        // about a build side carrying no bound at all.
+        // Applied only when asked, so the unbounded plan carries no `Limit` node
+        // at all — the shape a plan with no bound actually has, and the one
+        // upstream's own fixture builds. The unparser reads `limit(0, None)` as
+        // no bound either, so this is fidelity rather than a change of outcome.
         let build = match fetch {
             Some(fetch) => build.limit(0, Some(fetch)).expect("limit build side"),
             None => build,
@@ -541,9 +547,12 @@ mod tests {
     ///
     /// Both readings are wrong — the subquery's own `FROM` already shadows the
     /// outer relation, so the correlation is lost whatever the bound does — and
-    /// that unscoped output binds and runs, so an anti join drops a row it
-    /// should return. Emitting these correctly needs the correlation's
-    /// qualifiers rewritten to the derived scope, tracked by #12840.
+    /// that unscoped output binds and runs. The `EXISTS` then reduces to "this
+    /// table has a row", so the semi join this builds keeps every probe row,
+    /// including the rows that match nothing (an anti join over the same SQL
+    /// drops every row instead). Emitting these correctly needs the
+    /// correlation's qualifiers rewritten to the derived scope, tracked by
+    /// #12840.
     #[test]
     fn a_bounded_exists_refuses_a_correlation_qualified_by_the_probe() {
         let err = federated_sql_result(&a_correlation_qualified_by_the_probe(Some(5)))

--- a/crates/data_components/src/federation.rs
+++ b/crates/data_components/src/federation.rs
@@ -560,7 +560,10 @@ mod tests {
             "expected the refusal to name the probe-qualified correlation, got: {err}"
         );
 
-        // Gated on the bound here too.
+        // Gated on the bound here too. That unbounded output is not correct --
+        // the shadowing still loses the correlation -- but it is the pre-existing
+        // #12840 defect rather than anything the bound introduces, so what this
+        // pins is only that the refusal does not widen to reach it.
         let unbounded = federated_sql_result(&a_correlation_qualified_by_the_probe(None))
             .expect("an unbounded build side has no bound to scope, so it still unparses");
         assert!(

--- a/crates/data_components/src/federation.rs
+++ b/crates/data_components/src/federation.rs
@@ -331,10 +331,15 @@ mod tests {
     /// here, so the SQL is the default dialect's rather than any one connector's.
     /// The plan shapes, not the spelling, are what these assert.
     fn federated_sql(plan: &LogicalPlan) -> String {
+        federated_sql_result(plan).expect("plan should unparse")
+    }
+
+    /// Unparse without demanding success, so a guard can pin a refusal as well
+    /// as a rendering.
+    fn federated_sql_result(plan: &LogicalPlan) -> DataFusionResult<String> {
         Unparser::new(test_executor().dialect().as_ref())
             .plan_to_sql(plan)
-            .expect("plan should unparse")
-            .to_string()
+            .map(|statement| statement.to_string())
     }
 
     /// Assert `first` is rendered before `second`, which pins the clause order
@@ -422,14 +427,6 @@ mod tests {
         assert_precedes(&federated_sql(&plan), "LIMIT 5", "WHERE");
     }
 
-    /// Unparse without demanding success, so a guard can pin a refusal as well
-    /// as a rendering.
-    fn federated_sql_result(plan: &LogicalPlan) -> DataFusionResult<String> {
-        Unparser::new(test_executor().dialect().as_ref())
-            .plan_to_sql(plan)
-            .map(|statement| statement.to_string())
-    }
-
     /// Two `Int32` columns, matching the schema the upstream `EXISTS` bound
     /// cases use so these plans are the same shapes.
     fn exists_fetch_fields() -> Vec<Field> {
@@ -439,21 +436,30 @@ mod tests {
         ]
     }
 
+    fn exists_scan(name: &str) -> LogicalPlanBuilder {
+        LogicalPlanBuilder::scan(name, table_source(exists_fetch_fields()), None)
+            .expect("scan should build")
+    }
+
+    /// The same correlation still pushes down when there is no bound to scope,
+    /// so the refusal stays gated on the bound rather than on the correlation's
+    /// shape.
+    fn assert_unbounded_exists_pushdown(plan: &LogicalPlan) {
+        let sql = federated_sql_result(plan)
+            .expect("an unbounded build side has no bound to scope, so it still unparses");
+        assert!(
+            sql.contains("EXISTS") && !sql.contains("LIMIT"),
+            "expected an unbounded EXISTS pushdown, got: {sql}"
+        );
+    }
+
     /// `LeftSemi Join: t1.c = t2.c AND t1.d = t3.d` over a `t2 INNER JOIN t3`
     /// build side, bounded only when asked — the correlation names both of the
     /// build side's inputs.
     fn a_correlation_naming_two_build_inputs(fetch: Option<usize>) -> LogicalPlan {
-        let probe = LogicalPlanBuilder::scan("t1", table_source(exists_fetch_fields()), None)
-            .expect("scan t1")
-            .build()
-            .expect("build t1");
-        let build = LogicalPlanBuilder::scan("t2", table_source(exists_fetch_fields()), None)
-            .expect("scan t2")
+        let build = exists_scan("t2")
             .join_on(
-                LogicalPlanBuilder::scan("t3", table_source(exists_fetch_fields()), None)
-                    .expect("scan t3")
-                    .build()
-                    .expect("build t3"),
+                exists_scan("t3").build().expect("build t3"),
                 JoinType::Inner,
                 [col("t2.c").eq(col("t3.c"))],
             )
@@ -467,7 +473,7 @@ mod tests {
         .build()
         .expect("build build side");
 
-        LogicalPlanBuilder::from(probe)
+        exists_scan("t1")
             .project(vec![col("t1.d")])
             .expect("project")
             .join_on(
@@ -484,10 +490,6 @@ mod tests {
     /// the probe, bounded only when asked — the correlation's only qualifier is
     /// one the probe side also answers to.
     fn a_correlation_qualified_by_the_probe(fetch: Option<usize>) -> LogicalPlan {
-        let probe = LogicalPlanBuilder::scan("t", table_source(exists_fetch_fields()), None)
-            .expect("scan probe")
-            .build()
-            .expect("build probe");
         let build = LogicalPlanBuilder::scan_with_filters_fetch(
             "t",
             table_source(exists_fetch_fields()),
@@ -499,7 +501,7 @@ mod tests {
         .build()
         .expect("build build side");
 
-        LogicalPlanBuilder::from(probe)
+        exists_scan("t")
             .project(vec![col("t.d")])
             .expect("project")
             .join_on(build, JoinType::LeftSemi, [col("t.c").eq(col("t.c"))])
@@ -529,14 +531,7 @@ mod tests {
             "expected the refusal to name the unscopable correlation, got: {err}"
         );
 
-        // The refusal is gated on the bound, not on the correlation's shape, so
-        // the same correlation still pushes down when nothing has to be scoped.
-        let unbounded = federated_sql_result(&a_correlation_naming_two_build_inputs(None))
-            .expect("an unbounded build side has no bound to scope, so it still unparses");
-        assert!(
-            unbounded.contains("EXISTS") && !unbounded.contains("LIMIT"),
-            "expected an unbounded EXISTS pushdown, got: {unbounded}"
-        );
+        assert_unbounded_exists_pushdown(&a_correlation_naming_two_build_inputs(None));
     }
 
     /// Regression test for #13277: the sibling shape, where the correlation's
@@ -560,15 +555,10 @@ mod tests {
             "expected the refusal to name the probe-qualified correlation, got: {err}"
         );
 
-        // Gated on the bound here too. That unbounded output is not correct --
-        // the shadowing still loses the correlation -- but it is the pre-existing
-        // #12840 defect rather than anything the bound introduces, so what this
-        // pins is only that the refusal does not widen to reach it.
-        let unbounded = federated_sql_result(&a_correlation_qualified_by_the_probe(None))
-            .expect("an unbounded build side has no bound to scope, so it still unparses");
-        assert!(
-            unbounded.contains("EXISTS") && !unbounded.contains("LIMIT"),
-            "expected an unbounded EXISTS pushdown, got: {unbounded}"
-        );
+        // That unbounded output is not correct either — the shadowing still loses
+        // the correlation — but it is the pre-existing #12840 defect rather than
+        // anything the bound introduces, so what this pins is only that the
+        // refusal does not widen to reach it.
+        assert_unbounded_exists_pushdown(&a_correlation_qualified_by_the_probe(None));
     }
 }

--- a/crates/data_components/src/federation.rs
+++ b/crates/data_components/src/federation.rs
@@ -448,6 +448,11 @@ mod tests {
     /// The same correlation still pushes down when there is no bound to scope,
     /// so the refusal stays gated on the bound rather than on the correlation's
     /// shape.
+    ///
+    /// Only sound where the unbounded rendering is correct in its own right. It
+    /// is for a correlation naming several build inputs — every qualifier binds
+    /// to the relation it came from — and it is not for the probe-qualified
+    /// self-join, whose unbounded form loses the correlation to shadowing.
     fn assert_unbounded_exists_pushdown(plan: &LogicalPlan) {
         let sql = federated_sql_result(plan)
             .expect("an unbounded build side has no bound to scope, so it still unparses");
@@ -564,10 +569,11 @@ mod tests {
             "expected the refusal to name the probe-qualified correlation, got: {err}"
         );
 
-        // That unbounded output is not correct either — the shadowing still loses
-        // the correlation — but it is the pre-existing #12840 defect rather than
-        // anything the bound introduces, so what this pins is only that the
-        // refusal does not widen to reach it.
-        assert_unbounded_exists_pushdown(&a_correlation_qualified_by_the_probe(None));
+        // The unbounded sibling is deliberately left unpinned. Unlike the
+        // multi-relation shape, its rendering is *itself* wrong — the inner
+        // `FROM` shadows the outer relation, so the `EXISTS` reduces to "this
+        // table has a row" with or without a bound — so asserting that it still
+        // unparses would pin a defect and stand in the way of #12840's rewrite,
+        // which should be free to refuse this shape at any bound.
     }
 }

--- a/crates/data_components/src/federation.rs
+++ b/crates/data_components/src/federation.rs
@@ -421,4 +421,151 @@ mod tests {
         // filter sits outside of.
         assert_precedes(&federated_sql(&plan), "LIMIT 5", "WHERE");
     }
+
+    /// Unparse without demanding success, so a guard can pin a refusal as well
+    /// as a rendering.
+    fn federated_sql_result(plan: &LogicalPlan) -> DataFusionResult<String> {
+        Unparser::new(test_executor().dialect().as_ref())
+            .plan_to_sql(plan)
+            .map(|statement| statement.to_string())
+    }
+
+    /// Two `Int32` columns, matching the schema the upstream `EXISTS` bound
+    /// cases use so these plans are the same shapes.
+    fn exists_fetch_fields() -> Vec<Field> {
+        vec![
+            Field::new("c", DataType::Int32, false),
+            Field::new("d", DataType::Int32, false),
+        ]
+    }
+
+    /// `LeftSemi Join: t1.c = t2.c AND t1.d = t3.d` over a `t2 INNER JOIN t3`
+    /// build side, bounded only when asked — the correlation names both of the
+    /// build side's inputs.
+    fn a_correlation_naming_two_build_inputs(fetch: Option<usize>) -> LogicalPlan {
+        let probe = LogicalPlanBuilder::scan("t1", table_source(exists_fetch_fields()), None)
+            .expect("scan t1")
+            .build()
+            .expect("build t1");
+        let build = LogicalPlanBuilder::scan("t2", table_source(exists_fetch_fields()), None)
+            .expect("scan t2")
+            .join_on(
+                LogicalPlanBuilder::scan("t3", table_source(exists_fetch_fields()), None)
+                    .expect("scan t3")
+                    .build()
+                    .expect("build t3"),
+                JoinType::Inner,
+                [col("t2.c").eq(col("t3.c"))],
+            )
+            .expect("join build inputs");
+        // `limit(0, None)` still inserts a `Limit`, and the unbounded case is
+        // about a build side carrying no bound at all.
+        let build = match fetch {
+            Some(fetch) => build.limit(0, Some(fetch)).expect("limit build side"),
+            None => build,
+        }
+        .build()
+        .expect("build build side");
+
+        LogicalPlanBuilder::from(probe)
+            .project(vec![col("t1.d")])
+            .expect("project")
+            .join_on(
+                build,
+                JoinType::LeftSemi,
+                [col("t1.c").eq(col("t2.c")), col("t1.d").eq(col("t3.d"))],
+            )
+            .expect("semi join")
+            .build()
+            .expect("build plan")
+    }
+
+    /// `LeftSemi Join: t.c = t.c` where the build side is the same relation as
+    /// the probe, bounded only when asked — the correlation's only qualifier is
+    /// one the probe side also answers to.
+    fn a_correlation_qualified_by_the_probe(fetch: Option<usize>) -> LogicalPlan {
+        let probe = LogicalPlanBuilder::scan("t", table_source(exists_fetch_fields()), None)
+            .expect("scan probe")
+            .build()
+            .expect("build probe");
+        let build = LogicalPlanBuilder::scan_with_filters_fetch(
+            "t",
+            table_source(exists_fetch_fields()),
+            None,
+            vec![],
+            fetch,
+        )
+        .expect("scan build side")
+        .build()
+        .expect("build build side");
+
+        LogicalPlanBuilder::from(probe)
+            .project(vec![col("t.d")])
+            .expect("project")
+            .join_on(build, JoinType::LeftSemi, [col("t.c").eq(col("t.c"))])
+            .expect("semi join")
+            .build()
+            .expect("build plan")
+    }
+
+    /// Regression test for #13277: a row bound on an `EXISTS`-style build side
+    /// has to be moved into a scope of its own, and the scope can carry only one
+    /// relation name. When the correlation names both of the build side's inputs,
+    /// no name keeps every reference bound to the relation it came from.
+    ///
+    /// Leaving the bound beside the correlation is not a safe fallback: that SQL
+    /// binds — `t1` to the outer query, `t2`/`t3` to the subquery's own inputs —
+    /// so the remote engine runs it and answers from rows outside the bound. A
+    /// semi join then reports a match on a row the plan never read. Refusing
+    /// costs the pushdown instead of returning wrong rows.
+    #[test]
+    fn a_bounded_exists_refuses_a_correlation_naming_two_build_inputs() {
+        let err = federated_sql_result(&a_correlation_naming_two_build_inputs(Some(5)))
+            .expect_err("a correlation naming two build-side inputs must be refused");
+        assert!(
+            err.to_string().contains(
+                "not supported when the correlation names more than one of the build side's inputs"
+            ),
+            "expected the refusal to name the unscopable correlation, got: {err}"
+        );
+
+        // The refusal is gated on the bound, not on the correlation's shape, so
+        // the same correlation still pushes down when nothing has to be scoped.
+        let unbounded = federated_sql_result(&a_correlation_naming_two_build_inputs(None))
+            .expect("an unbounded build side has no bound to scope, so it still unparses");
+        assert!(
+            unbounded.contains("EXISTS") && !unbounded.contains("LIMIT"),
+            "expected an unbounded EXISTS pushdown, got: {unbounded}"
+        );
+    }
+
+    /// Regression test for #13277: the sibling shape, where the correlation's
+    /// only qualifier is one the probe side also answers to. Naming the scope
+    /// anything else rebinds those references to the probe, turning the
+    /// correlation into a comparison of the outer row with itself.
+    ///
+    /// Both readings are wrong — the subquery's own `FROM` already shadows the
+    /// outer relation, so the correlation is lost whatever the bound does — and
+    /// that unscoped output binds and runs, so an anti join drops a row it
+    /// should return. Emitting these correctly needs the correlation's
+    /// qualifiers rewritten to the derived scope, tracked by #12840.
+    #[test]
+    fn a_bounded_exists_refuses_a_correlation_qualified_by_the_probe() {
+        let err = federated_sql_result(&a_correlation_qualified_by_the_probe(Some(5)))
+            .expect_err("a correlation qualified by the probe side must be refused");
+        assert!(
+            err.to_string().contains(
+                "not supported when the correlation's only qualifier is one the probe side also answers to"
+            ),
+            "expected the refusal to name the probe-qualified correlation, got: {err}"
+        );
+
+        // Gated on the bound here too.
+        let unbounded = federated_sql_result(&a_correlation_qualified_by_the_probe(None))
+            .expect("an unbounded build side has no bound to scope, so it still unparses");
+        assert!(
+            unbounded.contains("EXISTS") && !unbounded.contains("LIMIT"),
+            "expected an unbounded EXISTS pushdown, got: {unbounded}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`Cargo.toml` pinned `spiceai/datafusion` at `b5cb7bb3`, exactly one commit behind `spiceai-54`. That
commit is spiceai/datafusion#205, and until the pin moved, two bounded `EXISTS` shapes returned wrong
rows on `trunk`.

When a row bound sits on an `EXISTS`-style join's build side, the unparser has to move it into a
derived table of its own, and that derived table's alias can carry only one relation name. For two
shapes `exists_scope_name` could not name one, and the caller then left the bound beside the
correlation:

| Shape | Emitted before the bump |
|---|---|
| the correlation names more than one of the build side's inputs | `SELECT t1.d FROM t1 WHERE EXISTS (SELECT 1 FROM t2 INNER JOIN t3 ON (t2.c = t3.c) WHERE ((t1.c = t2.c) AND (t1.d = t3.d)) LIMIT 5)` |
| the correlation's only qualifier is one the probe side also answers to | `SELECT t.d FROM t WHERE EXISTS (SELECT 1 FROM t WHERE (t.c = t.c) LIMIT 5)` |

Neither fails to bind, which is what made this quiet: `t1` resolves to the outer query and `t2`/`t3`
to the subquery's own inputs, so the remote engine runs the query and evaluates the correlation over
the whole relation, then applies `LIMIT` to a result `EXISTS` never looks past. The bound selects
nothing. A semi or mark join reports a match on a row the plan never read; an anti join drops a row it
should return. On the self-join shape the inner `FROM "t"` shadows the outer one outright, so
`"t"."c" = "t"."c"` binds entirely inside and the `EXISTS` degenerates to "this table has a row".

#205 makes both refuse with `not_impl_err!` instead — the same trade the neighbouring
fully-qualified-dialect arm already makes. It costs the pushdown for these two shapes rather than
returning wrong rows. Refusing is not repairing: emitting them correctly needs the correlation's
qualifiers rewritten to the scope the derived table introduces, which stays open as #12840.

## Changes

- `Cargo.toml` / `Cargo.lock` — the 35 `spiceai/datafusion` rev strings move to `8e881090`.
  `ahead_by: 1, behind_by: 0`, so the bump carries that one commit and nothing else; the package set
  is byte-identical (1970 packages, no version or dependency-edge change).
- `crates/data_components/src/federation.rs` — a guard per refusal, beside the two existing unparser
  guards, each paired with its unbounded sibling so the refusal is pinned as gated on the *bound*
  rather than on the correlation's shape. The module doc asks for exactly this whenever a bump carries
  another fix.

The guards unparse through the federation executor, which is the only seam available —
`exists_scope_name` is private to the dependency — and assert the clause of the error message that
distinguishes the two shapes, since both return `NotImplemented`.

## Performance impact

Two federated query shapes lose a pushdown they should never have had: a bounded `EXISTS` whose
correlation names several build-side inputs, and the self-join shape above. Those queries now fail at
`execute()` with a `NotImplemented` rather than executing remotely and answering from the wrong rows.
Nothing else changes — the refusals are gated on the row bound, so unbounded `EXISTS` pushdown is
untouched, and the bump carries no other commit.

## How this was verified

Reverting the pin to `b5cb7bb3` fails exactly the two new guards and passes the other six, printing
the pre-bump SQL in the table above — which matches, independently, what #205 and #13277 each
documented. Re-run after the cleanup passes below: still 2 fail / 6 pass.

## Test plan

- [x] `make lint`
- [x] `make nextest`
- [x] Pin-revert neuter: 2 fail / 6 pass, re-confirmed after `/simplify` restructured the tests

## Review gate

- Adversarial review: `codex` — job `review-mt04eye4-hfwvzb` — verdict `needs-attention`, 3 findings across three passes, all triaged. **Pass 1** found the cross-schema alias collision — confirmed by rendering, but byte-identical at both pins, so filed as #13279 rather than folded in. **Pass 2** found that the probe-qualified guard's unbounded assertion required a known-wrong rendering to keep working, which would have obstructed #12840's rewrite — correct, and fixed here by dropping that assertion (the bound-gating claim stays on the multi-relation shape, whose unbounded form binds every qualifier correctly). **Pass 3**'s remaining objection is that this PR does not also repair the unbounded probe-qualified shadowing; that is #12840 Shape 2, which states it predates #201 and is independent of the bound, and I added the confirmed unbounded rendering there. Its "no-ship" rests on this bump being responsible for those shapes, which the both-pins comparison refutes
- `/security-review`: no findings on the diff itself; its comparative pass caught that the first
  lockfile regeneration had rewritten 12 unrelated dependency edges to older versions already in the
  graph (`hashbrown 0.17.1` → `0.5.0`, `itertools 0.14.0` → `0.10.5`, `base64 0.22.1` → `0.21.7`, and
  nine more). Reconciled from the manifest change alone, so every changed lockfile line is now one of
  the 35 rev strings. Worth noting the package-set check passed while this was live — only diffing
  per-package dependency edges exposed it.
- `/simplify`: applied — one `Unparser` construction site instead of two, a shared scan fixture, and
  the bound-gating assertion behind one helper. Its altitude pass then found three things worth
  fixing, all of them mine: the fetch-branch comment implied an outcome the unparser does not produce
  (verified: an unconditional `limit(0, fetch)` leaves the test green, so the branch is plan-shape
  fidelity only), the probe-qualified guard described an anti join's symptom while building a semi
  join, and the collapse had left the "extend these on each pin bump" rationale stranded on a
  two-line delegation the new guards never call. Light checks re-run green.

## Notes for the reviewer

- **Scope, deliberately left out.** The adversarial pass found a *third* wrong-row shape: because a
  dialect with `full_qualified_col() == false` renders a qualified column using only its table
  component, a probe `s1.t` against a bounded build `s2.t` reads as two distinct relations to the
  guard but renders both as `t`, so the derived alias collides with the probe and the correlation is
  lost again. It is **not a regression here** — rendering is byte-identical at both pins, since #205
  does not touch that arm — so it is filed as #13279 rather than folded in. Its fix belongs upstream,
  followed by another bump.
- **`Cargo.lock` carries a 5-line `[[patch.unused]]` block** for the already-unused
  `datafusion-federation` patch. Cargo re-adds it deterministically on any invocation, so it cannot be
  kept out of a regenerated lockfile; #13257 removes that patch entirely.
- **Overlaps #13278** in the same test module (that PR adds three guards for the *previous* bump).
  Both add distinct functions, so a textual conflict there should keep both sets.

Fixes #13277

## Checklist

- [x] Tests added that fail before the change and pass after
- [x] The refusal is pinned as gated on the bound, so unbounded pushdown cannot silently regress
- [x] Lockfile change limited to the pinned rev
- [x] Out-of-scope finding filed (#13279) rather than folded in