### PR TITLE
fix(postgres): rebuild the datasets already streaming when a join replaces their replication slot (fixes #13229)

### DIFF
--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -2060,10 +2060,6 @@ fn get_or_create_source(key: &SourceKey, params: &ReplicationParams) -> Arc<Shar
     source
 }
 
-/// Register one member on the source (caller holds the setup lock):
-/// validate + publication ADD TABLE + slot create-if-first, decide whether a
-/// snapshot is needed, wire the routing channel, and start the pump if this is
-/// the first member.
 /// Take on, for the source as a whole, what this member's slot setup established.
 ///
 /// Runs before the joining member is registered, so everything here describes the
@@ -2073,7 +2069,7 @@ fn get_or_create_source(key: &SourceKey, params: &ReplicationParams) -> Arc<Shar
 /// Callers must hold [`SharedSource::setup_lock`] — `attach_member` does, which is
 /// also what keeps the replacement handling below from racing the pump's own
 /// recovery of the same slot.
-async fn adopt_slot_setup(
+async fn apply_slot_setup(
     source: &Arc<SharedSource>,
     setup: &slot::SharedMemberSetup,
     metrics: &ReplicationMetricsCollector,
@@ -2088,14 +2084,12 @@ async fn adopt_slot_setup(
         source.ack.seed(setup.slot.consistent_lsn);
         metrics.set_confirmed_flush_lsn(setup.slot.consistent_lsn);
     }
-    // This setup found the slot invalidated and put a replacement in its place, so
-    // the members already streaming on this source hold positions nothing can reach
-    // any more. They are asked to rebuild here, on the same terms the pump's own
-    // recovery asks — `created_fresh` is deliberately not the condition, because it
-    // is also true where no history was thrown away and rebuilding on it moves
-    // floors that are still owed their changes (#12609).
+    // This setup put a replacement in place of an invalidated slot, so the members
+    // already streaming hold positions nothing can reach any more. The condition is
+    // `history_discarded` rather than `created_fresh` for the reason given on that
+    // field.
     if setup.slot.history_discarded {
-        adopt_replacement_slot(source, setup.slot.consistent_lsn).await;
+        install_replacement_slot(source, setup.slot.consistent_lsn).await;
     }
     // Before anything can be credited on this source, pin the floor for the
     // published tables whose datasets have not joined yet — including, when
@@ -2104,6 +2098,10 @@ async fn adopt_slot_setup(
     source.install_reservations(setup);
 }
 
+/// Register one member on the source (caller holds the setup lock):
+/// validate + publication ADD TABLE + slot create-if-first, decide whether a
+/// snapshot is needed, wire the routing channel, and start the pump if this is
+/// the first member.
 async fn attach_member(
     source: &Arc<SharedSource>,
     input: ReplicationStreamInput,
@@ -2185,7 +2183,7 @@ async fn attach_member(
 
     // Slot + publication DDL (idempotent, retried on transient errors).
     let setup = slot::setup_shared_member(&source.params, &schema_name, &table_name).await?;
-    adopt_slot_setup(source, &setup, &metrics).await;
+    apply_slot_setup(source, &setup, &metrics).await;
 
     let rejoining = lock(&source.detached).remove(&member_key);
     // Snapshot when this slot epoch has no usable history for the table:
@@ -2644,21 +2642,8 @@ impl SlotReplacementBudget {
 /// path relies on for a rebuild decided at startup — back-pressure in the member
 /// mailbox, not a wait here.
 ///
-/// Each member is *held* before its request is enqueued — not routed to, never
-/// credited, floor pinned — and released only when the consumer commits the
-/// rebuild. That is load-bearing rather than tidy. [`AckTable::credit_idle`]
-/// advances a streaming member's floor to the WAL head whenever it has nothing in
-/// flight, and a queued control envelope is not in flight by that measure, so a
-/// member left streaming would be credited past the replacement's start while its
-/// rebuild was still sitting in its mailbox. [`publish_idle_positions`] would then
-/// *record* that position, and a crash in the window would resume on a watermark
-/// describing contents the acceleration never received — every row deleted while
-/// the slot was gone surviving for good, which is the failure this whole path
-/// exists to prevent.
-///
-/// Members' `committed` floors are otherwise left where they are. The recorded
-/// position only moves forward through the rebuild's own committer, which runs
-/// after the consumer has made those contents durable.
+/// What the members are then owed — a rebuild each, held until its contents are
+/// durable — is [`install_replacement_slot`]'s, which the join path shares.
 ///
 /// On failure returns a message describing what could not be done, for the caller
 /// to surface.
@@ -2666,13 +2651,11 @@ async fn recover_unusable_slot(
     source: &Arc<SharedSource>,
     refused_generation: u64,
 ) -> std::result::Result<(), String> {
-    // The same lock `attach_member` holds for slot DDL. Without it a member can
-    // register between `request_rebuild_of_attached_members`'s snapshot of the
-    // member set and `reseat_held_floors` below, and that member is then neither
-    // asked to rebuild nor reseated — it resumes on a watermark the replacement
-    // cannot reach, with every change since it missing for good. Safe to take from
-    // the pump: `attach_member` holds it only across synchronous setup and never
-    // waits on the pump, and the pump already takes it in `try_finish_if_empty`.
+    // The same lock `attach_member` holds for slot DDL, which is what makes the
+    // member set stable across `install_replacement_slot` (see there) and what
+    // serializes this against a join replacing the same slot. Safe to take from the
+    // pump: `attach_member` holds it only across synchronous setup and never waits
+    // on the pump, and the pump already takes it in `try_finish_if_empty`.
     let _setup = source.setup_lock.lock().await;
     // The refusal describes the slot as it was when this connection ended, and a
     // join can replace an invalidated slot during the reconnect backoff that
@@ -2694,7 +2677,7 @@ async fn recover_unusable_slot(
         .await
         .map_err(|e| e.to_string())?;
 
-    adopt_replacement_slot(source, new_lsn).await;
+    install_replacement_slot(source, new_lsn).await;
     Ok(())
 }
 
@@ -2704,15 +2687,28 @@ async fn recover_unusable_slot(
 /// Two paths put a replacement under a live source, and both owe it everything
 /// here: the pump's recovery from a stream the slot refused, and a joining member
 /// whose setup found the slot invalidated and recreated it. One function is what
-/// keeps them from drifting — the join path used to do none of this, so a slot
-/// replaced while other datasets were streaming left each of them resuming from a
-/// position the replacement cannot reach, and any row deleted at the source in
-/// between kept no change event to carry the deletion: it survived in the
-/// acceleration, and in every later query (#13229).
+/// keeps them from drifting, because a replacement adopted without this leaves the
+/// members already streaming resuming from a position it cannot reach — and a row
+/// deleted at the source in between has no change event left to carry the
+/// deletion, so it survives in the acceleration and in every later query (#13229).
+///
+/// Each member is *held* before its request is enqueued — not routed to, never
+/// credited, floor pinned — and released only when the consumer commits the
+/// rebuild. That is load-bearing rather than tidy. [`AckTable::credit_idle`]
+/// advances a streaming member's floor to the WAL head whenever it has nothing in
+/// flight, and a queued control envelope is not in flight by that measure, so a
+/// member left streaming would be credited past the replacement's start while its
+/// rebuild was still sitting in its mailbox. [`publish_idle_positions`] would then
+/// *record* that position, and a crash in the window would resume on a watermark
+/// describing contents the acceleration never received.
+///
+/// Members' `committed` floors are otherwise left where they are. The recorded
+/// position only moves forward through the rebuild's own committer, which runs
+/// after the consumer has made those contents durable.
 ///
 /// Callers must hold [`SharedSource::setup_lock`], so the member set is stable
 /// across the walk below — see [`request_rebuild_of_attached_members`].
-async fn adopt_replacement_slot(source: &Arc<SharedSource>, new_lsn: u64) {
+async fn install_replacement_slot(source: &Arc<SharedSource>, new_lsn: u64) {
     // Retires every observation of the slot this replaces, so a refusal the pump
     // latched against it is not acted on a second time (see
     // [`recover_unusable_slot`]).
@@ -2735,7 +2731,7 @@ async fn adopt_replacement_slot(source: &Arc<SharedSource>, new_lsn: u64) {
 /// starts at `new_lsn` and carries no history.
 ///
 /// Callers must hold [`SharedSource::setup_lock`], and reach this through
-/// [`adopt_replacement_slot`], which needs the set of attached members to be stable
+/// [`install_replacement_slot`], which needs the set of attached members to be stable
 /// across the walk: a member registering between the snapshot below and the reseat
 /// that follows would be neither asked to rebuild nor reseated, and would then
 /// resume on a watermark the replacement cannot reach.
@@ -3070,11 +3066,11 @@ async fn run_pump(source: Arc<SharedSource>) {
     // Declared outside the reconnect loop so the bound is over the pump's life,
     // not per attempt.
     let mut slot_replacements = SlotReplacementBudget::new();
-    // Set when a connection reports the slot unusable, and acted on at the top of
-    // the reconnect loop — see there for why the two are separated. Carries the
-    // slot generation the refusal was observed at, so a slot replaced in between is
-    // not replaced again.
-    let mut slot_unusable: Option<u64> = None;
+    // Set to [`SharedSource::slot_generation`] when a connection reports the slot
+    // unusable, and acted on at the top of the reconnect loop — see there for why
+    // the two are separated, and `recover_unusable_slot` for why the generation
+    // rather than a bare flag.
+    let mut unusable_slot_generation: Option<u64> = None;
     // Throttle idle-heartbeat fan-out: keepalives arrive in bursts (one per
     // chunk of filtered/unrelated WAL the slot decodes), so emit at most one
     // heartbeat round per `heartbeat_every`. The per-keepalive `credit_idle`
@@ -3121,8 +3117,12 @@ async fn run_pump(source: Arc<SharedSource>) {
         // connection still live. `PostgreSQL` refuses to drop a slot an active
         // walsender holds, and the client is dropped when the recv loop exits, so
         // this is the first point at which the drop can succeed.
-        if let Some(refused_generation) = slot_unusable.take() {
+        if let Some(refused_generation) = unusable_slot_generation.take() {
             disconnect_at.get_or_insert_with(std::time::Instant::now);
+            // The budget counts slot replacements *observed* in the window, not the
+            // ones this path performed: a refusal `recover_unusable_slot` skips is
+            // one a join already replaced the slot for, and a source burning through
+            // replacements is the condition the budget exists to stop either way.
             if slot_replacements.admit(std::time::Instant::now()) {
                 if let Err(reason) = recover_unusable_slot(&source, refused_generation).await {
                     fatal_broadcast(
@@ -3369,7 +3369,8 @@ async fn run_pump(source: Arc<SharedSource>) {
                     // dropped when this loop exits. Reconnecting without replacing
                     // would ask the same dead slot for changes forever.
                     if resilience::is_slot_unusable(&e) {
-                        slot_unusable = Some(source.slot_generation.load(Ordering::Acquire));
+                        unusable_slot_generation =
+                            Some(source.slot_generation.load(Ordering::Acquire));
                         source.for_each_member_metrics(ReplicationMetricsCollector::inc_reconnect);
                         break 'recv;
                     }
@@ -5964,7 +5965,7 @@ mod tests {
 
         let mut setup = shared_setup(500, true, &["t0", "t1", "unjoined"]);
         setup.slot.history_discarded = true;
-        adopt_slot_setup(&source, &setup, &ReplicationMetricsCollector::new()).await;
+        apply_slot_setup(&source, &setup, &ReplicationMetricsCollector::new()).await;
 
         // The pump's next connect promotes whatever is ready. The members asked to
         // rebuild must not be among them: a promoted member is credited to the WAL
@@ -6042,7 +6043,7 @@ mod tests {
             setup.slot.created_fresh && !setup.slot.history_discarded,
             "the outcome under test is a fresh-looking slot that discarded nothing"
         );
-        adopt_slot_setup(&source, &setup, &ReplicationMetricsCollector::new()).await;
+        apply_slot_setup(&source, &setup, &ReplicationMetricsCollector::new()).await;
 
         source.ack.promote_ready_members();
         for (member_key, _, rx) in &mut probes {
@@ -6087,7 +6088,7 @@ mod tests {
 
         // A join replaces the slot and adopts the replacement, which is what asks
         // this member to rebuild.
-        adopt_replacement_slot(&source, 500).await;
+        install_replacement_slot(&source, 500).await;
         assert!(
             futures::FutureExt::now_or_never(rx.next()).is_some(),
             "the join's replacement is what asks the member to rebuild"

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -2056,6 +2056,46 @@ fn get_or_create_source(key: &SourceKey, params: &ReplicationParams) -> Arc<Shar
 /// validate + publication ADD TABLE + slot create-if-first, decide whether a
 /// snapshot is needed, wire the routing channel, and start the pump if this is
 /// the first member.
+/// Take on, for the source as a whole, what this member's slot setup established.
+///
+/// Runs before the joining member is registered, so everything here describes the
+/// source as it was *without* it: the members already attached, and the floors
+/// already held.
+///
+/// Callers must hold [`SharedSource::setup_lock`] — `attach_member` does, which is
+/// also what keeps the replacement handling below from racing the pump's own
+/// recovery of the same slot.
+async fn adopt_slot_setup(
+    source: &Arc<SharedSource>,
+    setup: &slot::SharedMemberSetup,
+    metrics: &ReplicationMetricsCollector,
+) {
+    // Whichever member set the slot up read this; keep it for the shutdown
+    // message, which has no connection of its own to ask on.
+    *lock(&source.retention_posture) = Some(setup.slot.retention_posture);
+    if setup.slot.created_fresh {
+        source.slot_created_fresh.store(true, Ordering::Release);
+    }
+    if setup.slot.consistent_lsn > 0 {
+        source.ack.seed(setup.slot.consistent_lsn);
+        metrics.set_confirmed_flush_lsn(setup.slot.consistent_lsn);
+    }
+    // This setup found the slot invalidated and put a replacement in its place, so
+    // the members already streaming on this source hold positions nothing can reach
+    // any more. They are asked to rebuild here, on the same terms the pump's own
+    // recovery asks — `created_fresh` is deliberately not the condition, because it
+    // is also true where no history was thrown away and rebuilding on it moves
+    // floors that are still owed their changes (#12609).
+    if setup.slot.history_discarded {
+        adopt_replacement_slot(source, setup.slot.consistent_lsn).await;
+    }
+    // Before anything can be credited on this source, pin the floor for the
+    // published tables whose datasets have not joined yet — including, when
+    // this member is the first to arrive on a resuming slot, the ones that will
+    // join after it.
+    source.install_reservations(setup);
+}
+
 async fn attach_member(
     source: &Arc<SharedSource>,
     input: ReplicationStreamInput,
@@ -2137,21 +2177,7 @@ async fn attach_member(
 
     // Slot + publication DDL (idempotent, retried on transient errors).
     let setup = slot::setup_shared_member(&source.params, &schema_name, &table_name).await?;
-    // Whichever member set the slot up read this; keep it for the shutdown
-    // message, which has no connection of its own to ask on.
-    *lock(&source.retention_posture) = Some(setup.slot.retention_posture);
-    if setup.slot.created_fresh {
-        source.slot_created_fresh.store(true, Ordering::Release);
-    }
-    if setup.slot.consistent_lsn > 0 {
-        source.ack.seed(setup.slot.consistent_lsn);
-        metrics.set_confirmed_flush_lsn(setup.slot.consistent_lsn);
-    }
-    // Before anything can be credited on this source, pin the floor for the
-    // published tables whose datasets have not joined yet — including, when
-    // this member is the first to arrive on a resuming slot, the ones that will
-    // join after it.
-    source.install_reservations(&setup);
+    adopt_slot_setup(source, &setup, &metrics).await;
 
     let rejoining = lock(&source.detached).remove(&member_key);
     // Snapshot when this slot epoch has no usable history for the table:
@@ -2641,6 +2667,25 @@ async fn recover_unusable_slot(source: &Arc<SharedSource>) -> std::result::Resul
         .await
         .map_err(|e| e.to_string())?;
 
+    adopt_replacement_slot(source, new_lsn).await;
+    Ok(())
+}
+
+/// Take on a slot that replaced the one this source's positions were measured
+/// against, and which starts at `new_lsn` carrying no history.
+///
+/// Two paths put a replacement under a live source, and both owe it everything
+/// here: the pump's recovery from a stream the slot refused, and a joining member
+/// whose setup found the slot invalidated and recreated it. One function is what
+/// keeps them from drifting — the join path used to do none of this, so a slot
+/// replaced while other datasets were streaming left each of them resuming from a
+/// position the replacement cannot reach, and any row deleted at the source in
+/// between kept no change event to carry the deletion: it survived in the
+/// acceleration, and in every later query (#13229).
+///
+/// Callers must hold [`SharedSource::setup_lock`], so the member set is stable
+/// across the walk below — see [`request_rebuild_of_attached_members`].
+async fn adopt_replacement_slot(source: &Arc<SharedSource>, new_lsn: u64) {
     // The replacement carries no history, so a member joining after this cannot
     // resume either — it snapshots, exactly as it would on a slot this process had
     // just created.
@@ -2652,19 +2697,17 @@ async fn recover_unusable_slot(source: &Arc<SharedSource>) -> std::result::Resul
 
     request_rebuild_of_attached_members(source, new_lsn).await;
     source.ack.reseat_held_floors(new_lsn);
-    Ok(())
 }
 
 /// Ask every already-attached member to rebuild from the source, because the slot
 /// their recorded positions were measured against has been replaced by one that
 /// starts at `new_lsn` and carries no history.
 ///
-/// Callers must hold [`SharedSource::setup_lock`]. Both call sites replace the slot
-/// — the pump's recovery, and a joining member whose `ensure_slot` found the slot
-/// gone — and each needs the set of attached members to be stable across the walk:
-/// a member registering between the snapshot below and the caller's follow-up would
-/// be neither asked to rebuild nor reseated, and would then resume on a watermark
-/// the replacement cannot reach.
+/// Callers must hold [`SharedSource::setup_lock`], and reach this through
+/// [`adopt_replacement_slot`], which needs the set of attached members to be stable
+/// across the walk: a member registering between the snapshot below and the reseat
+/// that follows would be neither asked to rebuild nor reseated, and would then
+/// resume on a watermark the replacement cannot reach.
 ///
 /// Ordering is carried by the member mailbox rather than by waiting here. Changes
 /// already staged for a member sit *ahead* of its request and are applied first,
@@ -4322,6 +4365,7 @@ mod tests {
                 consistent_lsn,
                 snapshot_name: None,
                 created_fresh,
+                history_discarded: false,
                 generated_columns: vec![],
                 retention_posture: retention::SlotRetentionPosture {
                     server_version_num: 170_000,
@@ -4529,7 +4573,9 @@ mod tests {
     ) -> (Arc<SharedSource>, Vec<MemberProbe>) {
         let source_key = SourceKey::from_params(&test_params());
         let source = Arc::new(SharedSource::new(source_key, test_params()));
-        let schema: SchemaRef = Arc::new(arrow::datatypes::Schema::empty());
+        // One column rather than none: a zero-row envelope carries a struct array,
+        // which cannot be built over zero fields. See [`TINY_SCHEMA`].
+        let schema = tiny_schema();
         let mut probes = Vec::with_capacity(n);
         for i in 0..n {
             let member_key = key(&format!("t{i}"));
@@ -5858,6 +5904,123 @@ mod tests {
             source
                 .take_expired_reservations(std::time::Duration::ZERO)
                 .is_empty()
+        );
+    }
+
+    /// Two datasets share a slot. The server invalidates it, and the *second*
+    /// dataset's join is what notices — its setup drops the invalidated slot and
+    /// creates a replacement at the current WAL position.
+    ///
+    /// The first dataset is still attached, and its recorded position was measured
+    /// against the slot that just went away. Nothing in the replacement reaches it:
+    /// a row deleted at the source in between has no change event left to carry the
+    /// deletion, so an acceleration allowed to resume keeps that row in every later
+    /// query. The join owes it exactly what the pump's own recovery owes it — a
+    /// rebuild from the source, and a hold until that rebuild is durable (#13229).
+    #[tokio::test]
+    async fn a_join_that_replaced_the_slot_rebuilds_the_members_already_attached() {
+        let (source, mut probes) = test_source_with_members(2);
+        for (member_key, _, _) in &probes {
+            source.ack.register(member_key, false);
+            source.ack.commit(member_key, 100);
+        }
+        source.ack.promote_ready_members();
+        // A published table whose dataset has not joined, holding the floor at the
+        // point the old slot resumed from.
+        source.ack.reserve(&key("unjoined"), 100);
+
+        let mut setup = shared_setup(500, true, &["t0", "t1", "unjoined"]);
+        setup.slot.history_discarded = true;
+        adopt_slot_setup(&source, &setup, &ReplicationMetricsCollector::new()).await;
+
+        // The pump's next connect promotes whatever is ready. The members asked to
+        // rebuild must not be among them: a promoted member is credited to the WAL
+        // head by `credit_idle` and recorded there, for contents its rebuild has not
+        // delivered.
+        source.ack.promote_ready_members();
+        for (member_key, _, rx) in &mut probes {
+            let envelope = rx
+                .next()
+                .await
+                .expect("each attached member is asked to rebuild")
+                .expect("a valid rebuild request");
+            assert!(
+                envelope.history_unavailable(),
+                "the member must be asked to replace its contents from the source, not to apply \
+                 anything onto them"
+            );
+            assert!(
+                !source.ack.is_streaming(member_key),
+                "a member with a rebuild outstanding must stay held, so nothing credits it past \
+                 contents the rebuild has not delivered"
+            );
+            assert_eq!(
+                source.ack.committed(member_key),
+                100,
+                "an attached member's floor moves only through its rebuild's own committer"
+            );
+        }
+
+        assert_eq!(
+            source.ack.committed(&key("unjoined")),
+            500,
+            "the replacement has no changes below its own start for an unjoined table to be owed, \
+             so a held floor left below it would pin the slot's acknowledgement there for good"
+        );
+        assert_eq!(
+            source.ack.flush_lsn(),
+            500,
+            "the slot acks the replacement's start"
+        );
+        assert!(
+            source.slot_created_fresh.load(Ordering::Acquire),
+            "a dataset joining after this cannot resume from the replacement either"
+        );
+    }
+
+    /// The counterpart: a slot that kept its history must leave the members already
+    /// attached alone, and `created_fresh` cannot be the signal that tells the two
+    /// apart — it is also true where nothing was discarded (a slot that exists but
+    /// has never been acknowledged, and the fast-forward for a re-bootstrap).
+    ///
+    /// Rebuilding on it moves floors that are still owed their changes: it regressed
+    /// `a_bootstrap_lost_before_it_was_durable_is_reloaded_not_resumed` and
+    /// `a_dataset_re_added_after_its_reservation_lapsed_does_not_silently_skip_changes`
+    /// (#12609) when it was tried. This differs from the test above by the discard
+    /// signal alone.
+    #[tokio::test]
+    async fn a_join_on_a_slot_that_kept_its_history_leaves_attached_members_alone() {
+        let (source, mut probes) = test_source_with_members(2);
+        for (member_key, _, _) in &probes {
+            source.ack.register(member_key, false);
+            source.ack.commit(member_key, 100);
+        }
+        source.ack.promote_ready_members();
+        source.ack.reserve(&key("unjoined"), 100);
+
+        let setup = shared_setup(500, true, &["t0", "t1", "unjoined"]);
+        assert!(
+            setup.slot.created_fresh && !setup.slot.history_discarded,
+            "the outcome under test is a fresh-looking slot that discarded nothing"
+        );
+        adopt_slot_setup(&source, &setup, &ReplicationMetricsCollector::new()).await;
+
+        source.ack.promote_ready_members();
+        for (member_key, _, rx) in &mut probes {
+            assert!(
+                futures::FutureExt::now_or_never(rx.next()).is_none(),
+                "nothing was discarded, so no attached member is owed a rebuild"
+            );
+            assert!(
+                source.ack.is_streaming(member_key),
+                "an attached member must keep streaming when the slot kept its history"
+            );
+            assert_eq!(source.ack.committed(member_key), 100);
+        }
+        assert_eq!(
+            source.ack.committed(&key("unjoined")),
+            100,
+            "the hold for an unjoined table still covers changes nobody has consumed"
         );
     }
 

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -1656,6 +1656,13 @@ struct SharedSource {
     /// later must snapshot even if their table already sat in the publication:
     /// a fresh slot has no history for anyone.
     slot_created_fresh: AtomicBool,
+    /// How many times the slot behind this source has been replaced, so an actor
+    /// holding an observation of the *previous* slot can tell that it is stale.
+    ///
+    /// Only the pump reads it, and only to decide whether the refusal it is about
+    /// to act on still describes the slot that is there — see
+    /// [`recover_unusable_slot`].
+    slot_generation: AtomicU64,
     /// Tables whose member detached during this pump's lifetime; a rejoin is
     /// resumed via held-floor replay instead of a snapshot.
     detached: Mutex<HashSet<MemberKey>>,
@@ -1696,6 +1703,7 @@ impl SharedSource {
             watermark_notify: Arc::new(Notify::new()),
             orphaned_positions: Mutex::new(Vec::new()),
             slot_created_fresh: AtomicBool::new(false),
+            slot_generation: AtomicU64::new(0),
             detached: Mutex::new(HashSet::new()),
             reservations: Mutex::new(HashMap::new()),
             retention_posture: Mutex::new(None),
@@ -2654,7 +2662,10 @@ impl SlotReplacementBudget {
 ///
 /// On failure returns a message describing what could not be done, for the caller
 /// to surface.
-async fn recover_unusable_slot(source: &Arc<SharedSource>) -> std::result::Result<(), String> {
+async fn recover_unusable_slot(
+    source: &Arc<SharedSource>,
+    refused_generation: u64,
+) -> std::result::Result<(), String> {
     // The same lock `attach_member` holds for slot DDL. Without it a member can
     // register between `request_rebuild_of_attached_members`'s snapshot of the
     // member set and `reseat_held_floors` below, and that member is then neither
@@ -2663,6 +2674,22 @@ async fn recover_unusable_slot(source: &Arc<SharedSource>) -> std::result::Resul
     // the pump: `attach_member` holds it only across synchronous setup and never
     // waits on the pump, and the pump already takes it in `try_finish_if_empty`.
     let _setup = source.setup_lock.lock().await;
+    // The refusal describes the slot as it was when this connection ended, and a
+    // join can replace an invalidated slot during the reconnect backoff that
+    // follows — the only window in which it can, since `PostgreSQL` refuses to drop
+    // a slot an active walsender holds. That join adopts its replacement through
+    // the same path below, so replacing again would drop a healthy slot and leave
+    // every member holding *two* rebuild requests against one
+    // [`AckSlot::rebuild_pending`] flag: the first to commit would clear the hold
+    // the second still needs, and the member would be credited and its position
+    // recorded for contents that rebuild has not delivered.
+    if source.slot_generation.load(Ordering::Acquire) != refused_generation {
+        tracing::info!(
+            slot = %source.key.slot_name,
+            "the replication slot was replaced while this stream was reconnecting, and every acceleration on it was already asked to rebuild; streaming resumes on the replacement"
+        );
+        return Ok(());
+    }
     let new_lsn = slot::replace_unusable_slot(&source.params)
         .await
         .map_err(|e| e.to_string())?;
@@ -2686,6 +2713,10 @@ async fn recover_unusable_slot(source: &Arc<SharedSource>) -> std::result::Resul
 /// Callers must hold [`SharedSource::setup_lock`], so the member set is stable
 /// across the walk below — see [`request_rebuild_of_attached_members`].
 async fn adopt_replacement_slot(source: &Arc<SharedSource>, new_lsn: u64) {
+    // Retires every observation of the slot this replaces, so a refusal the pump
+    // latched against it is not acted on a second time (see
+    // [`recover_unusable_slot`]).
+    source.slot_generation.fetch_add(1, Ordering::AcqRel);
     // The replacement carries no history, so a member joining after this cannot
     // resume either — it snapshots, exactly as it would on a slot this process had
     // just created.
@@ -3040,8 +3071,10 @@ async fn run_pump(source: Arc<SharedSource>) {
     // not per attempt.
     let mut slot_replacements = SlotReplacementBudget::new();
     // Set when a connection reports the slot unusable, and acted on at the top of
-    // the reconnect loop — see there for why the two are separated.
-    let mut slot_unusable = false;
+    // the reconnect loop — see there for why the two are separated. Carries the
+    // slot generation the refusal was observed at, so a slot replaced in between is
+    // not replaced again.
+    let mut slot_unusable: Option<u64> = None;
     // Throttle idle-heartbeat fan-out: keepalives arrive in bursts (one per
     // chunk of filtered/unrelated WAL the slot decodes), so emit at most one
     // heartbeat round per `heartbeat_every`. The per-keepalive `credit_idle`
@@ -3088,10 +3121,10 @@ async fn run_pump(source: Arc<SharedSource>) {
         // connection still live. `PostgreSQL` refuses to drop a slot an active
         // walsender holds, and the client is dropped when the recv loop exits, so
         // this is the first point at which the drop can succeed.
-        if std::mem::take(&mut slot_unusable) {
+        if let Some(refused_generation) = slot_unusable.take() {
             disconnect_at.get_or_insert_with(std::time::Instant::now);
             if slot_replacements.admit(std::time::Instant::now()) {
-                if let Err(reason) = recover_unusable_slot(&source).await {
+                if let Err(reason) = recover_unusable_slot(&source, refused_generation).await {
                     fatal_broadcast(
                         &source,
                         format!(
@@ -3336,7 +3369,7 @@ async fn run_pump(source: Arc<SharedSource>) {
                     // dropped when this loop exits. Reconnecting without replacing
                     // would ask the same dead slot for changes forever.
                     if resilience::is_slot_unusable(&e) {
-                        slot_unusable = true;
+                        slot_unusable = Some(source.slot_generation.load(Ordering::Acquire));
                         source.for_each_member_metrics(ReplicationMetricsCollector::inc_reconnect);
                         break 'recv;
                     }
@@ -6027,6 +6060,51 @@ mod tests {
             source.ack.committed(&key("unjoined")),
             100,
             "the hold for an unjoined table still covers changes nobody has consumed"
+        );
+    }
+
+    /// The pump latches a refusal against the slot it was streaming, then waits out
+    /// its reconnect backoff — the one window in which a joining dataset can replace
+    /// that slot, because `PostgreSQL` will not drop one an active walsender holds.
+    ///
+    /// By the time the pump acts, the slot its refusal describes is gone and every
+    /// member has already been asked to rebuild. Replacing again would drop a
+    /// healthy slot and leave each member holding two rebuild requests against one
+    /// `rebuild_pending` flag, so the first to commit would release the hold the
+    /// second still needs — crediting the member, and recording its position, for
+    /// contents that rebuild has not delivered.
+    #[tokio::test]
+    async fn a_refusal_of_an_already_replaced_slot_does_not_replace_it_again() {
+        let (source, mut probes) = test_source_with_members(1);
+        let (member_key, _, rx) = &mut probes[0];
+        source.ack.register(member_key, false);
+        source.ack.commit(member_key, 100);
+        source.ack.promote_ready_members();
+
+        // What the pump holds: the slot generation as of the connection that was
+        // refused.
+        let refused_generation = source.slot_generation.load(Ordering::Acquire);
+
+        // A join replaces the slot and adopts the replacement, which is what asks
+        // this member to rebuild.
+        adopt_replacement_slot(&source, 500).await;
+        assert!(
+            futures::FutureExt::now_or_never(rx.next()).is_some(),
+            "the join's replacement is what asks the member to rebuild"
+        );
+
+        recover_unusable_slot(&source, refused_generation)
+            .await
+            .expect("a refusal of a slot that is already gone is not a failure");
+
+        assert!(
+            futures::FutureExt::now_or_never(rx.next()).is_none(),
+            "the member must not be asked to rebuild a second time for one replacement"
+        );
+        assert_eq!(
+            source.slot_generation.load(Ordering::Acquire),
+            refused_generation + 1,
+            "one replacement happened, so the generation moved exactly once"
         );
     }
 

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -2084,11 +2084,21 @@ async fn apply_slot_setup(
         source.ack.seed(setup.slot.consistent_lsn);
         metrics.set_confirmed_flush_lsn(setup.slot.consistent_lsn);
     }
-    // This setup put a replacement in place of an invalidated slot, so the members
-    // already streaming hold positions nothing can reach any more. The condition is
-    // `history_discarded` rather than `created_fresh` for the reason given on that
-    // field.
-    if setup.slot.history_discarded {
+    // Did this setup put a different slot under the members already streaming here?
+    // Their positions were measured against the one that was there before, and a
+    // slot created at the current WAL position cannot reach them.
+    let replaced = match setup.slot.history {
+        slot::SlotHistory::ReplacedInvalidated => true,
+        // Nothing existed to create a replacement *of* until this source has a
+        // member: the first one to arrive is what creates the slot in the ordinary
+        // case, and there is no history behind it.
+        slot::SlotHistory::CreatedFromAbsent => !source.live_members().is_empty(),
+        // `FastForwarded` discards history for every member too, but keying on it
+        // needs to be measured against two held-floor tests (#12609) that this
+        // cannot run — tracked in #13305.
+        slot::SlotHistory::Kept | slot::SlotHistory::FastForwarded => false,
+    };
+    if replaced {
         install_replacement_slot(source, setup.slot.consistent_lsn).await;
     }
     // Before anything can be credited on this source, pin the floor for the
@@ -2709,10 +2719,6 @@ async fn recover_unusable_slot(
 /// Callers must hold [`SharedSource::setup_lock`], so the member set is stable
 /// across the walk below — see [`request_rebuild_of_attached_members`].
 async fn install_replacement_slot(source: &Arc<SharedSource>, new_lsn: u64) {
-    // Retires every observation of the slot this replaces, so a refusal the pump
-    // latched against it is not acted on a second time (see
-    // [`recover_unusable_slot`]).
-    source.slot_generation.fetch_add(1, Ordering::AcqRel);
     // The replacement carries no history, so a member joining after this cannot
     // resume either — it snapshots, exactly as it would on a slot this process had
     // just created.
@@ -2724,6 +2730,12 @@ async fn install_replacement_slot(source: &Arc<SharedSource>, new_lsn: u64) {
 
     request_rebuild_of_attached_members(source, new_lsn).await;
     source.ack.reseat_held_floors(new_lsn);
+    // Last, so this reads as adopted only once every member has been asked to
+    // rebuild: the join reaches here from a stream future the consumer can drop, and
+    // publishing the new generation first would let a cancellation leave members
+    // unasked while [`recover_unusable_slot`] skipped the recovery that would have
+    // asked them.
+    source.slot_generation.fetch_add(1, Ordering::AcqRel);
 }
 
 /// Ask every already-attached member to rebuild from the source, because the slot
@@ -4399,7 +4411,7 @@ mod tests {
                 consistent_lsn,
                 snapshot_name: None,
                 created_fresh,
-                history_discarded: false,
+                history: slot::SlotHistory::Kept,
                 generated_columns: vec![],
                 retention_posture: retention::SlotRetentionPosture {
                     server_version_num: 170_000,
@@ -5964,7 +5976,7 @@ mod tests {
         source.ack.reserve(&key("unjoined"), 100);
 
         let mut setup = shared_setup(500, true, &["t0", "t1", "unjoined"]);
-        setup.slot.history_discarded = true;
+        setup.slot.history = slot::SlotHistory::ReplacedInvalidated;
         apply_slot_setup(&source, &setup, &ReplicationMetricsCollector::new()).await;
 
         // The pump's next connect promotes whatever is ready. The members asked to
@@ -6040,7 +6052,7 @@ mod tests {
 
         let setup = shared_setup(500, true, &["t0", "t1", "unjoined"]);
         assert!(
-            setup.slot.created_fresh && !setup.slot.history_discarded,
+            setup.slot.created_fresh && setup.slot.history == slot::SlotHistory::Kept,
             "the outcome under test is a fresh-looking slot that discarded nothing"
         );
         apply_slot_setup(&source, &setup, &ReplicationMetricsCollector::new()).await;
@@ -6061,6 +6073,60 @@ mod tests {
             source.ack.committed(&key("unjoined")),
             100,
             "the hold for an unjoined table still covers changes nobody has consumed"
+        );
+    }
+
+    /// The same replacement by a different route: an operator drops the slot while
+    /// the pump is between connections — the only time `PostgreSQL` lets them — and
+    /// the next dataset to join finds no slot and creates one.
+    ///
+    /// Nothing about that outcome says "invalidated", but the members already
+    /// streaming are in exactly the position they are after an invalidated slot is
+    /// replaced: their recorded positions were measured against a slot that is gone,
+    /// and the one created in its place starts at the current WAL position.
+    #[tokio::test]
+    async fn a_join_that_created_a_slot_under_members_already_attached_rebuilds_them() {
+        let (source, mut probes) = test_source_with_members(2);
+        for (member_key, _, _) in &probes {
+            source.ack.register(member_key, false);
+            source.ack.commit(member_key, 100);
+        }
+        source.ack.promote_ready_members();
+
+        let mut setup = shared_setup(500, true, &["t0", "t1"]);
+        setup.slot.history = slot::SlotHistory::CreatedFromAbsent;
+        apply_slot_setup(&source, &setup, &ReplicationMetricsCollector::new()).await;
+
+        source.ack.promote_ready_members();
+        for (member_key, _, rx) in &mut probes {
+            assert!(
+                futures::FutureExt::now_or_never(rx.next()).is_some(),
+                "a member streaming from the slot that was replaced must be rebuilt"
+            );
+            assert!(!source.ack.is_streaming(member_key));
+        }
+        assert_eq!(
+            source.slot_generation.load(Ordering::Acquire),
+            1,
+            "the slot under this source was replaced, so observations of the old one are stale"
+        );
+    }
+
+    /// The ordinary first start, which reaches the same outcome and must do none of
+    /// it: creating a slot because none existed replaces nothing when nobody was
+    /// streaming from one.
+    #[tokio::test]
+    async fn the_first_member_to_create_a_slot_replaces_nothing() {
+        let (source, _) = test_source_with_members(0);
+
+        let mut setup = shared_setup(500, true, &["t0"]);
+        setup.slot.history = slot::SlotHistory::CreatedFromAbsent;
+        apply_slot_setup(&source, &setup, &ReplicationMetricsCollector::new()).await;
+
+        assert_eq!(
+            source.slot_generation.load(Ordering::Acquire),
+            0,
+            "no slot was replaced, so nothing any actor observed has been retired"
         );
     }
 

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -2754,16 +2754,22 @@ async fn install_replacement_slot(source: &Arc<SharedSource>, new_lsn: u64) {
 /// a staged insert applied *after* the rebuild would resurrect a row the source has
 /// since deleted, and the replacement slot has no delete event left to correct it.
 async fn request_rebuild_of_attached_members(source: &Arc<SharedSource>, new_lsn: u64) {
-    for (member_key, member) in source.live_members() {
-        // Hold before enqueueing, so the member is never routable with its rebuild
-        // still queued. `AckTable::credit_idle` advances a streaming member's floor
-        // to the WAL head whenever it has nothing in flight, and a queued control
-        // envelope does not count as in flight — so a member left streaming would be
-        // credited, and then recorded, past contents its rebuild had not delivered.
-        source.ack.register(&member_key, true);
+    let members = source.live_members();
+    // Every member is held before *any* request is enqueued, and without an await in
+    // between. `AckTable::credit_idle` advances a streaming member's floor to the WAL
+    // head whenever it has nothing in flight, and a queued control envelope does not
+    // count as in flight — so a member still streaming would be credited, and then
+    // recorded, past contents its rebuild had not delivered. The send below can park
+    // on a full mailbox, and the pump reconnects without taking `setup_lock`, so
+    // holding as each member's turn came would leave the ones later in the walk
+    // promotable and creditable for the length of that park.
+    for (member_key, _) in &members {
+        source.ack.register(member_key, true);
         // Claim the hold as the rebuild's, so the member's own initial-snapshot
         // completion cannot release it out from under the rebuild.
-        source.ack.mark_rebuild_pending(&member_key);
+        source.ack.mark_rebuild_pending(member_key);
+    }
+    for (member_key, member) in members {
         let envelope = rebuild_request_envelope(source, &member_key, &member, new_lsn);
         if member.sender.send_control(envelope).await.is_some() {
             // The consumer is gone, so there is no acceleration left to rebuild.
@@ -3078,10 +3084,13 @@ async fn run_pump(source: Arc<SharedSource>) {
     // Declared outside the reconnect loop so the bound is over the pump's life,
     // not per attempt.
     let mut slot_replacements = SlotReplacementBudget::new();
-    // Set to [`SharedSource::slot_generation`] when a connection reports the slot
-    // unusable, and acted on at the top of the reconnect loop — see there for why
-    // the two are separated, and `recover_unusable_slot` for why the generation
-    // rather than a bare flag.
+    // Set to the slot generation *this connection* was streaming when it reports the
+    // slot unusable, and acted on at the top of the reconnect loop — see there for
+    // why the two are separated, and `recover_unusable_slot` for why the generation
+    // rather than a bare flag. Read at connect rather than when the refusal is
+    // dequeued: the error can sit in the client's queue while a join replaces the
+    // slot, and tagging it with the generation of the replacement would make a stale
+    // refusal look current and drop a healthy slot.
     let mut unusable_slot_generation: Option<u64> = None;
     // Throttle idle-heartbeat fan-out: keepalives arrive in bursts (one per
     // chunk of filtered/unrelated WAL the slot decodes), so emit at most one
@@ -3176,6 +3185,10 @@ async fn run_pump(source: Arc<SharedSource>) {
         // Joins that happened before this (re)connect are picked up by it.
         source.restart_requested.store(false, Ordering::Release);
 
+        // The slot epoch this connection streams, read before the config is built
+        // from it: a replacement installed after this point is one this connection
+        // never saw, and a refusal it reports must not be attributed to it.
+        let connection_generation = source.slot_generation.load(Ordering::Acquire);
         let config = client::build_replication_config(
             &params,
             &slot_name,
@@ -3381,8 +3394,7 @@ async fn run_pump(source: Arc<SharedSource>) {
                     // dropped when this loop exits. Reconnecting without replacing
                     // would ask the same dead slot for changes forever.
                     if resilience::is_slot_unusable(&e) {
-                        unusable_slot_generation =
-                            Some(source.slot_generation.load(Ordering::Acquire));
+                        unusable_slot_generation = Some(connection_generation);
                         source.for_each_member_metrics(ReplicationMetricsCollector::inc_reconnect);
                         break 'recv;
                     }

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -5939,10 +5939,12 @@ mod tests {
         // delivered.
         source.ack.promote_ready_members();
         for (member_key, _, rx) in &mut probes {
-            let envelope = rx
-                .next()
-                .await
-                .expect("each attached member is asked to rebuild")
+            // The request is enqueued before the join returns, so it is already
+            // there — polled rather than awaited so a missing one fails here
+            // instead of hanging on a wait that can never finish.
+            let envelope = futures::FutureExt::now_or_never(rx.next())
+                .expect("each attached member is asked to rebuild before the join returns")
+                .expect("the member's mailbox is open")
                 .expect("a valid rebuild request");
             assert!(
                 envelope.history_unavailable(),
@@ -5958,6 +5960,10 @@ mod tests {
                 source.ack.committed(member_key),
                 100,
                 "an attached member's floor moves only through its rebuild's own committer"
+            );
+            assert!(
+                futures::FutureExt::now_or_never(rx.next()).is_none(),
+                "one rebuild per member: a second request would re-read the whole table"
             );
         }
 

--- a/crates/data_components/src/postgres_replication/slot.rs
+++ b/crates/data_components/src/postgres_replication/slot.rs
@@ -383,12 +383,10 @@ async fn ensure_slot(
     // below, so retire it first and let the rest of this function create its
     // replacement.
     //
-    // Whether that happened is carried on every outcome below: it is the only one
-    // of them that destroys history someone may already be streaming against, and
-    // the caller has to rebuild those consumers before the replacement streams. It
-    // is set on the resuming branches too — reaching one after the drop means
-    // something recreated the slot underneath us, which does not give the
-    // discarded history back.
+    // Carried on every outcome below, including the resuming branches: reaching one
+    // of those after the drop means something recreated the slot underneath us,
+    // which does not give the discarded history back. See
+    // [`SlotInfo::history_discarded`] for what the caller owes on it.
     if drop_slot_if_invalidated(client, &params.slot_name).await? {
         history_discarded.store(true, Ordering::Release);
     }

--- a/crates/data_components/src/postgres_replication/slot.rs
+++ b/crates/data_components/src/postgres_replication/slot.rs
@@ -20,7 +20,7 @@ limitations under the License.
 //! PUBLICATION` is not allowed on replication connections and the slot state
 //! queries live in normal catalog tables.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use snafu::ResultExt;
 use tokio_postgres::NoTls;
@@ -60,6 +60,48 @@ pub enum SlotHistory {
     /// discards its history for every member (see
     /// [`advance_slot_for_rebootstrap`]).
     FastForwarded,
+}
+
+/// The strongest [`SlotHistory`] any attempt of a *retried* setup reached.
+///
+/// Setup is retried as a whole on transient errors, and an attempt that drops an
+/// invalidated slot or creates a missing one has changed the source before it can
+/// fail: the next attempt then finds an ordinary slot and would report
+/// [`SlotHistory::Kept`], leaving the members already attached on positions the new
+/// slot cannot reach and never rebuilding them. Latching the outcome outside the
+/// retry is what keeps a replacement from being forgotten by the attempt that
+/// followed it.
+///
+/// Ranked because attempts see different states, and the strongest wins: replacing
+/// an invalidated slot says more than creating an absent one, which says more than
+/// finding one already there.
+struct HistoryLatch(AtomicU8);
+
+impl HistoryLatch {
+    const KEPT: u8 = 0;
+    const CREATED: u8 = 1;
+    const REPLACED: u8 = 2;
+
+    fn new() -> Self {
+        Self(AtomicU8::new(Self::KEPT))
+    }
+
+    /// Record what this attempt did, and return what the setup as a whole must
+    /// report — which is this outcome only while no earlier attempt did more.
+    fn observe(&self, history: SlotHistory) -> SlotHistory {
+        let rank = match history {
+            // A fast-forward ranks with `Kept` because nothing acts on it yet
+            // (#13305); it still reports itself when no attempt outranks it.
+            SlotHistory::Kept | SlotHistory::FastForwarded => Self::KEPT,
+            SlotHistory::CreatedFromAbsent => Self::CREATED,
+            SlotHistory::ReplacedInvalidated => Self::REPLACED,
+        };
+        match self.0.fetch_max(rank, Ordering::AcqRel).max(rank) {
+            Self::REPLACED => SlotHistory::ReplacedInvalidated,
+            Self::CREATED => SlotHistory::CreatedFromAbsent,
+            _ => history,
+        }
+    }
 }
 
 /// Info about a slot after `setup_slot_and_publication` returns.
@@ -118,12 +160,12 @@ pub async fn setup_slot_and_publication(
     // checks. Fatal errors (permission denied, syntax) are propagated on the
     // first attempt.
     // Outside the retry: see [`ensure_slot`].
-    let replaced_invalidated = AtomicBool::new(false);
+    let history = HistoryLatch::new();
     super::resilience::retry_async(
         "postgres_replication::setup",
         super::resilience::DEFAULT_SETUP_MAX_ELAPSED,
         is_transient_setup_error,
-        || async { setup_once(params, schema_name, table_name, &replaced_invalidated).await },
+        || async { setup_once(params, schema_name, table_name, &history).await },
     )
     .await
 }
@@ -179,7 +221,7 @@ pub async fn setup_shared_member(
     table_name: &str,
 ) -> Result<SharedMemberSetup> {
     // Outside the retry: see [`ensure_slot`].
-    let replaced_invalidated = AtomicBool::new(false);
+    let history = HistoryLatch::new();
     super::resilience::retry_async(
         "postgres_replication::setup_shared_member",
         super::resilience::DEFAULT_SETUP_MAX_ELAPSED,
@@ -200,7 +242,7 @@ pub async fn setup_shared_member(
                 // root, which is the name members subscribe with.
                 let publication_tables =
                     list_publication_tables(&client, &params.publication_name).await?;
-                let slot = ensure_slot(&client, params, &replaced_invalidated).await?;
+                let slot = ensure_slot(&client, params, &history).await?;
                 let slot_restart_lsn = read_slot_restart_lsn(&client, &params.slot_name).await?;
                 Ok(SharedMemberSetup {
                     slot,
@@ -223,18 +265,11 @@ async fn setup_once(
     params: &ReplicationParams,
     schema_name: &str,
     table_name: &str,
-    replaced_invalidated: &AtomicBool,
+    history: &HistoryLatch,
 ) -> Result<SlotInfo> {
     let (client, conn_task) = connect_setup(params).await?;
 
-    let outcome = do_setup(
-        &client,
-        params,
-        schema_name,
-        table_name,
-        replaced_invalidated,
-    )
-    .await;
+    let outcome = do_setup(&client, params, schema_name, table_name, history).await;
 
     drop(client);
     let _ = conn_task.await;
@@ -288,12 +323,12 @@ async fn do_setup(
     params: &ReplicationParams,
     schema_name: &str,
     table_name: &str,
-    replaced_invalidated: &AtomicBool,
+    history: &HistoryLatch,
 ) -> Result<SlotInfo> {
     validate_replica_identity(client, schema_name, table_name).await?;
     let generated_columns = fetch_generated_columns(client, schema_name, table_name).await?;
     ensure_publication(client, &params.publication_name, schema_name, table_name).await?;
-    let mut slot = ensure_slot(client, params, replaced_invalidated).await?;
+    let mut slot = ensure_slot(client, params, history).await?;
     slot.generated_columns = generated_columns;
     Ok(slot)
 }
@@ -390,17 +425,12 @@ async fn drop_slot_if_invalidated(
     }
 }
 
-/// `replaced_invalidated` latches [`SlotHistory::ReplacedInvalidated`] across the
-/// caller's *retries*, and is why it is a parameter rather than a local: the drop
-/// below is not undone by a later attempt failing. An attempt that retires the
-/// invalidated slot and then fails on a transient error further into setup leaves
-/// the replacement in place, so the next attempt finds an ordinary slot and would
-/// report that nothing was discarded — and the members already attached would never
-/// be rebuilt, which is the whole failure this signal exists to prevent.
+/// `history` is a parameter rather than a local because it outlives one attempt —
+/// see [`HistoryLatch`].
 async fn ensure_slot(
     client: &tokio_postgres::Client,
     params: &ReplicationParams,
-    replaced_invalidated: &AtomicBool,
+    history: &HistoryLatch,
 ) -> Result<SlotInfo> {
     // Read once, before anything branches, so every outcome below carries it and
     // the slot-creation message can name what will remove the slot it creates.
@@ -410,22 +440,12 @@ async fn ensure_slot(
     // below, so retire it first and let the rest of this function create its
     // replacement.
     //
-    // Outranks every other outcome below, including the resuming branches: reaching
-    // one of those after the drop means something recreated the slot underneath us,
-    // which does not give the discarded history back.
+    // Recorded before anything below can fail: reaching a resuming branch after this
+    // drop means something recreated the slot underneath us, which does not give the
+    // discarded history back.
     if drop_slot_if_invalidated(client, &params.slot_name).await? {
-        replaced_invalidated.store(true, Ordering::Release);
+        history.observe(SlotHistory::ReplacedInvalidated);
     }
-    let replaced_invalidated = replaced_invalidated.load(Ordering::Acquire);
-    // Classify a branch's own outcome, deferring to the drop above when there was
-    // one.
-    let history = |own: SlotHistory| {
-        if replaced_invalidated {
-            SlotHistory::ReplacedInvalidated
-        } else {
-            own
-        }
-    };
 
     // Distinguish three catalog states for the named slot:
     //   * None            — no slot exists; we create one and need a bootstrap.
@@ -452,7 +472,7 @@ async fn ensure_slot(
                     snapshot_name: None,
                     generated_columns: Vec::new(),
                     retention_posture,
-                    history: history(SlotHistory::FastForwarded),
+                    history: history.observe(SlotHistory::FastForwarded),
                     // The old history is gone, so this slot carries none for any
                     // member -- the same contract as a slot created this process.
                     created_fresh: true,
@@ -472,7 +492,7 @@ async fn ensure_slot(
                 snapshot_name: None,
                 generated_columns: Vec::new(),
                 retention_posture,
-                history: history(SlotHistory::Kept),
+                history: history.observe(SlotHistory::Kept),
                 created_fresh: false,
             });
         }
@@ -491,7 +511,7 @@ async fn ensure_slot(
                 snapshot_name: None,
                 generated_columns: Vec::new(),
                 retention_posture,
-                history: history(SlotHistory::Kept),
+                history: history.observe(SlotHistory::Kept),
                 created_fresh: true,
             });
         }
@@ -523,7 +543,7 @@ async fn ensure_slot(
                 // a bootstrap (same reasoning as the Some(0) path above).
                 generated_columns: Vec::new(),
                 retention_posture,
-                history: history(SlotHistory::CreatedFromAbsent),
+                history: history.observe(SlotHistory::CreatedFromAbsent),
                 created_fresh: confirmed == 0,
             });
         }
@@ -553,7 +573,7 @@ async fn ensure_slot(
         snapshot_name: Some(snapshot_name),
         generated_columns: Vec::new(),
         retention_posture,
-        history: history(SlotHistory::CreatedFromAbsent),
+        history: history.observe(SlotHistory::CreatedFromAbsent),
         created_fresh: true,
     })
 }
@@ -1446,6 +1466,49 @@ mod tests {
 
     /// The advance target is bound as `pg_lsn`, so it must round-trip through
     /// the exact textual form Postgres accepts.
+    /// Setup is retried as a whole, and an attempt that replaced the slot has
+    /// already changed the source when it fails. The attempt that follows finds an
+    /// ordinary slot, and reporting *its* view would leave the members already
+    /// attached on positions the replacement cannot reach, with nothing to rebuild
+    /// them.
+    #[test]
+    fn a_later_attempt_cannot_report_away_what_an_earlier_one_did() {
+        let latch = HistoryLatch::new();
+        assert_eq!(
+            latch.observe(SlotHistory::CreatedFromAbsent),
+            SlotHistory::CreatedFromAbsent
+        );
+        assert_eq!(
+            latch.observe(SlotHistory::Kept),
+            SlotHistory::CreatedFromAbsent,
+            "the slot this attempt found already there is the one the last attempt created"
+        );
+        assert_eq!(
+            latch.observe(SlotHistory::ReplacedInvalidated),
+            SlotHistory::ReplacedInvalidated,
+            "replacing an invalidated slot outranks creating an absent one"
+        );
+        assert_eq!(
+            latch.observe(SlotHistory::Kept),
+            SlotHistory::ReplacedInvalidated
+        );
+    }
+
+    /// A setup that changed nothing must still report what it found, or every
+    /// resume would read as a replacement and rebuild members that are owed their
+    /// changes instead (#12609).
+    #[test]
+    fn a_latch_no_attempt_wrote_reports_the_attempts_own_outcome() {
+        assert_eq!(
+            HistoryLatch::new().observe(SlotHistory::Kept),
+            SlotHistory::Kept
+        );
+        assert_eq!(
+            HistoryLatch::new().observe(SlotHistory::FastForwarded),
+            SlotHistory::FastForwarded
+        );
+    }
+
     #[test]
     fn advance_target_renders_as_a_pg_lsn_literal() {
         let target = parse_lsn("1B/4E300F8").expect("parse");

--- a/crates/data_components/src/postgres_replication/slot.rs
+++ b/crates/data_components/src/postgres_replication/slot.rs
@@ -20,6 +20,8 @@ limitations under the License.
 //! PUBLICATION` is not allowed on replication connections and the slot state
 //! queries live in normal catalog tables.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use snafu::ResultExt;
 use tokio_postgres::NoTls;
 
@@ -95,11 +97,13 @@ pub async fn setup_slot_and_publication(
     // are idempotent and slot/publication creation is guarded by `IF EXISTS`
     // checks. Fatal errors (permission denied, syntax) are propagated on the
     // first attempt.
+    // Outside the retry: see [`ensure_slot`].
+    let history_discarded = AtomicBool::new(false);
     super::resilience::retry_async(
         "postgres_replication::setup",
         super::resilience::DEFAULT_SETUP_MAX_ELAPSED,
         is_transient_setup_error,
-        || async { setup_once(params, schema_name, table_name).await },
+        || async { setup_once(params, schema_name, table_name, &history_discarded).await },
     )
     .await
 }
@@ -154,6 +158,8 @@ pub async fn setup_shared_member(
     schema_name: &str,
     table_name: &str,
 ) -> Result<SharedMemberSetup> {
+    // Outside the retry: see [`ensure_slot`].
+    let history_discarded = AtomicBool::new(false);
     super::resilience::retry_async(
         "postgres_replication::setup_shared_member",
         super::resilience::DEFAULT_SETUP_MAX_ELAPSED,
@@ -174,7 +180,7 @@ pub async fn setup_shared_member(
                 // root, which is the name members subscribe with.
                 let publication_tables =
                     list_publication_tables(&client, &params.publication_name).await?;
-                let slot = ensure_slot(&client, params).await?;
+                let slot = ensure_slot(&client, params, &history_discarded).await?;
                 let slot_restart_lsn = read_slot_restart_lsn(&client, &params.slot_name).await?;
                 Ok(SharedMemberSetup {
                     slot,
@@ -197,10 +203,11 @@ async fn setup_once(
     params: &ReplicationParams,
     schema_name: &str,
     table_name: &str,
+    history_discarded: &AtomicBool,
 ) -> Result<SlotInfo> {
     let (client, conn_task) = connect_setup(params).await?;
 
-    let outcome = do_setup(&client, params, schema_name, table_name).await;
+    let outcome = do_setup(&client, params, schema_name, table_name, history_discarded).await;
 
     drop(client);
     let _ = conn_task.await;
@@ -254,11 +261,12 @@ async fn do_setup(
     params: &ReplicationParams,
     schema_name: &str,
     table_name: &str,
+    history_discarded: &AtomicBool,
 ) -> Result<SlotInfo> {
     validate_replica_identity(client, schema_name, table_name).await?;
     let generated_columns = fetch_generated_columns(client, schema_name, table_name).await?;
     ensure_publication(client, &params.publication_name, schema_name, table_name).await?;
-    let mut slot = ensure_slot(client, params).await?;
+    let mut slot = ensure_slot(client, params, history_discarded).await?;
     slot.generated_columns = generated_columns;
     Ok(slot)
 }
@@ -355,9 +363,17 @@ async fn drop_slot_if_invalidated(
     }
 }
 
+/// `history_discarded` latches [`SlotInfo::history_discarded`] across the caller's
+/// *retries*, and is why it is a parameter rather than a local: the drop below is
+/// not undone by a later attempt failing. An attempt that retires the invalidated
+/// slot and then fails on a transient error further into setup leaves the
+/// replacement in place, so the next attempt finds an ordinary slot and would
+/// report that nothing was discarded — and the members already attached would
+/// never be rebuilt, which is the whole failure this signal exists to prevent.
 async fn ensure_slot(
     client: &tokio_postgres::Client,
     params: &ReplicationParams,
+    history_discarded: &AtomicBool,
 ) -> Result<SlotInfo> {
     // Read once, before anything branches, so every outcome below carries it and
     // the slot-creation message can name what will remove the slot it creates.
@@ -373,7 +389,10 @@ async fn ensure_slot(
     // is set on the resuming branches too — reaching one after the drop means
     // something recreated the slot underneath us, which does not give the
     // discarded history back.
-    let history_discarded = drop_slot_if_invalidated(client, &params.slot_name).await?;
+    if drop_slot_if_invalidated(client, &params.slot_name).await? {
+        history_discarded.store(true, Ordering::Release);
+    }
+    let history_discarded = history_discarded.load(Ordering::Acquire);
 
     // Distinguish three catalog states for the named slot:
     //   * None            — no slot exists; we create one and need a bootstrap.

--- a/crates/data_components/src/postgres_replication/slot.rs
+++ b/crates/data_components/src/postgres_replication/slot.rs
@@ -38,6 +38,23 @@ pub struct SlotInfo {
     pub consistent_lsn: u64,
     pub snapshot_name: Option<String>,
     pub created_fresh: bool,
+    /// Whether this call *discarded* an existing slot's history: the named slot
+    /// was found invalidated (`wal_status = 'lost'`), dropped, and the slot
+    /// described here created in its place.
+    ///
+    /// Distinct from [`Self::created_fresh`], which is also true where nothing
+    /// was thrown away — a slot created because none existed, one that exists but
+    /// has never been acknowledged, and the fast-forward for a re-bootstrap. Only
+    /// this outcome says the positions consumers recorded against the *previous*
+    /// slot can no longer be reached, so acting on `created_fresh` instead moves
+    /// floors that are still owed their changes (#12609).
+    ///
+    /// The caller owns the consequence: a shared source must rebuild every member
+    /// already attached to it before the replacement streams, because their
+    /// recorded positions predate a slot created at the current WAL position and
+    /// any row deleted in between has no change event left to carry the deletion
+    /// (#13229).
+    pub history_discarded: bool,
     /// `GENERATED` columns of the source table. Postgres does not publish
     /// generated columns over logical replication (they are absent from
     /// pgoutput `Relation` messages), so the WAL path must tolerate their
@@ -349,7 +366,14 @@ async fn ensure_slot(
     // A slot the server has invalidated still looks present to every check
     // below, so retire it first and let the rest of this function create its
     // replacement.
-    drop_slot_if_invalidated(client, &params.slot_name).await?;
+    //
+    // Whether that happened is carried on every outcome below: it is the only one
+    // of them that destroys history someone may already be streaming against, and
+    // the caller has to rebuild those consumers before the replacement streams. It
+    // is set on the resuming branches too — reaching one after the drop means
+    // something recreated the slot underneath us, which does not give the
+    // discarded history back.
+    let history_discarded = drop_slot_if_invalidated(client, &params.slot_name).await?;
 
     // Distinguish three catalog states for the named slot:
     //   * None            — no slot exists; we create one and need a bootstrap.
@@ -376,6 +400,7 @@ async fn ensure_slot(
                     snapshot_name: None,
                     generated_columns: Vec::new(),
                     retention_posture,
+                    history_discarded,
                     // The old history is gone, so this slot carries none for any
                     // member -- the same contract as a slot created this process.
                     created_fresh: true,
@@ -395,6 +420,7 @@ async fn ensure_slot(
                 snapshot_name: None,
                 generated_columns: Vec::new(),
                 retention_posture,
+                history_discarded,
                 created_fresh: false,
             });
         }
@@ -413,6 +439,7 @@ async fn ensure_slot(
                 snapshot_name: None,
                 generated_columns: Vec::new(),
                 retention_posture,
+                history_discarded,
                 created_fresh: true,
             });
         }
@@ -444,6 +471,7 @@ async fn ensure_slot(
                 // a bootstrap (same reasoning as the Some(0) path above).
                 generated_columns: Vec::new(),
                 retention_posture,
+                history_discarded,
                 created_fresh: confirmed == 0,
             });
         }
@@ -473,6 +501,7 @@ async fn ensure_slot(
         snapshot_name: Some(snapshot_name),
         generated_columns: Vec::new(),
         retention_posture,
+        history_discarded,
         created_fresh: true,
     })
 }

--- a/crates/data_components/src/postgres_replication/slot.rs
+++ b/crates/data_components/src/postgres_replication/slot.rs
@@ -32,6 +32,36 @@ use super::{
     retention::{self, SlotRemoval, SlotRetentionPosture},
 };
 
+/// What a setup call did to the slot's history — see [`SlotInfo::history`].
+///
+/// The caller owns the consequence, because only it knows whether anyone holds a
+/// position against the slot that was there before: a shared source must rebuild
+/// every member already attached to it before a replacement streams, since their
+/// recorded positions predate a slot created at the current WAL position and any
+/// row deleted in between has no change event left to carry the deletion (#13229).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SlotHistory {
+    /// The named slot was already there and keeps whatever history it had. Covers
+    /// a resume from its `confirmed_flush_lsn` and a slot the catalog has not
+    /// published one for yet — the latter has nothing to lose, having never
+    /// acknowledged anything.
+    Kept,
+    /// The named slot was found invalidated (`wal_status = 'lost'`), dropped, and
+    /// the slot described here created in its place. Every position measured
+    /// against the old one is unreachable.
+    ReplacedInvalidated,
+    /// No slot existed under that name, so this call created one — either itself or,
+    /// on a lost creation race, whichever consumer won. Whether that discards
+    /// anything is the caller's to decide: for a source whose first member is
+    /// arriving there was no history to begin with, while one with members already
+    /// attached has just had the slot they were streaming from replaced.
+    CreatedFromAbsent,
+    /// The named slot was fast-forwarded past its backlog for a re-bootstrap, which
+    /// discards its history for every member (see
+    /// [`advance_slot_for_rebootstrap`]).
+    FastForwarded,
+}
+
 /// Info about a slot after `setup_slot_and_publication` returns.
 #[derive(Clone, Debug)]
 pub struct SlotInfo {
@@ -40,23 +70,13 @@ pub struct SlotInfo {
     pub consistent_lsn: u64,
     pub snapshot_name: Option<String>,
     pub created_fresh: bool,
-    /// Whether this call *discarded* an existing slot's history: the named slot
-    /// was found invalidated (`wal_status = 'lost'`), dropped, and the slot
-    /// described here created in its place.
+    /// What this call did to the history a consumer may hold a position against.
     ///
-    /// Distinct from [`Self::created_fresh`], which is also true where nothing
-    /// was thrown away — a slot created because none existed, one that exists but
-    /// has never been acknowledged, and the fast-forward for a re-bootstrap. Only
-    /// this outcome says the positions consumers recorded against the *previous*
-    /// slot can no longer be reached, so acting on `created_fresh` instead moves
+    /// Reported instead of inferred from [`Self::created_fresh`], which does not
+    /// separate the cases: that is true both where an existing slot's history was
+    /// thrown away and where there was none to throw away, and acting on it moves
     /// floors that are still owed their changes (#12609).
-    ///
-    /// The caller owns the consequence: a shared source must rebuild every member
-    /// already attached to it before the replacement streams, because their
-    /// recorded positions predate a slot created at the current WAL position and
-    /// any row deleted in between has no change event left to carry the deletion
-    /// (#13229).
-    pub history_discarded: bool,
+    pub history: SlotHistory,
     /// `GENERATED` columns of the source table. Postgres does not publish
     /// generated columns over logical replication (they are absent from
     /// pgoutput `Relation` messages), so the WAL path must tolerate their
@@ -98,12 +118,12 @@ pub async fn setup_slot_and_publication(
     // checks. Fatal errors (permission denied, syntax) are propagated on the
     // first attempt.
     // Outside the retry: see [`ensure_slot`].
-    let history_discarded = AtomicBool::new(false);
+    let replaced_invalidated = AtomicBool::new(false);
     super::resilience::retry_async(
         "postgres_replication::setup",
         super::resilience::DEFAULT_SETUP_MAX_ELAPSED,
         is_transient_setup_error,
-        || async { setup_once(params, schema_name, table_name, &history_discarded).await },
+        || async { setup_once(params, schema_name, table_name, &replaced_invalidated).await },
     )
     .await
 }
@@ -159,7 +179,7 @@ pub async fn setup_shared_member(
     table_name: &str,
 ) -> Result<SharedMemberSetup> {
     // Outside the retry: see [`ensure_slot`].
-    let history_discarded = AtomicBool::new(false);
+    let replaced_invalidated = AtomicBool::new(false);
     super::resilience::retry_async(
         "postgres_replication::setup_shared_member",
         super::resilience::DEFAULT_SETUP_MAX_ELAPSED,
@@ -180,7 +200,7 @@ pub async fn setup_shared_member(
                 // root, which is the name members subscribe with.
                 let publication_tables =
                     list_publication_tables(&client, &params.publication_name).await?;
-                let slot = ensure_slot(&client, params, &history_discarded).await?;
+                let slot = ensure_slot(&client, params, &replaced_invalidated).await?;
                 let slot_restart_lsn = read_slot_restart_lsn(&client, &params.slot_name).await?;
                 Ok(SharedMemberSetup {
                     slot,
@@ -203,11 +223,18 @@ async fn setup_once(
     params: &ReplicationParams,
     schema_name: &str,
     table_name: &str,
-    history_discarded: &AtomicBool,
+    replaced_invalidated: &AtomicBool,
 ) -> Result<SlotInfo> {
     let (client, conn_task) = connect_setup(params).await?;
 
-    let outcome = do_setup(&client, params, schema_name, table_name, history_discarded).await;
+    let outcome = do_setup(
+        &client,
+        params,
+        schema_name,
+        table_name,
+        replaced_invalidated,
+    )
+    .await;
 
     drop(client);
     let _ = conn_task.await;
@@ -261,12 +288,12 @@ async fn do_setup(
     params: &ReplicationParams,
     schema_name: &str,
     table_name: &str,
-    history_discarded: &AtomicBool,
+    replaced_invalidated: &AtomicBool,
 ) -> Result<SlotInfo> {
     validate_replica_identity(client, schema_name, table_name).await?;
     let generated_columns = fetch_generated_columns(client, schema_name, table_name).await?;
     ensure_publication(client, &params.publication_name, schema_name, table_name).await?;
-    let mut slot = ensure_slot(client, params, history_discarded).await?;
+    let mut slot = ensure_slot(client, params, replaced_invalidated).await?;
     slot.generated_columns = generated_columns;
     Ok(slot)
 }
@@ -363,17 +390,17 @@ async fn drop_slot_if_invalidated(
     }
 }
 
-/// `history_discarded` latches [`SlotInfo::history_discarded`] across the caller's
-/// *retries*, and is why it is a parameter rather than a local: the drop below is
-/// not undone by a later attempt failing. An attempt that retires the invalidated
-/// slot and then fails on a transient error further into setup leaves the
-/// replacement in place, so the next attempt finds an ordinary slot and would
-/// report that nothing was discarded — and the members already attached would
-/// never be rebuilt, which is the whole failure this signal exists to prevent.
+/// `replaced_invalidated` latches [`SlotHistory::ReplacedInvalidated`] across the
+/// caller's *retries*, and is why it is a parameter rather than a local: the drop
+/// below is not undone by a later attempt failing. An attempt that retires the
+/// invalidated slot and then fails on a transient error further into setup leaves
+/// the replacement in place, so the next attempt finds an ordinary slot and would
+/// report that nothing was discarded — and the members already attached would never
+/// be rebuilt, which is the whole failure this signal exists to prevent.
 async fn ensure_slot(
     client: &tokio_postgres::Client,
     params: &ReplicationParams,
-    history_discarded: &AtomicBool,
+    replaced_invalidated: &AtomicBool,
 ) -> Result<SlotInfo> {
     // Read once, before anything branches, so every outcome below carries it and
     // the slot-creation message can name what will remove the slot it creates.
@@ -383,14 +410,22 @@ async fn ensure_slot(
     // below, so retire it first and let the rest of this function create its
     // replacement.
     //
-    // Carried on every outcome below, including the resuming branches: reaching one
-    // of those after the drop means something recreated the slot underneath us,
-    // which does not give the discarded history back. See
-    // [`SlotInfo::history_discarded`] for what the caller owes on it.
+    // Outranks every other outcome below, including the resuming branches: reaching
+    // one of those after the drop means something recreated the slot underneath us,
+    // which does not give the discarded history back.
     if drop_slot_if_invalidated(client, &params.slot_name).await? {
-        history_discarded.store(true, Ordering::Release);
+        replaced_invalidated.store(true, Ordering::Release);
     }
-    let history_discarded = history_discarded.load(Ordering::Acquire);
+    let replaced_invalidated = replaced_invalidated.load(Ordering::Acquire);
+    // Classify a branch's own outcome, deferring to the drop above when there was
+    // one.
+    let history = |own: SlotHistory| {
+        if replaced_invalidated {
+            SlotHistory::ReplacedInvalidated
+        } else {
+            own
+        }
+    };
 
     // Distinguish three catalog states for the named slot:
     //   * None            — no slot exists; we create one and need a bootstrap.
@@ -417,7 +452,7 @@ async fn ensure_slot(
                     snapshot_name: None,
                     generated_columns: Vec::new(),
                     retention_posture,
-                    history_discarded,
+                    history: history(SlotHistory::FastForwarded),
                     // The old history is gone, so this slot carries none for any
                     // member -- the same contract as a slot created this process.
                     created_fresh: true,
@@ -437,7 +472,7 @@ async fn ensure_slot(
                 snapshot_name: None,
                 generated_columns: Vec::new(),
                 retention_posture,
-                history_discarded,
+                history: history(SlotHistory::Kept),
                 created_fresh: false,
             });
         }
@@ -456,7 +491,7 @@ async fn ensure_slot(
                 snapshot_name: None,
                 generated_columns: Vec::new(),
                 retention_posture,
-                history_discarded,
+                history: history(SlotHistory::Kept),
                 created_fresh: true,
             });
         }
@@ -488,7 +523,7 @@ async fn ensure_slot(
                 // a bootstrap (same reasoning as the Some(0) path above).
                 generated_columns: Vec::new(),
                 retention_posture,
-                history_discarded,
+                history: history(SlotHistory::CreatedFromAbsent),
                 created_fresh: confirmed == 0,
             });
         }
@@ -518,7 +553,7 @@ async fn ensure_slot(
         snapshot_name: Some(snapshot_name),
         generated_columns: Vec::new(),
         retention_posture,
-        history_discarded,
+        history: history(SlotHistory::CreatedFromAbsent),
         created_fresh: true,
     })
 }


### PR DESCRIPTION
## 📝 Summary

Two code paths can replace a `PostgreSQL` logical replication slot, and only one of them tells the datasets already streaming from it that their recorded positions no longer reach it.

`slot::ensure_slot` — reached from `attach_member` when a dataset **joins** — drops a slot the server has invalidated (`wal_status = 'lost'`, from an exhausted `max_slot_wal_keep_size` or a `PostgreSQL` 18 idle-timeout) and creates a replacement at the current WAL position. Members already attached to the old slot are not told, so the pump's next connect succeeds against the replacement and streams on as though the history were still there: each already-attached member resumes from its own recorded position, which a slot created at the current WAL position cannot reach. Any row deleted at the source in between has no change event left to carry the deletion, so it survives in the acceleration and in every later query.

The pump's own recovery from a refused stream already did the right thing — replace, then ask every attached member to rebuild and hold it until that rebuild is durable. This makes the join path do the same, through one function the two now share.

## Changes

- **The setup reports what it did to the slot's history** (`SlotInfo::history`: `Kept`, `ReplacedInvalidated`, `CreatedFromAbsent`, `FastForwarded`) instead of the caller inferring it from `created_fresh`. `created_fresh` does not separate the cases — it is true both where an existing slot's history was thrown away and where there was none to throw away — and acting on it moves floors that are still owed their changes (#12609).
- **A slot created because none existed is a replacement too, when this source already has members.** An operator dropping the slot while the pump is between connections — the only time `PostgreSQL` permits it — reaches the same end state as an invalidated one, and the members streaming from what is now gone are owed the same rebuild. Whether it counts is the caller's decision, because only the source knows whether anyone was streaming.
- **The outcome is latched across setup's retries** (`HistoryLatch`). Setup is retried as a whole, and an attempt that drops or creates a slot has already changed the source when it fails; the next attempt would find an ordinary slot and report `Kept`.
- **`install_replacement_slot`** — the pump's recovery body, now shared with the join path: seed the shared flush at the replacement's start, ask every attached member to rebuild and hold it until that rebuild commits, and reseat the floors held for published tables whose datasets have not joined. Every member is now held *before* any request is enqueued, without an await in between: the send can park on a full mailbox and the pump reconnects without taking `setup_lock`, so holding as each member's turn came would leave the rest promotable and creditable for the length of that park.
- **`SharedSource::slot_generation`, so one replacement is not acted on twice.** The pump latches a refusal against the slot epoch its connection was streaming and acts on it after its reconnect backoff — the window in which a join can replace that slot. `recover_unusable_slot` compares the generation under the setup lock and skips a refusal whose slot is already gone; without it the pump would drop a healthy slot and leave every member holding two rebuild requests against one `rebuild_pending` flag, where the first to commit releases the hold the second still needs. The generation is published only after the fan-out completes, so an adoption that does not finish does not read as one that did.

## Test plan

- `make lint`
- `make nextest`
- New in-process tests:
  - `a_join_that_replaced_the_slot_rebuilds_the_members_already_attached` — one rebuild request per attached member, each still held across the pump's next promote, each keeping its own floor, and the unjoined table's held floor reseated to the replacement's start.
  - `a_join_on_a_slot_that_kept_its_history_leaves_attached_members_alone` — the #12609 direction, identical to the above but for the history signal.
  - `a_join_that_created_a_slot_under_members_already_attached_rebuilds_them` and `the_first_member_to_create_a_slot_replaces_nothing` — the two sides of the `CreatedFromAbsent` rule.
  - `a_refusal_of_an_already_replaced_slot_does_not_replace_it_again` — the generation guard.
  - `a_later_attempt_cannot_report_away_what_an_earlier_one_did` and `a_latch_no_attempt_wrote_reports_the_attempts_own_outcome` — the retry latch.
- Each was checked against a neuter matrix — removing the join-path rebuild, keying it on `created_fresh`, dropping `reseat_held_floors`, dropping the member hold, removing the generation guard, and forcing the `CreatedFromAbsent` rule to each constant — every neuter fails at least one test, and every test is failed by at least one neuter.

**Not included, and why.** The two-dataset integration test in the issue's Done-Done needs the `crates/runtime/tests/postgres` Docker harness, which is unavailable in the environment this was written in; it is filed as #13306 rather than shipped unverified. `FastForwarded` discards history for every member in the same way, and the issue excludes it from this signal because keying on it regressed two held-floor tests that also need Docker — #13305. Two residuals the review below surfaced are filed rather than grown into this PR: #13312 (a replacement discovered by a join that then fails or is cancelled is forgotten) and #13311 (the rebuild hold is one flag, so the first of two overlapping rebuilds releases the second's).

## Review gate

- Adversarial review: `codex` — job `review-mt0p1ohg-v533hy` — run four times as the diff changed; 12 findings across the runs. Acted on in this PR: the retry losing the discard signal, a stale refusal replacing the replacement, the `CreatedFromAbsent` path, the retry losing *that* outcome too, the fan-out holding members one at a time, and a refusal tagged at dequeue rather than at connect. Filed rather than grown into this PR: #13312, #13311, #13305. The final run still returns `needs-attention` on exactly those three filed residuals.
- `/security-review`: no findings — the diff adds no input, route, credential, or log surface; the only SQL it touches is the existing parameterized slot-catalog statements.
- `/simplify`: applied — four findings fixed (a doc comment stranded onto the wrong function by an insertion, `adopt_*` naming that collided with this module's schema-evolution vocabulary, a doc narrating prior behavior, and rationale duplicated across four comment blocks), light checks and the neuter matrix re-run green afterward.

## 🔗 Related

Fixes #13229

Follow-ups filed from this work: #13305, #13306, #13311, #13312.

## 👀 Notes for Reviewers

The signal is deliberately reported rather than inferred, because the issue's second requirement is that it must not overlap `created_fresh` — and the `CreatedFromAbsent` case shows why the decision has to be split between the two files: only `ensure_slot` knows what it did to the slot, and only the source knows whether anyone was streaming from what it replaced.