### PR TITLE
fix(cloud-connect): fix Windows build of identity state-file helpers

### DIFF
--- a/crates/runtime-cloud-connect/src/identity.rs
+++ b/crates/runtime-cloud-connect/src/identity.rs
@@ -738,13 +738,12 @@ pub fn snapshot_regular_file_create_new(
     source: &Path,
     destination: &Path,
 ) -> std::io::Result<bool> {
-    use std::io::Write as _;
-
     #[cfg(unix)]
-    let (mut source_file, mut destination_file) = {
+    {
+        use std::io::Write as _;
         use std::os::unix::fs::MetadataExt as _;
 
-        let Some(source_file) = open_regular_file_optional_unix(source)? else {
+        let Some(mut source_file) = open_regular_file_optional_unix(source)? else {
             return Ok(false);
         };
         let source_metadata = source_file.metadata()?;
@@ -755,23 +754,22 @@ pub fn snapshot_regular_file_create_new(
             ));
         }
 
-        let destination_file = create_regular_file_new_unix(destination)?;
-        (source_file, destination_file)
-    };
+        let mut destination_file = create_regular_file_new_unix(destination)?;
+        std::io::copy(&mut source_file, &mut destination_file)?;
+        destination_file.flush()?;
+        destination_file.sync_all()?;
+        sync_parent_directory(destination)?;
+        Ok(true)
+    }
 
     #[cfg(not(unix))]
     {
-        return Err(std::io::Error::new(
+        let _ = (source, destination);
+        Err(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             "secure state-file snapshots are unsupported on this platform",
-        ));
+        ))
     }
-
-    std::io::copy(&mut source_file, &mut destination_file)?;
-    destination_file.flush()?;
-    destination_file.sync_all()?;
-    sync_parent_directory(destination)?;
-    Ok(true)
 }
 
 /// Read a security-sensitive state file without following symlinks or opening
@@ -797,50 +795,49 @@ pub(crate) fn read_regular_file_optional_bounded(
     path: &Path,
     max_bytes: u64,
 ) -> std::io::Result<Option<Vec<u8>>> {
-    use std::io::Read as _;
-
-    #[cfg(unix)]
-    let Some(file) = open_regular_file_optional_unix(path)? else {
-        return Ok(None);
-    };
-
-    #[cfg(not(unix))]
-    let mut file = {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "secure state-file reads are unsupported on this platform",
-        ));
-    };
-
-    let metadata = file.metadata()?;
-    if !metadata.is_file() || metadata.len() > max_bytes {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "the state path must be a bounded regular file",
-        ));
-    }
-
     #[cfg(unix)]
     {
+        use std::io::Read as _;
         use std::os::unix::fs::MetadataExt as _;
+
+        let Some(file) = open_regular_file_optional_unix(path)? else {
+            return Ok(None);
+        };
+
+        let metadata = file.metadata()?;
+        if !metadata.is_file() || metadata.len() > max_bytes {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "the state path must be a bounded regular file",
+            ));
+        }
         if metadata.nlink() != 1 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "the state file must not be hard-linked",
             ));
         }
+
+        let mut contents = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
+        file.take(max_bytes.saturating_add(1))
+            .read_to_end(&mut contents)?;
+        if u64::try_from(contents.len()).unwrap_or(u64::MAX) > max_bytes {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "the state file exceeded its size limit",
+            ));
+        }
+        Ok(Some(contents))
     }
 
-    let mut contents = Vec::with_capacity(usize::try_from(metadata.len()).unwrap_or(0));
-    file.take(max_bytes.saturating_add(1))
-        .read_to_end(&mut contents)?;
-    if u64::try_from(contents.len()).unwrap_or(u64::MAX) > max_bytes {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "the state file exceeded its size limit",
-        ));
+    #[cfg(not(unix))]
+    {
+        let _ = (path, max_bytes);
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "secure state-file reads are unsupported on this platform",
+        ))
     }
-    Ok(Some(contents))
 }
 
 /// Open a state file relative to verified directory descriptors, refusing a


### PR DESCRIPTION
## What

Fixes the Windows build of `runtime-cloud-connect`, which fails to compile since #13203 and broke the `Build spice CLI (Windows)` step of `build_and_release` ([failing run](https://github.com/spiceai/spiceai/actions/runs/32295877636/job/96206966498)).

In `identity.rs`, `snapshot_regular_file_create_new` and `read_regular_file_optional_bounded` bound their file handles under `#[cfg(unix)]` but used them in unconditional code after the `#[cfg(not(unix))]` early return, so on Windows the compiler saw uses of variables that were never defined (E0425) and a diverging `let` binding (E0282). Unix builds never compile that arm, so PR CI and the nightly (macOS/Linux only) didn't catch it.

## Fix

Restructure both functions so the entire Unix path lives inside a `#[cfg(unix)]` block and the `#[cfg(not(unix))]` arm is a self-contained `Unsupported` error return. No behavior change on any platform: Unix logic is identical, and non-Unix already returned `Unsupported`.

Example run: https://github.com/spiceai/spiceai/actions/runs/32310295616/job/96251744737

## Validation

- `cargo check -p runtime-cloud-connect` and `cargo clippy -p runtime-cloud-connect --no-deps --all-targets`: clean.
- The fixed functions compile cleanly for `x86_64-pc-windows-msvc` with `-D warnings` (standalone `rustc --emit=metadata` check; a full crate cross-check isn't possible from macOS because `aws-lc-rs` needs a Windows C toolchain).

Needs a cherry-pick to `release/2.2` to unblock the release build.