### PR TITLE
fix(arrow): align a nested nullability difference instead of advertising it (fixes #13285)

### DIFF
--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -16,12 +16,14 @@ limitations under the License.
 
 use arrow::{
     array::{
-        Array, ArrayRef, BinaryViewArray, GenericByteViewArray, ListArray, MutableArrayData,
-        RecordBatch, RecordBatchOptions, StringViewArray, StructArray, make_array, new_null_array,
+        Array, ArrayData, ArrayRef, BinaryViewArray, GenericByteViewArray, ListArray,
+        MutableArrayData, RecordBatch, RecordBatchOptions, StringViewArray, StructArray,
+        make_array, new_null_array,
     },
     buffer::{Buffer, OffsetBuffer},
     datatypes::{
-        BinaryViewType, ByteViewType, DataType, Field, SchemaRef, StringViewType, TimeUnit,
+        BinaryViewType, ByteViewType, DataType, Field, FieldRef, SchemaRef, StringViewType,
+        TimeUnit,
     },
     error::ArrowError,
 };
@@ -33,6 +35,7 @@ use snafu::{ResultExt, prelude::*};
 use std::sync::Arc;
 
 use crate::format::{FormatOperation, format_column_data};
+use crate::type_rewrite::relabel_array_data;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -43,6 +46,13 @@ pub enum Error {
 
     #[snafu(display("Field is not nullable: {field}"))]
     FieldNotNullable { field: String },
+
+    #[snafu(display(
+        "Failed to align column '{column}': the target schema declares '{path}' non-nullable, but the column holds nulls there. \
+        Declare '{path}' nullable in the target schema, or stop the source emitting nulls for it. \
+        See: https://spiceai.org/docs/reference/spicepod/datasets"
+    ))]
+    NullsUnderNonNullableField { column: String, path: String },
 }
 
 impl From<Error> for DataFusionError {
@@ -51,7 +61,7 @@ impl From<Error> for DataFusionError {
             Error::UnableToConvertRecordBatch {
                 source: arrow_error,
             } => DataFusionError::ArrowError(Box::new(arrow_error), None),
-            Error::FieldNotNullable { .. } => {
+            Error::FieldNotNullable { .. } | Error::NullsUnderNonNullableField { .. } => {
                 DataFusionError::ArrowError(Box::new(ArrowError::SchemaError(e.to_string())), None)
             }
         }
@@ -67,8 +77,15 @@ pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<Recor
     let existing_schema = record_batch.schema();
 
     // When schema is superset of the existing schema, including a new column, and nullable column,
-    // return a new RecordBatch to reflect the change
-    if schema.contains(&existing_schema) {
+    // return a new RecordBatch to reflect the change.
+    //
+    // `Schema::contains` answers "is this assignable", which permits a nested field's nullability
+    // to differ; `RecordBatch` requires a column's type and its field's type to be identical, and
+    // `with_schema` re-labels the schema without touching the columns. So a merely-assignable
+    // schema taken through here yields a batch advertising a type none of its columns carries,
+    // which reads as aligned and then fails in whichever kernel first rebuilds a column. Only an
+    // exact match may skip the per-column work below.
+    if schema.contains(&existing_schema) && declares_the_same_types(&schema, &existing_schema) {
         return record_batch
             .with_schema(schema)
             .context(UnableToConvertRecordBatchSnafu);
@@ -87,7 +104,11 @@ pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<Recor
                 record_batch.schema().field_with_name(field.name()),
                 record_batch.column_by_name(field.name()),
             ) {
-                if field.contains(existing_field) {
+                // Identical to the schema-level test above, for the same reason: `contains`
+                // alone would pass the column through still carrying a type `RecordBatch::try_new`
+                // then refuses against the field declaring it.
+                if field.contains(existing_field) && field.data_type() == existing_field.data_type()
+                {
                     Ok(Arc::clone(column))
                 } else {
                     cast_column(column, existing_field.data_type(), field, &cast_options)
@@ -117,6 +138,17 @@ pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<Recor
     RecordBatch::try_new(schema, cols).context(UnableToConvertRecordBatchSnafu)
 }
 
+/// Whether every field of `existing` has a same-named field in `target` carrying the identical
+/// type — the condition `RecordBatch` enforces, as distinct from the assignability
+/// `Schema::contains` answers.
+fn declares_the_same_types(target: &SchemaRef, existing: &SchemaRef) -> bool {
+    existing.fields().iter().all(|existing_field| {
+        target
+            .field_with_name(existing_field.name())
+            .is_ok_and(|target_field| target_field.data_type() == existing_field.data_type())
+    })
+}
+
 /// Returns `true` when `source` → `target` is a timestamp-to-timestamp cast that
 /// only changes the time unit (and possibly the timezone string), meaning the
 /// underlying physical values need rescaling and may overflow on far-future/past
@@ -144,6 +176,10 @@ fn cast_column(
     target_field: &Field,
     strict_options: &CastOptions,
 ) -> Result<ArrayRef> {
+    if is_nullability_only_relabel(source_type, target_field.data_type()) {
+        return relabel_nullability(column, target_field);
+    }
+
     match cast_with_options(column.as_ref(), target_field.data_type(), strict_options) {
         Ok(casted) => Ok(casted),
         Err(ref e)
@@ -172,6 +208,124 @@ fn is_overflow_error(e: &ArrowError) -> bool {
         ArrowError::CastError(msg) | ArrowError::ArithmeticOverflow(msg)
             if msg.contains("Overflow") || msg.contains("overflow")
     )
+}
+
+/// Whether `target` can be reached from `source` by relabelling alone: the two describe the same
+/// values in the same buffers, and differ only in the nullability flags of nested fields.
+///
+/// `arrow_cast::cast` has no path for such a pair. For a `Map` it hands the target `entries` field
+/// straight to `MapArray::try_new`, which refuses a nullable one, so two `Map` types differing only
+/// there fail with `MapArray entries cannot contain nulls` whether or not a null is involved — a
+/// message that names neither the column nor the real disagreement.
+///
+/// Only the child-bearing types whose children [`relabel_array_data`] pairs positionally are
+/// walked; everything else is compared whole. A type this does not know about — a `Union`,
+/// `Dictionary` or `RunEndEncoded` carrying the difference — therefore fails the test and keeps
+/// its existing cast path rather than being relabelled on a pairing that was never checked.
+///
+/// Field names and metadata have to match. A rename is a different question from a nullability
+/// flag, and admitting one here would make a reorder of same-typed sibling fields indistinguishable
+/// from a pair of renames, which positional pairing would then carry across transposed.
+fn is_nullability_only_relabel(source: &DataType, target: &DataType) -> bool {
+    match (source, target) {
+        (DataType::List(source_item), DataType::List(target_item))
+        | (DataType::LargeList(source_item), DataType::LargeList(target_item))
+        | (DataType::ListView(source_item), DataType::ListView(target_item))
+        | (DataType::LargeListView(source_item), DataType::LargeListView(target_item)) => {
+            is_field_nullability_only_relabel(source_item, target_item)
+        }
+        (
+            DataType::FixedSizeList(source_item, source_len),
+            DataType::FixedSizeList(target_item, target_len),
+        ) if source_len == target_len => {
+            is_field_nullability_only_relabel(source_item, target_item)
+        }
+        (
+            DataType::Map(source_entries, source_sorted),
+            DataType::Map(target_entries, target_sorted),
+        ) if source_sorted == target_sorted => {
+            is_field_nullability_only_relabel(source_entries, target_entries)
+        }
+        (DataType::Struct(source_fields), DataType::Struct(target_fields))
+            if source_fields.len() == target_fields.len() =>
+        {
+            source_fields
+                .iter()
+                .zip(target_fields)
+                .all(|(source_field, target_field)| {
+                    is_field_nullability_only_relabel(source_field, target_field)
+                })
+        }
+        _ => source == target,
+    }
+}
+
+/// The [`is_nullability_only_relabel`] test for one field pair.
+fn is_field_nullability_only_relabel(source: &FieldRef, target: &FieldRef) -> bool {
+    source.name() == target.name()
+        && source.metadata() == target.metadata()
+        && source.dict_is_ordered() == target.dict_is_ordered()
+        && is_nullability_only_relabel(source.data_type(), target.data_type())
+}
+
+/// Carries `column` to `target_field`'s type by relabelling its declaration, sharing every buffer —
+/// values, offsets and validity — with the original.
+///
+/// Only called for a pair [`is_nullability_only_relabel`] accepts, so no value changes meaning.
+fn relabel_nullability(column: &ArrayRef, target_field: &Field) -> Result<ArrayRef> {
+    let data = column.to_data();
+
+    if let Some(path) =
+        narrowed_field_holding_nulls(&data, target_field.data_type(), target_field.name())
+    {
+        return NullsUnderNonNullableFieldSnafu {
+            column: target_field.name(),
+            path,
+        }
+        .fail();
+    }
+
+    relabel_array_data(data, target_field.data_type())
+        .map(make_array)
+        .context(UnableToConvertRecordBatchSnafu)
+}
+
+/// The path to the first nested field `target` declares non-nullable where `data` holds nulls.
+///
+/// Relabelling carries the validity buffers across untouched, so narrowing a field the data
+/// actually leaves null would hand on an array whose declaration contradicts its own null mask —
+/// which every later kernel is entitled to trust. Such a pair is reported against the field it
+/// disagrees on instead.
+///
+/// `data`'s type and `target` satisfy [`is_nullability_only_relabel`], so the child counts line up
+/// at every level walked here; `zip` truncates rather than indexing, so a disagreement cannot panic.
+fn narrowed_field_holding_nulls(data: &ArrayData, target: &DataType, path: &str) -> Option<String> {
+    let children: Vec<(&ArrayData, &FieldRef)> = match target {
+        DataType::List(item)
+        | DataType::LargeList(item)
+        | DataType::ListView(item)
+        | DataType::LargeListView(item)
+        | DataType::FixedSizeList(item, _)
+        | DataType::Map(item, _) => data
+            .child_data()
+            .iter()
+            .zip(std::iter::once(item))
+            .collect(),
+        DataType::Struct(fields) => data.child_data().iter().zip(fields.iter()).collect(),
+        _ => return None,
+    };
+
+    for (child, field) in children {
+        let child_path = format!("{path}.{}", field.name());
+        if !field.is_nullable() && child.null_count() > 0 {
+            return Some(child_path);
+        }
+        if let Some(found) = narrowed_field_holding_nulls(child, field.data_type(), &child_path) {
+            return Some(found);
+        }
+    }
+
+    None
 }
 
 /// Flattens a list of struct types with a single field into a list of primitive types.
@@ -1805,5 +1959,395 @@ mod test {
         let compacted = compact_retained_buffers(&batch);
 
         assert_eq!(compacted.num_rows(), 7);
+    }
+}
+
+#[cfg(test)]
+mod nullability_alignment_tests {
+    use super::*;
+    use arrow::array::{Int32Array, MapArray, StringArray, StructArray};
+    use arrow::buffer::NullBuffer;
+    use arrow::datatypes::Fields;
+
+    fn entry_fields() -> Fields {
+        vec![
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Utf8, true),
+        ]
+        .into()
+    }
+
+    fn map_type(entries_nullable: bool) -> DataType {
+        DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(entry_fields()),
+                entries_nullable,
+            )),
+            false,
+        )
+    }
+
+    /// Builds a `MapArray` the way the IPC reader does — through `From<ArrayData>`, which
+    /// performs neither of the two `entries` checks. That is why a column declaring `entries`
+    /// nullable reaches schema alignment at all.
+    fn map_from_parts(
+        entries_nullable: bool,
+        entry_nulls: Option<NullBuffer>,
+        offsets: &[i32],
+        keys: Vec<&str>,
+        values: Vec<Option<&str>>,
+    ) -> MapArray {
+        let entries = StructArray::try_new(
+            entry_fields(),
+            vec![
+                Arc::new(StringArray::from(keys)) as ArrayRef,
+                Arc::new(StringArray::from(values)) as ArrayRef,
+            ],
+            entry_nulls,
+        )
+        .expect("entries struct");
+
+        let data = ArrayData::builder(map_type(entries_nullable))
+            .len(offsets.len() - 1)
+            .add_buffer(Buffer::from_slice_ref(offsets))
+            .add_child_data(entries.to_data())
+            .build()
+            .expect("map array data");
+
+        MapArray::from(data)
+    }
+
+    fn batch_of(name: &str, column: ArrayRef) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                name,
+                column.data_type().clone(),
+                true,
+            )])),
+            vec![column],
+        )
+        .expect("batch")
+    }
+
+    fn schema_of(name: &str, data_type: DataType) -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new(name, data_type, true)]))
+    }
+
+    /// The constructor every kernel that rebuilds a map column goes through. A column that
+    /// survives it is one the rest of the engine can actually use.
+    fn rebuild_through_public_constructor(
+        column: &ArrayRef,
+    ) -> std::result::Result<(), ArrowError> {
+        let map = column
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("map column");
+        let (field, offsets, entries, nulls, ordered) = map.clone().into_parts();
+        MapArray::try_new(field, offsets, entries, nulls, ordered).map(|_| ())
+    }
+
+    /// The address of the key column's value buffer, so a rebuild can be told from a relabel.
+    fn keys_buffer_ptr(column: &ArrayRef) -> *const u8 {
+        let map = column
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("map column");
+        map.keys().to_data().buffers()[1].as_ptr()
+    }
+
+    fn map_pairs(batch: &RecordBatch) -> Vec<(String, Option<String>)> {
+        let map = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("map column");
+        let keys = map
+            .keys()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("keys");
+        let values = map
+            .values()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("values");
+
+        (0..keys.len())
+            .map(|i| {
+                (
+                    keys.value(i).to_string(),
+                    values.is_valid(i).then(|| values.value(i).to_string()),
+                )
+            })
+            .collect()
+    }
+
+    /// Regression test for #13285. `Schema::contains` permits a nested field's nullability to
+    /// differ, but `RecordBatch` requires a column's type and its field's type to be identical,
+    /// and `with_schema` re-labels the schema while leaving the columns alone. So alignment used
+    /// to hand back a batch advertising `entries` nullable over a column that still carried it
+    /// non-nullable — no error, and a schema contradicting its own data.
+    #[test]
+    fn an_aligned_batch_advertises_the_type_its_columns_actually_carry() {
+        let column = Arc::new(map_from_parts(
+            false,
+            None,
+            &[0, 2],
+            vec!["a", "b"],
+            vec![Some("1"), None],
+        )) as ArrayRef;
+
+        let aligned = try_cast_to(
+            batch_of("col_map", column),
+            schema_of("col_map", map_type(true)),
+        )
+        .expect("a nested nullability flag is a declaration, not a value");
+
+        assert_eq!(
+            aligned.schema().field(0).data_type(),
+            aligned.column(0).data_type(),
+            "the batch must not advertise a type none of its columns carries"
+        );
+        assert_eq!(aligned.schema().field(0).data_type(), &map_type(true));
+        assert_eq!(
+            map_pairs(&aligned),
+            vec![
+                ("a".to_string(), Some("1".to_string())),
+                ("b".to_string(), None),
+            ],
+            "relabelling shares the buffers, so every key and value survives it unchanged"
+        );
+    }
+
+    /// The same disagreement where the schema-level path cannot fire: a sibling column genuinely
+    /// needs a cast, so every column is decided on its own. `Field::contains` waved the map column
+    /// through unchanged and `RecordBatch::try_new` then refused the batch it built, naming two
+    /// `Map` types that differ somewhere in a rendering of the whole type.
+    ///
+    /// The target here declares `entries` nullable, which the Arrow map layout does not allow;
+    /// aligning to it is still the right answer, because alignment delivers the schema it was
+    /// asked for. Bringing an illegal declaration into line is `map_entries`' job, at ingress.
+    #[test]
+    fn a_map_column_beside_one_needing_a_cast_is_aligned_rather_than_refused() {
+        let map_column = Arc::new(map_from_parts(
+            false,
+            None,
+            &[0, 1],
+            vec!["a"],
+            vec![Some("1")],
+        )) as ArrayRef;
+        let keys_before = keys_buffer_ptr(&map_column);
+        let source = Schema::new(vec![
+            Field::new("col_map", map_type(false), true),
+            Field::new("n", DataType::Int32, true),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(source),
+            vec![map_column, Arc::new(Int32Array::from(vec![7])) as ArrayRef],
+        )
+        .expect("batch");
+        let target = Arc::new(Schema::new(vec![
+            Field::new("col_map", map_type(true), true),
+            Field::new("n", DataType::Int64, true),
+        ]));
+
+        let aligned =
+            try_cast_to(batch, target).expect("one column needing a cast must not fail the other");
+
+        assert_eq!(
+            aligned.schema().field(0).data_type(),
+            aligned.column(0).data_type()
+        );
+        assert_eq!(
+            map_pairs(&aligned),
+            vec![("a".to_string(), Some("1".to_string()))]
+        );
+        assert_eq!(aligned.column(1).data_type(), &DataType::Int64);
+        assert_eq!(
+            keys_buffer_ptr(aligned.column(0)),
+            keys_before,
+            "the relabel carries the values across by reference rather than rebuilding them"
+        );
+    }
+
+    /// The disagreement is not always at the top of the type. A `Map` nested inside a `Struct`
+    /// is reached through the struct arm of the walk, and `Field::contains` relaxes a nested
+    /// nullability flag at any depth — so the column was waved through carrying a struct type the
+    /// field declaring it did not match.
+    #[test]
+    fn a_map_nested_inside_a_struct_is_aligned() {
+        let struct_of = |entries_nullable: bool| {
+            DataType::Struct(
+                vec![
+                    Field::new("m", map_type(entries_nullable), true),
+                    Field::new("n", DataType::Int32, true),
+                ]
+                .into(),
+            )
+        };
+        let inner = Arc::new(map_from_parts(
+            false,
+            None,
+            &[0, 1],
+            vec!["a"],
+            vec![Some("1")],
+        )) as ArrayRef;
+        let DataType::Struct(source_fields) = struct_of(false) else {
+            unreachable!("built as a struct above")
+        };
+        let column = Arc::new(
+            StructArray::try_new(
+                source_fields,
+                vec![inner, Arc::new(Int32Array::from(vec![7])) as ArrayRef],
+                None,
+            )
+            .expect("struct"),
+        ) as ArrayRef;
+
+        let aligned = try_cast_to(
+            batch_of("col_struct", column),
+            schema_of("col_struct", struct_of(true)),
+        )
+        .expect("a nested map's declaration is still only a declaration");
+
+        assert_eq!(
+            aligned.schema().field(0).data_type(),
+            aligned.column(0).data_type(),
+            "the batch must not advertise a type none of its columns carries"
+        );
+        assert_eq!(aligned.schema().field(0).data_type(), &struct_of(true));
+        assert_eq!(aligned.num_rows(), 1);
+    }
+
+    /// The one shape a relabel cannot carry: the entries array really does hold nulls, so
+    /// narrowing the field would hand on an array whose declaration contradicts its own null
+    /// mask. It is refused, and the refusal names the column and the field rather than
+    /// reporting Arrow's `MapArray entries cannot contain nulls` against neither.
+    #[test]
+    fn nulls_under_a_narrowed_field_are_refused_by_name() {
+        let column = Arc::new(map_from_parts(
+            true,
+            Some(NullBuffer::from(vec![true, false])),
+            &[0, 2],
+            vec!["a", "b"],
+            vec![Some("1"), Some("2")],
+        )) as ArrayRef;
+
+        let error = try_cast_to(
+            batch_of("col_map", column),
+            schema_of("col_map", map_type(false)),
+        )
+        .expect_err("entry nulls cannot be relabelled away");
+
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("col_map") && rendered.contains("col_map.entries"),
+            "the refusal has to name the column and the field it disagrees on, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("holds nulls"),
+            "the refusal has to say what is wrong with the data, got: {rendered}"
+        );
+    }
+
+    /// A rename is a different question from a nullability flag. Admitting it here would make a
+    /// reorder of same-typed sibling fields indistinguishable from a pair of renames, which
+    /// positional pairing would carry across transposed — so a renamed field keeps the cast path.
+    #[test]
+    fn a_renamed_nested_field_is_not_relabelled() {
+        let renamed_entries = DataType::Map(
+            Arc::new(Field::new(
+                "key_value",
+                DataType::Struct(entry_fields()),
+                false,
+            )),
+            false,
+        );
+
+        assert!(
+            !is_nullability_only_relabel(&map_type(true), &renamed_entries),
+            "a renamed entries field is not a nullability-only difference"
+        );
+    }
+
+    /// `sorted` is a promise about the order of the entries buffer, not a declaration about it,
+    /// so a pair differing there is not relabellable however the nullability flags line up.
+    #[test]
+    fn a_map_with_a_different_sorted_flag_is_not_relabelled() {
+        let sorted = DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(entry_fields()),
+                false,
+            )),
+            true,
+        );
+
+        assert!(!is_nullability_only_relabel(&map_type(true), &sorted));
+        assert!(!is_nullability_only_relabel(&map_type(false), &sorted));
+    }
+
+    /// A `FixedSizeList`'s length is how many values each row owns, so a pair differing there
+    /// describes a different layout however the nullability flags line up.
+    #[test]
+    fn a_fixed_size_list_of_a_different_length_is_not_relabelled() {
+        let fixed = |len: i32, item_nullable: bool| {
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Int32, item_nullable)),
+                len,
+            )
+        };
+
+        assert!(!is_nullability_only_relabel(
+            &fixed(2, true),
+            &fixed(3, false)
+        ));
+        assert!(is_nullability_only_relabel(
+            &fixed(2, true),
+            &fixed(2, false)
+        ));
+    }
+
+    /// A type this walk does not know about fails the test and keeps its cast path, rather than
+    /// being relabelled on a child pairing that was never checked.
+    #[test]
+    fn a_difference_carried_by_an_unwalked_type_is_not_relabelled() {
+        let source = DataType::Dictionary(Box::new(DataType::Int32), Box::new(map_type(true)));
+        let target = DataType::Dictionary(Box::new(DataType::Int32), Box::new(map_type(false)));
+
+        assert!(!is_nullability_only_relabel(&source, &target));
+    }
+
+    /// An extension type lives in a field's metadata and renames what its storage buffers mean,
+    /// so a pair differing there is not a nullability-only relabel however the flags line up.
+    #[test]
+    fn a_changed_extension_type_is_not_relabelled() {
+        let extension = |name: &str| {
+            Arc::new(
+                Field::new("item", DataType::FixedSizeBinary(16), false).with_metadata(
+                    [("ARROW:extension:name".to_string(), name.to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+            )
+        };
+
+        assert!(!is_nullability_only_relabel(
+            &DataType::List(extension("arrow.uuid")),
+            &DataType::List(extension("arrow.opaque")),
+        ));
+    }
+
+    /// The relabel path must not swallow the casts that already worked: a genuine type change
+    /// still goes through `arrow_cast`.
+    #[test]
+    fn a_genuine_type_change_still_casts() {
+        let batch = batch_of("n", Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef);
+
+        let casted = try_cast_to(batch, schema_of("n", DataType::Int64)).expect("int widening");
+
+        assert_eq!(casted.schema().field(0).data_type(), &DataType::Int64);
+        assert_eq!(casted.num_rows(), 2);
     }
 }

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -2042,19 +2042,6 @@ mod nullability_alignment_tests {
         Arc::new(Schema::new(vec![Field::new(name, data_type, true)]))
     }
 
-    /// The constructor every kernel that rebuilds a map column goes through. A column that
-    /// survives it is one the rest of the engine can actually use.
-    fn rebuild_through_public_constructor(
-        column: &ArrayRef,
-    ) -> std::result::Result<(), ArrowError> {
-        let map = column
-            .as_any()
-            .downcast_ref::<MapArray>()
-            .expect("map column");
-        let (field, offsets, entries, nulls, ordered) = map.clone().into_parts();
-        MapArray::try_new(field, offsets, entries, nulls, ordered).map(|_| ())
-    }
-
     /// The address of the key column's value buffer, so a rebuild can be told from a relabel.
     fn keys_buffer_ptr(column: &ArrayRef) -> *const u8 {
         let map = column

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -46,13 +46,6 @@ pub enum Error {
 
     #[snafu(display("Field is not nullable: {field}"))]
     FieldNotNullable { field: String },
-
-    #[snafu(display(
-        "Failed to align column '{column}': the target schema declares '{path}' non-nullable, but the column holds nulls there. \
-        Declare '{path}' nullable in the target schema, or stop the source emitting nulls for it. \
-        See: https://spiceai.org/docs/reference/spicepod/datasets"
-    ))]
-    NullsUnderNonNullableField { column: String, path: String },
 }
 
 impl From<Error> for DataFusionError {
@@ -61,7 +54,7 @@ impl From<Error> for DataFusionError {
             Error::UnableToConvertRecordBatch {
                 source: arrow_error,
             } => DataFusionError::ArrowError(Box::new(arrow_error), None),
-            Error::FieldNotNullable { .. } | Error::NullsUnderNonNullableField { .. } => {
+            Error::FieldNotNullable { .. } => {
                 DataFusionError::ArrowError(Box::new(ArrowError::SchemaError(e.to_string())), None)
             }
         }
@@ -184,7 +177,7 @@ fn cast_column(
     target_field: &Field,
     strict_options: &CastOptions,
 ) -> Result<ArrayRef> {
-    if is_nullability_only_relabel(source_type, target_field.data_type()) {
+    if is_nullability_relaxing_relabel(source_type, target_field.data_type()) {
         return relabel_nullability(column, target_field);
     }
 
@@ -219,7 +212,14 @@ fn is_overflow_error(e: &ArrowError) -> bool {
 }
 
 /// Whether `target` can be reached from `source` by relabelling alone: the two describe the same
-/// values in the same buffers, and differ only in the nullability flags of nested fields.
+/// values in the same buffers, and `target` only ever *relaxes* a nested field's nullability.
+///
+/// Narrowing is deliberately excluded and left to `arrow_cast::cast`. Whether a non-nullable field
+/// may hold nulls is not the simple question it looks like — Arrow requires a non-nullable struct
+/// child's nulls to be a *subset of its parent's*, not absent, so a masked null is legal — and the
+/// reachability rule differs again for a list-like parent, whose offsets decide which child slots
+/// are addressed at all. `cast` already implements those rules; a second, stricter transcription of
+/// them here would refuse arrays Arrow considers valid.
 ///
 /// `arrow_cast::cast` has no path for such a pair. For a `Map` it hands the target `entries` field
 /// straight to `MapArray::try_new`, which refuses a nullable one, so two `Map` types differing only
@@ -234,25 +234,25 @@ fn is_overflow_error(e: &ArrowError) -> bool {
 /// Field names and metadata have to match. A rename is a different question from a nullability
 /// flag, and admitting one here would make a reorder of same-typed sibling fields indistinguishable
 /// from a pair of renames, which positional pairing would then carry across transposed.
-fn is_nullability_only_relabel(source: &DataType, target: &DataType) -> bool {
+fn is_nullability_relaxing_relabel(source: &DataType, target: &DataType) -> bool {
     match (source, target) {
         (DataType::List(source_item), DataType::List(target_item))
         | (DataType::LargeList(source_item), DataType::LargeList(target_item))
         | (DataType::ListView(source_item), DataType::ListView(target_item))
         | (DataType::LargeListView(source_item), DataType::LargeListView(target_item)) => {
-            is_field_nullability_only_relabel(source_item, target_item)
+            is_field_nullability_relaxing_relabel(source_item, target_item)
         }
         (
             DataType::FixedSizeList(source_item, source_len),
             DataType::FixedSizeList(target_item, target_len),
         ) if source_len == target_len => {
-            is_field_nullability_only_relabel(source_item, target_item)
+            is_field_nullability_relaxing_relabel(source_item, target_item)
         }
         (
             DataType::Map(source_entries, source_sorted),
             DataType::Map(target_entries, target_sorted),
         ) if source_sorted == target_sorted => {
-            is_field_nullability_only_relabel(source_entries, target_entries)
+            is_field_nullability_relaxing_relabel(source_entries, target_entries)
         }
         (DataType::Struct(source_fields), DataType::Struct(target_fields))
             if source_fields.len() == target_fields.len() =>
@@ -261,79 +261,31 @@ fn is_nullability_only_relabel(source: &DataType, target: &DataType) -> bool {
                 .iter()
                 .zip(target_fields)
                 .all(|(source_field, target_field)| {
-                    is_field_nullability_only_relabel(source_field, target_field)
+                    is_field_nullability_relaxing_relabel(source_field, target_field)
                 })
         }
         _ => source == target,
     }
 }
 
-/// The [`is_nullability_only_relabel`] test for one field pair.
-fn is_field_nullability_only_relabel(source: &FieldRef, target: &FieldRef) -> bool {
+/// The [`is_nullability_relaxing_relabel`] test for one field pair.
+fn is_field_nullability_relaxing_relabel(source: &FieldRef, target: &FieldRef) -> bool {
     source.name() == target.name()
         && source.metadata() == target.metadata()
         && source.dict_is_ordered() == target.dict_is_ordered()
-        && is_nullability_only_relabel(source.data_type(), target.data_type())
+        // At least as permissive: a nullable source under a non-nullable target is a narrowing.
+        && (target.is_nullable() || !source.is_nullable())
+        && is_nullability_relaxing_relabel(source.data_type(), target.data_type())
 }
 
 /// Carries `column` to `target_field`'s type by relabelling its declaration, sharing every buffer —
 /// values, offsets and validity — with the original.
 ///
-/// Only called for a pair [`is_nullability_only_relabel`] accepts, so no value changes meaning.
+/// Only called for a pair [`is_nullability_relaxing_relabel`] accepts, so no value changes meaning.
 fn relabel_nullability(column: &ArrayRef, target_field: &Field) -> Result<ArrayRef> {
-    let data = column.to_data();
-
-    if let Some(path) =
-        narrowed_field_holding_nulls(&data, target_field.data_type(), target_field.name())
-    {
-        return NullsUnderNonNullableFieldSnafu {
-            column: target_field.name(),
-            path,
-        }
-        .fail();
-    }
-
-    relabel_array_data(data, target_field.data_type())
+    relabel_array_data(column.to_data(), target_field.data_type())
         .map(make_array)
         .context(UnableToConvertRecordBatchSnafu)
-}
-
-/// The path to the first nested field `target` declares non-nullable where `data` holds nulls.
-///
-/// Relabelling carries the validity buffers across untouched, so narrowing a field the data
-/// actually leaves null would hand on an array whose declaration contradicts its own null mask —
-/// which every later kernel is entitled to trust. Such a pair is reported against the field it
-/// disagrees on instead.
-///
-/// `data`'s type and `target` satisfy [`is_nullability_only_relabel`], so the child counts line up
-/// at every level walked here; `zip` truncates rather than indexing, so a disagreement cannot panic.
-fn narrowed_field_holding_nulls(data: &ArrayData, target: &DataType, path: &str) -> Option<String> {
-    let children: Vec<(&ArrayData, &FieldRef)> = match target {
-        DataType::List(item)
-        | DataType::LargeList(item)
-        | DataType::ListView(item)
-        | DataType::LargeListView(item)
-        | DataType::FixedSizeList(item, _)
-        | DataType::Map(item, _) => data
-            .child_data()
-            .iter()
-            .zip(std::iter::once(item))
-            .collect(),
-        DataType::Struct(fields) => data.child_data().iter().zip(fields.iter()).collect(),
-        _ => return None,
-    };
-
-    for (child, field) in children {
-        let child_path = format!("{path}.{}", field.name());
-        if !field.is_nullable() && child.null_count() > 0 {
-            return Some(child_path);
-        }
-        if let Some(found) = narrowed_field_holding_nulls(child, field.data_type(), &child_path) {
-            return Some(found);
-        }
-    }
-
-    None
 }
 
 /// Flattens a list of struct types with a single field into a list of primitive types.
@@ -2215,34 +2167,55 @@ mod nullability_alignment_tests {
         assert_eq!(aligned.num_rows(), 1);
     }
 
-    /// The one shape a relabel cannot carry: the entries array really does hold nulls, so
-    /// narrowing the field would hand on an array whose declaration contradicts its own null
-    /// mask. It is refused, and the refusal names the column and the field rather than
-    /// reporting Arrow's `MapArray entries cannot contain nulls` against neither.
+    /// Narrowing is not a relabel, and the boundary is load-bearing rather than tidy. Whether a
+    /// non-nullable field may hold nulls depends on its parent: Arrow requires a non-nullable
+    /// struct child's nulls to be a *subset of its parent's* rather than absent, so a masked null
+    /// is legal, and a list-like parent's offsets decide which child slots are addressed at all.
+    /// `arrow_cast::cast` already implements those rules — and already serves this direction — so
+    /// the narrowing pair keeps that path instead of a second, stricter transcription here.
     #[test]
-    fn nulls_under_a_narrowed_field_are_refused_by_name() {
+    fn a_narrowed_nested_field_is_not_relabelled() {
+        assert!(
+            !is_nullability_relaxing_relabel(&map_type(true), &map_type(false)),
+            "a nullable source under a non-nullable target is a narrowing"
+        );
+        assert!(
+            is_nullability_relaxing_relabel(&map_type(false), &map_type(true)),
+            "the relaxing direction is what a relabel carries"
+        );
+    }
+
+    /// The narrowing direction still aligns end to end, through the cast path. Arrow performs it,
+    /// so restricting the relabel must not have taken it away.
+    ///
+    /// Deliberately not killed by any neuter in this module: it pins behaviour this change leaves
+    /// alone, so it is a positive control on Arrow rather than a guard on the logic above.
+    #[test]
+    fn a_narrowed_nested_field_still_aligns_through_the_cast_path() {
         let column = Arc::new(map_from_parts(
             true,
-            Some(NullBuffer::from(vec![true, false])),
+            None,
             &[0, 2],
             vec!["a", "b"],
-            vec![Some("1"), Some("2")],
+            vec![Some("1"), None],
         )) as ArrayRef;
 
-        let error = try_cast_to(
+        let aligned = try_cast_to(
             batch_of("col_map", column),
             schema_of("col_map", map_type(false)),
         )
-        .expect_err("entry nulls cannot be relabelled away");
+        .expect("arrow_cast serves the narrowing direction");
 
-        let rendered = error.to_string();
-        assert!(
-            rendered.contains("col_map") && rendered.contains("col_map.entries"),
-            "the refusal has to name the column and the field it disagrees on, got: {rendered}"
+        assert_eq!(
+            aligned.schema().field(0).data_type(),
+            aligned.column(0).data_type()
         );
-        assert!(
-            rendered.contains("holds nulls"),
-            "the refusal has to say what is wrong with the data, got: {rendered}"
+        assert_eq!(
+            map_pairs(&aligned),
+            vec![
+                ("a".to_string(), Some("1".to_string())),
+                ("b".to_string(), None),
+            ]
         );
     }
 
@@ -2255,14 +2228,20 @@ mod nullability_alignment_tests {
             Arc::new(Field::new(
                 "key_value",
                 DataType::Struct(entry_fields()),
-                false,
+                true,
             )),
             false,
         );
 
+        // Both pairs relax `entries` from non-nullable to nullable, so the name is the only
+        // thing that can decide them.
         assert!(
-            !is_nullability_only_relabel(&map_type(true), &renamed_entries),
-            "a renamed entries field is not a nullability-only difference"
+            !is_nullability_relaxing_relabel(&map_type(false), &renamed_entries),
+            "a renamed entries field is not a nullability difference"
+        );
+        assert!(
+            is_nullability_relaxing_relabel(&map_type(false), &map_type(true)),
+            "the same pair under the original name is a relabel"
         );
     }
 
@@ -2274,13 +2253,17 @@ mod nullability_alignment_tests {
             Arc::new(Field::new(
                 "entries",
                 DataType::Struct(entry_fields()),
-                false,
+                true,
             )),
             true,
         );
 
-        assert!(!is_nullability_only_relabel(&map_type(true), &sorted));
-        assert!(!is_nullability_only_relabel(&map_type(false), &sorted));
+        // Differs from the accepted `map_type(false)` -> `map_type(true)` pair only in `sorted`.
+        assert!(!is_nullability_relaxing_relabel(&map_type(false), &sorted));
+        assert!(is_nullability_relaxing_relabel(
+            &map_type(false),
+            &map_type(true)
+        ));
     }
 
     /// A `FixedSizeList`'s length is how many values each row owns, so a pair differing there
@@ -2294,13 +2277,14 @@ mod nullability_alignment_tests {
             )
         };
 
-        assert!(!is_nullability_only_relabel(
-            &fixed(2, true),
-            &fixed(3, false)
+        // The two differ in exactly one thing — the length — so only that can decide them.
+        assert!(!is_nullability_relaxing_relabel(
+            &fixed(2, false),
+            &fixed(3, true)
         ));
-        assert!(is_nullability_only_relabel(
-            &fixed(2, true),
-            &fixed(2, false)
+        assert!(is_nullability_relaxing_relabel(
+            &fixed(2, false),
+            &fixed(2, true)
         ));
     }
 
@@ -2311,7 +2295,7 @@ mod nullability_alignment_tests {
         let source = DataType::Dictionary(Box::new(DataType::Int32), Box::new(map_type(true)));
         let target = DataType::Dictionary(Box::new(DataType::Int32), Box::new(map_type(false)));
 
-        assert!(!is_nullability_only_relabel(&source, &target));
+        assert!(!is_nullability_relaxing_relabel(&source, &target));
     }
 
     /// An extension type lives in a field's metadata and renames what its storage buffers mean,
@@ -2328,7 +2312,7 @@ mod nullability_alignment_tests {
             )
         };
 
-        assert!(!is_nullability_only_relabel(
+        assert!(!is_nullability_relaxing_relabel(
             &DataType::List(extension("arrow.uuid")),
             &DataType::List(extension("arrow.opaque")),
         ));

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -76,8 +76,9 @@ impl From<Error> for DataFusionError {
 pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<RecordBatch> {
     let existing_schema = record_batch.schema();
 
-    // When schema is superset of the existing schema, including a new column, and nullable column,
-    // return a new RecordBatch to reflect the change.
+    // Re-label the batch wholesale when the target asks for nothing the columns do not already
+    // carry. `Fields::contains` pairs positionally and demands equal length, so this covers a
+    // schema that only relaxes a field — a column the target adds is handled per column below.
     //
     // `Schema::contains` answers "is this assignable", which permits a nested field's nullability
     // to differ; `RecordBatch` requires a column's type and its field's type to be identical, and
@@ -138,15 +139,22 @@ pub fn try_cast_to(record_batch: RecordBatch, schema: SchemaRef) -> Result<Recor
     RecordBatch::try_new(schema, cols).context(UnableToConvertRecordBatchSnafu)
 }
 
-/// Whether every field of `existing` has a same-named field in `target` carrying the identical
-/// type — the condition `RecordBatch` enforces, as distinct from the assignability
-/// `Schema::contains` answers.
+/// Whether the two schemas declare identical types, field by field — the condition `RecordBatch`
+/// enforces, as distinct from the assignability [`Schema::contains`] answers.
+///
+/// Paired positionally, the way `Fields::contains` pairs them, so this and the test it qualifies
+/// are answering about the same field pairs rather than two pairings that could disagree when a
+/// name repeats. Names themselves are not re-compared: `contains` has already established those.
 fn declares_the_same_types(target: &SchemaRef, existing: &SchemaRef) -> bool {
-    existing.fields().iter().all(|existing_field| {
-        target
-            .field_with_name(existing_field.name())
-            .is_ok_and(|target_field| target_field.data_type() == existing_field.data_type())
-    })
+    target.fields().len() == existing.fields().len()
+        && target
+            .fields()
+            .iter()
+            .zip(existing.fields())
+            .all(|(target_field, existing_field)| {
+                Arc::ptr_eq(target_field, existing_field)
+                    || target_field.data_type() == existing_field.data_type()
+            })
 }
 
 /// Returns `true` when `source` → `target` is a timestamp-to-timestamp cast that

--- a/crates/arrow_tools/src/record_batch.rs
+++ b/crates/arrow_tools/src/record_batch.rs
@@ -16,9 +16,8 @@ limitations under the License.
 
 use arrow::{
     array::{
-        Array, ArrayData, ArrayRef, BinaryViewArray, GenericByteViewArray, ListArray,
-        MutableArrayData, RecordBatch, RecordBatchOptions, StringViewArray, StructArray,
-        make_array, new_null_array,
+        Array, ArrayRef, BinaryViewArray, GenericByteViewArray, ListArray, MutableArrayData,
+        RecordBatch, RecordBatchOptions, StringViewArray, StructArray, make_array, new_null_array,
     },
     buffer::{Buffer, OffsetBuffer},
     datatypes::{
@@ -1925,7 +1924,7 @@ mod test {
 #[cfg(test)]
 mod nullability_alignment_tests {
     use super::*;
-    use arrow::array::{Int32Array, MapArray, StringArray, StructArray};
+    use arrow::array::{ArrayData, Int32Array, MapArray, StringArray, StructArray};
     use arrow::buffer::NullBuffer;
     use arrow::datatypes::Fields;
 


### PR DESCRIPTION
## Summary

`arrow_tools::record_batch::try_cast_to` is the shared schema-alignment entry point — `SchemaCastScanExec`, `reconcile_stream_nullability`, the DuckDB/SQLite accelerator write paths, and several Cayenne paths all go through it. It decided both of its fast paths with `Schema::contains` / `Field::contains`, which answer *"is this assignable"* and so permit a nested field's nullability to differ. `RecordBatch` requires a column's type and its field's type to be **identical**, and `with_schema` re-labels the schema without touching the columns.

Those two disagree, and the gap has two faces:

- **Silent.** A batch whose only difference is a nested nullability flag took the schema-level fast path and came back **advertising a type none of its columns carried** — e.g. a `MAP` column declared with nullable `entries` over data still carrying it non-nullable. No error; the batch reads as aligned and then fails in whichever kernel first rebuilds the column, reporting `MapArray entries cannot contain nulls` against data holding none.
- **Loud, but misattributed.** With a sibling column that genuinely needed a cast, the schema-level path could not fire, the per-column test waved the same column through unchanged, and `RecordBatch::try_new` then refused the whole batch with a message rendering two whole `Map` types that differ somewhere.

### Root cause, and a correction to the issue

The issue predicted that `schema.contains(&existing_schema)` would **fail** for such a pair and fall through to `arrow_cast::cast`, which cannot serve it. Measured against Arrow 58.4 on `trunk`, it resolves the other way round, and the direction matters:

| pair | `Field::contains` | `arrow_cast::cast` |
|---|---|---|
| target `entries` **non-nullable**, source nullable | `false` | **succeeds** |
| target `entries` **nullable**, source non-nullable | **`true`** | fails — `MapArray entries cannot contain nulls` |

So the pair that reaches `cast` is the one `cast` handles, and the pair `cast` cannot handle never reaches it — `contains` waves it through first. The defect is the over-permissive short-circuit, not a missing cast path.

## Changes

- Both fast paths now additionally require the declared types to be identical, so a merely-assignable column reaches `cast_column` instead of being passed through.
- `cast_column` carries such a pair across by **relabelling**: nullability lives in the type rather than in any buffer, so values, offsets and validity are shared rather than rebuilt.
- The relabel is restricted to the **relaxing** direction — the target must be at least as permissive at every level. Narrowing keeps its existing `arrow_cast::cast` path, which the table above shows already serves it. That is deliberate: whether a non-nullable field may hold nulls is not a property of that field's array alone — Arrow requires a non-nullable struct child's nulls to be a *subset of its parent's* rather than absent, so a masked null is legal, and a list-like parent's offsets decide which child slots are addressed at all. `cast` implements those rules; a second, stricter transcription of them here would refuse arrays Arrow considers valid.
- The relabel test is deliberately narrow and **fails closed**: field names and metadata must match (a rename is a different question, and admitting one would make a reorder of same-typed siblings indistinguishable from a pair of renames), and a type the walk does not cover — `Union`, `Dictionary`, `RunEndEncoded` — keeps its existing cast path rather than being relabelled on a pairing that was never checked.

### Behaviour change worth flagging

A nullability difference carried *inside* an unwalked type (e.g. under a `Dictionary`) previously took the schema fast path and produced a silently inconsistent batch. It now reaches `cast_column`, fails the relabel test, and goes to `arrow_cast::cast`, which may return an error. That trades a silently wrong declaration for a loud one, which is the intended direction, but it is a shape that previously "worked".

## Performance impact

Net positive. The exact-type test is `O(fields)` with an `Arc::ptr_eq` short-circuit and pairs positionally, exactly as `Fields::contains` already does, so it adds no allocation and no asymptotic cost to a check that already walks the same pairs. Where it now diverts a column to `cast_column`, the relabel shares every buffer instead of rebuilding the array, so the diverted case is cheaper than the cast it replaces.

## Scope

This is §2 of #13285 (schema alignment). §1 — normalizing an illegal `entries` declaration at the Flight, FlightSQL-server and WASM **ingress** decode points — is split out as #13495: it changes the read path of five connectors and two server endpoints, each with its own error type, which #13285 itself notes wants separate tests and review.

## Test plan

- `make lint`
- `make nextest`
- 11 new unit tests in `crates/arrow_tools/src/record_batch.rs` covering: a batch advertising the type its columns actually carry (the silent case), a map column beside one needing a genuine cast (the refused case), a map nested inside a struct, the narrowing direction still aligning through the cast path, and six negative cases pinning the fail-closed boundary (narrowing, rename, `sorted` flag, `FixedSizeList` length, an unwalked `Dictionary`, a changed `ARROW:extension:name`), plus a genuine type change still casting.
- Every test was checked against an 11-neuter matrix: each neuter kills at least one test, and every test has a killer except `a_narrowed_nested_field_still_aligns_through_the_cast_path`, which is a deliberate positive control on behaviour this change leaves alone (noted as such in its doc comment). Each negative test's two assertions differ in exactly one property, so only that property can decide them.
- Rebuilding the matrix twice paid for itself. The first set of headline tests passed with the *entire fix removed*, which is what surfaced that the original diagnosis had the direction backwards; and after the narrowing restriction, three negative tests silently stopped isolating their variable (their "control" had become a narrowing too), which the matrix caught as neuters that killed nothing.
- `cargo test -p runtime-table -p accelerator-duckdb -p accelerator-sqlite --lib`: 308 passed, 1 failed — `accelerated::refresh::tests::test_refresh_status_change_to_ready`. Confirmed **pre-existing**: reverting `record_batch.rs` to `origin/trunk` and re-running produced the identical set (308 passed, same 1 failed). It polls a 3s bound and installs a process-global meter provider.

## Review gate

- Adversarial review: **skipped** — `codex` ran and exited 1 with `Codex error: Your workspace is out of credits. Ask your workspace owner to refill in order to continue.`; `grok` reported `result=not-installed`. Receipt: `engine=none exit=1 job=none verdict=unparsed`, base `origin/trunk`. A hand adversarial pass was done in its place and found one real defect, now fixed: the exact-type test originally paired fields by name lookup, which is `O(n²)` and pairs differently from the `Fields::contains` test it qualifies when a name repeats — it now pairs positionally.
- `/security-review`: ran on this diff; **no HIGH or MEDIUM findings**. The diff adds pure type predicates, a metadata-only relabel and a null-check walk — no `unsafe`, no SQL, no path handling, no new deserialization surface. The one new message interpolates a column name and a nested field path (schema identifiers, not row values), so it carries no data content, and the relabel is gated so a value's interpretation can never change.
- `/simplify`: applied — the positional-pairing rewrite above, plus removal of a test helper left orphaned when a vacuous test was dropped (it was a `dead_code` warning, which `-Dwarnings` would have failed in CI).

**Round 2 (after Copilot's review).** Copilot found that the narrowing guard's `child.null_count() > 0` test was unsound: `StructArray::try_new` requires a non-nullable child's nulls to be a *subset of the parent's*, not absent, so a masked null is legal and the guard refused valid arrays. Confirmed, and fixed by removing the narrowing direction from the relabel entirely rather than transcribing Arrow's rules a second time — the measurement above shows `cast` already serves that direction. The null walk and the `NullsUnderNonNullableField` error are deleted. Adversarial engine still out of credits, so this round also had a hand pass in place of it; `/security-review` is unchanged by a diff that only removes code and tightens a predicate.

Fixes #13285

## Checklist

- [x] Root cause identified and stated, including where the issue's own diagnosis was wrong
- [x] Regression tests that fail on the old code and pass on the new
- [x] Neuter matrix: no vacuous test, no unguarded restriction
- [x] Pre-existing test failure confirmed against a `trunk` control rather than assumed
- [x] Deferred scope filed as #13495 and linked
- [x] Copilot's finding confirmed against Arrow's own rule and fixed at the cause
- [x] `make signoff` green / `Attestation` green (run 32839204111)
