### PR TITLE
Upgrade iceberg-rust to v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,7 +4146,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9037,8 +9037,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -10206,7 +10206,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -10220,8 +10220,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.10.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=c86f2f7ae9b37a8a795cc4c25574df436aa1d392#c86f2f7ae9b37a8a795cc4c25574df436aa1d392"
+version = "0.10.1"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=351d1bc7b6ac9a835397e248e9c687f305e947d1#351d1bc7b6ac9a835397e248e9c687f305e947d1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -10277,8 +10277,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-glue"
-version = "0.10.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=c86f2f7ae9b37a8a795cc4c25574df436aa1d392#c86f2f7ae9b37a8a795cc4c25574df436aa1d392"
+version = "0.10.1"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=351d1bc7b6ac9a835397e248e9c687f305e947d1#351d1bc7b6ac9a835397e248e9c687f305e947d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10292,8 +10292,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-catalog-rest"
-version = "0.10.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=c86f2f7ae9b37a8a795cc4c25574df436aa1d392#c86f2f7ae9b37a8a795cc4c25574df436aa1d392"
+version = "0.10.1"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=351d1bc7b6ac9a835397e248e9c687f305e947d1#351d1bc7b6ac9a835397e248e9c687f305e947d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10316,8 +10316,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-datafusion"
-version = "0.10.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=c86f2f7ae9b37a8a795cc4c25574df436aa1d392#c86f2f7ae9b37a8a795cc4c25574df436aa1d392"
+version = "0.10.1"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=351d1bc7b6ac9a835397e248e9c687f305e947d1#351d1bc7b6ac9a835397e248e9c687f305e947d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10332,8 +10332,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg-storage-opendal"
-version = "0.10.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=c86f2f7ae9b37a8a795cc4c25574df436aa1d392#c86f2f7ae9b37a8a795cc4c25574df436aa1d392"
+version = "0.10.1"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=351d1bc7b6ac9a835397e248e9c687f305e947d1#351d1bc7b6ac9a835397e248e9c687f305e947d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10351,8 +10351,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg_test_utils"
-version = "0.10.0"
-source = "git+https://github.com/spiceai/iceberg-rust.git?rev=c86f2f7ae9b37a8a795cc4c25574df436aa1d392#c86f2f7ae9b37a8a795cc4c25574df436aa1d392"
+version = "0.10.1"
+source = "git+https://github.com/spiceai/iceberg-rust.git?rev=351d1bc7b6ac9a835397e248e9c687f305e947d1#351d1bc7b6ac9a835397e248e9c687f305e947d1"
 dependencies = [
  "iceberg",
  "tracing-subscriber",
@@ -14918,7 +14918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6705a26ad89d241a989a5395641931ba37076f5ab5fbd19ee92402414a43af32"
 dependencies = [
  "arrayvec",
- "hashbrown 0.5.0",
+ "hashbrown 0.17.1",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -15407,7 +15407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -15428,7 +15428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -18898,7 +18898,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -24231,7 +24231,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,12 +298,12 @@ hf-hub = { version = "0.4", features = ["tokio"] }
 http = "1.3.1"
 httpdate = "1.0"
 humantime = "2.1.0"
-iceberg = "=0.10.0"
-iceberg-catalog-glue = "=0.10.0"
-iceberg-catalog-rest = "=0.10.0"
-iceberg-datafusion = "=0.10.0"
-iceberg-storage-opendal = { version = "=0.10.0", features = ["opendal-s3", "opendal-gcs", "opendal-fs"] }
-iceberg_test_utils = "=0.10.0"
+iceberg = "=0.10.1"
+iceberg-catalog-glue = "=0.10.1"
+iceberg-catalog-rest = "=0.10.1"
+iceberg-datafusion = "=0.10.1"
+iceberg-storage-opendal = { version = "=0.10.1", features = ["opendal-s3", "opendal-gcs", "opendal-fs"] }
+iceberg_test_utils = "=0.10.1"
 imap = { git = "https://github.com/jonhoo/rust-imap", rev = "6fe22ed11a1ccffe1799a73f48e589366d8d100f" }
 indexmap = "2"
 insta = { version = "1.46.3", features = ["filters"] }
@@ -558,12 +558,12 @@ duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "7229b20daf24
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "e39c9c46dea1f0983cd8d87dabb69b41c9efe1fd" } # master @ tip (PR #2 merged: rusqlite 0.40.1 + bundled-decimal)
 tokio-rusqlite = { git = "https://github.com/spiceai/tokio-rusqlite.git", rev = "b10df82e3bbc4f4700562a14a3a00714cbc2f0c7" }
 
-iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "c86f2f7ae9b37a8a795cc4c25574df436aa1d392" } # branch: spiceai-0.10.0-df-54
-iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "c86f2f7ae9b37a8a795cc4c25574df436aa1d392" } # branch: spiceai-0.10.0-df-54
-iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "c86f2f7ae9b37a8a795cc4c25574df436aa1d392" } # branch: spiceai-0.10.0-df-54
-iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "c86f2f7ae9b37a8a795cc4c25574df436aa1d392" } # branch: spiceai-0.10.0-df-54
-iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "c86f2f7ae9b37a8a795cc4c25574df436aa1d392" } # branch: spiceai-0.10.0-df-54
-iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "c86f2f7ae9b37a8a795cc4c25574df436aa1d392" } # branch: spiceai-0.10.0-df-54
+iceberg = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "351d1bc7b6ac9a835397e248e9c687f305e947d1" } # branch: spiceai-0.10.1-df-54
+iceberg-catalog-glue = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "351d1bc7b6ac9a835397e248e9c687f305e947d1" } # branch: spiceai-0.10.1-df-54
+iceberg-catalog-rest = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "351d1bc7b6ac9a835397e248e9c687f305e947d1" } # branch: spiceai-0.10.1-df-54
+iceberg-datafusion = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "351d1bc7b6ac9a835397e248e9c687f305e947d1" } # branch: spiceai-0.10.1-df-54
+iceberg-storage-opendal = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "351d1bc7b6ac9a835397e248e9c687f305e947d1" } # branch: spiceai-0.10.1-df-54
+iceberg_test_utils = { git = "https://github.com/spiceai/iceberg-rust.git", rev = "351d1bc7b6ac9a835397e248e9c687f305e947d1" } # branch: spiceai-0.10.1-df-54
 
 # candle-* crates are already redirected to the spiceai/candle fork via the
 # [patch.crates-io] block higher up in this file. Keeping those here would be


### PR DESCRIPTION
Upgrades the six `iceberg-rust` crates (`iceberg`, `iceberg-catalog-glue`, `iceberg-catalog-rest`, `iceberg-datafusion`, `iceberg-storage-opendal`, `iceberg_test_utils`) from v0.10.0 to v0.10.1.

## Verification

- Fork branch: `cargo check` across all six crates; `row_delta` unit tests 9/9; `iceberg-datafusion` unit tests 94/94.
- This repo: `cargo check -p runtime -p data_components -p runtime-execution-plans -p aws-sdk-credential-bridge --features runtime/iceberg-write` green against the new pin.
