### PR TITLE
feat(cloud-connect): export metrics every 10s

### DIFF
--- a/crates/runtime-cloud-connect/src/config.rs
+++ b/crates/runtime-cloud-connect/src/config.rs
@@ -82,9 +82,9 @@ pub const DEFAULT_TELEMETRY_INTERVAL: Duration = Duration::from_mins(1);
 
 /// Default cadence for `ExportMetrics` frames on an established stream.
 ///
-/// Matches the heartbeat cadence: the payload carries cumulative totals, so the
-/// interval sets chart resolution rather than what is or is not recorded.
-pub const DEFAULT_METRICS_INTERVAL: Duration = Duration::from_secs(30);
+/// The payload carries cumulative totals, so the interval sets chart resolution
+/// rather than what is or is not recorded.
+pub const DEFAULT_METRICS_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Default ceiling on a single `ExecuteQuery`.
 ///


### PR DESCRIPTION
Takes the default Cloud Connect `ExportMetrics` cadence from 30s to 10s, so metrics charted from the control stream resolve at 10s.

## Operational consequence

`ExportMetrics` frames go from **2/min to 6/min per enrolled instance** — a 3x increase in that frame's volume on the control stream. The payload is a fixed-size snapshot of cumulative totals, so this changes **chart resolution, not what is recorded**: no counter is reset by an export, and nothing is lost between exports. A dropped export costs one data point, not data — which is why the export task already offers its message and moves on rather than waiting for room behind a heartbeat.

The `Heartbeat` (30s) and `Telemetry` (1 min) cadences are unchanged, so the liveness contract this feature is judged on is untouched. That asymmetry is deliberate: metrics is the only one of the three whose payload is *cumulative*, so it is the only cadence where a finer interval buys resolution without changing semantics. A faster heartbeat would change what the control plane reads as an instance going away, and telemetry is not a series anyone charts at this granularity.

## Why this is the whole change

`DEFAULT_METRICS_INTERVAL` has exactly one production consumer — `CloudConnectConfig::from_env_at` — which feeds `client.rs`'s `ExportMetrics` ticker. Nothing on the control-plane side overrides `metrics_interval`, so the client default is the entire cadence. Every other `metrics_interval: Duration::from_secs(30)` in the crate is inside a `#[cfg(test)]` module or an integration test that constructs the config explicitly, and no test asserts the default's value, so none of them shift with this change.

The constant's doc comment described the cadence as matching the heartbeat's, which stops being true here. It now states only the cumulative-totals property — the reason the interval is a free choice.

## Verification

Every command below was run verbatim and exited 0.

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo check -p runtime-cloud-connect --all-targets --profile dev` | clean |
| `CLIPPY_CONF_DIR=".ci" cargo clippy --profile dev --keep-going -p runtime-cloud-connect -- -Dwarnings -Dclippy::pedantic -Dclippy::unwrap_used -Dclippy::expect_used -Dclippy::clone_on_ref_ptr …` | clean |
| `cargo clippy --profile dev --keep-going --tests -p runtime-cloud-connect -- -Dwarnings -Dclippy::pedantic …` | clean |
| `cargo test -p runtime-cloud-connect --profile dev` | **350 passed, 0 failed** |

Both clippy invocations carry the full lint set from the `lint-rust` Makefile target, including the second `--tests` pass and `CLIPPY_CONF_DIR=".ci"`. `runtime-cloud-connect` declares no `[features]`, so its workspace-resolved feature set is empty.

Test counts per target: 298 lib, 9 `contract`, 6 `enrollment_flow`, 37 `standalone_enrollment_e2e`, 0 doc-tests.

The full workspace gate runs under sign-off; `Attestation` is not fast-tracked here, since the changed path is a `.rs` file.
