### PR TITLE
fix(search): screen every vector write for a non-finite embedding (fixes #13089)

### DIFF
--- a/crates/search/src/index/duckdb/mod.rs
+++ b/crates/search/src/index/duckdb/mod.rs
@@ -365,9 +365,9 @@ pub(super) fn validate_vector(vector: &[f32], dims: i32, context: &str) -> DataF
             vector.len()
         )));
     }
-    if vector.iter().any(|value| !value.is_finite()) {
+    if let Some(position) = crate::index::write_util::first_non_finite(vector) {
         return Err(DataFusionError::Execution(format!(
-            "DuckDB vector {context} contains a non-finite value."
+            "DuckDB vector {context} contains a non-finite value at position {position}."
         )));
     }
     Ok(())

--- a/crates/search/src/index/duckdb/write.rs
+++ b/crates/search/src/index/duckdb/write.rs
@@ -27,7 +27,12 @@ use llms::embeddings::{Embed, EmbeddingInput};
 use snafu::{ResultExt, Snafu};
 use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
-use crate::index::{duckdb::DuckDBVectorIndex, embedding_col};
+use crate::index::{
+    Index,
+    duckdb::DuckDBVectorIndex,
+    embedding_col,
+    write_util::{first_non_finite, non_finite_embedding_warning},
+};
 
 #[derive(Debug, Snafu)]
 pub(super) enum WriteError {
@@ -80,6 +85,7 @@ pub(super) async fn write_embeddings(
     .await?;
 
     update_embedding_column_in_batch(
+        index.name(),
         &record,
         &index.embedded_column,
         &embedding_vectors,
@@ -127,6 +133,7 @@ async fn embed_column(
 }
 
 fn update_embedding_column_in_batch(
+    index_name: &str,
     record: &RecordBatch,
     embedded_column_name: &str,
     embedding_vectors: &[Option<Vec<f32>>],
@@ -135,7 +142,7 @@ fn update_embedding_column_in_batch(
     let embedding_column_name = embedding_col(embedded_column_name);
     let schema = record.schema();
     let mut columns = record.columns().to_vec();
-    let embedding_array = create_embedding_array(embedding_vectors, dimension)?;
+    let embedding_array = create_embedding_array(index_name, embedding_vectors, dimension)?;
 
     let target_schema = if let Some((idx, _)) = schema.column_with_name(&embedding_column_name) {
         columns[idx] = embedding_array;
@@ -156,6 +163,7 @@ fn update_embedding_column_in_batch(
 
 #[expect(clippy::cast_sign_loss)]
 fn create_embedding_array(
+    index_name: &str,
     embedding_vectors: &[Option<Vec<f32>>],
     dimension: i32,
 ) -> Result<Arc<dyn Array>, WriteError> {
@@ -176,11 +184,19 @@ fn create_embedding_array(
     let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), dim);
     builder = builder.with_field(Field::new_list_field(DataType::Float32, false));
 
+    let mut non_finite_rows: Vec<usize> = Vec::new();
     for (row, embedding) in embedding_vectors.iter().enumerate() {
         match embedding {
-            Some(vector) if vector.len() == expected => {
+            // A non-finite component has no defined distance under any metric the HNSW
+            // index offers, so the row is stored with a NULL embedding rather than indexed.
+            Some(vector) if vector.len() == expected && first_non_finite(vector).is_none() => {
                 builder.values().append_slice(vector);
                 builder.append(true);
+            }
+            Some(vector) if vector.len() == expected => {
+                non_finite_rows.push(row);
+                builder.values().append_value_n(0.0, expected);
+                builder.append(false);
             }
             Some(vector) => {
                 return Err(WriteError::EmbeddingDimensionMismatch {
@@ -197,5 +213,63 @@ fn create_embedding_array(
         }
     }
 
+    if !non_finite_rows.is_empty() {
+        tracing::warn!(
+            "{}",
+            non_finite_embedding_warning(index_name, &non_finite_rows, embedding_vectors.len())
+        );
+    }
+
     Ok(Arc::new(builder.finish()))
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::{Array, FixedSizeListArray};
+
+    use super::create_embedding_array;
+
+    /// The HNSW write path never screened its vectors — `validate_vector` existed but was
+    /// only ever called on the query side, so a `[NaN, 2.0]` embedding was indexed and every
+    /// distance computed against it came back NaN (regression test for #13089).
+    #[test]
+    fn a_non_finite_embedding_is_nulled_rather_than_indexed() {
+        let embeddings = vec![
+            Some(vec![0.1, 0.2]),
+            Some(vec![f32::NAN, 0.2]),
+            Some(vec![0.1, f32::INFINITY]),
+            Some(vec![f32::NEG_INFINITY, 0.2]),
+            None,
+            Some(vec![0.0, 0.0]),
+        ];
+
+        let array = create_embedding_array("duckdb_vector_index", &embeddings, 2)
+            .expect("builds the array");
+        let list = array
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("FixedSizeListArray");
+
+        assert_eq!(list.len(), 6);
+        assert!(list.is_valid(0), "a finite embedding stays indexed");
+        assert!(list.is_null(1), "a NaN component nulls the embedding");
+        assert!(list.is_null(2), "an infinite component nulls the embedding");
+        assert!(
+            list.is_null(3),
+            "a negative-infinite component nulls the embedding"
+        );
+        assert!(list.is_null(4), "a missing embedding stays null");
+        assert!(
+            list.is_valid(5),
+            "an all-zero embedding is finite and stays indexed"
+        );
+    }
+
+    /// A dimension mismatch must still be an error, not silently nulled by the new screen.
+    #[test]
+    fn a_dimension_mismatch_is_still_an_error() {
+        let embeddings = vec![Some(vec![0.1, 0.2, 0.3])];
+        create_embedding_array("duckdb_vector_index", &embeddings, 2)
+            .expect_err("a wrong-width embedding is rejected");
+    }
 }

--- a/crates/search/src/index/duckdb/write.rs
+++ b/crates/search/src/index/duckdb/write.rs
@@ -31,7 +31,7 @@ use crate::index::{
     Index,
     duckdb::DuckDBVectorIndex,
     embedding_col,
-    write_util::{first_non_finite, non_finite_embedding_warning},
+    write_util::{first_non_finite, warn_non_finite_embeddings},
 };
 
 #[derive(Debug, Snafu)]
@@ -213,12 +213,7 @@ fn create_embedding_array(
         }
     }
 
-    if !non_finite_rows.is_empty() {
-        tracing::warn!(
-            "{}",
-            non_finite_embedding_warning(index_name, &non_finite_rows, embedding_vectors.len())
-        );
-    }
+    warn_non_finite_embeddings(index_name, &non_finite_rows, embedding_vectors.len());
 
     Ok(Arc::new(builder.finish()))
 }

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -256,8 +256,9 @@ fn build_documents(
     let mut null_pk_samples: Vec<usize> = Vec::new();
     let mut zero_or_nan_skips: usize = 0;
     let mut zero_or_nan_samples: Vec<usize> = Vec::new();
-    let mut non_finite_skips: usize = 0;
-    let mut non_finite_samples: Vec<usize> = Vec::new();
+    // Every affected row, not a truncated sample: `warn_non_finite_embeddings` does the
+    // truncation for display and needs the real count to report it.
+    let mut non_finite_rows: Vec<usize> = Vec::new();
     let mut missing_embedding_skips: usize = 0;
 
     let expected_dims = usize::try_from(index.dims.max(0)).unwrap_or(0);
@@ -298,10 +299,7 @@ fn build_documents(
         }
 
         if first_non_finite(embedding).is_some() {
-            non_finite_skips += 1;
-            if non_finite_samples.len() < SAMPLE_LIMIT {
-                non_finite_samples.push(row);
-            }
+            non_finite_rows.push(row);
             continue;
         }
 
@@ -346,11 +344,10 @@ fn build_documents(
             "Skipped {zero_or_nan_skips} record(s) for Elasticsearch index '{es_index}': embedding vector is all zeros or NaN. Sample row indices: {zero_or_nan_samples:?}"
         );
     }
-    if non_finite_skips > 0 {
-        tracing::warn!(
-            "Skipped {non_finite_skips} record(s) for Elasticsearch index '{es_index}': embedding vector contains non-finite values (NaN or infinity). Sample row indices: {non_finite_samples:?}"
-        );
-    }
+    // This is the one place a non-finite embedding is reported for Elasticsearch: the
+    // embedding-column builder below runs over the same rows on every write, so reporting
+    // there as well would double every line.
+    warn_non_finite_embeddings(es_index, &non_finite_rows, embedding_vectors.len());
     if missing_embedding_skips > 0 {
         tracing::debug!(
             "Skipped {missing_embedding_skips} record(s) for Elasticsearch index '{es_index}': no embedding generated (expected when embedded column is NULL)."
@@ -499,8 +496,8 @@ fn create_embedding_array(
         }
     }
 
-    warn_non_finite_embeddings(es_index, &non_finite_rows, embedding_vectors.len());
-
+    // Deliberately silent: `build_documents` runs first on every write path that reaches
+    // here and has already reported these rows once.
     Ok(Arc::new(builder.finish()))
 }
 

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -38,7 +38,7 @@ use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
 use crate::index::elasticsearch::ElasticsearchIndex;
 use crate::index::embedding_col;
-use crate::index::write_util::{first_non_finite, non_finite_embedding_warning};
+use crate::index::write_util::{first_non_finite, warn_non_finite_embeddings};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -499,12 +499,7 @@ fn create_embedding_array(
         }
     }
 
-    if !non_finite_rows.is_empty() {
-        tracing::warn!(
-            "{}",
-            non_finite_embedding_warning(es_index, &non_finite_rows, embedding_vectors.len())
-        );
-    }
+    warn_non_finite_embeddings(es_index, &non_finite_rows, embedding_vectors.len());
 
     Ok(Arc::new(builder.finish()))
 }

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -38,7 +38,7 @@ use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
 use crate::index::elasticsearch::ElasticsearchIndex;
 use crate::index::embedding_col;
-use crate::index::write_util::{first_non_finite, warn_non_finite_embeddings};
+use crate::index::write_util::{EMBEDDING_REMEDY, first_non_finite, warn_non_finite_embeddings};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -341,7 +341,7 @@ fn build_documents(
     }
     if zero_or_nan_skips > 0 {
         tracing::warn!(
-            "Skipped {zero_or_nan_skips} record(s) for Elasticsearch index '{es_index}': embedding vector is all zeros or NaN. Sample row indices: {zero_or_nan_samples:?}"
+            "Skipped {zero_or_nan_skips} record(s) for Elasticsearch index '{es_index}': the embedding is all zeros, or mixes zeros with a NaN, so those records are not indexed and vector search will never return them (rows {zero_or_nan_samples:?}). {EMBEDDING_REMEDY}"
         );
     }
     // This is the one place a non-finite embedding is reported for Elasticsearch: the

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -38,6 +38,7 @@ use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
 use crate::index::elasticsearch::ElasticsearchIndex;
 use crate::index::embedding_col;
+use crate::index::write_util::{first_non_finite, non_finite_embedding_warning};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -296,7 +297,7 @@ fn build_documents(
             continue;
         }
 
-        if embedding.iter().any(|x| !x.is_finite()) {
+        if first_non_finite(embedding).is_some() {
             non_finite_skips += 1;
             if non_finite_samples.len() < SAMPLE_LIMIT {
                 non_finite_samples.push(row);
@@ -468,11 +469,19 @@ fn create_embedding_array(
     let item_field = Field::new_list_field(DataType::Float32, false);
     builder = builder.with_field(item_field);
 
+    let mut non_finite_rows: Vec<usize> = Vec::new();
     for (row, emb) in embedding_vectors.iter().enumerate() {
         match emb {
-            Some(v) if v.len() == expected => {
+            // The bulk path already declines to index a non-finite vector; null it here too so
+            // the batch handed downstream cannot carry a vector Elasticsearch never stored.
+            Some(v) if v.len() == expected && first_non_finite(v).is_none() => {
                 builder.values().append_slice(v);
                 builder.append(true);
+            }
+            Some(v) if v.len() == expected => {
+                non_finite_rows.push(row);
+                builder.values().append_value_n(0.0, expected);
+                builder.append(false);
             }
             Some(v) => {
                 return Err(Error::EmbeddingDimensionMismatch {
@@ -488,6 +497,13 @@ fn create_embedding_array(
                 builder.append(false);
             }
         }
+    }
+
+    if !non_finite_rows.is_empty() {
+        tracing::warn!(
+            "{}",
+            non_finite_embedding_warning(es_index, &non_finite_rows, embedding_vectors.len())
+        );
     }
 
     Ok(Arc::new(builder.finish()))
@@ -878,8 +894,11 @@ fn scan_failed_items(items: &[Value]) -> (usize, Option<String>) {
 mod tests {
     use serde_json::json;
 
+    use arrow::array::{Array, FixedSizeListArray};
+
     use super::{
-        Error, MAX_CATEGORY_LEN, UNRECOGNIZED_CATEGORY, categorical_token, inspect_bulk_response,
+        Error, MAX_CATEGORY_LEN, UNRECOGNIZED_CATEGORY, categorical_token, create_embedding_array,
+        inspect_bulk_response,
     };
 
     /// A primary-key value of the shape that makes this a data-leak: identifying on its own.
@@ -1218,5 +1237,32 @@ mod tests {
             message.contains("missing a boolean `errors` field"),
             "expected the non-boolean `errors` case to be rejected by shape: {message}"
         );
+    }
+
+    /// The bulk path already declines to index a non-finite vector, but the batch it hands
+    /// downstream is what the accelerated table and the schema check see. Before #13089 that
+    /// batch still carried the vector Elasticsearch had refused.
+    #[test]
+    fn a_non_finite_embedding_is_nulled_in_the_returned_batch() {
+        let embeddings = vec![
+            Some(vec![0.1, 0.2]),
+            Some(vec![f32::NAN, 0.2]),
+            Some(vec![0.1, f32::INFINITY]),
+            None,
+            Some(vec![0.0, 0.0]),
+        ];
+
+        let array =
+            create_embedding_array("idx", &embeddings, 2).expect("builds the embedding array");
+        let list = array
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("FixedSizeListArray");
+
+        assert!(list.is_valid(0), "a finite embedding stays indexed");
+        assert!(list.is_null(1), "a NaN component nulls the embedding");
+        assert!(list.is_null(2), "an infinite component nulls the embedding");
+        assert!(list.is_null(3), "a missing embedding stays null");
+        assert!(list.is_valid(4), "an all-zero embedding is finite");
     }
 }

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -208,15 +208,23 @@ impl MemoryVectorIndex {
                     (Some(key), Some(vector)) => {
                         // All-zero / all-NaN vectors have no defined direction and
                         // would corrupt similarity scores — skip them.
-                        let valid = !vector.iter().all(|&v| v == 0.0 || v.is_nan());
-                        if valid {
-                            keys.push(key.clone());
-                        } else {
+                        let all_zero_or_nan = vector.iter().all(|&v| v == 0.0 || v.is_nan());
+                        // A single NaN or infinity poisons every score computed against the
+                        // vector, so one bad component disqualifies the whole row too.
+                        let non_finite = write_util::first_non_finite(vector).is_some();
+                        if all_zero_or_nan {
                             tracing::warn!(
                                 "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes or contains only invalid values"
                             );
+                        } else if non_finite {
+                            tracing::warn!(
+                                "Skipping record '{key}' for memory vector index '{INDEX_NAME}': the embedding contains a NaN or infinite value, so the record is not indexed and vector search will never return it. {}",
+                                write_util::NON_FINITE_EMBEDDING_REMEDY
+                            );
+                        } else {
+                            keys.push(key.clone());
                         }
-                        valid
+                        !all_zero_or_nan && !non_finite
                     }
                     (None, _) => {
                         tracing::warn!(
@@ -426,6 +434,7 @@ impl SearchIndex for MemoryVectorIndex {
         );
 
         let updated = write_util::update_embedding_column_in_batch(
+            INDEX_NAME,
             &record,
             &self.embedded_column,
             &embedding_vectors,
@@ -526,6 +535,43 @@ mod tests {
         }
     }
 
+    /// An embedder that returns one bad component among real values for a chosen row — the
+    /// shape a provider produces on a numerically unstable response.
+    #[derive(Debug)]
+    struct PoisonEmbed {
+        poisoned_text: String,
+        bad_value: f32,
+    }
+
+    impl PoisonEmbed {
+        fn vector_for(&self, text: &str) -> Vec<f32> {
+            if text == self.poisoned_text {
+                let mut vector = byte_vector(text);
+                vector[0] = self.bad_value;
+                vector
+            } else {
+                byte_vector(text)
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Embed for PoisonEmbed {
+        async fn embed(&self, input: EmbeddingInput) -> llms::embeddings::Result<Vec<Vec<f32>>> {
+            match input {
+                EmbeddingInput::String(s) => Ok(vec![self.vector_for(&s)]),
+                EmbeddingInput::StringArray(v) => {
+                    Ok(v.iter().map(|s| self.vector_for(s)).collect())
+                }
+                _ => Ok(vec![]),
+            }
+        }
+
+        fn size(&self) -> i32 {
+            DIM
+        }
+    }
+
     /// These tests never execute a query plan, so the query-time `embed(text, model)` UDF is
     /// only needed to construct the index.
     fn embed_udf() -> Arc<ScalarUDF> {
@@ -543,11 +589,15 @@ mod tests {
     }
 
     fn memory_index() -> MemoryVectorIndex {
+        memory_index_with(Arc::new(ByteEmbed))
+    }
+
+    fn memory_index_with(embedder: Arc<dyn Embed>) -> MemoryVectorIndex {
         MemoryVectorIndex::try_new(
             "content".to_string(),
             vec![Field::new("id", DataType::Int64, false)],
             MetadataColumns::none(),
-            Arc::new(ByteEmbed),
+            embedder,
             embed_udf(),
             "model_name".to_string(),
             MemoryDistanceMetric::Cosine,
@@ -789,5 +839,43 @@ mod tests {
             .expect("the write window closes");
 
         assert_eq!(indexed_ids(&index), vec![1, 3]);
+    }
+
+    /// A vector carrying one NaN among real values must not reach the store. Before #13089 the
+    /// filter tested `all`, so only a wholly-zero-or-NaN vector was skipped and a poisoned row
+    /// was indexed — every score computed against it is NaN.
+    #[tokio::test]
+    async fn a_partially_non_finite_embedding_is_not_indexed() {
+        for bad_value in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let index = memory_index_with(Arc::new(PoisonEmbed {
+                poisoned_text: "row 2".to_string(),
+                bad_value,
+            }));
+            write_window(&index, WriteWindow::Append, &[1, 2, 3]).await;
+
+            assert_eq!(
+                indexed_ids(&index),
+                vec![1, 3],
+                "row 2's embedding carries {bad_value}, which has no defined distance under \
+                 any metric, so the row must not be indexed"
+            );
+        }
+    }
+
+    /// The screen is for non-finite components only: a vector with a zero among real values is
+    /// still finite and scoreable, so it must stay indexed.
+    #[tokio::test]
+    async fn a_zeroed_component_leaves_the_embedding_indexed() {
+        let index = memory_index_with(Arc::new(PoisonEmbed {
+            poisoned_text: "row 2".to_string(),
+            bad_value: 0.0,
+        }));
+        write_window(&index, WriteWindow::Append, &[1, 2, 3]).await;
+
+        assert_eq!(
+            indexed_ids(&index),
+            vec![1, 2, 3],
+            "zeroing one component leaves a finite vector, which stays indexed"
+        );
     }
 }

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -212,16 +212,16 @@ impl MemoryVectorIndex {
                         // A single NaN or infinity poisons every score computed against the
                         // vector, so one bad component disqualifies the whole row too.
                         let non_finite = write_util::first_non_finite(vector).is_some();
+                        // Only the all-zero case is reported per record. A non-finite one is
+                        // deliberately silent: `update_embedding_column_in_batch` runs first on
+                        // this path and has already named every affected row in one batched
+                        // warning, so warning again per row would multiply one degraded
+                        // embedding response into a line per record.
                         if all_zero_or_nan {
                             tracing::warn!(
                                 "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes or contains only invalid values"
                             );
-                        } else if non_finite {
-                            tracing::warn!(
-                                "Skipping record '{key}' for memory vector index '{INDEX_NAME}': the embedding contains a NaN or infinite value, so the record is not indexed and vector search will never return it. {}",
-                                write_util::NON_FINITE_EMBEDDING_REMEDY
-                            );
-                        } else {
+                        } else if !non_finite {
                             keys.push(key.clone());
                         }
                         !all_zero_or_nan && !non_finite

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -206,9 +206,9 @@ impl MemoryVectorIndex {
             .map(|(key, vector)| {
                 let keep = match (key, vector) {
                     (Some(key), Some(vector)) => {
-                        // All-zero / all-NaN vectors have no defined direction and
-                        // would corrupt similarity scores — skip them.
-                        let all_zero_or_nan = vector.iter().all(|&v| v == 0.0 || v.is_nan());
+                        // An all-zero vector has no defined direction and would corrupt
+                        // similarity scores — skip it.
+                        let all_zero = write_util::is_finite_all_zero(vector);
                         // A single NaN or infinity poisons every score computed against the
                         // vector, so one bad component disqualifies the whole row too.
                         let non_finite = write_util::first_non_finite(vector).is_some();
@@ -216,15 +216,16 @@ impl MemoryVectorIndex {
                         // deliberately silent: `update_embedding_column_in_batch` runs first on
                         // this path and has already named every affected row in one batched
                         // warning, so warning again per row would multiply one degraded
-                        // embedding response into a line per record.
-                        if all_zero_or_nan {
+                        // embedding response into a line per record. That is why `all_zero`
+                        // excludes `NaN` — `[0.0, NaN]` belongs to the batched report alone.
+                        if all_zero {
                             tracing::warn!(
-                                "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes or contains only invalid values"
+                                "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes"
                             );
                         } else if !non_finite {
                             keys.push(key.clone());
                         }
-                        !all_zero_or_nan && !non_finite
+                        !all_zero && !non_finite
                     }
                     (None, _) => {
                         tracing::warn!(
@@ -572,6 +573,40 @@ mod tests {
         }
     }
 
+    /// Embeds one row's text as a wholly zero vector and every other row normally.
+    /// `byte_vector` sums the text's bytes, so no other row can come out all-zero.
+    #[derive(Debug)]
+    struct ZeroEmbed {
+        zeroed_text: String,
+    }
+
+    impl ZeroEmbed {
+        fn vector_for(&self, text: &str) -> Vec<f32> {
+            if text == self.zeroed_text {
+                vec![0.0_f32; usize::try_from(DIM).expect("DIM is positive")]
+            } else {
+                byte_vector(text)
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Embed for ZeroEmbed {
+        async fn embed(&self, input: EmbeddingInput) -> llms::embeddings::Result<Vec<Vec<f32>>> {
+            match input {
+                EmbeddingInput::String(s) => Ok(vec![self.vector_for(&s)]),
+                EmbeddingInput::StringArray(v) => {
+                    Ok(v.iter().map(|s| self.vector_for(s)).collect())
+                }
+                _ => Ok(vec![]),
+            }
+        }
+
+        fn size(&self) -> i32 {
+            DIM
+        }
+    }
+
     /// These tests never execute a query plan, so the query-time `embed(text, model)` UDF is
     /// only needed to construct the index.
     fn embed_udf() -> Arc<ScalarUDF> {
@@ -876,6 +911,25 @@ mod tests {
             indexed_ids(&index),
             vec![1, 2, 3],
             "zeroing one component leaves a finite vector, which stays indexed"
+        );
+    }
+
+    /// A vector with no non-zero component has no direction, so every similarity score
+    /// against it is meaningless and the row must not be indexed. This branch is the only
+    /// warning such a row gets: the batched non-finite report deliberately does not claim
+    /// an all-zero vector, because it is finite.
+    #[tokio::test]
+    async fn an_all_zero_embedding_is_not_indexed() {
+        let index = memory_index_with(Arc::new(ZeroEmbed {
+            zeroed_text: "row 2".to_string(),
+        }));
+        write_window(&index, WriteWindow::Append, &[1, 2, 3]).await;
+
+        assert_eq!(
+            indexed_ids(&index),
+            vec![1, 3],
+            "row 2's embedding is wholly zero, which has no direction under cosine, so the \
+             row must not be indexed"
         );
     }
 }

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -220,7 +220,12 @@ impl MemoryVectorIndex {
                         // excludes `NaN` — `[0.0, NaN]` belongs to the batched report alone.
                         if all_zero {
                             tracing::warn!(
-                                "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes"
+                                "{}",
+                                write_util::all_zero_embedding_warning(
+                                    "memory vector",
+                                    INDEX_NAME,
+                                    key
+                                )
                             );
                         } else if !non_finite {
                             keys.push(key.clone());

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -27,7 +27,7 @@ use snafu::{ResultExt, Snafu};
 use spice_table::Index;
 
 use crate::index::write_util::{
-    self, embed_column, extract_and_format_primary_key, first_non_finite,
+    self, embed_column, extract_and_format_primary_key, first_non_finite, is_finite_all_zero,
     sort_columns_alphabetically, update_embedding_column_in_batch,
 };
 use crate::index::{SearchIndex, embedding_col, s3_vectors::S3Vector};
@@ -265,15 +265,17 @@ pub fn extract_and_format_metadata(
     Ok(metadata)
 }
 
-/// Filter out invalid embedding vectors where all values are either zero or NaN.
+/// Filter out embedding vectors that cannot be scored.
 ///
-/// This filters vectors that consist entirely of invalid values (zeros and/or NaNs), and
-/// vectors carrying any non-finite component at all — a single NaN or infinity poisons every
-/// score computed against the vector, so the whole record is dropped rather than indexed.
-/// For example:
-/// - `[0.0, 0.0]` -> filtered (all zeros)
-/// - `[NaN, NaN]` -> filtered (all NaN)
-/// - `[0.0, NaN]` -> filtered (all values are either zero or NaN)
+/// Two shapes are dropped: a vector whose every component is zero, which has no direction,
+/// and a vector carrying any non-finite component at all — a single NaN or infinity poisons
+/// every score computed against the vector, so the whole record is dropped rather than
+/// indexed. The two overlap, and which one claims a row decides which warning names it: the
+/// all-zero test excludes NaN so that a partly-NaN vector is reported once, by the batched
+/// non-finite warning, rather than once per record as well. For example:
+/// - `[0.0, 0.0]` -> filtered (all zeros), reported per record
+/// - `[NaN, NaN]` -> filtered (non-finite), reported in the batched warning
+/// - `[0.0, NaN]` -> filtered (non-finite), reported in the batched warning
 /// - `[1.0, NaN]` -> filtered (one non-finite component)
 /// - `[1.0, f32::INFINITY]` -> filtered (one non-finite component)
 /// - `[1.0, 0.0]` -> kept (finite, with a valid non-zero value)
@@ -293,12 +295,13 @@ fn filter_zero_vectors(
         let Some(embedding) = &embeddings[i] else {
             continue;
         };
-        // Single pass: check if all values are zero or NaN (both are invalid embeddings)
-        let all_zero_or_nan = embedding.iter().all(|&x| x == 0.0 || x.is_nan());
+        // An all-zero vector has no defined direction, so every score against it is
+        // meaningless.
+        let all_zero = is_finite_all_zero(embedding);
         // A single NaN or infinity poisons every score computed against the vector, so one
         // bad component disqualifies the whole record too.
         let non_finite = first_non_finite(embedding).is_some();
-        if !all_zero_or_nan && !non_finite {
+        if !all_zero && !non_finite {
             continue;
         }
 
@@ -309,10 +312,11 @@ fn filter_zero_vectors(
         // Only the all-zero case is reported per record. A non-finite one is deliberately
         // silent: `update_embedding_column_in_batch` runs before this filter and has already
         // named every affected row in one batched warning, so warning again per row would
-        // turn one degraded embedding response into a line per record.
-        if all_zero_or_nan {
+        // turn one degraded embedding response into a line per record. That is why
+        // `all_zero` excludes `NaN` — `[0.0, NaN]` belongs to the batched report alone.
+        if all_zero {
             tracing::warn!(
-                "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values"
+                "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes"
             );
         }
 

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -267,14 +267,16 @@ pub fn extract_and_format_metadata(
 
 /// Filter out invalid embedding vectors where all values are either zero or NaN.
 ///
-/// This filters vectors that consist entirely of invalid values (zeros and/or NaNs).
-/// A vector with any valid non-zero, non-NaN value is kept.
+/// This filters vectors that consist entirely of invalid values (zeros and/or NaNs), and
+/// vectors carrying any non-finite component at all — a single NaN or infinity poisons every
+/// score computed against the vector, so the whole record is dropped rather than indexed.
 /// For example:
 /// - `[0.0, 0.0]` -> filtered (all zeros)
 /// - `[NaN, NaN]` -> filtered (all NaN)
 /// - `[0.0, NaN]` -> filtered (all values are either zero or NaN)
-/// - `[1.0, 0.0]` -> kept (has a valid non-zero value)
-/// - `[1.0, NaN]` -> kept (has a valid non-NaN value)
+/// - `[1.0, NaN]` -> filtered (one non-finite component)
+/// - `[1.0, f32::INFINITY]` -> filtered (one non-finite component)
+/// - `[1.0, 0.0]` -> kept (finite, with a valid non-zero value)
 #[expect(clippy::type_complexity)]
 fn filter_zero_vectors(
     mut embeddings: Vec<Option<Vec<f32>>>,
@@ -304,14 +306,13 @@ fn filter_zero_vectors(
             .get(i)
             .and_then(|k| k.as_ref().map(String::as_str))
             .unwrap_or("unknown");
+        // Only the all-zero case is reported per record. A non-finite one is deliberately
+        // silent: `update_embedding_column_in_batch` runs before this filter and has already
+        // named every affected row in one batched warning, so warning again per row would
+        // turn one degraded embedding response into a line per record.
         if all_zero_or_nan {
             tracing::warn!(
                 "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values"
-            );
-        } else {
-            tracing::warn!(
-                "Skipping record '{key_str}' for S3 Vector index '{index_name}': the embedding contains a NaN or infinite value, so the record is not indexed and vector search will never return it. {}",
-                write_util::NON_FINITE_EMBEDDING_REMEDY
             );
         }
 

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -27,8 +27,8 @@ use snafu::{ResultExt, Snafu};
 use spice_table::Index;
 
 use crate::index::write_util::{
-    self, embed_column, extract_and_format_primary_key, sort_columns_alphabetically,
-    update_embedding_column_in_batch,
+    self, embed_column, extract_and_format_primary_key, first_non_finite,
+    sort_columns_alphabetically, update_embedding_column_in_batch,
 };
 use crate::index::{SearchIndex, embedding_col, s3_vectors::S3Vector};
 
@@ -177,6 +177,7 @@ async fn process_single_batch(
     // Update the embedding column in the batch with computed embeddings
     // Ideally, we can just do `S3VectorPartitionedTable::insert_into` (or similar) with this big boy
     let updated_record = update_embedding_column_in_batch(
+        index.name(),
         &record,
         &index.embedded_column,
         &embedding_vectors,
@@ -287,23 +288,37 @@ fn filter_zero_vectors(
 ) {
     // Filter in reverse order to avoid index shifting when removing elements
     for i in (0..embeddings.len()).rev() {
-        if let Some(embedding) = &embeddings[i]
-            // Single pass: check if all values are zero or NaN (both are invalid embeddings)
-            && embedding.iter().all(|&x| x == 0.0 || x.is_nan())
-        {
-            let key_str = primary_keys
-                .get(i)
-                .and_then(|k| k.as_ref().map(String::as_str))
-                .unwrap_or("unknown");
+        let Some(embedding) = &embeddings[i] else {
+            continue;
+        };
+        // Single pass: check if all values are zero or NaN (both are invalid embeddings)
+        let all_zero_or_nan = embedding.iter().all(|&x| x == 0.0 || x.is_nan());
+        // A single NaN or infinity poisons every score computed against the vector, so one
+        // bad component disqualifies the whole record too.
+        let non_finite = first_non_finite(embedding).is_some();
+        if !all_zero_or_nan && !non_finite {
+            continue;
+        }
+
+        let key_str = primary_keys
+            .get(i)
+            .and_then(|k| k.as_ref().map(String::as_str))
+            .unwrap_or("unknown");
+        if all_zero_or_nan {
             tracing::warn!(
                 "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values"
             );
+        } else {
+            tracing::warn!(
+                "Skipping record '{key_str}' for S3 Vector index '{index_name}': the embedding contains a NaN or infinite value, so the record is not indexed and vector search will never return it. {}",
+                write_util::NON_FINITE_EMBEDDING_REMEDY
+            );
+        }
 
-            embeddings.remove(i);
-            primary_keys.remove(i);
-            for values in metadata.values_mut() {
-                values.remove(i);
-            }
+        embeddings.remove(i);
+        primary_keys.remove(i);
+        for values in metadata.values_mut() {
+            values.remove(i);
         }
     }
 
@@ -355,6 +370,61 @@ mod tests {
         assert_eq!(filtered_embeddings[0], Some(vec![1.0, 2.0]));
         assert_eq!(filtered_embeddings[1], None);
         assert_eq!(filtered_embeddings[2], Some(vec![3.0, 4.0]));
+    }
+
+    /// A vector whose components are mostly real but carry one NaN or infinity has no
+    /// defined distance under any metric, so the record must not reach the index. Before
+    /// #13089 the filter tested `all`, so only a wholly-invalid vector was caught and
+    /// `[NaN, 2.0]` was written.
+    #[test]
+    fn filter_drops_a_partially_non_finite_vector() {
+        use serde_json::Value;
+        use std::collections::HashMap;
+
+        let embeddings = vec![
+            Some(vec![1.0, 2.0]),               // Keep — finite
+            Some(vec![f32::NAN, 2.0]),          // Drop — one NaN among real values
+            Some(vec![1.0, f32::INFINITY]),     // Drop — one infinity among real values
+            Some(vec![f32::NEG_INFINITY, 1.0]), // Drop — one negative infinity
+            Some(vec![0.0, 0.0]),               // Drop — all zero (pre-existing behaviour)
+            None,                               // Keep — no embedding to screen
+            Some(vec![3.0, 4.0]),               // Keep — finite
+        ];
+        let keys: Vec<Option<String>> = (1..=7).map(|i| Some(format!("key{i}"))).collect();
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "test".to_string(),
+            (1..=7)
+                .map(|i| Some(Value::Number(i.into())))
+                .collect::<Vec<_>>(),
+        );
+
+        let (filtered_embeddings, filtered_keys, filtered_metadata) =
+            filter_zero_vectors(embeddings, keys, metadata, "test_index");
+
+        assert_eq!(filtered_embeddings.len(), 3);
+        assert_eq!(filtered_keys.len(), 3);
+        assert_eq!(filtered_metadata["test"].len(), 3);
+        assert_eq!(filtered_embeddings[0], Some(vec![1.0, 2.0]));
+        assert_eq!(filtered_embeddings[1], None);
+        assert_eq!(filtered_embeddings[2], Some(vec![3.0, 4.0]));
+        assert_eq!(
+            filtered_keys,
+            vec![
+                Some("key1".to_string()),
+                Some("key6".to_string()),
+                Some("key7".to_string()),
+            ]
+        );
+        // The metadata stays aligned with the rows that survived.
+        assert_eq!(
+            filtered_metadata["test"],
+            vec![
+                Some(Value::Number(1.into())),
+                Some(Value::Number(6.into())),
+                Some(Value::Number(7.into())),
+            ]
+        );
     }
 
     /// Test that filter_zero_vectors correctly filters out NaN embeddings.

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -27,8 +27,9 @@ use snafu::{ResultExt, Snafu};
 use spice_table::Index;
 
 use crate::index::write_util::{
-    self, embed_column, extract_and_format_primary_key, first_non_finite, is_finite_all_zero,
-    sort_columns_alphabetically, update_embedding_column_in_batch,
+    self, all_zero_embedding_warning, embed_column, extract_and_format_primary_key,
+    first_non_finite, is_finite_all_zero, sort_columns_alphabetically,
+    update_embedding_column_in_batch,
 };
 use crate::index::{SearchIndex, embedding_col, s3_vectors::S3Vector};
 
@@ -316,7 +317,8 @@ fn filter_zero_vectors(
         // `all_zero` excludes `NaN` — `[0.0, NaN]` belongs to the batched report alone.
         if all_zero {
             tracing::warn!(
-                "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes"
+                "{}",
+                all_zero_embedding_warning("S3 Vector", index_name, key_str)
             );
         }
 

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -319,7 +319,7 @@ pub fn is_finite_all_zero(embedding: &[f32]) -> bool {
 /// The remedy clause every non-finite-embedding warning ends with, kept in one place so the
 /// advice and the docs link cannot drift between the paths that skip a record and the ones
 /// that null its embedding.
-pub const NON_FINITE_EMBEDDING_REMEDY: &str = "Re-embed the affected rows, or check the embedding model configured for this dataset. \
+pub const EMBEDDING_REMEDY: &str = "Re-embed the affected rows, or check the embedding model configured for this dataset. \
      See: https://spiceai.org/docs/components/embeddings";
 
 /// The maximum number of row indexes named in a [`non_finite_embedding_warning`].
@@ -360,8 +360,23 @@ pub fn non_finite_embedding_warning(
         ""
     };
     format!(
-        "Index '{index_name}': {} of {total_rows} embeddings contain a NaN or infinite value, so those rows are not indexed and vector search will never return them (rows {sample}{ellipsis}). {NON_FINITE_EMBEDDING_REMEDY}",
+        "Index '{index_name}': {} of {total_rows} embeddings contain a NaN or infinite value, so those rows are not indexed and vector search will never return them (rows {sample}{ellipsis}). {EMBEDDING_REMEDY}",
         affected_rows.len()
+    )
+}
+
+/// One line explaining why a single all-zero-embedding record is not searchable, built in a
+/// pure function so a reword cannot quietly drop the key, the index, the consequence or the
+/// docs link.
+///
+/// The cause is deliberately narrower than [`non_finite_embedding_warning`]'s: this line is
+/// only ever reached for a vector whose every component is a finite zero, so it must not
+/// mention NaN. A vector mixing zeroes with a NaN belongs to the batched non-finite report,
+/// and claiming "all zeroes" for it would name a cause the row does not have.
+#[must_use]
+pub fn all_zero_embedding_warning(index_kind: &str, index_name: &str, key: &str) -> String {
+    format!(
+        "Skipping record '{key}' for {index_kind} index '{index_name}': its embedding is all zeroes, which has no direction to compare against, so the record is not indexed and vector search will never return it. {EMBEDDING_REMEDY}"
     )
 }
 
@@ -792,6 +807,53 @@ mod tests {
             message.contains("https://spiceai.org/docs/components/embeddings"),
             "{message}"
         );
+    }
+
+    /// The per-record all-zero line has to carry what the batched non-finite one carries: the
+    /// record, the index, what the user will observe, and where to go. Only the cause differs.
+    ///
+    /// It must *not* mention NaN. The predicate feeding it is `is_finite_all_zero`, so a
+    /// vector mixing zeroes with a NaN reaches the batched non-finite report instead; naming
+    /// NaN here would describe a cause the reported row does not have.
+    #[test]
+    fn all_zero_warning_names_record_consequence_and_docs() {
+        let message = all_zero_embedding_warning("memory vector", "my_index", "row-7");
+        assert!(message.contains("'row-7'"), "{message}");
+        assert!(
+            message.contains("memory vector index 'my_index'"),
+            "{message}"
+        );
+        assert!(message.contains("all zeroes"), "{message}");
+        assert!(
+            message.contains("not indexed"),
+            "the line must state the consequence, not only the cause: {message}"
+        );
+        assert!(
+            message.contains("vector search will never return it"),
+            "{message}"
+        );
+        assert!(
+            message.contains("Re-embed the affected rows"),
+            "the line must give an actionable remedy: {message}"
+        );
+        assert!(
+            message.contains("https://spiceai.org/docs/components/embeddings"),
+            "{message}"
+        );
+        assert!(
+            !message.contains("NaN"),
+            "a NaN-bearing vector is reported by the batched non-finite line, so this one must not claim NaN as the cause: {message}"
+        );
+    }
+
+    /// Both causes point at the same fix, so the remedy is shared rather than restated — a
+    /// divergence would give two backends two different answers to the same question.
+    #[test]
+    fn both_embedding_warnings_share_one_remedy() {
+        let all_zero = all_zero_embedding_warning("S3 Vector", "idx", "k");
+        let non_finite = non_finite_embedding_warning("idx", &[0], 1);
+        assert!(all_zero.contains(EMBEDDING_REMEDY), "{all_zero}");
+        assert!(non_finite.contains(EMBEDDING_REMEDY), "{non_finite}");
     }
 
     /// Only the first few row indexes are named, so a whole-batch failure cannot produce a

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -382,10 +382,17 @@ pub fn non_finite_embedding_warning(
 /// only ever reached for a vector whose every component is a finite zero, so it must not
 /// mention NaN. A vector mixing zeroes with a NaN belongs to the batched non-finite report,
 /// and claiming "all zeroes" for it would name a cause the row does not have.
+///
+/// The *consequence*, by contrast, must stay narrower than it is tempting to write. What
+/// happens to a vector already indexed for this record is not a property of this call site:
+/// an appending write leaves it in place and searchable at its older value (#13504), while a
+/// `WriteWindow::ReplaceAll` refresh stages only the surviving rows and swaps the whole set
+/// in at `on_write_complete`, discarding it. So this line may not promise either outcome —
+/// only that this write did not index the record.
 #[must_use]
 pub fn all_zero_embedding_warning(index_kind: &str, index_name: &str, key: &str) -> String {
     format!(
-        "Skipping record '{key}' for {index_kind} index '{index_name}': its embedding is all zeroes, which has no direction to compare against, so this write did not index the record and any vector previously indexed for it stays searchable at that older value. {EMBEDDING_REMEDY}"
+        "Skipping record '{key}' for {index_kind} index '{index_name}': its embedding is all zeroes, which has no direction to compare against, so this write did not index the record and vector search will not match it on this write's data. {EMBEDDING_REMEDY}"
     )
 }
 
@@ -850,12 +857,12 @@ mod tests {
             "{message}"
         );
         assert!(
-            message.contains("stays searchable at that older value"),
-            "the line must not imply the record became unsearchable — a previously indexed vector survives a rejected rewrite: {message}"
+            !message.contains("never return"),
+            "an absolute an appending write does not deliver — the previously indexed vector stays searchable (#13504): {message}"
         );
         assert!(
-            !message.contains("never return"),
-            "an absolute the write path does not deliver: a stale vector is still returned: {message}"
+            !message.contains("stays searchable"),
+            "and not the mirror either: a ReplaceAll refresh stages only survivors and swaps the whole set in, discarding that older vector: {message}"
         );
         assert!(
             message.contains("Re-embed the affected rows"),

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -254,6 +254,7 @@ pub async fn embed_column(
 
 /// Update the embedding column in the `RecordBatch` with the computed embeddings.
 pub fn update_embedding_column_in_batch(
+    index_name: &str,
     record: &RecordBatch,
     embedded_column_name: &str,
     embedding_vectors: &[Option<Vec<f32>>],
@@ -265,7 +266,7 @@ pub fn update_embedding_column_in_batch(
     let mut columns = record.columns().to_vec();
 
     // Create new embedding array that will replace the existing column or be added as a new column
-    let embedding_array = create_embedding_array(embedding_vectors, dimension)?;
+    let embedding_array = create_embedding_array(index_name, embedding_vectors, dimension)?;
 
     // Check if the embedding column already exists
     let target_schema = if let Some((idx, _)) = schema.column_with_name(&embedding_column_name) {
@@ -290,9 +291,59 @@ pub fn update_embedding_column_in_batch(
         .map_err(Box::from)
 }
 
+/// The position of the first element of `embedding` that is not a finite number.
+///
+/// This is the one definition of "this vector cannot be scored" that every vector write
+/// path shares. A `NaN` or infinite component has no defined distance under any metric an
+/// index offers — cosine, L2 and inner product alike — so it poisons every score computed
+/// against it. An all-zero vector is a different case and deliberately not covered here:
+/// it is well defined for L2 and inner product, and `cosine_distance` answers `0.5` for it.
+#[must_use]
+pub fn first_non_finite(embedding: &[f32]) -> Option<usize> {
+    embedding.iter().position(|value| !value.is_finite())
+}
+
+/// The remedy clause every non-finite-embedding warning ends with, kept in one place so the
+/// advice and the docs link cannot drift between the paths that skip a record and the ones
+/// that null its embedding.
+pub const NON_FINITE_EMBEDDING_REMEDY: &str = "Re-embed the affected rows, or check the embedding model configured for this dataset. \
+     See: https://spiceai.org/docs/components/embeddings";
+
+/// The maximum number of row indexes named in a [`non_finite_embedding_warning`].
+const NON_FINITE_SAMPLE_LIMIT: usize = 5;
+
+/// One line explaining why some rows are not searchable, built in a pure function so a
+/// reword cannot quietly drop the index name, the consequence, or the docs link.
+#[must_use]
+pub fn non_finite_embedding_warning(
+    index_name: &str,
+    affected_rows: &[usize],
+    total_rows: usize,
+) -> String {
+    let sample = affected_rows
+        .iter()
+        .take(NON_FINITE_SAMPLE_LIMIT)
+        .map(usize::to_string)
+        .join(", ");
+    let ellipsis = if affected_rows.len() > NON_FINITE_SAMPLE_LIMIT {
+        ", ..."
+    } else {
+        ""
+    };
+    format!(
+        "Index '{index_name}': {} of {total_rows} embeddings contain a NaN or infinite value, so those rows are stored without an embedding and vector search will never return them (rows {sample}{ellipsis}). {NON_FINITE_EMBEDDING_REMEDY}",
+        affected_rows.len()
+    )
+}
+
 /// Create an Arrow array from embedding vectors.
+///
+/// An embedding carrying a non-finite value is stored as a NULL list slot rather than
+/// indexed — see [`first_non_finite`]. The row itself is kept, because this builds one
+/// column of a batch whose other columns already have their rows.
 #[expect(clippy::cast_sign_loss)]
 pub fn create_embedding_array(
+    index_name: &str,
     embedding_vectors: &[Option<Vec<f32>>],
     dimension: i32,
 ) -> Result<Arc<dyn Array>, Box<Error>> {
@@ -319,6 +370,7 @@ pub fn create_embedding_array(
     builder = builder.with_field(field);
 
     let expected_dim = dimension as usize;
+    let mut non_finite_rows: Vec<usize> = Vec::new();
     for (row_index, embedding_opt) in embedding_vectors.iter().enumerate() {
         if let Some(embedding) = embedding_opt {
             // Validate embedding dimension matches expected dimension
@@ -328,6 +380,12 @@ pub fn create_embedding_array(
                     actual: embedding.len(),
                     row_index,
                 }));
+            }
+            if first_non_finite(embedding).is_some() {
+                non_finite_rows.push(row_index);
+                builder.values().append_value_n(0.0, expected_dim);
+                builder.append(false);
+                continue;
             }
             // Optimized: append_slice automatically marks all values as valid
             // without needing to allocate a separate validity vector
@@ -339,6 +397,13 @@ pub fn create_embedding_array(
             builder.values().append_value_n(0.0, expected_dim);
             builder.append(false);
         }
+    }
+
+    if !non_finite_rows.is_empty() {
+        tracing::warn!(
+            "{}",
+            non_finite_embedding_warning(index_name, &non_finite_rows, embedding_vectors.len())
+        );
     }
 
     Ok(Arc::new(builder.finish()))
@@ -448,8 +513,8 @@ mod tests {
     fn test_create_embedding_array_valid_embeddings() {
         let embeddings = vec![Some(vec![0.1, 0.2, 0.3]), None, Some(vec![0.7, 0.8, 0.9])];
 
-        let result =
-            create_embedding_array(&embeddings, 3).expect("Failed to create embedding array");
+        let result = create_embedding_array("test_index", &embeddings, 3)
+            .expect("Failed to create embedding array");
 
         let list_array = result
             .as_any()
@@ -481,7 +546,7 @@ mod tests {
     fn test_create_embedding_array_empty_embeddings() {
         let embeddings: Vec<Option<Vec<f32>>> = vec![None, None];
 
-        let result = create_embedding_array(&embeddings, 0);
+        let result = create_embedding_array("test_index", &embeddings, 0);
 
         // Should fail because no valid embeddings to determine dimension
         assert!(result.is_err());
@@ -502,8 +567,9 @@ mod tests {
 
         let new_embeddings = vec![Some(vec![0.1, 0.2, 0.3]), Some(vec![0.4, 0.5, 0.6])];
 
-        let result = update_embedding_column_in_batch(&record, "text", &new_embeddings, 3)
-            .expect("Failed to update embedding column");
+        let result =
+            update_embedding_column_in_batch("test_index", &record, "text", &new_embeddings, 3)
+                .expect("Failed to update embedding column");
 
         // Verify the updated batch has the new embeddings
         let embedding_column = result.column(1);
@@ -532,8 +598,9 @@ mod tests {
 
         let new_embeddings = vec![Some(vec![0.1, 0.2, 0.3]), Some(vec![0.4, 0.5, 0.6])];
 
-        let result = update_embedding_column_in_batch(&record, "text", &new_embeddings, 3)
-            .expect("Failed to handle missing embedding column");
+        let result =
+            update_embedding_column_in_batch("test_index", &record, "text", &new_embeddings, 3)
+                .expect("Failed to handle missing embedding column");
 
         // Should append the embedding column with the correct name
         let expected_embedding_col = embedding_col("text");
@@ -574,7 +641,7 @@ mod tests {
             Some(vec![0.3, 0.4, 0.5]), // dimension 3 - MISMATCH!
         ];
 
-        let result = create_embedding_array(&embeddings, 2);
+        let result = create_embedding_array("test_index", &embeddings, 2);
 
         assert!(
             result.is_err(),
@@ -605,10 +672,89 @@ mod tests {
             Some(vec![0.7, 0.8, 0.9]),
         ];
 
-        let result = create_embedding_array(&embeddings, 3);
+        let result = create_embedding_array("test_index", &embeddings, 3);
         assert!(
             result.is_ok(),
             "Should succeed when all embedding dimensions match"
+        );
+    }
+
+    /// A vector with one bad component among real values must not be treated as usable —
+    /// the pre-fix predicate tested `all` and let `[NaN, 2.0, 3.0]` through (regression
+    /// test for #13089).
+    #[test]
+    fn first_non_finite_rejects_a_single_bad_component() {
+        assert_eq!(first_non_finite(&[f32::NAN, 2.0, 3.0]), Some(0));
+        assert_eq!(first_non_finite(&[1.0, f32::INFINITY, 3.0]), Some(1));
+        assert_eq!(first_non_finite(&[1.0, 2.0, f32::NEG_INFINITY]), Some(2));
+        assert_eq!(first_non_finite(&[f32::NAN, f32::NAN]), Some(0));
+    }
+
+    /// An all-zero vector is well defined for L2 and inner product, and `cosine_distance`
+    /// answers 0.5 for it, so it is deliberately not a non-finite defect.
+    #[test]
+    fn first_non_finite_accepts_finite_vectors_including_all_zero() {
+        assert_eq!(first_non_finite(&[0.0, 0.0, 0.0]), None);
+        assert_eq!(first_non_finite(&[-1.5, 0.0, 2.5]), None);
+        assert_eq!(first_non_finite(&[]), None);
+    }
+
+    /// The warning is what a user gets to explain a row that vanished from search, so it
+    /// must keep naming the index, the count, the consequence, and the docs link.
+    #[test]
+    fn non_finite_warning_names_index_consequence_and_docs() {
+        let message = non_finite_embedding_warning("my_index", &[1, 4], 10);
+        assert!(message.contains("'my_index'"), "{message}");
+        assert!(message.contains("2 of 10"), "{message}");
+        assert!(
+            message.contains("vector search will never return them"),
+            "{message}"
+        );
+        assert!(message.contains("rows 1, 4"), "{message}");
+        assert!(
+            message.contains("https://spiceai.org/docs/components/embeddings"),
+            "{message}"
+        );
+    }
+
+    /// Only the first few row indexes are named, so a whole-batch failure cannot produce a
+    /// log line proportional to the batch.
+    #[test]
+    fn non_finite_warning_truncates_a_long_row_list() {
+        let rows: Vec<usize> = (0..50).collect();
+        let message = non_finite_embedding_warning("my_index", &rows, 50);
+        assert!(message.contains("50 of 50"), "{message}");
+        assert!(message.contains("rows 0, 1, 2, 3, 4, ..."), "{message}");
+        assert!(!message.contains(", 5,"), "{message}");
+    }
+
+    /// A partially non-finite embedding is stored as a NULL list slot, not indexed, and the
+    /// rest of the batch is untouched (regression test for #13089).
+    #[test]
+    fn create_embedding_array_nulls_a_non_finite_embedding() {
+        let embeddings = vec![
+            Some(vec![0.1, 0.2, 0.3]),
+            Some(vec![f32::NAN, 2.0, 3.0]),
+            Some(vec![1.0, f32::INFINITY, 3.0]),
+            None,
+            Some(vec![0.0, 0.0, 0.0]),
+        ];
+
+        let array = create_embedding_array("test_index", &embeddings, 3)
+            .expect("builds the embedding array");
+        let list = array
+            .as_any()
+            .downcast_ref::<arrow::array::FixedSizeListArray>()
+            .expect("FixedSizeListArray");
+
+        assert_eq!(list.len(), 5);
+        assert!(list.is_valid(0), "a finite embedding stays indexed");
+        assert!(list.is_null(1), "a NaN component nulls the embedding");
+        assert!(list.is_null(2), "an infinite component nulls the embedding");
+        assert!(list.is_null(3), "a missing embedding stays null");
+        assert!(
+            list.is_valid(4),
+            "an all-zero embedding is finite and stays indexed"
         );
     }
 

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -314,8 +314,10 @@ const NON_FINITE_SAMPLE_LIMIT: usize = 5;
 
 /// Report the rows an embedding builder could not index, if there were any.
 ///
-/// Every builder that nulls a defective embedding emits through here, so the emptiness
-/// check and the log level cannot drift apart between them.
+/// Every write path that meets a non-finite embedding emits through here — the ones that
+/// null the embedding and the ones that drop the record entirely — so the emptiness check,
+/// the log level and the wording cannot drift apart between them. The message states the
+/// consequence both share ("not indexed") rather than the storage outcome, which differs.
 pub fn warn_non_finite_embeddings(index_name: &str, affected_rows: &[usize], total_rows: usize) {
     if affected_rows.is_empty() {
         return;
@@ -345,7 +347,7 @@ pub fn non_finite_embedding_warning(
         ""
     };
     format!(
-        "Index '{index_name}': {} of {total_rows} embeddings contain a NaN or infinite value, so those rows are stored without an embedding and vector search will never return them (rows {sample}{ellipsis}). {NON_FINITE_EMBEDDING_REMEDY}",
+        "Index '{index_name}': {} of {total_rows} embeddings contain a NaN or infinite value, so those rows are not indexed and vector search will never return them (rows {sample}{ellipsis}). {NON_FINITE_EMBEDDING_REMEDY}",
         affected_rows.len()
     )
 }
@@ -710,11 +712,22 @@ mod tests {
 
     /// The warning is what a user gets to explain a row that vanished from search, so it
     /// must keep naming the index, the count, the consequence, and the docs link.
+    ///
+    /// The consequence has to be the one every caller produces. Some paths null the
+    /// embedding and keep the row; `memory`, `s3_vectors` and Elasticsearch's document
+    /// builder drop the record instead. "Not indexed" is true of all of them, so a reword
+    /// back to a storage outcome would make the single shared line wrong for three of the
+    /// four backends emitting it.
     #[test]
     fn non_finite_warning_names_index_consequence_and_docs() {
         let message = non_finite_embedding_warning("my_index", &[1, 4], 10);
         assert!(message.contains("'my_index'"), "{message}");
         assert!(message.contains("2 of 10"), "{message}");
+        assert!(message.contains("not indexed"), "{message}");
+        assert!(
+            !message.contains("stored without an embedding"),
+            "the shared line must not promise a storage outcome the record-dropping callers do not produce: {message}"
+        );
         assert!(
             message.contains("vector search will never return them"),
             "{message}"

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -343,6 +343,15 @@ pub fn warn_non_finite_embeddings(index_name: &str, affected_rows: &[usize], tot
 
 /// One line explaining why some rows are not searchable, built in a pure function so a
 /// reword cannot quietly drop the index name, the consequence, or the docs link.
+///
+/// Callers disagree on **two** things, so the line may assert neither. They disagree on the
+/// storage outcome — `create_embedding_array` and the DuckDB builder null the embedding and
+/// keep the row, Elasticsearch's document builder drops it — and they disagree on what
+/// happens to a vector already indexed for that row: the two null-the-embedding callers
+/// overwrite it, so it stops matching, while the drop-the-record caller leaves it in place
+/// and searchable at its older value. "This write did not index those rows" is the only
+/// consequence all three deliver. Both an absolute ("will never return them") and a promise
+/// that the old vector survives would each be false for some caller.
 #[must_use]
 pub fn non_finite_embedding_warning(
     index_name: &str,
@@ -360,7 +369,7 @@ pub fn non_finite_embedding_warning(
         ""
     };
     format!(
-        "Index '{index_name}': {} of {total_rows} embeddings contain a NaN or infinite value, so those rows are not indexed and vector search will never return them (rows {sample}{ellipsis}). {EMBEDDING_REMEDY}",
+        "Index '{index_name}': {} of {total_rows} embeddings contain a NaN or infinite value, so this write did not index those rows and vector search will not match them on this write's data (rows {sample}{ellipsis}). {EMBEDDING_REMEDY}",
         affected_rows.len()
     )
 }
@@ -376,7 +385,7 @@ pub fn non_finite_embedding_warning(
 #[must_use]
 pub fn all_zero_embedding_warning(index_kind: &str, index_name: &str, key: &str) -> String {
     format!(
-        "Skipping record '{key}' for {index_kind} index '{index_name}': its embedding is all zeroes, which has no direction to compare against, so the record is not indexed and vector search will never return it. {EMBEDDING_REMEDY}"
+        "Skipping record '{key}' for {index_kind} index '{index_name}': its embedding is all zeroes, which has no direction to compare against, so this write did not index the record and any vector previously indexed for it stays searchable at that older value. {EMBEDDING_REMEDY}"
     )
 }
 
@@ -793,14 +802,22 @@ mod tests {
         let message = non_finite_embedding_warning("my_index", &[1, 4], 10);
         assert!(message.contains("'my_index'"), "{message}");
         assert!(message.contains("2 of 10"), "{message}");
-        assert!(message.contains("not indexed"), "{message}");
+        assert!(message.contains("did not index"), "{message}");
         assert!(
             !message.contains("stored without an embedding"),
             "the shared line must not promise a storage outcome the record-dropping callers do not produce: {message}"
         );
         assert!(
-            message.contains("vector search will never return them"),
+            message.contains("this write did not index those rows"),
             "{message}"
+        );
+        assert!(
+            !message.contains("never return"),
+            "an absolute one caller does not deliver — Elasticsearch's document builder leaves the previous document searchable at its older vector: {message}"
+        );
+        assert!(
+            !message.contains("stays searchable"),
+            "the mirror error: the two null-the-embedding callers overwrite the old vector, so the shared line cannot promise it survives either: {message}"
         );
         assert!(message.contains("rows 1, 4"), "{message}");
         assert!(
@@ -825,12 +842,20 @@ mod tests {
         );
         assert!(message.contains("all zeroes"), "{message}");
         assert!(
-            message.contains("not indexed"),
+            message.contains("this write did not index the record"),
             "the line must state the consequence, not only the cause: {message}"
         );
         assert!(
-            message.contains("vector search will never return it"),
+            message.contains("this write did not index the record"),
             "{message}"
+        );
+        assert!(
+            message.contains("stays searchable at that older value"),
+            "the line must not imply the record became unsearchable — a previously indexed vector survives a rejected rewrite: {message}"
+        );
+        assert!(
+            !message.contains("never return"),
+            "an absolute the write path does not deliver: a stale vector is still returned: {message}"
         );
         assert!(
             message.contains("Re-embed the affected rows"),

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -303,6 +303,19 @@ pub fn first_non_finite(embedding: &[f32]) -> Option<usize> {
     embedding.iter().position(|value| !value.is_finite())
 }
 
+/// Whether every component of `embedding` is exactly zero.
+///
+/// This is the predicate behind the per-record "all zeroes" report. It deliberately does
+/// not treat `NaN` as a zero: a vector such as `[0.0, NaN]` is already named by
+/// [`warn_non_finite_embeddings`] in one batched line, so counting it as all-zero here
+/// would report the same row twice — once per batch and once per record — and a wholly
+/// poisoned batch would emit a line per row. The two predicates together still cover the
+/// same rows, because any `NaN` a looser test would have absorbed is non-finite.
+#[must_use]
+pub fn is_finite_all_zero(embedding: &[f32]) -> bool {
+    embedding.iter().all(|&value| value == 0.0)
+}
+
 /// The remedy clause every non-finite-embedding warning ends with, kept in one place so the
 /// advice and the docs link cannot drift between the paths that skip a record and the ones
 /// that null its embedding.
@@ -708,6 +721,48 @@ mod tests {
         assert_eq!(first_non_finite(&[0.0, 0.0, 0.0]), None);
         assert_eq!(first_non_finite(&[-1.5, 0.0, 2.5]), None);
         assert_eq!(first_non_finite(&[]), None);
+    }
+
+    /// The per-record report is for finite all-zero vectors only. A predicate of
+    /// `v == 0.0 || v.is_nan()` also matches `[0.0, NaN]` and `[NaN, NaN]`, which the
+    /// batched non-finite warning has already named — reporting them here too turns one
+    /// degraded embedding response into a line per row.
+    #[test]
+    fn is_finite_all_zero_excludes_a_nan_padded_vector() {
+        assert!(is_finite_all_zero(&[0.0, 0.0, 0.0]));
+        assert!(is_finite_all_zero(&[0.0, -0.0]));
+        assert!(!is_finite_all_zero(&[0.0, f32::NAN]));
+        assert!(!is_finite_all_zero(&[f32::NAN, f32::NAN]));
+        assert!(!is_finite_all_zero(&[0.0, 1.0]));
+    }
+
+    /// Splitting the report between [`is_finite_all_zero`] and [`first_non_finite`] must
+    /// change only which warning a row gets, never whether it is written. Every vector the
+    /// looser `v == 0.0 || v.is_nan()` test absorbed carries a `NaN`, so the non-finite
+    /// half still claims it.
+    #[test]
+    fn the_split_predicates_filter_the_same_vectors_as_the_combined_one() {
+        let vectors: [&[f32]; 9] = [
+            &[],
+            &[0.0, 0.0],
+            &[0.0, -0.0],
+            &[0.0, f32::NAN],
+            &[f32::NAN, f32::NAN],
+            &[1.0, f32::NAN],
+            &[1.0, f32::INFINITY],
+            &[1.0, 2.0],
+            &[0.0, 1.0],
+        ];
+        for vector in vectors {
+            let combined = vector.iter().all(|&v| v == 0.0 || v.is_nan())
+                || first_non_finite(vector).is_some();
+            let split = is_finite_all_zero(vector) || first_non_finite(vector).is_some();
+            assert_eq!(
+                split, combined,
+                "{vector:?} changes whether the row is written, but the split only moves \
+                 which warning names it"
+            );
+        }
     }
 
     /// The warning is what a user gets to explain a row that vanished from search, so it

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -312,6 +312,20 @@ pub const NON_FINITE_EMBEDDING_REMEDY: &str = "Re-embed the affected rows, or ch
 /// The maximum number of row indexes named in a [`non_finite_embedding_warning`].
 const NON_FINITE_SAMPLE_LIMIT: usize = 5;
 
+/// Report the rows an embedding builder could not index, if there were any.
+///
+/// Every builder that nulls a defective embedding emits through here, so the emptiness
+/// check and the log level cannot drift apart between them.
+pub fn warn_non_finite_embeddings(index_name: &str, affected_rows: &[usize], total_rows: usize) {
+    if affected_rows.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        "{}",
+        non_finite_embedding_warning(index_name, affected_rows, total_rows)
+    );
+}
+
 /// One line explaining why some rows are not searchable, built in a pure function so a
 /// reword cannot quietly drop the index name, the consequence, or the docs link.
 #[must_use]
@@ -399,12 +413,7 @@ pub fn create_embedding_array(
         }
     }
 
-    if !non_finite_rows.is_empty() {
-        tracing::warn!(
-            "{}",
-            non_finite_embedding_warning(index_name, &non_finite_rows, embedding_vectors.len())
-        );
-    }
+    warn_non_finite_embeddings(index_name, &non_finite_rows, embedding_vectors.len());
 
     Ok(Arc::new(builder.finish()))
 }


### PR DESCRIPTION
## Summary

"Invalid embedding" had four different definitions across the vector write paths, and three of them let a vector like `[NaN, 2.0, 3.0]` through.

The root cause is an `all()` where an `any()` was needed. `filter_zero_vectors` (S3 Vectors) and `batch_for_store` (memory) both tested `embedding.iter().all(|x| x == 0.0 || x.is_nan())` — a predicate that only fires when *every* component is bad. One NaN among real values passes it, so the record was indexed. DuckDB had the correct per-element check in `validate_vector`, but it was only ever called on the query vector; the HNSW write path never called it at all. Elasticsearch was the only backend with a complete check.

A non-finite component has no defined distance under any metric an index offers — cosine, L2 and inner product alike — so a single NaN or infinity poisons every score computed against that vector. It was accepted at write, indexed, and for the memory and S3 Vectors backends never screened at read either.

## Changes

`write_util::first_non_finite` is now the one definition of an unscoreable vector, and every write path calls it:

- **`write_util::create_embedding_array`** (the shared generated path) and the near-duplicate **DuckDB** and **Elasticsearch** builders store a defective embedding as a NULL list slot instead of indexing it. The row is kept — these build one column of a batch whose other columns already have their rows — and NULL is the representation those builders already use for a missing embedding.
- **`memory::batch_for_store`** and **`s3_vectors::filter_zero_vectors`** skip the record, matching how they already handle an all-zero-or-NaN vector.
- **`duckdb::validate_vector`** (the query side) now delegates to the same predicate, so the two ends cannot drift.
- `warn_non_finite_embeddings` emits one batched line per builder naming the index, the count, the consequence and the docs link; `non_finite_embedding_warning` builds the text as a pure function so a reword can be asserted on.

**An all-zero vector is deliberately not covered.** It is well defined for L2 and inner product, and #13091 established that `cosine_distance` answers `0.5` for it rather than NULL. Widening the screen to all-zero would have removed rows that are legitimately scoreable and regressed the behavior #13091 just pinned — that conflict is why the earlier attempt at this fix (#13129) was closed. Each path's existing all-zero handling is left exactly as it was.

Two things left out of scope and filed instead:

- The three `create_embedding_array` builders stay duplicated. They disagree on how to recover a `dimension <= 0` write (the shared one errors, the other two fall back to a width of 1), so collapsing them is a behavior change that needs its own test — #13498.
- `native_vector.rs` (Cayenne) is a documented pass-through: the embedding column is written by the accelerator sink, with no Spice-side embedding on the path, and a vector column arriving from pgvector/Parquet/Delta becomes searchable with no embedding code involved at all. A write-side guard cannot cover that end; the read-side screen from #11263 is what does.

## Test plan

- `make lint`
- `make test`

New tests, all of which fail on the pre-fix code:

- `write_util`: `first_non_finite` accepts/rejects per element including `±inf`; the warning names the index, count, consequence and docs link and truncates a long row list; `create_embedding_array` nulls a partially non-finite embedding while leaving finite and all-zero rows indexed.
- `memory`: an end-to-end write through the index with an embedder that returns one bad component leaves the row out of the store (verified for `NaN`, `inf` and `-inf`); a zeroed component leaves the embedding indexed.
- `s3_vectors`: the record filter drops partially non-finite vectors and keeps the metadata columns aligned with the surviving rows.
- `duckdb` / `elasticsearch`: the builders null a non-finite embedding, and a dimension mismatch is still an error rather than being swallowed by the new screen.

Verified the regression direction empirically: with `first_non_finite` stubbed out, `a_partially_non_finite_embedding_is_not_indexed` fails with `left: [1, 2, 3], right: [1, 3]`.

## Review gate

Attests the review-fix commits `958ef3b`, `ecc3a4e` and `468da77` on this branch — the all-zero warning's consequence and remedy, then two narrowings of what either warning is allowed to claim.

- Adversarial review: **declared skip** — `codex` re-probed from the engine this pass and answered `Your workspace is out of credits. Ask your workspace owner to refill in order to continue.` No engine ran, so this is not recorded as clean.
- `/security-review`: **declared skip** with the reason — it scopes to the session's cwd rather than this PR's worktree, so it would have audited an unrelated diff. Reviewed by hand: the change is log wording plus one renamed `pub const` inside `crates/search`, adds no input handling and no new surface, and the strings carry no dataset content beyond the primary key already present on the lines they replace.
- Verification standing in for the adversarial pass: a **7-neuter matrix**, symmetric across both functions. Putting `never return` **or** `stays searchable` into the per-record all-zero line fails its test; putting either into the shared batched line fails the shared test; dropping the all-zero consequence, dropping its remedy, or widening its cause to include NaN each fail as well. 227 `search` lib tests green; clippy `--all-targets` clean over `elasticsearch,duckdb,s3_vectors,text_search,llms` — that crate's default features exclude `elasticsearch`, so a bare `-p search` check never compiles those edits.
- Deferred with an issue rather than silently: **#13504** — a rejected embedding leaves the previous vector searchable on the memory and S3 Vectors paths — alongside #13503 for the Elasticsearch half. The mechanism predates this PR, but this PR widens the class reaching it from all-zero-or-all-NaN to any non-finite component, which is recorded there so it is a decision rather than a side effect.

**What the review rounds actually found, since it is the useful part of this record:** one shared warning was wrong three times over, on three independent axes. It claimed a storage outcome two of four backends do not produce; then an absolute one caller does not deliver (a dropped record leaves its prior vector searchable); then a survival guarantee one *write window* does not deliver (`WriteWindow::ReplaceAll` stages only survivors and swaps the whole set in, discarding it). Each correction was itself wrong until the next round. The line now asserts only the intersection — "this write did not index …" — and both over-claims are pinned by negative assertions on both functions.

## Checklist

- [x] Regression test that fails on the old code and passes on the new
- [x] Edge cases covered: `NaN`, `+inf`, `-inf`, all-zero, empty vector, missing embedding, dimension mismatch
- [x] Same bug class fixed across every sibling write path, not just the reported one
- [x] No behavior change for all-zero vectors
- [x] `cargo fmt` + scoped clippy green
- [ ] `make signoff` / `Attestation` green





