### PR TITLE
fix(mysql): rebuild a purged-position acceleration whatever the snapshot mode says (fixes #13024)

### DIFF
--- a/crates/data-connectors/connector-mysql/src/lib.rs
+++ b/crates/data-connectors/connector-mysql/src/lib.rs
@@ -162,10 +162,9 @@ const PARAMETERS: &[ParameterSpec] = &[
              snapshots when no resumable binlog position exists and resumes without a snapshot \
              when one does; 'disabled' streams changes only; 'always' re-snapshots on every \
              start, discarding any persisted position. 'disabled' governs the first load only: \
-             an acceleration that already holds rows is still rebuilt when its recorded position \
-             can no longer be resumed from and \
-             `mysql_replication_invalid_checkpoint_behavior` is 'restart', because otherwise it \
-             would keep serving rows the source deleted while its history was gone. \
+             an acceleration that already holds rows is still re-read when its recorded position \
+             can no longer be resumed from and `mysql_replication_invalid_checkpoint_behavior` \
+             is 'restart', which would otherwise leave it serving rows the source deleted. \
              Default: auto.",
         )
         .default("auto")

--- a/crates/data-connectors/connector-mysql/src/lib.rs
+++ b/crates/data-connectors/connector-mysql/src/lib.rs
@@ -161,7 +161,12 @@ const PARAMETERS: &[ParameterSpec] = &[
             "When `refresh_mode: changes` loads the table's existing rows: 'auto' (default) \
              snapshots when no resumable binlog position exists and resumes without a snapshot \
              when one does; 'disabled' streams changes only; 'always' re-snapshots on every \
-             start, discarding any persisted position. Default: auto.",
+             start, discarding any persisted position. 'disabled' governs the first load only: \
+             an acceleration that already holds rows is still rebuilt when its recorded position \
+             can no longer be resumed from and \
+             `mysql_replication_invalid_checkpoint_behavior` is 'restart', because otherwise it \
+             would keep serving rows the source deleted while its history was gone. \
+             Default: auto.",
         )
         .default("auto")
         .one_of_ignore_ascii_case(InitialSnapshotMode::VALUES)
@@ -184,8 +189,8 @@ const PARAMETERS: &[ParameterSpec] = &[
     ParameterSpec::component("replication_invalid_checkpoint_behavior")
         .description(
             "What to do when the persisted binlog position was purged from the source: 'error' \
-             (default) surfaces an actionable error; 'restart' drops the saved position and \
-             re-snapshots the table. Default: error.",
+             (default) surfaces an actionable error; 'restart' re-reads the table, whatever \
+             `mysql_replication_initial_snapshot` is set to. Default: error.",
         )
         .default("error")
         .one_of_ignore_ascii_case(InvalidCheckpointBehavior::VALUES)

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -1080,6 +1080,58 @@ impl MemberStart {
     const fn is_loading(self) -> bool {
         matches!(self, Self::Snapshot | Self::Rebuild)
     }
+
+    /// Whether a start resolved *without* a usable position must persist the
+    /// head it just captured, before any rows land.
+    ///
+    /// Only [`Self::Stream`] does. The two loading starts carry a boundary
+    /// committer that persists the head after their rows are durably applied,
+    /// so recording it up front would let a crash mid-load resume past base
+    /// rows that never arrived. A member that loads nothing has no such
+    /// committer, and its head has to be recorded for the next start.
+    const fn persists_head_before_loading(self) -> bool {
+        // Exhaustive over the closed enum rather than a `matches!`: a start
+        // added later has to state which side it is on here, instead of
+        // inheriting "does not persist" from a wildcard.
+        match self {
+            Self::Stream => true,
+            Self::Snapshot | Self::Rebuild => false,
+        }
+    }
+}
+
+/// Which start a member takes when it holds no position it can resume from.
+///
+/// `has_recorded_position` is asked first, because it — not `snapshot_mode` —
+/// answers whether the acceleration is already holding rows. A position that
+/// was recorded but can no longer be resumed from means the source's binary log
+/// no longer explains those rows: a row deleted at the source inside the
+/// unreachable window has no change event left to carry the deletion, so
+/// streaming from the current head would serve that row in every later query,
+/// and persisting the head would make it permanent.
+///
+/// `initial_snapshot: disabled` does not suppress the rebuild. It says a
+/// *first* load must not read the table — a statement about rows the stream has
+/// not been asked to deliver — and cannot say that an acceleration whose
+/// history the source dropped may keep serving rows the source no longer has.
+/// `mysql_replication_invalid_checkpoint_behavior` decides that case, and
+/// `restart`, the behavior that let this member arrive here rather than failing
+/// its stream, asks for exactly this recovery. The rebuild does not use the
+/// snapshot path: it is a single zero-row signal the consumer answers with an
+/// atomic replacement ([`MemberStart::Rebuild`]).
+///
+/// Pure so the ordering is unit-testable without a live `MySQL`.
+fn start_without_usable_position(
+    snapshot_mode: InitialSnapshotMode,
+    has_recorded_position: bool,
+) -> MemberStart {
+    if has_recorded_position {
+        MemberStart::Rebuild
+    } else if snapshot_mode == InitialSnapshotMode::Disabled {
+        MemberStart::Stream
+    } else {
+        MemberStart::Snapshot
+    }
 }
 
 /// Resolve a fresh (non-rejoin) member's start position, applying
@@ -1221,9 +1273,9 @@ async fn resolve_start_position(
     }
 
     // No usable position: capture the head (and its executed GTID set, when
-    // GTID-positioning) first so the snapshot overlap replays idempotently, then
-    // either snapshot from it or (snapshot disabled) stream from it after
-    // persisting it up front.
+    // GTID-positioning) first so the load's overlap replays idempotently, then
+    // load from it — by snapshot or by rebuild — or, for a member with nothing
+    // to load, stream from it after persisting it up front.
     let (head, head_gtid) = if use_gtid {
         super::setup::fetch_head_and_gtid(conn).await?
     } else {
@@ -1232,7 +1284,8 @@ async fn resolve_start_position(
             GtidSet::new(),
         )
     };
-    if params.snapshot_mode == InitialSnapshotMode::Disabled {
+    let start = start_without_usable_position(params.snapshot_mode, has_recorded_position);
+    if start.persists_head_before_loading() {
         let initial = PersistedPosition {
             position: head.clone(),
             schema_json: checkpoint_schema_json.map(ToString::to_string),
@@ -1246,12 +1299,8 @@ async fn resolve_start_position(
         if let Err(e) = position_store.save(&initial).await {
             tracing::warn!(dataset = %dataset_name, error = %e, "failed to persist initial binlog head");
         }
-        Ok((head, head_gtid, MemberStart::Stream))
-    } else if has_recorded_position {
-        Ok((head, head_gtid, MemberStart::Rebuild))
-    } else {
-        Ok((head, head_gtid, MemberStart::Snapshot))
     }
+    Ok((head, head_gtid, start))
 }
 
 /// Apply `invalid_checkpoint_behavior` for one member: `Error` fails the
@@ -2671,6 +2720,73 @@ mod tests {
             assert!(!envelope.is_no_op_heartbeat());
             assert!(!envelope.is_dataset_ready());
         }
+    }
+
+    #[test]
+    fn an_unusable_position_rebuilds_even_when_the_initial_snapshot_is_disabled() {
+        // Regression test for #13024. Asking `initial_snapshot` before "is this
+        // acceleration already holding rows" lets a durable acceleration whose
+        // binlog position the source purged stream on from the current head:
+        // every row deleted at the source inside the purged window survives in
+        // the acceleration and is served by every later query, with nothing
+        // logged.
+        //
+        // A recorded position is the evidence that rows are there, so it
+        // decides, whatever the snapshot mode says.
+        for mode in [
+            InitialSnapshotMode::Auto,
+            InitialSnapshotMode::Always,
+            InitialSnapshotMode::Disabled,
+        ] {
+            assert_eq!(
+                start_without_usable_position(mode, true),
+                MemberStart::Rebuild,
+                "a recorded position that cannot be resumed from must be rebuilt under \
+                 initial_snapshot: {mode:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_first_load_still_honours_the_initial_snapshot_mode() {
+        // The other half of the ordering: with nothing recorded there are no
+        // rows to preserve, so the mode is the only instruction and it is
+        // followed. `disabled` must not be turned into a re-read of the whole
+        // table on every cold start.
+        assert_eq!(
+            start_without_usable_position(InitialSnapshotMode::Disabled, false),
+            MemberStart::Stream
+        );
+        assert_eq!(
+            start_without_usable_position(InitialSnapshotMode::Auto, false),
+            MemberStart::Snapshot
+        );
+        assert_eq!(
+            start_without_usable_position(InitialSnapshotMode::Always, false),
+            MemberStart::Snapshot
+        );
+    }
+
+    #[test]
+    fn only_a_start_that_loads_nothing_persists_the_head_up_front() {
+        // A loading start's head is persisted by its boundary committer, once
+        // its rows are durably applied. Recording it before they land would let
+        // a crash mid-load resume past base rows that never arrived — so a
+        // rebuild reached with the snapshot disabled must not pick up the
+        // streaming member's up-front save.
+        assert!(
+            !MemberStart::Rebuild.persists_head_before_loading(),
+            "a rebuild's head is persisted by its boundary committer, not before its rows land"
+        );
+        assert!(
+            !MemberStart::Snapshot.persists_head_before_loading(),
+            "a snapshot's head is persisted by its boundary committer, not before its rows land"
+        );
+        assert!(
+            MemberStart::Stream.persists_head_before_loading(),
+            "a member that loads nothing has no committer, so its head must be recorded here or \
+             the next start resumes from an older position"
+        );
     }
 
     #[test]

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -1109,22 +1109,33 @@ impl MemberStart {
 /// Which start a member takes when it holds no position it can resume from.
 ///
 /// `has_recorded_position` is asked first, because it — not `snapshot_mode` —
-/// answers whether the acceleration is already holding rows. A position that
-/// was recorded but can no longer be resumed from means the source's binary log
-/// no longer explains those rows: a row deleted at the source inside the
-/// unreachable window has no change event left to carry the deletion, so
-/// streaming from the current head would serve that row in every later query,
-/// and persisting the head would make it permanent.
+/// answers whether the acceleration is already holding rows. Two routes arrive
+/// here with one recorded, and a rebuild answers both:
 ///
-/// `initial_snapshot: disabled` does not suppress the rebuild. It says a
+/// * **The checkpoint was found unusable** and `invalid_checkpoint_behavior` is
+///   `restart` (`error` fails the member's stream before reaching here). The
+///   source's binary log no longer explains the rows already there: a row
+///   deleted at the source inside the unreachable window has no change event
+///   left to carry the deletion, so streaming from the current head would serve
+///   that row in every later query, and persisting the head would make it
+///   permanent.
+/// * **`initial_snapshot: always`**, which discards a still-resumable position
+///   by request. Nothing is wrong with the source on this route and
+///   `invalid_checkpoint_behavior` is never consulted — but the acceleration is
+///   holding rows just the same, so it is replaced rather than emptied and
+///   refilled.
+///
+/// `initial_snapshot: disabled` does not suppress the first of those. It says a
 /// *first* load must not read the table — a statement about rows the stream has
 /// not been asked to deliver — and cannot say that an acceleration whose
 /// history the source dropped may keep serving rows the source no longer has.
-/// `mysql_replication_invalid_checkpoint_behavior` decides that case, and
-/// `restart`, the behavior that let this member arrive here rather than failing
-/// its stream, asks for exactly this recovery. The rebuild does not use the
-/// snapshot path: it is a single zero-row signal the consumer answers with an
-/// atomic replacement ([`MemberStart::Rebuild`]).
+/// `mysql_replication_invalid_checkpoint_behavior` decides that, and `restart`
+/// asks for exactly this recovery. `disabled` and `always` are values of one
+/// parameter, so an acceleration reaching a rebuild under `disabled` reached it
+/// by the unusable-checkpoint route and no other.
+///
+/// Neither route uses the snapshot path: a rebuild is a single zero-row signal
+/// the consumer answers with an atomic replacement ([`MemberStart::Rebuild`]).
 ///
 /// Pure so the ordering is unit-testable without a live `MySQL`.
 fn start_without_usable_position(
@@ -2738,7 +2749,10 @@ mod tests {
         // logged.
         //
         // A recorded position is the evidence that rows are there, so it
-        // decides, whatever the snapshot mode says.
+        // decides, whatever the snapshot mode says. `always` is included
+        // because it reaches the same helper by the other route — it discards a
+        // still-resumable position by request — and must reload the rows it is
+        // holding by replacement rather than by emptying and refilling.
         for mode in [
             InitialSnapshotMode::Auto,
             InitialSnapshotMode::Always,
@@ -2747,7 +2761,7 @@ mod tests {
             assert_eq!(
                 start_without_usable_position(mode, true),
                 MemberStart::Rebuild,
-                "a recorded position that cannot be resumed from must be rebuilt under \
+                "a recorded position that will not be resumed from must be rebuilt under \
                  initial_snapshot: {mode:?}"
             );
         }

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -1321,7 +1321,8 @@ async fn resolve_start_position(
 }
 
 /// Apply `invalid_checkpoint_behavior` for one member: `Error` fails the
-/// member's stream; `Restart` clears its saved position so it re-snapshots.
+/// member's stream; `Restart` accepts the rebuild, leaving the unusable position
+/// in place for [`rebootstrap_member`]'s boundary committer to replace.
 fn apply_invalid_checkpoint(
     params: &ReplicationParams,
     dataset_name: &str,

--- a/crates/data_components/src/mysql_replication/shared.rs
+++ b/crates/data_components/src/mysql_replication/shared.rs
@@ -1089,6 +1089,12 @@ impl MemberStart {
     /// so recording it up front would let a crash mid-load resume past base
     /// rows that never arrived. A member that loads nothing has no such
     /// committer, and its head has to be recorded for the next start.
+    ///
+    /// That makes it the complement of [`Self::is_loading`] over today's three
+    /// starts, and it is still stated separately: the two answer different
+    /// questions — whether the ack floor is held, and who owns the checkpoint
+    /// write — so a start added later has to answer both rather than inherit
+    /// one from the other.
     const fn persists_head_before_loading(self) -> bool {
         // Exhaustive over the closed enum rather than a `matches!`: a start
         // added later has to state which side it is on here, instead of

--- a/crates/runtime/tests/mysql/replication.rs
+++ b/crates/runtime/tests/mysql/replication.rs
@@ -506,6 +506,64 @@ async fn purged_position_behavior() -> Result<(), anyhow::Error> {
         .expect("rebuild persists a fresh position")
         .position;
     assert_ne!(repersisted.file, "binlog.999999");
+    drop(stream);
+
+    // `restart` with the initial snapshot DISABLED: the same rebuild, reached
+    // end to end through `resolve_start_position`. Regression test for #13024.
+    //
+    // `initial_snapshot: disabled` governs the first load. It cannot mean that
+    // an acceleration whose history the source dropped may keep serving rows
+    // the source no longer has, and this is the arm where that used to happen:
+    // the member streamed on from a freshly captured head, so a row deleted at
+    // the source inside the purged window kept being served by every later
+    // query — and persisting that head up front made it permanent, because the
+    // next start resumed cleanly and never revisited the gap.
+    let store: Arc<MemoryPositionStore> = Arc::new(MemoryPositionStore::default());
+    store.save(&stale).await.expect("save stale position");
+    let mut input = stream_input(port, 200_203, Arc::clone(&store) as Arc<dyn PositionStore>);
+    input.params.invalid_position_behavior = InvalidCheckpointBehavior::Restart;
+    input.params.snapshot_mode = InitialSnapshotMode::Disabled;
+    let mut stream = start_replication_stream(input);
+
+    let envelope = next_envelope(
+        &mut stream,
+        "the rebuild signal under `initial_snapshot: disabled` (without it the member streams \
+         on from the source head and keeps every row deleted inside the purged window)",
+    )
+    .await?;
+    assert!(
+        envelope.history_unavailable(),
+        "a purged position under `restart` must ask the consumer to rebuild whatever \
+         `initial_snapshot` says"
+    );
+    // The rebuild does not use the snapshot machinery the mode disabled: it is
+    // one zero-row signal the consumer answers with an atomic replacement.
+    assert_eq!(num_rows(&envelope), 0);
+    assert!(ops_of(&envelope).is_empty());
+
+    // The stale position survives until the rebuild commits. Recording the new
+    // head before the replacement lands is what made the divergence permanent,
+    // and it would also let a crash mid-rebuild resume past rows that never
+    // arrived.
+    let held = store
+        .load()
+        .await
+        .expect("store readable")
+        .expect("the stale checkpoint is still there")
+        .position;
+    assert_eq!(
+        held.file, "binlog.999999",
+        "the fresh head must not be persisted before the rebuild is applied"
+    );
+
+    envelope.commit().await?;
+    let repersisted = store
+        .load()
+        .await
+        .expect("store readable")
+        .expect("rebuild persists a fresh position")
+        .position;
+    assert_ne!(repersisted.file, "binlog.999999");
 
     pool.disconnect().await?;
     Ok(())

--- a/docs/features/mysql-binlog-replication.md
+++ b/docs/features/mysql-binlog-replication.md
@@ -106,7 +106,7 @@ as the Postgres connector's snapshot/WAL boundary.
 | `mysql_replication_initial_snapshot` | `auto` | When existing rows load: `auto` snapshots when no resumable position exists; `disabled` streams changes only; `always` re-snapshots on every start. `disabled` governs the *first* load — see [position recovery](#when-the-position-is-purged) for the one case that reloads regardless. |
 | `mysql_replication_checkpoint_interval` | `10s` | How often the committed position persists to the sidecar. Bounds crash-replay volume. |
 | `mysql_replication_bootstrap_batch_size` | `8192` | Rows per emitted snapshot batch (max `1048576`). |
-| `mysql_replication_invalid_checkpoint_behavior` | `error` | What to do when the persisted position was purged from the source: `error` or `restart` (drop the position and rebuild the acceleration from the source, whatever `mysql_replication_initial_snapshot` is set to). |
+| `mysql_replication_invalid_checkpoint_behavior` | `error` | What to do when the persisted position was purged from the source: `error` or `restart` (rebuild the acceleration from the source, whatever `mysql_replication_initial_snapshot` is set to). |
 | `mysql_replication_ready_lag` | `2s` | For `refresh_mode: changes`, the dataset is marked Ready once its replication lag (now minus the newest applied change's source-commit time) falls below this — it stays not-ready while snapshotting or draining a backlog, so it never serves stale or incomplete data. Accepts any [fundu](https://docs.rs/fundu) duration string. |
 
 The runtime-level CDC apply tunables (`cdc_prefetch_buffer`,
@@ -126,7 +126,7 @@ params:
   mysql_replication_invalid_checkpoint_behavior: restart
 ```
 
-to instead drop the stale position and rebuild the acceleration from the
+to instead ignore the stale position and rebuild the acceleration from the
 source automatically.
 
 The rebuild replaces the acceleration's contents in one atomic swap, so
@@ -134,6 +134,16 @@ queries issued while it runs are answered from the pre-rebuild contents until
 the replacement completes — never from an empty or partially loaded table.
 Change streaming resumes on top of the replacement; the overlap between the
 captured position and the re-read replays idempotently.
+
+The stale position is not deleted when the rebuild starts; it is replaced with
+the rebuild's own position only once the accelerator has durably applied the
+replacement. While it sits there it is the only durable record that the
+acceleration holds rows no position explains, so a crash mid-rebuild costs at
+most one repeated rebuild — the next start re-detects the position as unusable
+and rebuilds again. Deleting it up front and then crashing would instead leave a
+populated acceleration with no position at all, which the next start reads as a
+first load, and a first load empties the table before refilling it from a
+snapshot — the very window this behavior exists to close.
 
 `mysql_replication_initial_snapshot: disabled` does **not** suppress this
 rebuild. That setting governs the first load — whether existing rows are read

--- a/docs/features/mysql-binlog-replication.md
+++ b/docs/features/mysql-binlog-replication.md
@@ -103,10 +103,10 @@ as the Postgres connector's snapshot/WAL boundary.
 | Parameter | Default | Description |
 | --- | --- | --- |
 | `mysql_replication_server_id` | derived | The `server_id` this replica registers with. Must be unique among all replicas attached to the source; the default is derived from the dataset name and process, so two spiced instances don't collide. |
-| `mysql_replication_initial_snapshot` | `auto` | When existing rows load: `auto` snapshots when no resumable position exists; `disabled` streams changes only; `always` re-snapshots on every start. |
+| `mysql_replication_initial_snapshot` | `auto` | When existing rows load: `auto` snapshots when no resumable position exists; `disabled` streams changes only; `always` re-snapshots on every start. `disabled` governs the *first* load — see [position recovery](#when-the-position-is-purged) for the one case that reloads regardless. |
 | `mysql_replication_checkpoint_interval` | `10s` | How often the committed position persists to the sidecar. Bounds crash-replay volume. |
 | `mysql_replication_bootstrap_batch_size` | `8192` | Rows per emitted snapshot batch (max `1048576`). |
-| `mysql_replication_invalid_checkpoint_behavior` | `error` | What to do when the persisted position was purged from the source: `error` or `restart` (drop the position and rebuild the acceleration from the source). |
+| `mysql_replication_invalid_checkpoint_behavior` | `error` | What to do when the persisted position was purged from the source: `error` or `restart` (drop the position and rebuild the acceleration from the source, whatever `mysql_replication_initial_snapshot` is set to). |
 | `mysql_replication_ready_lag` | `2s` | For `refresh_mode: changes`, the dataset is marked Ready once its replication lag (now minus the newest applied change's source-commit time) falls below this — it stays not-ready while snapshotting or draining a backlog, so it never serves stale or incomplete data. Accepts any [fundu](https://docs.rs/fundu) duration string. |
 
 The runtime-level CDC apply tunables (`cdc_prefetch_buffer`,
@@ -134,6 +134,15 @@ queries issued while it runs are answered from the pre-rebuild contents until
 the replacement completes — never from an empty or partially loaded table.
 Change streaming resumes on top of the replacement; the overlap between the
 captured position and the re-read replays idempotently.
+
+`mysql_replication_initial_snapshot: disabled` does **not** suppress this
+rebuild. That setting governs the first load — whether existing rows are read
+when the dataset starts with nothing recorded — and an acceleration that is
+already holding rows is a different situation: the source's binary log no
+longer explains what is in it, so a row deleted at the source inside the purged
+window has no change event left to carry the deletion and would survive every
+later query. The rebuild is a single re-read handed to the accelerator, not the
+snapshot path `disabled` turns off.
 
 ## Semantics and type notes
 


### PR DESCRIPTION
## Summary

`mysql_replication_invalid_checkpoint_behavior: restart` is documented to recover a binlog
position the source has purged. It did not when `mysql_replication_initial_snapshot: disabled`
was also set, and the failure was silent.

`resolve_start_position` asked the snapshot mode before it asked whether the acceleration was
already holding rows:

```rust
if params.snapshot_mode == InitialSnapshotMode::Disabled {
    // persist `head` and stream from it
} else if has_recorded_position {
    // rebuild
} else {
    // snapshot
}
```

So a **durable** acceleration whose position was purged persisted the freshly captured head and
resumed streaming from it. A row deleted at the source inside the unreachable window has no change
event left to carry the deletion, so it survived in the acceleration and was served by every later
query — and persisting the new head made it permanent: the next start resumed cleanly and never
revisited the gap. Nothing errored and nothing warned; the acceleration simply disagreed with the
source, indefinitely.

The same purge detected mid-stream already recovered (`rebootstrap_member` hands the consumer an
atomic rebuild regardless of the snapshot mode), so the behaviour also differed by *when* the purge
was noticed — which an operator can neither predict nor configure.

## Root cause

`has_recorded_position` — not `snapshot_mode` — is what answers "is this acceleration holding
rows", so it has to decide first. `initial_snapshot: disabled` governs the *first* load; it cannot
say that an acceleration whose history the source dropped may keep serving rows the source no
longer has. That is `invalid_checkpoint_behavior`'s question, and on the unusable-checkpoint route `restart`
is the only value that gets this far — `error` fails the member's stream earlier, via
`apply_invalid_checkpoint`. (`initial_snapshot: always` reaches the same decision by a different
route, discarding a still-resumable position by request; that route is unchanged by this PR and is
documented alongside the first.)

The rebuild does not use the snapshot machinery the mode disabled. Since #13023 it is a single
zero-row signal the consumer answers with an atomic replacement, so "snapshot disabled" and "cannot
be rebuilt" stopped being the same statement.

## Changes

- `start_without_usable_position` — a pure function that asks `has_recorded_position` first, then
  the snapshot mode. Extracted rather than left inline because `resolve_start_position` takes a live
  `Conn`, so the ordering is only unit-testable once it is separated from the connection, matching
  the `gtid_checkpoint_verdict` / `file_checkpoint_verdict` helpers already in this file.
- `MemberStart::persists_head_before_loading` — the up-front save of the captured head now follows
  the verdict rather than the mode. Only a start that loads nothing performs it; the two loading
  starts persist their head from a boundary committer once their rows are durably applied, so a
  crash mid-rebuild re-resolves and rebuilds again instead of resuming past base rows that never
  arrived. Exhaustive over the closed enum, so a start added later has to state which side it is on.
- Both `mysql_replication_initial_snapshot` and `mysql_replication_invalid_checkpoint_behavior`
  parameter descriptions now say which one governs this case.

### The one behaviour change worth a reviewer's attention

Under `initial_snapshot: disabled`, a purged position now causes the acceleration to be re-read
from the source table — including rows it deliberately never loaded. That is the trade the issue
framed, and it is decided the same way everywhere else in the codebase:

- **DynamoDB** already re-bootstraps from a fresh table scan under `restart`, regardless of
  `initial_snapshot` (`connector-dynamodb/src/connector.rs`).
- **Postgres** decides the rebuild by comparing the acceleration's watermark against the slot's
  `restart_lsn`, entirely independently of the snapshot mode; `initial_snapshot` gates only the
  *snapshot* path (`postgres_replication/shared.rs`).

MySQL was the outlier. `invalid_checkpoint_behavior` also defaults to `error`, so reaching this
path at all means an operator explicitly chose `restart` — documented as re-reading the table.

## Test plan

- `make lint`
- `make test`

New unit tests in `crates/data_components/src/mysql_replication/shared.rs`:

- `an_unusable_position_rebuilds_even_when_the_initial_snapshot_is_disabled` — the regression test:
  a recorded position that cannot be resumed from rebuilds under every one of `auto`, `always` and
  `disabled`.
- `a_first_load_still_honours_the_initial_snapshot_mode` — the other half of the ordering: with
  nothing recorded there are no rows to preserve, so `disabled` still streams and must not become a
  full re-read on every cold start.
- `only_a_start_that_loads_nothing_persists_the_head_up_front` — the up-front save stays off both
  loading starts.

End-to-end, through the real call site: a third arm of the existing live-`MySQL`
`purged_position_behavior` test (`crates/runtime/tests/mysql/replication.rs`) runs the purged
checkpoint at `initial_snapshot: disabled` with `invalid_checkpoint_behavior: restart` and asserts
both halves — the rebuild signal arrives at all (before the fix this arm produced
`MemberStart::Stream`, so nothing would come), and the stale checkpoint is still in the store when
it does, since persisting the fresh head before the replacement lands is what made the divergence
permanent. That test needs a `MySQL` container; Docker was unavailable in the environment this
branch was written in, so it is compile-checked (`cargo check -p runtime --tests --features mysql`,
clean) but not run locally — CI runs it.

Neuter matrix (each mutation applied alone, whole suite re-run; every neuter kills at least one
test and every new test has a killer):

| # | Neuter | Killed |
|---|---|---|
| N1 | the pre-fix ordering — snapshot mode asked first | `an_unusable_position_rebuilds_even_when_the_initial_snapshot_is_disabled` |
| N2 | `disabled` first load snapshots instead of streaming | `a_first_load_still_honours_the_initial_snapshot_mode` |
| N3 | a recorded position snapshots instead of rebuilding | `an_unusable_position_rebuilds_even_when_the_initial_snapshot_is_disabled` |
| N4 | the rebuild persists the head up front | `only_a_start_that_loads_nothing_persists_the_head_up_front` |
| N5 | the snapshot persists the head up front | `only_a_start_that_loads_nothing_persists_the_head_up_front` |
| N6 | the streaming member stops persisting its head | `only_a_start_that_loads_nothing_persists_the_head_up_front` |

The two pre-existing tests carried through the matrix as controls —
`rebuild_replaces_the_acceleration_instead_of_emptying_it` and
`both_loading_starts_hold_the_member_snapshotting` — survive every neuter, which is the intended
reading: they pin the mid-stream rebootstrap path and the ack-floor property, neither of which this
change touches.

Reaching `resolve_start_position` itself needs a live `MySQL`, which is why the decision is pinned
through the extracted function rather than end-to-end.

## Review gate

Attests the head this PR ships, `27c84b7` — the review-fix commit is prose and one rustdoc, so
the functional attestations below stand unchanged from `555bf8d`.

- Adversarial review: **skipped** — `codex` was re-probed from the engine for the `27c84b7` round
  and answered the same: "Your workspace is out of credits. Ask your workspace owner to refill in
  order to continue." `grok` is not installed in this environment, so the receipt records
  `engine=none exit=1 job=none verdict=unparsed`. A hand
  adversarial pass ran in its place and produced the "one behaviour change worth a reviewer's
  attention" section above, plus the check that `restart` is the only `invalid_checkpoint_behavior`
  that can reach this code and the confirmation that the rebuild boundary carries a committer (the
  property `rebuild_replaces_the_acceleration_instead_of_emptying_it` already asserts).
- `/security-review`: ran on the functional diff (only rustdoc and parameter-description text
  changed after it), no HIGH or MEDIUM findings. The two new functions are pure; the diff
  changes whether one existing checkpoint write happens on one path, never what is written or
  where; no log, error or metric string changed; the `connector-mysql` edit is parameter
  description text only, with the accepted value set unchanged.
- `/simplify`: ran. Two cleanups applied — the parameter description tightened, and
  `persists_head_before_loading`'s rustdoc now states its relationship to `is_loading` (the
  complement over today's three starts) and why the two are stated separately rather than one
  derived from the other. One altitude finding was considered and declined as out of scope: the
  "`restart` re-reads regardless of the snapshot mode" rule is now consistent across the MySQL,
  Postgres and DynamoDB connectors but is stated three times, and hoisting it into
  `crates/data_components/src/cdc/` would widen this PR across three connectors for a conclusion
  their differing inputs do not otherwise share.

## Review rounds

- **Copilot, round 1** — one finding, valid and accepted: the helper's rustdoc attributed every
  recorded-position arrival to an unusable checkpoint permitted by `restart`, but
  `initial_snapshot: always` reaches it too, on a position that may still be resumable and without
  `invalid_checkpoint_behavior` ever being consulted. Fixed in 8ecb4aa — the contract now names both
  routes and what distinguishes them. No behaviour change: the `always` route returned `Rebuild`
  before this PR and still does. The parameter description's `restart` condition stays exact,
  because `disabled` and `always` are two values of one parameter, so a rebuild reached under
  `disabled` reached it by the unusable-checkpoint route and no other.

- **Copilot, round 2** — two findings, both valid and both accepted (555bf8d).
  - The checked-in guide `docs/features/mysql-binlog-replication.md` still said `disabled` streams
    changes only, without exception. I had updated the connector parameter strings and assumed the
    rest lived in `spiceai/docs`. Both parameter rows and the purged-position section now say which
    parameter governs an acceleration that is already holding rows, and why.
  - The unit tests assert the extracted decision directly, so they would still pass if
    `resolve_start_position` stopped routing the live `disabled` + `restart` path through that
    verdict. The end-to-end arm described in the test plan closes it.

- **Copilot, round 3** — one finding, valid and accepted (27c84b7). Both the parameter table and
  the purged-position section said `restart` "drops" the stale position, but nothing deletes it:
  `apply_invalid_checkpoint`'s `Restart` arm returns `Ok(())` untouched, and the rebuild's boundary
  committer replaces it with the new head only after the accelerator has durably applied the
  replacement. The distinction is load-bearing, so the section now carries the crash argument
  rather than just the sequencing — the retained position is the only durable record that the
  acceleration holds rows no position explains, so a crash mid-rebuild costs at most one repeated
  rebuild, whereas deleting it up front would leave a populated acceleration with no position that
  the next start reads as a first load, which empties the table before refilling it. Only the
  first-load hazard is asserted, because that is the one `rebootstrap_member` documents.
  A third site the review did not name is fixed with them: `apply_invalid_checkpoint`'s own doc
  comment said `Restart` "clears its saved position so it re-snapshots", contradicting its body
  four lines below. That text is pre-existing on trunk, but it is the same claim in this PR's file
  and it is what a reader checks the invariant against.

Fixes #13024

## Checklist

- [x] Root cause identified and stated
- [x] Regression test that fails on the old code
- [x] Bug class checked across sibling CDC connectors (Postgres and DynamoDB already correct)
- [x] User-facing parameter documentation updated
- [x] End-to-end coverage through `resolve_start_position` (compile-checked here; runs in CI)
- [x] Checked-in `docs/features/mysql-binlog-replication.md` updated
- [ ] `docs.spiceai.org` note that `initial_snapshot: disabled` does not suppress a `restart`
      rebuild (separate repo — `spiceai/docs`)
