### PR TITLE
fix(write_back): acknowledged writes could be lost after a spiced crash

### DIFF
--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -843,6 +843,24 @@ const METRICS: &[MetricSpec] = &[
     )
     .auto_register(),
     MetricSpec::new(
+        "replication_acceleration_rebuilt",
+        MetricType::ObservableGaugeU64,
+    )
+    .description(
+        "1 while this dataset's acceleration was rebuilt from the source on its last \
+         attach instead of resuming from the position it had recorded. A rebuild re-reads \
+         the whole table without anyone asking for it, and the `cause` label says where to \
+         look: `rewound_source` means the source was restored or rewound (check whether \
+         other datasets on it resumed when they should not have), `foreign_source` means \
+         it is streaming from a different server, database, or table than it recorded, \
+         `unreadable` means its recorded position could not be read, `acknowledged_past` \
+         means the slot acknowledged past that position (NOT a WAL retention problem — the \
+         WAL may still be on disk), `retention_lost` means the source discarded the WAL \
+         after it, and `no_record` means it had never recorded one. Datasets that resumed \
+         report no series.",
+    )
+    .auto_register(),
+    MetricSpec::new(
         "replication_member_send_wait_micros_total",
         MetricType::ObservableCounterU64,
     )
@@ -1055,6 +1073,18 @@ impl MetricsProvider for PostgresMetricsProvider {
                             attrs.push(KeyValue::new("slot", slot));
                         }
                         instrument.observe(v, &attrs);
+                    }
+                })))
+            }
+            "replication_acceleration_rebuilt" => {
+                Some(ObserveMetricCallback::U64(Box::new(move |instrument| {
+                    // Observe only for a dataset that actually rebuilt (`Some`), so a
+                    // resumed one reports no series rather than a constant 0 that would
+                    // need a `cause` label it does not have.
+                    if let Some(cause) = m.rebuild_cause() {
+                        let mut attrs = attributes.clone();
+                        attrs.push(KeyValue::new("cause", cause));
+                        instrument.observe(1, &attrs);
                     }
                 })))
             }

--- a/crates/data-connectors/connector-postgres/src/replication.rs
+++ b/crates/data-connectors/connector-postgres/src/replication.rs
@@ -32,7 +32,8 @@ use data_components::cdc::{AccelerationContents, ChangesStream, InitialSnapshotM
 use data_components::postgres_replication::{
     AppliedLsn, AppliedLsnStore, NoopAppliedLsnStore, PgOutputFormat, RecordedPosition,
     ReplicationMetrics, ReplicationMetricsCollector, ReplicationParams, ReplicationStreamInput,
-    SchemaEvolutionPolicy, XactStatus, XidRegistry, config, start_replication_stream,
+    SchemaEvolutionPolicy, UnusableReason, XactStatus, XidRegistry, config,
+    start_replication_stream,
 };
 use data_connector_api::federated::FederatedTableProvider;
 use data_connector_api::parameters::ConnectorContext;
@@ -143,7 +144,7 @@ impl AppliedLsnStore for SidecarAppliedLsnStore {
                 streaming_from = %self.identity,
                 "this acceleration's recorded position belongs to a different source, so its contents cannot be resumed against this one; it will be rebuilt from the source"
             );
-            return Ok(RecordedPosition::ForeignSource);
+            return Ok(RecordedPosition::Unusable(UnusableReason::ForeignSource));
         }
         Ok(RecordedPosition::At(AppliedLsn { lsn: stored.lsn }))
     }

--- a/crates/data_components/src/postgres_replication/metrics.rs
+++ b/crates/data_components/src/postgres_replication/metrics.rs
@@ -83,6 +83,15 @@ pub struct MetricsCollector {
     /// datasets share one). Lets the analysis join the per-dataset view to the
     /// authoritative per-slot backlog and show grouping. Set at (shared) attach.
     slot_name: RwLock<Option<String>>,
+    /// Why this dataset's acceleration was rebuilt from the source instead of
+    /// resumed, as [`super::RebuildCause::label`], or `None` when it resumed.
+    ///
+    /// A rebuild is a full re-read nobody asked for, and the causes call for
+    /// different responses — a restored source, a repointed endpoint, a broken
+    /// sidecar, a slot lifecycle problem. Reporting only "rebuilt" would make
+    /// them indistinguishable without scraping log text. Set at attach; a member
+    /// classifies once, so this is a label rather than a counter.
+    rebuild_cause: RwLock<Option<&'static str>>,
     /// Cumulative seconds the shared-slot pump spent blocked trying to deliver
     /// committed changes into this member's mailbox because its sink was not
     /// draining. Non-zero means downstream backpressure stalled the pump (and
@@ -160,6 +169,18 @@ impl MetricsCollector {
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         *guard = Some(slot);
+    }
+
+    /// Record why this dataset's acceleration is being rebuilt rather than
+    /// resumed. Called once at attach, only on the rebuild path.
+    pub fn set_rebuild_cause(&self, cause: &'static str) {
+        // Recover through poisoning, as `set_slot_name` does: an unrelated panic must
+        // not leave a rebuild unattributed in the analysis.
+        let mut guard = self
+            .rebuild_cause
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = Some(cause);
     }
 
     pub fn inc_insert(&self) {
@@ -517,6 +538,16 @@ impl Metrics {
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
+    }
+    /// Why this dataset's acceleration was rebuilt, or `None` when it resumed.
+    #[must_use]
+    pub fn rebuild_cause(&self) -> Option<&'static str> {
+        // Recover through poisoning, as `slot_name` does.
+        *self
+            .collector
+            .rebuild_cause
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
     #[must_use]
     pub fn member_send_stalled_seconds_total(&self) -> u64 {

--- a/crates/data_components/src/postgres_replication/mod.rs
+++ b/crates/data_components/src/postgres_replication/mod.rs
@@ -273,12 +273,12 @@ pub fn needs_rebuild(
         // Nothing recorded: a gap only when absence is informative — see
         // `absence_implies_gap`.
         RecordedPosition::Absent => absence_implies_gap,
-        // Recorded against a different source. Whatever the acceleration holds
-        // came from somewhere else, and the LSN is not even comparable — a small
-        // LSN from the new source would otherwise read as "already covered" and
-        // leave the old source's rows in place while never loading the new
-        // source's.
-        RecordedPosition::ForeignSource => true,
+        // The record cannot be compared against this slot at all — see
+        // [`UnusableReason`] for the ways that happens. Whatever the
+        // acceleration holds is unproven, and the LSN is not usable as a
+        // position: a small one would otherwise read as "already covered" and
+        // leave stale rows in place while never loading the current ones.
+        RecordedPosition::Unusable(_) => true,
         // A gap when there is no slot at all, or when the slot can no longer
         // stream from as far back as the watermark.
         RecordedPosition::At(watermark) => {
@@ -287,22 +287,86 @@ pub fn needs_rebuild(
     }
 }
 
+/// Whether a recorded position lies ahead of the source's current WAL position.
+///
+/// Impossible within one server history: an applied position only ever comes
+/// from a commit the server itself streamed, so its WAL can never sit behind
+/// one. A position ahead of the current WAL therefore identifies a source that
+/// was restored or rewound (for example from a backup or point-in-time
+/// recovery) after the position was recorded. Callers must downgrade such a
+/// record to [`UnusableReason::RewoundSource`]: it describes an erased history,
+/// so resuming on it keeps pre-restore rows, and seating it as a replay floor
+/// would silently suppress every legitimate post-restore change at or below it
+/// until the WAL grows past it again.
+///
+/// Strictly greater, never equal: the last streamed commit's end LSN equals the
+/// WAL position of a source that has been idle since, and that is a normal
+/// resume.
+///
+/// A rewound source whose WAL has already grown back past the recorded position
+/// is not caught here, but the ordinary restore is still covered — by the
+/// reachability check rather than this one. A restore leaves no logical slot
+/// behind (`pg_basebackup` excludes `pg_replslot`, and managed-service
+/// point-in-time recovery hands back an instance without slots), so the slot
+/// created on the next start takes its `consistent_lsn` from the WAL head, which
+/// is above any pre-restore watermark; the two checks partition the comparison
+/// between them.
+///
+/// What escapes both is a slot that survives the rewind still valid and at a
+/// pre-rewind position — a block-level snapshot of `PGDATA` restored as crash
+/// recovery, for instance. Catching that needs the last observed
+/// `confirmed_flush_lsn` persisted alongside the position: it only ever advances
+/// in normal operation, and a recreated slot reports the head, so a lower value
+/// on restart is proof the source went backwards. The server's timeline and
+/// system identifier do not settle that case on their own — crash recovery
+/// neither promotes nor changes the identifier, so both match across it.
+#[must_use]
+pub fn recorded_position_is_ahead_of_source(
+    position: &RecordedPosition,
+    current_wal_lsn: u64,
+) -> bool {
+    matches!(position, RecordedPosition::At(recorded) if recorded.lsn > current_wal_lsn)
+}
+
 /// What the local record says about an acceleration's position.
 ///
-/// Three outcomes rather than `Option`, because "recorded against a different
-/// source" is neither "no record" nor a usable position: LSNs are only
-/// comparable within one source's history, so a watermark carried over to a
-/// different server, database, or table describes contents that have nothing to
-/// do with what this dataset now streams.
+/// Three outcomes rather than `Option`, because "a record exists but cannot be
+/// used" is neither "no record" nor a usable position: LSNs are only comparable
+/// within one source's history, so a record that cannot be tied to the history
+/// this dataset now streams describes contents that have nothing to do with it.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RecordedPosition {
     /// Nothing recorded.
     Absent,
-    /// A position exists, but for a different source than this dataset streams
-    /// from now. Its LSN cannot be compared and its contents cannot be trusted.
-    ForeignSource,
-    /// A position recorded against this same source.
+    /// A record exists but its position cannot be used — see [`UnusableReason`]
+    /// for which. Never resumed on, and never seated as a replay-suppression
+    /// floor.
+    Unusable(UnusableReason),
+    /// A position recorded against this same source, on a history the source
+    /// still has.
     At(AppliedLsn),
+}
+
+/// Why a record's position cannot be used.
+///
+/// Carried on [`RecordedPosition::Unusable`] rather than collapsed into one
+/// variant because all three rebuild for genuinely different reasons, and the
+/// message that explains the rebuild has to name the right one — an operator
+/// told their watermark "belongs to a different source" when it merely failed
+/// to parse will go looking for the wrong problem.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnusableReason {
+    /// Recorded against a different source than this dataset streams from now
+    /// (a different server, database, or table), so its LSN is not comparable
+    /// and its contents describe something else.
+    ForeignSource,
+    /// The record could not be read or parsed, so nothing about it is proven —
+    /// including whether the acceleration is missing deletions.
+    Unreadable,
+    /// Recorded on a history the source no longer has: the position is ahead of
+    /// the source's current WAL position, which only a restore or rewind can
+    /// produce (see [`recorded_position_is_ahead_of_source`]).
+    RewoundSource,
 }
 
 /// Durable, client-side record of how far a dataset's acceleration has been
@@ -495,7 +559,10 @@ pub(crate) fn err_to_stream(err: Error) -> StreamError {
 
 #[cfg(test)]
 mod tests {
-    use super::{AppliedLsn, RecordedPosition, needs_rebuild};
+    use super::{
+        AppliedLsn, RecordedPosition, UnusableReason, needs_rebuild,
+        recorded_position_is_ahead_of_source,
+    };
 
     /// The gap decision is the correctness hinge of the rebuild path: a wrong
     /// `false` resumes over rows the source has deleted (silent divergence, the
@@ -526,20 +593,19 @@ mod tests {
         assert!(needs_rebuild(&RecordedPosition::Absent, Some(100), true));
         assert!(needs_rebuild(&RecordedPosition::Absent, None, true));
 
-        // A position recorded against another source is never usable, whatever
-        // the slot says and whatever the acceleration's durability: its LSN is
-        // not comparable and its contents describe a different table.
-        assert!(needs_rebuild(
-            &RecordedPosition::ForeignSource,
-            Some(0),
-            true
-        ));
-        assert!(needs_rebuild(
-            &RecordedPosition::ForeignSource,
-            Some(0),
-            false
-        ));
-        assert!(needs_rebuild(&RecordedPosition::ForeignSource, None, false));
+        // A record whose position cannot be used is never usable, whatever the
+        // slot says and whatever the acceleration's durability — and every
+        // reason rebuilds alike, however differently each is explained.
+        for reason in [
+            UnusableReason::ForeignSource,
+            UnusableReason::Unreadable,
+            UnusableReason::RewoundSource,
+        ] {
+            let unusable = RecordedPosition::Unusable(reason);
+            assert!(needs_rebuild(&unusable, Some(0), true), "{reason:?}");
+            assert!(needs_rebuild(&unusable, Some(0), false), "{reason:?}");
+            assert!(needs_rebuild(&unusable, None, false), "{reason:?}");
+        }
 
         // The slot still holds WAL from at or before the watermark, so the gap is
         // replayable: resume.
@@ -610,5 +676,47 @@ mod tests {
             !needs_rebuild(&at(100), Some(restart_lsn), true),
             "control: comparing against retention alone calls the same gap resumable"
         );
+    }
+
+    /// A recorded position ahead of the source's current WAL position identifies
+    /// a source restored or rewound since the position was recorded — its history
+    /// no longer contains the recorded position. `attach_member` downgrades such
+    /// a record to [`UnusableReason::RewoundSource`], which always rebuilds and
+    /// is never seated as a replay-suppression floor; without the downgrade,
+    /// `needs_rebuild` alone reads the rewind as resumable (the slot's earliest
+    /// position sits below the watermark) and the seated floor would silently
+    /// suppress every legitimate post-restore change at or below it.
+    #[test]
+    fn a_watermark_ahead_of_the_source_wal_identifies_a_rewound_source() {
+        let at = |lsn| RecordedPosition::At(AppliedLsn { lsn });
+
+        // Ahead of the current WAL position: only a rewind can produce this.
+        assert!(recorded_position_is_ahead_of_source(&at(900), 800));
+        // Equal is a normal resume of an idle source: the last streamed commit's
+        // end LSN is exactly the WAL position when nothing has happened since.
+        assert!(!recorded_position_is_ahead_of_source(&at(800), 800));
+        // Behind is the ordinary case.
+        assert!(!recorded_position_is_ahead_of_source(&at(700), 800));
+        // Positions that are not comparable are never "ahead" — they are already
+        // handled as unusable in their own right.
+        assert!(!recorded_position_is_ahead_of_source(
+            &RecordedPosition::Absent,
+            800
+        ));
+        assert!(!recorded_position_is_ahead_of_source(
+            &RecordedPosition::Unusable(UnusableReason::ForeignSource),
+            800
+        ));
+
+        // The trap the downgrade closes: a fresh post-restore slot sits below the
+        // stale watermark, so `needs_rebuild` on its own would resume...
+        assert!(!needs_rebuild(&at(900), Some(500), true));
+        // ...while the downgraded record rebuilds, and — being no longer `At` —
+        // can never be seated as a replay floor.
+        assert!(needs_rebuild(
+            &RecordedPosition::Unusable(UnusableReason::RewoundSource),
+            Some(500),
+            true
+        ));
     }
 }

--- a/crates/data_components/src/postgres_replication/mod.rs
+++ b/crates/data_components/src/postgres_replication/mod.rs
@@ -202,22 +202,38 @@ pub struct AppliedLsn {
     pub lsn: u64,
 }
 
-/// Whether the acceleration must be rebuilt from the source rather than resumed.
+/// Why the acceleration must be rebuilt from the source, or `None` to resume.
 ///
-/// The whole gap decision, as arithmetic rather than inference:
+/// The whole gap decision *and* which [`RebuildCause`] it is, together, so the
+/// comparison that settles it is written once — deciding in one place and
+/// explaining in another leaves two encodings of one rule, free to drift.
 ///
-/// * `watermark` — the LSN the acceleration's contents are complete as of, or
-///   `None` when none has been recorded.
-/// * `slot_earliest_streamable_lsn` — the earliest LSN the slot can still stream
-///   from, or `None` when the slot does not exist. This is the later of its
-///   `restart_lsn` and its `confirmed_flush_lsn`, not `restart_lsn` alone:
-///   Postgres forwards a start position below `confirmed_flush_lsn` up to it, so
-///   an acknowledged change cannot be re-streamed even while its WAL is retained.
+/// * `position` — what the local record says, see [`RecordedPosition`].
+/// * `slot_restart_lsn` — the earliest LSN the slot still retains, or `None`
+///   when the slot does not exist.
+/// * `slot_acknowledged_lsn` — the later of the slot's `confirmed_flush_lsn` and
+///   this member's own seated floor. Retention is not reachability: Postgres
+///   forwards a start position below `confirmed_flush_lsn` up to it ("has been
+///   already streamed, forwarding to ..." in `CreateDecodingContext`), so once a
+///   slot has acknowledged past a change no client can ask for it again — the WAL
+///   may still be on disk under `restart_lsn`, but it is unreachable through this
+///   slot. A slot-mate's traffic can carry this member's own floor past the
+///   slot's snapshot the same way. Comparing against retention alone calls an
+///   unfillable gap resumable and skips the difference silently (#11289).
 /// * `absence_implies_gap` — whether a *missing* watermark is evidence of one.
 ///   True when the acceleration survives restarts (so it can hold rows this
 ///   process did not load), a position could have been recorded (so absence is
 ///   informative rather than permanent), and the acceleration is not known to be
 ///   empty (see below).
+///
+/// This is also where an ordinary backup or point-in-time restore is caught, in
+/// two halves depending on when the process comes back. Reconnect before the
+/// restored source has written anything and the stale position sits above its
+/// WAL head, which [`recorded_position_is_ahead_of_source`] turns into
+/// [`UnusableReason::RewoundSource`] before this is called. Reconnect later and
+/// the check here does it instead: a restore leaves no logical slot behind, so
+/// the one created on the next start takes `slot_acknowledged_lsn` from the WAL
+/// head, above any pre-restore position. The two partition the comparison.
 ///
 /// A watermark the slot cannot reach is a gap nothing can fill: the changes in
 /// between are gone from the source's log, so a row deleted there would never be
@@ -264,25 +280,123 @@ pub struct AppliedLsn {
 /// re-read wins. Revisit only if a post-load fatal can make the table refuse a
 /// scan (#13218); until then this arm is deliberate, not inherited.
 #[must_use]
-pub fn needs_rebuild(
+pub fn rebuild_cause(
     position: &RecordedPosition,
-    slot_earliest_streamable_lsn: Option<u64>,
+    slot_restart_lsn: Option<u64>,
+    slot_acknowledged_lsn: u64,
     absence_implies_gap: bool,
-) -> bool {
+) -> Option<RebuildCause> {
     match position {
         // Nothing recorded: a gap only when absence is informative — see
         // `absence_implies_gap`.
-        RecordedPosition::Absent => absence_implies_gap,
-        // The record cannot be compared against this slot at all — see
-        // [`UnusableReason`] for the ways that happens. Whatever the
+        RecordedPosition::Absent => absence_implies_gap.then_some(RebuildCause::NoRecord),
+        // The record cannot be compared against this slot at all. Whatever the
         // acceleration holds is unproven, and the LSN is not usable as a
         // position: a small one would otherwise read as "already covered" and
         // leave stale rows in place while never loading the current ones.
-        RecordedPosition::Unusable(_) => true,
-        // A gap when there is no slot at all, or when the slot can no longer
-        // stream from as far back as the watermark.
-        RecordedPosition::At(watermark) => {
-            slot_earliest_streamable_lsn.is_none_or(|earliest| earliest > watermark.lsn)
+        RecordedPosition::Unusable(UnusableReason::ForeignSource) => {
+            Some(RebuildCause::ForeignSource)
+        }
+        RecordedPosition::Unusable(UnusableReason::Unreadable) => Some(RebuildCause::Unreadable),
+        RecordedPosition::Unusable(UnusableReason::RewoundSource) => {
+            Some(RebuildCause::RewoundSource)
+        }
+        // Acknowledgement before retention: it is the tighter limit and the more
+        // misleading one, easily mistaken for a retention problem when the WAL is
+        // still on disk.
+        RecordedPosition::At(watermark) if slot_acknowledged_lsn > watermark.lsn => {
+            Some(RebuildCause::AcknowledgedPast)
+        }
+        // No slot at all retains nothing, and a slot retaining only past the
+        // position cannot replay the changes that follow it.
+        RecordedPosition::At(watermark)
+            if slot_restart_lsn.is_none_or(|restart_lsn| restart_lsn > watermark.lsn) =>
+        {
+            Some(RebuildCause::RetentionLost)
+        }
+        RecordedPosition::At(_) => None,
+    }
+}
+
+/// Why an acceleration was rebuilt from the source rather than resumed.
+///
+/// The causes are genuinely different situations calling for different
+/// responses — a restored source, a repointed endpoint, a broken sidecar, a slot
+/// lifecycle problem — so they are reported separately rather than as one
+/// "rebuilt" event, in the log line and on the member's metrics alike.
+///
+/// Two accessors, deliberately: [`Self::label`] is an identifier that dashboards
+/// and log queries match on and must stay stable, while [`Self::reason`] is prose
+/// written for whoever reads the warning and is free to be reworded. One string
+/// cannot be both.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RebuildCause {
+    /// No position was recorded, and its absence is informative — see
+    /// `absence_implies_gap` on [`rebuild_cause`].
+    NoRecord,
+    /// The record names a different source than this dataset streams from now.
+    ForeignSource,
+    /// The record could not be read or parsed, so nothing about it is proven.
+    Unreadable,
+    /// The record names a position the source's history no longer contains,
+    /// because it was restored or rewound afterwards.
+    ///
+    /// Worth alerting on rather than only counting, because one rewind escapes
+    /// detection entirely: a slot that survived it still valid and at a
+    /// pre-rewind position (a block-level snapshot of `PGDATA` restored as crash
+    /// recovery), once the WAL has grown back past the recorded position.
+    /// Catching that needs the last observed `confirmed_flush_lsn` persisted
+    /// alongside the position — it only advances in normal operation, so a lower
+    /// value on restart is proof the source went backwards. Timeline and system
+    /// identifier do not settle it, since crash recovery neither promotes nor
+    /// changes the identifier. So a dataset reporting this cause is reason to
+    /// check whether others on the same source resumed when they should not have.
+    RewoundSource,
+    /// The slot acknowledged past the recorded position, so it can no longer be
+    /// streamed from — even though its WAL may still be on disk.
+    AcknowledgedPast,
+    /// The slot no longer retains the WAL following the recorded position.
+    RetentionLost,
+}
+
+impl RebuildCause {
+    /// Stable identifier for metrics and log queries. Never reworded — renaming
+    /// one breaks every dashboard and saved search that selects on it.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::NoRecord => "no_record",
+            Self::ForeignSource => "foreign_source",
+            Self::Unreadable => "unreadable",
+            Self::RewoundSource => "rewound_source",
+            Self::AcknowledgedPast => "acknowledged_past",
+            Self::RetentionLost => "retention_lost",
+        }
+    }
+
+    /// The operator-facing clause, phrased to complete "this acceleration will be
+    /// rebuilt from the source before changes are applied: ...".
+    #[must_use]
+    pub fn reason(self) -> &'static str {
+        match self {
+            Self::NoRecord => {
+                "it has no recorded position, so any rows it already holds cannot be shown to be current"
+            }
+            Self::ForeignSource => {
+                "the position it recorded belongs to a different source, so it does not describe these rows"
+            }
+            Self::Unreadable => {
+                "the position it recorded could not be read, so any rows it already holds cannot be shown to be current"
+            }
+            Self::RewoundSource => {
+                "the position it recorded as applied is ahead of the source's current WAL position, so the source was restored or rewound after it was recorded and its contents do not describe the source's current history"
+            }
+            Self::AcknowledgedPast => {
+                "the slot has been acknowledged past the position it recorded as applied, so the changes in between can no longer be streamed from it"
+            }
+            Self::RetentionLost => {
+                "the slot no longer retains the changes following the position it recorded as applied"
+            }
         }
     }
 }
@@ -291,35 +405,18 @@ pub fn needs_rebuild(
 ///
 /// Impossible within one server history: an applied position only ever comes
 /// from a commit the server itself streamed, so its WAL can never sit behind
-/// one. A position ahead of the current WAL therefore identifies a source that
-/// was restored or rewound (for example from a backup or point-in-time
-/// recovery) after the position was recorded. Callers must downgrade such a
-/// record to [`UnusableReason::RewoundSource`]: it describes an erased history,
-/// so resuming on it keeps pre-restore rows, and seating it as a replay floor
-/// would silently suppress every legitimate post-restore change at or below it
-/// until the WAL grows past it again.
+/// one. A position ahead of it identifies a source restored or rewound after the
+/// position was recorded, and callers must downgrade such a record to
+/// [`UnusableReason::RewoundSource`] — resuming on it keeps pre-restore rows, and
+/// seating it as a replay floor would suppress post-restore changes below it.
 ///
 /// Strictly greater, never equal: the last streamed commit's end LSN equals the
 /// WAL position of a source that has been idle since, and that is a normal
 /// resume.
 ///
-/// A rewound source whose WAL has already grown back past the recorded position
-/// is not caught here, but the ordinary restore is still covered — by the
-/// reachability check rather than this one. A restore leaves no logical slot
-/// behind (`pg_basebackup` excludes `pg_replslot`, and managed-service
-/// point-in-time recovery hands back an instance without slots), so the slot
-/// created on the next start takes its `consistent_lsn` from the WAL head, which
-/// is above any pre-restore watermark; the two checks partition the comparison
-/// between them.
-///
-/// What escapes both is a slot that survives the rewind still valid and at a
-/// pre-rewind position — a block-level snapshot of `PGDATA` restored as crash
-/// recovery, for instance. Catching that needs the last observed
-/// `confirmed_flush_lsn` persisted alongside the position: it only ever advances
-/// in normal operation, and a recreated slot reports the head, so a lower value
-/// on restart is proof the source went backwards. The server's timeline and
-/// system identifier do not settle that case on their own — crash recovery
-/// neither promotes nor changes the identifier, so both match across it.
+/// This catches a restore only while the source has not written past the
+/// recorded position yet; [`rebuild_cause`] documents the other half, and
+/// [`RebuildCause::RewoundSource`] the rewind neither half sees.
 #[must_use]
 pub fn recorded_position_is_ahead_of_source(
     position: &RecordedPosition,
@@ -560,9 +657,24 @@ pub(crate) fn err_to_stream(err: Error) -> StreamError {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppliedLsn, RecordedPosition, UnusableReason, needs_rebuild,
+        AppliedLsn, RebuildCause, RecordedPosition, UnusableReason, rebuild_cause,
         recorded_position_is_ahead_of_source,
     };
+
+    /// A slot that reaches everything, so a case varies only what it is about.
+    fn needs_rebuild(
+        position: &RecordedPosition,
+        slot_earliest_streamable_lsn: Option<u64>,
+        absence_implies_gap: bool,
+    ) -> bool {
+        rebuild_cause(
+            position,
+            slot_earliest_streamable_lsn,
+            0,
+            absence_implies_gap,
+        )
+        .is_some()
+    }
 
     /// The gap decision is the correctness hinge of the rebuild path: a wrong
     /// `false` resumes over rows the source has deleted (silent divergence, the
@@ -594,17 +706,23 @@ mod tests {
         assert!(needs_rebuild(&RecordedPosition::Absent, None, true));
 
         // A record whose position cannot be used is never usable, whatever the
-        // slot says and whatever the acceleration's durability — and every
-        // reason rebuilds alike, however differently each is explained.
-        for reason in [
-            UnusableReason::ForeignSource,
-            UnusableReason::Unreadable,
-            UnusableReason::RewoundSource,
+        // slot says and whatever the acceleration's durability — and each way it
+        // happens is reported as its own cause, because they call for different
+        // responses.
+        for (reason, expected) in [
+            (UnusableReason::ForeignSource, RebuildCause::ForeignSource),
+            (UnusableReason::Unreadable, RebuildCause::Unreadable),
+            (UnusableReason::RewoundSource, RebuildCause::RewoundSource),
         ] {
             let unusable = RecordedPosition::Unusable(reason);
             assert!(needs_rebuild(&unusable, Some(0), true), "{reason:?}");
             assert!(needs_rebuild(&unusable, Some(0), false), "{reason:?}");
             assert!(needs_rebuild(&unusable, None, false), "{reason:?}");
+            assert_eq!(
+                rebuild_cause(&unusable, Some(0), 0, true),
+                Some(expected),
+                "{reason:?} must not be reported as another cause"
+            );
         }
 
         // The slot still holds WAL from at or before the watermark, so the gap is
@@ -665,17 +783,63 @@ mod tests {
     fn an_acknowledged_change_is_a_gap_even_while_its_wal_is_retained() {
         let at = |lsn| RecordedPosition::At(AppliedLsn { lsn });
         // A slot retaining from 40 but acknowledged to 200 cannot supply a
-        // watermark of 100, even though 100 sits inside the retained range.
+        // watermark of 100, even though 100 sits inside the retained range — and
+        // it must say so, because "acknowledged past" reads like a retention
+        // failure and is not one.
         let restart_lsn: u64 = 40;
         let confirmed_flush_lsn: u64 = 200;
-        assert!(
-            needs_rebuild(&at(100), Some(restart_lsn.max(confirmed_flush_lsn)), true),
-            "a watermark behind the acknowledged position is unreachable"
+        assert_eq!(
+            rebuild_cause(&at(100), Some(restart_lsn), confirmed_flush_lsn, true),
+            Some(RebuildCause::AcknowledgedPast),
+            "the acknowledged limit must not be reported as lost retention"
         );
-        assert!(
-            !needs_rebuild(&at(100), Some(restart_lsn), true),
+        assert_eq!(
+            rebuild_cause(&at(100), Some(restart_lsn), 0, true),
+            None,
             "control: comparing against retention alone calls the same gap resumable"
         );
+    }
+
+    /// `label` is matched on by dashboards and log queries, so two causes sharing
+    /// one would silently merge unrelated incidents; `reason` is all an operator
+    /// reads, so two sharing one sends them after the wrong problem. Neither may
+    /// collide, and neither may be empty.
+    #[test]
+    fn every_rebuild_cause_is_distinguishable_to_a_query_and_to_a_person() {
+        let causes = [
+            RebuildCause::NoRecord,
+            RebuildCause::ForeignSource,
+            RebuildCause::Unreadable,
+            RebuildCause::RewoundSource,
+            RebuildCause::AcknowledgedPast,
+            RebuildCause::RetentionLost,
+        ];
+        for (i, cause) in causes.iter().enumerate() {
+            assert!(!cause.label().is_empty(), "{cause:?} has no label");
+            assert!(!cause.reason().is_empty(), "{cause:?} has no reason");
+            // Labels are identifiers, not prose: whitespace means someone reworded
+            // one into a sentence and broke every query selecting on it.
+            assert!(
+                cause
+                    .label()
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c == '_'),
+                "{cause:?} label is not a stable identifier: {}",
+                cause.label()
+            );
+            for other in &causes[i + 1..] {
+                assert_ne!(
+                    cause.label(),
+                    other.label(),
+                    "{cause:?} and {other:?} share a label, so a query cannot separate them"
+                );
+                assert_ne!(
+                    cause.reason(),
+                    other.reason(),
+                    "{cause:?} and {other:?} read identically to an operator"
+                );
+            }
+        }
     }
 
     /// A recorded position ahead of the source's current WAL position identifies

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -646,6 +646,33 @@ impl AckSlot {
         advance_monotonic(&self.pending, lsn);
     }
 
+    /// Seat a member resuming on a position a previous process durably recorded
+    /// as applied. A recorded position means "everything at or below this LSN is
+    /// durably in the acceleration" (see [`Self::recorded`]), which makes it two
+    /// things at once:
+    ///
+    ///   * **recordable** — the idle carry-forward may extend it
+    ///     ([`publish_idle_positions`]), hence `note_recorded`/`note_pending`;
+    ///   * **the replay-suppression floor** — a reconnect replay must not
+    ///     re-deliver anything at or below it ([`Self::already_committed`]),
+    ///     hence `committed`/`delivered`.
+    ///
+    /// Seeding only the first half loses writes for a durable write-back dataset:
+    /// its echo registry prunes entries against this same recorded position, so a
+    /// crash while the slot's `confirmed_flush_lsn` lags it replays echoes whose
+    /// entries are already pruned — re-applied as ordinary changes, they regress
+    /// the acceleration to a stale echo image, and the next write-back delivery
+    /// then regresses the source too (#13368).
+    ///
+    /// `committed` before `delivered`, per the torn-read invariant on
+    /// [`AckTable::credit_idle`].
+    fn seat_recorded(&self, lsn: u64) {
+        self.note_recorded(lsn);
+        self.note_pending(lsn);
+        advance_monotonic(&self.committed, lsn);
+        advance_monotonic(&self.delivered, lsn);
+    }
+
     /// Advance this member's committed floor (monotonic). Called lock-free from
     /// the consumer commit path via [`SharedLsnCommitter`].
     fn commit(&self, lsn: u64) {
@@ -2425,12 +2452,15 @@ async fn attach_member(
     // A member resuming on a position a previous process recorded already has a
     // durable position, even though nothing has been committed in *this* process.
     // Seeding it lets an idle member carry that position forward (see
-    // `flush_idle_watermarks`) instead of waiting for a change that may never come.
+    // `flush_idle_watermarks`) instead of waiting for a change that may never come
+    // — and, through the member's `committed` floor, keeps the coming reconnect
+    // replay from re-delivering commits the acceleration durably holds (see
+    // `AckSlot::seat_recorded` for why re-delivery loses writes on a durable
+    // write-back dataset).
     if let (Some(slot), super::RecordedPosition::At(resumed)) = (&ack_slot, &watermark)
         && !rebuild_via_consumer
     {
-        slot.note_recorded(resumed.lsn);
-        slot.note_pending(resumed.lsn);
+        slot.seat_recorded(resumed.lsn);
     }
     lock(&source.members).insert(
         member_key.clone(),
@@ -7078,6 +7108,70 @@ mod tests {
             second.num_rows_hint(),
             0,
             "the echo is dropped again on reconnect replay, never re-applied"
+        );
+    }
+
+    /// Restart replay must not re-deliver commits at or below the position a
+    /// member durably recorded as applied. The echo registry prunes its entries
+    /// against that same recorded position, so a replayed echo below it arrives
+    /// unregistered — re-applying it as an ordinary change regresses the
+    /// acceleration to the stale echo image, silently losing acknowledged
+    /// writes (regression test for #13368). `seat_recorded` is exactly what
+    /// `attach_member` runs for a member resuming without a rebuild.
+    #[tokio::test]
+    async fn resumed_member_suppresses_replay_below_recorded_position() {
+        let (source, decoder, routes, mut receivers) = echo_scenario(None);
+        let recorded = 900u64;
+        let t0_slot = source.ack.slot(&key("t0")).expect("t0 slot");
+        t0_slot.seat_recorded(recorded);
+
+        // Replay of a commit at the recorded position: its registry entry was
+        // pruned before the restart, so only the seated floor protects it.
+        deliver_one_commit(
+            &source,
+            &decoder,
+            &routes,
+            txn_with(&[(100, "72"), (101, "72")]),
+            recorded,
+            Some(4242),
+        )
+        .await;
+
+        // t1 never recorded a position — the replay is delivered to it as usual.
+        let t1 = receivers[1]
+            .next()
+            .await
+            .expect("t1 envelope")
+            .expect("not an error");
+        assert_eq!(t1.num_rows_hint(), 1, "an unseated member gets the replay");
+
+        // t0 durably holds everything at or below `recorded`: nothing may be
+        // delivered, not even a zero-row ack (its floor already covers the LSN).
+        assert_eq!(
+            t0_slot.delivered(),
+            recorded,
+            "no envelope was staged for the seated member"
+        );
+
+        // A genuinely new commit above the recorded position flows normally.
+        deliver_one_commit(
+            &source,
+            &decoder,
+            &routes,
+            txn_with(&[(100, "79")]),
+            recorded + 1,
+            Some(4243),
+        )
+        .await;
+        let t0 = receivers[0]
+            .next()
+            .await
+            .expect("t0 envelope for the new commit")
+            .expect("not an error");
+        assert_eq!(
+            t0.num_rows_hint(),
+            1,
+            "commits above the recorded position are delivered"
         );
     }
 }

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -2338,16 +2338,37 @@ async fn attach_member(
     let watermark = match applied_lsn_store.load().await {
         Ok(watermark) => watermark,
         Err(e) => {
-            // Reading it failed, so we cannot prove the gap is fillable. Treat it
-            // the same as a position belonging to another source — unusable — so
-            // the acceleration is rebuilt: a needless rebuild costs a re-read,
-            // while a wrong resume silently keeps rows the source has deleted.
+            // Reading it failed, so we cannot prove the gap is fillable — the
+            // acceleration is rebuilt: a needless rebuild costs a re-read, while a
+            // wrong resume silently keeps rows the source has deleted.
             tracing::warn!(
                 dataset = %dataset_name,
                 "could not read how far this acceleration has been advanced, so it will be rebuilt from the source rather than resumed on an unproven position: {e}"
             );
-            super::RecordedPosition::ForeignSource
+            super::RecordedPosition::Unusable(super::UnusableReason::Unreadable)
         }
+    };
+    // A recorded position ahead of the source's current WAL position cannot
+    // belong to this server's history — the source was restored or rewound since
+    // it was recorded (see `recorded_position_is_ahead_of_source`). Downgrade it
+    // BEFORE classification and seating: resuming on it would keep pre-restore
+    // rows, and seating it as the replay floor would silently suppress every
+    // legitimate post-restore change at or below it.
+    let watermark = if super::recorded_position_is_ahead_of_source(
+        &watermark,
+        setup.current_wal_lsn,
+    ) {
+        if let super::RecordedPosition::At(recorded) = &watermark {
+            tracing::warn!(
+                dataset = %dataset_name,
+                recorded_lsn = recorded.lsn,
+                current_wal_lsn = setup.current_wal_lsn,
+                "Dataset '{dataset_name}' recorded its acceleration as applied up to a position ahead of the source's current WAL position, which means the source was restored or rewound (for example from a backup or point-in-time recovery) after the position was recorded, so the acceleration will be rebuilt from the source rather than resumed — resuming would keep pre-restore rows and skip post-restore changes. See: https://spiceai.org/docs/components/data-connectors/postgres"
+            );
+        }
+        super::RecordedPosition::Unusable(super::UnusableReason::RewoundSource)
+    } else {
+        watermark
     };
     // Absence of a watermark is evidence of a gap only when the acceleration
     // could be holding rows this process did not load AND a position could have
@@ -2428,7 +2449,7 @@ async fn attach_member(
         !params.ephemeral_accelerator && tracks_positions && !load_runs_without_rebuild,
     );
 
-    // Why the rebuild, in the terms the operator can act on. The four causes are
+    // Why the rebuild, in the terms the operator can act on. The causes are
     // genuinely different situations, and the acknowledged-past one is the easiest to
     // mistake for a retention problem: the WAL is still on disk, but a slot cannot
     // re-stream what it has already acknowledged.
@@ -2436,8 +2457,14 @@ async fn attach_member(
         super::RecordedPosition::Absent => {
             "it has no recorded position, so any rows it already holds cannot be shown to be current"
         }
-        super::RecordedPosition::ForeignSource => {
+        super::RecordedPosition::Unusable(super::UnusableReason::ForeignSource) => {
             "the position it recorded belongs to a different source, so it does not describe these rows"
+        }
+        super::RecordedPosition::Unusable(super::UnusableReason::Unreadable) => {
+            "the position it recorded could not be read, so any rows it already holds cannot be shown to be current"
+        }
+        super::RecordedPosition::Unusable(super::UnusableReason::RewoundSource) => {
+            "the position it recorded as applied is ahead of the source's current WAL position, so the source was restored or rewound after it was recorded and its contents do not describe the source's current history"
         }
         super::RecordedPosition::At(watermark)
             if setup.slot.consistent_lsn.max(seated_floor) > watermark.lsn =>
@@ -4532,6 +4559,9 @@ mod tests {
     ) -> slot::SharedMemberSetup {
         slot::SharedMemberSetup {
             slot_restart_lsn: Some(0),
+            // Far ahead of every LSN these tests use, so no test watermark ever
+            // reads as a rewound source (see `recorded_position_is_ahead_of_source`).
+            current_wal_lsn: u64::MAX,
             slot: slot::SlotInfo {
                 slot_name: "slot".to_string(),
                 publication_name: "pub".to_string(),

--- a/crates/data_components/src/postgres_replication/shared.rs
+++ b/crates/data_components/src/postgres_replication/shared.rs
@@ -2315,26 +2315,12 @@ async fn attach_member(
 
     let snapshotting = need_snapshot && params.initial_snapshot;
 
-    // Is there a gap this slot cannot supply?
-    //
-    // Computed, not inferred. The watermark records the LSN the acceleration's
-    // contents are complete as of; `restart_lsn` is the earliest LSN the slot can
-    // still stream from. A watermark older than that is a gap no stream can fill:
-    // a row deleted at the source in that window has no change event left to
-    // replay, so appending snapshot rows over the survivors would leave the
-    // deletion applied at the source and never here, in every later query.
-    //
-    // The three outcomes:
-    //
-    //   * no watermark -> this acceleration has never been loaded. A first
-    //     bootstrap, not a gap: snapshot-and-append is exactly right, and this is
-    //     also every ephemeral accelerator (their store records nothing, since
-    //     they boot empty and re-snapshot every start).
-    //   * watermark, and the slot still reaches it -> resume; the WAL between the
-    //     two is still there to replay.
-    //   * watermark the slot cannot reach (or no slot at all) -> hand the reload
-    //     to the consumer, which owns the accelerator and can replace its
-    //     contents atomically (see `cdc::ChangeEnvelope::history_unavailable`).
+    // How far a previous process advanced this acceleration. Whether that is a gap
+    // this slot cannot supply — and what to tell the operator when it is — is
+    // `super::rebuild_cause`'s, computed once the member is seated below. A gap
+    // the stream cannot fill is handed to the consumer, which owns the accelerator
+    // and can replace its contents atomically (see
+    // `cdc::ChangeEnvelope::history_unavailable`).
     let watermark = match applied_lsn_store.load().await {
         Ok(watermark) => watermark,
         Err(e) => {
@@ -2411,70 +2397,30 @@ async fn attach_member(
     source.claim_reservation(&member_key);
     let ack_slot = source.ack.slot(&member_key);
 
-    // The earliest position this member can actually be supplied from, which is *not*
-    // the earliest the slot still retains. Two distinct limits, and the later one
-    // binds:
-    //
-    //   * Postgres forwards a `START_REPLICATION` position below the slot's
-    //     `confirmed_flush_lsn` up to it ("has been already streamed, forwarding to
-    //     ..." in `CreateDecodingContext`), so once the slot has acknowledged past a
-    //     change no client can ask for it again — the WAL may still be on disk under
-    //     `restart_lsn`, but it is unreachable through this slot.
-    //   * this member's own seated floor, which a slot-mate's traffic may have
-    //     carried past the snapshot above.
-    //
-    // Comparing against `restart_lsn` alone would call an unfillable gap resumable
-    // and skip the difference silently.
-    let seated_floor = ack_slot.as_ref().map_or(0, |slot| slot.committed());
-    let earliest_streamable_lsn = setup
-        .slot_restart_lsn
-        .map(|restart_lsn| restart_lsn.max(setup.slot.consistent_lsn).max(seated_floor));
-    // A durable acceleration that has recorded no position is rebuilt, because a
-    // missing watermark cannot be told apart from one whose write failed — except
-    // when the acceleration is observed to hold no rows at all, which is proof
-    // enough on its own: nothing is present that could be stale, and no deletion
-    // can be missing.
-    //
-    // Gated on `snapshotting`, because emptiness only licenses skipping the
-    // rebuild when something *else* is going to load the table. When no snapshot
-    // runs — a pre-existing slot whose publication already carries this table, so
-    // none of `need_snapshot`'s conditions hold, or snapshots disabled outright —
-    // the rebuild is the only thing that would populate the acceleration, and
-    // skipping it would resume from the slot's position and leave every row that
-    // predates it missing for good.
+    // Emptiness licenses skipping the rebuild only when something *else* is going
+    // to load the table, hence the `snapshotting` gate. When no snapshot runs — a
+    // pre-existing slot whose publication already carries this table, or snapshots
+    // disabled outright — the rebuild is the only thing that would populate the
+    // acceleration, and skipping it would resume from the slot's position and
+    // leave every row that predates it missing for good.
     let load_runs_without_rebuild = params.acceleration.is_provably_empty() && snapshotting;
-    let rebuild_via_consumer = super::needs_rebuild(
+    // The floor passed here is the one the member was *actually* seated at above,
+    // not the snapshot `setup` was built from — see the registration comment for
+    // why the difference is a silent skip rather than a rounding error.
+    let seated_floor = ack_slot.as_ref().map_or(0, |slot| slot.committed());
+    let rebuild_cause = super::rebuild_cause(
         &watermark,
-        earliest_streamable_lsn,
+        setup.slot_restart_lsn,
+        setup.slot.consistent_lsn.max(seated_floor),
         !params.ephemeral_accelerator && tracks_positions && !load_runs_without_rebuild,
     );
-
-    // Why the rebuild, in the terms the operator can act on. The causes are
-    // genuinely different situations, and the acknowledged-past one is the easiest to
-    // mistake for a retention problem: the WAL is still on disk, but a slot cannot
-    // re-stream what it has already acknowledged.
-    let rebuild_reason = match &watermark {
-        super::RecordedPosition::Absent => {
-            "it has no recorded position, so any rows it already holds cannot be shown to be current"
-        }
-        super::RecordedPosition::Unusable(super::UnusableReason::ForeignSource) => {
-            "the position it recorded belongs to a different source, so it does not describe these rows"
-        }
-        super::RecordedPosition::Unusable(super::UnusableReason::Unreadable) => {
-            "the position it recorded could not be read, so any rows it already holds cannot be shown to be current"
-        }
-        super::RecordedPosition::Unusable(super::UnusableReason::RewoundSource) => {
-            "the position it recorded as applied is ahead of the source's current WAL position, so the source was restored or rewound after it was recorded and its contents do not describe the source's current history"
-        }
-        super::RecordedPosition::At(watermark)
-            if setup.slot.consistent_lsn.max(seated_floor) > watermark.lsn =>
-        {
-            "the slot has been acknowledged past the position it recorded as applied, so the changes in between can no longer be streamed from it"
-        }
-        super::RecordedPosition::At(_) => {
-            "the slot no longer retains the changes following the position it recorded as applied"
-        }
-    };
+    let rebuild_via_consumer = rebuild_cause.is_some();
+    // A rebuild is a full re-read nobody asked for, and which cause fired is what
+    // says whether to look at the source, the configuration, or the slot — so it
+    // is reported as a label rather than left to be recovered from log text.
+    if let Some(cause) = rebuild_cause {
+        metrics.set_rebuild_cause(cause.label());
+    }
 
     // A member resuming on a position a previous process recorded already has a
     // durable position, even though nothing has been committed in *this* process.
@@ -2612,7 +2558,9 @@ async fn attach_member(
                 _ => "none".to_string(),
             },
             slot_acknowledged_position = %slot::format_lsn(setup.slot.consistent_lsn),
-            "this acceleration will be rebuilt from the source before changes are applied: {rebuild_reason}"
+            rebuild_cause = rebuild_cause.map_or("", super::RebuildCause::label),
+            "this acceleration will be rebuilt from the source before changes are applied: {}",
+            rebuild_cause.map_or("", super::RebuildCause::reason)
         );
         // No snapshot runs on this path — the consumer's reload replaces it — so
         // the gauge's documented "finished, or skipped" state is reached here.

--- a/crates/data_components/src/postgres_replication/slot.rs
+++ b/crates/data_components/src/postgres_replication/slot.rs
@@ -122,6 +122,18 @@ pub struct SharedMemberSetup {
     /// us between the two reads is reported as the unfillable gap it is rather
     /// than silently compared against a fabricated position.
     pub slot_restart_lsn: Option<u64>,
+    /// The source's current WAL insert position (`pg_current_wal_lsn()`), read
+    /// in the same setup session and before the slot is ensured. An applied
+    /// position a previous process recorded can never legitimately be ahead of
+    /// this — positions only ever come from commits the server itself streamed —
+    /// so a recorded watermark above it identifies a source restored or rewound
+    /// since the watermark was written (see
+    /// [`super::recorded_position_is_ahead_of_source`]).
+    ///
+    /// Reading it before the slot is ensured keeps it at or below the resulting
+    /// `consistent_lsn`, so that check and the reachability check leave no band
+    /// of watermarks between them.
+    pub current_wal_lsn: u64,
 }
 
 /// Idempotent setup for one member of a shared slot: validates the table's
@@ -157,6 +169,15 @@ pub async fn setup_shared_member(
                 // root, which is the name members subscribe with.
                 let publication_tables =
                     list_publication_tables(&client, &params.publication_name).await?;
+                // Read before the slot is ensured, so this position is at or
+                // below the `consistent_lsn` that call produces. The ordering is
+                // what makes the two rebuild conditions overlap instead of
+                // leaving a band between them: read afterwards, WAL written
+                // between slot creation and this read is above `consistent_lsn`
+                // and at or below this position, so a watermark landing in it is
+                // neither ahead of the source nor behind what the slot can
+                // stream, and is resumed on.
+                let current_wal_lsn = current_wal_lsn(&client).await?;
                 let slot = ensure_slot(&client, params).await?;
                 let slot_restart_lsn = read_slot_restart_lsn(&client, &params.slot_name).await?;
                 Ok(SharedMemberSetup {
@@ -165,6 +186,7 @@ pub async fn setup_shared_member(
                     generated_columns,
                     publication_tables,
                     slot_restart_lsn,
+                    current_wal_lsn,
                 })
             }
             .await;


### PR DESCRIPTION
## Summary

Fixes acknowledged writes being lost after a `spiced` crash on durable write-back datasets (#13368).

After a `kill -9`, Postgres re-sends WAL from the slot's `confirmed_flush_lsn`, which under load trails the position the dataset durably recorded as applied. The echo-suppression registry prunes its entries against that recorded position, so replayed echoes in the gap were no longer recognized as Spice's own writes and got re-applied as ordinary changes — stamping stale row images over newer local commits. The next write-back delivery then pushed the regressed value back to Postgres, losing acknowledged writes at the source of truth.

## Fix

When a member resumes on a durably recorded position, seat its replay-suppression floor (`AckSlot::committed`/`delivered`) at that position too — the same watermark that already gates registry pruning and the rebuild-vs-resume decision. The two floors then agree by construction: a replayed transaction is either at/below the recorded position (skipped — already durably applied) or above it (still registered, dropped as an echo). Side benefit: resuming datasets no longer transiently re-apply already-applied changes during replay catch-up.

## Validation

The failure was first reproduced empirically on the unpatched build with a counter workload (concurrent read-modify-write increments over HTTP, exact client-side accounting of every HTTP-200 commit): after a `kill -9` under load, the accelerator recovered all acknowledged commits from local storage and was then observably regressed by the CDC replay within the same second, permanently — and the next delivery regressed Postgres itself.

With the fix, the same harness could not produce a single lost or regressed write:

- **Crash cycles**: repeated `kill -9` under sustained concurrent load (up to 96 workers on one hot key, and 64 workers across 8 keys), killing at load peak, during the post-load drain, and again seconds into restart catch-up (double-crash). Every cycle recovered exactly — Spice == Postgres == acknowledged count, per key — including commits acknowledged but not yet delivered to Postgres at the crash.
- **Source crashes**: Postgres SIGKILLed under load (with Spice staying up) and both processes SIGKILLed simultaneously. A Postgres crash rewinds the slot's replay position further than feedback lag ever does; the seated floor suppressed the widened replay correctly, writes kept committing while the source was down, and both sides converged exactly after recovery.
- **Monotonicity**: continuous polling throughout every scenario observed zero regressions — no transient dips even during catch-up.
- **Echo suppression end-to-end**: a 1000-increment benchmark (16 workers, ~13k conflict retries) passed all oracles — no lost writes, monotone, row present, Spice/Postgres converged.
- **Unit tests**: new regression test `resumed_member_suppresses_replay_below_recorded_position`; full `postgres_replication` suite green.
