### PR TITLE
fix(cloud-connect): resolve locked service state through the retained directory descriptor (fixes #13204)

### DIFF
--- a/bin/spice/src/commands/connect/mod.rs
+++ b/bin/spice/src/commands/connect/mod.rs
@@ -526,7 +526,7 @@ async fn start_instance(ctx: &RuntimeContext, dir: Option<&Path>, verbosity: u8)
     let Some(manifest) = service::resolve_with_state(
         backend,
         &instance_dir,
-        &state_config_dir,
+        &service::PinnedConfigDir::unlocked(&state_config_dir),
         &service_config_dir,
     )?
     else {
@@ -735,6 +735,14 @@ async fn remove_identity(
         .map_err(|source| Error::CloudConnectIo {
             message: format!("pin locked Cloud Connect state for removal: {source}"),
         })?;
+    // The service manifest is resolved and removed through the descriptor the
+    // lock retains, not through a name (see `PinnedConfigDir`). The identity,
+    // journals, endpoint binding and cache below are still derived from
+    // `config_dir`, which on a platform without Linux's descriptor-rooted
+    // traversal is a pathname re-resolved on each use, so one removal can still
+    // span two directories. Closing that is #13291.
+    let manifest_config_dir =
+        service::PinnedConfigDir::for_lock(display_config_dir.clone(), &mutation_lock)?;
     let _instance_lock =
         runtime_cloud_connect::RuntimeLock::acquire(&config_dir).map_err(|source| {
             Error::CloudConnectIo {
@@ -776,8 +784,12 @@ async fn remove_identity(
                 });
             }
         };
-    let installed =
-        service::resolve_with_state(backend, instance_dir, &config_dir, &display_config_dir)?;
+    let installed = service::resolve_with_state(
+        backend,
+        instance_dir,
+        &manifest_config_dir,
+        &display_config_dir,
+    )?;
 
     // `symlink_metadata` observes the directory entry itself. A dangling link
     // is state that `--force` must remove, not an absent file that can be left
@@ -968,13 +980,15 @@ async fn remove_identity(
     // `spice connect service uninstall`, while identity cleanup belongs only to
     // this command.
     let uninstall_failure = match installed.as_ref() {
-        Some(manifest) => match service::uninstall_resolved(backend, manifest, &config_dir) {
-            Ok(()) => {
-                println!("Stopped and uninstalled {}.", manifest.name);
-                None
+        Some(manifest) => {
+            match service::uninstall_resolved(backend, manifest, &manifest_config_dir) {
+                Ok(()) => {
+                    println!("Stopped and uninstalled {}.", manifest.name);
+                    None
+                }
+                Err(err) => Some(err),
             }
-            Err(err) => Some(err),
-        },
+        }
         None => None,
     };
 

--- a/bin/spice/src/commands/connect/service/cli.rs
+++ b/bin/spice/src/commands/connect/service/cli.rs
@@ -202,23 +202,34 @@ pub async fn execute(
                     "validate locked Cloud Connect state for service {action}: {source}"
                 ),
             })?;
-        let state_config_dir =
+        let identity_config_dir =
             lock.descriptor_relative_config_dir()
                 .map_err(|source| Error::CloudConnectIo {
                     message: format!(
                         "pin locked Cloud Connect state for service {action}: {source}"
                     ),
                 })?;
-        Some((service_config_dir, state_config_dir))
+        Some((service_config_dir, identity_config_dir))
     } else {
         None
     };
-    let (service_config_dir, state_config_dir) = locked_dirs.as_ref().map_or(
+    let (service_config_dir, identity_config_dir) = locked_dirs.as_ref().map_or(
         (config_dir, config_dir),
-        |(service_config_dir, state_config_dir)| {
-            (service_config_dir.as_path(), state_config_dir.as_path())
+        |(service_config_dir, identity_config_dir)| {
+            (service_config_dir.as_path(), identity_config_dir.as_path())
         },
     );
+    // Manifest state resolves through the descriptor the lock retains, not
+    // through a name (see `PinnedConfigDir`).
+    //
+    // `identity_config_dir` above is still a pathname on a platform without
+    // Linux's descriptor-rooted traversal, so identity validation and the
+    // manifest can resolve to different directories in one install. Closing
+    // that needs descriptor-relative reads through the whole state layer: #13291.
+    let state_config_dir = match mutation_lock.as_ref() {
+        Some(lock) => super::PinnedConfigDir::for_lock(service_config_dir, lock)?,
+        None => super::PinnedConfigDir::unlocked(config_dir),
+    };
     match command {
         ServiceCommand::Install => {
             install(
@@ -226,12 +237,13 @@ pub async fn execute(
                 backend,
                 instance_dir,
                 service_config_dir,
+                identity_config_dir,
                 state_config_dir,
             )
             .await
         }
         ServiceCommand::Uninstall => {
-            uninstall(backend, instance_dir, service_config_dir, state_config_dir)
+            uninstall(backend, instance_dir, service_config_dir, &state_config_dir)
         }
         ServiceCommand::Status(args) => {
             let status = ConnectStatus::collect(instance_dir, service_config_dir, endpoint).await;
@@ -243,7 +255,7 @@ pub async fn execute(
                 backend,
                 instance_dir,
                 service_config_dir,
-                state_config_dir,
+                &state_config_dir,
                 action,
             )?;
             with_recovery_detail(backend, &manifest, backend.start(&manifest))
@@ -252,7 +264,7 @@ pub async fn execute(
             backend,
             instance_dir,
             service_config_dir,
-            state_config_dir,
+            &state_config_dir,
             action,
         )? {
             Some(manifest) => with_recovery_detail(backend, &manifest, backend.stop(&manifest)),
@@ -263,7 +275,7 @@ pub async fn execute(
                 backend,
                 instance_dir,
                 service_config_dir,
-                state_config_dir,
+                &state_config_dir,
                 action,
             )?;
             with_recovery_detail(backend, &manifest, backend.restart(&manifest))
@@ -273,7 +285,7 @@ pub async fn execute(
                 backend,
                 instance_dir,
                 service_config_dir,
-                state_config_dir,
+                &state_config_dir,
                 action,
             )? {
                 Some(manifest) => {
@@ -322,9 +334,10 @@ async fn install(
     backend: &dyn ServiceBackend,
     instance_dir: &Path,
     service_config_dir: &Path,
-    state_config_dir: &Path,
+    identity_config_dir: &Path,
+    state_config_dir: super::PinnedConfigDir,
 ) -> Result<()> {
-    let identity = validate_service_identity(state_config_dir).await?;
+    let identity = validate_service_identity(identity_config_dir).await?;
 
     // Resolved, not derived from `$HOME`: `sudo` rewrites `HOME` to `/root`, and
     // the runtime the operator installed is normally under their own home.
@@ -357,13 +370,12 @@ async fn install(
     // install waits for the runtime to settle.
     let install_instance_dir = instance_dir.to_path_buf();
     let install_service_config_dir = service_config_dir.to_path_buf();
-    let install_state_config_dir = state_config_dir.to_path_buf();
     let manifest = tokio::task::spawn_blocking(move || {
         super::install_with_state(
             super::backend(),
             &install_instance_dir,
             &install_service_config_dir,
-            &install_state_config_dir,
+            &state_config_dir,
             &spiced_path,
             &runtime_version,
             &health_url,
@@ -439,7 +451,7 @@ fn uninstall(
     backend: &dyn ServiceBackend,
     instance_dir: &Path,
     service_config_dir: &Path,
-    state_config_dir: &Path,
+    state_config_dir: &super::PinnedConfigDir,
 ) -> Result<()> {
     let Some(manifest) =
         super::uninstall_with_state(backend, instance_dir, state_config_dir, service_config_dir)?
@@ -471,7 +483,7 @@ fn require_installed(
     backend: &dyn ServiceBackend,
     instance_dir: &Path,
     service_config_dir: &Path,
-    state_config_dir: &Path,
+    state_config_dir: &super::PinnedConfigDir,
     action: &str,
 ) -> Result<ServiceManifest> {
     super::resolve_with_state(backend, instance_dir, state_config_dir, service_config_dir)?
@@ -496,7 +508,7 @@ fn resolve_or_report(
     backend: &dyn ServiceBackend,
     instance_dir: &Path,
     service_config_dir: &Path,
-    state_config_dir: &Path,
+    state_config_dir: &super::PinnedConfigDir,
     action: &str,
 ) -> Result<Option<ServiceManifest>> {
     let resolved =

--- a/bin/spice/src/commands/connect/service/manifest.rs
+++ b/bin/spice/src/commands/connect/service/manifest.rs
@@ -37,12 +37,95 @@ use crate::error::{Error, Result};
 /// File name (relative to the resolved Spice config dir) of the manifest.
 pub(crate) const SERVICE_MANIFEST_FILE: &str = "service.json";
 
+/// [`SERVICE_MANIFEST_FILE`] as a C string, for the descriptor-relative
+/// syscalls. Spelled as a literal rather than built with `CString::new` so this
+/// fixed production path cannot trip the workspace's denied `expect_used` lint;
+/// `the_two_manifest_file_names_agree` keeps the two spellings in step.
+const SERVICE_MANIFEST_FILE_C: &std::ffi::CStr = c"service.json";
+
 /// Current manifest schema. A manifest from a newer CLI is refused rather
 /// than partially understood: acting on half a description of a service is
 /// how the wrong process gets stopped.
 pub(crate) const MANIFEST_SCHEMA_VERSION: u32 = 1;
 
 const MAX_SERVICE_MANIFEST_BYTES: u64 = 1024 * 1024;
+
+/// The config directory a manifest operation applies to.
+///
+/// A [`runtime_cloud_connect::MutationLock`] holds its directory open for the
+/// whole operation, and that descriptor is the one name for the directory its
+/// owner cannot replace. Carrying it here is what lets an install or uninstall
+/// resolve the instance by inode: a pathname re-resolved after the lock's
+/// identity check can still name a *different* directory the same owner
+/// created, and the ownership test alone cannot tell the two apart. Without a
+/// lock there is nothing to pin, and the pathname is all a read has.
+pub(crate) struct PinnedConfigDir {
+    path: PathBuf,
+    #[cfg(unix)]
+    directory: Option<std::fs::File>,
+}
+
+impl PinnedConfigDir {
+    /// A directory reached by pathname, for a caller holding no mutation lock.
+    pub(crate) fn unlocked(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            #[cfg(unix)]
+            directory: None,
+        }
+    }
+
+    /// The directory a mutation lock retains, named by the descriptor it holds
+    /// open. `path` is what messages show; every lookup goes through
+    /// `directory`.
+    #[cfg(unix)]
+    pub(crate) fn locked(path: impl Into<PathBuf>, directory: std::fs::File) -> Self {
+        Self {
+            path: path.into(),
+            directory: Some(directory),
+        }
+    }
+
+    /// The directory a mutation lock holds, taking the descriptor it retains
+    /// where the platform has one.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the retained descriptor cannot be duplicated.
+    pub(crate) fn for_lock(
+        path: impl Into<PathBuf>,
+        lock: &runtime_cloud_connect::MutationLock,
+    ) -> Result<Self> {
+        #[cfg(unix)]
+        {
+            let directory = lock
+                .pinned_directory()
+                .map_err(|source| Error::CloudConnectIo {
+                    message: format!("pin the locked Cloud Connect config directory: {source}"),
+                })?;
+            Ok(Self::locked(path, directory))
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = lock;
+            Ok(Self::unlocked(path))
+        }
+    }
+
+    /// What messages call this directory. When it is pinned this is only a
+    /// name for the operator to read: the directory it resolves to is exactly
+    /// what a locked operation must not trust, so every lookup goes through
+    /// [`PinnedConfigDir::descriptor`] instead.
+    fn display_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The retained descriptor, when this directory is held by a lock.
+    #[cfg(unix)]
+    fn descriptor(&self) -> Option<&std::fs::File> {
+        self.directory.as_ref()
+    }
+}
 
 /// The account the installed runtime runs as.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -120,38 +203,14 @@ impl ServiceManifest {
     /// Returns an error when the file cannot be read, does not parse, is not
     /// owner-only, or does not describe `instance_dir`.
     pub(crate) fn load(
-        config_dir: &Path,
+        config: &PinnedConfigDir,
         instance_dir: &Path,
         backend: &dyn ServiceBackend,
     ) -> Result<Option<Self>> {
-        Self::load_with_directory_binding(config_dir, instance_dir, backend, false)
-    }
-
-    /// Read through a directory descriptor retained by the caller's mutation
-    /// lock. On Unix that descriptor is spelled `/proc/self/fd/<n>` or
-    /// `/dev/fd/<n>` and is itself a magic symlink; the followed metadata is the
-    /// already-pinned directory inode, not a pathname lookup to reject.
-    pub(crate) fn load_from_pinned_directory(
-        config_dir: &Path,
-        instance_dir: &Path,
-        backend: &dyn ServiceBackend,
-    ) -> Result<Option<Self>> {
-        Self::load_with_directory_binding(config_dir, instance_dir, backend, true)
-    }
-
-    fn load_with_directory_binding(
-        config_dir: &Path,
-        instance_dir: &Path,
-        backend: &dyn ServiceBackend,
-        directory_is_pinned: bool,
-    ) -> Result<Option<Self>> {
-        let path = Self::path_in(config_dir);
-        let (bytes, metadata) = match super::super::state::read_bounded_regular_file_with_metadata(
-            &path,
-            MAX_SERVICE_MANIFEST_BYTES,
-        ) {
-            Ok(contents) => contents,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        let path = Self::path_in(config.display_path());
+        let (bytes, metadata) = match read_manifest_bytes(config, &path) {
+            Ok(Some(contents)) => contents,
+            Ok(None) => return Ok(None),
             Err(e) if is_symlink_loop(&e) => {
                 return Err(Error::InvalidArgument {
                     message: format!(
@@ -177,7 +236,7 @@ impl ServiceManifest {
             })?;
         ensure_owner_only(&path, &metadata, &manifest.owner)?;
 
-        manifest.validate(&path, instance_dir, backend, directory_is_pinned)?;
+        manifest.validate(&path, instance_dir, backend, config)?;
         Ok(Some(manifest))
     }
 
@@ -194,7 +253,7 @@ impl ServiceManifest {
         path: &Path,
         instance_dir: &Path,
         backend: &dyn ServiceBackend,
-        directory_is_pinned: bool,
+        config: &PinnedConfigDir,
     ) -> Result<()> {
         let reject = |reason: String| {
             Err(Error::InvalidArgument {
@@ -231,19 +290,21 @@ impl ServiceManifest {
         {
             use std::os::unix::fs::MetadataExt as _;
 
-            let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
-            let metadata = if directory_is_pinned {
-                std::fs::metadata(config_dir)
-            } else {
-                std::fs::symlink_metadata(config_dir)
-            }
-            .map_err(|source| Error::CloudConnectIo {
+            let config_dir = config.display_path();
+            // A pinned directory is described by the descriptor the lock holds
+            // open, so there is no name here to be a symlink or to be replaced
+            // between this check and the operation that follows it.
+            let (metadata, pinned) = match config.descriptor() {
+                Some(directory) => (directory.metadata(), true),
+                None => (std::fs::symlink_metadata(config_dir), false),
+            };
+            let metadata = metadata.map_err(|source| Error::CloudConnectIo {
                 message: format!(
                     "inspect service manifest directory {}: {source}",
                     config_dir.display()
                 ),
             })?;
-            if (!directory_is_pinned && metadata.file_type().is_symlink())
+            if (!pinned && metadata.file_type().is_symlink())
                 || !metadata.is_dir()
                 || metadata.uid() != self.owner.uid
             {
@@ -307,7 +368,8 @@ impl ServiceManifest {
     /// # Errors
     ///
     /// Returns an error when the manifest cannot be serialized or written.
-    pub(crate) fn write(&self, config_dir: &Path) -> Result<()> {
+    pub(crate) fn write(&self, config: &PinnedConfigDir) -> Result<()> {
+        let config_dir = config.display_path();
         let path = Self::path_in(config_dir);
         let json = serde_json::to_vec_pretty(self).map_err(|e| Error::CloudConnectIo {
             message: format!("serialize the service manifest for {}: {e}", path.display()),
@@ -328,7 +390,12 @@ impl ServiceManifest {
             // subsequent operation relative to its descriptor. The owner can
             // rename the directory or replace its pathname with a symlink, but
             // neither can redirect this privileged write after validation.
-            if !nix::unistd::Uid::effective().is_root() {
+            //
+            // A pinned directory needs no creating — taking the lock created
+            // it — and creating it by name here would build whatever the
+            // pathname now points at, which is what the descriptor exists to
+            // stop being trusted.
+            if config.descriptor().is_none() && !nix::unistd::Uid::effective().is_root() {
                 std::fs::create_dir_all(config_dir).map_err(|e| Error::CloudConnectIo {
                     message: format!(
                         "create the Spice config directory {}: {e}",
@@ -336,7 +403,7 @@ impl ServiceManifest {
                     ),
                 })?;
             }
-            let directory = open_pinned_manifest_directory(config_dir, &self.owner)?;
+            let directory = open_pinned_manifest_directory(config, &self.owner)?;
             write_manifest_in_directory(&directory, &path, &json, &self.owner)
         }
 
@@ -373,7 +440,8 @@ impl ServiceManifest {
     ///
     /// Returns an error when the file exists and cannot be removed — a
     /// manifest left behind would claim a service that is no longer installed.
-    pub(crate) fn remove(&self, config_dir: &Path) -> Result<()> {
+    pub(crate) fn remove(&self, config: &PinnedConfigDir) -> Result<()> {
+        let config_dir = config.display_path();
         let path = Self::path_in(config_dir);
 
         #[cfg(unix)]
@@ -382,7 +450,7 @@ impl ServiceManifest {
             // it relative to the same descriptor. A service account may rename
             // its config directory while a root uninstall is in progress; no
             // path lookup after this point may follow that replacement.
-            let directory = open_pinned_manifest_directory(config_dir, &self.owner)?;
+            let directory = open_pinned_manifest_directory(config, &self.owner)?;
             remove_manifest_in_directory(&directory, &path, self)
         }
 
@@ -493,7 +561,7 @@ fn ensure_owner_only(
 
 #[cfg(unix)]
 fn open_pinned_manifest_directory(
-    config_dir: &Path,
+    config: &PinnedConfigDir,
     owner: &ServiceOwner,
 ) -> Result<std::fs::File> {
     use std::ffi::CString;
@@ -501,19 +569,21 @@ fn open_pinned_manifest_directory(
     use std::os::unix::ffi::OsStrExt as _;
     use std::os::unix::fs::MetadataExt as _;
 
+    let config_dir = config.display_path();
     let io_error = |e: std::io::Error| Error::CloudConnectIo {
         message: format!(
             "open the service manifest directory {} safely: {e}",
             config_dir.display()
         ),
     };
-    let directory = if is_retained_descriptor_path(config_dir) {
-        // `MutationLock::descriptor_relative_config_dir` is already the
-        // authority for which inode is protected. Opening that procfs/devfs
-        // handle duplicates the retained directory; canonicalizing it first
-        // would turn it back into an ordinary pathname and reintroduce a
-        // rename-to-replacement race before this privileged open.
-        std::fs::File::open(config_dir).map_err(io_error)?
+    let directory = if let Some(retained) = config.descriptor() {
+        // The mutation lock already holds the protected directory open, and
+        // that descriptor is the authority for which inode is protected.
+        // Duplicating it keeps the identity this operation was authorized
+        // against; resolving the pathname again would let the owner point it
+        // at another directory they also own, which the ownership test below
+        // cannot distinguish.
+        retained.try_clone().map_err(io_error)?
     } else {
         let canonical = std::fs::canonicalize(config_dir).map_err(io_error)?;
         if !canonical.is_absolute() {
@@ -599,25 +669,87 @@ fn open_pinned_manifest_directory(
     Ok(directory)
 }
 
+/// Read `service.json` under `config`, applying the type, size, and link-count
+/// bounds a manifest read applies however the directory was reached.
+///
+/// `Ok(None)` means there is no manifest. A pinned directory is read relative
+/// to its retained descriptor, so the file that is read belongs to the
+/// instance the lock was taken for and not to whatever the config directory's
+/// pathname names by the time the read happens.
+fn read_manifest_bytes(
+    config: &PinnedConfigDir,
+    path: &Path,
+) -> std::io::Result<Option<(Vec<u8>, std::fs::Metadata)>> {
+    #[cfg(unix)]
+    if let Some(directory) = config.descriptor() {
+        return read_manifest_in_directory(directory);
+    }
+
+    match super::super::state::read_bounded_regular_file_with_metadata(
+        path,
+        MAX_SERVICE_MANIFEST_BYTES,
+    ) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Read `service.json` relative to an already-pinned directory descriptor.
+///
+/// No pathname lookup escapes the pinned config directory: only the final
+/// component is named, and `O_NOFOLLOW` is what keeps that name from being a
+/// symlink out of the directory.
 #[cfg(unix)]
-fn is_retained_descriptor_path(path: &Path) -> bool {
-    use std::os::unix::ffi::OsStrExt as _;
+fn read_manifest_in_directory(
+    directory: &std::fs::File,
+) -> std::io::Result<Option<(Vec<u8>, std::fs::Metadata)>> {
+    use std::io::Read as _;
+    use std::os::fd::{AsRawFd as _, FromRawFd as _};
+    use std::os::unix::fs::MetadataExt as _;
 
-    #[cfg(target_os = "linux")]
-    let base = Path::new("/proc/self/fd");
-    #[cfg(not(target_os = "linux"))]
-    let base = Path::new("/dev/fd");
-
-    let Ok(relative) = path.strip_prefix(base) else {
-        return false;
+    let fd = unsafe {
+        nix::libc::openat(
+            directory.as_raw_fd(),
+            SERVICE_MANIFEST_FILE_C.as_ptr(),
+            nix::libc::O_RDONLY
+                | nix::libc::O_CLOEXEC
+                | nix::libc::O_NOFOLLOW
+                | nix::libc::O_NONBLOCK,
+        )
     };
-    let mut components = relative.components();
-    let Some(std::path::Component::Normal(descriptor)) = components.next() else {
-        return false;
-    };
-    components.next().is_none()
-        && !descriptor.as_bytes().is_empty()
-        && descriptor.as_bytes().iter().all(u8::is_ascii_digit)
+    if fd < 0 {
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::NotFound {
+            return Ok(None);
+        }
+        return Err(error);
+    }
+    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.len() > MAX_SERVICE_MANIFEST_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the Cloud Connect state file was not a bounded regular file",
+        ));
+    }
+    if metadata.nlink() != 1 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the Cloud Connect state file must not be hard-linked",
+        ));
+    }
+    let mut bytes = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
+    (&mut file)
+        .take(MAX_SERVICE_MANIFEST_BYTES.saturating_add(1))
+        .read_to_end(&mut bytes)?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > MAX_SERVICE_MANIFEST_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "the Cloud Connect state file exceeded its size limit",
+        ));
+    }
+    Ok(Some((bytes, metadata)))
 }
 
 /// Create a unique owner-only staging inode and publish it relative to the
@@ -643,9 +775,7 @@ fn write_manifest_in_directory(
         message: "construct the service manifest staging name: generated name contains a NUL byte"
             .to_string(),
     })?;
-    // Kept as a C literal so this fixed production path cannot trip the
-    // workspace's denied `expect_used` lint.
-    let destination = c"service.json";
+    let destination = SERVICE_MANIFEST_FILE_C;
     let fd = unsafe {
         nix::libc::openat(
             directory.as_raw_fd(),
@@ -712,8 +842,7 @@ fn remove_manifest_in_directory(
     display_path: &Path,
     expected: &ServiceManifest,
 ) -> Result<()> {
-    use std::io::Read as _;
-    use std::os::fd::{AsRawFd as _, FromRawFd as _};
+    use std::os::fd::AsRawFd as _;
     use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
 
     let io_error = |error: std::io::Error| Error::CloudConnectIo {
@@ -722,46 +851,17 @@ fn remove_manifest_in_directory(
             display_path.display()
         ),
     };
-    let name = c"service.json";
-    let fd = unsafe {
-        nix::libc::openat(
-            directory.as_raw_fd(),
-            name.as_ptr(),
-            nix::libc::O_RDONLY | nix::libc::O_CLOEXEC | nix::libc::O_NOFOLLOW,
-        )
+    // The same bounded read the load path uses, so the type, link-count and
+    // size limits an uninstall re-checks cannot drift from the ones a load
+    // applies. An absent manifest is the idempotent case, not a failure.
+    let Some((bytes, metadata)) = read_manifest_in_directory(directory).map_err(&io_error)? else {
+        return directory.sync_all().map_err(io_error);
     };
-    if fd < 0 {
-        let error = std::io::Error::last_os_error();
-        if error.kind() == std::io::ErrorKind::NotFound {
-            return directory.sync_all().map_err(io_error);
-        }
-        return Err(io_error(error));
-    }
-    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
-    let metadata = file.metadata().map_err(&io_error)?;
     let mode = metadata.permissions().mode() & 0o7777;
-    if !metadata.is_file()
-        || metadata.nlink() != 1
-        || metadata.uid() != expected.owner.uid
-        || mode & 0o077 != 0
-        || metadata.len() > MAX_SERVICE_MANIFEST_BYTES
-    {
+    if metadata.uid() != expected.owner.uid || mode & 0o077 != 0 {
         return Err(Error::InvalidArgument {
             message: format!(
-                "Refusing to remove the re-opened service manifest {} because its type, owner, permissions, link count, or size changed during uninstall.",
-                display_path.display()
-            ),
-        });
-    }
-    let mut bytes = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
-    (&mut file)
-        .take(MAX_SERVICE_MANIFEST_BYTES + 1)
-        .read_to_end(&mut bytes)
-        .map_err(&io_error)?;
-    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > MAX_SERVICE_MANIFEST_BYTES {
-        return Err(Error::InvalidArgument {
-            message: format!(
-                "Refusing to remove the re-opened service manifest {} because it grew beyond the {MAX_SERVICE_MANIFEST_BYTES}-byte limit during uninstall.",
+                "Refusing to remove the re-opened service manifest {} because its owner or permissions changed during uninstall.",
                 display_path.display()
             ),
         });
@@ -782,7 +882,8 @@ fn remove_manifest_in_directory(
             ),
         });
     }
-    let removed = unsafe { nix::libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
+    let removed =
+        unsafe { nix::libc::unlinkat(directory.as_raw_fd(), SERVICE_MANIFEST_FILE_C.as_ptr(), 0) };
     if removed != 0 {
         return Err(io_error(std::io::Error::last_os_error()));
     }
@@ -833,6 +934,17 @@ mod tests {
     }
 
     #[test]
+    fn the_two_manifest_file_names_agree() {
+        // The descriptor-relative syscalls name the manifest with the C
+        // spelling, so a rename that missed it would leave them opening a file
+        // nothing else writes.
+        assert_eq!(
+            SERVICE_MANIFEST_FILE_C.to_bytes(),
+            SERVICE_MANIFEST_FILE.as_bytes()
+        );
+    }
+
+    #[test]
     fn a_written_manifest_round_trips() {
         let dir = tempfile::tempdir().expect("create tempdir");
         let fake = FakeBackend::new(dir.path());
@@ -840,10 +952,16 @@ mod tests {
         let config_dir = instance_dir.join(".spice");
         let manifest = manifest_for(&fake, &instance_dir);
 
-        manifest.write(&config_dir).expect("write manifest");
-        let loaded = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect("load manifest")
-            .expect("a manifest was written");
+        manifest
+            .write(&PinnedConfigDir::unlocked(&config_dir))
+            .expect("write manifest");
+        let loaded = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect("load manifest")
+        .expect("a manifest was written");
         assert_eq!(loaded, manifest);
     }
 
@@ -852,7 +970,12 @@ mod tests {
         let dir = tempfile::tempdir().expect("create tempdir");
         let fake = FakeBackend::new(dir.path());
         assert_eq!(
-            ServiceManifest::load(dir.path(), &dir.path().join("edge-1"), &fake).expect("load"),
+            ServiceManifest::load(
+                &PinnedConfigDir::unlocked(dir.path()),
+                &dir.path().join("edge-1"),
+                &fake
+            )
+            .expect("load"),
             None
         );
     }
@@ -867,11 +990,15 @@ mod tests {
         let instance_dir = dir.path().join("edge-1");
         let config_dir = dir.path().join("edge-2").join(".spice");
         manifest_for(&fake, &instance_dir)
-            .write(&config_dir)
+            .write(&PinnedConfigDir::unlocked(&config_dir))
             .expect("write manifest");
 
-        let error = ServiceManifest::load(&config_dir, &dir.path().join("edge-2"), &fake)
-            .expect_err("a manifest naming another directory must not resolve");
+        let error = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &dir.path().join("edge-2"),
+            &fake,
+        )
+        .expect_err("a manifest naming another directory must not resolve");
         assert!(
             error.to_string().contains("describes the service for"),
             "{error}"
@@ -888,10 +1015,16 @@ mod tests {
         let config_dir = instance_dir.join(".spice");
         let mut manifest = manifest_for(&fake, &instance_dir);
         manifest.name = "spiced-cloud-connect-someone-else.service".to_string();
-        manifest.write(&config_dir).expect("write manifest");
+        manifest
+            .write(&PinnedConfigDir::unlocked(&config_dir))
+            .expect("write manifest");
 
-        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect_err("a forged service name must not resolve");
+        let error = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect_err("a forged service name must not resolve");
         assert!(error.to_string().contains("derives"), "{error}");
     }
 
@@ -907,10 +1040,16 @@ mod tests {
         let config_dir = instance_dir.join(".spice");
         let mut manifest = manifest_for(&fake, &instance_dir);
         manifest.supervisor = Supervisor::Launchd;
-        manifest.write(&config_dir).expect("write manifest");
+        manifest
+            .write(&PinnedConfigDir::unlocked(&config_dir))
+            .expect("write manifest");
 
-        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect_err("a manifest for another supervisor must not resolve");
+        let error = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect_err("a manifest for another supervisor must not resolve");
         assert!(
             error.to_string().contains("this host is managed by"),
             "{error}"
@@ -925,10 +1064,16 @@ mod tests {
         let config_dir = instance_dir.join(".spice");
         let mut manifest = manifest_for(&fake, &instance_dir);
         manifest.schema_version = MANIFEST_SCHEMA_VERSION + 1;
-        manifest.write(&config_dir).expect("write manifest");
+        manifest
+            .write(&PinnedConfigDir::unlocked(&config_dir))
+            .expect("write manifest");
 
-        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect_err("a future schema must not be half-understood");
+        let error = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect_err("a future schema must not be half-understood");
         assert!(error.to_string().contains("schema version"), "{error}");
     }
 
@@ -940,10 +1085,16 @@ mod tests {
         let config_dir = instance_dir.join(".spice");
         let mut manifest = manifest_for(&fake, &instance_dir);
         manifest.runtime_path = PathBuf::from("relative/spiced");
-        manifest.write(&config_dir).expect("write manifest");
+        manifest
+            .write(&PinnedConfigDir::unlocked(&config_dir))
+            .expect("write manifest");
 
-        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect_err("a relative runtime path must not resolve");
+        let error = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect_err("a relative runtime path must not resolve");
         assert!(
             error.to_string().contains("relative runtime path"),
             "{error}"
@@ -960,10 +1111,16 @@ mod tests {
         let config_dir = instance_dir.join(".spice");
         let mut manifest = manifest_for(&fake, &instance_dir);
         manifest.definition_path = PathBuf::from("/etc/passwd");
-        manifest.write(&config_dir).expect("write manifest");
+        manifest
+            .write(&PinnedConfigDir::unlocked(&config_dir))
+            .expect("write manifest");
 
-        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect_err("an unrelated definition path must not resolve");
+        let error = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect_err("an unrelated definition path must not resolve");
         assert!(error.to_string().contains("/etc/passwd"), "{error}");
         assert!(
             error.to_string().contains("records the definition"),
@@ -981,10 +1138,16 @@ mod tests {
         let config_dir = dir.path().join("edge-1").join(".spice");
         let mut manifest = manifest_for(&fake, &instance_dir);
         manifest.directory = instance_dir.clone();
-        manifest.write(&config_dir).expect("write manifest");
+        manifest
+            .write(&PinnedConfigDir::unlocked(&config_dir))
+            .expect("write manifest");
 
-        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect_err("a relative instance directory must not resolve");
+        let error = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect_err("a relative instance directory must not resolve");
         assert!(
             error.to_string().contains("relative instance directory"),
             "{error}"
@@ -1000,8 +1163,12 @@ mod tests {
         std::fs::create_dir_all(&config_dir).expect("create config dir");
         std::fs::write(ServiceManifest::path_in(&config_dir), "not json").expect("write");
 
-        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect_err("a manifest that describes something unreadable must be reported");
+        let error = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect_err("a manifest that describes something unreadable must be reported");
         assert!(error.to_string().contains("service manifest"), "{error}");
     }
 
@@ -1011,7 +1178,7 @@ mod tests {
         let fake = FakeBackend::new(dir.path());
         let instance_dir = dir.path().join("edge-1");
         manifest_for(&fake, &instance_dir)
-            .remove(dir.path())
+            .remove(&PinnedConfigDir::unlocked(dir.path()))
             .expect("idempotent removal");
     }
 
@@ -1025,14 +1192,18 @@ mod tests {
         let instance_dir = dir.path().join("edge-1");
         let config_dir = instance_dir.join(".spice");
         manifest_for(&fake, &instance_dir)
-            .write(&config_dir)
+            .write(&PinnedConfigDir::unlocked(&config_dir))
             .expect("write manifest");
 
         let path = ServiceManifest::path_in(&config_dir);
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
             .expect("widen the mode");
-        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect_err("a manifest others can change must not decide what Spice controls");
+        let error = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect_err("a manifest others can change must not decide what Spice controls");
         assert!(error.to_string().contains("0644"), "{error}");
     }
 
@@ -1046,7 +1217,7 @@ mod tests {
         let instance_dir = dir.path().join("edge-1");
         let config_dir = instance_dir.join(".spice");
         manifest_for(&fake, &instance_dir)
-            .write(&config_dir)
+            .write(&PinnedConfigDir::unlocked(&config_dir))
             .expect("write manifest");
 
         let mode = std::fs::metadata(ServiceManifest::path_in(&config_dir))
@@ -1072,7 +1243,8 @@ mod tests {
             name: None,
         };
         let pinned =
-            open_pinned_manifest_directory(&config_dir, &owner).expect("pin original config dir");
+            open_pinned_manifest_directory(&PinnedConfigDir::unlocked(&config_dir), &owner)
+                .expect("pin original config dir");
 
         std::fs::rename(&config_dir, &moved_config_dir).expect("move original config dir");
         std::os::unix::fs::symlink(&attacker_dir, &config_dir)
@@ -1096,9 +1268,13 @@ mod tests {
         );
     }
 
-    #[cfg(target_os = "linux")]
+    /// The pinned directory has to be the inode the lock retained even after
+    /// the config directory's pathname names a *different* directory with the
+    /// same owner — which is what a re-resolved pathname cannot distinguish,
+    /// on every Unix rather than only where `/proc/self/fd` can be traversed.
+    #[cfg(unix)]
     #[tokio::test]
-    async fn a_mutation_lock_descriptor_is_duplicated_without_path_canonicalization() {
+    async fn a_pinned_directory_is_the_locked_inode_after_a_same_owner_replacement() {
         use std::os::unix::fs::MetadataExt as _;
 
         let dir = tempfile::tempdir().expect("create tempdir");
@@ -1107,24 +1283,129 @@ mod tests {
         let lock = runtime_cloud_connect::MutationLock::acquire(&config_dir, "manifest-test")
             .await
             .expect("lock config dir");
-        let descriptor_path = lock
-            .descriptor_relative_config_dir()
-            .expect("derive retained descriptor path");
-        assert!(is_retained_descriptor_path(&descriptor_path));
+        let locked = std::fs::metadata(&config_dir).expect("stat the locked config dir");
+        let pinned = PinnedConfigDir::locked(
+            config_dir.clone(),
+            lock.pinned_directory()
+                .expect("retain the locked directory"),
+        );
         let owner = ServiceOwner {
             uid: nix::unistd::Uid::effective().as_raw(),
             gid: nix::unistd::Gid::effective().as_raw(),
             name: None,
         };
 
-        let duplicated = open_pinned_manifest_directory(&descriptor_path, &owner)
-            .expect("duplicate the mutation lock directory descriptor");
-        let retained = std::fs::metadata(&descriptor_path).expect("stat retained descriptor");
-        let opened = duplicated.metadata().expect("stat duplicated descriptor");
+        let moved_config_dir = dir.path().join("instance").join("moved-spice");
+        std::fs::rename(&config_dir, &moved_config_dir).expect("move the locked config dir");
+        std::fs::create_dir_all(&config_dir).expect("create the replacement config dir");
+        let replacement = std::fs::metadata(&config_dir).expect("stat the replacement");
+        assert_ne!(
+            (replacement.dev(), replacement.ino()),
+            (locked.dev(), locked.ino()),
+            "the replacement must be a different directory for this test to mean anything"
+        );
+        assert_eq!(
+            replacement.uid(),
+            owner.uid,
+            "the replacement is owned by the same account, so ownership cannot discriminate"
+        );
+
+        let opened = open_pinned_manifest_directory(&pinned, &owner)
+            .expect("open the pinned directory")
+            .metadata()
+            .expect("stat the pinned directory");
 
         assert_eq!(
             (opened.dev(), opened.ino()),
-            (retained.dev(), retained.ino())
+            (locked.dev(), locked.ino()),
+            "a pinned manifest operation must resolve the directory the lock was taken for"
+        );
+    }
+
+    /// The write and the read that an install performs both have to land in
+    /// the locked instance's directory, not in whichever directory its
+    /// pathname names by the time they run.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_locked_manifest_is_published_and_read_back_from_the_locked_directory() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        let manifest = manifest_for(&fake, &instance_dir);
+
+        let lock = runtime_cloud_connect::MutationLock::acquire(&config_dir, "manifest-test")
+            .await
+            .expect("lock config dir");
+        let pinned = PinnedConfigDir::locked(
+            config_dir.clone(),
+            lock.pinned_directory()
+                .expect("retain the locked directory"),
+        );
+
+        let moved_config_dir = instance_dir.join("moved-spice");
+        std::fs::rename(&config_dir, &moved_config_dir).expect("move the locked config dir");
+        std::fs::create_dir_all(&config_dir).expect("create the replacement config dir");
+
+        manifest.write(&pinned).expect("publish through the lock");
+
+        assert!(
+            !ServiceManifest::path_in(&config_dir).exists(),
+            "the replacement pathname must not receive the manifest"
+        );
+        assert_eq!(
+            ServiceManifest::load(&pinned, &instance_dir, &fake)
+                .expect("read back through the lock"),
+            Some(manifest),
+            "the read must come from the locked directory"
+        );
+        assert!(
+            ServiceManifest::path_in(&moved_config_dir).exists(),
+            "the locked directory must hold the manifest"
+        );
+    }
+
+    /// Nothing a locked operation does may depend on the config directory's
+    /// pathname still resolving: the owner can move it out from under a root
+    /// install or uninstall, and the descriptor the lock holds is what names
+    /// the instance.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_locked_manifest_is_read_and_removed_after_its_pathname_is_gone() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fake = FakeBackend::new(dir.path());
+        let instance_dir = dir.path().join("edge-1");
+        let config_dir = instance_dir.join(".spice");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        let manifest = manifest_for(&fake, &instance_dir);
+
+        let lock = runtime_cloud_connect::MutationLock::acquire(&config_dir, "manifest-test")
+            .await
+            .expect("lock config dir");
+        let pinned = PinnedConfigDir::locked(
+            config_dir.clone(),
+            lock.pinned_directory()
+                .expect("retain the locked directory"),
+        );
+        manifest.write(&pinned).expect("publish through the lock");
+
+        let moved_config_dir = instance_dir.join("moved-spice");
+        std::fs::rename(&config_dir, &moved_config_dir).expect("move the locked config dir");
+        assert!(
+            !config_dir.exists(),
+            "the config directory's pathname must name nothing for this test to mean anything"
+        );
+
+        assert_eq!(
+            ServiceManifest::load(&pinned, &instance_dir, &fake).expect("read through the lock"),
+            Some(manifest.clone()),
+            "a locked read must not depend on the pathname"
+        );
+        manifest.remove(&pinned).expect("remove through the lock");
+        assert!(
+            !ServiceManifest::path_in(&moved_config_dir).exists(),
+            "the manifest in the locked directory must be removed"
         );
     }
 
@@ -1137,15 +1418,19 @@ mod tests {
         let config_dir = instance_dir.join(".spice");
         let elsewhere = dir.path().join("elsewhere.json");
         manifest_for(&fake, &instance_dir)
-            .write(dir.path())
+            .write(&PinnedConfigDir::unlocked(dir.path()))
             .expect("write manifest");
         std::fs::rename(ServiceManifest::path_in(dir.path()), &elsewhere).expect("move it aside");
         std::fs::create_dir_all(&config_dir).expect("create config dir");
         std::os::unix::fs::symlink(&elsewhere, ServiceManifest::path_in(&config_dir))
             .expect("symlink the manifest");
 
-        let error = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect_err("a symlinked manifest must not resolve a service");
+        let error = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect_err("a symlinked manifest must not resolve a service");
         assert!(error.to_string().contains("symlink"), "{error}");
     }
 
@@ -1158,13 +1443,21 @@ mod tests {
         let instance_dir = dir.path().join("edge-1");
         let config_dir = instance_dir.join(".spice");
         let mut manifest = manifest_for(&fake, &instance_dir);
-        manifest.write(&config_dir).expect("first write");
+        manifest
+            .write(&PinnedConfigDir::unlocked(&config_dir))
+            .expect("first write");
         manifest.runtime_version = "v2.3.0".to_string();
-        manifest.write(&config_dir).expect("second write");
+        manifest
+            .write(&PinnedConfigDir::unlocked(&config_dir))
+            .expect("second write");
 
-        let loaded = ServiceManifest::load(&config_dir, &instance_dir, &fake)
-            .expect("load")
-            .expect("a manifest is present");
+        let loaded = ServiceManifest::load(
+            &PinnedConfigDir::unlocked(&config_dir),
+            &instance_dir,
+            &fake,
+        )
+        .expect("load")
+        .expect("a manifest is present");
         assert_eq!(loaded.runtime_version, "v2.3.0");
     }
 }

--- a/bin/spice/src/commands/connect/service/mod.rs
+++ b/bin/spice/src/commands/connect/service/mod.rs
@@ -86,7 +86,7 @@ use sha2::{Digest as _, Sha256};
 use crate::error::{Error, Result};
 
 pub(crate) use backend::{InstallRequest, LogRequest, ServiceBackend, for_host as backend};
-pub(crate) use manifest::{ServiceManifest, ServiceOwner};
+pub(crate) use manifest::{PinnedConfigDir, ServiceManifest, ServiceOwner};
 pub(crate) use model::{ServiceScope, ServiceState, ServiceStatus};
 
 /// Longest directory-name fragment carried into a service name, so a deeply-named
@@ -464,7 +464,12 @@ pub(crate) fn resolve(
     instance_dir: &Path,
     config_dir: &Path,
 ) -> Result<Option<ServiceManifest>> {
-    resolve_with_state(backend, instance_dir, config_dir, config_dir)
+    resolve_with_state(
+        backend,
+        instance_dir,
+        &PinnedConfigDir::unlocked(config_dir),
+        config_dir,
+    )
 }
 
 /// Resolve a manifest through the retained state directory while comparing
@@ -472,14 +477,10 @@ pub(crate) fn resolve(
 pub(crate) fn resolve_with_state(
     backend: &dyn ServiceBackend,
     instance_dir: &Path,
-    state_config_dir: &Path,
+    state_config_dir: &PinnedConfigDir,
     service_config_dir: &Path,
 ) -> Result<Option<ServiceManifest>> {
-    let loaded = if state_config_dir == service_config_dir {
-        ServiceManifest::load(state_config_dir, instance_dir, backend)?
-    } else {
-        ServiceManifest::load_from_pinned_directory(state_config_dir, instance_dir, backend)?
-    };
+    let loaded = ServiceManifest::load(state_config_dir, instance_dir, backend)?;
     if let Some(manifest) = loaded {
         validate_manifest_definition(backend, instance_dir, service_config_dir, &manifest)?;
         return Ok(Some(manifest));
@@ -683,7 +684,7 @@ pub(crate) fn install(
         backend,
         instance_dir,
         config_dir,
-        config_dir,
+        &PinnedConfigDir::unlocked(config_dir),
         spiced_path,
         runtime_version,
         health_url,
@@ -694,7 +695,7 @@ pub(crate) fn install_with_state(
     backend: &dyn ServiceBackend,
     instance_dir: &Path,
     service_config_dir: &Path,
-    state_config_dir: &Path,
+    state_config_dir: &PinnedConfigDir,
     spiced_path: &Path,
     runtime_version: &str,
     health_url: &str,
@@ -1013,13 +1014,18 @@ pub(crate) fn uninstall(
     instance_dir: &Path,
     config_dir: &Path,
 ) -> Result<Option<ServiceManifest>> {
-    uninstall_with_state(backend, instance_dir, config_dir, config_dir)
+    uninstall_with_state(
+        backend,
+        instance_dir,
+        &PinnedConfigDir::unlocked(config_dir),
+        config_dir,
+    )
 }
 
 pub(crate) fn uninstall_with_state(
     backend: &dyn ServiceBackend,
     instance_dir: &Path,
-    state_config_dir: &Path,
+    state_config_dir: &PinnedConfigDir,
     service_config_dir: &Path,
 ) -> Result<Option<ServiceManifest>> {
     let Some(manifest) =
@@ -1038,7 +1044,7 @@ pub(crate) fn uninstall_with_state(
 pub(crate) fn uninstall_resolved(
     backend: &dyn ServiceBackend,
     manifest: &ServiceManifest,
-    state_config_dir: &Path,
+    state_config_dir: &PinnedConfigDir,
 ) -> Result<()> {
     backend.uninstall(manifest)?;
     manifest.remove(state_config_dir)
@@ -1711,9 +1717,13 @@ mod tests {
         assert_eq!(manifest.directory, instance_dir);
         assert_eq!(manifest.runtime_version, "v2.2.0");
         assert_eq!(
-            ServiceManifest::load(&config_dir, &instance_dir, &fake)
-                .expect("load")
-                .as_ref(),
+            ServiceManifest::load(
+                &PinnedConfigDir::unlocked(&config_dir),
+                &instance_dir,
+                &fake
+            )
+            .expect("load")
+            .as_ref(),
             Some(&manifest)
         );
 
@@ -2089,7 +2099,7 @@ mod tests {
     /// supervisor.
     fn write_manifest_for(backend: &FakeBackend, instance_dir: &Path, config_dir: &Path) {
         manifest_for(backend, instance_dir)
-            .write(config_dir)
+            .write(&PinnedConfigDir::unlocked(config_dir))
             .expect("write manifest");
     }
 
@@ -2111,11 +2121,12 @@ mod tests {
         );
     }
 
-    /// Only Linux pins the locked directory by descriptor
-    /// (`/proc/self/fd/<n>`); elsewhere `descriptor_relative_config_dir`
-    /// falls back to the pathname, so the redirection this rules out is not
-    /// ruled out there. The guarantee is scoped the same way the mechanism is.
-    #[cfg(target_os = "linux")]
+    /// A privileged uninstall applies to the instance its lock was taken for.
+    /// The locked directory is named by the descriptor the lock retains, so
+    /// this holds on every Unix — including where `/proc/self/fd` cannot be
+    /// traversed and a pathname would be re-resolved after the lock's identity
+    /// check.
+    #[cfg(unix)]
     #[tokio::test]
     async fn locked_uninstall_cannot_be_redirected_by_config_path_replacement() {
         let dir = tempfile::tempdir().expect("create tempdir");
@@ -2130,9 +2141,12 @@ mod tests {
         )
         .await
         .expect("acquire mutation lock");
-        let state_config_dir = mutation_lock
-            .descriptor_relative_config_dir()
-            .expect("pin state directory");
+        let state_config_dir = PinnedConfigDir::locked(
+            config_dir.clone(),
+            mutation_lock
+                .pinned_directory()
+                .expect("retain the locked directory"),
+        );
         let moved_config_dir = instance_dir.join("locked-spice");
         std::fs::rename(&config_dir, &moved_config_dir).expect("rename locked directory");
         std::fs::create_dir_all(&config_dir).expect("create replacement directory");

--- a/crates/runtime-cloud-connect/src/mutation_lock.rs
+++ b/crates/runtime-cloud-connect/src/mutation_lock.rs
@@ -127,13 +127,38 @@ impl MutationLock {
         Ok(&self.config_dir)
     }
 
+    /// Duplicate the directory descriptor this lock retained.
+    ///
+    /// The handle names the protected directory by inode and carries no
+    /// pathname, so an operation performed relative to it (`openat`,
+    /// `renameat`, `unlinkat`) applies to the instance the lock was taken for
+    /// even when the config directory's pathname is replaced afterwards — by
+    /// its own owner, and so past the ownership test a re-resolved pathname
+    /// can still satisfy. That holds on every Unix, whereas
+    /// `descriptor_relative_config_dir` can offer it on Linux alone, so a
+    /// privileged state operation should resolve through this rather than
+    /// through a name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error when the descriptor cannot be duplicated.
+    #[cfg(unix)]
+    pub fn pinned_directory(&self) -> Result<File> {
+        self.directory.try_clone().context(IoSnafu {
+            path: self.config_dir.clone(),
+        })
+    }
+
     /// A path whose directory component resolves through the retained
     /// descriptor rather than by looking up the original pathname again.
     ///
     /// On Linux, `/proc/self/fd` keeps child lookups rooted at the inode this
     /// guard opened even if its canonical name is replaced. Other platforms use
     /// the verified canonical path because `/dev/fd` does not provide Linux's
-    /// directory traversal semantics.
+    /// directory traversal semantics, which leaves the identity check and a
+    /// later open separated in time there: a caller that can work from a
+    /// descriptor instead of a path should take `pinned_directory` (Unix
+    /// only), which closes that interval on every Unix.
     ///
     /// # Errors
     ///
@@ -707,6 +732,57 @@ mod tests {
         .expect_err("an aliased path must reach the same lock, not a second one");
         assert!(matches!(error, Error::LockTimeout { .. }), "{error}");
         drop(held);
+    }
+
+    /// The retained descriptor names the locked directory by inode, so it
+    /// still reaches the protected state after the pathname it was acquired
+    /// through names a different directory the same owner created. This is the
+    /// guarantee `descriptor_relative_config_dir` can only give where
+    /// `/proc/self/fd` supports directory traversal.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_retained_descriptor_reaches_the_locked_state_after_a_same_owner_replacement() {
+        use std::os::fd::{AsRawFd as _, FromRawFd as _};
+
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let config_dir = dir.path().join(".spice");
+        let moved_config_dir = dir.path().join("moved-spice");
+        std::fs::create_dir_all(&config_dir).expect("create locked config dir");
+        std::fs::write(config_dir.join("identity.json"), "locked").expect("write locked identity");
+
+        let held = MutationLock::acquire(&config_dir, "remove")
+            .await
+            .expect("lock the original config directory");
+
+        // Replaced before the descriptor is taken: the lock verified the
+        // directory's identity when it was acquired, so every instant after
+        // that is one a re-resolved pathname would have to cross.
+        std::fs::rename(&config_dir, &moved_config_dir).expect("rename the locked directory");
+        std::fs::create_dir_all(&config_dir).expect("create the replacement directory");
+        std::fs::write(config_dir.join("identity.json"), "replacement")
+            .expect("write the replacement identity");
+
+        let retained = held
+            .pinned_directory()
+            .expect("retain the locked directory");
+        let name = c"identity.json";
+        let fd = unsafe {
+            libc::openat(
+                retained.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        assert!(fd >= 0, "{}", std::io::Error::last_os_error());
+        let mut contents = String::new();
+        unsafe { File::from_raw_fd(fd) }
+            .read_to_string(&mut contents)
+            .expect("read state through the retained descriptor");
+
+        assert_eq!(
+            contents, "locked",
+            "the retained descriptor must reach the locked instance, not the replacement"
+        );
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

`MutationLock::descriptor_relative_config_dir` gave a weaker guarantee on macOS than on Linux. On Linux it returns `/proc/self/fd/<n>`, so every later lookup stays rooted at the directory inode the lock opened. There is no equivalent on macOS — `/dev/fd/<n>` cannot be traversed as a directory — so the function performed a one-time `ensure_directory_stable()` and returned the canonical *pathname*, which each later use re-resolves.

That interval now has a privileged caller: `sudo spice connect service install` / `uninstall` performs service-state operations as root on macOS. `open_pinned_manifest_directory` already refuses a symlinked component and requires the resulting directory to be owned by the service owner, so a privileged operation cannot be steered into a directory the operator does not own. The residual is narrower: the config directory's owner can replace it, between the identity check and the privileged open, with **another directory they also own**. The ownership test still passes, so a root-run install or uninstall acts on service state belonging to a different instance than the one the lock was taken for.

This does not cross a privilege boundary — the actor owns the state in question either way. It is a correctness defect: the lock stops guaranteeing *which* instance a privileged operation applies to.

## Changes

- `MutationLock::pinned_directory()` duplicates the directory descriptor the lock already retains. It carries no pathname, so an operation performed relative to it applies to the locked inode on every Unix, not only where `/proc/self/fd` supports directory traversal.
- `PinnedConfigDir` carries that descriptor into the service layer. `ServiceManifest::load` / `write` / `remove` and the config-directory check in `validate` resolve through it; a caller holding no lock still reaches the directory by pathname, which is all an unlocked read has.
- The manifest read is descriptor-relative (`openat` with `O_NOFOLLOW`), keeping the regular-file, single-link and size bounds the pathname read applied.
- `is_retained_descriptor_path` is gone: no call site passes a `/proc/self/fd/<n>`-shaped pathname into the manifest layer any more, so a path of that shape no longer receives special trust.
- Linux keeps `descriptor_relative_config_dir` for the state it reaches by joining (identity, journals), so its behaviour is unchanged.

## Test plan

- `make lint`
- `make nextest`
- New coverage runs on macOS, not only under `#[cfg(target_os = "linux")]`, which is where the guarantee was missing:
  - `the_retained_descriptor_reaches_the_locked_state_after_a_same_owner_replacement` (`runtime-cloud-connect`) — the descriptor still reaches the locked state after the pathname it was acquired through names a different same-owner directory.
  - `a_pinned_directory_is_the_locked_inode_after_a_same_owner_replacement` — a pinned manifest operation opens the locked inode, with the replacement asserted to be a different directory owned by the same account, so ownership cannot discriminate.
  - `a_locked_manifest_is_published_and_read_back_from_the_locked_directory` — the write and the read-back both land in the locked directory.
  - `a_locked_manifest_is_read_and_removed_after_its_pathname_is_gone` — nothing a locked operation does depends on the pathname still resolving.
  - `locked_uninstall_cannot_be_redirected_by_config_path_replacement` was `#[cfg(target_os = "linux")]` because the guarantee did not hold elsewhere; it is now `#[cfg(unix)]` and passes on macOS.
- Each new test was checked against a neuter matrix on macOS — reverting the descriptor in the open, in the read, in `validate`'s directory stat, and in `pinned_directory` itself. Every neuter fails at least one test and every test is failed by at least one neuter; the `validate` stat is guarded only by the pathname-gone test.

## Review gate

- Adversarial review: `codex` — job `review-mt0fhsza-i0rjo2` (`exit=0`, verdict `needs-attention`). Two `[high]` findings, both the same observation: the fix pins the manifest while identity, journals, the endpoint binding and the Cloud-side project deletion still resolve by pathname on macOS, so one transaction can span two directories.
  - Deferred, not dismissed → #13291, which names each remaining call site and both consequences. The engine's recommendation to "fail closed on non-Linux rather than mixing" would disable the macOS service lifecycle that #13203 just shipped, which is a worse outcome than an owner-only inconsistency window; and for `connect remove` the harmful half (deleting another instance's Cloud project) is pre-existing and untouched here, while the half this PR covers becomes correct.
  - One stated consequence is refuted: the split does **not** leave an unmanageable service. `adopt_installed_definition` reconstructs a manifest from the installed definition when the file is absent, and its gate compares `installed.config_dir` against the resolved config dir — both the same pathname in this scenario — so `status`/`stop`/`uninstall` keep working. The real residual is an orphan manifest in the moved directory and an adopted record carrying no `runtime_digest`/`runtime_version` until the next install. #13291 says so.
  - The asymmetry is recorded at the site it lives (`service/cli.rs`), citing #13291.
- `/security-review`: no findings at or above the reporting threshold. It verified check-by-check that the old pathname walk dropped nothing — `O_NOFOLLOW`, the regular-file/`nlink`/size bounds, `ensure_owner_only`, the pinned-directory ownership gate and the `euid` gate are all retained, `O_CLOEXEC` is added, and the descriptor is `F_DUPFD_CLOEXEC` so it cannot leak to the unprivileged supervisor children. It independently raised the same scope note, now #13291.
- `/simplify`: four cleanup agents (reuse, simplification, efficiency, altitude). Applied: dropped `is_pinned()`, whose two call sites both sat inside `#[cfg(unix)]` blocks — on a Windows build it was dead code and `-Dwarnings` would have failed; `remove_manifest_in_directory` now shares the bounded read with the load path instead of keeping a second copy that had already drifted on `O_NONBLOCK`; one `PinnedConfigDir::for_lock` constructor replaces the same platform split written out at two call sites; the three descriptor-relative syscalls take the manifest name from a constant tied to `SERVICE_MANIFEST_FILE` by a test, rather than three literals; `path()` became `display_path()` to say what it is for; and a dead `NotFound` arm, a no-op rebinding and a doubly-built path are gone. The altitude pass also caught two comments claiming more than the code does — the descriptor-relative read does resolve its final component by name (`O_NOFOLLOW` is what makes that safe), and one sentence about `descriptor_relative_config_dir` parsed as the opposite of its intent — plus an intra-doc link from an ungated item to a `#[cfg(unix)]` one that would warn on a Windows doc build. Skipped: moving `PinnedConfigDir` down into `runtime-cloud-connect` and giving it the `openat` operations, which is the right shape but belongs with #13291 rather than widening this diff; extracting the bounded read into `state.rs` for all six state files, same reason; and collapsing `service_config_dir`/`state_config_dir`, which still carry different values at the unlocked call site.

  The neuter matrix was re-run after these edits and still discriminates: five neuters (the descriptor ignored in the open, in the read, in `validate`'s stat, in `pinned_directory` itself, and the manifest-name constant diverged) each fail at least one test, and every new test is failed by at least one neuter.

Fixes #13204

## Checklist

- [x] Tests added that fail on the old code and pass on the new
- [x] New coverage runs on macOS, the affected platform
- [x] Linux behaviour and its existing coverage unchanged
- [x] Deferred findings filed as #13291 and linked