### PR TITLE
fix(databricks): forward runtime's spark feature to the databricks connector

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -408,7 +408,7 @@ snowflake = [
     "db_connection_pool/snowflake",
     "data_components/snowflake",
 ]
-spark = ["data_components/spark_connect"]
+spark = ["data_components/spark_connect", "connector-databricks/spark"]
 # Registers the Cayenne catalog connector. Intended for benchmarking only;
 # deliberately excluded from the default feature set.
 spicebench = []

--- a/crates/runtime/tests/databricks_spark/mod.rs
+++ b/crates/runtime/tests/databricks_spark/mod.rs
@@ -27,6 +27,36 @@ use futures::TryStreamExt;
 use runtime::Runtime;
 use spicepod::{component::catalog::Catalog, param::Params};
 
+/// `runtime/spark` gates the Spark Connect suites below, but `mode: spark_connect` is
+/// implemented in `connector-databricks` behind that crate's own `spark` feature. If the two
+/// drift apart, the suites still compile while the connector rejects every Spark Connect
+/// dataset with `InvalidMode`, and only a run with live Databricks credentials would notice.
+///
+/// This check needs none: it asserts the mode is advertised, and naming a
+/// `connector-databricks/spark`-only variant turns the drift into a compile error.
+#[test]
+fn databricks_advertises_the_spark_connect_mode_it_implements() {
+    let advertises_spark_connect = connector_databricks::factory()
+        .parameters()
+        .iter()
+        .find(|spec| spec.name == "mode")
+        .and_then(|spec| spec.one_of)
+        .is_some_and(|modes| modes.contains(&"spark_connect"));
+
+    assert!(
+        advertises_spark_connect,
+        "the databricks connector must advertise `spark_connect` among its `mode` values"
+    );
+
+    // Compiles only while `connector-databricks/spark` is enabled alongside `runtime/spark`.
+    let _implemented: fn(connector_databricks::Error) -> bool = |err| {
+        matches!(
+            err,
+            connector_databricks::Error::UnableToConstructDatabricksSpark { .. }
+        )
+    };
+}
+
 fn make_catalog(path: &str, name: &str) -> Catalog {
     let mut catalog = Catalog::new(format!("databricks:{path}"), name.to_string());
     catalog.params = Some(get_params());

--- a/crates/runtime/tests/databricks_spark/mod.rs
+++ b/crates/runtime/tests/databricks_spark/mod.rs
@@ -32,8 +32,8 @@ use spicepod::{component::catalog::Catalog, param::Params};
 /// drift apart, the suites still compile while the connector rejects every Spark Connect
 /// dataset with `InvalidMode`, and only a run with live Databricks credentials would notice.
 ///
-/// This check needs none: it asserts the mode is advertised, and naming a
-/// `connector-databricks/spark`-only variant turns the drift into a compile error.
+/// This check needs none: it asserts the mode is advertised, and the guard below turns the
+/// drift into a compile error.
 #[test]
 fn databricks_advertises_the_spark_connect_mode_it_implements() {
     let advertises_spark_connect = connector_databricks::factory()
@@ -47,15 +47,16 @@ fn databricks_advertises_the_spark_connect_mode_it_implements() {
         advertises_spark_connect,
         "the databricks connector must advertise `spark_connect` among its `mode` values"
     );
-
-    // Compiles only while `connector-databricks/spark` is enabled alongside `runtime/spark`.
-    let _implemented: fn(connector_databricks::Error) -> bool = |err| {
-        matches!(
-            err,
-            connector_databricks::Error::UnableToConstructDatabricksSpark { .. }
-        )
-    };
 }
+
+/// Compiles only while `connector-databricks/spark` is enabled alongside `runtime/spark`:
+/// `UnableToConstructDatabricksSpark` exists only under that feature.
+const _: fn(connector_databricks::Error) -> bool = |err| {
+    matches!(
+        err,
+        connector_databricks::Error::UnableToConstructDatabricksSpark { .. }
+    )
+};
 
 fn make_catalog(path: &str, name: &str) -> Catalog {
     let mut catalog = Catalog::new(format!("databricks:{path}"), name.to_string());


### PR DESCRIPTION
## 📝 Summary

`runtime`'s `spark` feature enabled `data_components/spark_connect` but not `connector-databricks/spark`, which gates the `mode: spark_connect` dispatch. `spiced` forwards both, so released binaries are unaffected — but the integration suites are built with `-p runtime --features spark`, which is not.

Those suites are themselves gated on `runtime/spark`, so they compiled and ran while the connector rejected every Spark Connect dataset at load:

```
WARN runtime::init::dataset: Error initializing dataset nation. Failed to initialize data connector: Invalid `mode` value: 'spark_connect (feature disabled - requires spark-connect-rs with arrow 57)'. Valid modes are 'sql_warehouse', 'delta_lake', and 'spark_connect'. For details, visit: https://spiceai.org/docs/components/data-connectors/databricks#parameters
```

Because that is a warning on a degrade-and-continue path, the tests failed further downstream, where the cause is no longer visible:

```
Error: query `select * from db_uc.tpch.nation order by n_nationkey limit 10` to plan: Failed to execute query: Error during planning: table 'db_uc.tpch.nation' not found
assertion `left == right` failed: Expected 7 columns in databricks_demo schema, got 0
```

Changes:

- Forward `connector-databricks/spark` from `runtime`'s `spark` feature.
- Add a credential-free guard to the `databricks_spark` suite. Every other test there needs a live Databricks workspace and is `#[ignore]`d without `extended_tests`, so nothing covered this on a normal build. The guard names an error variant that exists only with `connector-databricks/spark`, so the same drift becomes a compile error rather than a runtime rejection:

  ```
  error[E0599]: no variant named `UnableToConstructDatabricksSpark` found for enum `connector_databricks::Error`
  error: could not compile `runtime` (test "integration") due to 1 previous error
  ```

## 🔗 Related

#9585 reported and fixed this same propagation gap in `bin/spiced/Cargo.toml`. The `runtime` crate was never given the same treatment, so the defect persisted on the path the integration tests are built from.

## 👀 Notes for Reviewers

The guard has to live in the test target rather than `crates/runtime/src`: `connector-databricks` is in the `extension` tier per `layers.toml`, above `runtime`, so it is a `[dev-dependencies]` entry and a normal dependency edge would fail the crate-layering check.

This unblocks the Spark Connect suites; it is not on its own enough to make them pass, which also needs the Databricks credentials and cluster warm-up those suites depend on.
