### PR TITLE
fix(release): read release notes from a file and trim them to GitHub's body limit

### DIFF
--- a/.github/scripts/github_release.py
+++ b/.github/scripts/github_release.py
@@ -11,12 +11,19 @@ if token == None:
 
 authHeader = { "Authorization": f"token {token}"}
 
+# GitHub rejects a release body longer than this with a 422. Release notes are
+# also read from a file rather than taken as an argument: a body this large
+# exceeds MAX_ARG_STRLEN (128 KiB), so the exec fails with E2BIG before Python
+# ever starts.
+MAX_BODY_CHARS = 125000
+
 parser = argparse.ArgumentParser()
 parser.add_argument('--owner')
 parser.add_argument('--repo')
 parser.add_argument('--tag')
 parser.add_argument('--release-name')
 parser.add_argument('--body')
+parser.add_argument('--body-file')
 parser.add_argument('--prerelease')
 parser.add_argument('action')
 parser.add_argument('artifact', nargs='+')
@@ -104,6 +111,36 @@ def updateRelease(id, owner, repo, release_name, body, prerelease):
         print(resp.json())
 
 
+def readBody(args):
+    """Resolve the release body, preferring --body-file over --body."""
+    if args.body_file:
+        with open(args.body_file, encoding="utf-8") as f:
+            return f.read()
+
+    return args.body
+
+def truncateBody(body, owner, repo, tag):
+    """Trim an oversized body to fit GitHub's limit, linking to the full notes."""
+    if body is None or len(body) <= MAX_BODY_CHARS:
+        return body
+
+    notice = (
+        "\n\n---\n\n"
+        f"Release notes truncated to fit GitHub's {MAX_BODY_CHARS} character limit. "
+        f"Full notes: https://github.com/{owner}/{repo}/blob/{tag}/docs/release_notes/{tag}.md\n"
+    )
+
+    kept = body[:MAX_BODY_CHARS - len(notice)]
+
+    # Cut on a line boundary so the body never ends mid-sentence or mid-link.
+    lastNewline = kept.rfind("\n")
+    if lastNewline > 0:
+        kept = kept[:lastNewline]
+
+    print(f"Body is {len(body)} characters, over the {MAX_BODY_CHARS} limit; truncating to {len(kept) + len(notice)}")
+
+    return kept + notice
+
 def extract_title_from_body(body, fallback_name):
     """Extract the first # heading from body as the release title, returning (title, remaining_body)."""
     if body:
@@ -120,7 +157,8 @@ def actionUpload(args):
 
     is_prerelease = args.prerelease == "true"
 
-    release_name, body = extract_title_from_body(args.body, args.release_name)
+    body = truncateBody(readBody(args), args.owner, args.repo, args.tag)
+    release_name, body = extract_title_from_body(body, args.release_name)
 
     # Step 2: Create the release if it doesn't exist
     if releaseInfo == None:

--- a/.github/scripts/github_release.py
+++ b/.github/scripts/github_release.py
@@ -133,9 +133,14 @@ def truncateBody(body, owner, repo, tag):
     kept = body[:MAX_BODY_CHARS - len(notice)]
 
     # Cut on a line boundary so the body never ends mid-sentence or mid-link.
-    lastNewline = kept.rfind("\n")
-    if lastNewline > 0:
-        kept = kept[:lastNewline]
+    # A body with no line break in the retained prefix falls back to a word
+    # break, which still drops a partial URL whole. Dropping the prefix
+    # entirely would discard the whole body to satisfy the boundary.
+    boundary = kept.rfind("\n")
+    if boundary <= 0:
+        boundary = kept.rfind(" ")
+    if boundary > 0:
+        kept = kept[:boundary]
 
     print(f"Body is {len(body)} characters, over the {MAX_BODY_CHARS} limit; truncating to {len(kept) + len(notice)}")
 

--- a/.github/scripts/test_github_release.py
+++ b/.github/scripts/test_github_release.py
@@ -182,6 +182,29 @@ class TruncateBodyTests(unittest.TestCase):
             result,
         )
 
+    def test_single_line_body_falls_back_to_a_word_break(self):
+        # rfind("\n") returns -1 when the retained prefix holds no line break,
+        # which previously left the final partial token -- a URL among them --
+        # in the published body.
+        body = "word " * github_release.MAX_BODY_CHARS
+
+        result = github_release.truncateBody(body, "spiceai", "spiceai", "v2.2.0")
+        kept = result.split("\n\n---\n\n")[0]
+
+        self.assertLessEqual(len(result), github_release.MAX_BODY_CHARS)
+        self.assertTrue(body.startswith(kept))
+        self.assertEqual(body[len(kept)], " ")
+
+    def test_leading_newline_body_keeps_its_content(self):
+        # rfind("\n") returns 0 here; cutting at it would leave an empty body.
+        body = "\n" + "word " * github_release.MAX_BODY_CHARS
+
+        result = github_release.truncateBody(body, "spiceai", "spiceai", "v2.2.0")
+        kept = result.split("\n\n---\n\n")[0]
+
+        self.assertLessEqual(len(result), github_release.MAX_BODY_CHARS)
+        self.assertGreater(len(kept), github_release.MAX_BODY_CHARS // 2)
+
     def test_oversized_body_is_cut_on_a_line_boundary(self):
         result = github_release.truncateBody(self._oversized(), "spiceai", "spiceai", "v2.2.0")
         kept = result.split("\n\n---\n\n")[0]

--- a/.github/scripts/test_github_release.py
+++ b/.github/scripts/test_github_release.py
@@ -1,6 +1,7 @@
 """Unit tests for github_release.py."""
 import os
 import sys
+import tempfile
 import unittest
 import unittest.mock
 
@@ -124,6 +125,105 @@ class ActionDeleteTests(unittest.TestCase):
         github_release.actionDelete(self._args(["./release/x.tar.gz"]))
 
         mock_delete.assert_not_called()
+
+
+class ReadBodyTests(unittest.TestCase):
+    def _notes_file(self, contents):
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
+            f.write(contents)
+        self.addCleanup(os.remove, f.name)
+        return f.name
+
+    def test_body_file_is_preferred_over_body(self):
+        path = self._notes_file("# From file\n\nnotes\n")
+
+        args = unittest.mock.Mock(body_file=path, body="from argv")
+
+        self.assertEqual(github_release.readBody(args), "# From file\n\nnotes\n")
+
+    def test_falls_back_to_body_when_no_file_given(self):
+        args = unittest.mock.Mock(body_file=None, body="from argv")
+
+        self.assertEqual(github_release.readBody(args), "from argv")
+
+
+class TruncateBodyTests(unittest.TestCase):
+    def _oversized(self):
+        body = "".join("- change {}\n".format(i) for i in range(20000))
+        self.assertGreater(len(body), github_release.MAX_BODY_CHARS)
+        return body
+
+    def test_short_body_is_unchanged(self):
+        body = "# v1.0\n\nA short set of notes.\n"
+
+        self.assertEqual(github_release.truncateBody(body, "o", "r", "v1.0"), body)
+
+    def test_missing_body_is_unchanged(self):
+        self.assertIsNone(github_release.truncateBody(None, "o", "r", "v1.0"))
+
+    def test_body_exactly_at_the_limit_is_unchanged(self):
+        body = "x" * github_release.MAX_BODY_CHARS
+
+        self.assertEqual(github_release.truncateBody(body, "o", "r", "v1.0"), body)
+
+    def test_oversized_body_fits_within_the_limit(self):
+        # Regression for the v2.2.0 release: 154,517 characters of notes both
+        # blew MAX_ARG_STRLEN at exec time and would have been rejected by
+        # GitHub with "body is too long (maximum is 125000 characters)".
+        result = github_release.truncateBody(self._oversized(), "spiceai", "spiceai", "v2.2.0")
+
+        self.assertLessEqual(len(result), github_release.MAX_BODY_CHARS)
+
+    def test_oversized_body_links_to_the_full_notes(self):
+        result = github_release.truncateBody(self._oversized(), "spiceai", "spiceai", "v2.2.0")
+
+        self.assertIn(
+            "https://github.com/spiceai/spiceai/blob/v2.2.0/docs/release_notes/v2.2.0.md",
+            result,
+        )
+
+    def test_oversized_body_is_cut_on_a_line_boundary(self):
+        result = github_release.truncateBody(self._oversized(), "spiceai", "spiceai", "v2.2.0")
+        kept = result.split("\n\n---\n\n")[0]
+
+        self.assertRegex(kept.rstrip("\n").rsplit("\n", 1)[-1], r"^- change \d+$")
+
+
+class ActionUploadBodyTests(unittest.TestCase):
+    @unittest.mock.patch("github_release.uploadArtifact")
+    @unittest.mock.patch("github_release.updateRelease")
+    @unittest.mock.patch("github_release.getReleaseByTag")
+    def test_oversized_notes_file_is_truncated_before_update(self, mock_get, mock_update, mock_upload):
+        mock_get.return_value = {
+            "id": 1,
+            "assets": [],
+            "upload_url": "https://example/{?name,label}",
+        }
+
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
+            f.write("# Spice v2.2.0\n")
+            f.write("".join("- change {}\n".format(i) for i in range(20000)))
+        self.addCleanup(os.remove, f.name)
+
+        args = unittest.mock.Mock(
+            owner="spiceai",
+            repo="spiceai",
+            tag="v2.2.0",
+            release_name="v2.2.0",
+            body=None,
+            body_file=f.name,
+            prerelease="false",
+            artifact=["./release/x.tar.gz"],
+        )
+
+        github_release.actionUpload(args)
+
+        _, _, _, release_name, body, is_prerelease = mock_update.call_args[0]
+
+        self.assertEqual(release_name, "Spice v2.2.0")
+        self.assertLessEqual(len(body), github_release.MAX_BODY_CHARS)
+        self.assertFalse(is_prerelease)
+        mock_upload.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -456,16 +456,19 @@ jobs:
             --owner $OWNER_NAME --repo $REPO_NAME \
             --tag "v${{ env.REL_VERSION }}" \
             ${RELEASE_ARTIFACT[*]}
+          # Pass the notes by path, not by value: a release body over 128 KiB
+          # exceeds MAX_ARG_STRLEN and the exec fails with E2BIG (exit 126)
+          # after every build has already succeeded.
           if [ "$LATEST_RELEASE" = "true" ]; then
-            export RELEASE_BODY=`cat ./docs/release_notes/v${{ env.REL_VERSION }}.md`
+            BODY_ARGS=(--body-file "./docs/release_notes/v${{ env.REL_VERSION }}.md")
           else
-            export RELEASE_BODY="This is the release candidate ${{ env.REL_VERSION }}"
+            BODY_ARGS=(--body "This is the release candidate ${{ env.REL_VERSION }}")
           fi
           echo "Uploading Spice.ai Binaries to GitHub Release"
           python ./.github/scripts/github_release.py upload \
             --owner $OWNER_NAME --repo $REPO_NAME \
             --tag "v${{ env.REL_VERSION }}" \
             --release-name "v${{ env.REL_VERSION }}" \
-            --body "${RELEASE_BODY}" \
+            "${BODY_ARGS[@]}" \
             --prerelease "$PRE_RELEASE" \
             ${RELEASE_ARTIFACT[*]}

--- a/.github/workflows/build_and_release_cuda.yml
+++ b/.github/workflows/build_and_release_cuda.yml
@@ -293,10 +293,13 @@ jobs:
             --tag "v${{ env.REL_VERSION }}" \
             "${RELEASE_ARTIFACTS[@]}"
 
+          # Pass the notes by path, not by value: a release body over 128 KiB
+          # exceeds MAX_ARG_STRLEN and the exec fails with E2BIG (exit 126)
+          # after every build has already succeeded.
           if [ "$LATEST_RELEASE" = "true" ]; then
-            export RELEASE_BODY=`cat ./docs/release_notes/v${{ env.REL_VERSION }}.md`
+            BODY_ARGS=(--body-file "./docs/release_notes/v${{ env.REL_VERSION }}.md")
           else
-            export RELEASE_BODY="This is the release candidate ${{ env.REL_VERSION }}"
+            BODY_ARGS=(--body "This is the release candidate ${{ env.REL_VERSION }}")
           fi
 
           echo "Uploading Spice.ai CUDA Binaries to GitHub Release"
@@ -304,6 +307,6 @@ jobs:
             --owner $OWNER_NAME --repo $REPO_NAME \
             --tag "v${{ env.REL_VERSION }}" \
             --release-name "v${{ env.REL_VERSION }}" \
-            --body "${RELEASE_BODY}" \
+            "${BODY_ARGS[@]}" \
             --prerelease "$PRE_RELEASE" \
             "${RELEASE_ARTIFACTS[@]}"

--- a/.github/workflows/release_from_run.yml
+++ b/.github/workflows/release_from_run.yml
@@ -49,7 +49,10 @@ jobs:
           mkdir -p "${ARTIFACT_DIR}"
 
           # Flatten downloaded artifacts to a single directory of .tar.gz release assets.
-          find "${ARTIFACT_DIR}/raw" -type f -name "*.tar.gz" -print -exec cp -f {} "${ARTIFACT_DIR}/" \;
+          # Match the asset set the tagged publish jobs attach. They download
+          # spice/spice.exe/spiced/spiced_metal by name and deliberately leave
+          # spiced_odbc off the release, so recovery must not add it.
+          find "${ARTIFACT_DIR}/raw" -type f -name "*.tar.gz" ! -name "spiced_odbc_*" -print -exec cp -f {} "${ARTIFACT_DIR}/" \;
 
           # Keep only flattened archives at top-level release dir.
           rm -rf "${ARTIFACT_DIR}/raw"
@@ -86,10 +89,12 @@ jobs:
             "${RELEASE_ARTIFACT[@]}"
 
           RELEASE_NOTES_FILE="./docs/release_notes/v${REL_VERSION}.md"
+          # Pass the notes by path, not by value: a release body over 128 KiB
+          # exceeds MAX_ARG_STRLEN and the exec fails with E2BIG (exit 126).
           if [ -f "$RELEASE_NOTES_FILE" ]; then
-            export RELEASE_BODY="$(cat "$RELEASE_NOTES_FILE")"
+            BODY_ARGS=(--body-file "$RELEASE_NOTES_FILE")
           else
-            export RELEASE_BODY="Release ${REL_VERSION}"
+            BODY_ARGS=(--body "Release ${REL_VERSION}")
           fi
 
           PRE_RELEASE="false"
@@ -102,6 +107,6 @@ jobs:
             --owner "$OWNER_NAME" --repo "$REPO_NAME" \
             --tag "v${REL_VERSION}" \
             --release-name "v${REL_VERSION}" \
-            --body "${RELEASE_BODY}" \
+            "${BODY_ARGS[@]}" \
             --prerelease "$PRE_RELEASE" \
             "${RELEASE_ARTIFACT[@]}"

--- a/.github/workflows/release_from_run.yml
+++ b/.github/workflows/release_from_run.yml
@@ -49,9 +49,10 @@ jobs:
           mkdir -p "${ARTIFACT_DIR}"
 
           # Flatten downloaded artifacts to a single directory of .tar.gz release assets.
-          # Match the asset set the tagged publish jobs attach. They download
-          # spice/spice.exe/spiced/spiced_metal by name and deliberately leave
-          # spiced_odbc off the release, so recovery must not add it.
+          # Match the asset set the tagged publish jobs attach: they download
+          # spice/spice.exe/spiced/spiced_metal by name, so spiced_odbc has
+          # never shipped on a release. Recovery must not be the path that
+          # adds it.
           find "${ARTIFACT_DIR}/raw" -type f -name "*.tar.gz" ! -name "spiced_odbc_*" -print -exec cp -f {} "${ARTIFACT_DIR}/" \;
 
           # Keep only flattened archives at top-level release dir.


### PR DESCRIPTION
## 📝 Summary

Every v2.2.0 publish job failed with exit 126 after all builds had succeeded:

```
/usr/bin/python: Argument list too long
```

`RELEASE_BODY` was `cat` of the release notes, passed to `github_release.py` as one `--body` argument. v2.2.0's notes are 154,517 characters, past the 131,072-byte `MAX_ARG_STRLEN` cap on a single argv entry, so `execve` returned `E2BIG`. Prior releases stayed under the cap only by size — the next largest notes file is 55 KB.

A second limit sits behind the first: GitHub rejects a release body over 125,000 characters with a 422.

Both are fixed in one place:

- `--body-file` on `github_release.py` — notes are read in Python, so the argv cap no longer applies.
- `truncateBody()` — trims an oversized body to 125,000 characters on a line boundary and links to the full notes. Oversized notes degrade to a trimmed body instead of failing the publish.

Applied to `build_and_release.yml`, `build_and_release_cuda.yml`, and `release_from_run.yml`. The "release candidate" fallback still uses `--body`.

Also stops `release_from_run` attaching `spiced_odbc`: it globs every `.tar.gz` on the run, while the tagged publish jobs fetch `spice`/`spice.exe`/`spiced`/`spiced_metal` by name and leave odbc off the release. Recovery now matches a normal release's asset set.

## 🚨 Breaking Changes

None. `--body` still works; `--body-file` is additive and takes precedence when both are given.

## 👀 Notes for Reviewers

- 19 unit tests pass — 9 new, existing 10 unchanged.
- Dry-run on the real `v2.2.0.md`: 154,517 → 124,926 characters, cut after a whole changelog entry, title and link intact.
- `check_workflow_yaml.py`: 116 definitions well-formed.

Out of scope: `make_latest` is still never sent, so "Latest" continues to rely on the API default.
