### PR TITLE
fix(benchmarks): open snapshot-update PRs against the dispatch branch, not always trunk

### DIFF
--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -634,8 +634,14 @@ jobs:
           **Profile:** \`${{ github.event.inputs.profile_option || 'release' }}\`
           EOF
           )
-              gh pr create --title "fix: Update ${{ github.event.inputs.query_set }} benchmark snapshots for ${{ github.event.inputs.spicepod_path }}" --body "${BODY}" --base trunk --head ${BRANCH_NAME} --label kind/bug
-              gh pr merge --squash --auto ${BRANCH_NAME}
+              # Target the branch the run was dispatched on
+              gh pr create --title "fix: Update ${{ github.event.inputs.query_set }} benchmark snapshots for ${{ github.event.inputs.spicepod_path }}" --body "${BODY}" --base "${{ github.ref_name }}" --head ${BRANCH_NAME} --label kind/bug
+              # Auto-merge only into trunk: on an unprotected feature branch
+              # --auto merges immediately, before the branch owner can review
+              # the snapshots.
+              if [ "${{ github.ref_name }}" = "trunk" ]; then
+                gh pr merge --squash --auto ${BRANCH_NAME}
+              fi
             fi
           fi
         env:


### PR DESCRIPTION
The benchmark workflow's automated snapshot-update PRs were always opened against `trunk`, even when the workflow was dispatched from another branch. Since the snapshot branch is cut from the dispatch ref, such PRs also dragged that branch's commits into the diff.

The PR is now opened against the branch the run was dispatched on, matching what `testoperator_run_schema.yml` and `testoperator_run_cluster_bench.yml` already do. Auto-merge is enabled only when the base is `trunk`, so snapshots landing on a feature branch wait for the branch owner's review.