### PR TITLE
fix(search): bound a search result set by the requested limit, not just the index read (fixes #13274)

### DIFF
--- a/crates/search/src/provider.rs
+++ b/crates/search/src/provider.rs
@@ -207,6 +207,22 @@ impl SearchQueryProvider {
         ))
     }
 
+    /// The tighter of [`Self::pre_limit`] (the `limit` argument the caller gave
+    /// `vector_search()` / `text_search()`) and any limit `DataFusion` pushed into the scan,
+    /// or `None` when neither side asked for one.
+    ///
+    /// This has to bound the provider's *output*, not just its search-index input:
+    /// [`Self::join_with_base`] joins on [`Self::primary_key`], and nothing requires the base
+    /// table to hold exactly one row per key, so the join can emit more rows than it consumed.
+    ///
+    /// The bound is a row count, and rows sharing a key tie under the sort below (`_score`
+    /// then primary key), so which of them survives is unspecified — and `N` rows can
+    /// represent fewer than `N` distinct hits. [`Self::new`] separately advertises that key as
+    /// a `PrimaryKey` constraint it has not verified. #13289 tracks both.
+    fn effective_limit(pre_limit: Option<usize>, limit: Option<usize>) -> Option<usize> {
+        [pre_limit, limit].into_iter().flatten().min()
+    }
+
     /// Build the underlying table scan, removing search index metadata columns from projection
     fn underlying_table_scan(
         &self,
@@ -659,7 +675,7 @@ impl TableProvider for SearchQueryProvider {
                 }));
                 sort_exprs
             },
-            limit,
+            Self::effective_limit(self.pre_limit, limit),
         )?;
 
         // Add final
@@ -741,10 +757,12 @@ mod tests {
     use datafusion::datasource::MemTable;
     use datafusion::prelude::SessionContext;
 
-    /// Base table: the source of truth. `extra` is deliberately absent from the
-    /// search index so a `SELECT *` cannot be served by the index alone and the
-    /// join under test is actually planned.
-    fn base_table() -> Result<Arc<dyn TableProvider>, DataFusionError> {
+    /// A base table of `(id, content, extra)` rows. `extra` is deliberately absent from the
+    /// search index so a `SELECT *` cannot be served by the index alone and the join under
+    /// test is actually planned.
+    fn base_table_of(
+        rows: &[(i64, &str, &str)],
+    ) -> Result<Arc<dyn TableProvider>, DataFusionError> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),
             Field::new("content", DataType::Utf8, true),
@@ -753,14 +771,72 @@ mod tests {
         let batch = RecordBatch::try_new(
             Arc::clone(&schema),
             vec![
-                Arc::new(Int64Array::from(vec![1, 2])),
-                Arc::new(StringArray::from(vec!["dog elephant", "cat"])),
-                Arc::new(StringArray::from(vec!["a", "b"])),
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|(id, _, _)| *id).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter()
+                        .map(|(_, content, _)| *content)
+                        .collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|(_, _, extra)| *extra).collect::<Vec<_>>(),
+                )),
             ],
         )
         .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
 
         Ok(Arc::new(MemTable::try_new(schema, vec![vec![batch]])?))
+    }
+
+    /// Base table: the source of truth, one row per `id`.
+    fn base_table() -> Result<Arc<dyn TableProvider>, DataFusionError> {
+        base_table_of(&[(1, "dog elephant", "a"), (2, "cat", "b")])
+    }
+
+    /// A base table holding **two** rows for `id = 1`, so an inner join on `id` emits more
+    /// rows than the search index handed it. This is in-contract: in production the join key
+    /// is whatever the index declared through `SearchIndex::primary_fields()`, and no
+    /// uniqueness check stands between that declaration and the join.
+    fn base_table_with_repeated_key() -> Result<Arc<dyn TableProvider>, DataFusionError> {
+        base_table_of(&[
+            (1, "dog elephant", "a1"),
+            (1, "dog elephant", "a2"),
+            (2, "cat", "b"),
+        ])
+    }
+
+    /// A provider over [`base_table_with_repeated_key`], with `pre_limit` carrying the
+    /// caller's `vector_search(.., N)` argument.
+    fn provider_over_repeated_key(
+        hits: &[(i64, f64)],
+        pre_limit: Option<usize>,
+    ) -> Result<SearchQueryProvider, DataFusionError> {
+        Ok(SearchQueryProvider::new(
+            search_index_plan(hits)?,
+            base_table_with_repeated_key()?,
+            "content".to_string(),
+            vec!["id".to_string()],
+            pre_limit,
+        ))
+    }
+
+    /// Run `sql` against [`provider_over_repeated_key`] registered as `searched`.
+    async fn search_repeated_key(
+        hits: &[(i64, f64)],
+        pre_limit: Option<usize>,
+        sql: &str,
+    ) -> Result<Vec<RecordBatch>, DataFusionError> {
+        let ctx = SessionContext::new();
+        ctx.register_table(
+            "searched",
+            Arc::new(provider_over_repeated_key(hits, pre_limit)?),
+        )?;
+        ctx.sql(sql).await?.collect().await
+    }
+
+    fn row_count(batches: &[RecordBatch]) -> usize {
+        batches.iter().map(RecordBatch::num_rows).sum()
     }
 
     /// A search index holding one entry per `(id, score)` pair. An `id` absent
@@ -941,6 +1017,168 @@ mod tests {
             .await?;
 
         assert_eq!(ids(&batches), vec![1]);
+        Ok(())
+    }
+
+    /// Regression test for #13274: the `limit` argument to `vector_search()` /
+    /// `text_search()` bounds the provider's output, not just how many entries it
+    /// reads from the search index. The limit was applied only to the search-index
+    /// input, so the join with the base table emitted `2` rows for a requested `1`.
+    #[tokio::test]
+    async fn a_requested_limit_survives_a_join_that_fans_out() -> Result<(), DataFusionError> {
+        let batches = search_repeated_key(
+            &[(1, 0.9), (2, 0.5)],
+            Some(1),
+            "SELECT id, extra FROM searched",
+        )
+        .await?;
+
+        assert_eq!(
+            row_count(&batches),
+            1,
+            "a search asked for 1 row must return at most 1 row, however many base-table rows the join finds for that key"
+        );
+
+        Ok(())
+    }
+
+    /// The rows kept under the limit must be the highest-ranked ones. Capping the
+    /// output is only correct if it drops the *worst* rows: keeping both `id = 1`
+    /// rows and dropping the better-scoring `id = 2` would satisfy a count-only
+    /// assertion while returning the wrong results.
+    #[tokio::test]
+    async fn the_rows_kept_under_the_limit_are_the_highest_scoring() -> Result<(), DataFusionError>
+    {
+        let batches = search_repeated_key(
+            &[(1, 0.5), (2, 0.98)],
+            Some(2),
+            "SELECT id, extra FROM searched ORDER BY id",
+        )
+        .await?;
+
+        assert_eq!(
+            ids(&batches),
+            vec![1, 2],
+            "the top-scoring hit must keep its slot; the surplus row of the lower-scoring key is the one dropped"
+        );
+
+        Ok(())
+    }
+
+    /// Every combination of the rule, asserted where the provider actually decides it. The
+    /// end-to-end form of the tighter-SQL-limit direction proves nothing on its own: the outer
+    /// `LIMIT` bounds the result whatever this provider returns.
+    #[test]
+    fn the_effective_limit_is_the_tighter_of_the_two() {
+        let effective = SearchQueryProvider::effective_limit;
+
+        assert_eq!(
+            effective(Some(5), Some(1)),
+            Some(1),
+            "a tighter limit from the SQL plan wins"
+        );
+        assert_eq!(
+            effective(Some(1), Some(5)),
+            Some(1),
+            "the caller's search argument wins over a looser SQL limit"
+        );
+        assert_eq!(
+            effective(Some(3), None),
+            Some(3),
+            "the caller's search argument applies with no SQL limit at all"
+        );
+        assert_eq!(
+            effective(None, Some(3)),
+            Some(3),
+            "a SQL limit applies with no search argument"
+        );
+        assert_eq!(
+            effective(None, None),
+            None,
+            "neither side asked for a limit, so none is invented"
+        );
+    }
+
+    /// The caller's argument bounds the output end to end, where only this provider
+    /// can enforce it: a looser SQL limit leaves the surplus join rows to it.
+    #[tokio::test]
+    async fn the_search_argument_wins_over_a_looser_sql_limit() -> Result<(), DataFusionError> {
+        let batches = search_repeated_key(
+            &[(1, 0.9), (2, 0.5)],
+            Some(1),
+            "SELECT id, extra FROM searched LIMIT 5",
+        )
+        .await?;
+
+        assert_eq!(row_count(&batches), 1);
+        Ok(())
+    }
+
+    /// The cap must not be invented: with no limit on either side every joined row
+    /// is still returned, including the surplus rows of a repeated key.
+    #[tokio::test]
+    async fn an_unlimited_search_still_returns_every_joined_row() -> Result<(), DataFusionError> {
+        let batches = search_repeated_key(
+            &[(1, 0.9), (2, 0.5)],
+            None,
+            "SELECT id, extra FROM searched",
+        )
+        .await?;
+
+        assert_eq!(
+            row_count(&batches),
+            3,
+            "two rows for id = 1 plus one for id = 2"
+        );
+
+        Ok(())
+    }
+
+    /// The plan-shape half of #13274, and the acceptance criterion stated directly: the
+    /// requested limit must survive as a fetch *above* the join, not only on the search-index
+    /// side beneath it. It is asserted on the plan rather than on a row count because the
+    /// property does not depend on how much the join fans out — the sibling tests above cover
+    /// the one fan-out shape this module can build, while a deployment can multiply rows for
+    /// reasons a unit test cannot reproduce.
+    ///
+    /// Deliberately shape-locked, so it is coupled to `DataFusion`'s rendered operator names.
+    /// The SQL must carry no outer `LIMIT`: that would plant a `fetch=` of its own above the
+    /// join and the assertion would pass with the fix reverted, so the fetch value is pinned
+    /// to `pre_limit` to make such a change fail rather than go quiet.
+    #[tokio::test]
+    async fn the_fetch_is_planned_above_the_join() -> Result<(), DataFusionError> {
+        let ctx = SessionContext::new();
+        ctx.register_table(
+            "searched",
+            Arc::new(provider_over_repeated_key(&[(1, 0.9), (2, 0.5)], Some(1))?),
+        )?;
+
+        let plan = ctx
+            .sql("SELECT id, extra FROM searched")
+            .await?
+            .create_physical_plan()
+            .await?;
+        let rendered = datafusion::physical_plan::displayable(plan.as_ref())
+            .indent(false)
+            .to_string();
+
+        let indent = |line: &str| line.len() - line.trim_start().len();
+        let (join_line, join_indent) = rendered
+            .lines()
+            .enumerate()
+            .find_map(|(i, line)| line.contains("HashJoinExec").then(|| (i, indent(line))))
+            .unwrap_or_else(|| {
+                panic!("the base-table join is what the limit has to survive:\n{rendered}")
+            });
+
+        assert!(
+            rendered
+                .lines()
+                .take(join_line)
+                .any(|line| line.contains("fetch=1") && indent(line) < join_indent),
+            "the requested limit of 1 must be planned as a fetch above the join, not only below it:\n{rendered}"
+        );
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

`vector_search(tbl, 'query', 10)` against an Elasticsearch-backed vector index returned 148 rows.

`SearchQueryProvider` applied the caller's `limit` argument only to the **search-index input**, then joined that input with the base table on `primary_key`. The final sort carried only the limit DataFusion had pushed down into the scan — so with no outer `LIMIT` in the SQL there was no bound above the join at all, and every extra row the join produced escaped:

```text
SortExec                       <- no fetch
  ...
    HashJoinExec               <- can emit more rows than it consumed
      SortExec: TopK(fetch=10) <- the requested limit, applied only here
```

Nothing requires the base table to hold exactly one row per key: the key is whatever the search index declared through `SearchIndex::primary_fields()`, and no uniqueness check stands between that declaration and the join. So the join is not 1:1 in general, and bounding only its input does not bound its output.

The same `min(pre_limit, pushed_limit)` rule already exists in both sibling providers — `FullTextSearchQuery::limit_to_use` and `VectorSearchUDTFProvider::limit_to_use` — and `vector_table.rs` already applies its limit *above* its joins. This provider was the outlier, so the fix applies the established rule at the one place missing it rather than introducing a new mechanism.

This covers `text_search()` as well as `vector_search()`: all four call sites (`crates/runtime/src/embeddings/udtf.rs` and the three in `crates/runtime-search/src/full_text_udtf.rs`) pass the user's own `limit` argument as `pre_limit`, so none of them relies on an over-fetch contract that a bounded output would break.

### What is not established: the reporter's multiplier

The bound is restored unconditionally, and that is deliberate, because **the specific reason the reporter's join fanned out is not identified here.** The chunk-distribution theory in the issue does not survive reading the code: a chunked index groups by the chunk-free primary key inside its own plan (`Aggregate` in `ChunkedSearchIndex::query_table_provider`), so per-chunk rows are collapsed to one row per hit *below* the pre-limit and never reach the join as separate rows.

What is proven is the plan property — there was no fetch above the join — and that any join which is not 1:1 therefore lets rows escape. Fixing the missing invariant rather than a suspected multiplier is what makes the fix correct without that diagnosis, and it is what the issue's acceptance criterion asks for ("the final logical/physical plan preserves the requested limit after all joins and projections"). If the reporter can share the dataset's declared primary key, the exact fan-out is worth confirming on top of this.

## Changes

- `SearchQueryProvider::effective_limit` — the tighter of the caller's `pre_limit` and any limit DataFusion pushed into the scan, inventing none when neither side asked.
- The final `sort_with_limit` in `SearchQueryProvider::scan` now uses it, so the fetch is planned above the base-table join.

No change to which rows are eligible: the inner join that decides row existence, the filter handling, the projection, and `_score`/`_match` synthesis are untouched.

## Performance impact

Neutral to cheaper; no plan node is added. `sort_with_limit` sets `fetch` on a `Sort` that already existed on both arms, so only the field's value changes:

- `pre_limit = Some(n)`, nothing pushed down (the common `vector_search(t, q, 10)` shape): the sort previously had **no** fetch and fully sorted the join output; it is now a bounded TopK heap. Strictly less buffering.
- both present: the fetch shrinks to the tighter value.
- `pre_limit = None`: byte-identical plan.

Limit pushdown is unaffected in both directions — `PushDownLimit` only fires on a `Limit` node, never on `Sort.fetch`, and it already declined to push through this `Inner` join. On the index-only arm, where both limits are already applied below, the new fetch is redundant and drops nothing.

## Test plan

Six tests in `crates/search/src/provider.rs`. A 3-neuter matrix proves each owns a distinct defect, so none is vacuous — re-run unchanged after `/simplify`:

| test | revert fix | `min`→`max` | invent cap |
|---|---|---|---|
| `a_requested_limit_survives_a_join_that_fans_out` | FAIL | pass | pass |
| `the_rows_kept_under_the_limit_are_the_highest_scoring` | FAIL | pass | pass |
| `the_search_argument_wins_over_a_looser_sql_limit` | FAIL | FAIL | pass |
| `the_fetch_is_planned_above_the_join` | FAIL | pass | pass |
| `an_unlimited_search_still_returns_every_joined_row` | pass | pass | FAIL |
| `the_effective_limit_is_the_tighter_of_the_two` | pass | FAIL | FAIL |

`the_rows_kept_under_the_limit_are_the_highest_scoring` is the one that matters most: a cap is only correct if it drops the *worst* rows, and a count-only assertion would pass on a fix that kept the wrong ones.

Two tests were rewritten after review found them unsound:

- An earlier version asserted the tighter-SQL-limit direction end to end. **Both neuters passed it** — the outer `LIMIT` bounds the result whatever the provider returns, so it was vacuous. It now asserts on `effective_limit` directly, where the provider actually decides it.
- `the_fetch_is_planned_above_the_join` originally accepted any `fetch=` above the join, which an outer `LIMIT` would have satisfied by itself. The fetch value is now pinned to `pre_limit`; verified by a 4th neuter that adds `LIMIT 5` *and* reverts the fix — it fails now (`TopK(fetch=5)` above, `fetch=1` only below the join) where the old form would have passed with the bug present.

- `make lint`
- `make nextest`

**Not covered here:** the issue asks for an integration test against a live Elasticsearch index with multiple chunks per row. Docker is unavailable in this environment, so that arm is not written, and per the section above it would not exercise the fan-out the issue attributes it to. `the_fetch_is_planned_above_the_join` is the substitute that holds independently of the multiplier.

## Review gate

- Adversarial review: `codex` — job `review-mt0dbxqi-uld7qm`, verdict `needs-attention` (2 × high). Both findings share one root cause and are **pre-existing on `trunk`, independent of this diff** — filed as #13289 rather than fixed here:
  - *A fan-out output advertises a false `PrimaryKey` constraint.* **Confirmed by experiment, not merely accepted:** `ORDER BY id, extra DESC LIMIT 1` over a repeated key plans as `SortExec: TopK(fetch=1), expr=[id@0 ASC NULLS LAST]` — the optimizer drops the secondary sort key because the unverified constraint makes it look redundant — and returns the wrong `extra`. A wrong-rows defect deserving its own fix; both the constraint and the fan-out are on `trunk` today and this diff neither creates nor widens either. `effective_limit`'s doc points at #13289 so the next reader meets the contradiction.
  - *An omitted limit leaves the fan-out uncapped.* Correct, and deliberately not fixed by borrowing the index's internal default: that default bounds how many *candidates* are read, not how many result rows are correct, and silently dropping rows nobody asked to drop is the worse failure for a query engine. `an_unlimited_search_still_returns_every_joined_row` pins "no limit asked ⇒ none invented" on purpose; #13289 carries the bound question.
  - Codex also reported the crate's test binary exiting 101. **Refuted by re-running it:** 161/161 pass, both with default threads and with its exact `--test-threads=1` invocation, on the same binary. Its findings do not rest on that run.
- `/security-review`: no findings. The diff adds one pure `Option<usize>` combinator and one call-site change; it constructs no string, adds no dependency or `unsafe`, touches no log or error message, and can only make a result set the same size or smaller — so it opens no new surface.
- `/simplify`: 4 agents; 8 findings applied, 2 skipped with reasons.
  - Applied: the 4-arm match collapsed to `[pre_limit, limit].into_iter().flatten().min()` (dropping an import and a comment that restated `min` in prose); made it an associated fn over the pair so its test needs no fixtures at all instead of building five providers; single-sourced the base-table schema behind `base_table_of(rows)` (was a 22-line copy-paste); extracted `provider_over_repeated_key` (the 7-line constructor was open-coded three times); fixed `expect("…{rendered}")`, which does not interpolate and printed the brace literal on the one failure path it exists for; dropped a dead `.enumerate()`; hardened the plan-shape assertion (above); corrected two doc claims — the chunked-index parenthetical, which the code refutes (see above), and a sentence implying the test exercised `primary_fields()` when it passes the key literally.
  - Skipped: **extracting the rule into a shared free function** — it would pull `crates/runtime` into a one-file correctness fix for what is now a single expression, and the altitude pass judged the siblings to be bounding an index read rather than a join output; noted here as follow-up work rather than done quietly. **Dropping `the_search_argument_wins_over_a_looser_sql_limit`** as a near-clone — the matrix shows it is the only end-to-end proof of the both-limits-present path, and the reviewing agent itself flagged the call-site neuter it uniquely catches.

Fixes #13274

## Checklist

- [x] Root cause identified and stated, including what is *not* established
- [x] Regression test that fails on the old code (4-neuter matrix, tables above)
- [x] Bug class checked across siblings (`vector_table.rs`, `pipeline.rs`, `candidate/vector.rs`, `rrf.rs`) — each already bounds above its join; this provider was the only site that did not
- [x] `make lint` / `make nextest` green via `make signoff`
- [x] Out-of-scope findings filed, not silently dropped (#13289)