### PR TITLE
Make tpcds q65/q71 deterministic

### DIFF
--- a/crates/test-framework/src/queries/tpcds/q65.sql
+++ b/crates/test-framework/src/queries/tpcds/q65.sql
@@ -24,4 +24,4 @@ select
        i_item_sk = sc.ss_item_sk
  order by s_store_name, i_item_desc,
           revenue desc --added to make results deterministic
- LIMIT 10;
+ LIMIT 100;

--- a/crates/test-framework/src/queries/tpcds/q65.sql
+++ b/crates/test-framework/src/queries/tpcds/q65.sql
@@ -22,5 +22,6 @@ select
        sc.revenue <= 0.1 * sb.ave and
        s_store_sk = sc.ss_store_sk and
        i_item_sk = sc.ss_item_sk
- order by s_store_name, i_item_desc
- LIMIT 100;
+ order by s_store_name, i_item_desc,
+          revenue desc --added to make results deterministic
+ LIMIT 10;

--- a/crates/test-framework/src/queries/tpcds/q71.sql
+++ b/crates/test-framework/src/queries/tpcds/q71.sql
@@ -32,7 +32,6 @@ select i_brand_id brand_id, i_brand brand,t_hour,t_minute,
    and i_manager_id=1
    and time_sk = t_time_sk
    and (t_meal_time = 'breakfast' or t_meal_time = 'dinner')
-   and ext_price is null
  group by i_brand, i_brand_id,t_hour,t_minute
  order by ext_price desc, i_brand_id,
       t_hour desc, t_minute desc -- added to make results deterministic

--- a/crates/test-framework/src/queries/tpcds/q71.sql
+++ b/crates/test-framework/src/queries/tpcds/q71.sql
@@ -32,6 +32,8 @@ select i_brand_id brand_id, i_brand brand,t_hour,t_minute,
    and i_manager_id=1
    and time_sk = t_time_sk
    and (t_meal_time = 'breakfast' or t_meal_time = 'dinner')
+   and ext_price is null
  group by i_brand, i_brand_id,t_hour,t_minute
- order by ext_price desc, i_brand_id
- ;
+ order by ext_price desc, i_brand_id,
+      t_hour desc, t_minute desc -- added to make results deterministic
+ limit 10;

--- a/crates/test-framework/src/queries/tpcds/q71.sql
+++ b/crates/test-framework/src/queries/tpcds/q71.sql
@@ -35,4 +35,4 @@ select i_brand_id brand_id, i_brand brand,t_hour,t_minute,
  group by i_brand, i_brand_id,t_hour,t_minute
  order by ext_price desc, i_brand_id,
       t_hour desc, t_minute desc -- added to make results deterministic
- limit 10;
+ ;


### PR DESCRIPTION
## 📝 Summary

Add more ordering to tpcds queries 65/71 to make the results deterministic