### PR TITLE
fix(acceleration): make the refresh-completion signal level-triggered (fixes #13086)

### DIFF
--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -80,7 +80,9 @@ pub mod write_back_worker;
 
 pub(crate) use write::WriteMode;
 
-pub use refresh_completion::{RefreshCompletion, RefreshCompletionWaiter};
+pub use refresh_completion::{
+    RefreshCompletion, RefreshCompletionOutcome, RefreshCompletionWaiter,
+};
 pub use refresh_task_runner::RefreshTaskRunner;
 pub use snapshots::SnapshotCreationConfig;
 

--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -61,12 +61,13 @@ use snafu::prelude::*;
 use spicepod::metric::Metrics;
 use synchronized_table::SynchronizedTable;
 use tokio::runtime::Handle;
-use tokio::sync::{Mutex, Notify, RwLock, Semaphore, mpsc};
+use tokio::sync::{Mutex, RwLock, Semaphore, mpsc};
 use tokio::task::JoinHandle;
 
 pub mod caching;
 pub mod federation;
 pub mod refresh;
+pub mod refresh_completion;
 pub mod refresh_task;
 pub mod refresh_task_runner;
 pub mod retention;
@@ -79,6 +80,7 @@ pub mod write_back_worker;
 
 pub(crate) use write::WriteMode;
 
+pub use refresh_completion::{RefreshCompletion, RefreshCompletionWaiter};
 pub use refresh_task_runner::RefreshTaskRunner;
 pub use snapshots::SnapshotCreationConfig;
 
@@ -777,7 +779,7 @@ impl Builder {
             return ExpectedAppendModeForAppendStreamSnafu.fail();
         }
 
-        let on_complete_notification = Arc::new(Notify::new());
+        let refresh_completion = RefreshCompletion::new();
 
         let (acceleration_refresh_mode, refresh_trigger) = match self.refresh.mode {
             RefreshMode::Disabled => (refresh::AccelerationRefreshMode::Disabled, None),
@@ -932,7 +934,7 @@ impl Builder {
             self.io_runtime.clone(),
             Arc::clone(&self.accelerator_write_mutex),
         );
-        refresher.with_completion_notifier(Arc::clone(&on_complete_notification));
+        refresher.with_refresh_completion(refresh_completion.clone());
         refresher.with_last_updated_at(Arc::clone(&last_updated_at));
         refresher.caching(&self.caching);
         refresher.checkpointer(self.checkpointer);
@@ -976,10 +978,12 @@ impl Builder {
                 // `refresh_trigger` is None because the receiver will be
                 // dropped (refresher.start() is not called).
                 //
-                // Notify completion waiters so the schedule-creation path
-                // doesn't block waiting on a refresh that won't run here —
-                // dataset readiness is a separate concern handled above.
-                on_complete_notification.notify_waiters();
+                // No refresh will ever be recorded for this table here, so
+                // close the completion signal: the schedule-creation path and
+                // every other caller resolves at once instead of waiting on a
+                // refresh that cannot arrive. Dataset readiness is a separate
+                // concern handled above.
+                refresh_completion.close();
                 (None, None)
             } else {
                 (
@@ -2375,6 +2379,67 @@ mod tests {
     use datafusion::logical_expr::expr::ScalarFunction;
     use datafusion::prelude::{col, lit};
     use datafusion_functions_json::udfs::json_get_str_udf;
+
+    /// Build an accelerated table over an empty in-memory source in the given
+    /// cluster role, returning its refresh-completion signal.
+    async fn built_table_completion(
+        cluster_role: Option<ClusterRole>,
+        refresh_mode: RefreshMode,
+    ) -> RefreshCompletion {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let source = Arc::new(
+            data_components::arrow::write::MemTable::try_new(Arc::clone(&schema), vec![vec![]])
+                .expect("source table builds"),
+        );
+        let accelerator = Arc::new(
+            data_components::arrow::write::MemTable::try_new(schema, vec![vec![]])
+                .expect("accelerator table builds"),
+        ) as Arc<dyn TableProvider>;
+
+        let mut builder = Builder::new(
+            status::RuntimeStatus::new(),
+            TableReference::bare("test"),
+            Arc::new(FederatedTable::new_unchecked(source)),
+            "mem_table".to_string(),
+            accelerator,
+            refresh::Refresh::new(refresh_mode),
+            Handle::current(),
+        );
+        builder.cluster_role(cluster_role);
+
+        let table = builder.build().await.expect("accelerated table builds");
+        table
+            .refresher()
+            .refresh_completion()
+            .expect("the table carries a refresh-completion signal")
+    }
+
+    /// Regression test for #13086. A cluster scheduler runs no refresh locally,
+    /// so a caller waiting on one must be released rather than left holding a
+    /// wait that nothing can ever satisfy.
+    #[tokio::test]
+    async fn test_a_scheduler_releases_refresh_completion_waiters() {
+        let completion =
+            built_table_completion(Some(ClusterRole::Scheduler), RefreshMode::Full).await;
+
+        // Taken after the build, which is the only order a caller can manage:
+        // the table has to exist before its refresher can be reached.
+        tokio::time::timeout(Duration::from_secs(5), completion.next().wait())
+            .await
+            .expect("a scheduler must release a waiter for a refresh it will never run");
+    }
+
+    /// The contrast that keeps the test above honest: off the scheduler path a
+    /// table with no refresh scheduled leaves its waiters pending, so the
+    /// release is the scheduler branch's doing and not the default.
+    #[tokio::test]
+    async fn test_a_table_with_no_refresh_scheduled_leaves_waiters_pending() {
+        let completion = built_table_completion(None, RefreshMode::Disabled).await;
+
+        tokio::time::timeout(Duration::from_millis(200), completion.next().wait())
+            .await
+            .expect_err("a table that is not a scheduler must not release the waiter itself");
+    }
 
     fn schema_with_fetched_at() -> SchemaRef {
         Arc::new(Schema::new(vec![

--- a/crates/runtime-table/src/accelerated/refresh.rs
+++ b/crates/runtime-table/src/accelerated/refresh.rs
@@ -23,6 +23,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use super::refresh_task_runner::RefreshTaskRunner;
 use super::synchronized_table::SynchronizedTable;
 use super::{SnapshotCreateTrigger, SnapshotCreationConfig, metrics};
+use crate::accelerated::refresh_completion::RefreshCompletion;
 use crate::accelerated::refresh_task::RefreshTask;
 use crate::accelerated::snapshots::{
     SnapshotCallback, canonical_checkpoint_schema, create_checkpoint_and_snapshot,
@@ -49,8 +50,8 @@ use snafu::prelude::*;
 use spicepod::metric::Metrics;
 use tokio::runtime::Handle;
 use tokio::select;
+use tokio::sync::Mutex;
 use tokio::sync::mpsc::Receiver;
-use tokio::sync::{Mutex, Notify};
 use tokio::sync::{RwLock, Semaphore};
 use tokio::time::sleep;
 
@@ -553,8 +554,9 @@ pub struct Refresher {
     initial_load_completed: Arc<AtomicBool>,
     disable_federation: bool,
     semaphore: Option<Arc<Semaphore>>,
-    /// Notification for completion of refresh operation
-    on_complete_notification: Option<Arc<Notify>>,
+    /// Records each completed refresh so callers can wait for one. `None` when
+    /// no refresh runs for this table in this process.
+    refresh_completion: Option<RefreshCompletion>,
     cpu_runtime: Option<Handle>,
     /// Dedicated nice-0 runtime for the CDC changes-apply loop; falls back to
     /// `cpu_runtime` when unset.
@@ -618,7 +620,7 @@ impl Refresher {
             initial_load_completed: Arc::new(AtomicBool::new(false)),
             disable_federation: false,
             semaphore: None,
-            on_complete_notification: None,
+            refresh_completion: None,
             snapshot_config: None,
             snapshot_refresh_state: None,
             snapshot_interval_task: None,
@@ -676,8 +678,8 @@ impl Refresher {
         self
     }
 
-    pub fn with_completion_notifier(&mut self, on_complete_notification: Arc<Notify>) -> &mut Self {
-        self.on_complete_notification = Some(on_complete_notification);
+    pub fn with_refresh_completion(&mut self, refresh_completion: RefreshCompletion) -> &mut Self {
+        self.refresh_completion = Some(refresh_completion);
         self
     }
 
@@ -710,9 +712,13 @@ impl Refresher {
         self
     }
 
+    /// The refresh-completion signal for this table, or `None` when no refresh
+    /// runs here. Callers pick the question they are asking:
+    /// [`RefreshCompletion::any`] for the initial load, or
+    /// [`RefreshCompletion::next`] for a refresh they are about to trigger.
     #[must_use]
-    pub fn on_complete_notification(&self) -> Option<Arc<Notify>> {
-        self.on_complete_notification.clone()
+    pub fn refresh_completion(&self) -> Option<RefreshCompletion> {
+        self.refresh_completion.clone()
     }
 
     pub fn set_initial_load_completed(&self, initial_load_completed: bool) {
@@ -937,7 +943,7 @@ impl Refresher {
         let refresh_task = Arc::clone(refresh_task_runner.refresh_task());
         self.refresh_task_runner = Some(refresh_task_runner);
 
-        let notifier = self.on_complete_notification.clone();
+        let refresh_completion = self.refresh_completion.clone();
         let refresh = Arc::clone(&self.refresh);
 
         let caching = self.caching.clone();
@@ -1092,10 +1098,14 @@ impl Refresher {
                         let refresh_changed_accelerator = refresh_result_changed_accelerator(&res);
 
                         if refresh_succeeded {
-                            if let Some(notifier) = &notifier {
-                                notify_refresh_done(&dataset_name, &refresh, Arc::clone(notifier)).await;
-                            }
+                            // Store the flag before recording the completion, so a
+                            // caller woken by the completion observes the initial
+                            // load as done. The CDC apply path already orders it
+                            // this way (`RefreshTask::signal_dataset_ready`).
                             initial_load_completed.store(true, Ordering::Relaxed);
+                            if let Some(refresh_completion) = &refresh_completion {
+                                record_refresh_done(&dataset_name, &refresh, refresh_completion).await;
+                            }
                         }
 
                         if refresh_changed_accelerator && let Some(cache_provider_ref) = caching.as_ref() {
@@ -1204,7 +1214,7 @@ impl Refresher {
         let refresh = Arc::clone(&self.refresh);
         let initial_load_completed = Arc::clone(&self.initial_load_completed);
 
-        let notifier = self.on_complete_notification.clone();
+        let refresh_completion = self.refresh_completion.clone();
         let changes_task = async move {
             let refresh_task = refresh_task_builder.build();
             if let Err(err) = refresh_task
@@ -1212,7 +1222,7 @@ impl Refresher {
                     refresh,
                     changes_stream,
                     caching,
-                    notifier,
+                    refresh_completion,
                     initial_load_completed,
                 )
                 .await
@@ -1260,12 +1270,14 @@ fn refresh_result_changed_accelerator(result: &super::Result<()>) -> bool {
     )
 }
 
-async fn notify_refresh_done(
+/// Records a completed refresh: releases the callers waiting on it, then
+/// publishes the refresh-time metric.
+async fn record_refresh_done(
     dataset_name: &TableReference,
     refresh: &Arc<RwLock<Refresh>>,
-    ready_sender: Arc<Notify>,
+    refresh_completion: &RefreshCompletion,
 ) {
-    ready_sender.notify_waiters();
+    refresh_completion.record();
 
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1449,6 +1461,136 @@ mod tests {
         )));
     }
 
+    /// Build a started `Full`-mode refresher over a one-row source, returning its
+    /// completion signal, its refresh trigger, and the handle that keeps the
+    /// refresh task alive.
+    async fn started_full_refresher(
+        status: Arc<status::RuntimeStatus>,
+    ) -> (
+        Arc<Refresher>,
+        RefreshCompletion,
+        mpsc::Sender<Option<RefreshOverrides>>,
+        Option<tokio::task::JoinHandle<()>>,
+    ) {
+        let schema = Arc::new(Schema::new(vec![arrow::datatypes::Field::new(
+            "time_in_string",
+            DataType::Utf8,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringArray::from(vec!["1970-01-01"]))],
+        )
+        .expect("source batch builds");
+        let federated = Arc::new(FederatedTable::new_unchecked(Arc::new(
+            MemTable::try_new(Arc::clone(&schema), vec![vec![batch]]).expect("source table builds"),
+        )));
+        let accelerator =
+            Arc::new(MemTable::try_new(schema, vec![vec![]]).expect("accelerator table builds"))
+                as Arc<dyn TableProvider>;
+
+        let refresh_completion = RefreshCompletion::new();
+        let mut refresher = Refresher::new(
+            status,
+            TableReference::bare("test"),
+            federated,
+            Some("mem_table".to_string()),
+            Arc::new(RwLock::new(Refresh::new(RefreshMode::Full))),
+            accelerator,
+            None,
+            None,
+            Handle::current(),
+            Arc::new(Mutex::new(())),
+        );
+        refresher.with_refresh_completion(refresh_completion.clone());
+
+        let (trigger, receiver) = mpsc::channel::<Option<RefreshOverrides>>(1);
+        let refresh_handle = refresher
+            .start(AccelerationRefreshMode::Full(receiver))
+            .await
+            .expect("refresh task starts");
+
+        (
+            Arc::new(refresher),
+            refresh_completion,
+            trigger,
+            refresh_handle,
+        )
+    }
+
+    /// Poll `initial_load_completed` rather than sleeping, so the refresh is
+    /// known to have finished before the wait below is entered.
+    async fn await_initial_load(refresher: &Refresher) {
+        timeout(Duration::from_secs(5), async {
+            while !refresher.initial_load_completed() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the triggered refresh completes");
+    }
+
+    /// Regression test for #13086. A caller asking about the initial load after
+    /// it has already finished — the shape every registration path has, since
+    /// the refresh starts inside the table build — must be told it finished.
+    /// An edge-triggered signal has nothing left to report by then, so the
+    /// caller waits for a refresh that already happened.
+    #[tokio::test]
+    async fn test_completion_taken_after_the_refresh_still_reports_it() {
+        let (refresher, refresh_completion, trigger, refresh_handle) =
+            started_full_refresher(status::RuntimeStatus::new()).await;
+
+        trigger.send(None).await.expect("trigger is accepted");
+        await_initial_load(&refresher).await;
+
+        timeout(Duration::from_secs(5), refresh_completion.any().wait())
+            .await
+            .expect("a refresh that already completed must satisfy a waiter taken afterwards");
+
+        drop(refresh_handle);
+    }
+
+    /// Regression test for #13086. A caller that triggers a refresh takes its
+    /// waiter first and awaits it after the trigger returns; the refresh may
+    /// finish inside that window, and the waiter must still resolve.
+    #[tokio::test]
+    async fn test_completion_taken_before_a_trigger_survives_the_window() {
+        let (refresher, refresh_completion, trigger, refresh_handle) =
+            started_full_refresher(status::RuntimeStatus::new()).await;
+
+        let waiter = refresh_completion.next();
+        trigger.send(None).await.expect("trigger is accepted");
+        await_initial_load(&refresher).await;
+
+        timeout(Duration::from_secs(5), waiter.wait())
+            .await
+            .expect("a refresh completing before the wait must still resolve it");
+
+        drop(refresh_handle);
+    }
+
+    /// The flag a caller pairs with the completion must already be observable
+    /// when the completion is reported, or the pairing reports a load that has
+    /// not been published yet.
+    #[tokio::test]
+    async fn test_initial_load_flag_is_stored_before_the_completion_is_recorded() {
+        let (refresher, refresh_completion, trigger, refresh_handle) =
+            started_full_refresher(status::RuntimeStatus::new()).await;
+
+        let waiter = refresh_completion.next();
+        trigger.send(None).await.expect("trigger is accepted");
+        timeout(Duration::from_secs(5), waiter.wait())
+            .await
+            .expect("the triggered refresh reports its completion");
+
+        assert!(
+            refresher.initial_load_completed(),
+            "a caller woken by the completion must observe the initial load as done"
+        );
+
+        drop(refresh_handle);
+    }
+
     async fn setup_and_test(
         status: Arc<status::RuntimeStatus>,
         source_data: Vec<&str>,
@@ -1482,7 +1624,7 @@ mod tests {
 
         let refresh = Refresh::new(RefreshMode::Full);
 
-        let notifier = Arc::new(Notify::new());
+        let refresh_completion = RefreshCompletion::new();
         let mut refresher = Refresher::new(
             status,
             TableReference::bare("test"),
@@ -1496,7 +1638,7 @@ mod tests {
             Arc::new(Mutex::new(())),
         );
 
-        refresher.with_completion_notifier(Arc::clone(&notifier));
+        refresher.with_refresh_completion(refresh_completion.clone());
         let (trigger, receiver) = mpsc::channel::<Option<RefreshOverrides>>(1);
         let acceleration_refresh_mode = AccelerationRefreshMode::Full(receiver);
         let refresh_handle = refresher
@@ -1509,12 +1651,9 @@ mod tests {
             .await
             .expect("trigger sent correctly to refresh");
 
-        timeout(
-            Duration::from_secs(2),
-            async move { notifier.notified().await },
-        )
-        .await
-        .expect("finish before the timeout");
+        timeout(Duration::from_secs(2), refresh_completion.any().wait())
+            .await
+            .expect("finish before the timeout");
 
         let ctx = SessionContext::new();
         let state = ctx.state();
@@ -1696,7 +1835,7 @@ mod tests {
                 .time_column("time_in_string".to_string())
                 .time_format(TimeFormat::ISO8601);
 
-            let notifier = Arc::new(Notify::new());
+            let refresh_completion = RefreshCompletion::new();
             let mut refresher = Refresher::new(
                 status::RuntimeStatus::new(),
                 TableReference::bare("test"),
@@ -1710,7 +1849,7 @@ mod tests {
                 Arc::new(Mutex::new(())),
             );
 
-            refresher.with_completion_notifier(Arc::clone(&notifier));
+            refresher.with_refresh_completion(refresh_completion.clone());
             let (trigger, receiver) = mpsc::channel::<Option<RefreshOverrides>>(1);
             let acceleration_refresh_mode = AccelerationRefreshMode::Append(receiver);
             let refresh_handle = refresher
@@ -1723,12 +1862,9 @@ mod tests {
                 .await
                 .expect("trigger sent correctly to refresh");
 
-            timeout(
-                Duration::from_secs(2),
-                async move { notifier.notified().await },
-            )
-            .await
-            .expect("finish before the timeout");
+            timeout(Duration::from_secs(2), refresh_completion.any().wait())
+                .await
+                .expect("finish before the timeout");
 
             let ctx = SessionContext::new();
             let state = ctx.state();
@@ -1859,7 +1995,7 @@ mod tests {
                 refresh = refresh.append_overlap(append_overlap);
             }
 
-            let notifier = Arc::new(Notify::new());
+            let refresh_completion = RefreshCompletion::new();
             let mut refresher = Refresher::new(
                 status::RuntimeStatus::new(),
                 TableReference::bare("test"),
@@ -1873,7 +2009,7 @@ mod tests {
                 Arc::new(Mutex::new(())),
             );
 
-            refresher.with_completion_notifier(Arc::clone(&notifier));
+            refresher.with_refresh_completion(refresh_completion.clone());
             let (trigger, receiver) = mpsc::channel::<Option<RefreshOverrides>>(1);
             let acceleration_refresh_mode = AccelerationRefreshMode::Append(receiver);
             let refresh_handle = refresher
@@ -1886,12 +2022,9 @@ mod tests {
                 .await
                 .expect("trigger sent correctly to refresh");
 
-            timeout(
-                Duration::from_secs(2),
-                async move { notifier.notified().await },
-            )
-            .await
-            .expect("finish before the timeout");
+            timeout(Duration::from_secs(2), refresh_completion.any().wait())
+                .await
+                .expect("finish before the timeout");
 
             let ctx = SessionContext::new();
             let state = ctx.state();
@@ -2068,7 +2201,7 @@ mod tests {
                 refresh = refresh.append_overlap(append_overlap);
             }
 
-            let notifier = Arc::new(Notify::new());
+            let refresh_completion = RefreshCompletion::new();
             let mut refresher = Refresher::new(
                 status::RuntimeStatus::new(),
                 TableReference::bare("test"),
@@ -2082,7 +2215,7 @@ mod tests {
                 Arc::new(Mutex::new(())),
             );
 
-            refresher.with_completion_notifier(Arc::clone(&notifier));
+            refresher.with_refresh_completion(refresh_completion.clone());
             let (trigger, receiver) = mpsc::channel::<Option<RefreshOverrides>>(1);
             let acceleration_refresh_mode = AccelerationRefreshMode::Append(receiver);
             let refresh_handle = refresher
@@ -2094,12 +2227,9 @@ mod tests {
                 .await
                 .expect("trigger sent correctly to refresh");
 
-            timeout(
-                Duration::from_secs(2),
-                async move { notifier.notified().await },
-            )
-            .await
-            .expect("finish before the timeout");
+            timeout(Duration::from_secs(2), refresh_completion.any().wait())
+                .await
+                .expect("finish before the timeout");
 
             let ctx = SessionContext::new();
             let state = ctx.state();

--- a/crates/runtime-table/src/accelerated/refresh_completion.rs
+++ b/crates/runtime-table/src/accelerated/refresh_completion.rs
@@ -27,8 +27,13 @@ limitations under the License.
 //! A waiter is taken up front and awaited later, so a completion landing in
 //! between resolves the wait instead of being dropped. That gap is why this is
 //! not a [`tokio::sync::Notify`]: `notify_waiters` stores no permit, so a
-//! completion that lands before the caller polls its future leaves the caller
-//! waiting for a refresh that already happened.
+//! completion that lands before the caller *creates* its `Notified` future
+//! leaves the caller waiting for a refresh that already happened. The boundary
+//! is creation, not polling — tokio guarantees a `Notified` receives
+//! `notify_waiters` wakeups as soon as it exists, so subscribing early is what
+//! closes the gap and polling early cannot. The paths this type replaced were
+//! all late *construction*: the future was built after the refresh had already
+//! been triggered, leaving nothing to poll in time.
 
 use tokio::sync::watch;
 
@@ -125,6 +130,50 @@ impl RefreshCompletion {
     }
 }
 
+/// How a wait ended, so a caller that *acts* on a completion can tell a refresh
+/// that happened from one that never will.
+///
+/// Both variants mean the caller should stop waiting; they differ in what it may
+/// do next. A caller merely gating on the initial load can proceed either way; a
+/// caller that treats the wait as proof a refresh landed — broadcasting
+/// readiness, creating a follow-on schedule — must not proceed on
+/// [`RefreshCompletionOutcome::Abandoned`].
+///
+/// `Answered` is the weaker half of that pair: it says *a* refresh completed, not
+/// that it was the one this waiter's caller triggered, nor that the table is
+/// still the live one. Binding a completion to its request and to a table
+/// generation is tracked in
+/// <https://github.com/spiceai/spiceai/issues/13603>.
+///
+/// Deliberately not `#[must_use]`: most waits are taken by a caller that acts on
+/// nothing afterwards and only wants to block, and marking the type would make
+/// every one of those state a choice it does not have. The callers that *do* act
+/// on a completion are the ones this enum exists for, and each of them reads it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshCompletionOutcome {
+    /// The question the waiter was taken for was answered: a refresh was
+    /// recorded, or the signal was closed to say none will run here.
+    Answered,
+    /// Every [`RefreshCompletion`] was dropped before the question was answered,
+    /// so no refresh ran and none can. The table the waiter was taken from is
+    /// gone.
+    Abandoned,
+}
+
+impl RefreshCompletionOutcome {
+    /// Whether a refresh completed, or was declared never to run here.
+    #[must_use]
+    pub fn is_answered(self) -> bool {
+        matches!(self, Self::Answered)
+    }
+
+    /// Whether the wait ended only because every recorder was dropped.
+    #[must_use]
+    pub fn is_abandoned(self) -> bool {
+        matches!(self, Self::Abandoned)
+    }
+}
+
 /// A pending wait for a refresh completion, taken from a [`RefreshCompletion`].
 #[derive(Debug)]
 pub struct RefreshCompletionWaiter {
@@ -132,14 +181,23 @@ pub struct RefreshCompletionWaiter {
 }
 
 impl RefreshCompletionWaiter {
-    /// Waits for the completion this waiter was taken for.
+    /// Waits for the completion this waiter was taken for, reporting whether one
+    /// arrived.
     ///
-    /// Returns without waiting when the question was already answered when the
-    /// waiter was taken, and returns early when the table that records
-    /// completions is gone — in both cases nothing is coming, and blocking would
-    /// strand the caller rather than inform it.
-    pub async fn wait(mut self) {
-        let _ = self.receiver.changed().await;
+    /// Returns [`RefreshCompletionOutcome::Answered`] without waiting when the
+    /// question was already answered when the waiter was taken, and
+    /// [`RefreshCompletionOutcome::Abandoned`] when every recorder is dropped
+    /// before it could be. Blocking on the latter would strand the caller rather
+    /// than inform it, but it is not a completed refresh: `changed` reports the
+    /// transition it has already observed ahead of the closed channel, so a
+    /// completion recorded before the last recorder went still reads as
+    /// `Answered`.
+    pub async fn wait(mut self) -> RefreshCompletionOutcome {
+        if self.receiver.changed().await.is_ok() {
+            RefreshCompletionOutcome::Answered
+        } else {
+            RefreshCompletionOutcome::Abandoned
+        }
     }
 }
 
@@ -149,7 +207,7 @@ mod tests {
 
     use tokio::time::timeout;
 
-    use super::RefreshCompletion;
+    use super::{RefreshCompletion, RefreshCompletionOutcome};
 
     const SHORT: Duration = Duration::from_millis(200);
 
@@ -162,9 +220,10 @@ mod tests {
 
         completion.record();
 
-        timeout(SHORT, waiter.wait())
+        let outcome = timeout(SHORT, waiter.wait())
             .await
             .expect("a completion recorded before the wait must still resolve it");
+        assert_eq!(outcome, RefreshCompletionOutcome::Answered);
     }
 
     #[tokio::test]
@@ -178,9 +237,10 @@ mod tests {
             recorder.record();
         });
 
-        timeout(SHORT, waiter.wait())
+        let outcome = timeout(SHORT, waiter.wait())
             .await
             .expect("a completion recorded during the wait must resolve it");
+        assert_eq!(outcome, RefreshCompletionOutcome::Answered);
     }
 
     /// `next` answers "the refresh I am about to trigger", so completions that
@@ -192,7 +252,7 @@ mod tests {
 
         let waiter = completion.next();
 
-        timeout(SHORT, waiter.wait())
+        let _ = timeout(SHORT, waiter.wait())
             .await
             .expect_err("an earlier completion must not satisfy a waiter taken after it");
     }
@@ -204,16 +264,17 @@ mod tests {
         let completion = RefreshCompletion::new();
         completion.record();
 
-        timeout(SHORT, completion.any().wait())
+        let outcome = timeout(SHORT, completion.any().wait())
             .await
             .expect("an earlier completion must satisfy a waiter for any completion");
+        assert_eq!(outcome, RefreshCompletionOutcome::Answered);
     }
 
     #[tokio::test]
     async fn any_waits_when_no_completion_has_been_recorded() {
         let completion = RefreshCompletion::new();
 
-        timeout(SHORT, completion.any().wait())
+        let _ = timeout(SHORT, completion.any().wait())
             .await
             .expect_err("no completion has been recorded, so there is nothing to observe");
     }
@@ -225,9 +286,14 @@ mod tests {
 
         completion.close();
 
-        timeout(SHORT, waiter.wait())
+        let outcome = timeout(SHORT, waiter.wait())
             .await
             .expect("closing must release a waiter already taken");
+        assert_eq!(
+            outcome,
+            RefreshCompletionOutcome::Answered,
+            "an explicit close is a deliberate answer, not an abandoned table"
+        );
     }
 
     #[tokio::test]
@@ -235,9 +301,10 @@ mod tests {
         let completion = RefreshCompletion::new();
         completion.close();
 
-        timeout(SHORT, completion.next().wait())
+        let outcome = timeout(SHORT, completion.next().wait())
             .await
             .expect("closing must release a waiter taken afterwards");
+        assert_eq!(outcome, RefreshCompletionOutcome::Answered);
     }
 
     /// The table that records completions can be dropped while a caller is
@@ -250,9 +317,50 @@ mod tests {
 
         drop(completion);
 
-        timeout(SHORT, waiter.wait())
+        let outcome = timeout(SHORT, waiter.wait())
             .await
             .expect("dropping the recorder must release its waiters");
+        assert_eq!(
+            outcome,
+            RefreshCompletionOutcome::Abandoned,
+            "a released waiter with no completion behind it must not read as a refresh"
+        );
+    }
+
+    /// A completion that landed before the last recorder went is still a
+    /// completion: dropping the recorder afterwards must not downgrade an
+    /// answered wait into an abandoned one.
+    #[tokio::test]
+    async fn a_completion_recorded_before_the_drop_still_reads_as_answered() {
+        let completion = RefreshCompletion::new();
+        let waiter = completion.next();
+
+        completion.record();
+        drop(completion);
+
+        let outcome = timeout(SHORT, waiter.wait())
+            .await
+            .expect("a recorded completion must resolve the wait");
+        assert_eq!(
+            outcome,
+            RefreshCompletionOutcome::Answered,
+            "the refresh happened; the recorder going afterwards does not unhappen it"
+        );
+    }
+
+    /// An `any` waiter taken after the last recorder is gone has no completion
+    /// behind it and must say so rather than resolving as one.
+    #[tokio::test]
+    async fn a_waiter_taken_after_the_recorder_is_dropped_is_abandoned() {
+        let completion = RefreshCompletion::new();
+        let waiter = completion.any();
+
+        drop(completion);
+
+        let outcome = timeout(SHORT, waiter.wait())
+            .await
+            .expect("a waiter with no live recorder must not block");
+        assert_eq!(outcome, RefreshCompletionOutcome::Abandoned);
     }
 
     /// Waiters are independent: satisfying one must not consume the completion
@@ -265,9 +373,10 @@ mod tests {
         completion.record();
 
         for waiter in waiters {
-            timeout(SHORT, waiter.wait())
+            let outcome = timeout(SHORT, waiter.wait())
                 .await
                 .expect("every waiter taken before the completion must resolve");
+            assert_eq!(outcome, RefreshCompletionOutcome::Answered);
         }
     }
 
@@ -284,8 +393,9 @@ mod tests {
         let waiter = completion.next();
         completion.record();
 
-        timeout(SHORT, waiter.wait())
+        let outcome = timeout(SHORT, waiter.wait())
             .await
             .expect("a wrapping generation must still resolve its waiter");
+        assert_eq!(outcome, RefreshCompletionOutcome::Answered);
     }
 }

--- a/crates/runtime-table/src/accelerated/refresh_completion.rs
+++ b/crates/runtime-table/src/accelerated/refresh_completion.rs
@@ -1,0 +1,282 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Level-triggered "a refresh finished" signal for an accelerated table.
+//!
+//! Callers ask two different questions of a refresh, and both are answered from
+//! the same monotonic generation counter:
+//!
+//! * *"has the initial load landed?"* — [`RefreshCompletion::any`], satisfied by
+//!   a refresh that finished before the caller asked.
+//! * *"has the refresh I just triggered finished?"* — [`RefreshCompletion::next`],
+//!   satisfied only by a refresh recorded after the waiter was taken.
+//!
+//! A waiter is taken up front and awaited later, so a completion landing in
+//! between resolves the wait instead of being dropped. That gap is why this is
+//! not a [`tokio::sync::Notify`]: `notify_waiters` stores no permit, so a
+//! completion that lands before the caller polls its future leaves the caller
+//! waiting for a refresh that already happened.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::sync::watch;
+
+/// Records refresh completions for one accelerated table and hands out waiters
+/// for them.
+///
+/// Cloning shares the underlying signal.
+#[derive(Debug, Clone)]
+pub struct RefreshCompletion {
+    /// Number of refreshes recorded so far. Monotonic, so a waiter can compare
+    /// the value it was taken at against the current one.
+    generation: watch::Sender<u64>,
+    /// Set once no further refresh can be recorded, so waiters taken after that
+    /// point resolve rather than blocking on a completion that cannot arrive.
+    closed: Arc<AtomicBool>,
+}
+
+impl Default for RefreshCompletion {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RefreshCompletion {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            generation: watch::Sender::new(0),
+            closed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Records a completed refresh, resolving every waiter taken before it.
+    pub fn record(&self) {
+        self.generation
+            .send_modify(|generation| *generation = generation.wrapping_add(1));
+    }
+
+    /// Records that no refresh will ever run for this table in this process, so
+    /// every waiter — including one taken after this call — resolves at once.
+    ///
+    /// A cluster scheduler holds accelerated tables it never refreshes locally;
+    /// without this, a caller waiting on one waits for the life of the process.
+    pub fn close(&self) {
+        // Ordered so a waiter woken by the bump below observes the flag: the
+        // bump releases live waiters, the flag releases later ones.
+        self.closed.store(true, Ordering::Release);
+        self.record();
+    }
+
+    /// Takes a waiter for the first refresh recorded *after* this call.
+    ///
+    /// This is the question a caller that triggers a refresh is asking. Take the
+    /// waiter before triggering — a waiter taken afterwards can miss the very
+    /// refresh it triggered.
+    #[must_use]
+    pub fn next(&self) -> RefreshCompletionWaiter {
+        RefreshCompletionWaiter {
+            // `subscribe` marks the receiver as having seen the current
+            // generation, so it resolves on the next one.
+            receiver: self.generation.subscribe(),
+            closed: Arc::clone(&self.closed),
+            satisfied: false,
+        }
+    }
+
+    /// Takes a waiter for the first refresh recorded since the table was built,
+    /// already satisfied if one has landed.
+    ///
+    /// This is the question a caller waiting on the initial load is asking; it
+    /// cannot miss the load by asking late.
+    #[must_use]
+    pub fn any(&self) -> RefreshCompletionWaiter {
+        let satisfied = *self.generation.borrow() > 0;
+        RefreshCompletionWaiter {
+            receiver: self.generation.subscribe(),
+            closed: Arc::clone(&self.closed),
+            satisfied,
+        }
+    }
+}
+
+/// A pending wait for a refresh completion, taken from a [`RefreshCompletion`].
+#[derive(Debug)]
+pub struct RefreshCompletionWaiter {
+    receiver: watch::Receiver<u64>,
+    closed: Arc<AtomicBool>,
+    satisfied: bool,
+}
+
+impl RefreshCompletionWaiter {
+    /// Waits for the completion this waiter was taken for.
+    ///
+    /// Returns immediately when the waiter was already satisfied when taken,
+    /// when no further refresh can be recorded, or when the table that records
+    /// them is gone — in each case the completion is never coming, and blocking
+    /// would strand the caller rather than inform it.
+    pub async fn wait(mut self) {
+        if self.satisfied || self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        let _ = self.receiver.changed().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use super::RefreshCompletion;
+
+    const SHORT: Duration = Duration::from_millis(200);
+
+    /// The lost wakeup this type exists to remove: a completion that lands
+    /// between taking the waiter and awaiting it still resolves the wait.
+    #[tokio::test]
+    async fn next_observes_a_completion_recorded_before_the_wait() {
+        let completion = RefreshCompletion::new();
+        let waiter = completion.next();
+
+        completion.record();
+
+        timeout(SHORT, waiter.wait())
+            .await
+            .expect("a completion recorded before the wait must still resolve it");
+    }
+
+    #[tokio::test]
+    async fn next_observes_a_completion_recorded_during_the_wait() {
+        let completion = RefreshCompletion::new();
+        let waiter = completion.next();
+
+        let recorder = completion.clone();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            recorder.record();
+        });
+
+        timeout(SHORT, waiter.wait())
+            .await
+            .expect("a completion recorded during the wait must resolve it");
+    }
+
+    /// `next` answers "the refresh I am about to trigger", so completions that
+    /// predate the waiter must not satisfy it.
+    #[tokio::test]
+    async fn next_ignores_a_completion_recorded_before_the_waiter_was_taken() {
+        let completion = RefreshCompletion::new();
+        completion.record();
+
+        let waiter = completion.next();
+
+        timeout(SHORT, waiter.wait())
+            .await
+            .expect_err("an earlier completion must not satisfy a waiter taken after it");
+    }
+
+    /// `any` answers "has the initial load landed", so it must be satisfied by a
+    /// completion that predates the waiter.
+    #[tokio::test]
+    async fn any_is_satisfied_by_a_completion_recorded_before_the_waiter_was_taken() {
+        let completion = RefreshCompletion::new();
+        completion.record();
+
+        timeout(SHORT, completion.any().wait())
+            .await
+            .expect("an earlier completion must satisfy a waiter for any completion");
+    }
+
+    #[tokio::test]
+    async fn any_waits_when_no_completion_has_been_recorded() {
+        let completion = RefreshCompletion::new();
+
+        timeout(SHORT, completion.any().wait())
+            .await
+            .expect_err("no completion has been recorded, so there is nothing to observe");
+    }
+
+    #[tokio::test]
+    async fn close_resolves_a_waiter_taken_before_it() {
+        let completion = RefreshCompletion::new();
+        let waiter = completion.next();
+
+        completion.close();
+
+        timeout(SHORT, waiter.wait())
+            .await
+            .expect("closing must release a waiter already taken");
+    }
+
+    #[tokio::test]
+    async fn close_resolves_a_waiter_taken_after_it() {
+        let completion = RefreshCompletion::new();
+        completion.close();
+
+        timeout(SHORT, completion.next().wait())
+            .await
+            .expect("closing must release a waiter taken afterwards");
+    }
+
+    /// The table that records completions can be dropped while a caller is
+    /// waiting; the caller learns that no completion is coming instead of
+    /// blocking for the life of the process.
+    #[tokio::test]
+    async fn a_waiter_resolves_when_the_recorder_is_dropped() {
+        let completion = RefreshCompletion::new();
+        let waiter = completion.next();
+
+        drop(completion);
+
+        timeout(SHORT, waiter.wait())
+            .await
+            .expect("dropping the recorder must release its waiters");
+    }
+
+    /// Waiters are independent: satisfying one must not consume the completion
+    /// another is waiting for.
+    #[tokio::test]
+    async fn concurrent_waiters_all_observe_one_completion() {
+        let completion = RefreshCompletion::new();
+        let waiters: Vec<_> = (0..8).map(|_| completion.next()).collect();
+
+        completion.record();
+
+        for waiter in waiters {
+            timeout(SHORT, waiter.wait())
+                .await
+                .expect("every waiter taken before the completion must resolve");
+        }
+    }
+
+    /// The counter is monotonic and wrapping; a waiter compares against the
+    /// value it was taken at, so a wrap cannot strand it.
+    #[tokio::test]
+    async fn a_waiter_resolves_across_a_generation_wrap() {
+        let completion = RefreshCompletion::new();
+        completion.generation.send_modify(|g| *g = u64::MAX);
+
+        let waiter = completion.next();
+        completion.record();
+
+        timeout(SHORT, waiter.wait())
+            .await
+            .expect("a wrapping generation must still resolve its waiter");
+    }
+}

--- a/crates/runtime-table/src/accelerated/refresh_completion.rs
+++ b/crates/runtime-table/src/accelerated/refresh_completion.rs
@@ -17,7 +17,7 @@ limitations under the License.
 //! Level-triggered "a refresh finished" signal for an accelerated table.
 //!
 //! Callers ask two different questions of a refresh, and both are answered from
-//! the same monotonic generation counter:
+//! the same count of completed refreshes:
 //!
 //! * *"has the initial load landed?"* — [`RefreshCompletion::any`], satisfied by
 //!   a refresh that finished before the caller asked.
@@ -30,10 +30,20 @@ limitations under the License.
 //! completion that lands before the caller polls its future leaves the caller
 //! waiting for a refresh that already happened.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use tokio::sync::watch;
+
+/// What every waiter is decided against. Held in one `watch` value so a
+/// completion and a close are each a single atomic transition that also wakes
+/// the waiters already registered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CompletionState {
+    /// Refreshes recorded so far. Wrapping, because a waiter is decided by the
+    /// `watch` version it subscribed at rather than by comparing this value.
+    completions: u64,
+    /// Set once no further refresh can be recorded here, so a waiter taken
+    /// afterwards resolves instead of blocking on one that cannot arrive.
+    closed: bool,
+}
 
 /// Records refresh completions for one accelerated table and hands out waiters
 /// for them.
@@ -41,12 +51,7 @@ use tokio::sync::watch;
 /// Cloning shares the underlying signal.
 #[derive(Debug, Clone)]
 pub struct RefreshCompletion {
-    /// Number of refreshes recorded so far. Monotonic, so a waiter can compare
-    /// the value it was taken at against the current one.
-    generation: watch::Sender<u64>,
-    /// Set once no further refresh can be recorded, so waiters taken after that
-    /// point resolve rather than blocking on a completion that cannot arrive.
-    closed: Arc<AtomicBool>,
+    state: watch::Sender<CompletionState>,
 }
 
 impl Default for RefreshCompletion {
@@ -59,15 +64,17 @@ impl RefreshCompletion {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            generation: watch::Sender::new(0),
-            closed: Arc::new(AtomicBool::new(false)),
+            state: watch::Sender::new(CompletionState {
+                completions: 0,
+                closed: false,
+            }),
         }
     }
 
     /// Records a completed refresh, resolving every waiter taken before it.
     pub fn record(&self) {
-        self.generation
-            .send_modify(|generation| *generation = generation.wrapping_add(1));
+        self.state
+            .send_modify(|state| state.completions = state.completions.wrapping_add(1));
     }
 
     /// Records that no refresh will ever run for this table in this process, so
@@ -76,10 +83,7 @@ impl RefreshCompletion {
     /// A cluster scheduler holds accelerated tables it never refreshes locally;
     /// without this, a caller waiting on one waits for the life of the process.
     pub fn close(&self) {
-        // Ordered so a waiter woken by the bump below observes the flag: the
-        // bump releases live waiters, the flag releases later ones.
-        self.closed.store(true, Ordering::Release);
-        self.record();
+        self.state.send_modify(|state| state.closed = true);
     }
 
     /// Takes a waiter for the first refresh recorded *after* this call.
@@ -89,13 +93,7 @@ impl RefreshCompletion {
     /// refresh it triggered.
     #[must_use]
     pub fn next(&self) -> RefreshCompletionWaiter {
-        RefreshCompletionWaiter {
-            // `subscribe` marks the receiver as having seen the current
-            // generation, so it resolves on the next one.
-            receiver: self.generation.subscribe(),
-            closed: Arc::clone(&self.closed),
-            satisfied: false,
-        }
+        self.waiter(false)
     }
 
     /// Takes a waiter for the first refresh recorded since the table was built,
@@ -105,34 +103,42 @@ impl RefreshCompletion {
     /// cannot miss the load by asking late.
     #[must_use]
     pub fn any(&self) -> RefreshCompletionWaiter {
-        let satisfied = *self.generation.borrow() > 0;
-        RefreshCompletionWaiter {
-            receiver: self.generation.subscribe(),
-            closed: Arc::clone(&self.closed),
-            satisfied,
+        self.waiter(true)
+    }
+
+    /// `accept_earlier` selects between the two questions above: whether a
+    /// refresh recorded before this call already answers it.
+    fn waiter(&self, accept_earlier: bool) -> RefreshCompletionWaiter {
+        // `subscribe` marks the receiver as having seen the value current now,
+        // so it resolves on the next transition. The state is then read back
+        // through the receiver rather than the sender: a completion landing
+        // between the two is either seen here or wakes the receiver, never
+        // dropped between them.
+        let mut receiver = self.state.subscribe();
+        let state = *receiver.borrow();
+        if state.closed || (accept_earlier && state.completions > 0) {
+            // Already answered — resolve on the first poll instead of waiting
+            // for a transition that has happened, or can never happen.
+            receiver.mark_changed();
         }
+        RefreshCompletionWaiter { receiver }
     }
 }
 
 /// A pending wait for a refresh completion, taken from a [`RefreshCompletion`].
 #[derive(Debug)]
 pub struct RefreshCompletionWaiter {
-    receiver: watch::Receiver<u64>,
-    closed: Arc<AtomicBool>,
-    satisfied: bool,
+    receiver: watch::Receiver<CompletionState>,
 }
 
 impl RefreshCompletionWaiter {
     /// Waits for the completion this waiter was taken for.
     ///
-    /// Returns immediately when the waiter was already satisfied when taken,
-    /// when no further refresh can be recorded, or when the table that records
-    /// them is gone — in each case the completion is never coming, and blocking
-    /// would strand the caller rather than inform it.
+    /// Returns without waiting when the question was already answered when the
+    /// waiter was taken, and returns early when the table that records
+    /// completions is gone — in both cases nothing is coming, and blocking would
+    /// strand the caller rather than inform it.
     pub async fn wait(mut self) {
-        if self.satisfied || self.closed.load(Ordering::Acquire) {
-            return;
-        }
         let _ = self.receiver.changed().await;
     }
 }
@@ -265,12 +271,15 @@ mod tests {
         }
     }
 
-    /// The counter is monotonic and wrapping; a waiter compares against the
-    /// value it was taken at, so a wrap cannot strand it.
+    /// The completion count wraps rather than saturating, and a waiter is
+    /// decided by the `watch` version it subscribed at, so a wrap cannot strand
+    /// it.
     #[tokio::test]
     async fn a_waiter_resolves_across_a_generation_wrap() {
         let completion = RefreshCompletion::new();
-        completion.generation.send_modify(|g| *g = u64::MAX);
+        completion
+            .state
+            .send_modify(|state| state.completions = u64::MAX);
 
         let waiter = completion.next();
         completion.record();

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -17,6 +17,7 @@ use super::DatasetMetricLabels;
 use super::RefreshTask;
 use super::{collect_all_indexes, indexes_from_federated};
 use crate::accelerated::refresh::Refresh;
+use crate::accelerated::refresh_completion::RefreshCompletion;
 use crate::accelerated::refresh_task::deletion::{
     build_batch_delete_expr_from_change_batch, build_pk_only_batch_from_change_batch,
 };
@@ -70,7 +71,7 @@ use std::hash::BuildHasherDefault;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
-use tokio::sync::{Notify, RwLock};
+use tokio::sync::RwLock;
 
 type PendingApplyFinalize = tokio::task::JoinHandle<crate::accelerated::Result<()>>;
 
@@ -397,7 +398,7 @@ struct ApplyContext<'a> {
     /// (see [`DatasetMetricLabels`]).
     metric_labels: &'a DatasetMetricLabels,
     caching: Option<&'a Weak<Caching>>,
-    ready_sender: Option<&'a Arc<Notify>>,
+    refresh_completion: Option<&'a RefreshCompletion>,
     initial_load_completed: &'a Arc<AtomicBool>,
     write_ctx: &'a SessionContext,
     write_session_state: &'a SessionState,
@@ -1041,7 +1042,7 @@ impl RefreshTask {
         refresh: Arc<RwLock<Refresh>>,
         changes_stream: ChangesStream,
         caching: Option<Weak<Caching>>,
-        ready_sender: Option<Arc<Notify>>,
+        refresh_completion: Option<RefreshCompletion>,
         initial_load_completed: Arc<AtomicBool>,
     ) -> crate::accelerated::Result<()> {
         // Effective CDC config = global (already env+default folded) with any
@@ -1055,7 +1056,7 @@ impl RefreshTask {
             refresh,
             changes_stream,
             caching,
-            ready_sender,
+            refresh_completion,
             initial_load_completed,
         )
         .await
@@ -1069,7 +1070,7 @@ impl RefreshTask {
         refresh: Arc<RwLock<Refresh>>,
         changes_stream: ChangesStream,
         caching: Option<Weak<Caching>>,
-        ready_sender: Option<Arc<Notify>>,
+        refresh_completion: Option<RefreshCompletion>,
         initial_load_completed: Arc<AtomicBool>,
     ) -> crate::accelerated::Result<()> {
         let dataset_name = self.dataset_name.clone();
@@ -1298,7 +1299,7 @@ impl RefreshTask {
                                 refresh: &refresh,
                                 metric_labels: &metric_labels,
                                 caching: caching.as_ref(),
-                                ready_sender: ready_sender.as_ref(),
+                                refresh_completion: refresh_completion.as_ref(),
                                 initial_load_completed: &initial_load_completed,
                                 write_ctx: &write_ctx,
                                 write_session_state: &write_session_state,
@@ -1551,7 +1552,7 @@ impl RefreshTask {
                 refresh: &refresh,
                 metric_labels: &metric_labels,
                 caching: caching.as_ref(),
-                ready_sender: ready_sender.as_ref(),
+                refresh_completion: refresh_completion.as_ref(),
                 initial_load_completed: &initial_load_completed,
                 write_ctx: &write_ctx,
                 write_session_state: &write_session_state,
@@ -1610,7 +1611,7 @@ impl RefreshTask {
                     refresh: &refresh,
                     metric_labels: &metric_labels,
                     caching: caching.as_ref(),
-                    ready_sender: ready_sender.as_ref(),
+                    refresh_completion: refresh_completion.as_ref(),
                     initial_load_completed: &initial_load_completed,
                     write_ctx: &write_ctx,
                     write_session_state: &write_session_state,
@@ -1817,15 +1818,15 @@ impl RefreshTask {
     /// a fatal commit error was surfaced and the stream should stop.
     /// Signal the dataset Ready: flip `initial_load_completed`, wake readiness
     /// waiters, then publish the `Ready` component status — in that order, so a
-    /// waiter woken by the notify observes the completed flag. The single
+    /// waiter woken by the completion observes the completed flag. The single
     /// definition of the readiness side effect for every apply path (write,
     /// post-finalize, and readiness-only heartbeat runs).
     async fn signal_dataset_ready(&self, context: &ApplyContext<'_>) {
         context
             .initial_load_completed
             .store(true, Ordering::Relaxed);
-        if let Some(sender) = context.ready_sender {
-            sender.notify_waiters();
+        if let Some(refresh_completion) = context.refresh_completion {
+            refresh_completion.record();
         }
         self.update_component_status(status::ComponentStatus::Ready)
             .await;
@@ -6110,12 +6111,18 @@ mod tests {
     async fn run_changes_stream(
         task: &RefreshTask,
         stream: ChangesStream,
-        ready_sender: Option<Arc<Notify>>,
+        refresh_completion: Option<RefreshCompletion>,
         initial_load_completed: Arc<AtomicBool>,
     ) -> crate::accelerated::Result<()> {
         let refresh = Arc::new(RwLock::new(crate::accelerated::refresh::Refresh::default()));
-        task.start_changes_stream(refresh, stream, None, ready_sender, initial_load_completed)
-            .await
+        task.start_changes_stream(
+            refresh,
+            stream,
+            None,
+            refresh_completion,
+            initial_load_completed,
+        )
+        .await
     }
 
     // -- Correctness: ordering ------------------------------------------------
@@ -6518,7 +6525,7 @@ mod tests {
             dataset_name: &dataset_name,
             metric_labels: &metric_labels,
             caching: None,
-            ready_sender: None,
+            refresh_completion: None,
             initial_load_completed: &initial_load_completed,
             write_ctx: &write_ctx,
             write_session_state: &write_session_state,
@@ -6771,7 +6778,7 @@ mod tests {
             dataset_name: &dataset_name,
             metric_labels: &metric_labels,
             caching: None,
-            ready_sender: None,
+            refresh_completion: None,
             initial_load_completed: &initial_load_completed,
             write_ctx: &write_ctx,
             write_session_state: &write_session_state,
@@ -6835,7 +6842,7 @@ mod tests {
             dataset_name: &dataset_name,
             metric_labels: &metric_labels,
             caching: None,
-            ready_sender: None,
+            refresh_completion: None,
             initial_load_completed: &initial_load_completed,
             write_ctx: &write_ctx,
             write_session_state: &write_session_state,
@@ -6933,21 +6940,12 @@ mod tests {
         let task = make_refresh_task(make_mem_table() as Arc<dyn TableProvider>);
         let log = CommitLog::new();
         let initial_load = Arc::new(AtomicBool::new(false));
-        let notify = Arc::new(Notify::new());
+        let refresh_completion = RefreshCompletion::new();
 
-        // Subscribe BEFORE running so we don't miss the notify_waiters signal.
-        let notified = {
-            let n = Arc::clone(&notify);
-            tokio::spawn(async move {
-                let waiter = n.notified();
-                tokio::pin!(waiter);
-                tokio::time::timeout(Duration::from_secs(5), &mut waiter)
-                    .await
-                    .is_ok()
-            })
-        };
-        // Yield so the subscriber registers before we proceed.
-        tokio::task::yield_now().await;
+        // Take the waiter before the stream runs, and await it only after the
+        // stream has finished — the ordering that loses an edge-triggered
+        // wakeup entirely (#13086).
+        let waiter = refresh_completion.next();
 
         let stream = make_changes_stream(vec![
             Ok(make_tracked_envelope(1, Arc::clone(&log), false)),
@@ -6957,7 +6955,7 @@ mod tests {
         run_changes_stream(
             &task,
             stream,
-            Some(Arc::clone(&notify)),
+            Some(refresh_completion.clone()),
             Arc::clone(&initial_load),
         )
         .await
@@ -6967,10 +6965,9 @@ mod tests {
             initial_load.load(Ordering::Relaxed),
             "initial_load_completed must flip to true once a ready envelope is processed"
         );
-        assert!(
-            notified.await.expect("ready notifier task must finish"),
-            "ready_sender.notify_waiters() must fire when a ready envelope is processed"
-        );
+        tokio::time::timeout(Duration::from_secs(5), waiter.wait())
+            .await
+            .expect("a ready envelope must release a waiter taken before the stream ran");
     }
 
     // -- Correctness: readiness heartbeats bypass the write/durability path ---
@@ -7058,7 +7055,7 @@ mod tests {
         });
         let task = make_refresh_task(provider as Arc<dyn TableProvider>);
         let initial_load = Arc::new(AtomicBool::new(false));
-        let notify = Arc::new(Notify::new());
+        let refresh_completion = RefreshCompletion::new();
 
         let stream = make_changes_stream(vec![
             Ok(make_heartbeat_envelope(false)),
@@ -7068,7 +7065,7 @@ mod tests {
         run_changes_stream(
             &task,
             stream,
-            Some(Arc::clone(&notify)),
+            Some(refresh_completion.clone()),
             Arc::clone(&initial_load),
         )
         .await
@@ -7098,7 +7095,7 @@ mod tests {
         let task = make_refresh_task(make_mem_table() as Arc<dyn TableProvider>);
         let log = CommitLog::new();
         let initial_load = Arc::new(AtomicBool::new(false));
-        let notify = Arc::new(Notify::new());
+        let refresh_completion = RefreshCompletion::new();
 
         let stream = make_changes_stream(vec![
             Ok(make_tracked_envelope(1, Arc::clone(&log), false)),
@@ -7110,7 +7107,7 @@ mod tests {
         run_changes_stream(
             &task,
             stream,
-            Some(Arc::clone(&notify)),
+            Some(refresh_completion.clone()),
             Arc::clone(&initial_load),
         )
         .await

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Duration;
 
 use crate::accelerated::refresh::{self, RefreshOverrides};
+use crate::accelerated::refresh_completion::RefreshCompletionWaiter;
 use crate::accelerated::refresh_task::changes::{CdcSchemaEvolution, install_cdc_schema_evolution};
 use crate::accelerated::refresh_task::probe_acceleration_contents;
 use crate::accelerated::snapshots::SnapshotRefreshState;
@@ -1226,12 +1227,13 @@ impl DataFusion {
         Arc::new(ComposedCatalogProvider::new(external, internal_schemas))
     }
 
-    // Returns a Notify if the table supports notifying the runtime when the table is ready.
+    /// Returns a waiter for the dataset's initial load when the table has one to
+    /// report, so the caller can act on it however late it asks.
     pub async fn register_table(
         &self,
         dataset: Arc<Dataset>,
         table: Table,
-    ) -> Result<Option<Arc<Notify>>> {
+    ) -> Result<Option<RefreshCompletionWaiter>> {
         ensure_schema_exists(&self.ctx, SPICE_DEFAULT_CATALOG, &dataset.name)?;
 
         let dataset_access_mode = dataset.access();
@@ -1250,7 +1252,10 @@ impl DataFusion {
                     tracing::debug!(
                         "Registering dataset {dataset:?} with preloaded accelerated table"
                     );
-                    let notifier = accelerated_table.refresher().on_complete_notification();
+                    let notifier = accelerated_table
+                        .refresher()
+                        .refresh_completion()
+                        .map(|completion| completion.any());
                     let table_provider = table_provider_with_spicepod_metadata(
                         accelerated_table.table_provider(),
                         &dataset.metadata,
@@ -3973,7 +3978,7 @@ impl DataFusion {
         secrets: Arc<TokioRwLock<Secrets>>,
         bootstrap_status: BootstrapStatus,
         initial_partition_filters: Option<Vec<datafusion_expr::Expr>>,
-    ) -> Result<Option<Arc<Notify>>> {
+    ) -> Result<Option<RefreshCompletionWaiter>> {
         let mut accelerated_table = self
             .create_accelerated_table(
                 &dataset,
@@ -3984,7 +3989,10 @@ impl DataFusion {
                 initial_partition_filters,
             )
             .await?;
-        let notifier = accelerated_table.refresher().on_complete_notification();
+        let notifier = accelerated_table
+            .refresher()
+            .refresh_completion()
+            .map(|completion| completion.any());
 
         source
             .on_accelerated_table_registration(&dataset, &mut accelerated_table)
@@ -4014,7 +4022,7 @@ impl DataFusion {
         self: &Arc<Self>,
         dataset_name: &TableReference,
         overrides: Option<RefreshOverrides>,
-    ) -> Result<Option<Arc<Notify>>> {
+    ) -> Result<Option<RefreshCompletionWaiter>> {
         // If we're a scheduler with a partition service, forward refresh to executors
         // instead of trying to refresh locally (the scheduler doesn't run refresh workers).
         if matches!(
@@ -4034,7 +4042,12 @@ impl DataFusion {
             table.as_ref(),
             spice_table::LayerWalk::Read,
         ) {
-            let notifier = accelerated_table.refresher().on_complete_notification();
+            // Taken before the trigger, so the refresh it starts cannot finish
+            // unobserved between here and the caller's wait (#13086).
+            let notifier = accelerated_table
+                .refresher()
+                .refresh_completion()
+                .map(|completion| completion.next());
             accelerated_table.trigger_refresh(overrides).await.context(
                 UnableToTriggerRefreshSnafu {
                     dataset_name: dataset_name.to_string(),
@@ -4060,7 +4073,7 @@ impl DataFusion {
         partition_service: &PartitionService,
         dataset_name: &TableReference,
         overrides: Option<&RefreshOverrides>,
-    ) -> Result<Option<Arc<Notify>>> {
+    ) -> Result<Option<RefreshCompletionWaiter>> {
         // Run on-demand partition discovery before forwarding the refresh command.
         // This ensures that any new partition values in the source data are discovered,
         // assigned to executors, and executors are notified -- before they receive the
@@ -4330,7 +4343,7 @@ impl DataFusion {
         self: &Arc<Self>,
         view: Arc<View>,
         secrets: Arc<TokioRwLock<Secrets>>,
-    ) -> Result<JoinHandle<Option<Arc<Notify>>>> {
+    ) -> Result<JoinHandle<Option<RefreshCompletionWaiter>>> {
         tracing::info!("Initializing view {}", &view.name);
         if self.ctx.table_exist(view.name.clone()).unwrap_or(false) {
             return TableAlreadyExistsSnafu.fail();
@@ -4357,7 +4370,7 @@ impl DataFusion {
         let table = view.name.clone();
         tracing::debug!("Creating view {table} with dependent tables {dependent_table_names:?}");
 
-        let register_task: JoinHandle<Option<Arc<Notify>>> = spawn(async move {
+        let register_task: JoinHandle<Option<RefreshCompletionWaiter>> = spawn(async move {
             // Tables are currently lazily created (i.e. not created until first data is received) so that we know the table schema.
             // This means that we can't create a view on top of a table until the first data is received for all dependent tables and therefore
             // the tables are created. To handle this, wait until all tables are created.
@@ -4466,7 +4479,7 @@ impl DataFusion {
         view: &View,
         view_table: Arc<dyn TableProvider>,
         secrets: Arc<TokioRwLock<Secrets>>,
-    ) -> Result<Option<Arc<Notify>>> {
+    ) -> Result<Option<RefreshCompletionWaiter>> {
         let table = &view.name;
 
         let acceleration =
@@ -4586,7 +4599,10 @@ impl DataFusion {
                     dataset_name: table.to_string(),
                 })?;
 
-        let is_ready = accelerated_table.refresher().on_complete_notification();
+        let is_ready = accelerated_table
+            .refresher()
+            .refresh_completion()
+            .map(|completion| completion.any());
 
         let table_provider = table_provider_with_spicepod_metadata(
             Arc::new(accelerated_table).table_provider(),

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -126,7 +126,7 @@ use spicepod::acceleration::SnapshotsTrigger;
 use spicepod::metric::Metrics;
 use tokio::runtime::Handle;
 use tokio::spawn;
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::Mutex;
 use tokio::sync::{RwLock as TokioRwLock, Semaphore};
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, sleep};

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -23,6 +23,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::accelerated::refresh_completion::RefreshCompletionWaiter;
 use crate::cluster::partition::get_partition_filter_exprs;
 use crate::dataaccelerator::BootstrapStatus;
 use crate::dataconnector::refresh_source::ConnectorRefreshSource;
@@ -1339,14 +1340,13 @@ impl Runtime {
         );
 
         let refresher = accelerated_table.refresher();
-        let notifier = refresher.on_complete_notification();
 
         // wait for accelerated table to be ready
-        if let Some(notifier) = notifier {
+        if let Some(completion) = refresher.refresh_completion() {
             await_hot_reload_initial_refresh(
                 &ds.name,
                 &|| refresher.initial_load_completed(),
-                &notifier,
+                completion.any(),
                 &self.status.shutdown_token(),
                 HOT_RELOAD_INITIAL_REFRESH_TIMEOUT,
             )
@@ -1657,10 +1657,10 @@ impl Runtime {
                 crate::datafusion::SPICE_DEFAULT_SCHEMA,
             );
             tokio::task::spawn(async move {
-                // Wait for the dataset's status to reach `Ready` rather than
-                // relying on the `Notify`-based completion handle (which is
-                // edge-triggered and can race with this spawn for fast
-                // initial refreshes).
+                // Gate on the dataset's status reaching `Ready` rather than on
+                // the refresh completion: the ack reports the partitions this
+                // executor serves, and the dataset is only servable once its
+                // status has been published.
                 // A shutdown before the dataset became ready means the initial
                 // load never finished: there is no partition state worth acking.
                 if runtime_status
@@ -2007,27 +2007,19 @@ pub struct RegisterDatasetContext {
 /// loaded yet.
 ///
 /// The wait is bounded because `apply_app` holds `apply_app_lock` across it, and
-/// three shapes never deliver a notification the caller can see:
+/// one shape never delivers a completion at all: a `refresh_mode: changes` stream
+/// that never produces a ready envelope, since the completion is recorded only
+/// when one is applied.
 ///
-/// - a `refresh_mode: changes` stream that never produces a ready envelope — the
-///   notifier fires only when one is applied;
-/// - a refresh completing before this wait is entered at all.
-///   [`tokio::sync::Notify::notify_waiters`] stores no permit, so that wakeup is
-///   gone, and a `RefreshMode::Full` dataset with no `check_interval` never fires
-///   a second one;
-/// - a cluster scheduler, which notifies waiters from inside the builder —
-///   before any caller holds the notifier — precisely because it runs no refresh.
+/// A refresh that finished before this call is not that shape. The waiter is
+/// level-triggered and satisfied by a completion recorded before it was taken, and
+/// `initial_load_completed` — stored before the completion is recorded — is read
+/// both before the bound and after it, so a load that lands either side of the
+/// wait resolves as success instead of discarding a table that is loaded.
 ///
-/// Only the second is recoverable here, and only via `initial_load_completed`:
-/// the refresher sets that flag just *after* it notifies (`Refresher::start`), so
-/// the flag is what remains once the edge is gone. It is read after the bound as
-/// well as before it, so a wakeup that predates this call resolves as success
-/// instead of discarding a table that is loaded.
-///
-/// The scheduler shape is not recoverable here — nothing local ever sets the flag
-/// on a scheduler — so it spends the bound and then takes the full reload. That is
-/// still strictly better than the unbounded wait it replaces, which never
-/// returned at all; removing the edge at its source is #13086.
+/// On a cluster scheduler no refresh runs locally, so the table's completion
+/// signal is closed when it is built and the waiter resolves at once rather than
+/// spending the bound.
 ///
 /// Returns `Ok(())` when the table loaded (or the runtime is shutting down), and
 /// [`Error::HotReloadRefreshTimedOut`] when the bound expires with the table
@@ -2035,31 +2027,26 @@ pub struct RegisterDatasetContext {
 async fn await_hot_reload_initial_refresh(
     dataset_name: &TableReference,
     initial_load_completed: &(dyn Fn() -> bool + Sync),
-    notifier: &tokio::sync::Notify,
+    completion: RefreshCompletionWaiter,
     shutdown_token: &tokio_util::sync::CancellationToken,
     timeout: Duration,
 ) -> Result<()> {
-    // Built before the check below, not after: a `Notified` "is guaranteed to
-    // receive wakeups from `notify_waiters()` as soon as it has been created,
-    // even if it has not yet been polled" (`tokio::sync::Notify::notified`), and
-    // `notify_waiters` is what both producers call. So a refresh completing
-    // between here and the `select!` still wakes this wait; constructing after
-    // the check would drop it and cost the whole bound.
-    let refresh_notified = notifier.notified();
-
     if initial_load_completed() {
         return Ok(());
     }
 
     tokio::select! {
-        () = refresh_notified => return Ok(()),
+        // A `RefreshCompletionWaiter` for any completion is satisfied by a
+        // refresh that finished before this wait began, so the load cannot be
+        // missed by arriving here late.
+        () = completion.wait() => return Ok(()),
         () = shutdown_token.cancelled() => return Ok(()),
         () = tokio::time::sleep(timeout) => {}
     }
 
-    // The bound is a backstop, not the verdict: a wakeup that fired before this
-    // wait was even entered leaves a table that is loaded and must not be
-    // discarded.
+    // The bound is a backstop, not the verdict: the flag is stored before the
+    // completion is recorded, so a load that finished as the bound expired
+    // leaves a table that must not be discarded.
     if initial_load_completed() {
         return Ok(());
     }

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -2544,8 +2544,13 @@ mod tests {
     /// #12862: it was untimed, and `apply_app_lock` is held across it.
     mod hot_reload_initial_refresh {
         use super::*;
-        use tokio::sync::Notify;
+        use crate::accelerated::refresh_completion::RefreshCompletion;
         use tokio_util::sync::CancellationToken;
+
+        /// A completion signal no refresh ever reports on.
+        fn silent() -> RefreshCompletionWaiter {
+            RefreshCompletion::new().any()
+        }
 
         /// The production bound, so these arms cannot drift from it. A paused
         /// clock makes its size irrelevant to how long they take.
@@ -2563,12 +2568,12 @@ mod tests {
             await_hot_reload_initial_refresh(
                 &reloading(),
                 &|| true,
-                &Notify::new(),
+                silent(),
                 &CancellationToken::new(),
                 TIMEOUT,
             )
             .await
-            .expect("a table that has already loaded needs no notification");
+            .expect("a table that has already loaded needs no completion");
 
             assert_eq!(
                 started.elapsed(),
@@ -2577,30 +2582,83 @@ mod tests {
             );
         }
 
-        /// The ordinary case: the refresh completes and notifies.
+        /// The ordinary case: the refresh completes and reports it.
         #[tokio::test(start_paused = true)]
-        async fn a_completion_notification_ends_the_wait() {
-            let notifier = Arc::new(Notify::new());
-            let notify_from = Arc::clone(&notifier);
+        async fn a_reported_completion_ends_the_wait() {
+            let completion = RefreshCompletion::new();
+            let waiter = completion.any();
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(1)).await;
-                notify_from.notify_waiters();
+                completion.record();
             });
 
             let started = tokio::time::Instant::now();
             await_hot_reload_initial_refresh(
                 &reloading(),
                 &|| false,
-                &notifier,
+                waiter,
                 &CancellationToken::new(),
                 TIMEOUT,
             )
             .await
-            .expect("a notified refresh completes the wait");
+            .expect("a reported refresh completes the wait");
 
             assert!(
                 started.elapsed() < TIMEOUT,
-                "the wait must end on the notification, not on the bound"
+                "the wait must end on the completion, not on the bound"
+            );
+        }
+
+        /// Regression test for #13086. A refresh that finished before the reload
+        /// reached this wait must end it at once. The edge-triggered signal this
+        /// replaced had nothing left to report by then, so the reload spent the
+        /// whole bound and then discarded a table that was loaded.
+        #[tokio::test(start_paused = true)]
+        async fn a_completion_that_predates_the_wait_ends_it_immediately() {
+            let completion = RefreshCompletion::new();
+            completion.record();
+
+            let started = tokio::time::Instant::now();
+            await_hot_reload_initial_refresh(
+                &reloading(),
+                &|| false,
+                completion.any(),
+                &CancellationToken::new(),
+                TIMEOUT,
+            )
+            .await
+            .expect("a refresh that already completed must end the wait");
+
+            assert_eq!(
+                started.elapsed(),
+                Duration::ZERO,
+                "a completion recorded before the wait must be observed, not waited out"
+            );
+        }
+
+        /// Regression test for #13086. A cluster scheduler runs no refresh
+        /// locally and closes the table's completion signal instead, which must
+        /// end the wait rather than spend the bound on every hot reload.
+        #[tokio::test(start_paused = true)]
+        async fn a_closed_completion_signal_ends_the_wait() {
+            let completion = RefreshCompletion::new();
+            completion.close();
+
+            let started = tokio::time::Instant::now();
+            await_hot_reload_initial_refresh(
+                &reloading(),
+                &|| false,
+                completion.any(),
+                &CancellationToken::new(),
+                TIMEOUT,
+            )
+            .await
+            .expect("a signal that will never report again must end the wait");
+
+            assert_eq!(
+                started.elapsed(),
+                Duration::ZERO,
+                "a closed signal must be recognised immediately, not at the bound"
             );
         }
 
@@ -2613,7 +2671,7 @@ mod tests {
             let err = await_hot_reload_initial_refresh(
                 &reloading(),
                 &|| false,
-                &Notify::new(),
+                silent(),
                 &CancellationToken::new(),
                 TIMEOUT,
             )
@@ -2631,58 +2689,55 @@ mod tests {
             );
         }
 
-        /// A completion landing between the `Notified`'s construction and the
-        /// `select!` must still wake the wait, which is why the future is built
-        /// before the loaded-check rather than after it. Build it after and this
-        /// notification is dropped, costing the whole bound. The closure is the
-        /// seam: it runs in exactly that window.
+        /// A completion landing between the loaded-check and the `select!` must
+        /// still end the wait. The closure is the seam: it runs in exactly that
+        /// window.
         #[tokio::test(start_paused = true)]
         async fn a_completion_racing_the_loaded_check_is_not_missed() {
-            let notifier = Arc::new(Notify::new());
-            let notify_from = Arc::clone(&notifier);
-            let notifies_then_reports_unloaded = move || {
-                notify_from.notify_waiters();
+            let completion = RefreshCompletion::new();
+            let waiter = completion.any();
+            let records_then_reports_unloaded = move || {
+                completion.record();
                 false
             };
 
             let started = tokio::time::Instant::now();
             await_hot_reload_initial_refresh(
                 &reloading(),
-                &notifies_then_reports_unloaded,
-                &notifier,
+                &records_then_reports_unloaded,
+                waiter,
                 &CancellationToken::new(),
                 TIMEOUT,
             )
             .await
-            .expect("a completion racing the wait setup must wake it, not be missed");
+            .expect("a completion racing the wait setup must end it, not be missed");
 
             assert_eq!(
                 started.elapsed(),
                 Duration::ZERO,
-                "a registered waiter must be woken immediately, not at the bound"
+                "a waiter must be released immediately, not at the bound"
             );
         }
 
-        /// `Notify::notify_waiters` stores no permit, so a completion landing
-        /// before the waiter is registered is lost. The table is loaded
-        /// regardless, and must not be discarded.
+        /// The bound and the completion can become ready together, and
+        /// `select!` picks between ready branches at random. The table is loaded
+        /// either way, so the backstop check must not let the bound discard it.
         #[tokio::test(start_paused = true)]
-        async fn a_lost_wakeup_resolves_as_loaded_at_the_bound() {
+        async fn a_load_landing_at_the_bound_is_not_discarded() {
             // False for the pre-wait check, true for the backstop check: the
-            // refresh completed while nothing was subscribed, and the refresher
-            // sets the flag just after it notifies.
+            // refresh completed while the wait was outstanding.
             let checks = AtomicUsize::new(0);
             let loaded = || checks.fetch_add(1, Ordering::SeqCst) >= 1;
 
             await_hot_reload_initial_refresh(
                 &reloading(),
                 &loaded,
-                &Notify::new(),
+                silent(),
                 &CancellationToken::new(),
                 TIMEOUT,
             )
             .await
-            .expect("a wakeup lost before the wait must not discard a loaded table");
+            .expect("a load that lands at the bound must not discard the table");
         }
 
         /// Shutdown ends the wait without reporting a reload failure.
@@ -2696,15 +2751,9 @@ mod tests {
             });
 
             let started = tokio::time::Instant::now();
-            await_hot_reload_initial_refresh(
-                &reloading(),
-                &|| false,
-                &Notify::new(),
-                &token,
-                TIMEOUT,
-            )
-            .await
-            .expect("a runtime shutting down is not a failed reload");
+            await_hot_reload_initial_refresh(&reloading(), &|| false, silent(), &token, TIMEOUT)
+                .await
+                .expect("a runtime shutting down is not a failed reload");
 
             assert!(
                 started.elapsed() < TIMEOUT,

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -2547,9 +2547,14 @@ mod tests {
         use crate::accelerated::refresh_completion::RefreshCompletion;
         use tokio_util::sync::CancellationToken;
 
-        /// A completion signal no refresh ever reports on.
-        fn silent() -> RefreshCompletionWaiter {
-            RefreshCompletion::new().any()
+        /// A completion signal no refresh ever reports on. The recorder comes
+        /// back with the waiter and has to be held for the length of the wait:
+        /// dropping it releases the waiter, which is the opposite of what these
+        /// arms are asking for.
+        fn silent() -> (RefreshCompletion, RefreshCompletionWaiter) {
+            let completion = RefreshCompletion::new();
+            let waiter = completion.any();
+            (completion, waiter)
         }
 
         /// The production bound, so these arms cannot drift from it. A paused
@@ -2564,11 +2569,12 @@ mod tests {
         /// the refresh finished before the reload got here.
         #[tokio::test(start_paused = true)]
         async fn an_already_loaded_table_does_not_wait() {
+            let (_recorder, waiter) = silent();
             let started = tokio::time::Instant::now();
             await_hot_reload_initial_refresh(
                 &reloading(),
                 &|| true,
-                silent(),
+                waiter,
                 &CancellationToken::new(),
                 TIMEOUT,
             )
@@ -2663,15 +2669,16 @@ mod tests {
         }
 
         /// A `refresh_mode: changes` stream that never produces a ready envelope
-        /// never fires the notifier. Before #12862 this held the apply lock for
-        /// the life of the process.
+        /// never reports a completion. Before #12862 this held the apply lock
+        /// for the life of the process.
         #[tokio::test(start_paused = true)]
         async fn a_refresh_that_never_completes_gives_up_at_the_bound() {
+            let (_recorder, waiter) = silent();
             let started = tokio::time::Instant::now();
             let err = await_hot_reload_initial_refresh(
                 &reloading(),
                 &|| false,
-                silent(),
+                waiter,
                 &CancellationToken::new(),
                 TIMEOUT,
             )
@@ -2729,10 +2736,11 @@ mod tests {
             let checks = AtomicUsize::new(0);
             let loaded = || checks.fetch_add(1, Ordering::SeqCst) >= 1;
 
+            let (_recorder, waiter) = silent();
             await_hot_reload_initial_refresh(
                 &reloading(),
                 &loaded,
-                silent(),
+                waiter,
                 &CancellationToken::new(),
                 TIMEOUT,
             )
@@ -2750,8 +2758,9 @@ mod tests {
                 cancel.cancel();
             });
 
+            let (_recorder, waiter) = silent();
             let started = tokio::time::Instant::now();
-            await_hot_reload_initial_refresh(&reloading(), &|| false, silent(), &token, TIMEOUT)
+            await_hot_reload_initial_refresh(&reloading(), &|| false, waiter, &token, TIMEOUT)
                 .await
                 .expect("a runtime shutting down is not a failed reload");
 

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -2022,8 +2022,11 @@ pub struct RegisterDatasetContext {
 /// spending the bound.
 ///
 /// Returns `Ok(())` when the table loaded (or the runtime is shutting down), and
-/// [`Error::HotReloadRefreshTimedOut`] when the bound expires with the table
-/// still unloaded, which drops the in-place swap in favour of a full reload.
+/// [`Error::HotReloadRefreshTimedOut`] when the table is still unloaded once
+/// there is nothing left to wait for, which drops the in-place swap in favour of
+/// a full reload. That is either the bound expiring or the new table being
+/// dropped before its first refresh: waiting out the rest of the bound on a
+/// table nobody can refresh only delays the same verdict.
 async fn await_hot_reload_initial_refresh(
     dataset_name: &TableReference,
     initial_load_completed: &(dyn Fn() -> bool + Sync),
@@ -2038,8 +2041,13 @@ async fn await_hot_reload_initial_refresh(
     tokio::select! {
         // A `RefreshCompletionWaiter` for any completion is satisfied by a
         // refresh that finished before this wait began, so the load cannot be
-        // missed by arriving here late.
-        () = completion.wait() => return Ok(()),
+        // missed by arriving here late. An abandoned wait falls through to the
+        // flag re-check below rather than returning: every recorder is gone, so
+        // no refresh is coming, but a load that landed before they went still
+        // counts.
+        outcome = completion.wait() => if outcome.is_answered() {
+            return Ok(());
+        },
         () = shutdown_token.cancelled() => return Ok(()),
         () = tokio::time::sleep(timeout) => {}
     }

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -342,7 +342,15 @@ impl Runtime {
             let notifier = register_task.await;
             match notifier {
                 Ok(Some(completion)) => {
-                    completion.wait().await;
+                    if completion.wait().await.is_abandoned() {
+                        // The accelerated table was dropped before its initial
+                        // refresh landed. Creating the schedule now would
+                        // resurrect one for a view that is no longer there.
+                        tracing::debug!(
+                            "Accelerated view '{view_name}' was removed before its initial refresh completed; not creating a refresh schedule."
+                        );
+                        return;
+                    }
                     if let Err(e) = runtime.create_dataset_or_view_schedule(view).await {
                         tracing::error!(
                             "Failed to create refresh schedule for accelerated view '{view_name}': {e}."

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -341,8 +341,8 @@ impl Runtime {
             let view_name = view.name.clone();
             let notifier = register_task.await;
             match notifier {
-                Ok(Some(notifier)) => {
-                    notifier.notified().await;
+                Ok(Some(completion)) => {
+                    completion.wait().await;
                     if let Err(e) = runtime.create_dataset_or_view_schedule(view).await {
                         tracing::error!(
                             "Failed to create refresh schedule for accelerated view '{view_name}': {e}."

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1058,8 +1058,16 @@ impl Runtime {
             // case here would leave the dataset stuck in `Refreshing`.
             let table_name = table.to_string();
             tokio::spawn(async move {
-                if let Some(completion) = notifier {
-                    completion.wait().await;
+                if let Some(completion) = notifier
+                    && completion.wait().await.is_abandoned()
+                {
+                    // The table was removed before the refresh we triggered
+                    // landed. Acking readiness here would tell the scheduler a
+                    // partition set is loaded that never was.
+                    tracing::debug!(
+                        "{table_name} was removed before its partition refresh completed; not broadcasting PartitionsLoaded."
+                    );
+                    return;
                 }
                 // Statistics flow via the periodic ExecutorStatistics reporter, not
                 // this readiness ack.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1058,8 +1058,8 @@ impl Runtime {
             // case here would leave the dataset stuck in `Refreshing`.
             let table_name = table.to_string();
             tokio::spawn(async move {
-                if let Some(n) = notifier {
-                    n.notified().await;
+                if let Some(completion) = notifier {
+                    completion.wait().await;
                 }
                 // Statistics flow via the periodic ExecutorStatistics reporter, not
                 // this readiness ack.

--- a/crates/runtime/src/scheduling/dataset/mod.rs
+++ b/crates/runtime/src/scheduling/dataset/mod.rs
@@ -43,9 +43,9 @@ impl ScheduledTask for DatasetRefreshTask {
                 .refresh_table(&dataset.name, None)
                 .await
             {
-                Ok(notifier) => {
-                    if let Some(notifier) = notifier {
-                        notifier.notified().await;
+                Ok(completion) => {
+                    if let Some(completion) = completion {
+                        completion.wait().await;
                     }
                     Ok(())
                 }

--- a/crates/runtime/src/scheduling/dataset/mod.rs
+++ b/crates/runtime/src/scheduling/dataset/mod.rs
@@ -44,8 +44,18 @@ impl ScheduledTask for DatasetRefreshTask {
                 .await
             {
                 Ok(completion) => {
-                    if let Some(completion) = completion {
-                        completion.wait().await;
+                    if let Some(completion) = completion
+                        && completion.wait().await.is_abandoned()
+                    {
+                        // The dataset was removed while its scheduled refresh
+                        // was in flight. The task acts on nothing after the
+                        // wait, so there is no phantom completion to guard
+                        // against; raising it would report a task failure on
+                        // every ordinary removal and shutdown.
+                        let dataset_name = &dataset.name;
+                        tracing::debug!(
+                            "{dataset_name} was removed before its scheduled refresh completed."
+                        );
                     }
                     Ok(())
                 }

--- a/crates/runtime/src/scheduling/view/mod.rs
+++ b/crates/runtime/src/scheduling/view/mod.rs
@@ -41,8 +41,17 @@ impl ScheduledTask for ViewRefreshTask {
 
             match runtime.datafusion().refresh_table(&view.name, None).await {
                 Ok(completion) => {
-                    if let Some(completion) = completion {
-                        completion.wait().await;
+                    if let Some(completion) = completion
+                        && completion.wait().await.is_abandoned()
+                    {
+                        // The view was removed while its scheduled refresh was
+                        // in flight. As for datasets, the task acts on nothing
+                        // after the wait, so this is recorded rather than
+                        // raised.
+                        let view_name = &view.name;
+                        tracing::debug!(
+                            "{view_name} was removed before its scheduled refresh completed."
+                        );
                     }
                     Ok(())
                 }

--- a/crates/runtime/src/scheduling/view/mod.rs
+++ b/crates/runtime/src/scheduling/view/mod.rs
@@ -40,9 +40,9 @@ impl ScheduledTask for ViewRefreshTask {
             let runtime = Arc::clone(&view.runtime);
 
             match runtime.datafusion().refresh_table(&view.name, None).await {
-                Ok(notifier) => {
-                    if let Some(notifier) = notifier {
-                        notifier.notified().await;
+                Ok(completion) => {
+                    if let Some(completion) = completion {
+                        completion.wait().await;
                     }
                     Ok(())
                 }

--- a/crates/runtime/tests/acceleration/cayenne_memory.rs
+++ b/crates/runtime/tests/acceleration/cayenne_memory.rs
@@ -57,7 +57,7 @@ async fn refresh(rt: &Arc<Runtime>, table: &str) -> Result<(), anyhow::Error> {
         .map_err(|e| anyhow::anyhow!("refresh_table failed: {e}"))?;
     notifier
         .ok_or_else(|| anyhow::anyhow!("no refresh notifier for {table}"))?
-        .notified()
+        .wait()
         .await;
     Ok(())
 }

--- a/crates/runtime/tests/acceleration/localpod_sync.rs
+++ b/crates/runtime/tests/acceleration/localpod_sync.rs
@@ -220,7 +220,7 @@ async fn test_localpod_refresh_invalidates_child_cached_results() -> Result<(), 
                     .expect("trigger parent refresh");
                 if let Some(notify) = notify {
                     tokio::select! {
-                        () = notify.notified() => {}
+                        () = notify.wait() => {}
                         () = tokio::time::sleep(Duration::from_secs(5)) => {}
                     }
                 }
@@ -365,7 +365,7 @@ async fn test_localpod_full_refresh_synchronization_with_arrow_parent() -> Resul
                     .expect("trigger parent refresh");
                 if let Some(notify) = notify {
                     tokio::select! {
-                        () = notify.notified() => {}
+                        () = notify.wait() => {}
                         () = tokio::time::sleep(Duration::from_secs(5)) => {}
                     }
                 }

--- a/crates/runtime/tests/acceleration/localpod_sync.rs
+++ b/crates/runtime/tests/acceleration/localpod_sync.rs
@@ -220,7 +220,7 @@ async fn test_localpod_refresh_invalidates_child_cached_results() -> Result<(), 
                     .expect("trigger parent refresh");
                 if let Some(notify) = notify {
                     tokio::select! {
-                        () = notify.wait() => {}
+                        _ = notify.wait() => {}
                         () = tokio::time::sleep(Duration::from_secs(5)) => {}
                     }
                 }
@@ -365,7 +365,7 @@ async fn test_localpod_full_refresh_synchronization_with_arrow_parent() -> Resul
                     .expect("trigger parent refresh");
                 if let Some(notify) = notify {
                     tokio::select! {
-                        () = notify.wait() => {}
+                        _ = notify.wait() => {}
                         () = tokio::time::sleep(Duration::from_secs(5)) => {}
                     }
                 }

--- a/crates/runtime/tests/acceleration/refresh/common.rs
+++ b/crates/runtime/tests/acceleration/refresh/common.rs
@@ -332,7 +332,7 @@ pub(crate) async fn refresh_table(rt: Arc<Runtime>, table_name: &str) -> Result<
         .await?;
     notifier
         .ok_or_else(|| anyhow::anyhow!("Failed to refresh table"))?
-        .notified()
+        .wait()
         .await;
     Ok(())
 }

--- a/crates/runtime/tests/acceleration/retention_arrow.rs
+++ b/crates/runtime/tests/acceleration/retention_arrow.rs
@@ -49,7 +49,7 @@ async fn refresh_table(rt: &Arc<Runtime>, table_name: &str) -> Result<(), anyhow
         .await?;
     notifier
         .ok_or_else(|| anyhow::anyhow!("Failed to refresh table"))?
-        .notified()
+        .wait()
         .await;
     Ok(())
 }

--- a/crates/runtime/tests/cdc_cayenne_heartbeat.rs
+++ b/crates/runtime/tests/cdc_cayenne_heartbeat.rs
@@ -64,12 +64,13 @@ use datafusion_table_providers::util::{
 };
 use futures::StreamExt;
 use runtime::accelerated::refresh::Refresh;
+use runtime::accelerated::refresh_completion::RefreshCompletion;
 use runtime::accelerated::refresh_task::RefreshTaskBuilder;
 use runtime::federated::FederatedTable;
 use runtime::status::RuntimeStatus;
 use tempfile::TempDir;
 use tokio::runtime::Handle;
-use tokio::sync::{Mutex as TokioMutex, Notify, RwLock};
+use tokio::sync::{Mutex as TokioMutex, RwLock};
 
 /// All-nullable data schema, matching what CDC sources produce (and what the
 /// heartbeat envelope normalizes to), so heartbeats and change batches share
@@ -244,33 +245,29 @@ async fn heartbeat_must_not_force_mem_tier_checkpoint_or_ack_deferred_commits() 
 
     let commits: Arc<TokioMutex<Vec<i64>>> = Arc::new(TokioMutex::new(Vec::new()));
     let initial_load = Arc::new(AtomicBool::new(false));
-    let ready_notify = Arc::new(Notify::new());
+    let refresh_completion = RefreshCompletion::new();
+    // Taken before the stream runs: the waiter is level-triggered, so a ready
+    // signal landing before the assertion below still resolves it.
+    let ready_waiter = refresh_completion.next();
 
     // Channel-driven stream so envelope timing is under test control.
     let (tx, rx) = futures::channel::mpsc::unbounded::<Result<ChangeEnvelope, StreamError>>();
 
     let stream_task = {
-        let notify = Arc::clone(&ready_notify);
+        let completion = refresh_completion.clone();
         let load = Arc::clone(&initial_load);
         let refresh = Arc::new(RwLock::new(Refresh::default()));
         tokio::spawn(async move {
-            task.start_changes_stream(refresh, rx.boxed(), None, Some(notify), load)
+            task.start_changes_stream(refresh, rx.boxed(), None, Some(completion), load)
                 .await
         })
     };
 
-    // Subscribe to the ready notification BEFORE the heartbeat is sent so the
-    // notify_waiters signal cannot be missed.
-    let ready_seen = {
-        let notify = Arc::clone(&ready_notify);
-        tokio::spawn(async move {
-            let waiter = notify.notified();
-            tokio::pin!(waiter);
-            tokio::time::timeout(Duration::from_secs(10), &mut waiter)
-                .await
-                .is_ok()
-        })
-    };
+    let ready_seen = tokio::spawn(async move {
+        tokio::time::timeout(Duration::from_secs(10), ready_waiter.wait())
+            .await
+            .is_ok()
+    });
     tokio::task::yield_now().await;
 
     // 1. A real change lands in the mem tier; its committer is DEFERRED

--- a/crates/runtime/tests/metrics.rs
+++ b/crates/runtime/tests/metrics.rs
@@ -519,7 +519,7 @@ async fn an_accelerated_dataset_reports_the_query_and_refresh_families() {
         .await
         .expect("the refresh request to be accepted")
         .expect("an accelerated table to return a refresh notifier");
-    tokio::time::timeout(Duration::from_mins(1), notifier.notified())
+    tokio::time::timeout(Duration::from_mins(1), notifier.wait())
         .await
         .expect("the refresh to complete within a minute");
 

--- a/crates/runtime/tests/models/hnsw_index.rs
+++ b/crates/runtime/tests/models/hnsw_index.rs
@@ -140,7 +140,7 @@ async fn refresh_table(rt: &Arc<Runtime>, table_name: &str) -> Result<(), anyhow
         .await?;
     notifier
         .ok_or_else(|| anyhow::anyhow!("No refresh notifier returned for {table_name}"))?
-        .notified()
+        .wait()
         .await;
     Ok(())
 }

--- a/crates/runtime/tests/postgres/dml.rs
+++ b/crates/runtime/tests/postgres/dml.rs
@@ -138,7 +138,7 @@ async fn refresh_dataset(rt: &runtime::Runtime, name: &str) -> Result<(), anyhow
         .await?;
     notifier
         .ok_or_else(|| anyhow::anyhow!("no completion notifier for {name}"))?
-        .notified()
+        .wait()
         .await;
     Ok(())
 }

--- a/crates/runtime/tests/postgres/schema_inference.rs
+++ b/crates/runtime/tests/postgres/schema_inference.rs
@@ -171,7 +171,7 @@ async fn refresh_dataset(rt: &runtime::Runtime, name: &str) -> Result<(), anyhow
         .refresh_table(&datafusion::common::TableReference::from(name), None)
         .await?;
     let notify = notifier.ok_or_else(|| anyhow::anyhow!("no completion notifier for {name}"))?;
-    tokio::time::timeout(Duration::from_mins(1), notify.notified())
+    tokio::time::timeout(Duration::from_mins(1), notify.wait())
         .await
         .map_err(|_| {
             anyhow::anyhow!("timed out after 1 minute waiting for {name} refresh to complete")

--- a/crates/runtime/tests/retention/mod.rs
+++ b/crates/runtime/tests/retention/mod.rs
@@ -169,7 +169,7 @@ async fn refresh_table(rt: Arc<Runtime>, table_name: &str) -> Result<(), anyhow:
         .await?;
     notifier
         .ok_or_else(|| anyhow::anyhow!("Failed to refresh table"))?
-        .notified()
+        .wait()
         .await;
     Ok(())
 }

--- a/crates/runtime/tests/snapshot_integration/mod.rs
+++ b/crates/runtime/tests/snapshot_integration/mod.rs
@@ -1902,7 +1902,7 @@ async fn snapshot_int_test12_onchange_policy_skips_refresh_based_snapshots() -> 
                 .await
                 .expect("Table refresh")
                 .expect("Notify")
-                .notified()
+                .wait()
                 .await;
             runtime
                 .datafusion()
@@ -1910,7 +1910,7 @@ async fn snapshot_int_test12_onchange_policy_skips_refresh_based_snapshots() -> 
                 .await
                 .expect("Table refresh")
                 .expect("Notify")
-                .notified()
+                .wait()
                 .await;
             runtime
                 .datafusion()
@@ -1918,7 +1918,7 @@ async fn snapshot_int_test12_onchange_policy_skips_refresh_based_snapshots() -> 
                 .await
                 .expect("Table refresh")
                 .expect("Notify")
-                .notified()
+                .wait()
                 .await;
             runtime
                 .datafusion()
@@ -1926,7 +1926,7 @@ async fn snapshot_int_test12_onchange_policy_skips_refresh_based_snapshots() -> 
                 .await
                 .expect("Table refresh")
                 .expect("Notify")
-                .notified()
+                .wait()
                 .await;
             tokio::time::sleep(Duration::from_secs(5)).await;
 
@@ -2024,7 +2024,7 @@ async fn snapshot_int_test13_refresh_based_snapshots() -> Result<()> {
                 .await
                 .expect("Table refresh")
                 .expect("Notify")
-                .notified()
+                .wait()
                 .await;
             runtime
                 .datafusion()
@@ -2032,7 +2032,7 @@ async fn snapshot_int_test13_refresh_based_snapshots() -> Result<()> {
                 .await
                 .expect("Table refresh")
                 .expect("Notify")
-                .notified()
+                .wait()
                 .await;
             runtime
                 .datafusion()
@@ -2040,7 +2040,7 @@ async fn snapshot_int_test13_refresh_based_snapshots() -> Result<()> {
                 .await
                 .expect("Table refresh")
                 .expect("Notify")
-                .notified()
+                .wait()
                 .await;
             tokio::time::sleep(Duration::from_secs(10)).await;
 


### PR DESCRIPTION
## Summary

`Refresher::on_complete_notification` handed callers a bare `Arc<Notify>`, and a completion was
published with `notify_waiters()`, which stores no permit. A completion landing before a caller had
registered its wait was dropped with no record, and the caller went on waiting for a refresh that had
already happened.

Two of the five callers stall permanently on that, because nothing else ever wakes them:

- a dataset or view **refresh schedule** gates its next tick on task completion, so that schedule
  stops for the life of the process;
- an **accelerated view** never gets a refresh schedule at all.

The window is not narrow. `refresh_table` read the notifier, triggered the refresh, and returned the
notifier to its caller, who only then called `.notified()` — the refresh had the whole of that gap to
finish in. On a cluster scheduler the compensation could not work at all: it fired `notify_waiters()`
from inside `Builder::build()`, before the table existed for any caller to reach, so no waiter could
possibly be registered.

## Changes

- **A completion count instead of an edge.** `RefreshCompletion` (new,
  `crates/runtime-table/src/accelerated/refresh_completion.rs`) records each completed refresh as one
  atomic transition on a `watch` value. A caller takes a `RefreshCompletionWaiter` up front and
  awaits it later; a completion recorded in between resolves the wait rather than being lost.
- **Two accessors for the two questions callers actually ask.** `RefreshCompletion::any` — "has the
  initial load landed?" — is satisfied by a refresh that finished before the caller asked, which is
  what every registration path needs, since the refresh starts inside the table build.
  `RefreshCompletion::next` — "has the refresh I just triggered finished?" — resolves only on a
  completion recorded after the waiter was taken, and `DataFusion::refresh_table` now takes its
  waiter **before** triggering. Collapsing the two would reintroduce the lost wakeup one way and make
  a scheduled refresh return instantly on a stale completion the other.
- **`initial_load_completed` is stored before the completion is recorded**, so a caller woken by one
  observes the flag. The CDC apply path (`RefreshTask::signal_dataset_ready`) already ordered it this
  way and says why; the full-refresh loop did the opposite.
- **A cluster scheduler closes the signal** rather than firing an edge nobody can receive. No refresh
  runs locally there, so every waiter — including one taken later — resolves at once instead of
  waiting on a completion that cannot arrive.

`Option<Arc<Notify>>` becomes `Option<RefreshCompletionWaiter>` across `register_table`,
`register_accelerated_table`, `refresh_table`, `register_view` and `create_accelerated_view`. `None`
keeps its existing meaning of "nothing to wait for" at every call site, which is why the scheduler
closes its signal rather than declining to install one — at `register_view`, `None` also means "not
an accelerated view", and creating a refresh schedule for one of those would be wrong.

**Accepted consequence.** A scheduler-role node now creates the refresh schedules it previously never
got as far as creating. With a partition service — the configured case — each tick forwards the
refresh to the executors, which is what the schedule was for. Without one (a scheduler whose
`runtime.scheduler` block is missing), each tick now fails with the same
`ManualRefreshIsNotSupported` the trigger has always returned, instead of hanging silently. That
misconfiguration becomes loud rather than invisible; it is not otherwise changed.

## Test plan

- `make lint`
- `make test`

New coverage: 10 unit tests on the completion signal — including its negative controls, since `next`
must *not* accept an earlier completion and `any` must *not* be satisfied without one — 3 driving the
production `Refresher::start` loop, 2 on the scheduler branch and its off-scheduler contrast, 2 new
arms in the hot-reload wait, and the CDC ready-signal test re-aimed to take its waiter before the
stream runs and await it after, which is the ordering that loses an edge entirely.

All 16 were checked against an 11-mutation matrix, each guard neutered in turn; every test is killed
by at least one mutation, so none passes vacuously. One result is worth stating rather than burying:
reverting *only* the `initial_load_completed` ordering kills nothing, because observing that
reordering means losing a race inside a single task. It is a publication-order guarantee that keeps
the hot-reload backstop sound, not a behaviour change carrying its own coverage.

## Review gate

**Original PR (`69467eaf4b` and earlier)**

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits."; `grok` not installed
- `/security-review`: no findings — the change adds no route, parser, deserializer, path operation or logging, and carries no user-controlled value; the one early-resolution path (recorder dropped) was traced and cannot be reached while a caller holds the table
- `/simplify`: applied — folded the close flag into the watched value, so closing is one atomic transition and the wait is a single `changed()`; the 16 tests and the full neuter matrix were re-run green afterwards

In place of the engine, a hand adversarial pass checked the approach: `watch` is the primitive this
repo already uses for level-triggered state (`runtime-status`), and there was no existing completion
helper to reuse; `trigger_refresh` has exactly one caller, so the take-waiter-before-trigger ordering
holds everywhere; and the only consumers of `register_table`'s waiter read `is_some()`, so the
`next`→`any` change there is not observable.

**Review-thread fix `d0a4b62eac`** — the `Answered`/`Abandoned` outcome and the `notify_waiters` doc correction. Attests that commit only, not the work above.

- Adversarial review: **`codex`** (`gpt-5.4-codex` refused for this account; ran on the CLI default) — scoped to `69467eaf4b…d0a4b62eac`, run directly rather than through the plugin companion, which needs `node` and this host has none. Four findings. One was **valid, in scope, and fixed before the push**: marking `RefreshCompletionOutcome` `#[must_use]` would have turned ~28 existing `wait()` call sites into `-D warnings` failures, so the attribute was dropped and the reasoning recorded on the type. Three were **valid but out of scope** and are filed: the request-correlation gap as #13544 (already open — the review rediscovered it independently) and the table-revalidation gap as #13603. It also independently confirmed the tokio ordering the fix rests on, and endorsed `close()` as `Answered` and the two scheduled tasks returning `Ok`.
- `/security-review`: **not run as a tool** — the pass needs the repository as the session's working directory and this run is driving several repos from outside any of them. Assessed by hand instead, on the same checklist: the diff adds no route, parser, deserializer, or path operation; the only new output is two `debug!` lines naming a table and a view, both already logged at the same level a few lines away; no new user-controlled value reaches an unbounded surface. No findings.
- `/simplify`: **not run as a tool** (same working-directory constraint). A hand quality pass tightened the two scheduled-task comments and moved both `debug!` calls to inline format captures, matching the neighbouring style; `cargo fmt --all --check` clean afterwards.

Local verification: `cargo check -p runtime-table --lib` and the module's 12 unit tests pass. **`crates/runtime` cannot be compiled on this host at all** — `crates/cayenne` does not build on Windows and `crates/runtime` names it unconditionally in source while depending on it only under `cfg(not(windows))` — so the four `crates/runtime` call-site edits are attested by the remote sign-off rather than locally. The let-chain and `select!` shapes they use were verified against a standalone edition-2024 reproduction first.

Fixes #13086

## Checklist

- [x] Tests added for the fix and its edge cases
- [x] Every new test verified against a mutation of the guard it covers
- [ ] `make lint` and `make test` green via `make signoff`
