### PR TITLE
test(postgres): cover durable write-back delivery, and stop tagging xids nobody reads

### DIFF
--- a/crates/data_components/src/postgres_replication/changes.rs
+++ b/crates/data_components/src/postgres_replication/changes.rs
@@ -344,18 +344,49 @@ pub struct PgChangeRows {
     /// merging pushes a `Vec` instead of moving every `Bytes` while holding the
     /// member mailbox lock.
     raw_chunks: Vec<Vec<bytes::Bytes>>,
-    /// The source transaction id (pgoutput's 32-bit stream xid) that produced
-    /// each entry of `raw_chunks`, same length and index-aligned. `None` for a
-    /// chunk built with no known xid (e.g. a test fixture); `xid` 0 is Postgres's
-    /// "no transaction assigned" sentinel and is likewise stored as `None`, which
-    /// is why the slot is a `NonZeroU32` — it also keeps the tag a compact 32 bits
-    /// with no separate discriminant. See [`Self::drop_echoed`] for what this drives.
-    chunk_xids: Vec<Option<NonZeroU32>>,
+    /// The source transaction ids behind `raw_chunks`, tracked only for a member
+    /// that can act on them. See [`ChunkXids`].
+    chunk_xids: ChunkXids,
     source_commit_ts_ms: Option<i64>,
     /// Precomputed `num_rows_hint` (upper bound) and `encoded_len` so the
     /// consumer's coalescing/metric reads are O(1) rather than rescanning `raw`.
     row_hint: usize,
     byte_len: usize,
+}
+
+/// The source transaction ids behind [`PgChangeRows`]'s buffered chunks.
+///
+/// Tracking them serves exactly one purpose: letting a durable write-back
+/// dataset recognize the echo of its own delivery. The shared pump therefore
+/// tracks them per *member*, and only for a member that holds an echo-suppression
+/// registry — every other dataset (which is every dataset in a deployment that
+/// does not write through Spice) allocates nothing and does no per-commit
+/// bookkeeping for a feature it cannot use, even while sharing a slot with a
+/// write-back table.
+enum ChunkXids {
+    /// This member suppresses no echoes, so no xid was recorded. Holds no
+    /// allocation.
+    Untracked,
+    /// One entry per `raw_chunks` entry, same length and index-aligned. `None`
+    /// for a chunk built with no known xid (e.g. a test fixture); `xid` 0 is
+    /// Postgres's "no transaction assigned" sentinel and is likewise stored as
+    /// `None`, which is why the slot is a `NonZeroU32` — it also keeps the tag a
+    /// compact 32 bits with no separate discriminant.
+    Tracked(Vec<Option<NonZeroU32>>),
+}
+
+/// What one [`PgChangeRows::drop_echoed`] pass observed about the source
+/// transactions buffered in an envelope.
+#[derive(Default)]
+pub(super) struct EchoScan {
+    /// The xids dropped as this dataset's own write-back echo, for the caller to
+    /// persist via [`XidRegistry::mark_commit_observed`].
+    pub(super) dropped: Vec<u32>,
+    /// Whether a chunk survived the filter carrying a transaction id this dataset
+    /// did not issue — a write to this table from outside Spice. Drives the
+    /// one-time external-writer report in
+    /// [`super::shared::MemberMailboxReceiver::pop`].
+    pub(super) saw_foreign_txn: bool,
 }
 
 impl PgChangeRows {
@@ -371,25 +402,30 @@ impl PgChangeRows {
             schema,
             relation,
             raw_chunks: vec![raw],
-            chunk_xids: vec![None],
+            // Only a member that can act on the xids pays for them; see
+            // `with_source_xid`, which the pump calls for exactly those members.
+            chunk_xids: ChunkXids::Untracked,
             source_commit_ts_ms,
             row_hint,
             byte_len,
         }
     }
 
-    /// Tag this instance's one transaction chunk with the source `xid` that
-    /// produced it (pgoutput's 32-bit stream xid), so a later
-    /// [`Self::drop_echoed`] can recognize whether it is the echo of this
-    /// dataset's own write-back delivery. Called once, immediately after
-    /// [`Self::new`], before any [`Self::try_append`].
+    /// Track the source `xid` (pgoutput's 32-bit stream xid) that produced this
+    /// instance's one transaction chunk, so a later [`Self::drop_echoed`] can
+    /// recognize whether it is the echo of this dataset's own write-back
+    /// delivery. Called once, immediately after [`Self::new`] and before any
+    /// [`Self::try_append`], and **only** for a member holding an
+    /// echo-suppression registry — a member without one leaves the envelope
+    /// [`ChunkXids::Untracked`] and allocates nothing.
     #[must_use]
     pub(super) fn with_source_xid(mut self, xid: Option<u32>) -> Self {
-        if let Some(slot) = self.chunk_xids.first_mut() {
-            // `xid` 0 is Postgres's "no transaction assigned" sentinel, so it
-            // collapses to `None` alongside a genuinely absent xid.
-            *slot = xid.and_then(NonZeroU32::new);
-        }
+        // `xid` 0 is Postgres's "no transaction assigned" sentinel, so it
+        // collapses to `None` alongside a genuinely absent xid.
+        self.chunk_xids = ChunkXids::Tracked(vec![
+            xid.and_then(NonZeroU32::new);
+            self.raw_chunks.len()
+        ]);
         self
     }
 
@@ -455,8 +491,15 @@ impl PgChangeRows {
             return Some(other);
         }
 
+        // Both sides come from the same member, so both were built with the same
+        // tracking decision. Declining a mixed merge costs a coalescing
+        // opportunity at worst, and never mis-attributes an xid to a chunk.
+        match (&mut self.chunk_xids, &mut other.chunk_xids) {
+            (ChunkXids::Untracked, ChunkXids::Untracked) => {}
+            (ChunkXids::Tracked(ours), ChunkXids::Tracked(theirs)) => ours.append(theirs),
+            _ => return Some(other),
+        }
         self.raw_chunks.append(&mut other.raw_chunks);
-        self.chunk_xids.append(&mut other.chunk_xids);
         self.row_hint = self.row_hint.saturating_add(other.row_hint);
         self.byte_len = self.byte_len.saturating_add(other.byte_len);
         self.source_commit_ts_ms = match (self.source_commit_ts_ms, other.source_commit_ts_ms) {
@@ -476,10 +519,9 @@ impl PgChangeRows {
     /// dataset that actually produced the echo pays for decoding (and
     /// immediately discarding) it, rather than every table sharing the pump.
     ///
-    /// Returns the dropped chunks' xids, for the caller to persist via
-    /// [`XidRegistry::mark_commit_observed`] — this method only reads the
+    /// Returns what the pass observed ([`EchoScan`]) — this method only reads the
     /// registry's lock-free membership mirror, never its own (async) state.
-    pub(super) fn drop_echoed(&mut self, registry: &XidRegistry) -> Vec<u32> {
+    pub(super) fn drop_echoed(&mut self, registry: &XidRegistry) -> EchoScan {
         // Compact both index-aligned vectors in place: keep a write cursor at the
         // next surviving slot, shift each kept chunk down over the gaps an echo
         // leaves, then truncate. When nothing echoes — the common case, since most
@@ -487,33 +529,45 @@ impl PgChangeRows {
         // lockstep with the scan, no swap runs, and the buffers (and their hints)
         // are left untouched, so a clean pop pays nothing beyond the membership
         // reads.
-        let mut dropped = Vec::new();
+        // Unreachable in production: the pump tracks xids for exactly the members
+        // that hold a registry, and only such a member calls this. Keeping every
+        // chunk is the safe direction for a state that should not arise — it
+        // delivers a change rather than discarding one.
+        let ChunkXids::Tracked(xids) = &mut self.chunk_xids else {
+            return EchoScan::default();
+        };
+        let mut scan = EchoScan::default();
         let mut kept = 0;
-        for read in 0..self.chunk_xids.len() {
-            if let Some(xid) = self.chunk_xids[read] {
+        for read in 0..xids.len() {
+            if let Some(xid) = xids[read] {
                 if registry.contains(xid.get()) {
                     // Leave the echoed chunk behind the write cursor; the final
                     // `truncate` discards it. Record its xid for the caller.
-                    dropped.push(xid.get());
+                    scan.dropped.push(xid.get());
                     continue;
                 }
+                // Surviving with a transaction id this dataset did not issue:
+                // someone else wrote this table. A chunk with no xid is not
+                // counted either way — only a positively identified foreign
+                // transaction is.
+                scan.saw_foreign_txn = true;
             }
             if read != kept {
                 self.raw_chunks.swap(read, kept);
-                self.chunk_xids.swap(read, kept);
+                xids.swap(read, kept);
             }
             kept += 1;
         }
-        if dropped.is_empty() {
-            return dropped;
+        if scan.dropped.is_empty() {
+            return scan;
         }
         self.raw_chunks.truncate(kept);
-        self.chunk_xids.truncate(kept);
+        xids.truncate(kept);
         let (row_hint, byte_len) =
             Self::compute_hints(&self.schema, self.raw_chunks.iter().flatten());
         self.row_hint = row_hint;
         self.byte_len = byte_len;
-        dropped
+        scan
     }
 }
 

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -6657,8 +6657,15 @@ mod tests {
             .await
             .expect("t0 envelope")
             .expect("t0 envelope is not an error");
+        // Built, not hinted. `num_rows_hint` is an estimate precomputed beside
+        // the buffered chunks, so it keeps claiming a row after the chunks have
+        // been dropped — the exact shape of the regression this test names. Only
+        // the built batch proves the change survived the filter.
         assert_eq!(
-            t0.num_rows_hint(),
+            t0.change_batch()
+                .expect("the surviving change builds")
+                .record
+                .num_rows(),
             1,
             "a transaction this member did not write back is delivered unchanged"
         );
@@ -6822,6 +6829,17 @@ mod tests {
         )
         .await;
 
+        // Claim the first pass's envelope before replaying. An unclaimed
+        // `Changes` tail absorbs the next publish — `try_publish` folds a
+        // compatible envelope into it rather than appending an item — so leaving
+        // it unread would merge the replay into the first delivery and there
+        // would be only one envelope to read, not two.
+        let first = receivers[0]
+            .next()
+            .await
+            .expect("first ack")
+            .expect("not an error");
+
         // Reconnect replay of the very same transaction, no prune in between.
         deliver_one_commit(
             &source,
@@ -6835,11 +6853,6 @@ mod tests {
 
         // Both passes produced a zero-row ack for t0, never a data envelope: the
         // echo was dropped on the replay just as on the first delivery.
-        let first = receivers[0]
-            .next()
-            .await
-            .expect("first ack")
-            .expect("not an error");
         let second = receivers[0]
             .next()
             .await

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -1522,10 +1522,64 @@ impl<T> MailboxSendOutcome<T> {
 struct MemberMailboxReceiver {
     shared: Arc<MemberMailbox>,
     draining: Vec<PendingItem>,
-    /// This member's write-back registry, if it is a durable write-back
-    /// dataset. `None` for every other dataset, which makes `pop`'s echo-drop
-    /// check a single pointer read.
-    write_back_registry: Option<Arc<XidRegistry>>,
+    /// This member's echo filter, if it is a durable write-back dataset. `None`
+    /// for every other dataset, which makes `pop`'s echo-drop check a single
+    /// pointer read.
+    echo_filter: Option<EchoFilter>,
+}
+
+/// A durable write-back member's view of its own change stream: the registry
+/// that recognizes the echo of its deliveries, plus the once-per-dataset report
+/// that someone *else* is writing the same table.
+struct EchoFilter {
+    registry: Arc<XidRegistry>,
+    /// Named in the external-writer report, so an operator knows which dataset
+    /// to act on.
+    dataset_name: String,
+    /// Whether [`external_write_warning`] has already been reported for this
+    /// dataset. The receiver is owned by the single per-dataset consumer and
+    /// `pop` takes `&mut self`, so a plain `bool` needs no synchronization.
+    warned_external_write: bool,
+}
+
+impl EchoFilter {
+    fn new(registry: Arc<XidRegistry>, dataset_name: String) -> Self {
+        Self {
+            registry,
+            dataset_name,
+            warned_external_write: false,
+        }
+    }
+
+    /// The external-writer report to log for one envelope, or `None` — either no
+    /// foreign transaction reached it, or the report has already been made for
+    /// this dataset. Split out from the logging so the once-only behaviour is
+    /// asserted directly rather than through a captured subscriber.
+    fn external_write_report(&mut self, saw_foreign_txn: bool) -> Option<String> {
+        if !saw_foreign_txn || self.warned_external_write {
+            return None;
+        }
+        self.warned_external_write = true;
+        Some(external_write_warning(&self.dataset_name))
+    }
+}
+
+/// The one-time report a durable write-back dataset makes the first time a
+/// change reaches it from a transaction Spice did not issue.
+///
+/// Durable write-back delivers each committed accelerator row to the source as an
+/// unconditional `INSERT ... ON CONFLICT (pk) DO UPDATE` — it never compares
+/// against what the source currently holds — so it is safe only while the
+/// accelerator is the sole writer of the rows it delivers. A foreign transaction
+/// on the table is the only evidence the runtime ever gets that a deployment has
+/// left that regime, and it is worth saying out loud once.
+///
+/// Built here, and asserted in this module's tests, so a reword cannot silently
+/// drop the dataset name, the consequence, or the docs link.
+fn external_write_warning(dataset_name: &str) -> String {
+    format!(
+        "Dataset '{dataset_name}' received a change from a transaction Spice did not issue, so this table has a writer other than Spice and durable write-back may overwrite that writer's row on its next delivery: it upserts each committed row by primary key without comparing against the source. Write to '{dataset_name}' only through Spice, or use a different `write_mode` for its acceleration. Reported once per dataset per run. See: https://spiceai.org/docs/reference/spicepod/datasets#acceleration"
+    )
 }
 
 impl MemberMailboxReceiver {
@@ -1553,11 +1607,19 @@ impl MemberMailboxReceiver {
         // recognizes as one of its own write-back deliveries. `contains` is a
         // lock-free mirror read, so this never blocks; a member with no
         // registry (the overwhelming majority of datasets) skips straight past.
-        if let (PendingItem::Changes(pending), Some(registry)) =
-            (&mut item, self.write_back_registry.as_ref())
+        if let (PendingItem::Changes(pending), Some(filter)) =
+            (&mut item, self.echo_filter.as_mut())
         {
-            let dropped = pending.rows.drop_echoed(registry);
-            if !dropped.is_empty() {
+            let scan = pending.rows.drop_echoed(&filter.registry);
+            // A change from a transaction this dataset did not issue means the
+            // accelerator is not the only writer of this table, the one condition
+            // durable write-back cannot make safe. Report it once: every later
+            // foreign write says the same thing, and a per-envelope log would
+            // drown the stream it is describing.
+            if let Some(report) = filter.external_write_report(scan.saw_foreign_txn) {
+                tracing::warn!(dataset = %filter.dataset_name, "{report}");
+            }
+            if !scan.dropped.is_empty() {
                 // `flush_to` is this envelope's *latest* folded commit
                 // (coalescing takes the max — see `try_merge`), which can be
                 // at or after an earlier-folded dropped chunk's real commit
@@ -1572,8 +1634,9 @@ impl MemberMailboxReceiver {
                 // Spawned rather than awaited because `pop` drives a sync
                 // `Stream::poll_next` — `mark_commit_observed` cannot run
                 // inline without blocking it on the registry's async state.
-                let registry = Arc::clone(registry);
+                let registry = Arc::clone(&filter.registry);
                 let flush_to = pending.flush_to;
+                let dropped = scan.dropped;
                 tokio::spawn(async move {
                     for xid in dropped {
                         registry.mark_commit_observed(xid, flush_to).await;
@@ -1676,8 +1739,8 @@ fn member_mailbox_with_limits(
             // Set by the caller after construction for a write-back dataset
             // (see the member registration call site); every other caller
             // (including every test that isn't exercising echo-drop) leaves
-            // this `None`, matching the pre-refactor absence of a registry.
-            write_back_registry: None,
+            // this `None`, so the filter costs one pointer read per envelope.
+            echo_filter: None,
         },
     )
 }
@@ -2287,10 +2350,12 @@ async fn attach_member(
     // branch, keeping the held floor — so the replay this member is owed starts where
     // the slot resumed, not where a slot-mate was credited.
     let (sender, mut receiver) = member_mailbox(params.member_channel_capacity);
-    // This member's own echo-drop registry, if it is a durable write-back
-    // dataset (see `MemberMailboxReceiver::pop`) — cloned here because
+    // This member's own echo filter, if it is a durable write-back dataset (see
+    // `MemberMailboxReceiver::pop`) — the registry is cloned here because
     // `write_back_registry` itself is moved into `MemberHandle` below.
-    receiver.write_back_registry.clone_from(&write_back_registry);
+    receiver.echo_filter = write_back_registry
+        .clone()
+        .map(|registry| EchoFilter::new(registry, dataset_name.clone()));
     // Grouping signal for the analysis: record which shared slot this dataset joined.
     // (Membership liveness is marked by `mark_member_attached` below.)
     metrics.set_slot_name(source.key.slot_name.clone());
@@ -4273,8 +4338,16 @@ async fn deliver_commit(
             Arc::clone(rel),
             raw,
             commit_ts_ms,
-        )
-        .with_source_xid(current_txn_xid);
+        );
+        // Tag only a member that holds a registry: one without it can never match
+        // an xid, so tagging would buy nothing and cost an allocation per relation
+        // per commit. A slot with no write-back member therefore does no xid
+        // bookkeeping at all, and on a mixed slot only the write-back table pays.
+        let rows = if member.write_back_registry.is_some() {
+            rows.with_source_xid(current_txn_xid)
+        } else {
+            rows
+        };
         member.metrics.inc_transaction();
         // Lag-based readiness: this WAL envelope marks the dataset Ready only if
         // its source commit time is within the member's `ready_lag` of now, i.e.
@@ -6479,7 +6552,9 @@ mod tests {
             // The echo-drop decision now lives on the receiver (see
             // `MemberMailboxReceiver::pop`), so the test's registry must be
             // attached here too, matching the real member-registration path.
-            receiver.write_back_registry = registry.clone();
+            receiver.echo_filter = registry
+                .clone()
+                .map(|registry| EchoFilter::new(registry, table.to_string()));
             lock(&source.members).insert(
                 member_key.clone(),
                 Arc::new(MemberHandle {
@@ -6747,6 +6822,136 @@ mod tests {
             "no registry means no filtering for t0"
         );
         assert_eq!(t1.num_rows_hint(), 1, "t1 delivers as usual");
+    }
+
+    /// The report is made on the first foreign transaction and never again, and
+    /// it carries the three things an operator acts on: which dataset, what
+    /// delivery may do to the other writer's row, and where to read more.
+    /// Asserted on the string so a reword cannot quietly drop one.
+    #[tokio::test]
+    async fn an_external_write_is_reported_once_and_names_the_dataset() {
+        // The registry's contents are irrelevant here — this asserts only the
+        // once-only report and its wording.
+        let mut filter = EchoFilter::new(registry_with_xid(1).await, "orders_wb".to_string());
+
+        assert!(
+            filter.external_write_report(false).is_none(),
+            "an envelope with no foreign transaction reports nothing"
+        );
+
+        let report = filter
+            .external_write_report(true)
+            .expect("the first foreign transaction is reported");
+        assert!(report.contains("'orders_wb'"), "names the dataset: {report}");
+        assert!(
+            report.contains("overwrite"),
+            "states what delivery may do to the other writer's row: {report}"
+        );
+        assert!(
+            report.contains("https://spiceai.org/docs/"),
+            "links the docs: {report}"
+        );
+        assert!(!report.contains('\n'), "stays on a single line: {report}");
+
+        assert!(
+            filter.external_write_report(true).is_none(),
+            "every later foreign transaction says the same thing and is not repeated"
+        );
+    }
+
+    /// A transaction Spice did not issue is reported: the write-back table has a
+    /// second writer, the one condition the feature cannot make safe. (That such
+    /// a transaction is also *delivered* is
+    /// `unregistered_xid_delivers_all_rows_on_write_back_member`.)
+    #[tokio::test]
+    async fn a_foreign_transaction_is_reported() {
+        let registry = registry_with_xid(11).await;
+        let (source, decoder, routes, mut receivers) = echo_scenario(Some(registry));
+
+        deliver_one_commit(
+            &source,
+            &decoder,
+            &routes,
+            txn_with(&[(100, "1")]),
+            800,
+            Some(22),
+        )
+        .await;
+
+        receivers[0]
+            .next()
+            .await
+            .expect("t0 envelope")
+            .expect("not an error");
+        assert!(
+            receivers[0]
+                .echo_filter
+                .as_ref()
+                .expect("t0 has an echo filter")
+                .warned_external_write,
+            "the external writer is reported"
+        );
+    }
+
+    /// A dataset's own write-back echo must not be mistaken for someone else's
+    /// write — that would warn about the very writes the feature is delivering.
+    #[tokio::test]
+    async fn a_datasets_own_echo_is_not_reported_as_external() {
+        let xid = 33u32;
+        let registry = registry_with_xid(xid).await;
+        let (source, decoder, routes, mut receivers) = echo_scenario(Some(registry));
+
+        deliver_one_commit(
+            &source,
+            &decoder,
+            &routes,
+            txn_with(&[(100, "1")]),
+            810,
+            Some(xid),
+        )
+        .await;
+
+        let ack = receivers[0]
+            .next()
+            .await
+            .expect("t0 ack envelope")
+            .expect("not an error");
+        assert_eq!(ack.num_rows_hint(), 0, "the echo is dropped");
+        assert!(
+            !receivers[0]
+                .echo_filter
+                .as_ref()
+                .expect("t0 has an echo filter")
+                .warned_external_write,
+            "the dataset's own delivery is not an external write"
+        );
+    }
+
+    /// An envelope built for a member that suppresses no echoes carries no xids,
+    /// and the filter must then keep every chunk. Unreachable through the pump
+    /// (it tags exactly the members that hold a registry), but it pins the safe
+    /// direction: deliver the change rather than discard it.
+    #[tokio::test]
+    async fn an_untracked_envelope_keeps_every_chunk() {
+        let registry = registry_with_xid(7).await;
+        let mut rows = PgChangeRows::new(
+            tiny_schema(),
+            Arc::clone(&TINY_RELATION),
+            vec![Bytes::from_static(b"I")],
+            Some(0),
+        );
+
+        let scan = rows.drop_echoed(&registry);
+
+        assert!(scan.dropped.is_empty(), "nothing can match an untagged chunk");
+        assert!(
+            !scan.saw_foreign_txn,
+            "an untagged chunk is not evidence of a foreign transaction"
+        );
+        assert!(
+            !ChangeRows::is_empty(&rows),
+            "the chunk survives an untracked pass"
+        );
     }
 
     /// The commit is observed (so the entry becomes prunable at its LSN) but the

--- a/crates/runtime/tests/cayenne/transaction.rs
+++ b/crates/runtime/tests/cayenne/transaction.rs
@@ -192,6 +192,35 @@ async fn read_n(rt: &Runtime, table: &str, id: &str) -> Option<i64> {
     Some(col.value(0))
 }
 
+/// `SUM(n)` across `table`, as the quota tests' oracle. `COALESCE` so an empty
+/// table reads 0 rather than NULL — the reservation gate is written the same way,
+/// because a NULL gate aborts (see `test_txn_null_gate_fail_safe`) and a quota
+/// system must admit its first reservation.
+async fn read_sum(rt: &Runtime, table: &str) -> i64 {
+    let df = rt.datafusion();
+    let sql = format!("SELECT COALESCE(SUM(n), 0) FROM {table}");
+    let batches = df
+        .query_builder(&sql)
+        .build()
+        .run()
+        .await
+        .unwrap_or_else(|e| panic!("read query `{sql}` failed to plan: {e}"))
+        .data
+        .try_collect::<Vec<RecordBatch>>()
+        .await
+        .unwrap_or_else(|e| panic!("read query `{sql}` failed to execute: {e}"));
+    let batch = batches
+        .iter()
+        .find(|b| b.num_rows() > 0)
+        .unwrap_or_else(|| panic!("read query `{sql}` returned no rows"));
+    batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("SUM(n) should be Int64")
+        .value(0)
+}
+
 // ---------------------------------------------------------------------------
 // Tests driving the run_transaction orchestrator
 // ---------------------------------------------------------------------------
@@ -353,6 +382,164 @@ async fn test_txn_cap_enforcement() -> Result<(), String> {
                 read_n(&rt, "t", "a").await,
                 Some(CAP),
                 "final counter must be pinned at the cap"
+            );
+            Ok(())
+        })
+        .await
+}
+
+/// quota reservation, sequential: an `assert(SUM + k <= QUOTA)` gate followed by
+/// an `INSERT` admits exactly the reservations that fit and aborts the rest.
+///
+/// Distinct from [`test_txn_cap_enforcement`] in the two ways that matter. The
+/// gate reads an **aggregate over every row** rather than one key, so the
+/// transaction's read set is the whole table; and the write **inserts a new key**
+/// rather than updating an existing one. Together those are the shape a
+/// reservation system has — "is there room left, and if so take some" — and they
+/// reach the staged commit path differently from a single-key counter.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "windows"))]
+async fn test_txn_quota_reservation_admits_only_what_fits() -> Result<(), String> {
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            const QUOTA: i64 = 100;
+            const RESERVATION: i64 = 30;
+            const ATTEMPTS: usize = 5;
+            // The seed already holds 10 of the quota, so three reservations of 30
+            // fit exactly (10 + 90 = 100) and the fourth would exceed it.
+            const SEEDED: i64 = 10;
+            const EXPECTED_COMMITS: usize = 3;
+
+            let temp = tempfile::tempdir().map_err(|e| e.to_string())?;
+            let csv = temp.path().join("seed.csv");
+            write_seed_csv(&csv, &[("r0", SEEDED)])?;
+            let app = AppBuilder::new("test_txn_quota_sequential")
+                .with_dataset(make_txn_dataset(
+                    "t",
+                    &csv,
+                    &temp.path().join("data"),
+                    &temp.path().join("meta"),
+                ))
+                .build();
+            let rt = build_ready_runtime(app).await?;
+            assert_eq!(read_sum(&rt, "t").await, SEEDED, "seeded quota usage");
+
+            let mut commits = 0usize;
+            let mut aborts = 0usize;
+            for attempt in 0..ATTEMPTS {
+                // A distinct key per attempt: reserving is an insert, and reusing a
+                // key would upsert over an earlier reservation instead of adding to
+                // the total, quietly making the quota unreachable.
+                let sql = format!(
+                    "BEGIN; \
+                     SELECT assert((SELECT COALESCE(SUM(n), 0) FROM t) + {RESERVATION} <= {QUOTA}); \
+                     INSERT INTO t (id, n) VALUES ('r{attempt}_user', {RESERVATION}); COMMIT;"
+                );
+                match run_txn(&rt, &sql).await {
+                    Ok(_) => commits += 1,
+                    Err(err @ (TransactionError::Query(_) | TransactionError::Stream(_))) => {
+                        assert!(
+                            describe(&err).contains("assertion failed"),
+                            "attempt {attempt}: expected a gate abort, got {}",
+                            describe(&err)
+                        );
+                        aborts += 1;
+                    }
+                    Err(other) => {
+                        return Err(format!(
+                            "attempt {attempt}: unexpected error {}",
+                            describe(&other)
+                        ));
+                    }
+                }
+            }
+
+            assert_eq!(commits, EXPECTED_COMMITS, "only the reservations that fit commit");
+            assert_eq!(aborts, ATTEMPTS - EXPECTED_COMMITS, "the rest abort at the gate");
+            assert_eq!(
+                read_sum(&rt, "t").await,
+                QUOTA,
+                "the admitted reservations must land exactly on the quota"
+            );
+            Ok(())
+        })
+        .await
+}
+
+/// quota reservation, concurrent: the quota is never oversubscribed.
+///
+/// This is the write-skew question, and the reason the aggregate gate deserves
+/// its own test. Per-key optimistic concurrency compares the keys a transaction
+/// touched, but every reservation here inserts a *different* key while reading
+/// the same aggregate — so nothing about the keys reveals the conflict, and two
+/// transactions that each saw room could each take it. Cayenne's answer is to
+/// degrade the keyset and fall back to per-table conflict detection
+/// (`mark_pk_keyset_occ_degraded`), which until now only a unit test covered.
+///
+/// The safety invariant is asserted strictly: committed reservations must never
+/// exceed the quota. Liveness is asserted weakly — at least one must get through
+/// — because a concurrent attempt may legitimately lose either at the gate or to
+/// a conflict, and pinning the exact commit count would make the test a race.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[cfg(not(target_os = "windows"))]
+async fn test_txn_quota_holds_under_concurrent_reservations() -> Result<(), String> {
+    let _tracing = crate::init_tracing(Some("integration=debug,info"));
+
+    test_request_context()
+        .scope(async {
+            const QUOTA: i64 = 100;
+            const RESERVATION: i64 = 30;
+            const SEEDED: i64 = 10;
+            // More contenders than can fit, so the gate and the conflict detector
+            // are both under real pressure.
+            const CONTENDERS: usize = 8;
+
+            let temp = tempfile::tempdir().map_err(|e| e.to_string())?;
+            let csv = temp.path().join("seed.csv");
+            write_seed_csv(&csv, &[("r0", SEEDED)])?;
+            let app = AppBuilder::new("test_txn_quota_concurrent")
+                .with_dataset(make_txn_dataset(
+                    "t",
+                    &csv,
+                    &temp.path().join("data"),
+                    &temp.path().join("meta"),
+                ))
+                .build();
+            let rt = build_ready_runtime(app).await?;
+
+            let mut tasks = Vec::with_capacity(CONTENDERS);
+            for contender in 0..CONTENDERS {
+                let rt = Arc::clone(&rt);
+                tasks.push(tokio::spawn(async move {
+                    let sql = format!(
+                        "BEGIN; \
+                         SELECT assert((SELECT COALESCE(SUM(n), 0) FROM t) + {RESERVATION} <= {QUOTA}); \
+                         INSERT INTO t (id, n) VALUES ('u{contender}', {RESERVATION}); COMMIT;"
+                    );
+                    run_txn(&rt, &sql).await.is_ok()
+                }));
+            }
+
+            let mut commits = 0usize;
+            for task in tasks {
+                if task.await.map_err(|e| format!("reservation task panicked: {e}"))? {
+                    commits += 1;
+                }
+            }
+
+            let total = read_sum(&rt, "t").await;
+            assert!(
+                total <= QUOTA,
+                "the quota was oversubscribed: {commits} reservations of {RESERVATION} \
+                 committed over a seeded {SEEDED}, leaving SUM(n)={total} against a \
+                 quota of {QUOTA}"
+            );
+            assert!(
+                commits >= 1,
+                "no reservation got through at all (SUM(n)={total}); the gate or the \
+                 conflict detector is rejecting everything"
             );
             Ok(())
         })

--- a/crates/runtime/tests/postgres/mod.rs
+++ b/crates/runtime/tests/postgres/mod.rs
@@ -45,6 +45,8 @@ pub mod replication_shared;
 pub mod replication_tpch;
 #[cfg(all(feature = "postgres", feature = "duckdb"))]
 pub mod schema_inference;
+#[cfg(all(feature = "postgres", not(target_os = "windows")))]
+pub mod write_back_delivery;
 
 #[tokio::test]
 async fn test_postgres_types() -> Result<(), anyhow::Error> {

--- a/crates/runtime/tests/postgres/write_back_delivery.rs
+++ b/crates/runtime/tests/postgres/write_back_delivery.rs
@@ -1,0 +1,566 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![allow(clippy::expect_used)]
+//! Integration tests for what durable write-back *delivers* to a `PostgreSQL`
+//! source, driven through a full `Runtime`.
+//!
+//! These sit beside the echo-suppression suite and deliberately do not repeat
+//! it: the question here is not whether an echo is dropped but whether the row
+//! the source ends up holding is the row the accelerator committed.
+//!
+//! Both tests use the same WAL-ordering barrier the echo suite established,
+//! because an upsert-keyed CDC apply makes a leaked echo largely idempotent and
+//! a time-based assertion would be a guess: once a local write has demonstrably
+//! reached the source, an *external* sentinel row is written directly to the
+//! source, and the test waits for that sentinel to appear in the accelerator.
+//! Logical replication is delivered in commit order, so a visible sentinel
+//! proves the pump has already processed every earlier transaction — including
+//! the echo of our own delivery. Only then is the table asserted.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::anyhow;
+use app::AppBuilder;
+use runtime::Runtime;
+use secrecy::ExposeSecret;
+use spicepod::acceleration::{Acceleration, Mode, OnConflictBehavior, RefreshMode, WriteMode};
+use spicepod::component::dataset::replication::Replication;
+use spicepod::component::{access::AccessMode, dataset::Dataset};
+use spicepod::param::Params;
+use tokio::time::sleep;
+use tokio_postgres::{Client, NoTls};
+
+use crate::postgres::common;
+use crate::utils::{register_test_connectors, run_query, runtime_ready_check, test_request_context};
+use crate::{configure_test_datafusion, init_tracing};
+
+/// How long to wait for a value to propagate in either direction — Spice → the
+/// source through the delivery worker (which polls once a second), or the source
+/// → Spice through the CDC stream.
+const PROPAGATION_TIMEOUT: Duration = Duration::from_secs(60);
+/// Poll interval while waiting.
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+// ── source helpers ──────────────────────────────────────────────────────────
+
+async fn connect(port: usize) -> Result<Client, anyhow::Error> {
+    let mut cfg = tokio_postgres::Config::new();
+    cfg.host("localhost")
+        .port(u16::try_from(port)?)
+        .user("postgres")
+        .password(common::PG_PASSWORD)
+        .dbname("postgres");
+    let (client, connection) = cfg.connect(NoTls).await?;
+    tokio::spawn(async move {
+        let _: Result<(), tokio_postgres::Error> = connection.await;
+    });
+    Ok(client)
+}
+
+async fn exec(client: &Client, sql: &str) -> Result<(), anyhow::Error> {
+    client
+        .simple_query(sql)
+        .await
+        .map_err(|e| anyhow!("postgres error running `{sql}`: {e}"))?;
+    Ok(())
+}
+
+/// A single `int4` column from the source, or `None` when no row matched.
+async fn source_value(client: &Client, sql: &str) -> Result<Option<i64>, anyhow::Error> {
+    let rows = client
+        .query(sql, &[])
+        .await
+        .map_err(|e| anyhow!("postgres error running `{sql}`: {e}"))?;
+    match rows.first() {
+        None => Ok(None),
+        Some(row) => Ok(row.try_get::<_, Option<i32>>(0)?.map(i64::from)),
+    }
+}
+
+/// A single `count(*)` from the source.
+async fn source_count(client: &Client, sql: &str) -> Result<i64, anyhow::Error> {
+    let row = client
+        .query_one(sql, &[])
+        .await
+        .map_err(|e| anyhow!("postgres error running `{sql}`: {e}"))?;
+    Ok(row.try_get::<_, i64>(0)?)
+}
+
+// ── accelerator helpers ─────────────────────────────────────────────────────
+
+/// A single integer scalar from a Spice query, or `None` for an empty result.
+async fn accel_scalar(rt: &Arc<Runtime>, sql: &str) -> Result<Option<i64>, anyhow::Error> {
+    let batches = run_query(rt, sql).await?;
+    let Some(batch) = batches.iter().find(|b| b.num_rows() > 0) else {
+        return Ok(None);
+    };
+    let column = batch.column(0);
+    if let Some(ints) = column.as_any().downcast_ref::<arrow::array::Int64Array>() {
+        return Ok(Some(ints.value(0)));
+    }
+    if let Some(ints) = column.as_any().downcast_ref::<arrow::array::Int32Array>() {
+        return Ok(Some(i64::from(ints.value(0))));
+    }
+    Err(anyhow!(
+        "query `{sql}` returned an unexpected column type {} (expected an integer)",
+        column.data_type()
+    ))
+}
+
+/// Poll until `probe` yields `expected`, or fail naming the last value seen, so
+/// a timeout says which direction of the round trip stalled.
+async fn wait_for<F, Fut>(
+    what: &str,
+    expected: Option<i64>,
+    mut probe: F,
+) -> Result<(), anyhow::Error>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<Option<i64>, anyhow::Error>>,
+{
+    let deadline = Instant::now() + PROPAGATION_TIMEOUT;
+    loop {
+        let last = probe().await?;
+        if last == expected {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "timed out waiting for {what} to become {expected:?}; last saw {last:?}"
+            ));
+        }
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Assert a Spice scalar equals `expected` right now, with no waiting — for use
+/// after a barrier has already established that the pump is caught up.
+async fn assert_accel(
+    rt: &Arc<Runtime>,
+    sql: &str,
+    expected: i64,
+    why: &str,
+) -> Result<(), anyhow::Error> {
+    let actual = accel_scalar(rt, sql).await?;
+    if actual != Some(expected) {
+        return Err(anyhow!(
+            "`{sql}` was {actual:?}, expected {expected}: {why}"
+        ));
+    }
+    Ok(())
+}
+
+// ── dataset construction ────────────────────────────────────────────────────
+
+/// A durable-write-back Cayenne dataset over `public.{table}`: writable,
+/// replicating, CDC-fed, upserting by a single-column primary key. The
+/// accelerator is file-backed because the outstanding-xid registry lives in the
+/// accelerator's store, so a memory-only accelerator would not persist it.
+fn write_back_dataset(port: usize, table: &str, slot: &str, accel_dir: &Path) -> Dataset {
+    cdc_dataset(port, table, Some(slot), accel_dir, WriteMode::WriteBack)
+}
+
+/// A `PostgreSQL`-sourced, Cayenne-file, CDC dataset. `write_mode` and the
+/// presence of an explicit replication slot are the axes the control tests below
+/// vary one at a time, to find which of them a stalled load depends on.
+fn cdc_dataset(
+    port: usize,
+    table: &str,
+    slot: Option<&str>,
+    accel_dir: &Path,
+    write_mode: WriteMode,
+) -> Dataset {
+    let mut dataset = Dataset::new(format!("postgres:public.{table}"), table.to_string());
+
+    let mut params: HashMap<String, String> = common::get_pg_params(port)
+        .into_iter()
+        .map(|(k, v)| (k, v.expose_secret().to_string()))
+        .collect();
+    if let Some(slot) = slot {
+        params.insert("pg_replication_slot".to_string(), slot.to_string());
+    }
+    dataset.params = Some(Params::from_string_map(params));
+
+    let mut accel_params = HashMap::new();
+    accel_params.insert(
+        "cayenne_file_path".to_string(),
+        accel_dir.join(format!("{table}_data")).display().to_string(),
+    );
+    accel_params.insert(
+        "cayenne_metadata_dir".to_string(),
+        accel_dir.join(format!("{table}_meta")).display().to_string(),
+    );
+
+    dataset.acceleration = Some(Acceleration {
+        enabled: true,
+        engine: Some("cayenne".to_string()),
+        mode: Mode::File,
+        refresh_mode: Some(RefreshMode::Changes),
+        primary_key: Some("id".to_string()),
+        on_conflict: [("id".to_string(), OnConflictBehavior::Upsert)]
+            .into_iter()
+            .collect(),
+        write_mode,
+        params: Some(Params::from_string_map(accel_params)),
+        ..Acceleration::default()
+    });
+    // Write-back is local-first with asynchronous source durability, so the
+    // runtime requires both the writable access mode and the explicit opt-in.
+    if write_mode == WriteMode::WriteBack {
+        dataset.access = AccessMode::ReadWrite;
+        dataset.replication = Some(Replication { enabled: true });
+    }
+
+    dataset
+}
+
+async fn build_runtime(name: &str, datasets: Vec<Dataset>) -> Result<Arc<Runtime>, anyhow::Error> {
+    register_test_connectors().await;
+    let mut builder = AppBuilder::new(name);
+    for dataset in datasets {
+        builder = builder.with_dataset(dataset);
+    }
+    configure_test_datafusion();
+    let rt = Arc::new(Runtime::builder().with_app(builder.build()).build().await);
+
+    // Phase markers go to stderr, not `tracing`: the harness installs its
+    // subscriber as a thread-local default, so anything the loader logs from a
+    // worker thread is dropped and a stall says only that it elapsed.
+    eprintln!("[{name}] runtime built; loading components");
+    tokio::select! {
+        () = tokio::time::sleep(Duration::from_secs(120)) => {
+            // Deliberately does not read component statuses: that lock is held by
+            // the load still in flight, so inspecting it here hangs instead of
+            // reporting.
+            return Err(anyhow!("timed out waiting for datasets to load"));
+        }
+        () = Arc::clone(&rt).load_components() => {}
+    }
+    eprintln!("[{name}] components loaded; waiting for readiness");
+    runtime_ready_check(&rt).await;
+    eprintln!("[{name}] ready");
+    Ok(rt)
+}
+
+fn tracing_filter() -> Option<&'static str> {
+    Some(
+        "integration=debug,runtime=debug,connector_postgres=debug,\
+         data_components::postgres_replication=debug,info",
+    )
+}
+
+// ── UPDATE delivery ─────────────────────────────────────────────────────────
+
+/// An UPDATE committed through Spice reaches the source.
+///
+/// The write path for an update is its own code (`update_write_back`) and the
+/// delivery worker reconciles it by upserting the row's *current* committed
+/// value, so an update exercises a different pair of legs than the insert and
+/// delete the echo suite drives. This asserts the value the source ends up
+/// holding, and — after the barrier — that the accelerator still holds it once.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_write_back_update_reaches_the_source() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(tracing_filter());
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+            let source = connect(port).await?;
+            exec(
+                &source,
+                "CREATE TABLE public.wb_update (id int PRIMARY KEY, amount int NOT NULL)",
+            )
+            .await?;
+            exec(&source, "INSERT INTO public.wb_update VALUES (1, 10), (2, 20)").await?;
+
+            let accel = tempfile::tempdir()?;
+            let rt = build_runtime(
+                "write_back_update",
+                vec![write_back_dataset(
+                    port,
+                    "wb_update",
+                    "spice_wb_update_slot",
+                    accel.path(),
+                )],
+            )
+            .await?;
+            wait_for("the bootstrap snapshot", Some(2), || {
+                accel_scalar(&rt, "SELECT count(*) FROM wb_update")
+            })
+            .await?;
+
+            // An UPDATE of a bootstrapped row: committed to the accelerator, then
+            // delivered to the source as an upsert of its current value.
+            run_query(&rt, "UPDATE wb_update SET amount = 99 WHERE id = 2").await?;
+            wait_for("the updated row at the source", Some(99), || {
+                source_value(&source, "SELECT amount FROM public.wb_update WHERE id = 2")
+            })
+            .await?;
+
+            // Barrier: an external sentinel committed after the delivery. Once it
+            // is visible here, the pump has processed past the delivery's echo.
+            exec(&source, "INSERT INTO public.wb_update VALUES (100, 7)").await?;
+            wait_for("the sentinel", Some(1), || {
+                accel_scalar(&rt, "SELECT count(*) FROM wb_update WHERE id = 100")
+            })
+            .await?;
+
+            assert_accel(
+                &rt,
+                "SELECT amount FROM wb_update WHERE id = 2",
+                99,
+                "the accelerator must still hold the value it committed",
+            )
+            .await?;
+            assert_accel(
+                &rt,
+                "SELECT count(*) FROM wb_update",
+                3,
+                "the update must not have added a row",
+            )
+            .await?;
+            assert_accel(
+                &rt,
+                "SELECT sum(amount) FROM wb_update",
+                116,
+                "10 + 99 + 7: a re-applied update would double-count",
+            )
+            .await?;
+            // The source agrees, so nothing was delivered twice or lost.
+            let source_sum = source_count(&source, "SELECT sum(amount)::int8 FROM public.wb_update")
+                .await?;
+            assert_eq!(source_sum, 116, "the source holds the same total");
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}
+
+// ── a source-side trigger inside the delivery transaction ───────────────────
+
+/// A source-side trigger that rewrites the delivered row converges: the
+/// accelerator ends up holding the trigger's value, not the one it committed.
+///
+/// This is worth pinning because the obvious prediction is the opposite. The
+/// trigger fires *inside* the delivery transaction, so the rewritten row is
+/// written under the delivery's own transaction id — exactly what echo
+/// suppression discards — which would leave the accelerator on its own value
+/// forever. Measured, that is not what happens: the rewrite reaches the
+/// accelerator and the two sides agree on the source's value.
+///
+/// The assertion is a bounded wait rather than an instantaneous read, so it
+/// states the outcome without depending on whether the rewrite arrives as a
+/// suppressed-then-refreshed value or an applied one. If suppression ever did
+/// keep the rewrite out, this wait would time out and say so.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_source_trigger_rewrite_reaches_the_accelerator() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(tracing_filter());
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+            let source = connect(port).await?;
+            exec(
+                &source,
+                "CREATE TABLE public.wb_trigger (id int PRIMARY KEY, amount int NOT NULL)",
+            )
+            .await?;
+            // Seeded before the trigger exists, so the bootstrap snapshot is the
+            // plain value and only delivered rows are rewritten.
+            exec(&source, "INSERT INTO public.wb_trigger VALUES (1, 10)").await?;
+            // Doubling makes a rewrite unmistakable rather than a plausible
+            // off-by-one.
+            exec(
+                &source,
+                "CREATE FUNCTION double_amount() RETURNS trigger AS $$
+                 BEGIN NEW.amount := NEW.amount * 2; RETURN NEW; END;
+                 $$ LANGUAGE plpgsql",
+            )
+            .await?;
+            exec(
+                &source,
+                "CREATE TRIGGER double_amount_trigger BEFORE INSERT OR UPDATE
+                 ON public.wb_trigger FOR EACH ROW EXECUTE FUNCTION double_amount()",
+            )
+            .await?;
+
+            let accel = tempfile::tempdir()?;
+            let rt = build_runtime(
+                "write_back_source_trigger",
+                vec![write_back_dataset(
+                    port,
+                    "wb_trigger",
+                    "spice_wb_trigger_slot",
+                    accel.path(),
+                )],
+            )
+            .await?;
+            wait_for("the bootstrap snapshot", Some(1), || {
+                accel_scalar(&rt, "SELECT count(*) FROM wb_trigger")
+            })
+            .await?;
+
+            // Spice commits 50. The trigger stores 100.
+            run_query(&rt, "INSERT INTO wb_trigger (id, amount) VALUES (2, 50)").await?;
+            wait_for("the trigger's rewrite at the source", Some(100), || {
+                source_value(&source, "SELECT amount FROM public.wb_trigger WHERE id = 2")
+            })
+            .await?;
+
+            // Barrier: the sentinel is an external transaction, so it is not
+            // suppressed. Its own value is doubled by the trigger too, which is
+            // why the barrier waits on the row's presence and not its value.
+            exec(&source, "INSERT INTO public.wb_trigger VALUES (100, 7)").await?;
+            wait_for("the sentinel", Some(1), || {
+                accel_scalar(&rt, "SELECT count(*) FROM wb_trigger WHERE id = 100")
+            })
+            .await?;
+
+            // The trigger's rewrite reaches the accelerator: both sides end up on
+            // the source's value, not the one Spice committed.
+            wait_for("the trigger's rewrite in the accelerator", Some(100), || {
+                accel_scalar(&rt, "SELECT amount FROM wb_trigger WHERE id = 2")
+            })
+            .await?;
+            // The sentinel is an external transaction, so its own rewrite is never
+            // a suppression candidate — it confirms the stream is live rather than
+            // stalled at the row above.
+            assert_accel(
+                &rt,
+                "SELECT amount FROM wb_trigger WHERE id = 100",
+                14,
+                "an external transaction's rewrite reaches the accelerator",
+            )
+            .await?;
+            assert_eq!(
+                source_value(&source, "SELECT amount FROM public.wb_trigger WHERE id = 2").await?,
+                Some(100),
+                "the source holds the trigger's value"
+            );
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}
+
+// ── controls: which axis does a stalled load depend on? ─────────────────────
+
+/// Control: the same Cayenne-file CDC dataset as the tests above, but a plain
+/// replicated reader — no write-back, no writable access, no replication opt-in.
+///
+/// A declared `refresh_mode: changes` *dataset* has no other integration
+/// coverage in a `--features postgres` build (`replication_tpch` is gated on
+/// `duckdb`), so this is the baseline the write-back tests are read against: it
+/// separates "this dataset shape does not come up" from "write-back does not
+/// come up". Kept as a permanent test, not scaffolding — the baseline is worth
+/// having on its own.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_plain_cdc_dataset_bootstraps_and_follows_the_source() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(tracing_filter());
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+            let source = connect(port).await?;
+            exec(
+                &source,
+                "CREATE TABLE public.cdc_plain (id int PRIMARY KEY, amount int NOT NULL)",
+            )
+            .await?;
+            exec(&source, "INSERT INTO public.cdc_plain VALUES (1, 10)").await?;
+
+            let accel = tempfile::tempdir()?;
+            let rt = build_runtime(
+                "cdc_plain",
+                vec![cdc_dataset(
+                    port,
+                    "cdc_plain",
+                    Some("spice_cdc_plain_slot"),
+                    accel.path(),
+                    WriteMode::WriteThrough,
+                )],
+            )
+            .await?;
+
+            wait_for("the bootstrap snapshot", Some(1), || {
+                accel_scalar(&rt, "SELECT count(*) FROM cdc_plain")
+            })
+            .await?;
+
+            // A source-side write reaches the accelerator over CDC.
+            exec(&source, "INSERT INTO public.cdc_plain VALUES (2, 20)").await?;
+            wait_for("the source insert", Some(20), || {
+                accel_scalar(&rt, "SELECT amount FROM cdc_plain WHERE id = 2")
+            })
+            .await?;
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}
+
+/// Control: write-back, but with no explicit `pg_replication_slot` — the slot is
+/// named per dataset instead of shared. Isolates the slot parameter from the
+/// write-back path, since the tests above set both.
+#[tokio::test(flavor = "multi_thread")]
+async fn write_back_bootstraps_without_an_explicit_slot() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(tracing_filter());
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+            let source = connect(port).await?;
+            exec(
+                &source,
+                "CREATE TABLE public.wb_noslot (id int PRIMARY KEY, amount int NOT NULL)",
+            )
+            .await?;
+            exec(&source, "INSERT INTO public.wb_noslot VALUES (1, 10)").await?;
+
+            let accel = tempfile::tempdir()?;
+            let rt = build_runtime(
+                "wb_noslot",
+                vec![cdc_dataset(
+                    port,
+                    "wb_noslot",
+                    None,
+                    accel.path(),
+                    WriteMode::WriteBack,
+                )],
+            )
+            .await?;
+
+            wait_for("the bootstrap snapshot", Some(1), || {
+                accel_scalar(&rt, "SELECT count(*) FROM wb_noslot")
+            })
+            .await?;
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}


### PR DESCRIPTION
Stacked on #13350 — targets `feat/11840-xid-registry`, not trunk. Scoped to avoid
overlapping #13355, which covers echo suppression end-to-end (drop, restart,
reconnect, per-relation cascade, external write applying normally); nothing here
re-tests those.

## Two echo-suppression tests could not fail

`reconnect_replay_without_prune_drops_echo_again` delivers a transaction twice
and then reads two envelopes. Both passes publish an ordinary
`PendingItem::Changes` for the same member, and `try_publish` folds a compatible
envelope into an unclaimed `Changes` tail rather than appending an item — so the
replay merged into the first delivery, only one envelope ever reached the
mailbox, and the second read waited forever. **This hangs unconditionally**, so
`make nextest` cannot have passed on this branch since the echo drop moved off
the shared pump. Claiming the first envelope before replaying keeps the two
passes distinct, which is what the test set out to compare.

`unregistered_xid_delivers_all_rows_on_write_back_member` asserted
`num_rows_hint()` — an estimate precomputed alongside the buffered chunks and
left untouched when they are removed, so it still read 1 for an envelope whose
chunks were all gone. That is the exact shape of the regression the test is named
for, so it would have passed against the bug. It now asserts the built batch,
which reads the chunks.

Both are in the first commit, isolated so they can be cherry-picked into #13350
independently of the rest.

## A write-back table reports an external writer, once

Durable write-back delivers each committed row as an unconditional
`INSERT … ON CONFLICT (pk) DO UPDATE` and never compares against what the source
holds, so it is safe only while the accelerator is the sole writer of the rows it
delivers. A transaction the dataset did not issue is the only evidence the
runtime gets that a deployment has left that regime, and it was silent about it.

The same compaction pass that finds echoes now reports whether a chunk survived
carrying a foreign transaction id, and the member's filter turns the first one
into a single warning naming the dataset, what delivery may do to the other
writer's row, and where to read more. Once per dataset per run: every later
foreign write says the same thing, and a per-envelope log would drown the stream
it describes. The message is built by a pure function and asserted as a string,
so a reword cannot drop the dataset name, the consequence, or the docs link.

## Transaction ids are tracked only where they can be used

Tagging a chunk with its source transaction id serves one purpose: letting a
durable write-back dataset recognise the echo of its own delivery. Every member's
envelope was tagged regardless, so each relation of each commit paid a `Vec`
allocation for a feature the dataset could not use.

`chunk_xids` becomes `ChunkXids::{Untracked, Tracked}`, starting untracked and
allocating nothing, and the pump tags only a member holding an echo-suppression
registry. The decision reads the same `MemberHandle` field that gives the
receiver its filter, so "tracked" and "needs the tags" cannot disagree — no
source-level flag, and no registration-versus-promotion ordering to reason about.
A slot with no write-back member now does no xid bookkeeping at all, and on a
mixed slot only the write-back table pays.

`try_append` declines a mixed-variant merge — both sides come from one member so
it cannot arise, and declining costs a coalescing opportunity at worst rather
than mis-attributing an xid. `drop_echoed` on an untracked envelope keeps every
chunk, the safe direction for a state the pump does not produce.

Verified not to weaken suppression: with the gate removed entirely (every member
tagged, the previous behaviour) the write-back integration tests produce
identical results.

## Write-back delivery tests

`crates/runtime/tests/postgres/write_back_delivery.rs`, kept separate from the
echo suite: the question here is not whether an echo is dropped but whether the
row the source ends up holding is the row the accelerator committed. All four use
the WAL-ordering barrier that suite established — an upsert-keyed apply makes a
leaked echo largely idempotent, so after a local write reaches the source an
external sentinel row is written there, and the sentinel becoming visible proves
the pump has processed past the echo.

- **A plain `refresh_mode: changes` dataset bootstraps and follows the source.** A
  declared CDC *dataset* had no integration coverage at all in a
  `--features postgres` build (`replication_tpch` is gated on `duckdb`), so this
  is the baseline the write-back tests are read against — and what separates
  "this dataset shape does not come up" from "write-back does not come up".
- **An UPDATE committed through Spice reaches the source.** The update write path
  is its own code and the worker reconciles it by upserting the row's current
  committed value, so it exercises different legs than an insert or a delete.
- **A source-side trigger that rewrites the delivered row converges.** Worth
  pinning because the obvious prediction is the opposite: the trigger fires
  inside the delivery transaction, so its rewrite carries the delivery's own
  transaction id, which is what echo suppression discards — that would leave the
  accelerator on its own value forever. Measured, the rewrite reaches the
  accelerator and both sides agree on the source's value. The assertion is a
  bounded wait, so it states the outcome without claiming a mechanism, and it
  fails loudly if suppression ever does keep the rewrite out.
- **Write-back bootstraps without an explicit replication slot**, separating the
  slot parameter from the write-back path.

### Running these needs `sqlite`

Durable write-back needs an accelerator sidecar, and Cayenne's is
`#[cfg(feature = "sqlite")]`. Without that feature the xid-registry load fails
into a `UnableToGetWriteBackDeliverer`, which `Error::is_retriable` treats as
transient — so the dataset retries for the life of the process and never becomes
ready, with no error surfaced. Build with `--features postgres,sqlite`.

That retry classification is worth fixing separately: the failure should be
raised where the sidecar is found unavailable, as an `InvalidConfiguration`
(already classified permanent), rather than by reclassifying the whole variant,
whose other causes — an unreachable source during setup — are genuinely
transient.

## Quota-bounded reservation transaction

The gated-transaction suite covered a single-key counter against a cap
(`test_txn_cap_enforcement`). A reservation system is a different shape in the
two ways that matter: the gate reads an **aggregate over every row**, so the read
set is the whole table rather than one key, and the write **inserts a new key**.

Sequentially that admits exactly what fits — quota 100 with 10 used, reservations
of 30, five attempts, three commits and two gate aborts landing exactly on the
quota. Each attempt takes a distinct key, because reserving is an insert and
reusing a key would upsert over an earlier reservation instead of adding to the
total, quietly making the quota unreachable.

Concurrently it is the write-skew question. Per-key optimistic concurrency
compares the keys a transaction touched, but every reservation inserts a
different key while reading the same aggregate, so nothing about the keys reveals
the conflict and two transactions that each saw room could each take it.
`mark_pk_keyset_occ_degraded`'s fall back to per-table conflict detection is what
prevents that, and it had only unit coverage. Eight contenders against room for
three: the quota holds. Safety is asserted strictly and reports the commit count
and observed total on failure; liveness is asserted weakly, because a concurrent
attempt may legitimately lose at the gate or to a conflict and pinning the exact
count would make the test a race.

This suite is accelerator-only Cayenne over a local CSV, so it needs no Docker
and runs under default features.

## Verification

- write-back delivery: 4 passed, 0 failed (`--features postgres,sqlite`)
- quota reservation: 2 passed, 0 failed
- `data_components` `postgres_replication`: 207 passed, 0 failed

`make lint-rust` is **not** clean on this branch, for reasons outside this diff:
`connector-postgres` has three clippy errors at `--features postgres`
(`replication.rs:261`, `lib.rs:86`, `lib.rs:1137`), and `cayenne/mod.rs:3121` has
an unused `registry` binding that appears only when `sqlite` is enabled — a
combination the gate's feature set never lints. None of those files are in this
diff, so they are left for the parent branch to resolve holistically.
