### PR TITLE
chore(deps): bump datafusion-table-providers for NUMERIC scale fidelity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,7 +4146,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7126,7 +7126,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=3c40145d671792f3974bc95af5587b699c86c86c#3c40145d671792f3974bc95af5587b699c86c86c"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=f2dad23247908d284a226cbb294ef7c3c08b16f1#f2dad23247908d284a226cbb294ef7c3c08b16f1"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -9037,8 +9037,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -10206,7 +10206,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -14918,7 +14918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6705a26ad89d241a989a5395641931ba37076f5ab5fbd19ee92402414a43af32"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
+ "hashbrown 0.5.0",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -15395,7 +15395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -15416,7 +15416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -18850,7 +18850,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -24178,7 +24178,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "3c40145d671792f3974bc95af5587b699c86c86c" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "f2dad23247908d284a226cbb294ef7c3c08b16f1" } # spiceai-54
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",


### PR DESCRIPTION
Picks up [spiceai/datafusion-table-providers#53](https://github.com/spiceai/datafusion-table-providers/pull/53), which is the only commit between the pinned rev (`3c40145`) and this one (`f2dad23`).

A PostgreSQL `NUMERIC` column read through the connector could come back holding a different number, with no error. Four defects, each verified against a live PostgreSQL and each covered by a test that fails without its fix:

| | before |
| --- | --- |
| Unconstrained `NUMERIC` took its scale from whichever row the schema sampled (`SELECT * FROM t LIMIT 1`) | a NULL there carries no scale, so the column was read as `Decimal128(38, 0)` and every value lost its fraction |
| Scaling ran through `Decimal::rescale`, whose 96-bit coefficient silently stops short of the requested scale | `1000000000` read back as `100000000`; an 18-digit value nine orders of magnitude out |
| A coefficient fitting `i128` but not the column precision was appended anyway | an array contradicting its own type — Arrow does not validate on `finish()` |
| A negative scale (PostgreSQL allows one; the catalog carries it as a signed `i8`) was read as `0` | the whole coefficient landed in the column, a thousandfold out |

The second is the widest: the catalog maps an unconstrained `NUMERIC` to `Decimal128(38, 20)`, so `rescale(20)` ran on the ordinary query path, not just the schema-less one.

## Verification

- `cargo check` green for `data_components`, `runtime-checkpoint-postgres`, `db_connection_pool` on the new rev.
- Upstream: PostgreSQL integration suite 15/15 against a live container, clippy and fmt clean, and every new test confirmed to fail with only its fix reverted.
- Lockfile moves one package; 398 dependencies unchanged.