### PR TITLE
fix(search): render a DuckDB search filter against the table schema (fixes #13144)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7302,7 +7302,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=beeecde18a72d2b6cad9d75aa44279398f084bce#beeecde18a72d2b6cad9d75aa44279398f084bce"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=d9da7cd1f100144e37bcd233296d9112a043e146#d9da7cd1f100144e37bcd233296d9112a043e146"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,7 +270,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "beeecde18a72d2b6cad9d75aa44279398f084bce" } # spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "d9da7cd1f100144e37bcd233296d9112a043e146" } # spiceai-54
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",

--- a/crates/search/src/index/duckdb/query_exec.rs
+++ b/crates/search/src/index/duckdb/query_exec.rs
@@ -325,9 +325,8 @@ mod tests {
 
     /// regression test for #13144: the filters are rendered against the whole table's schema, so a
     /// timezone-aware timestamp column keeps its sub-millisecond digits even when the projection
-    /// drops it. Rendering against the *projected* schema — or against no schema, which is what the
-    /// two sites did before — leaves the column unresolved and normalizes it through `EPOCH_MS`,
-    /// truncating the comparison to whole milliseconds.
+    /// drops it. Against the projected schema — or against no schema — that column is unresolved,
+    /// so it normalizes through `EPOCH_MS` and the comparison is truncated to whole milliseconds.
     #[tokio::test]
     async fn scan_renders_filters_against_the_whole_table_schema() {
         let schema: SchemaRef = Arc::new(Schema::new(vec![

--- a/crates/search/src/index/duckdb/query_exec.rs
+++ b/crates/search/src/index/duckdb/query_exec.rs
@@ -77,7 +77,7 @@ impl DuckDBVectorQueryExec {
             table_name,
             &self.embedded_column,
             &self.projected_columns,
-            &ScopedFilters {
+            ScopedFilters {
                 filters: &self.filters,
                 schema: &self.table_schema,
             },

--- a/crates/search/src/index/duckdb/query_exec.rs
+++ b/crates/search/src/index/duckdb/query_exec.rs
@@ -32,13 +32,19 @@ use futures::TryStreamExt;
 use llms::embeddings::{Embed, EmbeddingInput};
 
 use super::{
-    DuckDBVectorQueryContext, hnsw::DuckDBHnswOptions, resolve_current_table_name,
-    sql::duckdb_vector_sql, to_execution_error, validate_vector, vector_literal,
+    DuckDBVectorQueryContext,
+    hnsw::DuckDBHnswOptions,
+    resolve_current_table_name,
+    sql::{ScopedFilters, duckdb_vector_sql},
+    to_execution_error, validate_vector, vector_literal,
 };
 
 #[derive(Debug, Clone)]
 pub(super) struct DuckDBVectorQueryExec {
     pub(super) projected_schema: SchemaRef,
+    /// The whole table's schema, which the pushed-down filters are rendered against. A filter may
+    /// reference a column the projection drops, so `projected_schema` cannot answer for it.
+    pub(super) table_schema: SchemaRef,
     pub(super) projected_columns: Vec<String>,
     pub(super) filters: Vec<Expr>,
     pub(super) limit: Option<usize>,
@@ -71,7 +77,10 @@ impl DuckDBVectorQueryExec {
             table_name,
             &self.embedded_column,
             &self.projected_columns,
-            &self.filters,
+            &ScopedFilters {
+                filters: &self.filters,
+                schema: &self.table_schema,
+            },
             self.limit,
             &self.hnsw,
             &vector_lit,
@@ -278,6 +287,19 @@ fn empty_projected_batch(schema: SchemaRef, row_count: usize) -> DataFusionResul
 mod tests {
     use super::*;
 
+    use arrow_schema::TimeUnit;
+    use async_trait::async_trait;
+    use datafusion::catalog::TableProvider;
+    use datafusion::common::TableReference;
+    use datafusion::prelude::{SessionContext, col, lit};
+    use datafusion::scalar::ScalarValue;
+    use datafusion_table_providers::duckdb::{RelationName, TableDefinition};
+    use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
+    use llms::embeddings::EmbeddingInput;
+
+    use crate::SEARCH_SCORE_COLUMN_NAME;
+    use crate::index::duckdb::query_table::DuckDBVectorQueryTable;
+
     #[test]
     fn empty_projected_batch_preserves_row_count() {
         let schema = Arc::new(Schema::empty());
@@ -285,5 +307,85 @@ mod tests {
 
         assert_eq!(batch.num_columns(), 0);
         assert_eq!(batch.num_rows(), 3);
+    }
+
+    #[derive(Debug)]
+    struct NoopEmbed;
+
+    #[async_trait]
+    impl Embed for NoopEmbed {
+        async fn embed(&self, _input: EmbeddingInput) -> llms::embeddings::Result<Vec<Vec<f32>>> {
+            Ok(vec![])
+        }
+
+        fn size(&self) -> i32 {
+            2
+        }
+    }
+
+    /// regression test for #13144: the filters are rendered against the whole table's schema, so a
+    /// timezone-aware timestamp column keeps its sub-millisecond digits even when the projection
+    /// drops it. Rendering against the *projected* schema — or against no schema, which is what the
+    /// two sites did before — leaves the column unresolved and normalizes it through `EPOCH_MS`,
+    /// truncating the comparison to whole milliseconds.
+    #[tokio::test]
+    async fn scan_renders_filters_against_the_whole_table_schema() {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                false,
+            ),
+            Field::new(SEARCH_SCORE_COLUMN_NAME, DataType::Float64, false),
+        ]));
+        let pool = Arc::new(
+            DuckDbConnectionPool::new_memory().expect("in-memory DuckDB pool should build"),
+        );
+        let table = DuckDBVectorQueryTable {
+            query_text: "hello".to_string(),
+            embedded_column: "body_embedding".to_string(),
+            compute_query: Arc::new(NoopEmbed),
+            dims: 2,
+            schema: Arc::clone(&schema),
+            hnsw: DuckDBHnswOptions::default(),
+            context: DuckDBVectorQueryContext {
+                pool,
+                table_definition: Arc::new(TableDefinition::new(
+                    RelationName::from(TableReference::bare("docs")),
+                    Arc::clone(&schema),
+                )),
+            },
+        };
+
+        let filter = col("ts").gt(lit(ScalarValue::TimestampMicrosecond(
+            Some(1_767_225_600_000_999),
+            Some("UTC".into()),
+        )));
+        let state = SessionContext::new().state();
+        // Project `id` alone: the filter's column is deliberately outside the projection.
+        let plan = table
+            .scan(
+                &state,
+                Some(&vec![0]),
+                std::slice::from_ref(&filter),
+                Some(10),
+            )
+            .await
+            .expect("scan should plan");
+        let exec = plan
+            .downcast_ref::<DuckDBVectorQueryExec>()
+            .expect("scan returns a DuckDBVectorQueryExec");
+
+        let sql = exec.sql("docs", &[1.0, 0.0]).expect("SQL should build");
+
+        assert!(
+            !sql.contains("EPOCH_MS"),
+            "a timezone-aware column must not be rendered through whole milliseconds: {sql}"
+        );
+        assert!(
+            sql.contains(".000999"),
+            "the comparison must keep its sub-millisecond digits: {sql}"
+        );
     }
 }

--- a/crates/search/src/index/duckdb/query_table.rs
+++ b/crates/search/src/index/duckdb/query_table.rs
@@ -98,6 +98,7 @@ impl TableProvider for DuckDBVectorQueryTable {
 
         Ok(Arc::new(DuckDBVectorQueryExec {
             projected_schema,
+            table_schema: Arc::clone(&self.schema),
             projected_columns,
             filters: filters.to_vec(),
             limit,

--- a/crates/search/src/index/duckdb/sql.rs
+++ b/crates/search/src/index/duckdb/sql.rs
@@ -450,11 +450,11 @@ mod tests {
         );
     }
 
-    /// regression test for #13144: a search filter on a timezone-aware timestamp column used to be
-    /// rendered `TO_TIMESTAMP(EPOCH_MS("ts") / 1000)`, which truncates the column to whole
-    /// milliseconds, so a comparison inside a millisecond selected a different set of rows than the
-    /// caller asked for. `flat_sql` projects `id` alone, so this also covers a filter on a column
-    /// the projection drops.
+    /// regression test for #13144: a timezone-aware timestamp column is already the type and the
+    /// reference frame the rendered literal is in, so it must be compared directly. Rendered
+    /// through `EPOCH_MS` it is truncated to whole milliseconds, and a comparison inside a
+    /// millisecond then selects a different set of rows than the caller asked for. `flat_sql`
+    /// projects `id` alone, so this also covers a filter on a column the projection drops.
     #[test]
     fn a_timezone_aware_timestamp_filter_is_rendered_without_the_millisecond_truncation() {
         let schema = docs_schema(vec![Field::new(

--- a/crates/search/src/index/duckdb/sql.rs
+++ b/crates/search/src/index/duckdb/sql.rs
@@ -44,12 +44,17 @@ pub(super) const EMPTY_PROJECTION_ROW_COLUMN: &str = "__spice_empty_projection_r
 /// a render site holding the filters alone renders a timezone-aware timestamp through
 /// `EPOCH_MS`, which truncates it to whole milliseconds and moves which rows a comparison inside
 /// that millisecond selects.
+#[derive(Clone, Copy)]
 pub(super) struct ScopedFilters<'a> {
     pub(super) filters: &'a [Expr],
     pub(super) schema: &'a SchemaRef,
 }
 
 impl ScopedFilters<'_> {
+    fn is_empty(&self) -> bool {
+        self.filters.is_empty()
+    }
+
     fn render(&self) -> DataFusionResult<Vec<String>> {
         self.filters
             .iter()
@@ -86,14 +91,14 @@ pub(super) fn duckdb_vector_sql(
     table_name: &str,
     embedding_column: &str,
     projected_columns: &[String],
-    filters: &ScopedFilters<'_>,
+    filters: ScopedFilters<'_>,
     limit: Option<usize>,
     hnsw: &DuckDBHnswOptions,
     vector_literal: &str,
 ) -> DataFusionResult<String> {
     let limit = limit.unwrap_or(DEFAULT_DUCKDB_VECTOR_SEARCH_LIMIT);
 
-    if filters.filters.is_empty() {
+    if filters.is_empty() {
         // CTE path — activates HNSW index scan
         Ok(duckdb_vector_sql_cte(
             table_name,
@@ -153,7 +158,7 @@ fn duckdb_vector_sql_flat(
     table_name: &str,
     embedding_column: &str,
     projected_columns: &[String],
-    filters: &ScopedFilters<'_>,
+    filters: ScopedFilters<'_>,
     limit: usize,
     hnsw: &DuckDBHnswOptions,
     vector_literal: &str,
@@ -263,7 +268,7 @@ mod tests {
             "docs",
             "body_embedding",
             &["id".to_string()],
-            &ScopedFilters {
+            ScopedFilters {
                 filters: std::slice::from_ref(filter),
                 schema,
             },
@@ -280,7 +285,7 @@ mod tests {
             "docs",
             "body_embedding",
             &["id".to_string(), SEARCH_SCORE_COLUMN_NAME.to_string()],
-            &ScopedFilters {
+            ScopedFilters {
                 filters: &[],
                 schema: &schema,
             },
@@ -310,7 +315,7 @@ mod tests {
             "docs",
             "body_embedding",
             &[],
-            &ScopedFilters {
+            ScopedFilters {
                 filters: &[],
                 schema: &schema,
             },
@@ -375,7 +380,7 @@ mod tests {
             "docs",
             "body_embedding",
             &["id".to_string()],
-            &ScopedFilters {
+            ScopedFilters {
                 filters: &[],
                 schema: &schema,
             },
@@ -396,7 +401,7 @@ mod tests {
             "docs",
             "body_embedding",
             &["id".to_string(), SEARCH_SCORE_COLUMN_NAME.to_string()],
-            &ScopedFilters {
+            ScopedFilters {
                 filters: &filters,
                 schema: &schema,
             },
@@ -422,7 +427,7 @@ mod tests {
             "docs",
             "body_embedding",
             &["id".to_string(), SEARCH_SCORE_COLUMN_NAME.to_string()],
-            &ScopedFilters {
+            ScopedFilters {
                 filters: &[],
                 schema: &schema,
             },
@@ -448,7 +453,8 @@ mod tests {
     /// regression test for #13144: a search filter on a timezone-aware timestamp column used to be
     /// rendered `TO_TIMESTAMP(EPOCH_MS("ts") / 1000)`, which truncates the column to whole
     /// milliseconds, so a comparison inside a millisecond selected a different set of rows than the
-    /// caller asked for.
+    /// caller asked for. `flat_sql` projects `id` alone, so this also covers a filter on a column
+    /// the projection drops.
     #[test]
     fn a_timezone_aware_timestamp_filter_is_rendered_without_the_millisecond_truncation() {
         let schema = docs_schema(vec![Field::new(
@@ -456,21 +462,9 @@ mod tests {
             DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
             false,
         )]);
-        let filters = vec![col("ts").gt(micros_literal(1_767_225_600_000_999))];
+        let filter = col("ts").gt(micros_literal(1_767_225_600_000_999));
 
-        let sql = duckdb_vector_sql(
-            "docs",
-            "body_embedding",
-            &["id".to_string()],
-            &ScopedFilters {
-                filters: &filters,
-                schema: &schema,
-            },
-            Some(10),
-            &DuckDBHnswOptions::default(),
-            "[1.0, 0.0]::FLOAT[2]",
-        )
-        .expect("SQL should build");
+        let sql = flat_sql(&schema, &filter).expect("SQL should build");
 
         assert!(
             !sql.contains("EPOCH_MS"),
@@ -495,58 +489,13 @@ mod tests {
             DataType::Timestamp(TimeUnit::Microsecond, None),
             false,
         )]);
-        let filters = vec![col("ts").gt(micros_literal(1_767_225_600_000_999))];
+        let filter = col("ts").gt(micros_literal(1_767_225_600_000_999));
 
-        let sql = duckdb_vector_sql(
-            "docs",
-            "body_embedding",
-            &["id".to_string()],
-            &ScopedFilters {
-                filters: &filters,
-                schema: &schema,
-            },
-            Some(10),
-            &DuckDBHnswOptions::default(),
-            "[1.0, 0.0]::FLOAT[2]",
-        )
-        .expect("SQL should build");
+        let sql = flat_sql(&schema, &filter).expect("SQL should build");
 
         assert!(
             sql.contains(r#"TO_TIMESTAMP(EPOCH_MS("ts") / 1000)"#),
             "a naive column still has to be pinned to UTC to compare with the literal: {sql}"
-        );
-    }
-
-    /// A filter may reference a column the projection drops, so the schema the filters are rendered
-    /// against is the whole table's — a projected schema would leave the column unresolved and
-    /// normalize it back to whole milliseconds.
-    #[test]
-    fn a_filter_column_outside_the_projection_is_still_resolved() {
-        let schema = docs_schema(vec![Field::new(
-            "ts",
-            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
-            false,
-        )]);
-        let filters = vec![col("ts").gt(micros_literal(1_767_225_600_000_999))];
-
-        let sql = duckdb_vector_sql(
-            "docs",
-            "body_embedding",
-            // `ts` is deliberately absent from the projection.
-            &["id".to_string(), SEARCH_SCORE_COLUMN_NAME.to_string()],
-            &ScopedFilters {
-                filters: &filters,
-                schema: &schema,
-            },
-            Some(10),
-            &DuckDBHnswOptions::default(),
-            "[1.0, 0.0]::FLOAT[2]",
-        )
-        .expect("SQL should build");
-
-        assert!(
-            !sql.contains("EPOCH_MS"),
-            "the filter's column resolves in the table schema even when the projection drops it: {sql}"
         );
     }
 
@@ -555,21 +504,9 @@ mod tests {
     #[test]
     fn an_unresolved_filter_column_keeps_the_normalization() {
         let schema = docs_schema(vec![]);
-        let filters = vec![col("ts").gt(micros_literal(1_767_225_600_000_999))];
+        let filter = col("ts").gt(micros_literal(1_767_225_600_000_999));
 
-        let sql = duckdb_vector_sql(
-            "docs",
-            "body_embedding",
-            &["id".to_string()],
-            &ScopedFilters {
-                filters: &filters,
-                schema: &schema,
-            },
-            Some(10),
-            &DuckDBHnswOptions::default(),
-            "[1.0, 0.0]::FLOAT[2]",
-        )
-        .expect("SQL should build");
+        let sql = flat_sql(&schema, &filter).expect("SQL should build");
 
         assert!(
             sql.contains(r#"TO_TIMESTAMP(EPOCH_MS("ts") / 1000)"#),

--- a/crates/search/src/index/duckdb/sql.rs
+++ b/crates/search/src/index/duckdb/sql.rs
@@ -37,6 +37,36 @@ pub(super) const CTE_DISTANCE_ALIAS: &str = "__spice_dist";
 pub(super) const DEFAULT_DUCKDB_VECTOR_SEARCH_LIMIT: usize = 1000;
 pub(super) const EMPTY_PROJECTION_ROW_COLUMN: &str = "__spice_empty_projection_row";
 
+/// The pushed-down filters together with the schema their columns come from.
+///
+/// The two travel together because the DuckDB rendering needs both: it declines the timestamp
+/// normalization only for a column whose *resolved* type proves the normalization unnecessary, and
+/// a render site holding the filters alone renders a timezone-aware timestamp through
+/// `EPOCH_MS`, which truncates it to whole milliseconds and moves which rows a comparison inside
+/// that millisecond selects.
+pub(super) struct ScopedFilters<'a> {
+    pub(super) filters: &'a [Expr],
+    pub(super) schema: &'a SchemaRef,
+}
+
+impl ScopedFilters<'_> {
+    fn render(&self) -> DataFusionResult<Vec<String>> {
+        self.filters
+            .iter()
+            .map(|filter| render_filter(filter, self.schema))
+            .collect()
+    }
+}
+
+/// Render one filter as DuckDB SQL, against the schema its columns come from.
+///
+/// Both the capability probe and the statement render through here, so they cannot disagree about
+/// what is renderable or about how a given column's type is rendered.
+fn render_filter(filter: &Expr, schema: &SchemaRef) -> DataFusionResult<String> {
+    expr::to_sql_with_engine_and_schema(filter, Some(Engine::DuckDB), Some(schema.as_ref()))
+        .map_err(|e| DataFusionError::Plan(e.to_string()))
+}
+
 /// Build vector search SQL for DuckDB.
 ///
 /// When **no filters** are present, uses a CTE that preserves the clean
@@ -56,14 +86,14 @@ pub(super) fn duckdb_vector_sql(
     table_name: &str,
     embedding_column: &str,
     projected_columns: &[String],
-    filters: &[Expr],
+    filters: &ScopedFilters<'_>,
     limit: Option<usize>,
     hnsw: &DuckDBHnswOptions,
     vector_literal: &str,
 ) -> DataFusionResult<String> {
     let limit = limit.unwrap_or(DEFAULT_DUCKDB_VECTOR_SEARCH_LIMIT);
 
-    if filters.is_empty() {
+    if filters.filters.is_empty() {
         // CTE path — activates HNSW index scan
         Ok(duckdb_vector_sql_cte(
             table_name,
@@ -123,7 +153,7 @@ fn duckdb_vector_sql_flat(
     table_name: &str,
     embedding_column: &str,
     projected_columns: &[String],
-    filters: &[Expr],
+    filters: &ScopedFilters<'_>,
     limit: usize,
     hnsw: &DuckDBHnswOptions,
     vector_literal: &str,
@@ -133,11 +163,7 @@ fn duckdb_vector_sql_flat(
 
     let select_exprs = build_select_exprs(projected_columns, &score_expr);
 
-    let filter_exprs: Vec<String> = filters
-        .iter()
-        .map(|filter| expr::to_sql_with_engine(filter, Some(Engine::DuckDB)))
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| DataFusionError::Plan(e.to_string()))?;
+    let filter_exprs = filters.render()?;
     let mut predicates = Vec::with_capacity(filter_exprs.len() + 1);
     predicates.push(embedding_not_null_predicate(embedding_column));
     predicates.extend(filter_exprs);
@@ -194,7 +220,7 @@ pub(super) fn duckdb_filter_pushdown(
         return TableProviderFilterPushDown::Unsupported;
     }
 
-    match expr::to_sql_with_engine(filter, Some(Engine::DuckDB)) {
+    match render_filter(filter, schema) {
         Ok(_) => TableProviderFilterPushDown::Exact,
         Err(_) => TableProviderFilterPushDown::Unsupported,
     }
@@ -203,19 +229,61 @@ pub(super) fn duckdb_filter_pushdown(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_schema::{DataType, Field, Schema};
+    use arrow_schema::{DataType, Field, Schema, TimeUnit};
+    use datafusion::common::Column;
     use datafusion::prelude::{col, lit};
+    use datafusion::scalar::ScalarValue;
     use std::sync::Arc;
 
     use crate::index::duckdb::hnsw::DuckDBHnswOptions;
 
+    /// A schema in the shape `query_result_schema` builds: the source columns plus `_score`.
+    fn docs_schema(extra: Vec<Field>) -> SchemaRef {
+        let mut fields = vec![Field::new("id", DataType::Int64, false)];
+        fields.extend(extra);
+        fields.push(Field::new(
+            SEARCH_SCORE_COLUMN_NAME,
+            DataType::Float64,
+            false,
+        ));
+        Arc::new(Schema::new(fields))
+    }
+
+    /// A microsecond timestamp literal DuckDB renders with its sub-millisecond digits intact.
+    fn micros_literal(micros: i64) -> Expr {
+        lit(ScalarValue::TimestampMicrosecond(
+            Some(micros),
+            Some("UTC".into()),
+        ))
+    }
+
+    /// The flat (filtered) statement for one filter, rendered against `schema`.
+    fn flat_sql(schema: &SchemaRef, filter: &Expr) -> DataFusionResult<String> {
+        duckdb_vector_sql(
+            "docs",
+            "body_embedding",
+            &["id".to_string()],
+            &ScopedFilters {
+                filters: std::slice::from_ref(filter),
+                schema,
+            },
+            Some(10),
+            &DuckDBHnswOptions::default(),
+            "[1.0, 0.0]::FLOAT[2]",
+        )
+    }
+
     #[test]
     fn duckdb_vector_sql_orders_by_distance_and_projects_score() {
+        let schema = docs_schema(vec![]);
         let sql = duckdb_vector_sql(
             "docs",
             "body_embedding",
             &["id".to_string(), SEARCH_SCORE_COLUMN_NAME.to_string()],
-            &[],
+            &ScopedFilters {
+                filters: &[],
+                schema: &schema,
+            },
             Some(10),
             &DuckDBHnswOptions::default(),
             "[1.0, 0.0]::FLOAT[2]",
@@ -237,11 +305,15 @@ mod tests {
 
     #[test]
     fn duckdb_vector_sql_handles_empty_projection() {
+        let schema = docs_schema(vec![]);
         let sql = duckdb_vector_sql(
             "docs",
             "body_embedding",
             &[],
-            &[],
+            &ScopedFilters {
+                filters: &[],
+                schema: &schema,
+            },
             Some(10),
             &DuckDBHnswOptions::default(),
             "[1.0, 0.0]::FLOAT[2]",
@@ -263,10 +335,7 @@ mod tests {
 
     #[test]
     fn duckdb_filter_pushdown_rejects_score_column() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int64, false),
-            Field::new(SEARCH_SCORE_COLUMN_NAME, DataType::Float64, false),
-        ]));
+        let schema = docs_schema(vec![]);
         let filter = col(SEARCH_SCORE_COLUMN_NAME).gt(lit(0.5));
 
         assert_eq!(
@@ -277,10 +346,7 @@ mod tests {
 
     #[test]
     fn duckdb_filter_pushdown_allows_base_column() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int64, false),
-            Field::new(SEARCH_SCORE_COLUMN_NAME, DataType::Float64, false),
-        ]));
+        let schema = docs_schema(vec![]);
         let filter = col("id").gt(lit(10_i64));
 
         assert_eq!(
@@ -291,10 +357,7 @@ mod tests {
 
     #[test]
     fn duckdb_filter_pushdown_rejects_mixed_score_filter() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int64, false),
-            Field::new(SEARCH_SCORE_COLUMN_NAME, DataType::Float64, false),
-        ]));
+        let schema = docs_schema(vec![]);
         let filter = col("id")
             .gt(lit(10_i64))
             .and(col(SEARCH_SCORE_COLUMN_NAME).gt(lit(0.5)));
@@ -307,11 +370,15 @@ mod tests {
 
     #[test]
     fn duckdb_vector_sql_applies_default_limit() {
+        let schema = docs_schema(vec![]);
         let sql = duckdb_vector_sql(
             "docs",
             "body_embedding",
             &["id".to_string()],
-            &[],
+            &ScopedFilters {
+                filters: &[],
+                schema: &schema,
+            },
             None,
             &DuckDBHnswOptions::default(),
             "[1.0, 0.0]::FLOAT[2]",
@@ -323,12 +390,16 @@ mod tests {
 
     #[test]
     fn duckdb_vector_sql_uses_flat_query_with_filters() {
-        let filter = col("id").gt(lit(10_i64));
+        let schema = docs_schema(vec![]);
+        let filters = vec![col("id").gt(lit(10_i64))];
         let sql = duckdb_vector_sql(
             "docs",
             "body_embedding",
             &["id".to_string(), SEARCH_SCORE_COLUMN_NAME.to_string()],
-            &[filter],
+            &ScopedFilters {
+                filters: &filters,
+                schema: &schema,
+            },
             Some(10),
             &DuckDBHnswOptions::default(),
             "[1.0, 0.0]::FLOAT[2]",
@@ -346,11 +417,15 @@ mod tests {
 
     #[test]
     fn duckdb_vector_sql_uses_cte_without_filters() {
+        let schema = docs_schema(vec![]);
         let sql = duckdb_vector_sql(
             "docs",
             "body_embedding",
             &["id".to_string(), SEARCH_SCORE_COLUMN_NAME.to_string()],
-            &[],
+            &ScopedFilters {
+                filters: &[],
+                schema: &schema,
+            },
             Some(10),
             &DuckDBHnswOptions::default(),
             "[1.0, 0.0]::FLOAT[2]",
@@ -368,5 +443,190 @@ mod tests {
              FROM __spice_nn \
              ORDER BY __spice_dist ASC"
         );
+    }
+
+    /// regression test for #13144: a search filter on a timezone-aware timestamp column used to be
+    /// rendered `TO_TIMESTAMP(EPOCH_MS("ts") / 1000)`, which truncates the column to whole
+    /// milliseconds, so a comparison inside a millisecond selected a different set of rows than the
+    /// caller asked for.
+    #[test]
+    fn a_timezone_aware_timestamp_filter_is_rendered_without_the_millisecond_truncation() {
+        let schema = docs_schema(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            false,
+        )]);
+        let filters = vec![col("ts").gt(micros_literal(1_767_225_600_000_999))];
+
+        let sql = duckdb_vector_sql(
+            "docs",
+            "body_embedding",
+            &["id".to_string()],
+            &ScopedFilters {
+                filters: &filters,
+                schema: &schema,
+            },
+            Some(10),
+            &DuckDBHnswOptions::default(),
+            "[1.0, 0.0]::FLOAT[2]",
+        )
+        .expect("SQL should build");
+
+        assert!(
+            !sql.contains("EPOCH_MS"),
+            "a timezone-aware column needs no normalization, so it must not be rendered through whole milliseconds: {sql}"
+        );
+        assert!(
+            sql.contains(r#""ts" > "#),
+            "the column must be compared directly: {sql}"
+        );
+        assert!(
+            sql.contains(".000999"),
+            "the literal must keep its sub-millisecond digits: {sql}"
+        );
+    }
+
+    /// The normalization is what makes a *naive* timestamp compare against the rendered UTC
+    /// literal at all, so passing a schema must not remove it there.
+    #[test]
+    fn a_naive_timestamp_filter_keeps_the_utc_normalization() {
+        let schema = docs_schema(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        )]);
+        let filters = vec![col("ts").gt(micros_literal(1_767_225_600_000_999))];
+
+        let sql = duckdb_vector_sql(
+            "docs",
+            "body_embedding",
+            &["id".to_string()],
+            &ScopedFilters {
+                filters: &filters,
+                schema: &schema,
+            },
+            Some(10),
+            &DuckDBHnswOptions::default(),
+            "[1.0, 0.0]::FLOAT[2]",
+        )
+        .expect("SQL should build");
+
+        assert!(
+            sql.contains(r#"TO_TIMESTAMP(EPOCH_MS("ts") / 1000)"#),
+            "a naive column still has to be pinned to UTC to compare with the literal: {sql}"
+        );
+    }
+
+    /// A filter may reference a column the projection drops, so the schema the filters are rendered
+    /// against is the whole table's — a projected schema would leave the column unresolved and
+    /// normalize it back to whole milliseconds.
+    #[test]
+    fn a_filter_column_outside_the_projection_is_still_resolved() {
+        let schema = docs_schema(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            false,
+        )]);
+        let filters = vec![col("ts").gt(micros_literal(1_767_225_600_000_999))];
+
+        let sql = duckdb_vector_sql(
+            "docs",
+            "body_embedding",
+            // `ts` is deliberately absent from the projection.
+            &["id".to_string(), SEARCH_SCORE_COLUMN_NAME.to_string()],
+            &ScopedFilters {
+                filters: &filters,
+                schema: &schema,
+            },
+            Some(10),
+            &DuckDBHnswOptions::default(),
+            "[1.0, 0.0]::FLOAT[2]",
+        )
+        .expect("SQL should build");
+
+        assert!(
+            !sql.contains("EPOCH_MS"),
+            "the filter's column resolves in the table schema even when the projection drops it: {sql}"
+        );
+    }
+
+    /// A column the schema does not carry keeps the normalization, which is what makes the types it
+    /// exists for bind. Only a resolved timezone-aware type declines it.
+    #[test]
+    fn an_unresolved_filter_column_keeps_the_normalization() {
+        let schema = docs_schema(vec![]);
+        let filters = vec![col("ts").gt(micros_literal(1_767_225_600_000_999))];
+
+        let sql = duckdb_vector_sql(
+            "docs",
+            "body_embedding",
+            &["id".to_string()],
+            &ScopedFilters {
+                filters: &filters,
+                schema: &schema,
+            },
+            Some(10),
+            &DuckDBHnswOptions::default(),
+            "[1.0, 0.0]::FLOAT[2]",
+        )
+        .expect("SQL should build");
+
+        assert!(
+            sql.contains(r#"TO_TIMESTAMP(EPOCH_MS("ts") / 1000)"#),
+            "an unresolved column must keep the normalization: {sql}"
+        );
+    }
+
+    /// The capability probe promises `Exact` for every filter it accepts, so a filter the probe
+    /// accepts has to be one the statement can render — and one it rejects for being unrenderable
+    /// must be one the statement would have failed on. Both go through `render_filter`, and this
+    /// pins the consequence.
+    #[test]
+    fn the_pushdown_probe_accepts_exactly_the_filters_the_statement_can_render() {
+        let schema = docs_schema(vec![
+            Field::new(
+                "aware",
+                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                false,
+            ),
+            Field::new(
+                "naive",
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                false,
+            ),
+        ]);
+
+        let renderable = [
+            col("aware").gt(micros_literal(1_767_225_600_000_999)),
+            col("naive").gt(micros_literal(1_767_225_600_000_999)),
+            col("id").gt(lit(10_i64)),
+        ];
+        // Two relations in one expression is the shape the renderer refuses; both column *names*
+        // are in the schema, so the probe gets past its own column check and has to ask the
+        // renderer.
+        let unrenderable = [
+            Expr::from(Column::new(Some("a"), "id")).gt(Expr::from(Column::new(Some("b"), "id")))
+        ];
+
+        for filter in &renderable {
+            assert_eq!(
+                duckdb_filter_pushdown(&schema, filter),
+                TableProviderFilterPushDown::Exact,
+                "the probe must accept {filter}"
+            );
+            flat_sql(&schema, filter).expect("a filter the probe accepted must render");
+        }
+
+        for filter in &unrenderable {
+            assert_eq!(
+                duckdb_filter_pushdown(&schema, filter),
+                TableProviderFilterPushDown::Unsupported,
+                "the probe must reject {filter}"
+            );
+            assert!(
+                flat_sql(&schema, filter).is_err(),
+                "a filter the probe rejected must not render: {filter}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`crates/search/src/index/duckdb/sql.rs` rendered its pushed-down filters with
`expr::to_sql_with_engine`, the schema-blind entry point. Without a schema that renderer cannot
tell a column that *needs* the DuckDB timestamp normalization from one that does not, so it applies
it unconditionally: the column operand of a comparison becomes
`TO_TIMESTAMP(EPOCH_MS(<column>) / 1000)`. `EPOCH_MS` yields **whole milliseconds**.

For a timezone-aware timestamp column that rewrite is pure loss — the column is already the type
and the reference frame the rendered literal is in — so a search filter comparing inside a
millisecond selected by a truncated instant and returned a different set of rows than the caller
asked for, with nothing in the plan or the logs to say so.

Two sites were affected, and `duckdb_filter_pushdown` is the one that makes it silent: it promises
`Exact`, so DataFusion drops the filter rather than re-checking the rows the statement returns.

## Root cause

`to_sql_with_engine_and_schema` — the schema-aware entry point — declines the normalization for a
column whose *resolved* type proves it unnecessary. It was not reachable from this repo: the
`datafusion-table-providers` pin sat exactly one commit behind the merge of its own fix
(spiceai/datafusion-table-providers#50, for #12574). That is why #12574's fix stopped at the DML
paths inside the fork.

## Changes

- **Bump `datafusion-table-providers`** `beeecde18a` → `d9da7cd1f1`. One commit on `spiceai-54`,
  three files, all DuckDB expression rendering and DML. The lockfile edit is the one `source =`
  line: the fork's own manifest did not change, and I diffed the resolved graph per package to
  confirm no other edge moved (1978 packages before and after, no dependency-set change on any
  shared package).
- **`ScopedFilters`** carries the filters together with the schema their columns come from, so a
  render site cannot be added schema-blind — which is the shape of this bug.
- **One `render_filter`** for both the capability probe and the statement, so they cannot disagree
  about what is renderable or about how a column's type is rendered.
- **The schema is the whole table's, not the projection's.** A filter may reference a column the
  projection drops; against a projected schema that column is unresolved and normalizes back to
  whole milliseconds. `DuckDBVectorQueryExec` therefore carries `table_schema` alongside
  `projected_schema`.

Verified the two assumptions the fix rests on, since both decide whether the right columns are
exempted:

- The schema is authoritative for the physical column type — `try_from_table` is handed
  `accelerator_provider.schema()`, the DuckDB-accelerated table's own schema, and the same schema
  builds the `TableDefinition` the writer uses.
- The exemption matches exactly what DuckDB stores as `TIMESTAMPTZ`: the fork maps
  `DataType::Timestamp(_unit, Some(tz))` to `ColumnType::TimestampWithTimeZone` at **every** unit,
  and every naive unit to plain `TIMESTAMP`, so no unit is exempted that DuckDB holds as a naive
  type.

## Known remainder

The naive microsecond and nanosecond columns are still truncated by the normalization they need for
the reference frame — #13146, in the fork, and deliberately not widened into here. A comparison
between two timestamp *columns* is still left un-normalized and refused — #13145.

## Performance impact

Neutral. The rendering does one extra `column_with_name` lookup per comparison — a linear scan of a
schema that holds a handful of fields, at plan time — and emits a shorter predicate on the exempted
path. No change to the scan itself: a filter that was `Exact` before is `Exact` now (the schema
selects between two renderings, never between success and failure), so the same rows are read, with
the correct bound.

## Test plan

- `make lint`
- `make test`

New tests (`crates/search/src/index/duckdb/`), and a 5-neuter matrix over the diff:

| neuter | kills |
|---|---|
| N1 `render_filter` renders schema-blind (the pre-fix rendering) | 2 |
| N2 the probe alone renders schema-blind | **0** |
| N3 the probe promises `Exact` for everything | 1 |
| N4 the exec renders against `projected_schema` | 1 |
| N5 `scan` hands the exec the projected schema | 1 |

- `a_timezone_aware_timestamp_filter_is_rendered_without_the_millisecond_truncation` — killed by N1.
- `scan_renders_filters_against_the_whole_table_schema` — drives the real `TableProvider::scan`,
  downcasts the plan and asks it for its SQL, so it pins the wiring rather than a copy of it.
  Killed by N1, N4 and N5.
- `the_pushdown_probe_accepts_exactly_the_filters_the_statement_can_render` — killed by N3.
- `a_naive_timestamp_filter_keeps_the_utc_normalization` and
  `an_unresolved_filter_column_keeps_the_normalization` pin behaviour this PR deliberately does
  **not** change, so no neuter of this diff kills them; what would is a renderer that stopped
  normalizing a naive or unresolved column, which is the regression they exist to catch. They are
  not vacuous: the timezone-aware test asserts the opposite through the same helper and passes.
- **N2 kills nothing, and that is the finding, not a gap.** Routing the probe through
  `render_filter` is behaviour-preserving by construction — no error path in the renderer consults
  the schema, so the probe's accept/reject verdict cannot change. It is a structural change (one
  render path, so the two cannot drift), recorded as such rather than claimed as a fix.

## Review gate

- Adversarial review: **skipped** — `codex` started and read the diff, the pinned fork's
  `expr.rs`, and the runtime call paths, then died mid-turn: *"Your workspace is out of credits.
  Ask your workspace owner to refill in order to continue."* Receipt records `engine=none exit=1
  job=none`; the `Verdict: approve` line in its output is the turn-start placeholder
  (*"Review in progress: inspecting the branch diff ... before issuing the final ship/no-ship
  verdict"*), not a verdict, and is not being read as one. `grok` is not installed, so there was no
  cross-model fallback. In its place I re-derived the two assumptions the approach rests on from
  source — the schema's provenance and the Arrow-to-DuckDB type mapping, both written up under
  *Changes* above.
- `/security-review`: ran on this diff, correctly scoped (the session cwd is the worktree holding
  it). No HIGH or MEDIUM findings. The one category it plausibly touches is SQL injection, and the
  surface is unchanged: both renderings interpolate the same operand, produced by the same
  `Expr::Column` arm that escapes through `quoted_identifier`, and the schema is read for
  `data_type()` only — never interpolated. The dependency bump adds no transitive code (identical
  package set), so it is not a supply-chain change either.
- `/simplify`: applied. Passed `ScopedFilters` by value (it is two references) and moved the
  emptiness check onto the type; deleted `a_filter_column_outside_the_projection_is_still_resolved`,
  which asserted what the timezone-aware test already covers — the shared helper projects `id`
  alone while the filter names `ts` — and had the same killer, so it added no coverage. Considered
  and declined: giving the exec an owned filters-plus-schema pair, which would push the invariant a
  level deeper but make `DisplayAs` reach through a wrapper for no gain, and a "can this render"
  probe API in the fork that would avoid the discarded `String` (pre-existing shape, outside this
  diff).

Fixes #13144