### PR TITLE
fix(cloud): name the organization searched when link finds no projects

### DIFF
--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -2697,7 +2697,7 @@ async fn execute_link(ctx: &RuntimeContext, args: &LinkArgs, flag_org: Option<&s
         resolve_project_target(Some(project), flag_org).await?
     } else {
         let (requested_org, requested_source) = resolve_org_with_source(flag_org)?;
-        let token =
+        let (token, credential_org) =
             user_token_for_cloud_connect(&endpoint, requested_org.as_deref(), "Linking", "link")
                 .await?;
         let attach_client = crate::commands::connect::project::ProjectClient::new(&endpoint)
@@ -2710,7 +2710,7 @@ async fn execute_link(ctx: &RuntimeContext, args: &LinkArgs, flag_org: Option<&s
             .map_err(|error| Error::CloudConnectIo {
                 message: error.to_string(),
             })?;
-        let selected = choose_attachable_project(projects).await?;
+        let selected = choose_attachable_project(projects, &credential_org).await?;
         if let Some(selected_org) = selected.org.as_deref() {
             ensure_orgs_agree(
                 selected_org,
@@ -2728,7 +2728,8 @@ async fn execute_link(ctx: &RuntimeContext, args: &LinkArgs, flag_org: Option<&s
             "Pass an explicit <org>/<project> target.",
         )
     })?;
-    let token = user_token_for_cloud_connect(&endpoint, Some(org), "Linking", "link").await?;
+    let (token, _credential_org) =
+        user_token_for_cloud_connect(&endpoint, Some(org), "Linking", "link").await?;
     let management_client = CloudClient::with_token_for_org_at(token, Some(org), &endpoint)?;
     let project = management_client.get_project(&target).await?;
 
@@ -2774,7 +2775,7 @@ async fn user_token_for_cloud_connect(
     requested_org: Option<&str>,
     action: &str,
     command: &str,
-) -> Result<String> {
+) -> Result<(String, String)> {
     let mut candidates = Vec::new();
     for token in [
         requested_org.and_then(org::token_for_org),
@@ -2801,13 +2802,15 @@ async fn user_token_for_cloud_connect(
 
     for token in candidates {
         let client = CloudClient::with_token_for_org_at(token.clone(), None, endpoint)?;
-        if client.optional_user_auth_context().await?.is_none() {
+        let Some(auth_context) = client.optional_user_auth_context().await? else {
             continue;
-        }
+        };
         if let Some(org) = requested_org {
             client.get_auth_context_for_org(org).await?;
         }
-        return Ok(token);
+        // The credential's own organization is the one every org-unaware
+        // request (like listing attachable projects) is answered for.
+        return Ok((token, auth_context.org_name));
     }
 
     Err(Error::cloud_with_hint(
@@ -2830,12 +2833,20 @@ fn ensure_link_chooser_tty(is_terminal: bool) -> Result<()> {
 
 async fn choose_attachable_project(
     projects: Vec<crate::commands::connect::project::AttachableProject>,
+    credential_org: &str,
 ) -> Result<ProjectTarget> {
     if projects.is_empty() {
+        // Attachable projects are listed for the credential's own
+        // organization only; `org use` and `--org` do not change that, so
+        // say which organization was actually searched (#13379).
         return Err(Error::cloud_with_hint(
             CloudErrorCode::ProjectNotFound,
-            "Spice Cloud returned no projects that can be attached.",
-            "Create a project in Spice Cloud, then retry `spice cloud link`.",
+            format!(
+                "Spice Cloud returned no attachable projects in organization '{credential_org}',                  the organization this credential acts on."
+            ),
+            format!(
+                "Create a project in organization '{credential_org}', or attach to another                  organization with `spice cloud login token --org <org>` and retry."
+            ),
         ));
     }
     let items: Vec<String> = projects
@@ -3065,7 +3076,7 @@ async fn execute_unlink() -> Result<()> {
         &configured_endpoint,
     );
     let requested_org = identity.org_name.as_deref().filter(|org| !org.is_empty());
-    let token =
+    let (token, _credential_org) =
         user_token_for_cloud_connect(endpoint, requested_org, "Unlinking", "unlink").await?;
     match runtime_cloud_connect::release::release(endpoint, &identity, &token, None).await {
         Ok(_) => {}


### PR DESCRIPTION
Issue Number: close #13379

### What problem does this PR solve?

`spice cloud link` lists attachable projects **for the credential's own organization only** — `org use` and `--org` select a credential, they do not scope the request. The empty-list error reported `Spice Cloud returned no projects that can be attached.` with a hint to create a project, which is actively misleading for a user administering several organizations: `orgs` lists them all, `projects --org <org>` lists their projects, and linking silently disagrees. (#13379)

### What is changed and how it works?

The CLI-only half of the fix proposed in the issue:

- `user_token_for_cloud_connect` now returns the credential's organization alongside the token — it already fetches the auth context to validate each candidate token, and `AuthContext` carries `org_name`.
- `choose_attachable_project` takes that organization and, when the list is empty, errors with:

```
Spice Cloud returned no attachable projects in organization '<org>', the organization this credential acts on.
Create a project in organization '<org>', or attach to another organization with `spice cloud login token --org <org>` and retry.
```

Passing the selected organization through to the endpoint (so `org use` scopes the request like everywhere else) depends on a server change and stays tracked internally, per the issue.

### Validation

`cargo check -p spice` and `cargo fmt --check` clean. The changed paths are interactive CLI flows (TTY chooser) without unit-test scaffolding in this file; behavior verified by inspection of the two call sites (`link` naming the org, `unlink` ignoring it via `_credential_org`).
