### PR TITLE
fix(spiced): stop warning about the default pods watcher

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -1390,9 +1390,10 @@ enum DeploymentNote {
         error: String,
         local_error: String,
     },
-    /// `--pods-watcher-enabled` was passed on an instance serving a deployment.
-    /// The watcher is not installed: reconciling the local spicepod into a
-    /// deployed app would swap the deployed configuration out from under it.
+    /// `--pods-watcher-enabled` was passed on a Cloud Connect managed instance.
+    /// The watcher is not installed: reconciling the local spicepod into an app
+    /// that arrives by deployment would swap that configuration out from under
+    /// the control plane.
     PodsWatcherDeclined,
     /// A cloud-managed instance found no spicepod — neither deployed nor local —
     /// and started on an empty one.
@@ -1407,6 +1408,13 @@ enum DeploymentNote {
 }
 
 impl DeploymentNote {
+    /// Why a Cloud Connect managed instance does not watch the local spicepod.
+    ///
+    /// Names no deployment: this note also reaches an instance whose first
+    /// deployment has not landed, one whose deployment did not build, and one
+    /// with no spicepod at all.
+    const PODS_WATCHER_DECLINED_MESSAGE: &str = "Spice Cloud Connect: `--pods-watcher-enabled` was ignored because this instance is Cloud Connect managed, so it will not reload when the local `spicepod.yaml` changes. Edit the app in Spice Cloud and deploy it there instead. See: https://spiceai.org/docs";
+
     fn log(&self) {
         match self {
             Self::Loaded { path } => tracing::info!(
@@ -1425,9 +1433,12 @@ impl DeploymentNote {
                 "Spice Cloud Connect: this instance started with no configuration — the deployed spicepod at {} could not be loaded ({error}), and neither could the local one ({local_error}). It serves nothing until a deployment replaces the file; the runtime stays reachable so that deployment can land.",
                 path.display()
             ),
-            Self::PodsWatcherDeclined => tracing::warn!(
-                "Spice Cloud Connect: --pods-watcher-enabled was ignored because this instance serves a deployed spicepod. Watching the local spicepod.yaml would replace the deployed configuration while the instance kept reporting the deployment as applied. Edit the app in Spice Cloud and deploy it instead."
-            ),
+            // `spice run` passes `--pods-watcher-enabled` on every runtime it
+            // launches, so reaching this arm does not mean the operator asked
+            // for the watcher.
+            Self::PodsWatcherDeclined => {
+                tracing::debug!("{}", Self::PODS_WATCHER_DECLINED_MESSAGE);
+            }
             Self::NoSpicepod => {
                 tracing::warn!("No existing spicepod was found. Starting Runtime without one.");
             }
@@ -2235,6 +2246,20 @@ mod tests {
         assert!(message.contains("/tmp/spicepod.yaml"));
         assert!(message.contains("will be replaced by Spice Cloud"));
         assert!(!message.contains("Copy it to the project's Spicepod in Spice Cloud"));
+        assert!(message.contains("https://spiceai.org/docs"));
+        assert!(!message.contains('\n'));
+    }
+
+    #[test]
+    fn the_declined_pods_watcher_note_claims_no_deployment() {
+        let message = DeploymentNote::PODS_WATCHER_DECLINED_MESSAGE;
+        assert!(message.contains("`--pods-watcher-enabled`"));
+        assert!(message.contains("Cloud Connect managed"));
+        assert!(message.contains("`spicepod.yaml`"));
+        let lowercase = message.to_lowercase();
+        assert!(!lowercase.contains("deployed"));
+        assert!(!lowercase.contains("deployment"));
+        assert!(message.contains("Edit the app in Spice Cloud and deploy it there instead"));
         assert!(message.contains("https://spiceai.org/docs"));
         assert!(!message.contains('\n'));
     }


### PR DESCRIPTION
Closes #13488

## What an operator saw

Every `spice run` in a Spice Cloud Connect managed instance directory logged, at WARN:

```
Spice Cloud Connect: --pods-watcher-enabled was ignored because this instance serves a deployed spicepod. Watching the local spicepod.yaml would replace the deployed configuration while the instance kept reporting the deployment as applied. Edit the app in Spice Cloud and deploy it instead.
```

They never passed `--pods-watcher-enabled`. The CLI adds it to every runtime it launches, so the runtime declined a flag nobody typed and then explained the refusal to someone with nothing to act on — on every start.

Two things were wrong, and neither was the behaviour underneath.

**The level.** Because the flag arrives by default rather than by request, the note reaches an operator who did not ask far more often than one who did. It moves to `debug`, where the operator who did pass the flag still finds it at `-v` (`spiced` is in `INTERNAL_COMPONENTS`, and `LogVerbosity::Verbose` maps those to `DEBUG` while `Default` maps them to `INFO`).

**The wording.** It claimed the instance "serves a deployed spicepod". The note is pushed whenever `cloud_connect_configured` is true — a usable durable identity — which also covers an instance whose first deployment has not landed, one whose deployment did not build, and one with no spicepod at all. Three of those four have no deployment, so an operator reading the old text went looking for one that does not exist. The replacement names no deployment: it gives the cause, what the operator loses, and where to make the change instead. It lives in one associated const with a unit test over its wording, matching the sibling notes in the same `impl`.

## Behaviour is unchanged

The flag is still passed by the CLI, the watcher is still declined on a managed instance, and the separate startup path that also reads `pods_watcher_enabled` — the one that lets `spiced` start when the local spicepod is missing or does not build — is untouched. This is a log level and a string.

## Why not just stop the CLI passing the flag

That is the first fix everyone reaches for, and it is not safe. The full analysis is in #13488; in short:

- **The flag has a second, load-bearing effect.** Besides installing the watcher, `--pods-watcher-enabled` with no `--spicepod` is what lets `spiced` start on a missing or unbuildable local spicepod instead of exiting with "run spice init". That path is gated on `identity_observed`, not on the watcher's condition, so dropping the flag changes startup behaviour wherever the two disagree.
- **No CLI-side signal provably implies the runtime's condition.** `spiced` does not build its Cloud Connect config with `CloudConnectConfig::from_env`: it first reconciles the control-plane endpoint and **clears** `enroll_endpoint` on an unreadable or conflicting binding, which makes an otherwise-valid identity unusable. The same identity read the way the CLI reads it elsewhere validates fine. Where they disagree in that direction the CLI would suppress a flag the runtime would have honoured, and local hot-reload would vanish with no message at all — worse than the noise being fixed.
- **Two gaps no CLI-side detection can close.** `spiced --token` enrolls before the app bundle is built, so on a first enrollment there is no identity to detect; and there is an unavoidable TOCTOU between the CLI's read and the child's.

## Accepted consequences

- An operator who passes `--pods-watcher-enabled` themselves on a managed instance no longer gets an explanation at default verbosity. It is at `-v`. This is deliberate.
- An operator who relied on the CLI-supplied watcher gets no default-verbosity explanation either: on a managed instance still serving a local spicepod, hot-reload stays off. That is the same line, and suppressing it is the point of the change; the sibling `LocalAwaitingDeployment` warning still tells them the local file is provisional.

## Not affected

Installed services never reach this path: the systemd unit's `ExecStart` and the launchd job's `ProgramArguments` pass no `--pods-watcher-enabled`, and neither do the container images or the Helm chart.

## Validation

- `cargo fmt -p spiced -- --check`
- `cargo clippy --profile dev --keep-going -p spiced -- -Dwarnings -Dclippy::pedantic ...`
- `cargo clippy --profile dev --keep-going --tests -p spiced -- -Dwarnings -Dclippy::pedantic ...`
- `cargo nextest run --no-tests=pass -p spiced --lib` — 123 passed
