### PR TITLE
fix(cli): attribute a project listing to the org it was requested for

### DIFF
--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -271,25 +271,35 @@ impl CloudClient {
     /// is also where a "wrong org" mistake is caught: an app that exists under a
     /// different org produces a switch hint rather than a bare "not found".
     pub async fn get_project(&self, target: &ProjectTarget) -> Result<Project> {
-        let project_id = self.resolve_id(target).await?;
+        let (project_id, listing_org) = self.resolve_id_and_org(target).await?;
         let project = self.get_project_by_id(project_id).await?;
-        Ok(self.attribute(project, target.org.as_deref()))
+        Ok(self.attribute(project, listing_org.as_deref()))
     }
 
-    /// Stamp the org a project was addressed by onto a payload that omits it.
+    /// Stamp the org a project belongs to onto a payload that omits it.
     ///
-    /// Spice Cloud returns no `org` on a project, so a command that resolved
-    /// `<org>/<project>` would otherwise print a bare name and serialize
-    /// `"org": ""` for the very project whose org it just used to find it.
-    fn attribute(&self, mut project: Project, target_org: Option<&str>) -> Project {
+    /// Spice Cloud returns no `org` on a project, so a command would otherwise
+    /// print a bare name and serialize `"org": ""` for the very project whose
+    /// org it just used to find it — while `spice cloud projects`, run against
+    /// the same credential, named the org for that same project.
+    fn attribute(&self, mut project: Project, org: Option<&str>) -> Project {
         if project.org.is_empty()
-            && let Some(org) = target_org
-                .or(self.org.as_deref())
-                .filter(|org| !org.is_empty())
+            && let Some(org) = org.or(self.org.as_deref()).filter(|org| !org.is_empty())
         {
             project.org = org.to_string();
         }
         project
+    }
+
+    /// The org whose projects this credential sees when no command named one.
+    ///
+    /// `None` for a service-account token, which has no user identity to ask.
+    async fn credential_org(&self) -> Result<Option<String>> {
+        Ok(self
+            .optional_user_auth_context()
+            .await?
+            .map(|context| context.org_name)
+            .filter(|org| !org.is_empty()))
     }
 
     /// Resolve a target to its numeric id without fetching the full project.
@@ -298,13 +308,25 @@ impl CloudClient {
     /// whole project for that costs a round trip per call, and the id cannot
     /// change for the life of a command.
     pub async fn resolve_id(&self, target: &ProjectTarget) -> Result<i64> {
+        Ok(self.resolve_id_and_org(target).await?.0)
+    }
+
+    /// Resolve a target to its id and to the org of the listing that resolved
+    /// it, so a caller can attribute a payload Spice Cloud returns without one.
+    ///
+    /// The org is a by-product of the resolution rather than a second lookup:
+    /// discarding it here is what left the default path unable to name an org
+    /// it had already been told.
+    async fn resolve_id_and_org(&self, target: &ProjectTarget) -> Result<(i64, Option<String>)> {
         // A listing this client asked an organization for describes that
         // organization, so the identity is not worth a round trip: it would
         // answer with the org the credential is bound to, and every project
         // would be attributed to it.
         if let Some(org) = self.org.as_deref() {
             let projects = self.list_projects().await?;
-            return resolve_project_id(&projects, target, resolve_listing_org(Some(org), None));
+            let listing_org = resolve_listing_org(Some(org), None);
+            let id = resolve_project_id(&projects, target, listing_org)?;
+            return Ok((id, listing_org.map(ToString::to_string)));
         }
 
         // Nothing named an organization, so the listing is the credential's
@@ -312,7 +334,9 @@ impl CloudClient {
         let (context, projects) =
             tokio::try_join!(self.optional_user_auth_context(), self.list_projects())?;
         let credential_org = context.as_ref().map(|c| c.org_name.as_str());
-        resolve_project_id(&projects, target, resolve_listing_org(None, credential_org))
+        let listing_org = resolve_listing_org(None, credential_org);
+        let id = resolve_project_id(&projects, target, listing_org)?;
+        Ok((id, listing_org.map(ToString::to_string)))
     }
 
     /// List deployments for an already-resolved project.
@@ -396,7 +420,17 @@ impl CloudClient {
             .create_project(&request)
             .await
             .map_err(|error| self.err(error))?;
-        Ok(self.attribute(project, None))
+
+        // Spice Cloud creates the project in the org this client acts on, so
+        // that org is its org. There is no listing here to learn it from, so
+        // when the command named none it is worth asking the identity for the
+        // credential's own — a create is a one-off, and the alternative is a
+        // `--output json` payload that cannot say where the project now lives.
+        let created_in = match self.org {
+            Some(_) => None,
+            None => self.credential_org().await?,
+        };
+        Ok(self.attribute(project, created_in.as_deref()))
     }
 
     pub async fn update_project(
@@ -431,7 +465,10 @@ impl CloudClient {
             .update_project(app.id, &request)
             .await
             .map_err(|error| self.err(error))?;
-        Ok(self.attribute(project, target.org.as_deref()))
+        // The project this update just read is the same one, already attributed
+        // by the resolution above, so the update response costs no extra lookup
+        // to name.
+        Ok(self.attribute(project, Some(app.org.as_str())))
     }
 
     pub async fn delete_project(&self, target: &ProjectTarget) -> Result<()> {
@@ -1404,6 +1441,45 @@ mod tests {
             rendered.contains("'spicehq'") && rendered.contains("login token --org spicehq"),
             "the error must name the org and how to authenticate for it: {rendered}"
         );
+    }
+
+    /// A client that names no org, as `spice cloud project get <name>` builds.
+    fn client_without_an_org() -> CloudClient {
+        CloudClient::with_token_for_org_at("token", None, "https://api.spice.ai")
+            .expect("cloud client should build")
+    }
+
+    #[test]
+    fn a_payload_is_attributed_to_the_org_that_resolved_it() {
+        // Regression for the default path: with no `--org` and no active org,
+        // both the target and the client name no org, and the org the
+        // resolution had already learned from the identity was discarded — so
+        // `project get <name>` printed a bare name and serialized `"org": ""`
+        // for a project `spice cloud projects`, on the same credential, had
+        // just listed as `<org>/<name>`.
+        let attributed =
+            client_without_an_org().attribute(test_app(812, "docs", ""), Some("lukekim"));
+
+        assert_eq!(attributed.org, "lukekim");
+        assert_eq!(attributed.full_name(), "lukekim/docs");
+    }
+
+    #[test]
+    fn attribution_never_overrides_an_org_the_payload_carries() {
+        let attributed =
+            client_without_an_org().attribute(test_app(1, "docs", "spiceai"), Some("lukekim"));
+
+        assert_eq!(attributed.org, "spiceai");
+    }
+
+    #[test]
+    fn attribution_is_absent_rather_than_guessed_when_no_org_is_known() {
+        // A service-account credential has no user identity, so nothing can
+        // name an org — a bare name is the honest answer, not a made-up one.
+        let attributed = client_without_an_org().attribute(test_app(1, "docs", ""), None);
+
+        assert_eq!(attributed.org, "");
+        assert_eq!(attributed.full_name(), "docs");
     }
 
     #[test]

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -414,22 +414,25 @@ impl CloudClient {
         visibility: &str,
         placement: CreateProjectPlacement,
     ) -> Result<Project> {
+        // Spice Cloud creates the project in the org this client acts on, so
+        // that org is its org. There is no listing here to learn it from, so
+        // when the command named none, ask the identity for the credential's
+        // own — and ask *before* the create, so that a failed lookup stays
+        // side-effect free instead of reporting a project that now exists as a
+        // failure and sending the caller into a duplicate retry. The org is a
+        // label on the answer rather than part of it, so a lookup that fails
+        // anyway leaves the project unattributed rather than uncreated.
+        let created_in = match self.org {
+            Some(_) => None,
+            None => self.credential_org().await.ok().flatten(),
+        };
+
         let request = build_create_project_request(name, description, visibility, placement);
         let project = self
             .inner
             .create_project(&request)
             .await
             .map_err(|error| self.err(error))?;
-
-        // Spice Cloud creates the project in the org this client acts on, so
-        // that org is its org. There is no listing here to learn it from, so
-        // when the command named none it is worth asking the identity for the
-        // credential's own — a create is a one-off, and the alternative is a
-        // `--output json` payload that cannot say where the project now lives.
-        let created_in = match self.org {
-            Some(_) => None,
-            None => self.credential_org().await?,
-        };
         Ok(self.attribute(project, created_in.as_deref()))
     }
 

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -272,7 +272,24 @@ impl CloudClient {
     /// different org produces a switch hint rather than a bare "not found".
     pub async fn get_project(&self, target: &ProjectTarget) -> Result<Project> {
         let project_id = self.resolve_id(target).await?;
-        self.get_project_by_id(project_id).await
+        let project = self.get_project_by_id(project_id).await?;
+        Ok(self.attribute(project, target.org.as_deref()))
+    }
+
+    /// Stamp the org a project was addressed by onto a payload that omits it.
+    ///
+    /// Spice Cloud returns no `org` on a project, so a command that resolved
+    /// `<org>/<project>` would otherwise print a bare name and serialize
+    /// `"org": ""` for the very project whose org it just used to find it.
+    fn attribute(&self, mut project: Project, target_org: Option<&str>) -> Project {
+        if project.org.is_empty()
+            && let Some(org) = target_org
+                .or(self.org.as_deref())
+                .filter(|org| !org.is_empty())
+        {
+            project.org = org.to_string();
+        }
+        project
     }
 
     /// Resolve a target to its numeric id without fetching the full project.
@@ -281,11 +298,21 @@ impl CloudClient {
     /// whole project for that costs a round trip per call, and the id cannot
     /// change for the life of a command.
     pub async fn resolve_id(&self, target: &ProjectTarget) -> Result<i64> {
-        // The listing and the identity are independent; overlap them.
+        // A listing this client asked an organization for describes that
+        // organization, so the identity is not worth a round trip: it would
+        // answer with the org the credential is bound to, and every project
+        // would be attributed to it.
+        if let Some(org) = self.org.as_deref() {
+            let projects = self.list_projects().await?;
+            return resolve_project_id(&projects, target, resolve_listing_org(Some(org), None));
+        }
+
+        // Nothing named an organization, so the listing is the credential's
+        // own. The listing and the identity are independent; overlap them.
         let (context, projects) =
             tokio::try_join!(self.optional_user_auth_context(), self.list_projects())?;
-        let context_org = context.as_ref().map(|c| c.org_name.as_str());
-        resolve_project_id(&projects, target, context_org)
+        let credential_org = context.as_ref().map(|c| c.org_name.as_str());
+        resolve_project_id(&projects, target, resolve_listing_org(None, credential_org))
     }
 
     /// List deployments for an already-resolved project.
@@ -364,10 +391,12 @@ impl CloudClient {
         placement: CreateProjectPlacement,
     ) -> Result<Project> {
         let request = build_create_project_request(name, description, visibility, placement);
-        self.inner
+        let project = self
+            .inner
             .create_project(&request)
             .await
-            .map_err(|error| self.err(error))
+            .map_err(|error| self.err(error))?;
+        Ok(self.attribute(project, None))
     }
 
     pub async fn update_project(
@@ -397,10 +426,12 @@ impl CloudClient {
             storage_size_gb: params.storage_size_gb,
             spicepod: params.spicepod,
         };
-        self.inner
+        let project = self
+            .inner
             .update_project(app.id, &request)
             .await
-            .map_err(|error| self.err(error))
+            .map_err(|error| self.err(error))?;
+        Ok(self.attribute(project, target.org.as_deref()))
     }
 
     pub async fn delete_project(&self, target: &ProjectTarget) -> Result<()> {
@@ -697,11 +728,27 @@ pub fn parse_org_project(org_app: &str) -> (Option<String>, String) {
     }
 }
 
+/// The organization a project listing describes.
+///
+/// Spice Cloud scopes `/v1/apps` to the organization named in the request
+/// header, so the org a client acts on is the org its listing belongs to. The
+/// credential's own org answers only when nothing named one: the identity
+/// endpoint reports the org the *token* is bound to, which is a different
+/// organization whenever a command names one, and labelling one org's projects
+/// with another's name is wrong in the table, in `--output json`, and in every
+/// name resolved from it.
+pub(super) fn resolve_listing_org<'a>(
+    client_org: Option<&'a str>,
+    credential_org: Option<&'a str>,
+) -> Option<&'a str> {
+    client_org.or(credential_org).filter(|org| !org.is_empty())
+}
+
 /// The org an app belongs to: its own when the payload carries one, otherwise
-/// the credential's org, which is the only org `/v1/apps` can be listing.
-fn effective_project_org<'a>(app: &'a Project, context_org: Option<&'a str>) -> Option<&'a str> {
+/// the org whose listing it arrived in.
+fn effective_project_org<'a>(app: &'a Project, listing_org: Option<&'a str>) -> Option<&'a str> {
     if app.org.is_empty() {
-        context_org.filter(|org| !org.is_empty())
+        listing_org.filter(|org| !org.is_empty())
     } else {
         Some(app.org.as_str())
     }
@@ -718,12 +765,12 @@ fn effective_project_org<'a>(app: &'a Project, context_org: Option<&'a str>) -> 
 fn resolve_project_id(
     apps: &[Project],
     target: &ProjectTarget,
-    context_org: Option<&str>,
+    listing_org: Option<&str>,
 ) -> Result<i64> {
     let wanted_org = target
         .org
         .as_deref()
-        .or(context_org)
+        .or(listing_org)
         .filter(|o| !o.is_empty());
 
     let mut org_unknown_matches = Vec::new();
@@ -734,7 +781,7 @@ fn resolve_project_id(
             continue;
         }
 
-        match (effective_project_org(app, context_org), wanted_org) {
+        match (effective_project_org(app, listing_org), wanted_org) {
             (Some(app_org), Some(wanted)) if app_org.eq_ignore_ascii_case(wanted) => {
                 return Ok(app.id);
             }
@@ -780,7 +827,7 @@ fn resolve_project_id(
 
     let visible_orgs: Vec<String> = apps
         .iter()
-        .filter_map(|app| effective_project_org(app, context_org).map(ToString::to_string))
+        .filter_map(|app| effective_project_org(app, listing_org).map(ToString::to_string))
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect();
@@ -1184,9 +1231,9 @@ mod tests {
     }
 
     #[test]
-    fn resolve_project_id_uses_context_org_when_the_listing_omits_it() {
-        // `/v1/apps` does not populate `org`, so the credential's own org is
-        // the only evidence of which org the listing describes.
+    fn resolve_project_id_uses_the_listing_org_when_the_payload_omits_it() {
+        // `/v1/apps` does not populate `org`, so the org the listing was
+        // requested for is the only evidence of which org it describes.
         let apps = vec![test_app(7, "dashboard", "")];
 
         let id = resolve_project_id(
@@ -1194,9 +1241,46 @@ mod tests {
             &target(Some("analytics"), "dashboard"),
             Some("analytics"),
         )
-        .expect("should match via auth context org");
+        .expect("should match via the listing org");
 
         assert_eq!(id, 7);
+    }
+
+    #[test]
+    fn the_listing_org_is_the_org_the_client_acted_on() {
+        // Regression for the cross-org mis-attribution this replaced: Spice
+        // Cloud scopes `/v1/apps` to the requested org but returns no `org` on
+        // any row, so preferring the credential's org labelled another
+        // organization's projects with the caller's own — and every name
+        // resolved from that listing then failed, or hit a same-named project
+        // in the wrong org.
+        assert_eq!(
+            resolve_listing_org(Some("spiceai"), Some("lukekim")),
+            Some("spiceai")
+        );
+    }
+
+    #[test]
+    fn the_listing_org_falls_back_to_the_credential_when_no_org_was_named() {
+        assert_eq!(resolve_listing_org(None, Some("lukekim")), Some("lukekim"));
+        assert_eq!(resolve_listing_org(None, None), None);
+        // A service-account credential reports no org rather than an empty one.
+        assert_eq!(resolve_listing_org(None, Some("")), None);
+    }
+
+    #[test]
+    fn a_project_in_a_named_org_resolves_from_that_orgs_listing() {
+        // End of the same regression, one layer up: the listing Spice Cloud
+        // returned for 'spiceai' carries no org, and resolving 'spiceai/docs'
+        // against it must find the project rather than report it as living
+        // somewhere else.
+        let apps = vec![test_app(680, "docs", "")];
+        let listing_org = resolve_listing_org(Some("spiceai"), Some("lukekim"));
+
+        let id = resolve_project_id(&apps, &target(Some("spiceai"), "docs"), listing_org)
+            .expect("a project in the org the listing was fetched for should resolve");
+
+        assert_eq!(id, 680);
     }
 
     #[test]

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -3108,7 +3108,6 @@ fn release_endpoint<'a>(
 async fn execute_projects(args: &ProjectsArgs, flag_org: Option<&str>) -> Result<()> {
     let active_org = resolve_org(flag_org)?;
     let client = CloudClient::connect(active_org.as_deref()).await?;
-    let context = client.optional_user_auth_context().await?;
     let mut projects = client.list_projects().await?;
 
     if projects.is_empty() {
@@ -3123,22 +3122,25 @@ async fn execute_projects(args: &ProjectsArgs, flag_org: Option<&str>) -> Result
         return Ok(());
     }
 
-    // Label with the org the *credential* reports, never the one that was
-    // requested. Stamping the requested org onto a listing the server actually
-    // produced for another org would assert an attribution the CLI has not
-    // verified — and `--output json` would carry it into scripts.
-    let context_org = context
-        .as_ref()
-        .map(|c| c.org_name.as_str())
-        .filter(|org| !org.is_empty())
-        .or(active_org.as_deref())
-        .unwrap_or("");
+    // Spice Cloud scoped this listing to the org the client asked for, so that
+    // org is what these projects belong to. Only when nothing named one does
+    // the credential's own org apply, and it is worth a round trip only then.
+    let credential_org = if active_org.is_some() {
+        None
+    } else {
+        client
+            .optional_user_auth_context()
+            .await?
+            .map(|context| context.org_name)
+    };
+    let listing_org =
+        client::resolve_listing_org(active_org.as_deref(), credential_org.as_deref()).unwrap_or("");
     // The Spice Cloud `/v1/apps` endpoint does not populate `org` per project, so
-    // backfill it from the auth-context org — the same fallback the table
-    // rendering applies via `display_project_name`. Without this, `--output json`
-    // emitted `"org": ""` while the table showed `<org>/<name>`, breaking
-    // format parity and machine-readable scripting (see #11041).
-    backfill_project_orgs(&mut projects, context_org);
+    // backfill it from the listing's org — the same fallback the table rendering
+    // applies via `display_project_name`. Without this, `--output json` emitted
+    // `"org": ""` while the table showed `<org>/<name>`, breaking format parity
+    // and machine-readable scripting (see #11041).
+    backfill_project_orgs(&mut projects, listing_org);
 
     if args.output == OutputFormat::Json {
         return write_json(&projects);
@@ -3152,7 +3154,7 @@ async fn execute_projects(args: &ProjectsArgs, flag_org: Option<&str>) -> Result
         "CREATED",
     ]);
     for project in &projects {
-        let display_name = display_project_name(project, context_org);
+        let display_name = display_project_name(project, listing_org);
         table.add_row(vec![
             display_name,
             project.description.clone().unwrap_or_default(),
@@ -3172,29 +3174,29 @@ async fn execute_projects(args: &ProjectsArgs, flag_org: Option<&str>) -> Result
     Ok(())
 }
 
-/// Backfill each project's empty `org` from the auth-context org so machine-readable
-/// (`--output json`) output matches the human-readable table, which already
-/// applies this fallback when rendering via [`display_project_name`]. The Spice
-/// Cloud `/v1/apps` endpoint does not populate `org` on each project, so the auth
-/// context is the only source of truth for the user's org. A no-op when
-/// `context_org` is empty (nothing to fall back to) or the project already carries
-/// an org.
-fn backfill_project_orgs(projects: &mut [spice_cloud_client::types::Project], context_org: &str) {
-    if context_org.is_empty() {
+/// Backfill each project's empty `org` from the org whose listing it arrived in,
+/// so machine-readable (`--output json`) output matches the human-readable table,
+/// which already applies this fallback when rendering via [`display_project_name`].
+/// The Spice Cloud `/v1/apps` endpoint does not populate `org` on each project, so
+/// the org the listing was requested for is the only evidence of which org these
+/// projects belong to. A no-op when `listing_org` is empty (nothing to fall back
+/// to) or the project already carries an org.
+fn backfill_project_orgs(projects: &mut [spice_cloud_client::types::Project], listing_org: &str) {
+    if listing_org.is_empty() {
         return;
     }
     for project in projects.iter_mut() {
         if project.org.is_empty() {
-            project.org = context_org.to_string();
+            project.org = listing_org.to_string();
         }
     }
 }
 
-/// Format a project's display name as `org/name`, falling back to the auth
-/// context org when the project payload does not include one.
-fn display_project_name(project: &spice_cloud_client::types::Project, context_org: &str) -> String {
+/// Format a project's display name as `org/name`, falling back to the org whose
+/// listing it arrived in when the project payload does not include one.
+fn display_project_name(project: &spice_cloud_client::types::Project, listing_org: &str) -> String {
     let org = if project.org.is_empty() {
-        context_org
+        listing_org
     } else {
         project.org.as_str()
     };
@@ -5107,7 +5109,7 @@ mod tests {
     }
 
     #[test]
-    fn display_project_name_falls_back_to_context_org_when_project_org_is_empty() {
+    fn display_project_name_falls_back_to_the_listing_org_when_project_org_is_empty() {
         let project = test_project("", "dashboard");
         assert_eq!(
             display_project_name(&project, "analytics"),
@@ -5122,7 +5124,7 @@ mod tests {
     }
 
     #[test]
-    fn backfill_project_orgs_fills_empty_org_from_context() {
+    fn backfill_project_orgs_fills_empty_org_from_the_listing_org() {
         let mut projects = vec![
             test_project("", "ltd-mint"),
             test_project("", "zippy-cayenne"),
@@ -5144,10 +5146,31 @@ mod tests {
     }
 
     #[test]
-    fn backfill_project_orgs_noop_when_context_empty() {
+    fn backfill_project_orgs_noop_when_the_listing_org_is_empty() {
         let mut projects = vec![test_project("", "ltd-mint")];
         backfill_project_orgs(&mut projects, "");
         assert_eq!(projects[0].org, "");
+    }
+
+    #[test]
+    fn a_listing_requested_for_an_org_is_labelled_with_that_org() {
+        // Regression for the cross-org mis-attribution this replaced: Spice
+        // Cloud scopes the listing to the requested org but returns no `org` on
+        // any row, so preferring the credential's org labelled another
+        // organization's projects — table and `--output json` alike — with the
+        // caller's own, and a name copied from that listing addressed either
+        // nothing or a same-named project in the wrong org.
+        let listing_org = client::resolve_listing_org(Some("spiceai"), Some("lukekim"))
+            .expect("a requested org is a listing org");
+        let mut projects = vec![test_project("", "docs")];
+
+        backfill_project_orgs(&mut projects, listing_org);
+
+        assert_eq!(projects[0].org, "spiceai");
+        assert_eq!(
+            display_project_name(&projects[0], listing_org),
+            "spiceai/docs"
+        );
     }
 
     // ========================================================================


### PR DESCRIPTION
## The problem

Spice Cloud scopes `GET /v1/apps` to the organization named in the `X-Org-Name` request header, but returns no `org` on any row. The CLI therefore has to supply the attribution itself — and it took it from the identity endpoint, which deliberately sends no org and so always answers with the organization the *token* is bound to. Any listing fetched for a different organization was labelled with the caller's own.

Against `dev-api.spice.ai`, for a user whose credential org is `lukekim`:

```
$ spice cloud projects --org spiceai
 NAME                  DESCRIPTION                 REGION  VISIBILITY  CREATED
 lukekim/quickstart    Taxi trips sample dataset   -       public      2026-01-17T15:15:03.739699+00:00
 lukekim/cves                                      -       private     2026-03-20T08:02:43.167543+00:00
```

Those are `spiceai` projects. The label was not merely unverified — it was wrong, and it was wrong everywhere it was used:

- **Cross-organization addressing did not work at all.** `project get spiceai/quickstart`, `deployments --project spiceai/quickstart` and `SPICE_CLOUD_ORG=spiceai project get quickstart` all failed with *"Project 'quickstart' was not found in organization 'spiceai', but exists in 'lukekim'"*, and the suggested `lukekim/quickstart` does not exist. Project resolution is shared, so `deploy`, `logs`, `secrets`, `status` and `delete` inherited it.
- **A name copied out of the listing could address the wrong project, silently.** Both organizations hold a project named `docs` — id 680 in `spiceai`, id 812 in `lukekim`. Listing `--org spiceai` printed `lukekim/docs` for id 680. Pasting that into `spice cloud deploy --project lukekim/docs` reaches id 812, the personal project, with no error.
- **`--output json` carried the same claim into scripts**, serializing `"org": "lukekim"` for projects that live elsewhere.

## The change

The organization a listing was requested for is now its attribution; the credential's own organization is the fallback only when nothing named one. Both the listing label and project resolution go through a single `resolve_listing_org`, so the precedence cannot be inverted in one place and not the other. When a command names an organization the identity call is skipped entirely, dropping a round trip from every organization-scoped command.

`get_project`, `update_project` and `create_project` stamp the organization they resolved by onto payloads that omit it — `spice cloud project get <org>/<name>` printed a bare `Name: docs` and serialized `"org": ""` for the very project whose organization it had just used to find it.

## Verification

Live against `dev-api.spice.ai`:

| | before | after |
|---|---|---|
| `projects --org spiceai` | `lukekim/quickstart` | `spiceai/quickstart` |
| `project get spiceai/quickstart` | *not found … exists in 'lukekim'* | resolves |
| `project get spiceai/docs` | — | id **680** |
| `project get lukekim/docs` | id 812 | id **812** |
| `project get spiceai/docs -o json` | `"org": ""` | `"org": "spiceai"` |

Also confirmed: `--org`, `SPICE_CLOUD_ORG` and inline `<org>/<project>` agree; `deployments`/`status --project spiceai/…` work; a third organization (`spicehq`) behaves the same; an organization the user does not belong to still fails closed with the membership error; and the default-organization paths are unchanged.

Five unit tests pin the precedence, the fallback, the service-account case (no org rather than an empty one), resolution against an organization's own listing, and the listing label. 549 `spice` lib tests pass; `cargo clippy -p spice --all-targets` is clean.

## Notes

The cross-organization surface arrived with #12515 and is not in any release, so no shipped CLI is affected. Found while validating #9450 and #9451 — both of which are fixed and stay fixed here.
