### PR TITLE
fix(cli): resolve a Cloud Connect project's data-plane region from its config

### DIFF
--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -1216,11 +1216,11 @@ async fn execute_status(
     // — is reported: rendering it as "no instances are running" would make the
     // diagnosis command lie about the thing it exists to diagnose.
     let never_deployed = latest.is_none();
+    // Real health-read failures only. A data-plane refusal to inspect a
+    // self-hosted runtime deliberately never lands here (see
+    // `classify_health_failures`): this value feeds the degradation exit
+    // contract, and a healthy Cloud Connect project must exit 0.
     let mut runtime_error: Option<String> = None;
-    // Set when the health read failed only because the data plane refuses to
-    // inspect a self-hosted runtime: for a Cloud Connect project that is the
-    // project's shape, not an outage, and rendering it as a failure would make
-    // every status of a healthy Cloud Connect project read as degraded.
     let mut self_hosted = false;
 
     let (instances, datasets) =
@@ -1239,14 +1239,11 @@ async fn execute_status(
                 )
                 .await;
 
-                for failure in [instances.as_ref().err(), datasets.as_ref().err()] {
-                    if let Some(err) = failure
-                        && runtime_error.is_none()
-                    {
-                        self_hosted = health_not_served_for_self_hosted(err);
-                        runtime_error = Some(err.to_string());
-                    }
-                }
+                (runtime_error, self_hosted) = classify_health_failures(
+                    [instances.as_ref().err(), datasets.as_ref().err()]
+                        .into_iter()
+                        .flatten(),
+                );
 
                 (
                     instances
@@ -1280,6 +1277,10 @@ async fn execute_status(
             "datasets_total": datasets.len(),
             "datasets_unhealthy": unhealthy,
             "runtime_error": &runtime_error,
+            // Why `instances` can be empty with no `runtime_error`: the data
+            // plane does not inspect a self-hosted runtime, so its health is
+            // absent by design rather than unknown.
+            "self_hosted": self_hosted,
             "link": {
                 "connection": local.connection,
                 "service": local.service,
@@ -1315,19 +1316,17 @@ async fn execute_status(
     }
 
     println!();
-    if let Some(err) = &runtime_error
-        && !self_hosted
-    {
+    if let Some(err) = &runtime_error {
         // Say the fleet is unknown rather than empty.
         println!("Could not read instance or dataset health: {err}");
         println!("  Instance and dataset state below may be incomplete.");
         println!();
     }
     if instances.is_empty() {
-        if self_hosted {
-            println!("{}", self_hosted_instances_note(&target));
-        } else if runtime_error.is_some() {
+        if runtime_error.is_some() {
             println!("Instances: unknown.");
+        } else if self_hosted {
+            println!("{}", self_hosted_instances_note(&target));
         } else {
             println!("No instances are running.");
         }
@@ -4620,6 +4619,29 @@ fn health_not_served_for_self_hosted(error: &Error) -> bool {
     matches!(error, Error::RuntimeHttp { status: 501, .. })
 }
 
+/// Fold the health-read outcomes into what status reports: the first real
+/// failure, and whether the data plane declined because the runtime is
+/// self-hosted.
+///
+/// A refusal is the project's expected shape, not a failure — it never
+/// reaches the error slot, which feeds the degradation exit contract, so a
+/// healthy Cloud Connect project exits 0. Real failures still land there
+/// even when a refusal accompanies them: the two report unrelated facts.
+fn classify_health_failures<'a>(
+    failures: impl IntoIterator<Item = &'a Error>,
+) -> (Option<String>, bool) {
+    let mut first_failure = None;
+    let mut self_hosted = false;
+    for error in failures {
+        if health_not_served_for_self_hosted(error) {
+            self_hosted = true;
+        } else if first_failure.is_none() {
+            first_failure = Some(error.to_string());
+        }
+    }
+    (first_failure, self_hosted)
+}
+
 /// The status line for a project whose instances Spice Cloud cannot inspect.
 ///
 /// This line is the only explanation the user gets for an absent health
@@ -4767,6 +4789,34 @@ mod tests {
             body: String::new(),
         };
         assert!(!health_not_served_for_self_hosted(&failed));
+    }
+
+    #[test]
+    fn a_self_hosted_refusal_never_reaches_the_error_slot() {
+        let refused = Error::RuntimeHttp {
+            status: 501,
+            body: "not available for a self-hosted runtime".to_string(),
+        };
+        let failed = Error::RuntimeHttp {
+            status: 500,
+            body: "boom".to_string(),
+        };
+
+        // Refusal alone: nothing degrades, so status exits 0; the self-hosted
+        // note is the explanation the user gets instead.
+        let (error, self_hosted) = classify_health_failures([&refused]);
+        assert_eq!(error, None);
+        assert!(self_hosted);
+
+        // A real failure alongside the refusal must still degrade the command.
+        let (error, self_hosted) = classify_health_failures([&refused, &failed]);
+        assert!(error.is_some(), "a real failure must not be masked");
+        assert!(self_hosted);
+
+        // Real failures only: reported, with no self-hosted note.
+        let (error, self_hosted) = classify_health_failures([&failed]);
+        assert!(error.is_some());
+        assert!(!self_hosted);
     }
 
     #[test]

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -4893,11 +4893,17 @@ mod tests {
         let reason = "its runtime is reachable only from that cluster";
 
         let instances = instances_not_inspected_note(&target, reason);
-        assert!(instances.contains("spicehq/team-app"), "note was: {instances}");
+        assert!(
+            instances.contains("spicehq/team-app"),
+            "note was: {instances}"
+        );
         assert!(instances.contains(reason), "note was: {instances}");
 
         let datasets = dataset_health_not_reported_note(&target, reason);
-        assert!(datasets.contains("spicehq/team-app"), "note was: {datasets}");
+        assert!(
+            datasets.contains("spicehq/team-app"),
+            "note was: {datasets}"
+        );
         assert!(datasets.contains(reason), "note was: {datasets}");
     }
 

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -1217,6 +1217,11 @@ async fn execute_status(
     // diagnosis command lie about the thing it exists to diagnose.
     let never_deployed = latest.is_none();
     let mut runtime_error: Option<String> = None;
+    // Set when the health read failed only because the data plane refuses to
+    // inspect a self-hosted runtime: for a Cloud Connect project that is the
+    // project's shape, not an outage, and rendering it as a failure would make
+    // every status of a healthy Cloud Connect project read as degraded.
+    let mut self_hosted = false;
 
     let (instances, datasets) =
         match project_runtime_context(ctx, &client, &target, args.instance.as_deref()).await {
@@ -1238,6 +1243,7 @@ async fn execute_status(
                     if let Some(err) = failure
                         && runtime_error.is_none()
                     {
+                        self_hosted = health_not_served_for_self_hosted(err);
                         runtime_error = Some(err.to_string());
                     }
                 }
@@ -1309,14 +1315,18 @@ async fn execute_status(
     }
 
     println!();
-    if let Some(err) = &runtime_error {
+    if let Some(err) = &runtime_error
+        && !self_hosted
+    {
         // Say the fleet is unknown rather than empty.
         println!("Could not read instance or dataset health: {err}");
         println!("  Instance and dataset state below may be incomplete.");
         println!();
     }
     if instances.is_empty() {
-        if runtime_error.is_some() {
+        if self_hosted {
+            println!("{}", self_hosted_instances_note(&target));
+        } else if runtime_error.is_some() {
             println!("Instances: unknown.");
         } else {
             println!("No instances are running.");
@@ -4545,22 +4555,25 @@ async fn project_runtime_context(
 ) -> Result<RuntimeContext> {
     let project = client.get_project(target).await?;
 
-    let region = project.region.clone().ok_or_else(|| {
+    let region = project.data_plane_region().ok_or_else(|| {
         Error::cloud_with_hint(
             CloudErrorCode::NotFound,
             format!(
                 "Project {target} does not report a region, so its instance endpoint is unknown."
             ),
-            format!("Check it with 'spice cloud status --project {target}'."),
+            format!(
+                "A Cloud Connect project reports its region once an instance is linked and \
+                 connected: link this directory to {target} and start it with 'spice run'. \
+                 See: https://spiceai.org/docs/spice-cloud"
+            ),
         )
     })?;
-    let region =
-        spice_cloud_client::endpoints::normalize_data_region(&region).ok_or_else(|| {
-            Error::cloud(
-                CloudErrorCode::InvalidRequest,
-                format!("Project {target} reports an unrecognized region '{region}'."),
-            )
-        })?;
+    let region = spice_cloud_client::endpoints::normalize_data_region(region).ok_or_else(|| {
+        Error::cloud(
+            CloudErrorCode::InvalidRequest,
+            format!("Project {target} reports an unrecognized region '{region}'."),
+        )
+    })?;
 
     // Prefer the key the management API reports for this project; fall back to
     // a key stored for the same org only if the API withholds one. Never reach
@@ -4594,6 +4607,29 @@ async fn project_runtime_context(
     }
 
     Ok(runtime_ctx)
+}
+
+/// Whether a health read failed only because the data plane declines to
+/// inspect a self-hosted runtime.
+///
+/// Spice Cloud relays deployments and secrets to a runtime the user hosts
+/// themself, but answers HTTP 501 when asked to inspect it — that runtime is
+/// reachable only from the machine it runs on. For `spice cloud status` this
+/// is the expected shape of a Cloud Connect project, not a failure.
+fn health_not_served_for_self_hosted(error: &Error) -> bool {
+    matches!(error, Error::RuntimeHttp { status: 501, .. })
+}
+
+/// The status line for a project whose instances Spice Cloud cannot inspect.
+///
+/// This line is the only explanation the user gets for an absent health
+/// section on a healthy Cloud Connect project, so it must say where the
+/// health can actually be read.
+fn self_hosted_instances_note(target: &ProjectTarget) -> String {
+    format!(
+        "Instances: self-hosted — Spice Cloud does not inspect the runtime serving project \
+         {target}. Check it with 'spice status' on the machine that runs it."
+    )
 }
 
 /// Name what a report describes: one pinned instance, or the project as a whole.
@@ -4712,6 +4748,35 @@ fn dataset_needs_attention(status: Option<&str>) -> bool {
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+
+    #[test]
+    fn only_a_501_reads_as_health_not_served_for_self_hosted() {
+        // The data plane answers 501 when asked to inspect a runtime the user
+        // hosts themself; every other failure is a real one and must keep
+        // rendering as a degradation, or status would hide genuine outages.
+        let refused = Error::RuntimeHttp {
+            status: 501,
+            body: "this endpoint is not available for an app attached to a self-hosted Spice \
+                   runtime"
+                .to_string(),
+        };
+        assert!(health_not_served_for_self_hosted(&refused));
+
+        let failed = Error::RuntimeHttp {
+            status: 500,
+            body: String::new(),
+        };
+        assert!(!health_not_served_for_self_hosted(&failed));
+    }
+
+    #[test]
+    fn self_hosted_note_names_the_project_and_where_health_lives() {
+        let target = ProjectTarget::new(Some("spicehq".to_string()), "team-app");
+        let note = self_hosted_instances_note(&target);
+        assert!(note.contains("spicehq/team-app"), "note was: {note}");
+        assert!(note.contains("'spice status'"), "note was: {note}");
+        assert!(note.contains("machine that runs it"), "note was: {note}");
+    }
 
     #[test]
     fn metrics_table_row_matches_header_count() {

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -1217,11 +1217,14 @@ async fn execute_status(
     // diagnosis command lie about the thing it exists to diagnose.
     let never_deployed = latest.is_none();
     // Real health-read failures only. A data-plane refusal to inspect a
-    // self-hosted runtime deliberately never lands here (see
+    // runtime hosted outside Spice Cloud deliberately never lands here (see
     // `classify_health_failures`): this value feeds the degradation exit
-    // contract, and a healthy Cloud Connect project must exit 0.
+    // contract, and a healthy Cloud Connect or BYOC project must exit 0.
     let mut runtime_error: Option<String> = None;
-    let mut self_hosted = false;
+    // The server's stated reason when the data plane declined to inspect the
+    // runtime (HTTP 501), for the sections that would otherwise be missing
+    // with no explanation.
+    let mut health_refusal: Option<String> = None;
 
     let (instances, datasets) =
         match project_runtime_context(ctx, &client, &target, args.instance.as_deref()).await {
@@ -1239,7 +1242,7 @@ async fn execute_status(
                 )
                 .await;
 
-                (runtime_error, self_hosted) = classify_health_failures(
+                (runtime_error, health_refusal) = classify_health_failures(
                     [instances.as_ref().err(), datasets.as_ref().err()]
                         .into_iter()
                         .flatten(),
@@ -1278,9 +1281,11 @@ async fn execute_status(
             "datasets_unhealthy": unhealthy,
             "runtime_error": &runtime_error,
             // Why `instances` can be empty with no `runtime_error`: the data
-            // plane does not inspect a self-hosted runtime, so its health is
-            // absent by design rather than unknown.
-            "self_hosted": self_hosted,
+            // plane does not inspect a runtime hosted outside Spice Cloud (a
+            // Cloud Connect instance, a BYOC cluster), so its health is absent
+            // by design rather than unknown. Carries the server's stated
+            // reason verbatim.
+            "health_not_reported": &health_refusal,
             "link": {
                 "connection": local.connection,
                 "service": local.service,
@@ -1325,8 +1330,15 @@ async fn execute_status(
     if instances.is_empty() {
         if runtime_error.is_some() {
             println!("Instances: unknown.");
-        } else if self_hosted {
-            println!("{}", self_hosted_instances_note(&target));
+        } else if let Some(reason) = &health_refusal {
+            // The CLI names the friendly Cloud Connect shape itself; for any
+            // other kind the server's reason says where the runtime actually
+            // is, so a new kind never gets mislabeled by an old binary.
+            if project.kind.as_deref() == Some("standalone") {
+                println!("{}", self_hosted_instances_note(&target));
+            } else {
+                println!("{}", instances_not_inspected_note(&target, reason));
+            }
         } else {
             println!("No instances are running.");
         }
@@ -1376,6 +1388,15 @@ async fn execute_status(
             println!();
             println!("  Logs: spice cloud logs --project {target} --level error");
         }
+    } else if let Some(reason) = &health_refusal
+        && !instances.is_empty()
+    {
+        // The instances table rendered, so the refusal came from the dataset
+        // read alone; without this line the section is silently missing and
+        // reads as "no datasets". When the instances section is also absent,
+        // its note already explains the whole health read.
+        println!();
+        println!("{}", dataset_health_not_reported_note(&target, reason));
     }
 
     println!();
@@ -4608,38 +4629,52 @@ async fn project_runtime_context(
     Ok(runtime_ctx)
 }
 
-/// Whether a health read failed only because the data plane declines to
-/// inspect a self-hosted runtime.
+/// The server's stated reason when the data plane declines to inspect the
+/// project's runtime, rather than failing to reach it.
 ///
-/// Spice Cloud relays deployments and secrets to a runtime the user hosts
-/// themself, but answers HTTP 501 when asked to inspect it — that runtime is
-/// reachable only from the machine it runs on. For `spice cloud status` this
-/// is the expected shape of a Cloud Connect project, not a failure.
-fn health_not_served_for_self_hosted(error: &Error) -> bool {
-    matches!(error, Error::RuntimeHttp { status: 501, .. })
+/// Spice Cloud relays deployments and secrets to a runtime hosted outside the
+/// platform — a Cloud Connect standalone instance, a BYOC cluster — but
+/// answers HTTP 501 when asked to inspect it, with a reason naming where that
+/// runtime actually is. The reason travels to the user verbatim: the server
+/// knows the deployment kind, and this binary may predate kinds the server
+/// has since learned.
+fn health_refusal_reason(error: &Error) -> Option<&str> {
+    match error {
+        Error::RuntimeHttp { status: 501, body } => Some(body.as_str()),
+        _ => None,
+    }
 }
 
 /// Fold the health-read outcomes into what status reports: the first real
-/// failure, and whether the data plane declined because the runtime is
-/// self-hosted.
+/// failure, and the server's reason when it declined to inspect the runtime.
 ///
 /// A refusal is the project's expected shape, not a failure — it never
 /// reaches the error slot, which feeds the degradation exit contract, so a
-/// healthy Cloud Connect project exits 0. Real failures still land there
-/// even when a refusal accompanies them: the two report unrelated facts.
+/// healthy Cloud Connect or BYOC project exits 0. Real failures still land
+/// there even when a refusal accompanies them: the two report unrelated
+/// facts. A refusal with no reason text gets a generic one, so the sections
+/// it explains never render an empty clause.
 fn classify_health_failures<'a>(
     failures: impl IntoIterator<Item = &'a Error>,
-) -> (Option<String>, bool) {
+) -> (Option<String>, Option<String>) {
     let mut first_failure = None;
-    let mut self_hosted = false;
+    let mut refusal = None;
     for error in failures {
-        if health_not_served_for_self_hosted(error) {
-            self_hosted = true;
+        if let Some(reason) = health_refusal_reason(error) {
+            if refusal.is_none() {
+                let reason = if reason.is_empty() {
+                    "the runtime is hosted outside Spice Cloud, which cannot reach it to \
+                     inspect it"
+                } else {
+                    reason
+                };
+                refusal = Some(reason.to_string());
+            }
         } else if first_failure.is_none() {
             first_failure = Some(error.to_string());
         }
     }
-    (first_failure, self_hosted)
+    (first_failure, refusal)
 }
 
 /// The status line for a project whose instances Spice Cloud cannot inspect.
@@ -4652,6 +4687,23 @@ fn self_hosted_instances_note(target: &ProjectTarget) -> String {
         "Instances: self-hosted — Spice Cloud does not inspect the runtime serving project \
          {target}. Check it with 'spice status' on the machine that runs it."
     )
+}
+
+/// The status line when Spice Cloud declines to inspect the runtime and the
+/// CLI cannot name the deployment kind — the server's reason says where the
+/// runtime actually is.
+fn instances_not_inspected_note(target: &ProjectTarget, reason: &str) -> String {
+    format!(
+        "Instances: not inspected — Spice Cloud cannot inspect the runtime serving project \
+         {target}: {reason}"
+    )
+}
+
+/// Explains an absent dataset-health section when the instances table
+/// rendered but the dataset read was declined — without it the section is
+/// silently missing and reads as "this project has no datasets".
+fn dataset_health_not_reported_note(target: &ProjectTarget, reason: &str) -> String {
+    format!("Dataset health is not reported for project {target}: {reason}")
 }
 
 /// Name what a report describes: one pinned instance, or the project as a whole.
@@ -4772,27 +4824,31 @@ mod tests {
     use std::collections::BTreeSet;
 
     #[test]
-    fn only_a_501_reads_as_health_not_served_for_self_hosted() {
-        // The data plane answers 501 when asked to inspect a runtime the user
-        // hosts themself; every other failure is a real one and must keep
-        // rendering as a degradation, or status would hide genuine outages.
+    fn only_a_501_carries_a_health_refusal_reason() {
+        // The data plane answers 501 when asked to inspect a runtime hosted
+        // outside Spice Cloud, and its body names where that runtime is —
+        // Cloud Connect and BYOC each get their own wording. Every other
+        // failure is a real one and must keep rendering as a degradation, or
+        // status would hide genuine outages.
         let refused = Error::RuntimeHttp {
             status: 501,
-            body: "this endpoint is not available for an app attached to a self-hosted Spice \
-                   runtime"
+            body: "this endpoint is not available for an app deployed to your own cluster"
                 .to_string(),
         };
-        assert!(health_not_served_for_self_hosted(&refused));
+        assert_eq!(
+            health_refusal_reason(&refused),
+            Some("this endpoint is not available for an app deployed to your own cluster")
+        );
 
         let failed = Error::RuntimeHttp {
             status: 500,
             body: String::new(),
         };
-        assert!(!health_not_served_for_self_hosted(&failed));
+        assert_eq!(health_refusal_reason(&failed), None);
     }
 
     #[test]
-    fn a_self_hosted_refusal_never_reaches_the_error_slot() {
+    fn a_refusal_never_reaches_the_error_slot() {
         let refused = Error::RuntimeHttp {
             status: 501,
             body: "not available for a self-hosted runtime".to_string(),
@@ -4802,21 +4858,47 @@ mod tests {
             body: "boom".to_string(),
         };
 
-        // Refusal alone: nothing degrades, so status exits 0; the self-hosted
-        // note is the explanation the user gets instead.
-        let (error, self_hosted) = classify_health_failures([&refused]);
+        // Refusal alone: nothing degrades, so status exits 0; the note built
+        // from the reason is the explanation the user gets instead.
+        let (error, refusal) = classify_health_failures([&refused]);
         assert_eq!(error, None);
-        assert!(self_hosted);
+        assert_eq!(
+            refusal.as_deref(),
+            Some("not available for a self-hosted runtime")
+        );
 
         // A real failure alongside the refusal must still degrade the command.
-        let (error, self_hosted) = classify_health_failures([&refused, &failed]);
+        let (error, refusal) = classify_health_failures([&refused, &failed]);
         assert!(error.is_some(), "a real failure must not be masked");
-        assert!(self_hosted);
+        assert!(refusal.is_some());
 
-        // Real failures only: reported, with no self-hosted note.
-        let (error, self_hosted) = classify_health_failures([&failed]);
+        // Real failures only: reported, with no refusal note.
+        let (error, refusal) = classify_health_failures([&failed]);
         assert!(error.is_some());
-        assert!(!self_hosted);
+        assert_eq!(refusal, None);
+
+        // A refusal with no reason text still explains itself.
+        let bare = Error::RuntimeHttp {
+            status: 501,
+            body: String::new(),
+        };
+        let (_, refusal) = classify_health_failures([&bare]);
+        let reason = refusal.expect("a bare refusal must still carry a reason");
+        assert!(!reason.is_empty(), "the fallback reason must not be empty");
+    }
+
+    #[test]
+    fn refusal_notes_name_the_project_and_carry_the_servers_reason() {
+        let target = ProjectTarget::new(Some("spicehq".to_string()), "team-app");
+        let reason = "its runtime is reachable only from that cluster";
+
+        let instances = instances_not_inspected_note(&target, reason);
+        assert!(instances.contains("spicehq/team-app"), "note was: {instances}");
+        assert!(instances.contains(reason), "note was: {instances}");
+
+        let datasets = dataset_health_not_reported_note(&target, reason);
+        assert!(datasets.contains("spicehq/team-app"), "note was: {datasets}");
+        assert!(datasets.contains(reason), "note was: {datasets}");
     }
 
     #[test]

--- a/crates/spice-cloud-client/src/types.rs
+++ b/crates/spice-cloud-client/src/types.rs
@@ -178,6 +178,22 @@ impl Project {
             format!("{}/{}", self.org, self.name)
         }
     }
+
+    /// The region whose data plane serves this project's instances.
+    ///
+    /// Spice Cloud reports a Spice-managed project's region at the top level
+    /// of the project record. A Cloud Connect project has no region of its
+    /// own at creation — it follows from where the attached instance
+    /// connects, and Spice Cloud records it only on the project config — so
+    /// consult both. `None` means no instance can be reached yet.
+    #[must_use]
+    pub fn data_plane_region(&self) -> Option<&str> {
+        self.region.as_deref().or_else(|| {
+            self.config
+                .as_ref()
+                .and_then(|config| config.region.as_deref())
+        })
+    }
 }
 
 /// Wire format for a project listing.
@@ -638,6 +654,42 @@ mod tests {
             serde_json::from_str(r#"{"apps":[{"id":1,"name":"team-app","org":"spicehq"}]}"#)
                 .expect("legacy apps envelope should deserialize");
         assert_eq!(apps.into_projects()[0].name, "team-app");
+    }
+
+    #[test]
+    fn data_plane_region_consults_the_project_record_then_the_config() {
+        fn project(region: Option<&str>, config_region: Option<&str>) -> Project {
+            Project {
+                id: 1,
+                name: "team-app".to_string(),
+                org: "spicehq".to_string(),
+                kind: None,
+                description: None,
+                visibility: None,
+                created_at: None,
+                region: region.map(str::to_string),
+                production_branch: None,
+                config: config_region.map(|region| ProjectConfig {
+                    region: Some(region.to_string()),
+                    ..ProjectConfig::default()
+                }),
+            }
+        }
+
+        // A Spice-managed project reports its region on the project record.
+        assert_eq!(
+            project(Some("us-east-1-prod-aws-data"), Some("us-west-2")).data_plane_region(),
+            Some("us-east-1-prod-aws-data")
+        );
+        // A Cloud Connect project reports it only on the project config, once
+        // an instance is attached; commands that reach the data plane must
+        // resolve this shape too, or every health/logs/datasets read fails.
+        assert_eq!(
+            project(None, Some("us-west-2")).data_plane_region(),
+            Some("us-west-2")
+        );
+        // Neither set: there is no data-plane endpoint to derive.
+        assert_eq!(project(None, None).data_plane_region(), None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/spiceai/spiceai/issues/13364

## Description

`spice cloud status`, `spice cloud datasets`, and `spice cloud logs` failed for every Cloud Connect project once it had a deployment:

```
Project <org>/<project> does not report a region, so its instance endpoint is unknown.
```

Spice Cloud reports a Cloud Connect project's region only on the project config — it follows from where the attached instance connects — while the CLI read only the top-level `region` field of the project record, so every data-plane read failed before a request was ever sent.

- Resolve the data-plane region from the project record first, then the project config (`Project::data_plane_region`), with unit tests.
- Replace the error's hint, which recommended the failing command itself, with the actual remedy.
- `spice cloud status`: render the data plane's refusal to inspect a self-hosted runtime (HTTP 501) as the project's expected shape — a note pointing at `spice status` on the host machine — instead of a health-read failure.

With the region resolved, status and logs now work end to end for Cloud Connect projects. Dataset reads still answer 501 until the Cloud Connect contract carries a command for them — tracked in #13369.
