### PR TITLE
fix(cli): keep a granted Spice Cloud login when the identity endpoint is silent

### DIFF
--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -1272,7 +1272,9 @@ pub async fn first_user_credential(
             if !is_org_refusal(&err) {
                 return Err(err);
             }
-            tracing::debug!("A stored credential may not act on organization '{org}' ({err}); trying the next one");
+            tracing::debug!(
+                "A stored credential may not act on organization '{org}' ({err}); trying the next one"
+            );
             refusal = Some(err);
             continue;
         }
@@ -1787,7 +1789,10 @@ mod tests {
             IdentityFailure::Undescribed,
             "a credential Spice Cloud cannot describe must stay usable"
         );
-        assert_eq!(classify_identity_failure(&forbidden), IdentityFailure::Fatal);
+        assert_eq!(
+            classify_identity_failure(&forbidden),
+            IdentityFailure::Fatal
+        );
         assert_eq!(
             classify_identity_failure(&server_error),
             IdentityFailure::Fatal

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -133,12 +133,32 @@ impl CloudClient {
         let default = org::default_token().ok_or_else(|| org_credential_missing(org))?;
 
         let probe = Self::with_token_for_org(default.clone(), None)?;
-        match probe.optional_user_auth_context().await? {
-            Some(_) => {
+        // Ask for the identity directly rather than through
+        // [`Self::optional_user_auth_context`]: that helper folds "rejected"
+        // and "cannot describe" into one absent answer, and they mean opposite
+        // things here.
+        match probe.get_auth_context().await {
+            Ok(_) => {
                 probe.get_auth_context_for_org(org).await?;
                 Self::with_token_for_org(default, Some(org))
             }
-            None => Err(org_credential_missing(org)),
+            // A rejected credential has no user membership to spend on another
+            // organization: it is a machine token, which stays org-bound.
+            Err(err) if err.cloud_code() == Some(CloudErrorCode::TokenExpired) => {
+                Err(org_credential_missing(org))
+            }
+            // No identity came back, so whether this is a user token — usable
+            // for every member org — is unknown. Declining would refuse a
+            // member their own organization on the strength of a lookup that
+            // failed, so send the request and let the server, which is
+            // authoritative on membership, answer.
+            Err(err) if is_absent_user_identity_error(&err) => {
+                tracing::debug!(
+                    "Spice Cloud did not describe the identity behind the default credential ({err}); acting on organization '{org}' with it and letting the server decide"
+                );
+                Self::with_token_for_org(default, Some(org))
+            }
+            Err(err) => Err(err),
         }
     }
 

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -238,7 +238,7 @@ impl CloudClient {
     pub async fn optional_user_auth_context(&self) -> Result<Option<AuthContext>> {
         match self.get_auth_context().await {
             Ok(ctx) => Ok(Some(ctx)),
-            Err(err) if is_unauthorized_auth_context_error(&err) => Ok(None),
+            Err(err) if is_absent_user_identity_error(&err) => Ok(None),
             Err(err) => Err(err),
         }
     }
@@ -1086,12 +1086,18 @@ fn build_executor(
     })
 }
 
-/// A rejected credential on the auth-context endpoint.
+/// The auth-context endpoint did not describe a user for this credential.
 ///
-/// Service-account tokens are valid for the management API but have no user
-/// identity, so callers that only want the identity treat this as "absent".
-pub fn is_unauthorized_auth_context_error(err: &crate::error::Error) -> bool {
-    err.cloud_code() == Some(CloudErrorCode::TokenExpired)
+/// Two answers mean the same thing to a caller that only wants the identity:
+/// the endpoint rejected the credential (401), or it has no user record to
+/// return for it (404). Service-account tokens are valid for the management
+/// API but have no user identity, so both are "absent" rather than fatal —
+/// a caller that needs the identity says so with its own error.
+pub fn is_absent_user_identity_error(err: &crate::error::Error) -> bool {
+    matches!(
+        err.cloud_code(),
+        Some(CloudErrorCode::TokenExpired | CloudErrorCode::NotFound)
+    )
 }
 
 pub fn is_device_authorization_denied_error(error: &crate::error::Error) -> bool {
@@ -1492,6 +1498,19 @@ mod tests {
         });
 
         assert_eq!(err.cloud_code(), Some(CloudErrorCode::TokenExpired));
-        assert!(is_unauthorized_auth_context_error(&err));
+        assert!(is_absent_user_identity_error(&err));
+    }
+
+    /// Spice Cloud answers the identity endpoint with 404 for credentials it
+    /// cannot describe. Treating that as fatal blocks `spice cloud link` and
+    /// `spice cloud whoami` behind an identity neither of them requires.
+    #[test]
+    fn not_found_is_an_absent_identity_rather_than_a_failure() {
+        let err = map_cloud_error(None)(spice_cloud_client::error::Error::NotFound {
+            message: "{}".to_string(),
+        });
+
+        assert_eq!(err.cloud_code(), Some(CloudErrorCode::NotFound));
+        assert!(is_absent_user_identity_error(&err));
     }
 }

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -251,10 +251,15 @@ impl CloudClient {
             .map_err(|error| self.err(error))
     }
 
-    /// Returns user auth context when the token supports it.
+    /// Returns user auth context when Spice Cloud describes one.
     ///
-    /// Service-account tokens cannot access the auth-context endpoint; those
-    /// `Unauthorized` failures are treated as absent user context.
+    /// `None` means the identity endpoint did not describe a user, which
+    /// covers two different situations and does not distinguish them: it
+    /// rejected the credential (401 — a service-account token, which has no
+    /// user identity), or it had no user to return (404). A caller that must
+    /// tell those apart — because one proves the credential unusable and the
+    /// other proves nothing — should call [`Self::get_auth_context`] and match
+    /// the error itself.
     pub async fn optional_user_auth_context(&self) -> Result<Option<AuthContext>> {
         match self.get_auth_context().await {
             Ok(ctx) => Ok(Some(ctx)),
@@ -1106,6 +1111,87 @@ fn build_executor(
     })
 }
 
+/// What an identity-endpoint failure proves about a credential.
+#[derive(Debug, PartialEq, Eq)]
+enum IdentityFailure {
+    /// Spice Cloud rejected it: a machine token, with no user identity to spend.
+    Rejected,
+    /// Spice Cloud had no user to describe. The credential may still be a
+    /// perfectly good user token — this says nothing either way.
+    Undescribed,
+    /// Something the caller has to see, such as a refusal or a server error.
+    Fatal,
+}
+
+fn classify_identity_failure(err: &crate::error::Error) -> IdentityFailure {
+    match err.cloud_code() {
+        Some(CloudErrorCode::TokenExpired) => IdentityFailure::Rejected,
+        Some(CloudErrorCode::NotFound) => IdentityFailure::Undescribed,
+        _ => IdentityFailure::Fatal,
+    }
+}
+
+/// Confirm this credential may act on `org`, or say why not.
+///
+/// A 404 here is the identity endpoint declining to describe the credential,
+/// not the organization refusing it — a refusal arrives as 403. Treating the
+/// two alike would deny a member their own organization on the strength of a
+/// lookup that failed, so an undescribed credential is allowed through and the
+/// server, which is authoritative on membership, answers the real request.
+pub async fn confirm_org_access(client: &CloudClient, org: &str) -> Result<()> {
+    match client.get_auth_context_for_org(org).await {
+        Ok(_) => Ok(()),
+        Err(err) if err.cloud_code() == Some(CloudErrorCode::NotFound) => {
+            tracing::debug!(
+                "Spice Cloud did not describe this credential's access to organization '{org}' ({err}); continuing and letting the server decide"
+            );
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// The first credential in `candidates` that can act as a user, if any.
+///
+/// Both Cloud Connect entry points — the `spice cloud link` preflight and the
+/// enrollment transaction — choose a credential this way, and they must agree:
+/// one accepting a credential the other rejects strands a link half-done.
+///
+/// A credential the identity endpoint *rejects* has no user identity to spend
+/// (a machine token), so it is skipped. One it merely cannot *describe* is
+/// unknown rather than unusable, and is kept as a fallback behind any
+/// credential that does describe a user.
+pub async fn first_user_credential(
+    candidates: &[String],
+    endpoint: &str,
+    org: Option<&str>,
+) -> Result<Option<String>> {
+    let mut undescribed: Option<&String> = None;
+
+    for token in candidates {
+        let client = CloudClient::with_token_for_org_at(token.clone(), None, endpoint)?;
+        if let Err(err) = client.get_auth_context().await {
+            match classify_identity_failure(&err) {
+                IdentityFailure::Rejected => continue,
+                IdentityFailure::Undescribed => {
+                    tracing::debug!(
+                        "Spice Cloud did not describe the identity behind a stored credential ({err}); keeping it as a fallback"
+                    );
+                    undescribed.get_or_insert(token);
+                    continue;
+                }
+                IdentityFailure::Fatal => return Err(err),
+            }
+        }
+        if let Some(org) = org {
+            confirm_org_access(&client, org).await?;
+        }
+        return Ok(Some(token.clone()));
+    }
+
+    Ok(undescribed.cloned())
+}
+
 /// The auth-context endpoint did not describe a user for this credential.
 ///
 /// Two answers mean the same thing to a caller that only wants the identity:
@@ -1519,6 +1605,40 @@ mod tests {
 
         assert_eq!(err.cloud_code(), Some(CloudErrorCode::TokenExpired));
         assert!(is_absent_user_identity_error(&err));
+    }
+
+    /// 401 is the one answer that disqualifies a credential; 404 leaves it
+    /// unknown, and anything else is a failure the caller must see.
+    #[test]
+    fn identity_failures_are_classified_by_what_they_prove() {
+        let rejected = map_cloud_error(None)(spice_cloud_client::error::Error::Unauthorized {
+            message: "invalid or expired token".to_string(),
+        });
+        let undescribed = map_cloud_error(None)(spice_cloud_client::error::Error::NotFound {
+            message: "{}".to_string(),
+        });
+        let forbidden = map_cloud_error(None)(spice_cloud_client::error::Error::Forbidden {
+            message: "missing scope".to_string(),
+        });
+        let server_error = map_cloud_error(None)(spice_cloud_client::error::Error::Api {
+            status: 500,
+            message: "boom".to_string(),
+        });
+
+        assert_eq!(
+            classify_identity_failure(&rejected),
+            IdentityFailure::Rejected
+        );
+        assert_eq!(
+            classify_identity_failure(&undescribed),
+            IdentityFailure::Undescribed,
+            "a credential Spice Cloud cannot describe must stay usable"
+        );
+        assert_eq!(classify_identity_failure(&forbidden), IdentityFailure::Fatal);
+        assert_eq!(
+            classify_identity_failure(&server_error),
+            IdentityFailure::Fatal
+        );
     }
 
     /// Spice Cloud answers the identity endpoint with 404 for credentials it

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -139,7 +139,7 @@ impl CloudClient {
         // things here.
         match probe.get_auth_context().await {
             Ok(_) => {
-                probe.get_auth_context_for_org(org).await?;
+                confirm_org_access(&probe, org).await?;
                 Self::with_token_for_org(default, Some(org))
             }
             // A rejected credential has no user membership to spend on another

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -1252,7 +1252,20 @@ pub async fn first_user_credential(
         return Ok(Some(token.clone()));
     }
 
-    Ok(undescribed.cloned())
+    let Some(token) = undescribed else {
+        return Ok(None);
+    };
+
+    // Confirm the fallback the same way, or the one credential that skips the
+    // check is the one nothing could describe — and both link stages choose
+    // independently, so an unconfirmed choice here is one the other stage may
+    // not make.
+    if let Some(org) = org {
+        let client = CloudClient::with_token_for_org_at(token.clone(), None, endpoint)?;
+        confirm_org_access(&client, org).await?;
+    }
+
+    Ok(Some(token.clone()))
 }
 
 /// The auth-context endpoint did not describe a user for this credential.

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -410,19 +410,28 @@ impl CloudClient {
         self.inner
             .get_auth_context_for_org(Some(org))
             .await
-            .map_err(|error| match error {
-                spice_cloud_client::error::Error::NotFound { .. } => Error::cloud_with_hint(
-                    CloudErrorCode::OrgNotFound,
-                    format!("Organization '{org}' was not found."),
-                    "Run 'spice cloud orgs' to list the organizations you can access.",
-                ),
-                spice_cloud_client::error::Error::Forbidden { .. } => Error::cloud_with_hint(
-                    CloudErrorCode::OrgForbidden,
-                    format!("You are not a member of organization '{org}'."),
-                    "Ask an owner of that organization to add you, then run 'spice cloud orgs'.",
-                ),
-                error => self.err(error),
-            })
+            .map_err(|error| self.map_org_probe_error(org, error))
+    }
+
+    /// Render a failed organization probe.
+    ///
+    /// Named rather than inline because [`org_probe_is_inconclusive`] has to
+    /// agree with the codes produced here: a rule that tolerates a code this
+    /// never emits reads as working and silently does nothing.
+    fn map_org_probe_error(&self, org: &str, error: spice_cloud_client::error::Error) -> Error {
+        match error {
+            spice_cloud_client::error::Error::NotFound { .. } => Error::cloud_with_hint(
+                CloudErrorCode::OrgNotFound,
+                format!("Organization '{org}' was not found."),
+                "Run 'spice cloud orgs' to list the organizations you can access.",
+            ),
+            spice_cloud_client::error::Error::Forbidden { .. } => Error::cloud_with_hint(
+                CloudErrorCode::OrgForbidden,
+                format!("You are not a member of organization '{org}'."),
+                "Ask an owner of that organization to add you, then run 'spice cloud orgs'.",
+            ),
+            error => self.err(error),
+        }
     }
 
     pub async fn get_project_by_id(&self, project_id: i64) -> Result<Project> {
@@ -1131,6 +1140,20 @@ fn classify_identity_failure(err: &crate::error::Error) -> IdentityFailure {
     }
 }
 
+/// Whether a failed organization probe leaves access undecided.
+///
+/// The identity endpoint answers 404 for several conditions — including an
+/// organization that exists but has no app — and the probe renders all of them
+/// as [`CloudErrorCode::OrgNotFound`]. None of them prove the credential may
+/// not act on the organization, so none of them should decide it here. A
+/// refusal arrives as `OrgForbidden`, which is conclusive and is not tolerated.
+fn org_probe_is_inconclusive(err: &crate::error::Error) -> bool {
+    matches!(
+        err.cloud_code(),
+        Some(CloudErrorCode::OrgNotFound | CloudErrorCode::NotFound)
+    )
+}
+
 /// Confirm this credential may act on `org`, or say why not.
 ///
 /// A 404 here is the identity endpoint declining to describe the credential,
@@ -1141,7 +1164,7 @@ fn classify_identity_failure(err: &crate::error::Error) -> IdentityFailure {
 pub async fn confirm_org_access(client: &CloudClient, org: &str) -> Result<()> {
     match client.get_auth_context_for_org(org).await {
         Ok(_) => Ok(()),
-        Err(err) if err.cloud_code() == Some(CloudErrorCode::NotFound) => {
+        Err(err) if org_probe_is_inconclusive(&err) => {
             tracing::debug!(
                 "Spice Cloud did not describe this credential's access to organization '{org}' ({err}); continuing and letting the server decide"
             );
@@ -1605,6 +1628,40 @@ mod tests {
 
         assert_eq!(err.cloud_code(), Some(CloudErrorCode::TokenExpired));
         assert!(is_absent_user_identity_error(&err));
+    }
+
+    /// The organization probe's own rendering decides what
+    /// [`org_probe_is_inconclusive`] must accept. Asserting the rule against a
+    /// hand-built error would pass while the two disagreed, which is exactly
+    /// how tolerating `NotFound` alone came to be a no-op: the probe renders
+    /// that response as `OrgNotFound`.
+    #[test]
+    fn the_org_probe_renders_a_missing_answer_as_something_the_rule_tolerates() {
+        let client = CloudClient::new_unauthenticated().expect("client should build");
+
+        let undescribed = client.map_org_probe_error(
+            "acme",
+            spice_cloud_client::error::Error::NotFound {
+                message: "{}".to_string(),
+            },
+        );
+        assert_eq!(undescribed.cloud_code(), Some(CloudErrorCode::OrgNotFound));
+        assert!(
+            org_probe_is_inconclusive(&undescribed),
+            "an undescribed organization must not decide access: {undescribed}"
+        );
+
+        let refused = client.map_org_probe_error(
+            "acme",
+            spice_cloud_client::error::Error::Forbidden {
+                message: "not a member".to_string(),
+            },
+        );
+        assert_eq!(refused.cloud_code(), Some(CloudErrorCode::OrgForbidden));
+        assert!(
+            !org_probe_is_inconclusive(&refused),
+            "a refusal is conclusive and must be surfaced: {refused}"
+        );
     }
 
     /// 401 is the one answer that disqualifies a credential; 404 leaves it

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -413,6 +413,14 @@ impl CloudClient {
             .map_err(|error| self.map_org_probe_error(org, error))
     }
 
+    /// This client, carrying `org` on every request it makes.
+    fn scoped_to_org(&self, org: &str) -> Self {
+        Self {
+            inner: self.inner.clone().with_org(org),
+            org: Some(org.to_string()),
+        }
+    }
+
     /// Render a failed organization probe.
     ///
     /// Named rather than inline because [`org_probe_is_inconclusive`] has to
@@ -1181,18 +1189,25 @@ fn org_probe_is_inconclusive(err: &crate::error::Error) -> bool {
 
 /// Confirm this credential may act on `org`, or say why not.
 ///
-/// A 404 here is the identity endpoint declining to describe the credential,
-/// not the organization refusing it — a refusal arrives as 403. Treating the
-/// two alike would deny a member their own organization on the strength of a
-/// lookup that failed, so an undescribed credential is allowed through and the
-/// server, which is authoritative on membership, answers the real request.
+/// The identity endpoint answers 404 for conditions that say nothing about
+/// access — an organization with no app reads the same as one that does not
+/// exist — so that answer decides nothing here. It is also not proof of
+/// access: callers store a credential under the organization this confirms,
+/// and filing one under an organization it cannot act on makes every later
+/// command fail obscurely.
+///
+/// So an inconclusive answer is followed by a question whose answer cannot be
+/// ambiguous: list the organization's projects. That is a read the server
+/// refuses for a non-member, so success requires membership and nothing else
+/// is inferred.
 pub async fn confirm_org_access(client: &CloudClient, org: &str) -> Result<()> {
     match client.get_auth_context_for_org(org).await {
         Ok(_) => Ok(()),
         Err(err) if org_probe_is_inconclusive(&err) => {
             tracing::debug!(
-                "Spice Cloud did not describe this credential's access to organization '{org}' ({err}); continuing and letting the server decide"
+                "Spice Cloud did not describe this credential's access to organization '{org}' ({err}); confirming membership by listing that organization's projects instead"
             );
+            client.scoped_to_org(org).list_projects().await?;
             Ok(())
         }
         Err(err) => Err(err),

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -1140,6 +1140,31 @@ fn classify_identity_failure(err: &crate::error::Error) -> IdentityFailure {
     }
 }
 
+/// The stored credentials that could act as a user, most specific first.
+///
+/// Both link stages build this list, and they must build the same one: if the
+/// preflight considers a credential the enrollment transaction does not, a
+/// link passes its checks and then reports no credential at all.
+pub fn user_credential_candidates(requested: Option<&str>) -> Vec<String> {
+    let mut candidates = Vec::new();
+    for token in [
+        requested.and_then(org::token_for_org),
+        org::default_token(),
+        org::active_org()
+            .ok()
+            .flatten()
+            .and_then(|active| org::token_for_org(&active)),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if !candidates.contains(&token) {
+            candidates.push(token);
+        }
+    }
+    candidates
+}
+
 /// Whether a failed organization probe leaves access undecided.
 ///
 /// The identity endpoint answers 404 for several conditions — including an

--- a/bin/spice/src/commands/cloud/client.rs
+++ b/bin/spice/src/commands/cloud/client.rs
@@ -1173,6 +1173,20 @@ pub fn user_credential_candidates(requested: Option<&str>) -> Vec<String> {
     candidates
 }
 
+/// Whether an organization check refused this particular credential.
+///
+/// A refusal reaches us under two codes, because two different questions can
+/// ask it: the identity probe renders one as `OrgForbidden`, and the scoped
+/// project listing renders its own as `Forbidden`. Both say the same thing —
+/// *this* credential may not act there — which is a fact about the credential,
+/// not about the request, so another credential is still worth trying.
+fn is_org_refusal(err: &crate::error::Error) -> bool {
+    matches!(
+        err.cloud_code(),
+        Some(CloudErrorCode::OrgForbidden | CloudErrorCode::Forbidden)
+    )
+}
+
 /// Whether a failed organization probe leaves access undecided.
 ///
 /// The identity endpoint answers 404 for several conditions — including an
@@ -1229,43 +1243,57 @@ pub async fn first_user_credential(
     endpoint: &str,
     org: Option<&str>,
 ) -> Result<Option<String>> {
-    let mut undescribed: Option<&String> = None;
+    // A credential Spice Cloud describes wins, but only among those that may
+    // actually act on the organization: a refusal is a fact about one
+    // credential, so it disqualifies that candidate rather than the search.
+    let mut fallback: Option<&String> = None;
+    let mut refusal: Option<crate::error::Error> = None;
 
     for token in candidates {
         let client = CloudClient::with_token_for_org_at(token.clone(), None, endpoint)?;
-        if let Err(err) = client.get_auth_context().await {
-            match classify_identity_failure(&err) {
+
+        let described = match client.get_auth_context().await {
+            Ok(_) => true,
+            Err(err) => match classify_identity_failure(&err) {
                 IdentityFailure::Rejected => continue,
+                IdentityFailure::Fatal => return Err(err),
                 IdentityFailure::Undescribed => {
                     tracing::debug!(
-                        "Spice Cloud did not describe the identity behind a stored credential ({err}); keeping it as a fallback"
+                        "Spice Cloud did not describe the identity behind a stored credential ({err}); considering it a fallback"
                     );
-                    undescribed.get_or_insert(token);
-                    continue;
+                    false
                 }
-                IdentityFailure::Fatal => return Err(err),
+            },
+        };
+
+        if let Some(org) = org
+            && let Err(err) = confirm_org_access(&client, org).await
+        {
+            if !is_org_refusal(&err) {
+                return Err(err);
             }
+            tracing::debug!("A stored credential may not act on organization '{org}' ({err}); trying the next one");
+            refusal = Some(err);
+            continue;
         }
-        if let Some(org) = org {
-            confirm_org_access(&client, org).await?;
+
+        if described {
+            return Ok(Some(token.clone()));
         }
+        fallback.get_or_insert(token);
+    }
+
+    if let Some(token) = fallback {
         return Ok(Some(token.clone()));
     }
 
-    let Some(token) = undescribed else {
-        return Ok(None);
-    };
-
-    // Confirm the fallback the same way, or the one credential that skips the
-    // check is the one nothing could describe — and both link stages choose
-    // independently, so an unconfirmed choice here is one the other stage may
-    // not make.
-    if let Some(org) = org {
-        let client = CloudClient::with_token_for_org_at(token.clone(), None, endpoint)?;
-        confirm_org_access(&client, org).await?;
+    // Nothing was usable. A refusal explains that far better than the caller's
+    // "no user login" fallback message, so surface it.
+    if let Some(err) = refusal {
+        return Err(err);
     }
 
-    Ok(Some(token.clone()))
+    Ok(None)
 }
 
 /// The auth-context endpoint did not describe a user for this credential.
@@ -1715,6 +1743,21 @@ mod tests {
             !org_probe_is_inconclusive(&refused),
             "a refusal is conclusive and must be surfaced: {refused}"
         );
+    }
+
+    /// A refusal disqualifies one credential, not the search — and it arrives
+    /// under two codes, since the identity probe and the scoped listing render
+    /// theirs differently. Missing either would abort the search on a
+    /// credential that was merely the wrong one to try.
+    #[test]
+    fn both_renderings_of_a_refusal_disqualify_only_that_credential() {
+        let from_identity_probe = Error::cloud(CloudErrorCode::OrgForbidden, "not a member");
+        let from_scoped_listing = Error::cloud(CloudErrorCode::Forbidden, "not permitted");
+        let not_a_refusal = Error::cloud(CloudErrorCode::ApiError, "boom");
+
+        assert!(is_org_refusal(&from_identity_probe));
+        assert!(is_org_refusal(&from_scoped_listing));
+        assert!(!is_org_refusal(&not_a_refusal));
     }
 
     /// 401 is the one answer that disqualifies a credential; 404 leaves it

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -1950,7 +1950,7 @@ async fn verify_login_org(
     // Do not compare a user's default org with the requested org: doing so
     // rejects valid member access before the membership endpoint can decide.
     let _ = token_org;
-    client.get_auth_context_for_org(requested).await?;
+    client::confirm_org_access(client, requested).await?;
     Ok(Some(requested.to_string()))
 }
 
@@ -2387,7 +2387,7 @@ async fn execute_whoami(args: &WhoamiArgs, flag_org: Option<&str>) -> Result<()>
             if client.list_projects().await.is_ok() {
                 return Err(Error::cloud_with_hint(
                     CloudErrorCode::Forbidden,
-                    "Spice Cloud returned no user identity for this credential, so there is no user or email to show. The credential itself still authenticates — Spice Cloud accepted it for a project listing — so 'spice cloud orgs', 'projects', 'deploy', and 'logs' keep working.",
+                    "Spice Cloud returned no user identity for this credential, so there is no user or email to show. The credential itself still authenticates: Spice Cloud accepted it for a project listing, so commands that do not need a user identity can still run. Each one is authorized on its own, so a missing role or scope can still refuse an individual command.",
                     "Run 'spice cloud login subscription' or 'spice cloud login token' to authenticate as a user, or continue using this credential for commands that do not need a user identity.",
                 ));
             }
@@ -2777,22 +2777,7 @@ async fn user_token_for_cloud_connect(
     action: &str,
     command: &str,
 ) -> Result<String> {
-    let mut candidates = Vec::new();
-    for token in [
-        requested_org.and_then(org::token_for_org),
-        org::default_token(),
-        org::active_org()
-            .ok()
-            .flatten()
-            .and_then(|org| org::token_for_org(&org)),
-    ]
-    .into_iter()
-    .flatten()
-    {
-        if !candidates.contains(&token) {
-            candidates.push(token);
-        }
-    }
+    let candidates = client::user_credential_candidates(requested_org);
     if candidates.is_empty() {
         return Err(Error::cloud_with_hint(
             CloudErrorCode::NotAuthenticated,

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -2387,7 +2387,7 @@ async fn execute_whoami(args: &WhoamiArgs, flag_org: Option<&str>) -> Result<()>
             if client.list_projects().await.is_ok() {
                 return Err(Error::cloud_with_hint(
                     CloudErrorCode::Forbidden,
-                    "Spice Cloud returned no user identity for this credential, so there is no user or email to show. The credential itself works: it listed this organization's projects, and 'spice cloud projects', 'deploy', and 'logs' will keep working.",
+                    "Spice Cloud returned no user identity for this credential, so there is no user or email to show. The credential itself still authenticates — Spice Cloud accepted it for a project listing — so 'spice cloud orgs', 'projects', 'deploy', and 'logs' keep working.",
                     "Run 'spice cloud login subscription' or 'spice cloud login token' to authenticate as a user, or continue using this credential for commands that do not need a user identity.",
                 ));
             }

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -2378,15 +2378,17 @@ async fn execute_whoami(args: &WhoamiArgs, flag_org: Option<&str>) -> Result<()>
 
     let context = match client.get_auth_context().await {
         Ok(ctx) => ctx,
-        Err(err) if client::is_unauthorized_auth_context_error(&err) => {
-            // The auth-context endpoint requires a user token (subscription
-            // or PAT). Service-account tokens (OAuth client credentials) are
-            // valid for API calls but do not have a user identity.
+        Err(err) if client::is_absent_user_identity_error(&err) => {
+            // The auth-context endpoint answers for user tokens (subscription
+            // or PAT) only. A service-account token (OAuth client credentials)
+            // authenticates API calls but carries no user identity, and the
+            // endpoint can also have no user record to return. Both leave the
+            // credential usable, so report that rather than the raw failure.
             if client.list_projects().await.is_ok() {
                 return Err(Error::cloud_with_hint(
                     CloudErrorCode::Forbidden,
-                    "User identity is not available for this authentication method. The current credential is a valid service-account token and can be used for API calls, but has no user identity.",
-                    "Run 'spice cloud login subscription' or 'spice cloud login token' to obtain a user token.",
+                    "Spice Cloud returned no user identity for this credential, so there is no user or email to show. The credential itself works: it listed this organization's projects, and 'spice cloud projects', 'deploy', and 'logs' will keep working.",
+                    "Run 'spice cloud login subscription' or 'spice cloud login token' to authenticate as a user, or continue using this credential for commands that do not need a user identity.",
                 ));
             }
             return Err(err);
@@ -2799,14 +2801,34 @@ async fn user_token_for_cloud_connect(
         ));
     }
 
+    // A credential the identity endpoint cannot describe (404) is not the same
+    // as one it rejects (401): the first leaves the token's kind unknown, the
+    // second proves it unusable. Keep the unknown ones as a fallback so a
+    // silent identity endpoint cannot strand a user who is logged in, and let
+    // the server — the authority on what a token may do — answer for real.
+    let mut unidentified: Option<String> = None;
+
     for token in candidates {
         let client = CloudClient::with_token_for_org_at(token.clone(), None, endpoint)?;
-        if client.optional_user_auth_context().await?.is_none() {
-            continue;
+        match client.get_auth_context().await {
+            Ok(_) => {}
+            Err(err) if err.cloud_code() == Some(CloudErrorCode::TokenExpired) => continue,
+            Err(err) if client::is_absent_user_identity_error(&err) => {
+                tracing::debug!(
+                    "Spice Cloud did not describe the identity behind a stored credential ({err}); keeping it as a fallback for {command}"
+                );
+                unidentified.get_or_insert(token);
+                continue;
+            }
+            Err(err) => return Err(err),
         }
         if let Some(org) = requested_org {
             client.get_auth_context_for_org(org).await?;
         }
+        return Ok(token);
+    }
+
+    if let Some(token) = unidentified {
         return Ok(token);
     }
 
@@ -4808,7 +4830,7 @@ mod tests {
     fn is_cloud_unauthorized_error_matches_a_rejected_credential() {
         let err = Error::cloud(CloudErrorCode::TokenExpired, "Unauthorized: token expired");
 
-        assert!(client::is_unauthorized_auth_context_error(&err));
+        assert!(client::is_absent_user_identity_error(&err));
     }
 
     #[test]
@@ -4817,7 +4839,7 @@ mod tests {
         // not allowed — that must not be mistaken for a missing user identity.
         let err = Error::cloud(CloudErrorCode::Forbidden, "Forbidden: missing scope");
 
-        assert!(!client::is_unauthorized_auth_context_error(&err));
+        assert!(!client::is_absent_user_identity_error(&err));
     }
 
     #[test]

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -2801,34 +2801,8 @@ async fn user_token_for_cloud_connect(
         ));
     }
 
-    // A credential the identity endpoint cannot describe (404) is not the same
-    // as one it rejects (401): the first leaves the token's kind unknown, the
-    // second proves it unusable. Keep the unknown ones as a fallback so a
-    // silent identity endpoint cannot strand a user who is logged in, and let
-    // the server — the authority on what a token may do — answer for real.
-    let mut unidentified: Option<String> = None;
-
-    for token in candidates {
-        let client = CloudClient::with_token_for_org_at(token.clone(), None, endpoint)?;
-        match client.get_auth_context().await {
-            Ok(_) => {}
-            Err(err) if err.cloud_code() == Some(CloudErrorCode::TokenExpired) => continue,
-            Err(err) if client::is_absent_user_identity_error(&err) => {
-                tracing::debug!(
-                    "Spice Cloud did not describe the identity behind a stored credential ({err}); keeping it as a fallback for {command}"
-                );
-                unidentified.get_or_insert(token);
-                continue;
-            }
-            Err(err) => return Err(err),
-        }
-        if let Some(org) = requested_org {
-            client.get_auth_context_for_org(org).await?;
-        }
-        return Ok(token);
-    }
-
-    if let Some(token) = unidentified {
+    if let Some(token) = client::first_user_credential(&candidates, endpoint, requested_org).await?
+    {
         return Ok(token);
     }
 

--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -2378,20 +2378,29 @@ async fn execute_whoami(args: &WhoamiArgs, flag_org: Option<&str>) -> Result<()>
 
     let context = match client.get_auth_context().await {
         Ok(ctx) => ctx,
+        // Spice Cloud returned no user identity. That happens for a
+        // service-account token (OAuth client credentials), which authenticates
+        // API calls but has no user behind it, and when the endpoint has no
+        // user record to return at all. Neither says the credential is
+        // unusable, so neither should reach the user as a raw failure.
         Err(err) if client::is_absent_user_identity_error(&err) => {
-            // The auth-context endpoint answers for user tokens (subscription
-            // or PAT) only. A service-account token (OAuth client credentials)
-            // authenticates API calls but carries no user identity, and the
-            // endpoint can also have no user record to return. Both leave the
-            // credential usable, so report that rather than the raw failure.
-            if client.list_projects().await.is_ok() {
-                return Err(Error::cloud_with_hint(
-                    CloudErrorCode::Forbidden,
-                    "Spice Cloud returned no user identity for this credential, so there is no user or email to show. The credential itself still authenticates: Spice Cloud accepted it for a project listing, so commands that do not need a user identity can still run. Each one is authorized on its own, so a missing role or scope can still refuse an individual command.",
-                    "Run 'spice cloud login subscription' or 'spice cloud login token' to authenticate as a user, or continue using this credential for commands that do not need a user identity.",
-                ));
-            }
-            return Err(err);
+            // Whether other commands work is a separate question, and the
+            // answer only widens the guidance — it never withholds it, or a
+            // second failure here would put the unusable original message back
+            // in front of the user.
+            let usable = client.list_projects().await.is_ok();
+            let detail = if usable {
+                "The credential itself still authenticates: Spice Cloud accepted it for a project listing, so commands that do not need a user identity can still run. Each one is authorized on its own, so a missing role or scope can still refuse an individual command."
+            } else {
+                "Whether the credential works for anything else is unknown: listing this organization's projects did not succeed either, which a missing role or scope would also explain."
+            };
+            return Err(Error::cloud_with_hint(
+                CloudErrorCode::Forbidden,
+                format!(
+                    "Spice Cloud returned no user identity for this credential, so there is no user or email to show. {detail}"
+                ),
+                "Run 'spice cloud login subscription' or 'spice cloud login token' to authenticate as a user, or continue using this credential for commands that do not need a user identity.",
+            ));
         }
         Err(err) => return Err(err),
     };

--- a/bin/spice/src/commands/connect/transaction.rs
+++ b/bin/spice/src/commands/connect/transaction.rs
@@ -35,7 +35,7 @@ use runtime_cloud_connect::identity::{AppAttachment, Identity, IdentityStore};
 use runtime_cloud_connect::{CloudConnectConfig, EnrollmentTransactionLock};
 use zeroize::Zeroizing;
 
-use crate::commands::cloud::{CloudClient, org as cloud_org};
+use crate::commands::cloud::org as cloud_org;
 use crate::context::RuntimeContext;
 use crate::error::{CloudErrorCode, Error, Result};
 
@@ -989,19 +989,16 @@ async fn stored_user_login(
             candidates.push(token);
         }
     }
-    for token in candidates {
-        let client = CloudClient::with_token_for_org_at(token.clone(), None, endpoint)?;
-        if client.optional_user_auth_context().await?.is_none() {
-            continue;
-        }
-        if let Some(org) = org_hint {
-            client.get_auth_context_for_org(org).await?;
-        }
-        return Ok(Some(LoginCredential {
-            token: SessionToken::new(token),
-        }));
-    }
-    Ok(None)
+    // Share the preflight's policy rather than restating it: `spice cloud link`
+    // chooses a credential before this transaction runs, and a rule that
+    // accepted one here but not there would strand a link half-done.
+    Ok(
+        crate::commands::cloud::client::first_user_credential(&candidates, endpoint, org_hint)
+            .await?
+            .map(|token| LoginCredential {
+                token: SessionToken::new(token),
+            }),
+    )
 }
 
 fn org_credential_missing(org: &str) -> Error {

--- a/bin/spice/src/commands/connect/transaction.rs
+++ b/bin/spice/src/commands/connect/transaction.rs
@@ -977,18 +977,10 @@ async fn stored_user_login(
     endpoint: &str,
     org_hint: Option<&str>,
 ) -> Result<Option<LoginCredential>> {
-    let mut candidates = Vec::new();
-    for token in [
-        org_hint.and_then(cloud_org::token_for_org),
-        cloud_org::default_token(),
-    ]
-    .into_iter()
-    .flatten()
-    {
-        if !candidates.contains(&token) {
-            candidates.push(token);
-        }
-    }
+    // Share the preflight's candidates and policy rather than restating them:
+    // `spice cloud link` chooses a credential before this transaction runs, and
+    // a list or a rule that differed would strand a link half-done.
+    let candidates = crate::commands::cloud::client::user_credential_candidates(org_hint);
     // Share the preflight's policy rather than restating it: `spice cloud link`
     // chooses a credential before this transaction runs, and a rule that
     // accepted one here but not there would strand a link half-done.

--- a/bin/spice/src/commands/login/mod.rs
+++ b/bin/spice/src/commands/login/mod.rs
@@ -22,7 +22,6 @@ pub mod session;
 
 use crate::context::RuntimeContext;
 use crate::error::Result;
-use crate::manifest;
 use clap::{Args, Subcommand};
 use spice_cloud_client::redirect::same_origin_redirect_policy;
 
@@ -491,112 +490,6 @@ fn generate_auth_code() -> String {
             CHARSET[idx] as char
         })
         .collect()
-}
-
-/// Read org and app name from spicepod.yaml or spicepod.yml if it exists.
-fn read_spicepod_metadata() -> (Option<String>, Option<String>) {
-    let Some(spicepod_path) = manifest::existing_spicepod_path(std::path::Path::new(".")) else {
-        return (None, None);
-    };
-
-    let Ok(contents) = std::fs::read_to_string(spicepod_path) else {
-        return (None, None);
-    };
-
-    let Ok(yaml) = yaml::from_str::<yaml::Value>(&contents) else {
-        return (None, None);
-    };
-
-    let org_name = yaml
-        .get("metadata")
-        .and_then(|m| m.get("org"))
-        .and_then(|o| o.as_str())
-        .map(String::from);
-
-    let app_name = yaml.get("name").and_then(|n| n.as_str()).map(String::from);
-
-    (org_name, app_name)
-}
-
-/// Auth context from Spice.ai API.
-pub(crate) struct SpiceAuthContext {
-    username: String,
-    email: String,
-    org_name: String,
-    app_name: Option<String>,
-    app_api_key: Option<String>,
-}
-
-/// Redacts the app API key: the context rides inside login outcomes and
-/// sessions whose `Debug` output can reach logs and assertion messages.
-impl std::fmt::Debug for SpiceAuthContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SpiceAuthContext")
-            .field("username", &self.username)
-            .field("email", &self.email)
-            .field("org_name", &self.org_name)
-            .field("app_name", &self.app_name)
-            .field(
-                "app_api_key",
-                &self.app_api_key.as_ref().map(|_| "<redacted>"),
-            )
-            .finish()
-    }
-}
-
-/// Get auth context from Spice.ai API.
-async fn get_spice_auth_context(
-    base_url: &str,
-    access_token: &str,
-    org_name: Option<&str>,
-    app_name: Option<&str>,
-) -> Result<SpiceAuthContext> {
-    let mut url = format!("{base_url}/api/spice-cli/auth");
-
-    let mut params = Vec::new();
-    if let Some(org) = org_name {
-        params.push(format!("org_name={}", urlencoding::encode(org)));
-    }
-    if let Some(app) = app_name {
-        params.push(format!("app_name={}", urlencoding::encode(app)));
-    }
-    if !params.is_empty() {
-        url = format!("{url}?{}", params.join("&"));
-    }
-
-    let client = credentialed_client()?;
-    let response = client
-        .get(&url)
-        .header("Authorization", format!("Bearer {access_token}"))
-        .send()
-        .await
-        .map_err(|e| crate::error::Error::InvalidResponse {
-            message: format!("Failed to get auth context: {e}"),
-        })?;
-
-    if !response.status().is_success() {
-        let text = response.text().await.unwrap_or_default();
-        return Err(crate::error::Error::InvalidResponse {
-            message: format!("Auth context request failed: {text}"),
-        });
-    }
-
-    // Parse the response - API returns nested org/app objects
-    let body: serde_json::Value =
-        response
-            .json()
-            .await
-            .map_err(|e| crate::error::Error::InvalidResponse {
-                message: format!("Failed to parse auth context: {e}"),
-            })?;
-
-    Ok(SpiceAuthContext {
-        username: body["username"].as_str().unwrap_or_default().to_string(),
-        email: body["email"].as_str().unwrap_or_default().to_string(),
-        org_name: body["org"]["name"].as_str().unwrap_or_default().to_string(),
-        app_name: body["app"]["name"].as_str().map(String::from),
-        app_api_key: body["app"]["api_key"].as_str().map(String::from),
-    })
 }
 
 #[cfg(test)]

--- a/bin/spice/src/commands/login/session.rs
+++ b/bin/spice/src/commands/login/session.rs
@@ -19,16 +19,11 @@ limitations under the License.
 
 use crate::error::Result;
 
-use super::SpiceAuthContext;
-
 /// How the browser authorization ended: with a token, or with the user
 /// refusing it.
 pub(crate) enum BrowserLoginOutcome {
     /// The user authorized the login.
-    Granted {
-        access_token: String,
-        context: SpiceAuthContext,
-    },
+    Granted { access_token: String },
     /// The user refused the authorization in the browser.
     Declined,
 }
@@ -37,10 +32,9 @@ pub(crate) enum BrowserLoginOutcome {
 impl std::fmt::Debug for BrowserLoginOutcome {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Granted { context, .. } => f
+            Self::Granted { .. } => f
                 .debug_struct("Granted")
                 .field("access_token", &"<redacted>")
-                .field("context", context)
                 .finish(),
             Self::Declined => f.write_str("Declined"),
         }
@@ -90,12 +84,19 @@ impl BrowserLogin {
         });
     }
 
-    /// Wait for the browser authorization, then fetch who it authenticated.
+    /// Wait for the browser authorization and return the granted token.
+    ///
+    /// Resolving *who* the token belongs to is the caller's job, and is
+    /// optional: a token Spice Cloud has granted authenticates the management
+    /// API whether or not the identity endpoint can describe its owner, and
+    /// the `spice cloud login` save path already degrades to a token-only
+    /// success when that lookup fails. Failing here instead would discard a
+    /// working credential the user just approved.
     ///
     /// # Errors
     ///
     /// Returns an error if the exchange fails in a way waiting cannot clear,
-    /// if the wait times out, or if the auth context cannot be fetched.
+    /// or if the wait times out.
     pub(crate) async fn authenticate(&self) -> Result<BrowserLoginOutcome> {
         self.authenticate_within(super::LOGIN_POLL_TIMEOUT, super::LOGIN_POLL_INTERVAL)
             .await
@@ -124,22 +125,7 @@ impl BrowserLogin {
             super::AccessTokenPoll::Denied => return Ok(BrowserLoginOutcome::Declined),
         };
 
-        // The spicepod manifest in the working directory may name a preferred
-        // org/app for the auth context to resolve against.
-        let (org_name, app_name) = super::read_spicepod_metadata();
-
-        let context = super::get_spice_auth_context(
-            &self.base_url,
-            &access_token,
-            org_name.as_deref(),
-            app_name.as_deref(),
-        )
-        .await?;
-
-        Ok(BrowserLoginOutcome::Granted {
-            access_token,
-            context,
-        })
+        Ok(BrowserLoginOutcome::Granted { access_token })
     }
 }
 
@@ -155,18 +141,11 @@ mod tests {
     fn browser_outcome_debug_redacts_the_token() {
         let outcome = BrowserLoginOutcome::Granted {
             access_token: "tok_super_secret".to_string(),
-            context: SpiceAuthContext {
-                username: "jane".to_string(),
-                email: "jane@example.com".to_string(),
-                org_name: "acme".to_string(),
-                app_name: None,
-                app_api_key: Some("key_super_secret".to_string()),
-            },
         };
 
         let rendered = format!("{outcome:?}");
         assert!(
-            !rendered.contains("tok_super_secret") && !rendered.contains("key_super_secret"),
+            !rendered.contains("tok_super_secret"),
             "a live credential leaked into Debug output: {rendered}"
         );
     }
@@ -187,49 +166,25 @@ mod tests {
             .await;
     }
 
-    /// The full mock-server flow: the exchange grants a token, the auth
-    /// context answers who it belongs to, and the outcome carries both.
+    /// The full mock-server flow: the exchange grants a token, and that token
+    /// is the whole outcome.
     #[tokio::test]
-    async fn a_granted_authorization_yields_the_token_and_identity() {
+    async fn a_granted_authorization_yields_the_token() {
         let server = wiremock::MockServer::start().await;
         mount_exchange(
             &server,
             serde_json::json!({ "access_token": "tok_live_123" }),
         )
         .await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .and(wiremock::matchers::path("/api/spice-cli/auth"))
-            .and(wiremock::matchers::header(
-                "Authorization",
-                "Bearer tok_live_123",
-            ))
-            .respond_with(
-                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                    "username": "jane",
-                    "email": "jane@example.com",
-                    "org": { "name": "acme" },
-                    "app": { "name": "retail-analytics", "api_key": "key_123" },
-                })),
-            )
-            .mount(&server)
-            .await;
 
         let outcome = flow_against(&server)
             .await
             .expect("a granted flow should succeed");
 
-        let BrowserLoginOutcome::Granted {
-            access_token,
-            context,
-        } = outcome
-        else {
+        let BrowserLoginOutcome::Granted { access_token } = outcome else {
             panic!("expected a granted outcome");
         };
         assert_eq!(access_token, "tok_live_123");
-        assert_eq!(context.username, "jane");
-        assert_eq!(context.org_name, "acme");
-        assert_eq!(context.app_name.as_deref(), Some("retail-analytics"));
-        assert_eq!(context.app_api_key.as_deref(), Some("key_123"));
     }
 
     /// A refusal in the browser is a decided outcome rather than a retryable
@@ -245,24 +200,27 @@ mod tests {
         assert!(matches!(outcome, BrowserLoginOutcome::Declined));
     }
 
-    /// The token is only as good as the identity behind it: a granted exchange
-    /// whose auth context cannot be fetched is a failed login.
+    /// A token the user approved survives an identity endpoint that cannot
+    /// describe it. The flow asks the exchange and nothing else, so a broken
+    /// `/api/spice-cli/auth` — which answers this way for real accounts —
+    /// cannot discard the credential before it is ever stored.
     #[tokio::test]
-    async fn a_failed_auth_context_fails_the_flow() {
+    async fn a_broken_identity_endpoint_does_not_discard_the_token() {
         let server = wiremock::MockServer::start().await;
         mount_exchange(&server, serde_json::json!({ "access_token": "tok_live" })).await;
         wiremock::Mock::given(wiremock::matchers::method("GET"))
             .and(wiremock::matchers::path("/api/spice-cli/auth"))
-            .respond_with(wiremock::ResponseTemplate::new(500))
+            .respond_with(wiremock::ResponseTemplate::new(404).set_body_json(serde_json::json!({})))
             .mount(&server)
             .await;
 
-        let err = flow_against(&server)
+        let outcome = flow_against(&server)
             .await
-            .expect_err("an unfetchable auth context should fail the login");
-        assert!(
-            err.to_string().contains("Auth context request failed"),
-            "unexpected error: {err}"
-        );
+            .expect("an unfetchable identity must not fail the login");
+
+        let BrowserLoginOutcome::Granted { access_token } = outcome else {
+            panic!("expected a granted outcome");
+        };
+        assert_eq!(access_token, "tok_live");
     }
 }


### PR DESCRIPTION
Fixes #13374

## Description

`spice cloud login` ended at `ERROR Invalid HTTP response: Auth context request failed: {}`, and `spice cloud link` and `spice cloud whoami` at `ERROR Not found: {}`, for an account whose credential works everywhere else — `spice cloud orgs` listed its memberships throughout.

Spice Cloud answers the CLI's identity endpoint with `404` and an empty body for some accounts. That is a server-side problem being fixed separately, but it should never have blocked the CLI, because nothing in these flows needs the identity:

- The browser flow fetched the identity with `?`, so the failure discarded a token the user had just approved in the browser. Its caller then dropped that identity on the floor (`Granted { access_token, .. }`) and fetched it again through `save_token_and_print_login_result`, which deliberately tolerates failure with `.ok()` and prints a token-only success. The tolerant path existed and was unreachable. `--org` did not help either, since the early fetch never saw it.
- The "this credential has no user identity" fallback matched only a rejected credential (401), so a 404 from the same endpoint skipped the guidance and surfaced the raw body instead.
- `spice cloud link` propagated the same failure while selecting a user token, and every `--org`-scoped command concluded "No Spice Cloud credential is stored for organization X" for a user token that lists X among its own memberships — because a successful identity lookup was the only accepted proof that a credential is user-backed.

## Changes

- The browser flow returns the granted token alone. The duplicate fetch and the helpers that served only it (`get_spice_auth_context`, `SpiceAuthContext`, `read_spicepod_metadata`) are deleted.
- An absent identity means 401 **or** 404: neither says the credential is unusable. `is_unauthorized_auth_context_error` becomes `is_absent_user_identity_error`.
- Where the difference matters, the two are kept apart rather than folded together. A credential the endpoint *rejects* is a machine token that stays organization-bound; one it merely *cannot describe* is unknown, so `spice cloud link` keeps it as a fallback and `connect()` acts on the requested organization — and lets the server, the authority on membership, refuse if it must.
- `spice cloud whoami` reports what it cannot show and what still works, instead of naming a service-account token as the only possible cause.

## Testing

Unit tests: the case that pinned the old contract is replaced by `a_broken_identity_endpoint_does_not_discard_the_token`, which mounts the exact `404 {}` the server returns and asserts the token survives; `not_found_is_an_absent_identity_rather_than_a_failure` covers the predicate. 553 pass.

Verified live against an affected account, with the identity endpoint still returning `404 {}`:

| Command | Before | After |
| --- | --- | --- |
| `spice cloud login` | `Auth context request failed: {}` | logs in and stores the token |
| `spice cloud whoami` | `Not found: {}` | explains no identity came back, and what still works |
| `spice cloud projects --org <org>` | `Not found: {}`, then "no credential is stored for organization" | lists projects |

This does not restore the identity itself: `spice cloud whoami` stays degraded, without a username or email, until the endpoint answers. It stops that from blocking login, linking, and organization-scoped commands, which is what the issue reports; the endpoint itself is tracked with the platform fix.

`user_token_for_cloud_connect` has no unit test for the new fallback — it reads credentials from the environment, the keychain, and `.env`, so covering it needs environment manipulation that races other tests in the same process. Its behavior is covered by the live run above.
