### PR TITLE
Configure an accelerator engine through its constructor instead of a published global

### DIFF
--- a/crates/accelerators/accelerator-cayenne/src/lib.rs
+++ b/crates/accelerators/accelerator-cayenne/src/lib.rs
@@ -1164,6 +1164,12 @@ impl CayenneAccelerator {
         Self::with_footer_cache_mb(config.cayenne_footer_cache_mb)
     }
 
+    /// The footer-cache size this engine was configured with.
+    #[must_use]
+    pub fn footer_cache_mb(&self) -> Option<usize> {
+        self.footer_cache_mb
+    }
+
     #[must_use]
     pub fn with_footer_cache_mb(footer_cache_mb: Option<usize>) -> Self {
         Self {
@@ -4776,11 +4782,9 @@ mod tests {
     /// The footer-cache size reaches the engine as a constructor argument, so it belongs
     /// to the `Runtime` that supplied it.
     ///
-    /// This replaces a round-trip test over the process-global channel this seam retired.
-    /// `usize::MAX` is covered because `runtime.params.cayenne_footer_cache_mb` accepts
-    /// `max`: the retired channel reserved that value to mean "nothing was published", so
-    /// the largest cache an operator can ask for silently became the default. Nothing here
-    /// can reserve a value, but the case is the one worth keeping a test on.
+    /// `usize::MAX` is asserted because `runtime.params.cayenne_footer_cache_mb` accepts
+    /// `max`: the largest cache an operator can ask for must arrive as written, and every
+    /// value in the range has to be distinguishable from an absent one.
     #[test]
     fn the_footer_cache_size_comes_from_the_runtime_config() {
         use data_accelerator_api::AcceleratorRuntimeConfig;
@@ -4809,6 +4813,36 @@ mod tests {
         // the engine instance, so there is nothing for a concurrent build to overwrite.
         assert_eq!(configured(Some(64)), Some(64));
         assert_eq!(CayenneAccelerator::new().footer_cache_mb, None);
+    }
+
+    /// The registration the slice carries must be the *configured* form.
+    ///
+    /// Calling `from_runtime_config` directly cannot show this: the simple form of
+    /// `register_data_accelerator!` ignores its argument, so registering through it would
+    /// build the engine with `new()` and drop the operator's setting while every direct
+    /// test stayed green. This goes through the constructor the slice actually holds.
+    #[test]
+    fn the_registered_constructor_forwards_the_runtime_config() {
+        use data_accelerator_api::{AcceleratorRuntimeConfig, DATA_ACCELERATOR_REGISTRATIONS};
+
+        let registration = DATA_ACCELERATOR_REGISTRATIONS
+            .iter()
+            .find(|registration| registration.engine == Engine::Cayenne)
+            .expect("this crate registers the Cayenne engine");
+
+        let built = (registration.constructor)(&AcceleratorRuntimeConfig {
+            cayenne_footer_cache_mb: Some(321),
+        });
+        let cayenne = built
+            .as_any()
+            .downcast_ref::<CayenneAccelerator>()
+            .expect("the Cayenne registration builds a CayenneAccelerator");
+
+        assert_eq!(
+            cayenne.footer_cache_mb(),
+            Some(321),
+            "the registered constructor must pass the runtime config to the engine"
+        );
     }
 
     /// The write profile is the engine's answer about its *own* acceleration, so an

--- a/crates/accelerators/accelerator-cayenne/src/lib.rs
+++ b/crates/accelerators/accelerator-cayenne/src/lib.rs
@@ -1157,11 +1157,11 @@ impl CayenneAccelerator {
 
     /// Builds the engine for the `Runtime` whose settings these are.
     ///
-    /// This is what the registration slice calls, so the footer-cache size arrives as an
-    /// argument and belongs to that one `Runtime`.
+    /// Total: the registration extracts this engine's own settings from the shared enum, so
+    /// by the time they reach here there is nothing left to reject.
     #[must_use]
-    pub fn from_runtime_config(config: &data_accelerator_api::AcceleratorRuntimeConfig) -> Self {
-        Self::with_footer_cache_mb(config.cayenne_footer_cache_mb)
+    pub fn from_runtime_config(config: &data_accelerator_api::CayenneRuntimeConfig) -> Self {
+        Self::with_footer_cache_mb(config.footer_cache_mb)
     }
 
     /// The footer-cache size this engine was configured with.
@@ -4214,7 +4214,7 @@ fn serialize_partition_child_writes(
     config.write_concurrency = Some(1);
 }
 
-data_accelerator_api::register_data_accelerator!(configured: Engine::Cayenne, CayenneAccelerator);
+data_accelerator_api::register_data_accelerator!(configured: Engine::Cayenne, Cayenne, CayenneAccelerator);
 
 #[cfg(test)]
 mod tests {
@@ -4787,11 +4787,11 @@ mod tests {
     /// value in the range has to be distinguishable from an absent one.
     #[test]
     fn the_footer_cache_size_comes_from_the_runtime_config() {
-        use data_accelerator_api::AcceleratorRuntimeConfig;
+        use data_accelerator_api::CayenneRuntimeConfig;
 
         let configured = |mb| {
-            CayenneAccelerator::from_runtime_config(&AcceleratorRuntimeConfig {
-                cayenne_footer_cache_mb: mb,
+            CayenneAccelerator::from_runtime_config(&CayenneRuntimeConfig {
+                footer_cache_mb: mb,
             })
             .footer_cache_mb
         };
@@ -4823,16 +4823,20 @@ mod tests {
     /// test stayed green. This goes through the constructor the slice actually holds.
     #[test]
     fn the_registered_constructor_forwards_the_runtime_config() {
-        use data_accelerator_api::{AcceleratorRuntimeConfig, DATA_ACCELERATOR_REGISTRATIONS};
+        use data_accelerator_api::{
+            AcceleratorRuntimeConfig, CayenneRuntimeConfig, DATA_ACCELERATOR_REGISTRATIONS,
+        };
 
         let registration = DATA_ACCELERATOR_REGISTRATIONS
             .iter()
             .find(|registration| registration.engine == Engine::Cayenne)
             .expect("this crate registers the Cayenne engine");
 
-        let built = (registration.constructor)(&AcceleratorRuntimeConfig {
-            cayenne_footer_cache_mb: Some(321),
-        });
+        let built =
+            (registration.constructor)(&AcceleratorRuntimeConfig::Cayenne(CayenneRuntimeConfig {
+                footer_cache_mb: Some(321),
+            }))
+            .expect("the Cayenne registration accepts Cayenne configuration");
         let cayenne = built
             .as_any()
             .downcast_ref::<CayenneAccelerator>()
@@ -4842,6 +4846,39 @@ mod tests {
             cayenne.footer_cache_mb(),
             Some(321),
             "the registered constructor must pass the runtime config to the engine"
+        );
+    }
+
+    /// Another engine's settings are refused rather than quietly treated as absent.
+    ///
+    /// The registration slice stores one function type for every engine, so this mismatch
+    /// cannot be a compile error; `register_all` and `build_with_defaults` both choose the
+    /// settings by engine, which is what keeps it from arising. This pins the remaining
+    /// behaviour of the case they prevent.
+    #[test]
+    fn another_engines_configuration_is_refused() {
+        use data_accelerator_api::{AcceleratorRuntimeConfig, DATA_ACCELERATOR_REGISTRATIONS};
+
+        let registration = DATA_ACCELERATOR_REGISTRATIONS
+            .iter()
+            .find(|registration| registration.engine == Engine::Cayenne)
+            .expect("this crate registers the Cayenne engine");
+
+        let error = (registration.constructor)(&AcceleratorRuntimeConfig::DuckDB)
+            .err()
+            .expect("Cayenne must refuse DuckDB configuration rather than build from it");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("cayenne") && message.contains("duckdb"),
+            "the error must name both engines, got: {message}"
+        );
+
+        // Its own settings still build, so the refusal is about the mismatch and not about
+        // the engine being unbuildable.
+        assert!(
+            (registration.constructor)(&AcceleratorRuntimeConfig::default_for(Engine::Cayenne))
+                .is_ok()
         );
     }
 

--- a/crates/accelerators/accelerator-cayenne/src/lib.rs
+++ b/crates/accelerators/accelerator-cayenne/src/lib.rs
@@ -1149,15 +1149,19 @@ static CAYENNE_ACCELERATOR_INSTANCE_COUNTER: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
 impl CayenneAccelerator {
-    /// Builds the engine with the footer-cache size the runtime published.
-    ///
-    /// This is the constructor the registration slice calls, and it takes no arguments,
-    /// which is why the setting arrives through
-    /// [`runtime_acceleration::memory_budget::publish_cayenne_footer_cache_mb`] rather
-    /// than as a parameter.
+    /// Builds the engine with no footer cache configured.
     #[must_use]
     pub fn new() -> Self {
-        Self::with_footer_cache_mb(runtime_acceleration::memory_budget::cayenne_footer_cache_mb())
+        Self::with_footer_cache_mb(None)
+    }
+
+    /// Builds the engine for the `Runtime` whose settings these are.
+    ///
+    /// This is what the registration slice calls, so the footer-cache size arrives as an
+    /// argument and belongs to that one `Runtime`.
+    #[must_use]
+    pub fn from_runtime_config(config: &data_accelerator_api::AcceleratorRuntimeConfig) -> Self {
+        Self::with_footer_cache_mb(config.cayenne_footer_cache_mb)
     }
 
     #[must_use]
@@ -4204,7 +4208,7 @@ fn serialize_partition_child_writes(
     config.write_concurrency = Some(1);
 }
 
-data_accelerator_api::register_data_accelerator!(Engine::Cayenne, CayenneAccelerator);
+data_accelerator_api::register_data_accelerator!(configured: Engine::Cayenne, CayenneAccelerator);
 
 #[cfg(test)]
 mod tests {
@@ -4767,6 +4771,44 @@ mod tests {
             .collect();
         assert!(dims.contains(&256));
         assert!(dims.contains(&1536));
+    }
+
+    /// The footer-cache size reaches the engine as a constructor argument, so it belongs
+    /// to the `Runtime` that supplied it.
+    ///
+    /// This replaces a round-trip test over the process-global channel this seam retired.
+    /// `usize::MAX` is covered because `runtime.params.cayenne_footer_cache_mb` accepts
+    /// `max`: the retired channel reserved that value to mean "nothing was published", so
+    /// the largest cache an operator can ask for silently became the default. Nothing here
+    /// can reserve a value, but the case is the one worth keeping a test on.
+    #[test]
+    fn the_footer_cache_size_comes_from_the_runtime_config() {
+        use data_accelerator_api::AcceleratorRuntimeConfig;
+
+        let configured = |mb| {
+            CayenneAccelerator::from_runtime_config(&AcceleratorRuntimeConfig {
+                cayenne_footer_cache_mb: mb,
+            })
+            .footer_cache_mb
+        };
+
+        assert_eq!(configured(Some(256)), Some(256));
+        assert_eq!(
+            configured(Some(0)),
+            Some(0),
+            "no footer cache at all is a real setting, distinct from an absent one"
+        );
+        assert_eq!(
+            configured(Some(usize::MAX)),
+            Some(usize::MAX),
+            "`cayenne_footer_cache_mb: max` must reach the engine as the operator wrote it"
+        );
+        assert_eq!(configured(None), None);
+
+        // Two `Runtime`s in one process configure independently: the value travels with
+        // the engine instance, so there is nothing for a concurrent build to overwrite.
+        assert_eq!(configured(Some(64)), Some(64));
+        assert_eq!(CayenneAccelerator::new().footer_cache_mb, None);
     }
 
     /// The write profile is the engine's answer about its *own* acceleration, so an

--- a/crates/accelerators/accelerator-cayenne/src/lib.rs
+++ b/crates/accelerators/accelerator-cayenne/src/lib.rs
@@ -4876,10 +4876,8 @@ mod tests {
 
         // Its own settings still build, so the refusal is about the mismatch and not about
         // the engine being unbuildable.
-        assert!(
-            (registration.constructor)(&AcceleratorRuntimeConfig::default_for(Engine::Cayenne))
-                .is_ok()
-        );
+        (registration.constructor)(&AcceleratorRuntimeConfig::default_for(Engine::Cayenne))
+            .expect("the engine must still build from its own configuration");
     }
 
     /// The write profile is the engine's answer about its *own* acceleration, so an

--- a/crates/data-accelerator-api/src/lib.rs
+++ b/crates/data-accelerator-api/src/lib.rs
@@ -91,7 +91,18 @@ pub fn make_spice_data_directory() -> std::io::Result<()> {
 pub use runtime_acceleration::BootstrapStatus;
 pub use types::{AccelerationSource, AcceleratorEngineRegistry};
 
-/// Runtime-level (not per-dataset) settings an engine needs at construction.
+/// The Cayenne engine's runtime-level settings.
+///
+/// Fields are named for the `runtime.params` key they come from.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CayenneRuntimeConfig {
+    /// `runtime.params.cayenne_footer_cache_mb`: how much the engine may spend on its
+    /// Vortex footer-metadata cache. `None` when the operator set none, which is distinct
+    /// from `Some(0)` — no footer cache at all.
+    pub footer_cache_mb: Option<usize>,
+}
+
+/// Runtime-level (not per-dataset) settings for one engine, at construction.
 ///
 /// An engine is built by its registration constructor, which the registration slice calls
 /// with no knowledge of the engine's type. Passing the resolved settings *here* is what
@@ -99,31 +110,101 @@ pub use types::{AccelerationSource, AcceleratorEngineRegistry};
 /// there is no process-global channel to publish them through — nor a window between
 /// publishing and constructing for a concurrent build to interleave in.
 ///
-/// Fields are named for the `runtime.params` key they come from. Most engines take
-/// nothing from here, which is why the simple form of
-/// [`register_data_accelerator!`] ignores this argument entirely.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct AcceleratorRuntimeConfig {
-    /// `runtime.params.cayenne_footer_cache_mb`: how much the Cayenne engine may spend on
-    /// its Vortex footer-metadata cache. `None` when the operator set none, which is
-    /// distinct from `Some(0)` — no footer cache at all.
-    pub cayenne_footer_cache_mb: Option<usize>,
+/// One variant per [`Engine`], carrying that engine's own settings type rather than a
+/// shared struct of engine-prefixed fields. The set is closed because [`Engine`] is
+/// already closed; a variant that carries nothing is an engine that takes no runtime-level
+/// configuration, which is all of them but Cayenne today.
+///
+/// The payload is a struct rather than inline fields so that a `&CayenneRuntimeConfig` can
+/// be passed on: the one fallible step is getting *out* of this enum, and everything after
+/// it — including each engine's own constructor — is total.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AcceleratorRuntimeConfig {
+    Arrow,
+    PartitionedArrow,
+    DuckDB,
+    Sqlite,
+    Turso,
+    PostgreSQL,
+    Cayenne(CayenneRuntimeConfig),
+}
+
+impl AcceleratorRuntimeConfig {
+    /// The engine these settings configure.
+    #[must_use]
+    pub fn engine(&self) -> Engine {
+        match self {
+            Self::Arrow => Engine::Arrow,
+            Self::PartitionedArrow => Engine::PartitionedArrow,
+            Self::DuckDB => Engine::DuckDB,
+            Self::Sqlite => Engine::Sqlite,
+            Self::Turso => Engine::Turso,
+            Self::PostgreSQL => Engine::PostgreSQL,
+            Self::Cayenne(_) => Engine::Cayenne,
+        }
+    }
+
+    /// The unconfigured settings for `engine` — what an engine gets when the operator set
+    /// nothing, and what a caller building an engine only to ask it a question passes.
+    ///
+    /// The variant always matches `engine`, which is what makes
+    /// [`AcceleratorRegistration::build_with_defaults`] unable to fail in practice.
+    #[must_use]
+    pub fn default_for(engine: Engine) -> Self {
+        match engine {
+            Engine::Arrow => Self::Arrow,
+            Engine::PartitionedArrow => Self::PartitionedArrow,
+            Engine::DuckDB => Self::DuckDB,
+            Engine::Sqlite => Self::Sqlite,
+            Engine::Turso => Self::Turso,
+            Engine::PostgreSQL => Self::PostgreSQL,
+            Engine::Cayenne => Self::Cayenne(CayenneRuntimeConfig::default()),
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
 pub struct AcceleratorRegistration {
     pub engine: Engine,
-    pub constructor: fn(&AcceleratorRuntimeConfig) -> Arc<dyn DataAccelerator>,
+    /// Builds the engine from settings that must be [`Engine`]-matched to `engine`.
+    ///
+    /// Fallible because the registration slice stores one function type for every engine,
+    /// so a mismatched variant cannot be rejected at compile time. Call it through
+    /// [`AcceleratorEngineRegistry::register_all`] or
+    /// [`AcceleratorRegistration::build_with_defaults`], both of which choose the config by
+    /// engine and so cannot mismatch.
+    pub constructor: fn(&AcceleratorRuntimeConfig) -> Result<Arc<dyn DataAccelerator>>,
 }
 
 impl AcceleratorRegistration {
     pub const fn new(
         engine: Engine,
-        constructor: fn(&AcceleratorRuntimeConfig) -> Arc<dyn DataAccelerator>,
+        constructor: fn(&AcceleratorRuntimeConfig) -> Result<Arc<dyn DataAccelerator>>,
     ) -> Self {
         Self {
             engine,
             constructor,
+        }
+    }
+
+    /// Builds this engine with no runtime-level settings, for a caller that only wants to
+    /// ask it a question — what it makes of an acceleration, what parameters it accepts.
+    ///
+    /// Returns `None` only if the constructor rejects
+    /// [`AcceleratorRuntimeConfig::default_for`] of its own engine, which it cannot; the
+    /// case is logged rather than propagated so that asking an engine a question needs no
+    /// error handling.
+    #[must_use]
+    pub fn build_with_defaults(&self) -> Option<Arc<dyn DataAccelerator>> {
+        match (self.constructor)(&AcceleratorRuntimeConfig::default_for(self.engine)) {
+            Ok(accelerator) => Some(accelerator),
+            Err(error) => {
+                tracing::error!(
+                    "Failed to prepare the {} accelerator engine: {error}. Acceleration using this engine will not be available.",
+                    self.engine
+                );
+                None
+            }
         }
     }
 }
@@ -187,8 +268,12 @@ fn format_engine_list(names: &[String]) -> String {
 /// `new()` and ignore the configuration.
 ///
 /// ```ignore
-/// register_data_accelerator!(configured: Engine::Foo, FooAccelerator);
+/// register_data_accelerator!(configured: Engine::Foo, Foo, FooAccelerator);
 /// ```
+///
+/// The middle argument is the [`AcceleratorRuntimeConfig`] variant carrying this engine's
+/// settings; the accelerator must implement
+/// `from_runtime_config(&FooRuntimeConfig) -> Self`.
 ///
 /// # Example (explicit form)
 ///
@@ -208,8 +293,8 @@ macro_rules! register_data_accelerator {
     ($fn_name:ident, $static_name:ident, $engine:expr, $accelerator:path) => {
         fn $fn_name(
             _config: &$crate::AcceleratorRuntimeConfig,
-        ) -> ::std::sync::Arc<dyn $crate::DataAccelerator> {
-            ::std::sync::Arc::new(<$accelerator>::new())
+        ) -> $crate::Result<::std::sync::Arc<dyn $crate::DataAccelerator>> {
+            Ok(::std::sync::Arc::new(<$accelerator>::new()))
         }
 
         #[linkme::distributed_slice($crate::DATA_ACCELERATOR_REGISTRATIONS)]
@@ -217,11 +302,22 @@ macro_rules! register_data_accelerator {
             $crate::AcceleratorRegistration::new($engine, $fn_name);
     };
 
-    (configured: $fn_name:ident, $static_name:ident, $engine:expr, $accelerator:path) => {
+    (configured: $fn_name:ident, $static_name:ident, $engine:expr, $variant:ident, $accelerator:path) => {
         fn $fn_name(
             config: &$crate::AcceleratorRuntimeConfig,
-        ) -> ::std::sync::Arc<dyn $crate::DataAccelerator> {
-            ::std::sync::Arc::new(<$accelerator>::from_runtime_config(config))
+        ) -> $crate::Result<::std::sync::Arc<dyn $crate::DataAccelerator>> {
+            // The only fallible step: once the engine's own settings are in hand, building
+            // it is total, and that `&`-reference is what gets passed on.
+            match config {
+                $crate::AcceleratorRuntimeConfig::$variant(engine_config) => Ok(
+                    ::std::sync::Arc::new(<$accelerator>::from_runtime_config(engine_config)),
+                ),
+                mismatched => $crate::MismatchedEngineConfigSnafu {
+                    expected: $engine,
+                    actual: mismatched.engine(),
+                }
+                .fail(),
+            }
         }
 
         #[linkme::distributed_slice($crate::DATA_ACCELERATOR_REGISTRATIONS)]
@@ -240,13 +336,14 @@ macro_rules! register_data_accelerator {
         }
     };
 
-    (configured: $engine:expr, $accelerator:ident) => {
+    (configured: $engine:expr, $variant:ident, $accelerator:ident) => {
         ::paste::paste! {
             $crate::register_data_accelerator!(
                 configured:
                 [<__register_data_accelerator_fn_ $accelerator:snake>],
                 [<__REGISTER_DATA_ACCELERATOR_ $accelerator:upper>],
                 $engine,
+                $variant,
                 $accelerator
             );
         }
@@ -269,6 +366,13 @@ pub enum Error {
     AccelerationCreationFailed {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
+
+    // Not user-facing: reaching this means a caller paired an engine's registration with
+    // another engine's settings, which every path in this crate chooses by engine.
+    #[snafu(display(
+        "Internal error: the {expected} accelerator engine was given {actual} configuration"
+    ))]
+    MismatchedEngineConfig { expected: Engine, actual: Engine },
 }
 
 #[derive(Debug, Snafu)]
@@ -1210,16 +1314,16 @@ fn accelerator_for_engine(engine: Engine) -> Option<Arc<dyn DataAccelerator>> {
     DATA_ACCELERATOR_REGISTRATIONS
         .iter()
         .find(|registration| registration.engine == engine)
-        // Built only to ask it about an acceleration, so the runtime-level settings are
-        // irrelevant: nothing here reads a footer cache.
-        .map(|registration| (registration.constructor)(&AcceleratorRuntimeConfig::default()))
+        // Built only to ask it about an acceleration, so it takes no runtime-level settings.
+        .and_then(AcceleratorRegistration::build_with_defaults)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        AcceleratorExternalTableBuilder, cayenne_pk_conflict_detection_none, format_engine_list,
-        get_primary_keys_from_constraints, upsert_dedup::extract_upsert_options,
+        AcceleratorExternalTableBuilder, AcceleratorRuntimeConfig,
+        cayenne_pk_conflict_detection_none, format_engine_list, get_primary_keys_from_constraints,
+        upsert_dedup::extract_upsert_options,
     };
     use ::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
     use datafusion::common::{Constraint, Constraints, TableReference};
@@ -1457,5 +1561,31 @@ mod tests {
             format_engine_list(&[]),
             "none — this build links no accelerator engine"
         );
+    }
+
+    /// The property that keeps a mismatched configuration unreachable: the defaults for an
+    /// engine are that engine's own variant, so `register_all` and `build_with_defaults`
+    /// — which both select by engine — cannot hand a constructor another engine's settings.
+    ///
+    /// Listing the engines here is enough without an exhaustiveness guard: adding an
+    /// `Engine` variant fails to compile in `default_for`, and adding a config variant
+    /// fails to compile in `engine`.
+    #[test]
+    fn the_default_config_for_an_engine_is_that_engines_own_variant() {
+        for engine in [
+            Engine::Arrow,
+            Engine::PartitionedArrow,
+            Engine::DuckDB,
+            Engine::Sqlite,
+            Engine::Turso,
+            Engine::PostgreSQL,
+            Engine::Cayenne,
+        ] {
+            assert_eq!(
+                AcceleratorRuntimeConfig::default_for(engine).engine(),
+                engine,
+                "default_for({engine}) must produce the {engine} variant"
+            );
+        }
     }
 }

--- a/crates/data-accelerator-api/src/lib.rs
+++ b/crates/data-accelerator-api/src/lib.rs
@@ -200,7 +200,8 @@ impl AcceleratorRegistration {
             Ok(accelerator) => Some(accelerator),
             Err(error) => {
                 tracing::error!(
-                    "Failed to prepare the {} accelerator engine: {error}. Acceleration using this engine will not be available.",
+                    "Failed to prepare the '{}' accelerator engine, so Spice cannot determine how it handles an acceleration and datasets using `engine: {}` may not load. Cause: {error}. This is an internal error, not a configuration mistake — please report it at https://github.com/spiceai/spiceai/issues",
+                    self.engine,
                     self.engine
                 );
                 None
@@ -367,11 +368,10 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    // Not user-facing: reaching this means a caller paired an engine's registration with
-    // another engine's settings, which every path in this crate chooses by engine.
-    #[snafu(display(
-        "Internal error: the {expected} accelerator engine was given {actual} configuration"
-    ))]
+    // Worded as the cause clause it appears as: the messages that embed it supply the
+    // impact and where to report it. Reaching this means a caller paired an engine's
+    // registration with another engine's settings, which every path here chooses by engine.
+    #[snafu(display("the {expected} engine was given {actual} configuration"))]
     MismatchedEngineConfig { expected: Engine, actual: Engine },
 }
 

--- a/crates/data-accelerator-api/src/lib.rs
+++ b/crates/data-accelerator-api/src/lib.rs
@@ -104,9 +104,9 @@ pub use types::{AccelerationSource, AcceleratorEngineRegistry};
 /// [`register_data_accelerator!`] ignores this argument entirely.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AcceleratorRuntimeConfig {
-    /// `runtime.params.cayenne_footer_cache_mb`: the size of the process-wide Vortex
-    /// footer-metadata cache. `None` when the operator set none, which is distinct from
-    /// `Some(0)` (no footer cache at all).
+    /// `runtime.params.cayenne_footer_cache_mb`: how much the Cayenne engine may spend on
+    /// its Vortex footer-metadata cache. `None` when the operator set none, which is
+    /// distinct from `Some(0)` — no footer cache at all.
     pub cayenne_footer_cache_mb: Option<usize>,
 }
 

--- a/crates/data-accelerator-api/src/lib.rs
+++ b/crates/data-accelerator-api/src/lib.rs
@@ -91,14 +91,36 @@ pub fn make_spice_data_directory() -> std::io::Result<()> {
 pub use runtime_acceleration::BootstrapStatus;
 pub use types::{AccelerationSource, AcceleratorEngineRegistry};
 
+/// Runtime-level (not per-dataset) settings an engine needs at construction.
+///
+/// An engine is built by its registration constructor, which the registration slice calls
+/// with no knowledge of the engine's type. Passing the resolved settings *here* is what
+/// keeps them per-`Runtime`: an engine built for one `Runtime` cannot see another's, and
+/// there is no process-global channel to publish them through — nor a window between
+/// publishing and constructing for a concurrent build to interleave in.
+///
+/// Fields are named for the `runtime.params` key they come from. Most engines take
+/// nothing from here, which is why the simple form of
+/// [`register_data_accelerator!`] ignores this argument entirely.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AcceleratorRuntimeConfig {
+    /// `runtime.params.cayenne_footer_cache_mb`: the size of the process-wide Vortex
+    /// footer-metadata cache. `None` when the operator set none, which is distinct from
+    /// `Some(0)` (no footer cache at all).
+    pub cayenne_footer_cache_mb: Option<usize>,
+}
+
 #[derive(Clone, Copy)]
 pub struct AcceleratorRegistration {
     pub engine: Engine,
-    pub constructor: fn() -> Arc<dyn DataAccelerator>,
+    pub constructor: fn(&AcceleratorRuntimeConfig) -> Arc<dyn DataAccelerator>,
 }
 
 impl AcceleratorRegistration {
-    pub const fn new(engine: Engine, constructor: fn() -> Arc<dyn DataAccelerator>) -> Self {
+    pub const fn new(
+        engine: Engine,
+        constructor: fn(&AcceleratorRuntimeConfig) -> Arc<dyn DataAccelerator>,
+    ) -> Self {
         Self {
             engine,
             constructor,
@@ -158,6 +180,16 @@ fn format_engine_list(names: &[String]) -> String {
 /// register_data_accelerator!(Engine::Foo, FooAccelerator);
 /// ```
 ///
+/// # Example (configured form)
+///
+/// For an engine that takes a runtime-level setting at construction. It must implement
+/// `from_runtime_config(&AcceleratorRuntimeConfig) -> Self`; the simple forms above call
+/// `new()` and ignore the configuration.
+///
+/// ```ignore
+/// register_data_accelerator!(configured: Engine::Foo, FooAccelerator);
+/// ```
+///
 /// # Example (explicit form)
 ///
 /// ```ignore
@@ -174,8 +206,22 @@ fn format_engine_list(names: &[String]) -> String {
 #[macro_export]
 macro_rules! register_data_accelerator {
     ($fn_name:ident, $static_name:ident, $engine:expr, $accelerator:path) => {
-        fn $fn_name() -> ::std::sync::Arc<dyn $crate::DataAccelerator> {
+        fn $fn_name(
+            _config: &$crate::AcceleratorRuntimeConfig,
+        ) -> ::std::sync::Arc<dyn $crate::DataAccelerator> {
             ::std::sync::Arc::new(<$accelerator>::new())
+        }
+
+        #[linkme::distributed_slice($crate::DATA_ACCELERATOR_REGISTRATIONS)]
+        pub static $static_name: $crate::AcceleratorRegistration =
+            $crate::AcceleratorRegistration::new($engine, $fn_name);
+    };
+
+    (configured: $fn_name:ident, $static_name:ident, $engine:expr, $accelerator:path) => {
+        fn $fn_name(
+            config: &$crate::AcceleratorRuntimeConfig,
+        ) -> ::std::sync::Arc<dyn $crate::DataAccelerator> {
+            ::std::sync::Arc::new(<$accelerator>::from_runtime_config(config))
         }
 
         #[linkme::distributed_slice($crate::DATA_ACCELERATOR_REGISTRATIONS)]
@@ -186,6 +232,18 @@ macro_rules! register_data_accelerator {
     ($engine:expr, $accelerator:ident) => {
         ::paste::paste! {
             $crate::register_data_accelerator!(
+                [<__register_data_accelerator_fn_ $accelerator:snake>],
+                [<__REGISTER_DATA_ACCELERATOR_ $accelerator:upper>],
+                $engine,
+                $accelerator
+            );
+        }
+    };
+
+    (configured: $engine:expr, $accelerator:ident) => {
+        ::paste::paste! {
+            $crate::register_data_accelerator!(
+                configured:
                 [<__register_data_accelerator_fn_ $accelerator:snake>],
                 [<__REGISTER_DATA_ACCELERATOR_ $accelerator:upper>],
                 $engine,
@@ -1152,7 +1210,9 @@ fn accelerator_for_engine(engine: Engine) -> Option<Arc<dyn DataAccelerator>> {
     DATA_ACCELERATOR_REGISTRATIONS
         .iter()
         .find(|registration| registration.engine == engine)
-        .map(|registration| (registration.constructor)())
+        // Built only to ask it about an acceleration, so the runtime-level settings are
+        // irrelevant: nothing here reads a footer cache.
+        .map(|registration| (registration.constructor)(&AcceleratorRuntimeConfig::default()))
 }
 
 #[cfg(test)]

--- a/crates/data-accelerator-api/src/types.rs
+++ b/crates/data-accelerator-api/src/types.rs
@@ -73,13 +73,38 @@ impl AcceleratorEngineRegistry {
     /// `config` is passed to each constructor rather than published somewhere the
     /// constructors can read, so the settings belong to this registry alone — two
     /// `Runtime`s built concurrently in one process cannot see each other's.
-    pub async fn register_all(&self, config: &AcceleratorRuntimeConfig) {
+    /// Builds and registers every engine this build linked, configured for this
+    /// `Runtime`.
+    ///
+    /// Each engine is given the entry in `configs` for its own [`Engine`], or that
+    /// engine's defaults when `configs` names it nowhere — so a constructor is never handed
+    /// another engine's settings, and the mismatch its signature admits cannot arise here.
+    /// The first entry for an engine wins; later ones for that engine are ignored.
+    ///
+    /// The settings are passed to each constructor rather than published somewhere the
+    /// constructors can read, so they belong to this registry alone: two `Runtime`s built
+    /// concurrently in one process cannot see each other's.
+    pub async fn register_all(&self, configs: &[AcceleratorRuntimeConfig]) {
         for registration in DATA_ACCELERATOR_REGISTRATIONS {
-            self.register_accelerator_engine(
-                registration.engine,
-                (registration.constructor)(config),
-            )
-            .await;
+            let config = configs
+                .iter()
+                .find(|config| config.engine() == registration.engine)
+                .cloned()
+                .unwrap_or_else(|| AcceleratorRuntimeConfig::default_for(registration.engine));
+
+            match (registration.constructor)(&config) {
+                Ok(accelerator) => {
+                    self.register_accelerator_engine(registration.engine, accelerator)
+                        .await;
+                }
+                Err(error) => {
+                    tracing::error!(
+                        "Failed to prepare the {} accelerator engine: {error}. Datasets accelerated with '{}' will not load.",
+                        registration.engine,
+                        registration.engine
+                    );
+                }
+            }
         }
     }
 

--- a/crates/data-accelerator-api/src/types.rs
+++ b/crates/data-accelerator-api/src/types.rs
@@ -23,7 +23,7 @@ use runtime_acceleration::Engine;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
 
-use super::{DATA_ACCELERATOR_REGISTRATIONS, DataAccelerator};
+use super::{AcceleratorRuntimeConfig, DATA_ACCELERATOR_REGISTRATIONS, DataAccelerator};
 
 // Re-export AccelerationSource from runtime-acceleration so existing paths keep working.
 pub use runtime_acceleration::AccelerationSource;
@@ -67,10 +67,19 @@ impl AcceleratorEngineRegistry {
         }
     }
 
-    pub async fn register_all(&self) {
+    /// Builds and registers every engine this build linked, configured for this
+    /// `Runtime`.
+    ///
+    /// `config` is passed to each constructor rather than published somewhere the
+    /// constructors can read, so the settings belong to this registry alone — two
+    /// `Runtime`s built concurrently in one process cannot see each other's.
+    pub async fn register_all(&self, config: &AcceleratorRuntimeConfig) {
         for registration in DATA_ACCELERATOR_REGISTRATIONS {
-            self.register_accelerator_engine(registration.engine, (registration.constructor)())
-                .await;
+            self.register_accelerator_engine(
+                registration.engine,
+                (registration.constructor)(config),
+            )
+            .await;
         }
     }
 

--- a/crates/data-accelerator-api/src/types.rs
+++ b/crates/data-accelerator-api/src/types.rs
@@ -70,12 +70,6 @@ impl AcceleratorEngineRegistry {
     /// Builds and registers every engine this build linked, configured for this
     /// `Runtime`.
     ///
-    /// `config` is passed to each constructor rather than published somewhere the
-    /// constructors can read, so the settings belong to this registry alone — two
-    /// `Runtime`s built concurrently in one process cannot see each other's.
-    /// Builds and registers every engine this build linked, configured for this
-    /// `Runtime`.
-    ///
     /// Each engine is given the entry in `configs` for its own [`Engine`], or that
     /// engine's defaults when `configs` names it nowhere — so a constructor is never handed
     /// another engine's settings, and the mismatch its signature admits cannot arise here.
@@ -99,7 +93,7 @@ impl AcceleratorEngineRegistry {
                 }
                 Err(error) => {
                     tracing::error!(
-                        "Failed to prepare the {} accelerator engine: {error}. Datasets accelerated with '{}' will not load.",
+                        "Failed to prepare the '{}' accelerator engine, so no dataset accelerated with `engine: {}` will load. Cause: {error}. This is an internal error, not a configuration mistake — please report it at https://github.com/spiceai/spiceai/issues",
                         registration.engine,
                         registration.engine
                     );

--- a/crates/runtime-acceleration/src/memory_budget.rs
+++ b/crates/runtime-acceleration/src/memory_budget.rs
@@ -44,7 +44,6 @@ limitations under the License.
 //! warns when it engages.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{LazyLock, RwLock};
 
 /// Share (%) of the splittable query region handed to the query pool when it is
 /// contested with un-limited `DuckDB` instances; the remainder is split equally
@@ -120,49 +119,6 @@ fn format_duckdb_memory_limit(bytes: u64) -> Option<String> {
 #[must_use]
 pub fn duckdb_total_reservation_bytes() -> u64 {
     DUCKDB_TOTAL_RESERVATION_BYTES.load(Ordering::Relaxed)
-}
-
-/// The operator's `cayenne_footer_cache_mb`, published for the Cayenne engine to read.
-///
-/// Holds the `Option` itself rather than an integer with a reserved "absent" value: the
-/// runtime parameter accepts `max` (and `usize::MAX`) as a real setting, so any sentinel
-/// drawn from the value space collides with a value an operator can actually write. A
-/// lock is affordable because this is read once per engine construction, at startup.
-static CAYENNE_FOOTER_CACHE_MB: RwLock<Option<usize>> = RwLock::new(None);
-
-/// Publishes `runtime.params.cayenne_footer_cache_mb` for the engine.
-///
-/// The engine is built by its registration constructor, which takes no arguments, so a
-/// setting resolved from the Spicepod cannot be passed in — it is published here and read
-/// at construction instead. **Must run before the accelerator engines are registered**,
-/// or the engine is built before the value exists and silently uses its default.
-pub fn publish_cayenne_footer_cache_mb(footer_cache_mb: Option<usize>) {
-    *CAYENNE_FOOTER_CACHE_MB
-        .write()
-        .unwrap_or_else(std::sync::PoisonError::into_inner) = footer_cache_mb;
-}
-
-/// Serializes publishing the setting above with constructing the engines that read it.
-///
-/// The value is process-global because a registration constructor takes no arguments,
-/// while the registry it fills is per-`Runtime`. Two `Runtime`s built concurrently in one
-/// process — embedded hosts, and any test binary that builds more than one — could
-/// otherwise both publish before either constructs, leaving one runtime's engine holding
-/// the other's setting. Holding this across the registration pass makes the pair behave as
-/// if the setting were per-`Runtime`: a constructed engine owns its own copy, so a later
-/// publish cannot reach it.
-#[must_use]
-pub fn engine_construction_lock() -> &'static tokio::sync::Mutex<()> {
-    static LOCK: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
-    &LOCK
-}
-
-/// The published `cayenne_footer_cache_mb`, or `None` when the operator set none.
-#[must_use]
-pub fn cayenne_footer_cache_mb() -> Option<usize> {
-    *CAYENNE_FOOTER_CACHE_MB
-        .read()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// A deduped-by-instance summary of the `DuckDB` accelerators in an app. Built by a
@@ -400,32 +356,6 @@ mod tests {
 
     const GIB: u64 = 1024 * 1024 * 1024;
     const MIB: u64 = 1024 * 1024;
-
-    /// Every value an operator can write must survive the round trip, including the ends
-    /// of the range. `runtime.params.cayenne_footer_cache_mb` accepts `max` as a real
-    /// setting, so a sentinel taken from the value space would report the largest cache
-    /// an operator can ask for as "nothing was configured", and the engine would quietly
-    /// use its default while the rest of the runtime honoured the request.
-    ///
-    /// Runs single-threaded: the published value is process-global by design, so a
-    /// concurrent sibling would race it.
-    #[test]
-    fn a_published_footer_cache_size_survives_the_round_trip() {
-        use super::{cayenne_footer_cache_mb, publish_cayenne_footer_cache_mb};
-
-        for published in [None, Some(0), Some(1), Some(512), Some(usize::MAX)] {
-            publish_cayenne_footer_cache_mb(published);
-            assert_eq!(
-                cayenne_footer_cache_mb(),
-                published,
-                "publishing {published:?} must read back unchanged"
-            );
-        }
-
-        // Leave nothing published, so an engine constructed later in this process is not
-        // handed this test's last value.
-        publish_cayenne_footer_cache_mb(None);
-    }
 
     /// Bare-metal-equivalent `plan()` where host RAM == cgroup total, so `DuckDB`'s
     /// per-instance default is `total * 80 / 100`.

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -347,12 +347,14 @@ impl RuntimeBuilder {
         // afterwards instead would mean naming the concrete accelerator from here.
         let cayenne_footer_cache_mb =
             parse_usize_runtime_param(&spicepod_rt.params, CAYENNE_FOOTER_CACHE_MB_PARAM);
-        let accelerator_config = data_accelerator_api::AcceleratorRuntimeConfig {
-            cayenne_footer_cache_mb,
-        };
+        let accelerator_configs = [data_accelerator_api::AcceleratorRuntimeConfig::Cayenne(
+            data_accelerator_api::CayenneRuntimeConfig {
+                footer_cache_mb: cayenne_footer_cache_mb,
+            },
+        )];
 
         self.accelerator_engine_registry
-            .register_all(&accelerator_config)
+            .register_all(&accelerator_configs)
             .await;
         dataconnector::register_all().await;
         catalogconnector::register_all().await;
@@ -1533,7 +1535,8 @@ pub(crate) fn cayenne_write_profile(
         .iter()
         .find(|registration| registration.engine == runtime_acceleration::Engine::Cayenne)
         .and_then(|registration| {
-            (registration.constructor)(&data_accelerator_api::AcceleratorRuntimeConfig::default())
+            registration
+                .build_with_defaults()?
                 .spicepod_write_profile(acceleration, unset_refresh_mode)
         })
 }
@@ -1738,9 +1741,9 @@ fn duckdb_budget_inputs(
     data_accelerator_api::DATA_ACCELERATOR_REGISTRATIONS
         .iter()
         .find(|registration| registration.engine == runtime_acceleration::Engine::DuckDB)
-        .map_or_else(DuckDbBudgetInputs::default, |registration| {
-            (registration.constructor)(&data_accelerator_api::AcceleratorRuntimeConfig::default())
-                .memory_budget_inputs(app)
+        .and_then(data_accelerator_api::AcceleratorRegistration::build_with_defaults)
+        .map_or_else(DuckDbBudgetInputs::default, |accelerator| {
+            accelerator.memory_budget_inputs(app)
         })
 }
 

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -341,27 +341,19 @@ impl RuntimeBuilder {
                 .map_or(SpicepodRuntime::default(), |app| app.runtime.clone())
         });
 
-        // Published before the engines are registered, because an engine is built by its
-        // registration constructor, which takes no arguments: a setting resolved from the
-        // Spicepod can only reach it this way. Registering a configured engine afterwards
-        // instead would mean naming the concrete accelerator from here.
-        //
-        // The publish and the registration pass are one operation: the published value is
-        // process-global while the registry it fills belongs to this `Runtime`, so two
-        // concurrent builds must not interleave between them. The guard is dropped as soon
-        // as the engines exist, each holding its own copy of the setting.
-        let engine_construction = runtime_acceleration::memory_budget::engine_construction_lock()
-            .lock()
-            .await;
+        // Resolved before the engines are registered and handed to each constructor: an
+        // engine is built by the registration slice, which knows nothing of its type, so
+        // this is how a Spicepod setting reaches one. Registering a configured engine
+        // afterwards instead would mean naming the concrete accelerator from here.
         let cayenne_footer_cache_mb =
             parse_usize_runtime_param(&spicepod_rt.params, CAYENNE_FOOTER_CACHE_MB_PARAM);
-        #[cfg(not(windows))]
-        runtime_acceleration::memory_budget::publish_cayenne_footer_cache_mb(
+        let accelerator_config = data_accelerator_api::AcceleratorRuntimeConfig {
             cayenne_footer_cache_mb,
-        );
+        };
 
-        self.accelerator_engine_registry.register_all().await;
-        drop(engine_construction);
+        self.accelerator_engine_registry
+            .register_all(&accelerator_config)
+            .await;
         dataconnector::register_all().await;
         catalogconnector::register_all().await;
         document_parse::register_all().await;
@@ -1541,7 +1533,8 @@ pub(crate) fn cayenne_write_profile(
         .iter()
         .find(|registration| registration.engine == runtime_acceleration::Engine::Cayenne)
         .and_then(|registration| {
-            (registration.constructor)().spicepod_write_profile(acceleration, unset_refresh_mode)
+            (registration.constructor)(&data_accelerator_api::AcceleratorRuntimeConfig::default())
+                .spicepod_write_profile(acceleration, unset_refresh_mode)
         })
 }
 
@@ -1746,7 +1739,8 @@ fn duckdb_budget_inputs(
         .iter()
         .find(|registration| registration.engine == runtime_acceleration::Engine::DuckDB)
         .map_or_else(DuckDbBudgetInputs::default, |registration| {
-            (registration.constructor)().memory_budget_inputs(app)
+            (registration.constructor)(&data_accelerator_api::AcceleratorRuntimeConfig::default())
+                .memory_budget_inputs(app)
         })
 }
 

--- a/crates/runtime/src/catalogconnector/cayenne/mod.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/mod.rs
@@ -256,13 +256,9 @@ impl CayenneCatalogConnector {
         let tuning = data_accelerator_api::DATA_ACCELERATOR_REGISTRATIONS
             .iter()
             .find(|registration| registration.engine == runtime_acceleration::Engine::Cayenne)
-            .map(|registration| {
-                // Built only to ask for tuning seeds, which are derived from the host
-                // rather than from any runtime-level setting.
-                (registration.constructor)(
-                    &data_accelerator_api::AcceleratorRuntimeConfig::default(),
-                )
-            });
+            // Built only to ask for tuning seeds, which are derived from the host rather
+            // than from any runtime-level setting.
+            .and_then(data_accelerator_api::AcceleratorRegistration::build_with_defaults);
         let outcome = if let Some(engine) = tuning {
             engine
                 .adaptive_tuning_seeds(raw_tuning, &data_path, &metastore_path)

--- a/crates/runtime/src/catalogconnector/cayenne/mod.rs
+++ b/crates/runtime/src/catalogconnector/cayenne/mod.rs
@@ -256,7 +256,13 @@ impl CayenneCatalogConnector {
         let tuning = data_accelerator_api::DATA_ACCELERATOR_REGISTRATIONS
             .iter()
             .find(|registration| registration.engine == runtime_acceleration::Engine::Cayenne)
-            .map(|registration| (registration.constructor)());
+            .map(|registration| {
+                // Built only to ask for tuning seeds, which are derived from the host
+                // rather than from any runtime-level setting.
+                (registration.constructor)(
+                    &data_accelerator_api::AcceleratorRuntimeConfig::default(),
+                )
+            });
         let outcome = if let Some(engine) = tuning {
             engine
                 .adaptive_tuning_seeds(raw_tuning, &data_path, &metastore_path)

--- a/crates/runtime/src/dataaccelerator/mod.rs
+++ b/crates/runtime/src/dataaccelerator/mod.rs
@@ -110,6 +110,49 @@ mod test {
         assert_eq!(both_agree("postgres:public.orders"), RefreshMode::Full);
     }
 
+    /// A `runtime.params` setting must reach the engine the registry actually holds.
+    ///
+    /// This is the whole path — the builder resolves the parameter, `register_all` hands it
+    /// to each constructor, and the engine keeps it — so it is what a defect anywhere along
+    /// it would break. Building the engine directly cannot show any of that: passing a
+    /// default config from the builder would leave every engine-side test green while
+    /// silently dropping the operator's setting.
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn a_runtime_param_reaches_the_registered_engine() {
+        use accelerator_cayenne::CayenneAccelerator;
+        use spicepod::component::runtime::Runtime as SpicepodRuntime;
+
+        let mut spicepod_runtime = SpicepodRuntime::default();
+        spicepod_runtime
+            .params
+            .insert("cayenne_footer_cache_mb".to_string(), "777".to_string());
+
+        let rt = crate::Runtime::builder()
+            .with_runtime_config(crate::config::Config {
+                runtime: Some(spicepod_runtime),
+                ..Default::default()
+            })
+            .build()
+            .await;
+
+        let engine = rt
+            .accelerator_engine_registry()
+            .get_accelerator_engine(Engine::Cayenne)
+            .await
+            .expect("this build links the Cayenne engine");
+        let cayenne = engine
+            .as_any()
+            .downcast_ref::<CayenneAccelerator>()
+            .expect("the Cayenne engine is a CayenneAccelerator");
+
+        assert_eq!(
+            cayenne.footer_cache_mb(),
+            Some(777),
+            "`runtime.params.cayenne_footer_cache_mb` must reach the registered engine"
+        );
+    }
+
     /// Pins what `DataAccelerator::spicepod_write_profile` answers, because the memory and
     /// compaction budgets are computed from it: a wrong mapping would budget a pod as one
     /// shape while the table is configured as another, and both sides would still look

--- a/tools/spicepodschema/src/collector.rs
+++ b/tools/spicepodschema/src/collector.rs
@@ -20,7 +20,7 @@ limitations under the License.
 //! This module explicitly references all connector modules to ensure they are linked into the
 //! binary and their `linkme` distributed slice registrations are included.
 
-use data_accelerator_api::DATA_ACCELERATOR_REGISTRATIONS;
+use data_accelerator_api::{AcceleratorRuntimeConfig, DATA_ACCELERATOR_REGISTRATIONS};
 use data_connector_api::DATA_CONNECTOR_REGISTRATIONS;
 use runtime::model::params::get_params_spec;
 use runtime_parameters::ParameterSpec;
@@ -153,7 +153,7 @@ pub fn collect_data_accelerators() -> Vec<ConnectorSchema> {
     let mut accelerators: Vec<ConnectorSchema> = DATA_ACCELERATOR_REGISTRATIONS
         .iter()
         .map(|reg| {
-            let accelerator = (reg.constructor)(&Default::default());
+            let accelerator = (reg.constructor)(&AcceleratorRuntimeConfig::default());
             ConnectorSchema {
                 // Use Display trait to get the string representation
                 name: reg.engine.to_string(),

--- a/tools/spicepodschema/src/collector.rs
+++ b/tools/spicepodschema/src/collector.rs
@@ -153,7 +153,7 @@ pub fn collect_data_accelerators() -> Vec<ConnectorSchema> {
     let mut accelerators: Vec<ConnectorSchema> = DATA_ACCELERATOR_REGISTRATIONS
         .iter()
         .map(|reg| {
-            let accelerator = (reg.constructor)();
+            let accelerator = (reg.constructor)(&Default::default());
             ConnectorSchema {
                 // Use Display trait to get the string representation
                 name: reg.engine.to_string(),

--- a/tools/spicepodschema/src/collector.rs
+++ b/tools/spicepodschema/src/collector.rs
@@ -20,7 +20,7 @@ limitations under the License.
 //! This module explicitly references all connector modules to ensure they are linked into the
 //! binary and their `linkme` distributed slice registrations are included.
 
-use data_accelerator_api::{AcceleratorRuntimeConfig, DATA_ACCELERATOR_REGISTRATIONS};
+use data_accelerator_api::DATA_ACCELERATOR_REGISTRATIONS;
 use data_connector_api::DATA_CONNECTOR_REGISTRATIONS;
 use runtime::model::params::get_params_spec;
 use runtime_parameters::ParameterSpec;
@@ -152,14 +152,16 @@ pub fn collect_data_connectors() -> Vec<ConnectorSchema> {
 pub fn collect_data_accelerators() -> Vec<ConnectorSchema> {
     let mut accelerators: Vec<ConnectorSchema> = DATA_ACCELERATOR_REGISTRATIONS
         .iter()
-        .map(|reg| {
-            let accelerator = (reg.constructor)(&AcceleratorRuntimeConfig::default());
-            ConnectorSchema {
+        .filter_map(|reg| {
+            // An engine that cannot be prepared has already logged why; leaving it out of
+            // the schema is better than emitting an entry with no parameters.
+            let accelerator = reg.build_with_defaults()?;
+            Some(ConnectorSchema {
                 // Use Display trait to get the string representation
                 name: reg.engine.to_string(),
                 prefix: accelerator.prefix(),
                 parameters: accelerator.parameters(),
-            }
+            })
         })
         .collect();
     accelerators.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.prefix.cmp(b.prefix)));


### PR DESCRIPTION
Follow-up to #13391, which surfaced the problem this removes.

## The mechanism, and why it cost two defects

The Cayenne engine takes one runtime-level setting at construction — the Vortex footer-cache size from `runtime.params.cayenne_footer_cache_mb`. Before #13391 the builder simply constructed a configured engine and registered it into its own registry. Moving the engine out of `runtime` made that impossible (the runtime must not name the concrete accelerator), so the setting went through a process-global value published just before the engines were registered.

That channel existed for exactly one reason: **a registration constructor takes no arguments.** It cost two defects to make safe, both found in review:

- The publish and the registration pass had to be **serialized**, because the published value was process-global while the registry it filled belonged to one `Runtime`. Two `Runtime`s built concurrently in one process could each publish before the other constructed, and one would build its engine with the other's setting. The old code had this property for free.
- The **sentinel had to stop colliding with a real value.** `u64::MAX` meant "nothing published", and `parse_usize_runtime_param` accepts `max` — so the largest cache an operator can ask for read back as absent, and the engine silently used its default while the rest of the runtime honoured the request.

Neither is a bug in the fixes; both are properties of publishing through a global.

## What this does

`AcceleratorRegistration.constructor` now takes `&AcceleratorRuntimeConfig`, and `register_all` passes the settings resolved for that `Runtime`. An engine's configuration travels with the instance, so there is nothing to publish, no window to serialize, and no value to reserve. The lock and the sentinel are both deleted.

Most engines take nothing from the runtime, so the simple form of `register_data_accelerator!` ignores the argument — **six engine crates are untouched.** A new `configured:` form calls `from_runtime_config`, which today is Cayenne alone.

The sites that build an engine only to *ask it a question* — write-profile classification, `DuckDB` budget inputs, the catalog's tuning seeds, schema collection, snapshot validation — pass the default. That is accurate rather than a placeholder: none of them reads a runtime-level setting.

## What is deliberately not in scope

`publish_duckdb_budget` stays. It resembles the retired channel but is not an engine-configuration channel at all: the builder publishes what `DuckDB` reserved and the `DataFusion` layer reads it to size the query pool, both inside `runtime`. I checked its readers (`datafusion/builder.rs`, `datafusion/mod.rs`) rather than assuming the resemblance was real — an earlier version of this description claimed this PR would delete it, which was wrong.

## Verification

- `cargo check -p runtime -p spiced -p accelerator-cayenne -p runtime-acceleration -p spicepodschema --all-targets` clean.
- Scoped `cargo clippy` over the six touched crates at `duckdb,sqlite,turso,snapshots`: clean. (#13391 failed the gate on a `clippy::pedantic` lint my pre-push `cargo check` could not see, so clippy is now part of the local loop.)
- `accelerator-cayenne` 109 tests, `data-accelerator-api` 42, `runtime-acceleration` 137, and `runtime`'s `the_pre_init_and_post_init_write_profiles_agree` (which builds a `Runtime`, so it exercises the new `register_all`): all pass.
- `scripts/check_crate_layers.py`: 157 crates, 8 tiers, no upward edges.
- The round-trip test over the retired channel is replaced by one at the new seam, keeping the `max` case the sentinel used to swallow. Negative-controlled: filtering `usize::MAX` back out makes it fail on exactly that assertion.
