### PR TITLE
Add OrcaRouter as a named model provider

### DIFF
--- a/crates/llms/src/lib.rs
+++ b/crates/llms/src/lib.rs
@@ -26,6 +26,7 @@ pub mod google;
 #[cfg(feature = "local_embed")]
 pub mod model2vec;
 pub mod openai;
+pub mod orcarouter;
 pub mod progress;
 pub mod provider;
 pub mod rerank;

--- a/crates/llms/src/orcarouter/chat.rs
+++ b/crates/llms/src/orcarouter/chat.rs
@@ -1,0 +1,108 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Chat completions against the OrcaRouter AI gateway.
+
+use crate::config::HostedModelConfig;
+use crate::openai::{Openai, new_openai_client_with_config};
+
+/// The OrcaRouter AI gateway.
+pub const DEFAULT_ENDPOINT: &str = "https://api.orcarouter.ai";
+
+/// Resolves an OrcaRouter endpoint to the base URL of its `OpenAI`-compatible API.
+///
+/// The gateway serves the `OpenAI`-compatible API under `/v1`. An endpoint that already
+/// names `/v1` is taken as-is, so either spelling resolves to the same base URL.
+#[must_use]
+pub fn api_base(endpoint: Option<&str>) -> String {
+    let root = endpoint
+        .map(str::trim)
+        .filter(|e| !e.is_empty())
+        .unwrap_or(DEFAULT_ENDPOINT)
+        .trim_end_matches('/');
+
+    if root.ends_with("/v1") {
+        root.to_string()
+    } else {
+        format!("{root}/v1")
+    }
+}
+
+/// Creates a chat client for a model served by the OrcaRouter AI gateway.
+///
+/// OrcaRouter authenticates with a bearer token (`sk-orca-...`), which `HostedModelConfig`
+/// sends as an `Authorization: Bearer` header — matching the gateway's requirement (unlike
+/// `x-api-key`, which OrcaRouter rejects).
+#[must_use]
+pub fn new_orcarouter_client(
+    model: String,
+    endpoint: Option<&str>,
+    api_key: Option<&str>,
+) -> Openai<HostedModelConfig> {
+    let config = HostedModelConfig::from_url(&api_base(endpoint)).with_bearer_token(api_key);
+    new_openai_client_with_config(model, config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_openai::config::Config;
+
+    #[test]
+    fn api_base_defaults_to_the_orcarouter_gateway() {
+        assert_eq!(api_base(None), "https://api.orcarouter.ai/v1");
+        assert_eq!(api_base(Some("")), "https://api.orcarouter.ai/v1");
+        assert_eq!(api_base(Some("   ")), "https://api.orcarouter.ai/v1");
+    }
+
+    #[test]
+    fn api_base_appends_the_openai_compatible_path() {
+        assert_eq!(
+            api_base(Some("https://api.orcarouter.ai")),
+            "https://api.orcarouter.ai/v1"
+        );
+        assert_eq!(
+            api_base(Some("https://api.orcarouter.ai/")),
+            "https://api.orcarouter.ai/v1"
+        );
+        assert_eq!(
+            api_base(Some("  https://api.orcarouter.ai  ")),
+            "https://api.orcarouter.ai/v1"
+        );
+    }
+
+    #[test]
+    fn api_base_accepts_an_endpoint_that_already_names_v1() {
+        assert_eq!(
+            api_base(Some("https://api.orcarouter.ai/v1")),
+            "https://api.orcarouter.ai/v1"
+        );
+        assert_eq!(
+            api_base(Some("https://api.orcarouter.ai/v1/")),
+            "https://api.orcarouter.ai/v1"
+        );
+    }
+
+    #[test]
+    fn client_uses_bearer_authentication() {
+        let config = HostedModelConfig::from_url(&api_base(None)).with_bearer_token("sk-orca-test");
+        let headers = config.headers();
+        let auth = headers.get("authorization").and_then(|v| v.to_str().ok());
+        assert_eq!(auth, Some("Bearer sk-orca-test"));
+        // OrcaRouter rejects `x-api-key`; the header must not be set.
+        assert!(headers.get("x-api-key").is_none());
+    }
+}

--- a/crates/llms/src/orcarouter/list_models.rs
+++ b/crates/llms/src/orcarouter/list_models.rs
@@ -1,0 +1,138 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Model listing functionality for the OrcaRouter model provider.
+
+use async_openai::Client;
+use async_trait::async_trait;
+use secrecy::{ExposeSecret, SecretString};
+use std::collections::HashMap;
+
+use crate::config::HostedModelConfig;
+use crate::orcarouter::api_base;
+use crate::provider::{ListModels, ListModelsError, ListModelsResult, get_required_param};
+
+// Names the provider in credential/network errors.
+const PROVIDER_NAME: &str = "OrcaRouter";
+
+/// Model lister for the OrcaRouter AI gateway.
+pub struct OrcaRouterModelLister {
+    client: Client<HostedModelConfig>,
+}
+
+impl OrcaRouterModelLister {
+    /// Creates a new model lister from parameters.
+    ///
+    /// Optional parameter: `orcarouter_endpoint` (defaults to <https://api.orcarouter.ai>)
+    /// Parameter `orcarouter_api_key`: required to authenticate with the gateway.
+    pub fn from_params(params: &HashMap<String, SecretString>) -> ListModelsResult<Self> {
+        let endpoint = params
+            .get("orcarouter_endpoint")
+            .map(ExposeSecret::expose_secret);
+
+        let api_key = Some(get_required_param(params, "orcarouter_api_key")?);
+
+        Ok(Self::new(api_key, endpoint))
+    }
+
+    /// Creates a new model lister with explicit credentials.
+    #[must_use]
+    pub fn new(api_key: Option<&SecretString>, endpoint: Option<&str>) -> Self {
+        let config = HostedModelConfig::from_url(&api_base(endpoint))
+            .with_bearer_token(api_key.map(ExposeSecret::expose_secret));
+
+        Self {
+            client: Client::with_config(config),
+        }
+    }
+
+    /// Returns common OrcaRouter model names as a fallback.
+    #[must_use]
+    pub fn common_models() -> Vec<String> {
+        vec![
+            "orcarouter/auto".to_string(),
+            "orcarouter/free".to_string(),
+            "orcarouter/fusion".to_string(),
+        ]
+    }
+}
+
+#[async_trait]
+impl ListModels for OrcaRouterModelLister {
+    fn provider_name(&self) -> &'static str {
+        PROVIDER_NAME
+    }
+
+    async fn list_models(&self) -> ListModelsResult<Vec<String>> {
+        let response = self.client.models().list().await.map_err(|e| {
+            let message = e.to_string();
+            if message.contains("401") || message.contains("Unauthorized") {
+                ListModelsError::InvalidCredentials {
+                    provider: PROVIDER_NAME.to_string(),
+                }
+            } else if message.contains("429") || message.contains("rate") {
+                ListModelsError::RateLimited {
+                    provider: PROVIDER_NAME.to_string(),
+                }
+            } else {
+                ListModelsError::NetworkError {
+                    provider: PROVIDER_NAME.to_string(),
+                    message,
+                }
+            }
+        })?;
+
+        let models: Vec<String> = response.data.into_iter().map(|m| m.id).collect();
+
+        if models.is_empty() {
+            Ok(Self::common_models())
+        } else {
+            Ok(models)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_params_missing_key() {
+        let params = HashMap::new();
+        let result = OrcaRouterModelLister::from_params(&params);
+        assert!(matches!(
+            result,
+            Err(ListModelsError::MissingParameter { .. })
+        ));
+    }
+
+    #[test]
+    fn test_from_params_with_key() {
+        let mut params = HashMap::new();
+        params.insert(
+            "orcarouter_api_key".to_string(),
+            SecretString::from("sk-orca-test"),
+        );
+        let result = OrcaRouterModelLister::from_params(&params);
+        result.expect("should succeed");
+    }
+
+    #[test]
+    fn test_common_models_not_empty() {
+        let models = OrcaRouterModelLister::common_models();
+        assert!(!models.is_empty());
+    }
+}

--- a/crates/llms/src/orcarouter/mod.rs
+++ b/crates/llms/src/orcarouter/mod.rs
@@ -1,0 +1,28 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! OrcaRouter model provider — models served by the OrcaRouter AI gateway.
+//!
+//! OrcaRouter exposes an `OpenAI`-compatible API, so models are driven through
+//! the shared [`crate::openai::Openai`] client rather than a bespoke protocol.
+
+#![allow(clippy::missing_errors_doc)]
+
+mod chat;
+mod list_models;
+
+pub use chat::{DEFAULT_ENDPOINT, api_base, new_orcarouter_client};
+pub use list_models::OrcaRouterModelLister;

--- a/crates/runtime/src/model/chat.rs
+++ b/crates/runtime/src/model/chat.rs
@@ -51,6 +51,7 @@ use super::params::google::GoogleModelParams;
 #[cfg(feature = "models")]
 use super::params::huggingface::HuggingFaceModelParams;
 use super::params::openai::OpenAiModelParams;
+use super::params::orcarouter::OrcaRouterModelParams;
 use super::params::spiceai::SpiceAiModelParams;
 use super::params::xai::XaiModelParams;
 use super::wrapper::OPENAI_DEFAULT_PARAM_KEYS;
@@ -231,6 +232,12 @@ pub async fn construct_model(
             let p = typed_params::<SpiceAiModelParams>(component, params, source.clone(), secrets)
                 .await?;
             spiceai(model_id, &p)
+        }
+        ModelSource::OrcaRouter => {
+            let p =
+                typed_params::<OrcaRouterModelParams>(component, params, source.clone(), secrets)
+                    .await?;
+            orcarouter(model_id, &p)
         }
     }?;
 
@@ -604,6 +611,33 @@ fn spiceai(
     Ok(Arc::new(llms::spiceai::new_spiceai_client(
         model_id,
         Some(endpoint),
+        api_key,
+    )) as Arc<dyn Chat>)
+}
+
+/// Builds a chat model served by the OrcaRouter AI gateway, which exposes an
+/// `OpenAI`-compatible API under `/v1`.
+fn orcarouter(
+    model_id: Option<String>,
+    params: &OrcaRouterModelParams,
+) -> Result<Arc<dyn Chat>, LlmError> {
+    let Some(model_id) = model_id.filter(|id| !id.trim().is_empty()) else {
+        return Err(LlmError::ModelNotProvided {
+            model_source: "orcarouter".to_string(),
+        });
+    };
+
+    // The gateway always authenticates, so an unset key is a misconfiguration.
+    let api_key = params.api_key.as_ref().map(ExposeSecret::expose_secret);
+    if api_key.is_none() {
+        return Err(LlmError::FailedToLoadModel {
+            source: "Missing `orcarouter_api_key`. Models served by the OrcaRouter AI gateway require an API key. Set `orcarouter_api_key`. See: https://www.orcarouter.ai".into(),
+        });
+    }
+
+    Ok(Arc::new(llms::orcarouter::new_orcarouter_client(
+        model_id,
+        Some(params.endpoint.as_str()),
         api_key,
     )) as Arc<dyn Chat>)
 }

--- a/crates/runtime/src/model/params/mod.rs
+++ b/crates/runtime/src/model/params/mod.rs
@@ -34,6 +34,7 @@ pub mod file;
 pub mod google;
 pub mod huggingface;
 pub mod openai;
+pub mod orcarouter;
 pub mod spiceai;
 pub mod xai;
 
@@ -57,6 +58,7 @@ source_specs!(ANTHROPIC_SPEC, anthropic::AnthropicModelParams);
 source_specs!(XAI_SPEC, xai::XaiModelParams);
 source_specs!(BEDROCK_SPEC, bedrock::BedrockModelParams);
 source_specs!(SPICEAI_SPEC, spiceai::SpiceAiModelParams);
+source_specs!(ORCAROUTER_SPEC, orcarouter::OrcaRouterModelParams);
 source_specs!(GOOGLE_SPEC, google::GoogleModelParams);
 
 /// Returns the parameter specifications for a given model source, generated
@@ -75,6 +77,7 @@ pub fn get_params_spec(source: &ModelSource) -> &'static [ParameterSpec] {
         ModelSource::Xai => &XAI_SPEC,
         ModelSource::Bedrock => &BEDROCK_SPEC,
         ModelSource::SpiceAI => &SPICEAI_SPEC,
+        ModelSource::OrcaRouter => &ORCAROUTER_SPEC,
         ModelSource::Google => &GOOGLE_SPEC,
     }
 }
@@ -217,6 +220,22 @@ mod tests {
         assert!(
             hf.iter()
                 .any(|s| s.name == "openai_temperature" && s.deprecation_message.is_some())
+        );
+    }
+
+    #[tokio::test]
+    async fn orcarouter_defaults_and_key_are_accepted() {
+        let typed = orcarouter::OrcaRouterModelParams::try_from_params(
+            "model orcarouter",
+            params(&[("orcarouter_api_key", "sk-orca-1")]),
+            &empty_secrets(),
+        )
+        .await
+        .expect("orcarouter params should deserialize");
+        assert_eq!(typed.endpoint, "https://api.orcarouter.ai");
+        assert_eq!(
+            typed.api_key.as_ref().map(ExposeSecret::expose_secret),
+            Some("sk-orca-1")
         );
     }
 }

--- a/crates/runtime/src/model/params/orcarouter.rs
+++ b/crates/runtime/src/model/params/orcarouter.rs
@@ -1,0 +1,63 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use runtime_parameters::TypedParams;
+use secrecy::SecretString;
+
+/// Parameters for `from: orcarouter` chat models.
+#[derive(TypedParams)]
+#[params(
+    prefix = "orcarouter",
+    passthrough = crate::model::params::common::PREFIXED_COMMON,
+    emit_specs
+)]
+pub struct OrcaRouterModelParams {
+    /// The OrcaRouter API key (`sk-orca-...`). Required to authenticate with the gateway.
+    #[param(autoload_secret)]
+    pub api_key: Option<SecretString>,
+    /// The endpoint serving the model: the OrcaRouter AI gateway.
+    // The default mirrors `llms::orcarouter::DEFAULT_ENDPOINT`; `endpoint_default_matches_llms`
+    // guards against drift between the two.
+    #[param(default = "https://api.orcarouter.ai")]
+    pub endpoint: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use runtime_parameters_typed::TypedParams;
+    use secrecy::SecretString;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    use super::OrcaRouterModelParams;
+
+    fn empty_secrets() -> Arc<RwLock<runtime_secrets::Secrets>> {
+        Arc::new(RwLock::new(runtime_secrets::Secrets::new()))
+    }
+
+    #[tokio::test]
+    async fn endpoint_default_matches_llms() {
+        let typed = OrcaRouterModelParams::try_from_params(
+            "model orcarouter",
+            HashMap::<String, SecretString>::new(),
+            &empty_secrets(),
+        )
+        .await
+        .expect("orcarouter params should deserialize with defaults");
+        assert_eq!(typed.endpoint, llms::orcarouter::DEFAULT_ENDPOINT);
+    }
+}

--- a/crates/runtime/src/model/provider_models.rs
+++ b/crates/runtime/src/model/provider_models.rs
@@ -91,6 +91,15 @@ pub async fn get_available_models_hint(
                 return None;
             }
         },
+        ModelSource::OrcaRouter => {
+            match llms::orcarouter::OrcaRouterModelLister::from_params(params) {
+                Ok(lister) => Box::new(lister),
+                Err(e) => {
+                    tracing::debug!("Cannot create OrcaRouter model lister: {e}");
+                    return None;
+                }
+            }
+        }
         _ => {
             tracing::debug!("Model source {:?} does not support model listing", source);
             return None;

--- a/crates/runtime/src/model/rate_limit.rs
+++ b/crates/runtime/src/model/rate_limit.rs
@@ -105,6 +105,7 @@ fn provider_default_config(
         Some(ModelSource::Xai) => xai_config(model_id, params),
         Some(ModelSource::Bedrock) => config(20, 800),
         Some(ModelSource::Databricks | ModelSource::SpiceAI) => config(10, 500),
+        Some(ModelSource::OrcaRouter) => config(10, 500),
         // Local models: conservative concurrency (typically 1 GPU), no RPM limit.
         // Users with multi-GPU setups should override via max_concurrency.
         Some(ModelSource::HuggingFace | ModelSource::File) => RateLimitConfig {

--- a/crates/spicepod/src/component/model.rs
+++ b/crates/spicepod/src/component/model.rs
@@ -89,6 +89,7 @@ pub enum ModelSource {
     Xai,
     HuggingFace,
     SpiceAI,
+    OrcaRouter,
     File,
     Databricks,
     Bedrock,
@@ -99,6 +100,10 @@ pub enum ModelSource {
 /// matches the parameter prefix (`spiceai_api_key`). Both are accepted so a `from` reads the same
 /// whether it names a dataset or a model.
 pub const SPICEAI_PREFIXES: [&str; 2] = ["spice.ai", "spiceai"];
+
+/// The prefix that selects [`ModelSource::OrcaRouter`]. Matches the parameter prefix
+/// (`orcarouter_api_key`), so a `from` reads the same way it is configured.
+pub const ORCAROUTER_PREFIX: &str = "orcarouter";
 
 impl ModelSource {
     pub fn parse_from(&self, from: &str) -> Option<String> {
@@ -113,6 +118,15 @@ impl ModelSource {
                     from.strip_prefix(&format!("{p}:"))
                         .or_else(|| from.strip_prefix(&format!("{p}/")))
                 })
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(std::string::ToString::to_string),
+            // A bare prefix (`orcarouter:`, `orcarouter/`) carries no model id. Report that as
+            // absent rather than as an empty id, so the caller raises "no model provided" instead
+            // of dialing the endpoint with an empty model name.
+            ModelSource::OrcaRouter => from
+                .strip_prefix(&format!("{ORCAROUTER_PREFIX}:"))
+                .or_else(|| from.strip_prefix(&format!("{ORCAROUTER_PREFIX}/")))
                 .map(str::trim)
                 .filter(|id| !id.is_empty())
                 .map(std::string::ToString::to_string),
@@ -222,6 +236,8 @@ impl TryFrom<&str> for ModelSource {
             Ok(ModelSource::Xai)
         } else if SPICEAI_PREFIXES.iter().any(|p| value.starts_with(p)) {
             Ok(ModelSource::SpiceAI)
+        } else if value.starts_with("orcarouter") {
+            Ok(ModelSource::OrcaRouter)
         } else if value.starts_with("databricks") {
             Ok(ModelSource::Databricks)
         } else if value.starts_with("bedrock") {
@@ -244,6 +260,7 @@ impl Display for ModelSource {
             ModelSource::HuggingFace => write!(f, "huggingface"),
             ModelSource::File => write!(f, "file"),
             ModelSource::SpiceAI => write!(f, "spiceai"),
+            ModelSource::OrcaRouter => write!(f, "orcarouter"),
             ModelSource::Databricks => write!(f, "databricks"),
             ModelSource::Bedrock => write!(f, "bedrock"),
         }
@@ -262,6 +279,7 @@ impl ModelSource {
             ModelSource::HuggingFace => "hf",
             ModelSource::File => "file",
             ModelSource::SpiceAI => "spiceai",
+            ModelSource::OrcaRouter => "orcarouter",
             ModelSource::Databricks => "databricks",
             ModelSource::Bedrock => "bedrock",
         }
@@ -675,6 +693,52 @@ mod tests {
     fn spiceai_model_id_is_trimmed() {
         let model = Model::new("spice.ai: openai/gpt-4o ", "test");
         assert_eq!(model.get_model_id().as_deref(), Some("openai/gpt-4o"));
+    }
+
+    #[test]
+    fn orcarouter_source_parses_prefix_and_model_id() {
+        for from in [
+            "orcarouter",
+            "orcarouter:orcarouter/auto",
+            "orcarouter/orcarouter/auto",
+        ] {
+            let model = Model::new(from, "test");
+            assert_eq!(
+                model.get_source(),
+                Some(ModelSource::OrcaRouter),
+                "for {from}"
+            );
+        }
+        assert_eq!(
+            Model::new("orcarouter:orcarouter/auto", "test")
+                .get_model_id()
+                .as_deref(),
+            Some("orcarouter/auto")
+        );
+        assert_eq!(
+            Model::new("orcarouter/orcarouter/auto", "test")
+                .get_model_id()
+                .as_deref(),
+            Some("orcarouter/auto")
+        );
+    }
+
+    #[test]
+    fn orcarouter_bare_prefix_reports_no_model_id() {
+        for from in [
+            "orcarouter:",
+            "orcarouter/",
+            "orcarouter:   ",
+            "orcarouter/ ",
+        ] {
+            let model = Model::new(from, "test");
+            assert_eq!(
+                model.get_source(),
+                Some(ModelSource::OrcaRouter),
+                "for {from}"
+            );
+            assert_eq!(model.get_model_id(), None, "unexpected model id for {from}");
+        }
     }
 
     #[test]

--- a/docs/criteria/models/stable.md
+++ b/docs/criteria/models/stable.md
@@ -17,6 +17,7 @@ All criteria must be met for the model to be considered Stable.
 | Hugging Face            | ➖             |              |
 | Nvidia NIM              | ➖             |              |
 | OpenAI                  | ➖             |              |
+| OrcaRouter              | ➖             |              |
 | Spice.ai Cloud Platform | ➖             |              |
 | xAI (Grok)              | ➖             |              |
 


### PR DESCRIPTION
## 📝 Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a named model provider (`from: orcarouter`). OrcaRouter is an OpenAI-compatible AI gateway at `https://api.orcarouter.ai/v1` — a single endpoint routing to frontier models across providers.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The integration mirrors the existing `spiceai` gateway provider, with bearer-token authentication to match OrcaRouter's `Authorization: Bearer` requirement:

- `ModelSource::OrcaRouter` enum variant + `orcarouter` prefix parsing (`from: orcarouter:<model>`)
- `llms::orcarouter` module: `new_orcarouter_client` (chat completions) and `OrcaRouterModelLister` (model discovery via `GET /v1/models`)
- `OrcaRouterModelParams` typed params: `orcarouter_api_key` (required) and `orcarouter_endpoint` (defaults to the gateway)
- Dispatch in `construct_model`, model-listing in `provider_models`, and rate-limit defaults
- Unit tests for prefix parsing and params

## 🔗 Related

Omit.

## 🚨 Breaking Changes

None.

## 📚 Docs

Added OrcaRouter to `docs/criteria/models/stable.md` model table.

## 👀 Notes for Reviewers

Verification:
- `cargo check -p spicepod` ✅ and its unit tests pass (10/10, including the new OrcaRouter parsing tests).
- L3 live test against the real gateway: `GET /v1/models` → 200 (209 models), `POST /v1/chat/completions` with model `orcarouter/auto` → 200.

Disclosure: I'm an engineer on the OrcaRouter team.
