### PR TITLE
fix(duckdb): fix concurrent-query failures after a replace_file swap with multiple DuckDB files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4259,7 +4259,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7240,7 +7240,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=eeb4ef30df95df118a50b56f3b19f5a6528a4530#eeb4ef30df95df118a50b56f3b19f5a6528a4530"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=062a3d24af68eb31915901283bedecf521ea7521#062a3d24af68eb31915901283bedecf521ea7521"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -9151,8 +9151,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -10320,7 +10320,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -24355,7 +24355,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7240,7 +7240,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=062a3d24af68eb31915901283bedecf521ea7521#062a3d24af68eb31915901283bedecf521ea7521"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=beeecde18a72d2b6cad9d75aa44279398f084bce#beeecde18a72d2b6cad9d75aa44279398f084bce"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4259,7 +4259,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7240,7 +7240,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=f2dad23247908d284a226cbb294ef7c3c08b16f1#f2dad23247908d284a226cbb294ef7c3c08b16f1"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=eeb4ef30df95df118a50b56f3b19f5a6528a4530#eeb4ef30df95df118a50b56f3b19f5a6528a4530"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -9151,8 +9151,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -10320,7 +10320,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -15032,7 +15032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6705a26ad89d241a989a5395641931ba37076f5ab5fbd19ee92402414a43af32"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
+ "hashbrown 0.5.0",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -15521,7 +15521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -15542,7 +15542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -19014,7 +19014,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -24355,7 +24355,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "062a3d24af68eb31915901283bedecf521ea7521" } # branch: fix/duckdb-attach-swap-race (PR #55); repoint to spiceai-54 once merged
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "beeecde18a72d2b6cad9d75aa44279398f084bce" } # spiceai-54
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "f2dad23247908d284a226cbb294ef7c3c08b16f1" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "eeb4ef30df95df118a50b56f3b19f5a6528a4530" } # branch: fix/duckdb-attach-swap-race (PR #55); repoint to spiceai-54 once merged
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "eeb4ef30df95df118a50b56f3b19f5a6528a4530" } # branch: fix/duckdb-attach-swap-race (PR #55); repoint to spiceai-54 once merged
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "062a3d24af68eb31915901283bedecf521ea7521" } # branch: fix/duckdb-attach-swap-race (PR #55); repoint to spiceai-54 once merged
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",


### PR DESCRIPTION
## Problem

With two or more file-mode DuckDB accelerations on **separate `duckdb_file`s**, and at least one using `on_full_refresh: replace_file`, concurrent queries fail with:

```
Catalog Error: SET search_path: No catalog + schema named "attachment_XXXX_0" found.
```

Separate DuckDB files are cross-`ATTACH`ed into each other so queries can join across them, and each connection runs `SET search_path = 'main,attachment_XXXX_0'`. That attach state is cached per pool and only re-validated when a **peer** file changes on disk.

A `replace_file` refresh (and a CDC compaction) swaps the pool onto a **fresh DuckDB instance** that holds none of the `ATTACH`es. The cache survives the swap and its peer files are unchanged, so it looks valid — and the next query runs `SET search_path` over a catalog the new instance never attached. The failures continue until a peer file also swaps, which matches the reporter's clean ~20-second failure windows.

Only **multiple separate files + a file swap** is affected. A single shared `duckdb_file` never cross-attaches, and memory mode neither cross-attaches nor swaps.

## Fix

The fix is in the `datafusion-table-providers` fork — spiceai/datafusion-table-providers#55:

- `attach_once` self-heals: if `SET search_path` fails, it re-attaches on the connection's current instance and retries once, under the cache lock.
- `swap_database_file` invalidates the attachment cache so the common path re-attaches cleanly.

This PR bumps the pinned rev to pick that up.

> Note: the rev points at the fork PR branch commit; repoint to the merged `spiceai-54` SHA once #55 merges.

Fixes #13363