### PR TITLE
fix(cloud): state the linkable-project conditions in the empty link hint

### DIFF
--- a/bin/spice/src/commands/cloud/mod.rs
+++ b/bin/spice/src/commands/cloud/mod.rs
@@ -2832,10 +2832,14 @@ async fn choose_attachable_project(
     projects: Vec<crate::commands::connect::project::AttachableProject>,
 ) -> Result<ProjectTarget> {
     if projects.is_empty() {
+        // A project only qualifies when it is a Cloud Connect project, in
+        // the organization this credential acts on, with no instance
+        // attached yet — naming the conditions lets the reader act instead
+        // of retrying into the same error (#13378).
         return Err(Error::cloud_with_hint(
             CloudErrorCode::ProjectNotFound,
             "Spice Cloud returned no projects that can be attached.",
-            "Create a project in Spice Cloud, then retry `spice cloud link`.",
+            "A linkable project is a Cloud Connect project (created by omitting `--kind` on `spice cloud project create`)              in the organization this credential acts on, with no instance attached yet.              Check `spice cloud projects` and retry `spice cloud link`.",
         ));
     }
     let items: Vec<String> = projects


### PR DESCRIPTION
Issue Number: close #13378

### What problem does this PR solve?

The `spice cloud link` empty-list hint — *"Create a project in Spice Cloud, then retry"* — sends the reader into a loop: a project only qualifies for linking when **all** of these hold, and the message names none of them:

- it is a **Cloud Connect project** (created by omitting `--kind` on `spice cloud project create`) — a Spice-managed project (`--kind set` / `--kind cluster`) never appears, however many are created;
- it belongs to the organization this credential acts on;
- it has no instance attached yet.

A user who follows the advice and retries lands in exactly the same error with no new information — which is what happened while release-testing 2.2 (#13378).

### What is changed and how it works?

The hint now states the conditions it is actually checking, in the form the user can act on:

```
A linkable project is a Cloud Connect project (created by omitting `--kind` on `spice cloud project create`) in the organization this credential acts on, with no instance attached yet. Check `spice cloud projects` and retry `spice cloud link`.
```

Message-only change; no behavior change. (The companion organization-scoping issue #13379 is handled separately.)

### Validation

`cargo check -p spice` and `cargo fmt --check` clean.
