### PR TITLE
fix(duckdb): fix concurrent-query failures after a replace_file swap with multiple DuckDB files (#13383) into release/2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7122,7 +7122,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=3c40145d671792f3974bc95af5587b699c86c86c#3c40145d671792f3974bc95af5587b699c86c86c"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=beeecde18a72d2b6cad9d75aa44279398f084bce#beeecde18a72d2b6cad9d75aa44279398f084bce"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "3c40145d671792f3974bc95af5587b699c86c86c" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "beeecde18a72d2b6cad9d75aa44279398f084bce" } # spiceai-54
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",


### PR DESCRIPTION
Add the following change into release branch
- https://github.com/spiceai/spiceai/pull/13383