### PR TITLE
fix(databricks): publish a MAP column with the non-nullable entries field Arrow requires (fixes #7307)

### DIFF
--- a/crates/arrow_tools/src/lib.rs
+++ b/crates/arrow_tools/src/lib.rs
@@ -16,6 +16,7 @@ limitations under the License.
 
 pub mod decimal;
 pub mod format;
+pub mod map_entries;
 pub mod metadata_keys;
 pub mod record_batch;
 pub mod schema;

--- a/crates/arrow_tools/src/map_entries.rs
+++ b/crates/arrow_tools/src/map_entries.rs
@@ -25,18 +25,17 @@ limitations under the License.
 //! failure reports the same message, `MapArray entries cannot contain nulls`, whether or
 //! not a null is involved.
 //!
-//! [`normalize_map_entries`] relabels the declaration (metadata only — no buffer is
-//! touched) and refuses the one shape that cannot be relabelled without inventing an
-//! answer: entries that actually contain nulls.
+//! [`MapEntriesNormalizer`] relabels the declaration (metadata only — no buffer is touched)
+//! and refuses the one shape that cannot be relabelled without inventing an answer: entries
+//! that actually contain nulls.
 
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayData, RecordBatch, make_array};
-use arrow::datatypes::{DataType, Schema};
-use arrow_schema::SchemaRef;
+use arrow::array::{Array, ArrayData, ArrayRef, RecordBatch, make_array};
+use arrow::datatypes::{DataType, SchemaRef};
 use snafu::prelude::*;
 
-use crate::type_rewrite::{MapEntriesNonNullable, apply_rules, rewrite_data_type};
+use crate::type_rewrite::{MapEntriesNonNullable, apply_rules, relabel_array_data};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -48,85 +47,154 @@ pub enum Error {
     MapEntriesContainNulls { column: String },
 
     #[snafu(display("column '{column}' could not be rebuilt: {source}"))]
-    UnableToRelabelColumn {
+    UnableToNormalizeColumn {
         column: String,
         source: arrow::error::ArrowError,
     },
 
-    #[snafu(display("the normalized columns could not be reassembled: {source}"))]
-    UnableToRebuildRecordBatch { source: arrow::error::ArrowError },
+    #[snafu(display("the normalized columns do not fit schema '{schema}': {source}"))]
+    UnableToRebuildRecordBatch {
+        schema: String,
+        source: arrow::error::ArrowError,
+    },
 }
 
-/// Returns `true` when `data_type` declares a `Map` whose `entries` field is nullable,
-/// at any depth.
-#[must_use]
-pub fn declares_nullable_map_entries(data_type: &DataType) -> bool {
-    rewrite_data_type(data_type, &[&MapEntriesNonNullable]) != *data_type
+/// What the batches of one Arrow stream need, resolved once from the stream's schema.
+///
+/// An Arrow IPC stream carries a single schema, so whether a map declaration has to be
+/// relabelled — and what it becomes — is fixed for every batch. Deciding it per batch would
+/// rebuild the same schema over and over and hand each batch a distinct `SchemaRef`.
+pub struct MapEntriesNormalizer {
+    /// The schema every batch is relabelled to, shared by all of them. `None` when the
+    /// stream's own declarations already conform.
+    target: Option<SchemaRef>,
+    /// Whether any field holds a `Map` at all. When none does, no batch can carry entry
+    /// nulls, so no column is ever inspected.
+    holds_map: bool,
 }
 
-/// Returns the schema with every `Map`'s `entries` field marked non-nullable.
-#[must_use]
-pub fn normalize_map_entries_schema(schema: &Schema) -> Schema {
-    apply_rules(schema, &[&MapEntriesNonNullable])
-}
+impl MapEntriesNormalizer {
+    #[must_use]
+    pub fn for_schema(schema: &SchemaRef) -> Self {
+        let holds_map = schema
+            .fields()
+            .iter()
+            .any(|field| contains(field.data_type(), &is_map));
 
-/// Rewrites `batch` so every `Map` column — nested ones included — declares its `entries`
-/// field non-nullable, as the Arrow specification requires.
-///
-/// Nullability lives in the type rather than in any buffer, so this only relabels: the
-/// offsets, validity and child arrays are carried over by reference. A batch that already
-/// conforms is returned untouched.
-///
-/// # Errors
-///
-/// Returns [`Error::MapEntriesContainNulls`] when an entries array carries nulls. That is
-/// the one shape relabelling cannot fix, and it is not recoverable by guessing: Arrow
-/// gives a null entry no meaning, so treating it as a null map and treating it as a pair
-/// to drop are both inventions, and each yields different rows.
-pub fn normalize_map_entries(batch: RecordBatch) -> Result<RecordBatch> {
-    let schema = batch.schema();
-    if !schema
-        .fields()
-        .iter()
-        .any(|field| declares_nullable_map_entries(field.data_type()))
-    {
-        // Still reject entry nulls: they fail downstream whatever the declaration says.
-        for (field, column) in schema.fields().iter().zip(batch.columns()) {
-            ensure_no_map_entry_nulls(&column.to_data(), field.name())?;
-        }
-        return Ok(batch);
+        let target = (holds_map
+            && schema
+                .fields()
+                .iter()
+                .any(|field| contains(field.data_type(), &declares_nullable_entries)))
+        .then(|| Arc::new(apply_rules(schema, &[&MapEntriesNonNullable])) as SchemaRef);
+
+        Self { target, holds_map }
     }
 
-    let normalized: SchemaRef = Arc::new(normalize_map_entries_schema(schema.as_ref()));
+    /// Returns `batch` with every `Map` column — nested ones included — declaring its
+    /// `entries` field non-nullable, as the Arrow specification requires.
+    ///
+    /// Nullability lives in the type rather than in any buffer, so this only relabels: the
+    /// offsets, validity and child arrays are carried over by reference, and a column whose
+    /// type is already right is passed through untouched.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::MapEntriesContainNulls`] when an entries array carries nulls. That is
+    /// the one shape relabelling cannot fix, and it is not recoverable by guessing: Arrow
+    /// gives a null entry no meaning, so treating it as a null map and treating it as a pair
+    /// to drop are both inventions, and each yields different rows.
+    pub fn normalize(&self, batch: RecordBatch) -> Result<RecordBatch> {
+        if !self.holds_map {
+            return Ok(batch);
+        }
 
-    let columns = schema
-        .fields()
-        .iter()
-        .zip(batch.columns())
-        .zip(normalized.fields())
-        .map(|((field, column), target)| {
-            let data = column.to_data();
-            ensure_no_map_entry_nulls(&data, field.name())?;
-            let relabelled = relabel_array_data(data, target.data_type()).context(
-                UnableToRelabelColumnSnafu {
-                    column: field.name(),
-                },
-            )?;
-            Ok(make_array(relabelled))
+        let Some(target) = self.target.as_ref() else {
+            // Nothing to relabel, but entry nulls fail downstream whatever the declaration
+            // says, so they are still refused here where the column can be named.
+            Self::refuse_entry_nulls(&batch)?;
+            return Ok(batch);
+        };
+
+        let schema = batch.schema();
+        let columns = schema
+            .fields()
+            .iter()
+            .zip(batch.columns())
+            .zip(target.fields())
+            .map(|((field, column), target_field)| {
+                if !contains(field.data_type(), &is_map) {
+                    return Ok(Arc::clone(column));
+                }
+                let data = column.to_data();
+                refuse_entry_nulls_in(&data, field.name())?;
+                // `apply_rules` shares an unchanged field by refcount, so pointer equality is
+                // an exact test for "this column needs nothing".
+                if Arc::ptr_eq(field, target_field) {
+                    return Ok(Arc::clone(column));
+                }
+                let relabelled = relabel_array_data(data, target_field.data_type()).context(
+                    UnableToNormalizeColumnSnafu {
+                        column: field.name(),
+                    },
+                )?;
+                Ok(make_array(relabelled))
+            })
+            .collect::<Result<Vec<ArrayRef>>>()?;
+
+        RecordBatch::try_new(Arc::clone(target), columns).context(UnableToRebuildRecordBatchSnafu {
+            schema: target.to_string(),
         })
-        .collect::<Result<Vec<_>>>()?;
+    }
 
-    // `num_rows` is carried explicitly so a column-less batch keeps its row count.
-    RecordBatch::try_new_with_options(
-        normalized,
-        columns,
-        &arrow::array::RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
-    )
-    .context(UnableToRebuildRecordBatchSnafu)
+    fn refuse_entry_nulls(batch: &RecordBatch) -> Result<()> {
+        for (field, column) in batch.schema().fields().iter().zip(batch.columns()) {
+            if contains(field.data_type(), &is_map) {
+                refuse_entry_nulls_in(&column.to_data(), field.name())?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn is_map(data_type: &DataType) -> bool {
+    matches!(data_type, DataType::Map(_, _))
+}
+
+fn declares_nullable_entries(data_type: &DataType) -> bool {
+    matches!(data_type, DataType::Map(entries, _) if entries.is_nullable())
+}
+
+/// Returns `true` when `predicate` holds for `data_type` or for any type nested inside it.
+///
+/// Allocation-free and short-circuiting. Asking [`crate::type_rewrite::rewrite_data_type`] for
+/// a rewritten copy and comparing it would answer the same question, but it rebuilds the whole
+/// type tree — every nested `Field`, name included — to produce one bit.
+fn contains(data_type: &DataType, predicate: &impl Fn(&DataType) -> bool) -> bool {
+    if predicate(data_type) {
+        return true;
+    }
+    match data_type {
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::ListView(field)
+        | DataType::LargeListView(field)
+        | DataType::Map(field, _)
+        | DataType::RunEndEncoded(_, field) => contains(field.data_type(), predicate),
+        DataType::Struct(fields) => fields
+            .iter()
+            .any(|field| contains(field.data_type(), predicate)),
+        DataType::Union(fields, _) => fields
+            .iter()
+            .any(|(_, field)| contains(field.data_type(), predicate)),
+        DataType::Dictionary(_, value_type) => contains(value_type, predicate),
+        _ => false,
+    }
 }
 
 /// Walks `data` and fails on the first `Map` whose entries array carries nulls.
-fn ensure_no_map_entry_nulls(data: &ArrayData, column: &str) -> Result<()> {
+fn refuse_entry_nulls_in(data: &ArrayData, column: &str) -> Result<()> {
     if let (DataType::Map(_, _), Some(entries)) = (data.data_type(), data.child_data().first()) {
         ensure!(
             entries.null_count() == 0,
@@ -135,84 +203,24 @@ fn ensure_no_map_entry_nulls(data: &ArrayData, column: &str) -> Result<()> {
     }
 
     for child in data.child_data() {
-        ensure_no_map_entry_nulls(child, column)?;
+        refuse_entry_nulls_in(child, column)?;
     }
 
     Ok(())
 }
 
-/// Recursively rebuilds `data` so its (possibly nested) [`DataType`] becomes
-/// `target_type`, without touching any values, buffers or null masks.
-///
-/// Only the parts of a type that carry no data may differ — field names and nested
-/// nullability flags. Children are relabelled positionally, so `target_type` has to
-/// describe the same physical layout.
-///
-/// # Errors
-///
-/// Returns an `ArrowError` when `target_type` does not describe the layout `data` holds:
-/// the relabelled level goes back through [`ArrayData`] validation rather than
-/// reinterpreting the buffers under a type that does not fit them.
-pub fn relabel_array_data(
-    data: ArrayData,
-    target_type: &DataType,
-) -> std::result::Result<ArrayData, arrow::error::ArrowError> {
-    if data.data_type() == target_type {
-        return Ok(data);
-    }
-
-    let target_child_types: Vec<DataType> = match target_type {
-        DataType::Struct(fields) => fields.iter().map(|f| f.data_type().clone()).collect(),
-        DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _) => {
-            vec![field.data_type().clone()]
-        }
-        DataType::Map(field, _) => vec![field.data_type().clone()],
-        _ => Vec::new(),
-    };
-
-    let old_children = data.child_data().to_vec();
-    let new_children = if target_child_types.len() == old_children.len() {
-        old_children
-            .into_iter()
-            .zip(target_child_types.iter())
-            .map(|(child, child_target)| relabel_array_data(child, child_target))
-            .collect::<std::result::Result<Vec<_>, arrow::error::ArrowError>>()?
-    } else {
-        old_children
-    };
-
-    data.into_builder()
-        .data_type(target_type.clone())
-        .child_data(new_children)
-        .build()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{ArrayRef, Int32Array, ListArray, MapArray, StringArray, StructArray};
+    use arrow::array::{Int32Array, ListArray, MapArray, StringArray, StructArray};
     use arrow::buffer::{Buffer, NullBuffer, OffsetBuffer};
-    use arrow::datatypes::{Field, Fields};
+    use arrow::datatypes::{Field, Fields, Schema};
     use arrow::error::ArrowError;
 
-    /// Walks `data_type` for a `Map` with a nullable `entries` field, independently of the
-    /// rewrite rule under test — asserting through [`declares_nullable_map_entries`] would
-    /// be self-referential and would pass even if the rule stopped firing.
-    fn any_nullable_map_entries(data_type: &DataType) -> bool {
-        match data_type {
-            DataType::Map(entries, _) => {
-                entries.is_nullable() || any_nullable_map_entries(entries.data_type())
-            }
-            DataType::List(field)
-            | DataType::LargeList(field)
-            | DataType::FixedSizeList(field, _)
-            | DataType::ListView(field)
-            | DataType::LargeListView(field) => any_nullable_map_entries(field.data_type()),
-            DataType::Struct(fields) => fields
-                .iter()
-                .any(|f| any_nullable_map_entries(f.data_type())),
-            _ => false,
-        }
+    /// Every batch of a stream is normalized against that stream's schema; a test holds one
+    /// batch, so its own schema is the stream's.
+    fn normalize(batch: RecordBatch) -> Result<RecordBatch> {
+        MapEntriesNormalizer::for_schema(&batch.schema()).normalize(batch)
     }
 
     fn entry_fields() -> Fields {
@@ -315,7 +323,7 @@ mod tests {
             "unexpected error: {err}"
         );
 
-        let normalized = normalize_map_entries(batch.clone()).expect("normalization");
+        let normalized = normalize(batch.clone()).expect("normalization");
 
         match normalized.schema().field(0).data_type() {
             DataType::Map(entries, _) => assert!(
@@ -333,16 +341,11 @@ mod tests {
         rebuild_through_public_constructor(after)
             .expect("a spec-conforming map rebuilds through the public constructor");
 
-        let before = batch
-            .column(0)
-            .as_any()
-            .downcast_ref::<MapArray>()
-            .expect("map before");
         assert_eq!(normalized.num_rows(), batch.num_rows());
-        assert_eq!(after.offsets(), before.offsets());
-        assert_eq!(after.keys(), before.keys());
-        assert_eq!(after.values(), before.values());
-        assert_eq!(after.nulls(), before.nulls());
+        assert_eq!(after.offsets(), before_map.offsets());
+        assert_eq!(after.keys(), before_map.keys());
+        assert_eq!(after.values(), before_map.values());
+        assert_eq!(after.nulls(), before_map.nulls());
     }
 
     /// A null map row — validity 0 with an empty offset range — is preserved, since that is
@@ -367,7 +370,7 @@ mod tests {
             .expect("map data");
         let batch = batch_of(Arc::new(MapArray::from(data)) as ArrayRef);
 
-        let normalized = normalize_map_entries(batch).expect("normalization");
+        let normalized = normalize(batch).expect("normalization");
         let map = normalized
             .column(0)
             .as_any()
@@ -390,7 +393,7 @@ mod tests {
             vec!["k0", "k1"],
             vec![Some("v0"), None],
         );
-        let err = normalize_map_entries(batch_of(Arc::new(map) as ArrayRef))
+        let err = normalize(batch_of(Arc::new(map) as ArrayRef))
             .expect_err("entry nulls must be refused");
         assert!(
             matches!(&err, Error::MapEntriesContainNulls { column } if column == "col_map"),
@@ -417,7 +420,7 @@ mod tests {
         )
         .expect("list of maps");
 
-        let err = normalize_map_entries(batch_of(Arc::new(list) as ArrayRef))
+        let err = normalize(batch_of(Arc::new(list) as ArrayRef))
             .expect_err("nested entry nulls must be refused");
         assert!(
             matches!(&err, Error::MapEntriesContainNulls { column } if column == "col_map"),
@@ -454,15 +457,23 @@ mod tests {
         .expect("list");
 
         let batch = batch_of(Arc::new(list) as ArrayRef);
-        assert!(any_nullable_map_entries(
-            batch.schema().field(0).data_type()
-        ));
 
-        let normalized = normalize_map_entries(batch).expect("normalization");
-        assert!(
-            !any_nullable_map_entries(normalized.schema().field(0).data_type()),
-            "the nested map must be relabelled: {}",
-            normalized.schema().field(0).data_type()
+        let normalized = normalize(batch).expect("normalization");
+
+        // Spelled out rather than asked of the rewrite rule: the map is relabelled, and the
+        // field names and the untouched `n` beside it come through as they were.
+        let expected_fields: Fields = vec![
+            Field::new("m", map_type(false), true),
+            Field::new("n", DataType::Int32, true),
+        ]
+        .into();
+        assert_eq!(
+            normalized.schema().field(0).data_type(),
+            &DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Struct(expected_fields),
+                true
+            )))
         );
 
         // The values are still reachable through the relabelled type.
@@ -489,33 +500,18 @@ mod tests {
     fn a_conforming_batch_is_returned_unchanged() {
         let map = map_from_parts(false, None, &[0, 1], vec!["k0"], vec![Some("v0")]);
         let batch = batch_of(Arc::new(map) as ArrayRef);
-        let normalized = normalize_map_entries(batch.clone()).expect("normalization");
+        let normalized = normalize(batch.clone()).expect("normalization");
         assert_eq!(normalized.schema(), batch.schema());
         assert_eq!(normalized.column(0).to_data(), batch.column(0).to_data());
-    }
-
-    /// A row-count-only batch (no columns, as `SELECT COUNT(1)` produces) keeps its rows.
-    #[test]
-    fn a_column_less_batch_keeps_its_row_count() {
-        let batch = RecordBatch::try_new_with_options(
-            Arc::new(Schema::empty()),
-            vec![],
-            &arrow::array::RecordBatchOptions::new().with_row_count(Some(5)),
-        )
-        .expect("batch");
-        let normalized = normalize_map_entries(batch).expect("normalization");
-        assert_eq!(normalized.num_rows(), 5);
     }
 
     /// An empty map column — zero rows — normalizes without touching offsets.
     #[test]
     fn an_empty_map_column_normalizes() {
         let map = map_from_parts(true, None, &[0], vec![], vec![]);
-        let normalized = normalize_map_entries(batch_of(Arc::new(map) as ArrayRef))
+        let normalized = normalize(batch_of(Arc::new(map) as ArrayRef))
             .expect("normalization of an empty column");
         assert_eq!(normalized.num_rows(), 0);
-        assert!(!any_nullable_map_entries(
-            normalized.schema().field(0).data_type()
-        ));
+        assert_eq!(normalized.schema().field(0).data_type(), &map_type(false));
     }
 }

--- a/crates/arrow_tools/src/map_entries.rs
+++ b/crates/arrow_tools/src/map_entries.rs
@@ -1,0 +1,521 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Brings foreign Arrow data in line with the Arrow `Map` layout rules.
+//!
+//! The Arrow specification requires a map's `entries` field to be non-nullable, and
+//! `MapArray::try_new` enforces both halves of that: it rejects an `entries` field
+//! declared nullable *and* an entries array that carries nulls. Nothing enforces it on
+//! the way in — the IPC reader builds a `MapArray` straight from `ArrayData` without
+//! either check — so a producer that declares `entries` nullable hands us a column that
+//! decodes cleanly and then fails in whichever kernel first rebuilds it. Every such
+//! failure reports the same message, `MapArray entries cannot contain nulls`, whether or
+//! not a null is involved.
+//!
+//! [`normalize_map_entries`] relabels the declaration (metadata only — no buffer is
+//! touched) and refuses the one shape that cannot be relabelled without inventing an
+//! answer: entries that actually contain nulls.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayData, RecordBatch, make_array};
+use arrow::datatypes::{DataType, Schema};
+use arrow_schema::SchemaRef;
+use snafu::prelude::*;
+
+use crate::type_rewrite::{MapEntriesNonNullable, apply_rules, rewrite_data_type};
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "column '{column}' holds a MAP whose entries contain nulls, which the Arrow map layout has no way to represent"
+    ))]
+    MapEntriesContainNulls { column: String },
+
+    #[snafu(display("column '{column}' could not be rebuilt: {source}"))]
+    UnableToRelabelColumn {
+        column: String,
+        source: arrow::error::ArrowError,
+    },
+
+    #[snafu(display("the normalized columns could not be reassembled: {source}"))]
+    UnableToRebuildRecordBatch { source: arrow::error::ArrowError },
+}
+
+/// Returns `true` when `data_type` declares a `Map` whose `entries` field is nullable,
+/// at any depth.
+#[must_use]
+pub fn declares_nullable_map_entries(data_type: &DataType) -> bool {
+    rewrite_data_type(data_type, &[&MapEntriesNonNullable]) != *data_type
+}
+
+/// Returns the schema with every `Map`'s `entries` field marked non-nullable.
+#[must_use]
+pub fn normalize_map_entries_schema(schema: &Schema) -> Schema {
+    apply_rules(schema, &[&MapEntriesNonNullable])
+}
+
+/// Rewrites `batch` so every `Map` column — nested ones included — declares its `entries`
+/// field non-nullable, as the Arrow specification requires.
+///
+/// Nullability lives in the type rather than in any buffer, so this only relabels: the
+/// offsets, validity and child arrays are carried over by reference. A batch that already
+/// conforms is returned untouched.
+///
+/// # Errors
+///
+/// Returns [`Error::MapEntriesContainNulls`] when an entries array carries nulls. That is
+/// the one shape relabelling cannot fix, and it is not recoverable by guessing: Arrow
+/// gives a null entry no meaning, so treating it as a null map and treating it as a pair
+/// to drop are both inventions, and each yields different rows.
+pub fn normalize_map_entries(batch: RecordBatch) -> Result<RecordBatch> {
+    let schema = batch.schema();
+    if !schema
+        .fields()
+        .iter()
+        .any(|field| declares_nullable_map_entries(field.data_type()))
+    {
+        // Still reject entry nulls: they fail downstream whatever the declaration says.
+        for (field, column) in schema.fields().iter().zip(batch.columns()) {
+            ensure_no_map_entry_nulls(&column.to_data(), field.name())?;
+        }
+        return Ok(batch);
+    }
+
+    let normalized: SchemaRef = Arc::new(normalize_map_entries_schema(schema.as_ref()));
+
+    let columns = schema
+        .fields()
+        .iter()
+        .zip(batch.columns())
+        .zip(normalized.fields())
+        .map(|((field, column), target)| {
+            let data = column.to_data();
+            ensure_no_map_entry_nulls(&data, field.name())?;
+            let relabelled = relabel_array_data(data, target.data_type()).context(
+                UnableToRelabelColumnSnafu {
+                    column: field.name(),
+                },
+            )?;
+            Ok(make_array(relabelled))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // `num_rows` is carried explicitly so a column-less batch keeps its row count.
+    RecordBatch::try_new_with_options(
+        normalized,
+        columns,
+        &arrow::array::RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+    )
+    .context(UnableToRebuildRecordBatchSnafu)
+}
+
+/// Walks `data` and fails on the first `Map` whose entries array carries nulls.
+fn ensure_no_map_entry_nulls(data: &ArrayData, column: &str) -> Result<()> {
+    if let (DataType::Map(_, _), Some(entries)) = (data.data_type(), data.child_data().first()) {
+        ensure!(
+            entries.null_count() == 0,
+            MapEntriesContainNullsSnafu { column }
+        );
+    }
+
+    for child in data.child_data() {
+        ensure_no_map_entry_nulls(child, column)?;
+    }
+
+    Ok(())
+}
+
+/// Recursively rebuilds `data` so its (possibly nested) [`DataType`] becomes
+/// `target_type`, without touching any values, buffers or null masks.
+///
+/// Only the parts of a type that carry no data may differ — field names and nested
+/// nullability flags. Children are relabelled positionally, so `target_type` has to
+/// describe the same physical layout.
+///
+/// # Errors
+///
+/// Returns an `ArrowError` when `target_type` does not describe the layout `data` holds:
+/// the relabelled level goes back through [`ArrayData`] validation rather than
+/// reinterpreting the buffers under a type that does not fit them.
+pub fn relabel_array_data(
+    data: ArrayData,
+    target_type: &DataType,
+) -> std::result::Result<ArrayData, arrow::error::ArrowError> {
+    if data.data_type() == target_type {
+        return Ok(data);
+    }
+
+    let target_child_types: Vec<DataType> = match target_type {
+        DataType::Struct(fields) => fields.iter().map(|f| f.data_type().clone()).collect(),
+        DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _) => {
+            vec![field.data_type().clone()]
+        }
+        DataType::Map(field, _) => vec![field.data_type().clone()],
+        _ => Vec::new(),
+    };
+
+    let old_children = data.child_data().to_vec();
+    let new_children = if target_child_types.len() == old_children.len() {
+        old_children
+            .into_iter()
+            .zip(target_child_types.iter())
+            .map(|(child, child_target)| relabel_array_data(child, child_target))
+            .collect::<std::result::Result<Vec<_>, arrow::error::ArrowError>>()?
+    } else {
+        old_children
+    };
+
+    data.into_builder()
+        .data_type(target_type.clone())
+        .child_data(new_children)
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{ArrayRef, Int32Array, ListArray, MapArray, StringArray, StructArray};
+    use arrow::buffer::{Buffer, NullBuffer, OffsetBuffer};
+    use arrow::datatypes::{Field, Fields};
+    use arrow::error::ArrowError;
+
+    /// Walks `data_type` for a `Map` with a nullable `entries` field, independently of the
+    /// rewrite rule under test — asserting through [`declares_nullable_map_entries`] would
+    /// be self-referential and would pass even if the rule stopped firing.
+    fn any_nullable_map_entries(data_type: &DataType) -> bool {
+        match data_type {
+            DataType::Map(entries, _) => {
+                entries.is_nullable() || any_nullable_map_entries(entries.data_type())
+            }
+            DataType::List(field)
+            | DataType::LargeList(field)
+            | DataType::FixedSizeList(field, _)
+            | DataType::ListView(field)
+            | DataType::LargeListView(field) => any_nullable_map_entries(field.data_type()),
+            DataType::Struct(fields) => fields
+                .iter()
+                .any(|f| any_nullable_map_entries(f.data_type())),
+            _ => false,
+        }
+    }
+
+    fn entry_fields() -> Fields {
+        vec![
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Utf8, true),
+        ]
+        .into()
+    }
+
+    fn map_type(entries_nullable: bool) -> DataType {
+        DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(entry_fields()),
+                entries_nullable,
+            )),
+            false,
+        )
+    }
+
+    /// Builds a `MapArray` bypassing `MapArray::try_new`, the way the IPC reader does:
+    /// `From<ArrayData>` performs neither of the two `entries` checks, which is why a
+    /// non-conforming map reaches us at all.
+    fn map_from_parts(
+        entries_nullable: bool,
+        entry_nulls: Option<NullBuffer>,
+        offsets: &[i32],
+        keys: Vec<&str>,
+        values: Vec<Option<&str>>,
+    ) -> MapArray {
+        let entries = StructArray::try_new(
+            entry_fields(),
+            vec![
+                Arc::new(StringArray::from(keys)) as ArrayRef,
+                Arc::new(StringArray::from(values)) as ArrayRef,
+            ],
+            entry_nulls,
+        )
+        .expect("entries struct");
+
+        let data = ArrayData::builder(map_type(entries_nullable))
+            .len(offsets.len() - 1)
+            .add_buffer(Buffer::from_slice_ref(offsets))
+            .add_child_data(entries.to_data())
+            .build()
+            .expect("map array data");
+
+        MapArray::from(data)
+    }
+
+    fn batch_of(column: ArrayRef) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "col_map",
+                column.data_type().clone(),
+                true,
+            )])),
+            vec![column],
+        )
+        .expect("batch")
+    }
+
+    /// Rebuilds `map` through the public `MapArray` constructor, the one every kernel that
+    /// touches a map column goes through, keeping the declared `entries` field.
+    fn rebuild_through_public_constructor(map: &MapArray) -> Result<MapArray, ArrowError> {
+        let (field, offsets, entries, nulls, ordered) = map.clone().into_parts();
+        MapArray::try_new(field, offsets, entries, nulls, ordered)
+    }
+
+    /// Regression test for #7307: a `MAP` column whose `entries` field arrives declared
+    /// nullable cannot be rebuilt by any kernel, and the refusal reports nulls the data does
+    /// not contain — which is why the declaration was not the first suspect.
+    #[test]
+    fn a_nullable_entries_declaration_is_relabelled_so_the_column_can_be_rebuilt() {
+        let map = map_from_parts(
+            true,
+            None,
+            &[0, 1, 2],
+            vec!["k0", "k1"],
+            vec![Some("v0"), None],
+        );
+        let batch = batch_of(Arc::new(map) as ArrayRef);
+
+        let before_map = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("map before");
+        assert_eq!(
+            before_map.entries().null_count(),
+            0,
+            "the data holds no nulls at all"
+        );
+        let err = rebuild_through_public_constructor(before_map)
+            .expect_err("a nullable entries field is refused on its own");
+        assert!(
+            err.to_string()
+                .contains("MapArray entries cannot contain nulls"),
+            "unexpected error: {err}"
+        );
+
+        let normalized = normalize_map_entries(batch.clone()).expect("normalization");
+
+        match normalized.schema().field(0).data_type() {
+            DataType::Map(entries, _) => assert!(
+                !entries.is_nullable(),
+                "entries must be relabelled non-nullable"
+            ),
+            other => panic!("expected a Map, got {other}"),
+        }
+
+        let after = normalized
+            .column(0)
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("map after");
+        rebuild_through_public_constructor(after)
+            .expect("a spec-conforming map rebuilds through the public constructor");
+
+        let before = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("map before");
+        assert_eq!(normalized.num_rows(), batch.num_rows());
+        assert_eq!(after.offsets(), before.offsets());
+        assert_eq!(after.keys(), before.keys());
+        assert_eq!(after.values(), before.values());
+        assert_eq!(after.nulls(), before.nulls());
+    }
+
+    /// A null map row — validity 0 with an empty offset range — is preserved, since that is
+    /// the layout the relabelling exists to keep reachable.
+    #[test]
+    fn a_null_map_row_survives_normalization() {
+        let entries = StructArray::try_new(
+            entry_fields(),
+            vec![
+                Arc::new(StringArray::from(vec!["k0"])) as ArrayRef,
+                Arc::new(StringArray::from(vec![Some("v0")])) as ArrayRef,
+            ],
+            None,
+        )
+        .expect("entries");
+        let data = ArrayData::builder(map_type(true))
+            .len(2)
+            .add_buffer(Buffer::from_slice_ref([0i32, 1, 1]))
+            .nulls(Some(NullBuffer::from(vec![true, false])))
+            .add_child_data(entries.to_data())
+            .build()
+            .expect("map data");
+        let batch = batch_of(Arc::new(MapArray::from(data)) as ArrayRef);
+
+        let normalized = normalize_map_entries(batch).expect("normalization");
+        let map = normalized
+            .column(0)
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("map");
+        assert_eq!(map.len(), 2);
+        assert!(map.is_valid(0), "row 0 holds a map");
+        assert!(map.is_null(1), "row 1 is a null map");
+        assert_eq!(map.value(0).len(), 1);
+    }
+
+    /// Entries that genuinely carry nulls cannot be relabelled: Arrow gives a null entry no
+    /// meaning, so the column is refused by name rather than guessed at.
+    #[test]
+    fn entry_level_nulls_are_refused_by_column_name() {
+        let map = map_from_parts(
+            true,
+            Some(NullBuffer::from(vec![true, false])),
+            &[0, 1, 2],
+            vec!["k0", "k1"],
+            vec![Some("v0"), None],
+        );
+        let err = normalize_map_entries(batch_of(Arc::new(map) as ArrayRef))
+            .expect_err("entry nulls must be refused");
+        assert!(
+            matches!(&err, Error::MapEntriesContainNulls { column } if column == "col_map"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// The refusal holds for a map nested inside another container, where the offending
+    /// entries array is not the column's own child.
+    #[test]
+    fn entry_level_nulls_nested_in_a_list_are_refused() {
+        let map = map_from_parts(
+            true,
+            Some(NullBuffer::from(vec![false])),
+            &[0, 1],
+            vec!["k0"],
+            vec![None],
+        );
+        let list = ListArray::try_new(
+            Arc::new(Field::new("item", map.data_type().clone(), true)),
+            OffsetBuffer::new(vec![0, 1].into()),
+            Arc::new(map) as ArrayRef,
+            None,
+        )
+        .expect("list of maps");
+
+        let err = normalize_map_entries(batch_of(Arc::new(list) as ArrayRef))
+            .expect_err("nested entry nulls must be refused");
+        assert!(
+            matches!(&err, Error::MapEntriesContainNulls { column } if column == "col_map"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A map nested inside a struct inside a list is relabelled too — the rewrite has to
+    /// reach every depth, not just a top-level map column.
+    #[test]
+    fn a_deeply_nested_map_declaration_is_relabelled() {
+        let map = map_from_parts(true, None, &[0, 1], vec!["k0"], vec![Some("v0")]);
+        let map_type_before = map.data_type().clone();
+        let struct_fields: Fields = vec![
+            Field::new("m", map_type_before, true),
+            Field::new("n", DataType::Int32, true),
+        ]
+        .into();
+        let inner = StructArray::try_new(
+            struct_fields.clone(),
+            vec![
+                Arc::new(map) as ArrayRef,
+                Arc::new(Int32Array::from(vec![7])) as ArrayRef,
+            ],
+            None,
+        )
+        .expect("struct");
+        let list = ListArray::try_new(
+            Arc::new(Field::new("item", DataType::Struct(struct_fields), true)),
+            OffsetBuffer::new(vec![0, 1].into()),
+            Arc::new(inner) as ArrayRef,
+            None,
+        )
+        .expect("list");
+
+        let batch = batch_of(Arc::new(list) as ArrayRef);
+        assert!(any_nullable_map_entries(
+            batch.schema().field(0).data_type()
+        ));
+
+        let normalized = normalize_map_entries(batch).expect("normalization");
+        assert!(
+            !any_nullable_map_entries(normalized.schema().field(0).data_type()),
+            "the nested map must be relabelled: {}",
+            normalized.schema().field(0).data_type()
+        );
+
+        // The values are still reachable through the relabelled type.
+        let list = normalized
+            .column(0)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list");
+        let inner = list
+            .value(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("struct")
+            .column(0)
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("map")
+            .value(0);
+        assert_eq!(inner.len(), 1);
+    }
+
+    /// A batch that already conforms is handed back as-is, so the common case pays nothing.
+    #[test]
+    fn a_conforming_batch_is_returned_unchanged() {
+        let map = map_from_parts(false, None, &[0, 1], vec!["k0"], vec![Some("v0")]);
+        let batch = batch_of(Arc::new(map) as ArrayRef);
+        let normalized = normalize_map_entries(batch.clone()).expect("normalization");
+        assert_eq!(normalized.schema(), batch.schema());
+        assert_eq!(normalized.column(0).to_data(), batch.column(0).to_data());
+    }
+
+    /// A row-count-only batch (no columns, as `SELECT COUNT(1)` produces) keeps its rows.
+    #[test]
+    fn a_column_less_batch_keeps_its_row_count() {
+        let batch = RecordBatch::try_new_with_options(
+            Arc::new(Schema::empty()),
+            vec![],
+            &arrow::array::RecordBatchOptions::new().with_row_count(Some(5)),
+        )
+        .expect("batch");
+        let normalized = normalize_map_entries(batch).expect("normalization");
+        assert_eq!(normalized.num_rows(), 5);
+    }
+
+    /// An empty map column — zero rows — normalizes without touching offsets.
+    #[test]
+    fn an_empty_map_column_normalizes() {
+        let map = map_from_parts(true, None, &[0], vec![], vec![]);
+        let normalized = normalize_map_entries(batch_of(Arc::new(map) as ArrayRef))
+            .expect("normalization of an empty column");
+        assert_eq!(normalized.num_rows(), 0);
+        assert!(!any_nullable_map_entries(
+            normalized.schema().field(0).data_type()
+        ));
+    }
+}

--- a/crates/arrow_tools/src/map_entries.rs
+++ b/crates/arrow_tools/src/map_entries.rs
@@ -495,6 +495,159 @@ mod tests {
         assert_eq!(inner.len(), 1);
     }
 
+    /// A map nested under each wrapper type the rewrite descends into is relabelled, children
+    /// included.
+    ///
+    /// The rewrite rule reaches a map through `ListView`, `Union`, `Dictionary` and
+    /// `RunEndEncoded` as readily as through `List` and `Struct`, so the relabel has to rebuild
+    /// those children too. Where it does not, the wrapper is rebuilt carrying the new type over
+    /// children that still hold the old one, and Arrow rejects the mismatch — the query returns
+    /// an error rather than rows.
+    #[test]
+    fn a_map_under_every_traversed_wrapper_is_relabelled() {
+        // Every wrapper is reported, not just the first to break: a loop that panics on wrapper
+        // one leaves the rest unproven.
+        let mut failures: Vec<String> = Vec::new();
+        for (name, wrapped) in wrapped_maps() {
+            let expected = crate::type_rewrite::rewrite_data_type(
+                wrapped.data_type(),
+                &[&MapEntriesNonNullable],
+            );
+            assert!(
+                holds_nullable_entries(wrapped.data_type()) && !holds_nullable_entries(&expected),
+                "{name}: the fixture must start non-conforming and have a conforming rewrite"
+            );
+
+            match normalize(batch_of(Arc::clone(&wrapped))) {
+                Err(e) => failures.push(format!("{name}: {e}")),
+                Ok(normalized) => {
+                    let schema = normalized.schema();
+                    let published = schema.field(0).data_type();
+                    if published != &expected {
+                        failures.push(format!("{name}: published {published}, want {expected}"));
+                    }
+                    // The child array carries the relabelled type too — a parent-only rewrite
+                    // is what Arrow rejects.
+                    if normalized.column(0).data_type() != &expected {
+                        failures.push(format!(
+                            "{name}: column type {}, want {expected}",
+                            normalized.column(0).data_type()
+                        ));
+                    }
+                }
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "wrappers not normalized: {failures:#?}"
+        );
+    }
+
+    /// Independent of the rewrite rule: walks the type for a nullable `entries` field.
+    fn holds_nullable_entries(data_type: &DataType) -> bool {
+        match data_type {
+            DataType::Map(entries, _) => {
+                entries.is_nullable() || holds_nullable_entries(entries.data_type())
+            }
+            DataType::List(f)
+            | DataType::LargeList(f)
+            | DataType::FixedSizeList(f, _)
+            | DataType::ListView(f)
+            | DataType::LargeListView(f)
+            | DataType::RunEndEncoded(_, f) => holds_nullable_entries(f.data_type()),
+            DataType::Struct(fields) => {
+                fields.iter().any(|f| holds_nullable_entries(f.data_type()))
+            }
+            DataType::Union(fields, _) => fields
+                .iter()
+                .any(|(_, f)| holds_nullable_entries(f.data_type())),
+            DataType::Dictionary(_, value) => holds_nullable_entries(value),
+            _ => false,
+        }
+    }
+
+    /// One single-element array per wrapper type, each holding a map whose `entries` field is
+    /// declared nullable.
+    fn wrapped_maps() -> Vec<(&'static str, ArrayRef)> {
+        use arrow::array::{
+            DictionaryArray, FixedSizeListArray, Int32Array, ListViewArray, RunArray, UnionArray,
+        };
+        use arrow::buffer::ScalarBuffer;
+        use arrow::datatypes::{Int32Type, UnionFields};
+
+        let map = || {
+            Arc::new(map_from_parts(
+                true,
+                None,
+                &[0, 1],
+                vec!["k0"],
+                vec![Some("v0")],
+            ))
+        };
+        let item = |array: &ArrayRef| Arc::new(Field::new("item", array.data_type().clone(), true));
+
+        let mut out: Vec<(&'static str, ArrayRef)> = Vec::new();
+
+        let m = map() as ArrayRef;
+        out.push((
+            "FixedSizeList",
+            Arc::new(FixedSizeListArray::new(item(&m), 1, Arc::clone(&m), None)),
+        ));
+
+        let m = map() as ArrayRef;
+        out.push((
+            "ListView",
+            Arc::new(
+                ListViewArray::try_new(
+                    item(&m),
+                    ScalarBuffer::from(vec![0]),
+                    ScalarBuffer::from(vec![1]),
+                    Arc::clone(&m),
+                    None,
+                )
+                .expect("list view of a map"),
+            ),
+        ));
+
+        let m = map() as ArrayRef;
+        out.push((
+            "Dictionary",
+            Arc::new(
+                DictionaryArray::<Int32Type>::try_new(Int32Array::from(vec![0]), Arc::clone(&m))
+                    .expect("dictionary of maps"),
+            ),
+        ));
+
+        let m = map() as ArrayRef;
+        out.push((
+            "RunEndEncoded",
+            Arc::new(
+                RunArray::try_new(&Int32Array::from(vec![1]), m.as_ref())
+                    .expect("run-end encoded maps"),
+            ),
+        ));
+
+        let m = map() as ArrayRef;
+        let union_fields: UnionFields =
+            [(0_i8, Arc::new(Field::new("m", m.data_type().clone(), true)))]
+                .into_iter()
+                .collect();
+        out.push((
+            "Union",
+            Arc::new(
+                UnionArray::try_new(
+                    union_fields,
+                    ScalarBuffer::from(vec![0_i8]),
+                    Some(ScalarBuffer::from(vec![0_i32])),
+                    vec![Arc::clone(&m)],
+                )
+                .expect("union of maps"),
+            ),
+        ));
+
+        out
+    }
+
     /// A batch that already conforms is handed back as-is, so the common case pays nothing.
     #[test]
     fn a_conforming_batch_is_returned_unchanged() {

--- a/crates/arrow_tools/src/type_rewrite.rs
+++ b/crates/arrow_tools/src/type_rewrite.rs
@@ -43,6 +43,27 @@ impl TypeRewriteRule for DictionaryUnwrap {
     }
 }
 
+/// Rewrites `DataType::Map(entries, _)` so the `entries` field is non-nullable.
+///
+/// The Arrow specification requires it, and `MapArray::try_new` refuses a nullable
+/// `entries` field outright — so a map declared this way decodes from IPC without
+/// complaint and then fails in the first kernel that rebuilds it, reporting
+/// `MapArray entries cannot contain nulls` even when no null is involved. Nullability is
+/// part of the type and not of any buffer, so the correction is metadata-only.
+#[derive(Debug)]
+pub struct MapEntriesNonNullable;
+impl TypeRewriteRule for MapEntriesNonNullable {
+    fn rewrite(&self, dt: &DataType) -> Option<DataType> {
+        match dt {
+            DataType::Map(entries, sorted) if entries.is_nullable() => Some(DataType::Map(
+                Arc::new(entries.as_ref().clone().with_nullable(false)),
+                *sorted,
+            )),
+            _ => None,
+        }
+    }
+}
+
 /// Rewrites `DataType::Null` → `DataType::Int32`.
 ///
 /// `DuckDB` has no Null type and silently coerces it to INT32 when creating tables.

--- a/crates/arrow_tools/src/type_rewrite.rs
+++ b/crates/arrow_tools/src/type_rewrite.rs
@@ -16,11 +16,19 @@ limitations under the License.
 
 use std::sync::Arc;
 
+use arrow::array::ArrayData;
+use arrow::error::ArrowError;
 use arrow_schema::{DataType, Field, FieldRef, IntervalUnit, Schema, TimeUnit};
 
 /// A rewrite rule applied by [`apply_rules`] to every [`DataType`] node in a schema.
 ///
 /// Rules are applied post-order: children are rewritten before the parent sees them.
+///
+/// Two kinds of rule live here, and only one belongs in an engine's rule list. Most describe
+/// what a storage engine *can hold* — `DuckDB` has no Arrow Dictionary, no Null type — and are
+/// named in that engine's static list. [`MapEntriesNonNullable`] instead describes what a
+/// *source got wrong*, so it is applied where that source's data enters and belongs to no
+/// engine's list.
 ///
 /// `Debug` is required so a rule list can sit in a `#[derive(Debug)]` struct; the unit
 /// structs below satisfy it by name.
@@ -49,7 +57,11 @@ impl TypeRewriteRule for DictionaryUnwrap {
 /// `entries` field outright — so a map declared this way decodes from IPC without
 /// complaint and then fails in the first kernel that rebuilds it, reporting
 /// `MapArray entries cannot contain nulls` even when no null is involved. Nullability is
-/// part of the type and not of any buffer, so the correction is metadata-only.
+/// part of the type and not of any buffer, so the correction is metadata-only — pair it with
+/// [`relabel_array_data`] to carry the arrays over unchanged.
+///
+/// This is a source-conformance rule, not an engine-capability one: do not add it to an
+/// accelerator's rule list by analogy with the rules above it.
 #[derive(Debug)]
 pub struct MapEntriesNonNullable;
 impl TypeRewriteRule for MapEntriesNonNullable {
@@ -277,6 +289,65 @@ pub fn rewrite_data_type(dt: &DataType, rules: &[&dyn TypeRewriteRule]) -> DataT
         }
     }
     dt
+}
+
+/// Recursively rebuilds `data` so its (possibly nested) [`DataType`] becomes `target_type`,
+/// without changing any value, buffer or null mask.
+///
+/// This is the array-side counterpart to [`rewrite_data_type`]: that decides what a type
+/// should become, this carries the arrays across to it. Only the parts of a type that hold no
+/// data may differ — field names and nested nullability flags — and children are relabelled
+/// positionally, so `target_type` has to describe the layout `data` already has.
+///
+/// The result shares `data`'s buffers, but the call is not free: each rebuilt level goes back
+/// through [`ArrayData`] validation, which is `O(rows)` in its offsets and `O(bytes)` for a
+/// `Utf8` leaf. Only the levels whose type actually changes are rebuilt.
+///
+/// # Errors
+///
+/// Returns an `ArrowError` when `target_type` does not describe the layout `data` holds —
+/// validation refuses it rather than reinterpreting the buffers under a type that does not fit.
+pub fn relabel_array_data(
+    data: ArrayData,
+    target_type: &DataType,
+) -> Result<ArrayData, ArrowError> {
+    if data.data_type() == target_type {
+        return Ok(data);
+    }
+
+    let target_child_types: Vec<&DataType> = match target_type {
+        DataType::Struct(fields) => fields.iter().map(|f| f.data_type()).collect(),
+        DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _) => {
+            vec![field.data_type()]
+        }
+        DataType::Map(field, _) => vec![field.data_type()],
+        _ => Vec::new(),
+    };
+
+    // Usually a flag changes at one level and every child below it is already correct, so the
+    // child spine is carried over by move instead of cloned.
+    let children_change = target_child_types.len() == data.child_data().len()
+        && data
+            .child_data()
+            .iter()
+            .zip(&target_child_types)
+            .any(|(child, target)| child.data_type() != *target);
+
+    if !children_change {
+        return data.into_builder().data_type(target_type.clone()).build();
+    }
+
+    let children = data
+        .child_data()
+        .iter()
+        .zip(&target_child_types)
+        .map(|(child, target)| relabel_array_data(child.clone(), target))
+        .collect::<Result<Vec<_>, ArrowError>>()?;
+
+    data.into_builder()
+        .data_type(target_type.clone())
+        .child_data(children)
+        .build()
 }
 
 #[cfg(test)]

--- a/crates/arrow_tools/src/type_rewrite.rs
+++ b/crates/arrow_tools/src/type_rewrite.rs
@@ -315,22 +315,17 @@ pub fn relabel_array_data(
         return Ok(data);
     }
 
-    let target_child_types: Vec<&DataType> = match target_type {
-        DataType::Struct(fields) => fields.iter().map(|f| f.data_type()).collect(),
-        DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _) => {
-            vec![field.data_type()]
-        }
-        DataType::Map(field, _) => vec![field.data_type()],
-        _ => Vec::new(),
-    };
+    let targets = target_child_types(target_type);
 
     // Usually a flag changes at one level and every child below it is already correct, so the
-    // child spine is carried over by move instead of cloned.
-    let children_change = target_child_types.len() == data.child_data().len()
+    // child spine is carried over by move instead of cloned. A child count that disagrees with
+    // the target is a layout disagreement, and `build` refuses it below rather than leaving a
+    // rebuilt parent over children still carrying the old type.
+    let children_change = targets.len() == data.child_data().len()
         && data
             .child_data()
             .iter()
-            .zip(&target_child_types)
+            .zip(&targets)
             .any(|(child, target)| child.data_type() != *target);
 
     if !children_change {
@@ -340,7 +335,7 @@ pub fn relabel_array_data(
     let children = data
         .child_data()
         .iter()
-        .zip(&target_child_types)
+        .zip(&targets)
         .map(|(child, target)| relabel_array_data(child.clone(), target))
         .collect::<Result<Vec<_>, ArrowError>>()?;
 
@@ -348,6 +343,29 @@ pub fn relabel_array_data(
         .data_type(target_type.clone())
         .child_data(children)
         .build()
+}
+
+/// The types `target_type`'s children must carry, in the order [`ArrayData`] holds them.
+///
+/// This mirrors `ArrayData`'s own `validate_child_data`, and it has to cover every
+/// child-bearing type [`rewrite_data_type`] descends into: a type this misses is one whose
+/// parent gets rebuilt while its children keep the old type, which `build` then rejects.
+fn target_child_types(target_type: &DataType) -> Vec<&DataType> {
+    match target_type {
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::ListView(field)
+        | DataType::LargeListView(field)
+        | DataType::Map(field, _) => vec![field.data_type()],
+        DataType::Struct(fields) => fields.iter().map(|f| f.data_type()).collect(),
+        DataType::Union(fields, _) => fields.iter().map(|(_, f)| f.data_type()).collect(),
+        DataType::RunEndEncoded(run_ends, values) => {
+            vec![run_ends.data_type(), values.data_type()]
+        }
+        DataType::Dictionary(_, value_type) => vec![value_type.as_ref()],
+        _ => Vec::new(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -19,7 +19,7 @@ use arrow::{
     datatypes::{Field, Schema, SchemaRef},
     ipc::reader::StreamReader,
 };
-use arrow_tools::map_entries::normalize_map_entries;
+use arrow_tools::map_entries::MapEntriesNormalizer;
 use async_trait::async_trait;
 use datafusion::{
     datasource::TableProvider, error::DataFusionError, execution::SendableRecordBatchStream,
@@ -1309,16 +1309,21 @@ impl SqlWarehouseApi {
     ) -> Result<Vec<arrow::record_batch::RecordBatch>, Error> {
         let cursor = Cursor::new(bytes);
         let reader = StreamReader::try_new(cursor, None).context(ArrowStreamReadFailedSnafu)?;
+
+        // The warehouse declares a MAP's `entries` field nullable, which the Arrow map layout
+        // forbids. Such a batch decodes here and then fails in whichever kernel first rebuilds
+        // the column, so it is brought into line at the boundary rather than carried into the
+        // plan. One stream carries one schema, so what its batches need is resolved once and
+        // every batch comes out sharing the same `SchemaRef`.
+        let normalizer = MapEntriesNormalizer::for_schema(&reader.schema());
+
         reader
-            .collect::<Result<Vec<_>, _>>()
-            .context(ArrowStreamReadFailedSnafu)?
-            .into_iter()
-            .filter(|batch| batch.num_rows() > 0)
-            // The warehouse declares a MAP's `entries` field nullable, which the Arrow map
-            // layout forbids. Such a batch decodes here and then fails in whichever kernel
-            // first rebuilds the column, so it is brought into line at the boundary rather
-            // than carried into the plan.
-            .map(|batch| normalize_map_entries(batch).context(MapEntriesNotNormalizableSnafu))
+            .filter(|batch| !matches!(batch, Ok(batch) if batch.num_rows() == 0))
+            .map(|batch| {
+                normalizer
+                    .normalize(batch.context(ArrowStreamReadFailedSnafu)?)
+                    .context(MapEntriesNotNormalizableSnafu)
+            })
             .collect()
     }
 
@@ -2123,10 +2128,10 @@ mod tests {
         .into()
     }
 
-    fn map_column_batch(
-        entries_nullable: bool,
-        entry_nulls: Option<arrow::buffer::NullBuffer>,
-    ) -> RecordBatch {
+    /// A one-row MAP column declared the way the warehouse declares it — `entries` nullable,
+    /// which the Arrow map layout forbids. Built through `ArrayData` rather than
+    /// `MapArray::try_new`, the way the IPC reader does, since `try_new` is what refuses it.
+    fn wire_map_column_batch(entry_nulls: Option<arrow::buffer::NullBuffer>) -> RecordBatch {
         let entries = arrow::array::StructArray::try_new(
             map_entry_fields(),
             vec![
@@ -2142,7 +2147,7 @@ mod tests {
             Arc::new(Field::new(
                 "entries",
                 DataType::Struct(map_entry_fields()),
-                entries_nullable,
+                true,
             )),
             false,
         );
@@ -2166,13 +2171,7 @@ mod tests {
     /// `MapArray entries cannot contain nulls` even though the data holds no nulls.
     #[test]
     fn a_map_column_is_published_with_a_non_nullable_entries_field() {
-        let wire = map_column_batch(true, None);
-        match wire.schema().field(0).data_type() {
-            DataType::Map(entries, _) => {
-                assert!(entries.is_nullable(), "the wire schema is the reported one");
-            }
-            other => panic!("expected a Map, got {other}"),
-        }
+        let wire = wire_map_column_batch(None);
 
         let batches = SqlWarehouseApi::read_arrow_batches(arrow_stream_bytes(&wire))
             .expect("the chunk is readable");
@@ -2203,7 +2202,7 @@ mod tests {
     /// surfacing Arrow's message about a layout the user never chose.
     #[test]
     fn entry_level_nulls_fail_the_read_with_an_actionable_message() {
-        let wire = map_column_batch(true, Some(arrow::buffer::NullBuffer::from(vec![false])));
+        let wire = wire_map_column_batch(Some(arrow::buffer::NullBuffer::from(vec![false])));
 
         let err = SqlWarehouseApi::read_arrow_batches(arrow_stream_bytes(&wire))
             .expect_err("entry nulls must fail the read");

--- a/crates/data_components/src/databricks/sql_warehouse.rs
+++ b/crates/data_components/src/databricks/sql_warehouse.rs
@@ -19,6 +19,7 @@ use arrow::{
     datatypes::{Field, Schema, SchemaRef},
     ipc::reader::StreamReader,
 };
+use arrow_tools::map_entries::normalize_map_entries;
 use async_trait::async_trait;
 use datafusion::{
     datasource::TableProvider, error::DataFusionError, execution::SendableRecordBatchStream,
@@ -289,6 +290,15 @@ pub enum Error {
 
     #[snafu(display("Failed to read Arrow data from Databricks SQL Warehouse: {source}"))]
     ArrowStreamReadFailed { source: arrow::error::ArrowError },
+
+    #[snafu(display(
+        "Failed to read query results from Databricks SQL Warehouse ({source}), so the query cannot return rows. \
+        Cast the MAP column to a supported type in the query, or select it as a string with `to_json(<column>)`. \
+        See: https://spiceai.org/docs/components/data-connectors/databricks"
+    ))]
+    MapEntriesNotNormalizable {
+        source: arrow_tools::map_entries::Error,
+    },
 
     #[snafu(display(
         "Failed to load the dataset (databricks): {}",
@@ -1299,12 +1309,17 @@ impl SqlWarehouseApi {
     ) -> Result<Vec<arrow::record_batch::RecordBatch>, Error> {
         let cursor = Cursor::new(bytes);
         let reader = StreamReader::try_new(cursor, None).context(ArrowStreamReadFailedSnafu)?;
-        Ok(reader
+        reader
             .collect::<Result<Vec<_>, _>>()
             .context(ArrowStreamReadFailedSnafu)?
             .into_iter()
             .filter(|batch| batch.num_rows() > 0)
-            .collect())
+            // The warehouse declares a MAP's `entries` field nullable, which the Arrow map
+            // layout forbids. Such a batch decodes here and then fails in whichever kernel
+            // first rebuilds the column, so it is brought into line at the boundary rather
+            // than carried into the plan.
+            .map(|batch| normalize_map_entries(batch).context(MapEntriesNotNormalizableSnafu))
+            .collect()
     }
 
     fn extract_response_status(response: &Value) -> Result<ResponseStatus, Error> {
@@ -2085,6 +2100,131 @@ mod tests {
     use super::*;
     use arrow::datatypes::DataType;
     use serde_json::json;
+
+    /// Writes `batch` as an Arrow IPC stream, the way the warehouse hands back a result
+    /// chunk. Neither the writer nor the reader checks the `Map` layout rules, which is how
+    /// a non-conforming map reaches the plan.
+    fn arrow_stream_bytes(batch: &RecordBatch) -> bytes::Bytes {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut writer = arrow::ipc::writer::StreamWriter::try_new(&mut buf, &batch.schema())
+                .expect("stream writer");
+            writer.write(batch).expect("write batch");
+            writer.finish().expect("finish stream");
+        }
+        bytes::Bytes::from(buf)
+    }
+
+    fn map_entry_fields() -> arrow::datatypes::Fields {
+        vec![
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Utf8, true),
+        ]
+        .into()
+    }
+
+    fn map_column_batch(
+        entries_nullable: bool,
+        entry_nulls: Option<arrow::buffer::NullBuffer>,
+    ) -> RecordBatch {
+        let entries = arrow::array::StructArray::try_new(
+            map_entry_fields(),
+            vec![
+                Arc::new(arrow::array::StringArray::from(vec!["k0"])) as arrow::array::ArrayRef,
+                Arc::new(arrow::array::StringArray::from(vec![Some("v0")]))
+                    as arrow::array::ArrayRef,
+            ],
+            entry_nulls,
+        )
+        .expect("entries struct");
+
+        let map_type = DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(map_entry_fields()),
+                entries_nullable,
+            )),
+            false,
+        );
+        let data = arrow::array::ArrayData::builder(map_type.clone())
+            .len(1)
+            .add_buffer(arrow::buffer::Buffer::from_slice_ref([0i32, 1]))
+            .add_child_data(entries.to_data())
+            .build()
+            .expect("map array data");
+
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("col_map", map_type, true)])),
+            vec![Arc::new(arrow::array::MapArray::from(data)) as arrow::array::ArrayRef],
+        )
+        .expect("batch")
+    }
+
+    /// Regression test for #7307: the warehouse declares a `MAP`'s `entries` field nullable,
+    /// which the Arrow map layout forbids. Read as-is, the column publishes a schema no
+    /// kernel can rebuild — so a `SELECT` of the column fails with
+    /// `MapArray entries cannot contain nulls` even though the data holds no nulls.
+    #[test]
+    fn a_map_column_is_published_with_a_non_nullable_entries_field() {
+        let wire = map_column_batch(true, None);
+        match wire.schema().field(0).data_type() {
+            DataType::Map(entries, _) => {
+                assert!(entries.is_nullable(), "the wire schema is the reported one");
+            }
+            other => panic!("expected a Map, got {other}"),
+        }
+
+        let batches = SqlWarehouseApi::read_arrow_batches(arrow_stream_bytes(&wire))
+            .expect("the chunk is readable");
+        let published = batches
+            .first()
+            .expect("one batch was written")
+            .schema()
+            .field(0)
+            .data_type()
+            .clone();
+
+        match &published {
+            DataType::Map(entries, _) => assert!(
+                !entries.is_nullable(),
+                "the published entries field must be non-nullable: {published}"
+            ),
+            other => panic!("expected a Map, got {other}"),
+        }
+
+        // A plan casts batches to the schema the scan published, so that type has to be one
+        // `MapArray` accepts as a cast target.
+        arrow::compute::cast(batches[0].column(0), &published)
+            .expect("the published map type is a legal cast target");
+    }
+
+    /// Entries carrying real nulls cannot be relabelled — Arrow has no meaning for a null
+    /// entry — so the read fails naming the column and what to do instead, rather than
+    /// surfacing Arrow's message about a layout the user never chose.
+    #[test]
+    fn entry_level_nulls_fail_the_read_with_an_actionable_message() {
+        let wire = map_column_batch(true, Some(arrow::buffer::NullBuffer::from(vec![false])));
+
+        let err = SqlWarehouseApi::read_arrow_batches(arrow_stream_bytes(&wire))
+            .expect_err("entry nulls must fail the read");
+
+        let message = err.to_string();
+        assert!(
+            matches!(err, Error::MapEntriesNotNormalizable { .. }),
+            "unexpected error: {message}"
+        );
+        for expected in [
+            "col_map",
+            "Databricks SQL Warehouse",
+            "to_json(<column>)",
+            "https://spiceai.org/docs/components/data-connectors/databricks",
+        ] {
+            assert!(
+                message.contains(expected),
+                "message must mention {expected}: {message}"
+            );
+        }
+    }
 
     /// Regression test for #13015: a statement whose result carries no chunks
     /// must still carry the projected schema, so an empty result is an empty

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use arrow::array::{Array, ArrayData, make_array};
+use arrow::array::{Array, make_array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use arrow::record_batch::RecordBatch;
+use arrow_tools::map_entries::relabel_array_data;
 use async_trait::async_trait;
 use aws_sdk_credential_bridge;
 use chrono::TimeZone;
@@ -566,49 +567,6 @@ fn build_column_mapping_projection(
     Ok(Arc::new(ProjectionExec::try_new(projection_expr, exec)?))
 }
 
-/// Recursively rebuilds `data` so its (possibly nested) field names match
-/// `target_type`, without touching any values, buffers, or null masks.
-///
-/// Delta column mapping stores nested struct/list/map field names under opaque
-/// physical names; the logical schema uses the logical names. Field names live
-/// in the Arrow `DataType`, so renaming is a metadata-only operation: relabel
-/// each child to the matching target nested type (positionally — column mapping
-/// preserves field order), then rebuild this level carrying `target_type`.
-fn relabel_array_data(
-    data: ArrayData,
-    target_type: &DataType,
-) -> std::result::Result<ArrayData, DataFusionError> {
-    if data.data_type() == target_type {
-        return Ok(data);
-    }
-
-    let target_child_types: Vec<DataType> = match target_type {
-        DataType::Struct(fields) => fields.iter().map(|f| f.data_type().clone()).collect(),
-        DataType::List(field) | DataType::LargeList(field) | DataType::FixedSizeList(field, _) => {
-            vec![field.data_type().clone()]
-        }
-        DataType::Map(field, _) => vec![field.data_type().clone()],
-        _ => Vec::new(),
-    };
-
-    let old_children = data.child_data().to_vec();
-    let new_children = if target_child_types.len() == old_children.len() {
-        old_children
-            .into_iter()
-            .zip(target_child_types.iter())
-            .map(|(child, child_target)| relabel_array_data(child, child_target))
-            .collect::<std::result::Result<Vec<_>, DataFusionError>>()?
-    } else {
-        old_children
-    };
-
-    data.into_builder()
-        .data_type(target_type.clone())
-        .child_data(new_children)
-        .build()
-        .map_err(DataFusionError::from)
-}
-
 /// Physical expression that renames the (possibly nested) field names of its
 /// input array to `target_type` without changing any values. Used by Delta
 /// column mapping to map physical field names back to logical names; replaces a
@@ -656,7 +614,10 @@ impl PhysicalExpr for RelabelFieldsExpr {
 
     fn evaluate(&self, batch: &RecordBatch) -> std::result::Result<ColumnarValue, DataFusionError> {
         let array = self.arg.evaluate(batch)?.into_array(batch.num_rows())?;
-        let relabeled = make_array(relabel_array_data(array.to_data(), &self.target_type)?);
+        let relabeled = make_array(
+            relabel_array_data(array.to_data(), &self.target_type)
+                .map_err(DataFusionError::from)?,
+        );
         Ok(ColumnarValue::Array(relabeled))
     }
 

--- a/crates/data_components/src/delta_lake.rs
+++ b/crates/data_components/src/delta_lake.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use arrow::array::{Array, make_array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use arrow::record_batch::RecordBatch;
-use arrow_tools::map_entries::relabel_array_data;
+use arrow_tools::type_rewrite::relabel_array_data;
 use async_trait::async_trait;
 use aws_sdk_credential_bridge;
 use chrono::TimeZone;


### PR DESCRIPTION
## Summary

Querying a `MAP` column from a Databricks SQL Warehouse panicked the runtime with
`InvalidArgumentError("MapArray entries cannot contain nulls")` — on data holding no nulls.

The warehouse hands back a map whose `entries` field is declared **nullable**. The Arrow map
layout forbids that, and `MapArray::try_new` rejects it on the declaration alone:

```rust
if field.is_nullable() || entries.null_count() != 0 {
    return Err(ArrowError::InvalidArgumentError(
        "MapArray entries cannot contain nulls".to_string(),
    ));
}
```

Both halves report the same message, which is why the declaration was never the suspect — the
[earlier triage on the issue](https://github.com/spiceai/spiceai/issues/7307#issuecomment-3067442671)
correctly cleared the type parser (`parse_map_with_depth` builds `entries` non-nullable) and looked
for a null in the data instead. There is no null in the data.

Nothing enforces the rule on the way in: the IPC reader builds a `MapArray` from `ArrayData` via
`From<ArrayData>`, which performs neither check. So the column decodes cleanly, is published as the
scan's schema, and then fails in the first kernel that rebuilds it — `arrow_cast`'s
`cast_map_values`, reached from any cast onto that type. On the Arrow the panic was first seen
against, that refusal was an `unwrap` on a Tokio worker; on Arrow 58 it is an error, so the query
fails instead of the process, but it still fails.

Reproduced end to end in a unit test rather than against a warehouse: writing the reported schema
to an Arrow IPC stream, reading it back through `read_arrow_batches`, and casting to the published
type gives the reported message with `entries().null_count() == 0`.

## Changes

- **`arrow_tools::map_entries::MapEntriesNormalizer`** relabels a map's `entries` field to
  non-nullable, at any nesting depth. Nullability is part of the type, not of any buffer, so the
  offsets, validity and child arrays are carried over by reference and no value moves. An IPC
  stream carries one schema, so the decision and the target schema are resolved once per stream and
  every batch comes out sharing the same `SchemaRef`. A schema holding no `MAP` costs one
  allocation-free predicate per field and touches no column.
- **Entries that genuinely carry nulls are refused, naming the column**, rather than guessed at.
  Arrow gives a null entry no meaning, and the two readings of one — "the map is null" and "a pair
  to drop" — return different rows, so per `CLAUDE.md` this returns a structured error instead of
  possibly-wrong data. This is not a regression: today that shape already fails, with Arrow's
  message and no column named.
- **`relabel_array_data`** moves out of `delta_lake.rs` (where Delta column mapping had it as a
  private) into `arrow_tools::type_rewrite`, beside the type rewriting it is the array-side
  counterpart to, and loses its `DataFusionError` coupling so a foundation crate stops asserting a
  DataFusion-shaped contract. Its child-type propagation now mirrors `ArrayData::validate_child_data`
  and so covers every child-bearing type the rewrite descends into.
- **`MapEntriesNonNullable`** joins the `TypeRewriteRule` registry, documented as a
  source-conformance rule that belongs to no engine's rule list — unlike every rule above it, which
  describes what a storage engine can hold.

## Performance impact

Per batch on the Databricks read path: one allocation-free type walk per field. When the schema
holds no `MAP` — the common case — no column is inspected at all and the batch is returned by value.
When a map is present, only columns whose field the rewrite changed are rebuilt (pointer equality on
the shared `FieldRef` is an exact test), and a rebuilt level shares its buffers. Batches now share
one `SchemaRef` where deciding per batch would have allocated a `Schema` each.

## Test plan

- `make lint`
- `make test`

New tests, each verified to fail on the unfixed code:

| Test | Pins |
|---|---|
| `a_map_column_is_published_with_a_non_nullable_entries_field` | the reported shape, through the real IPC read path, and that the published type is a legal cast target |
| `entry_level_nulls_fail_the_read_with_an_actionable_message` | the refusal names the column, the connector and the remediation |
| `a_nullable_entries_declaration_is_relabelled_so_the_column_can_be_rebuilt` | the column rebuilds through `MapArray::try_new`, with offsets/keys/values/nulls unmoved |
| `a_map_under_every_traversed_wrapper_is_relabelled` | a map under `ListView`, `Dictionary`, `RunEndEncoded`, `Union`, `FixedSizeList` |
| `a_deeply_nested_map_declaration_is_relabelled` | a map inside a struct inside a list, asserted against the expected type outright |
| `a_null_map_row_survives_normalization` | a null map row keeps validity 0 over an empty range |
| `entry_level_nulls_are_refused_by_column_name` / `..._nested_in_a_list_are_refused` | the refusal, and that it recurses |
| `a_conforming_batch_is_returned_unchanged` / `an_empty_map_column_normalizes` | the pass-through and the zero-row case |

Each fix was neutered in place and the matrix re-run, so every defect fails exactly the tests that
own it. `FixedSizeList` passing while the other four wrappers failed is what established the
previous child-type arms were the whole of that gap.

## Review gate

- Adversarial review: `codex` — job `review-mt0d46me-cnrlj3` (verdict `needs-attention`, attesting
  `6f51af493b`). Run three times, because the diff changed under it twice:
  - `review-mt0bh6mp-6o1pkw` on the first draft — `approve`, no material findings.
  - `review-mt0cly2n-ifhozo` after `/simplify` restructured the module — found that the schema walk
    and the rewrite rule descend into `ListView`, `LargeListView`, `Union`, `Dictionary` and
    `RunEndEncoded` while `relabel_array_data` propagated child types through only five types, so a
    map under any of those would be rebuilt over children still holding the old type and Arrow would
    refuse the mismatch. **Valid and fixed** in `6f51af493b`, with a test that fails on the previous
    arms; `FixedSizeList` passing while the other four failed confirmed the scope of the gap.
  - `review-mt0d46me-cnrlj3` on the shipped HEAD — one finding, **valid but pre-existing and out of
    scope**: `read_arrow_batches` decodes a whole chunk synchronously inside the async
    `stream::unfold` future, so it can hold a Tokio query worker. That is true of `origin/trunk`
    already (the `StreamReader` drain is the dominant term and has no `.await`); this PR adds a
    relabel that touches only map columns and only rebuilt levels. Filed as #13287 rather than
    folded in, since the fix is `spawn_blocking` around the whole decode and wants a concurrency
    regression test of its own.
- `/security-review`: clean — no findings at or above the reporting threshold. It confirmed against
  the pinned Arrow rev that `relabel_array_data` terminates in the **validating** `build()` (never
  `build_unchecked`, and `into_builder` does not inherit a skip flag), so a target type describing a
  different layout is refused rather than reinterpreting buffers; that the target type is derived
  from the batch's own schema and so cannot be attacker-steered; that the diff adds no `unsafe`,
  `_unchecked`, or new dependency; and that the new messages carry only a column name and a static
  docs URL, no credential or connection detail. It noted stack depth on a hostile deeply-nested
  schema, which is the excluded DOS class and is bounded by Arrow's own recursive schema decode
  having to succeed first.
- `/simplify`: applied. Hoisted the per-batch decision to once per stream, replaced a
  rewrite-and-compare predicate with an allocation-free walk, skipped unchanged columns by refcount,
  borrowed rather than cloned the target child types, moved `relabel_array_data` to `type_rewrite`,
  collapsed an error variant, and corrected a doc comment that implied the relabel was free. It also
  found `a_column_less_batch_keeps_its_row_count` was **vacuous** — an empty schema took the early
  return, so it pinned nothing — and that `an_empty_map_column_normalizes` asserted through the very
  rewrite rule it was testing, passing against a rule that did nothing. The first test went with the
  dead row-count option it purported to cover; the second now asserts the expected type outright and
  fails when the rule is neutered. Deferred as out of scope, with reasons in the report: normalizing
  at `FlightClient::query` and teaching `try_cast_to` a nullability-only relabel, both filed as
  #13285.

Fixes #7307

## Checklist

- [x] Root cause identified and stated, not just the symptom
- [x] Regression test fails on the unfixed code (each fix neutered in place and the matrix re-run)
- [x] Edge cases covered: null map rows, zero-row columns, nested and wrapped maps, conforming input
- [x] No `.unwrap()`/`.expect()` in production code
- [x] Error messages name the resource and give an actionable fix with a docs link
- [x] `make lint` clean, including the `--tests` pedantic pass
- [x] Out-of-scope findings filed (#13285, #13287) rather than folded in
