### PR TITLE
fix(ci): stage the retention OOM test binary without its debug info

### DIFF
--- a/crates/runtime/tests/retention_oom.rs
+++ b/crates/runtime/tests/retention_oom.rs
@@ -453,8 +453,8 @@ async fn build_image_from_host_binary(
 
     stage_test_binary(host_test_binary, &staged_binary).await?;
 
-    // The staged size is what the build context costs, and this step has previously run out
-    // of budget transferring and exporting it rather than running the workload, so report it.
+    // The staged size is what the build context costs: an oversized one spends the step's
+    // budget transferring and exporting it rather than running the workload, so report it.
     if let Ok(metadata) = std::fs::metadata(&staged_binary) {
         eprintln!(
             "Staged test binary for the image build context: {} MiB",

--- a/crates/runtime/tests/retention_oom.rs
+++ b/crates/runtime/tests/retention_oom.rs
@@ -393,6 +393,57 @@ async fn build_image_from_source(
     Ok(())
 }
 
+/// Stage the test binary for the image without its debug info.
+///
+/// The staged copy becomes the entire Docker build context, so every byte is transferred to
+/// the daemon and then written again as an exported layer. An unstripped debug build of this
+/// test target is several gigabytes, nearly all of it DWARF the container never reads — it
+/// only executes the binary. `strip --strip-debug` writes the stripped output directly, so
+/// the oversized copy is never materialized at all, and it keeps the ELF symbol table so a
+/// panic inside the container still symbolizes.
+///
+/// Only the ELF path reaches here, so `strip` is GNU binutils and `--strip-debug` is the
+/// flag it takes; Apple's `strip` spells this `-S` and rejects the long form outright. That
+/// difference costs nothing rather than needing a second spelling, because `strip` is not
+/// guaranteed to be on the host at all: any absence, rejected flag, or failure falls back to
+/// a plain copy. A slower build is a far better outcome than a test that cannot run.
+async fn stage_test_binary(
+    host_test_binary: &Path,
+    staged_binary: &Path,
+) -> Result<(), anyhow::Error> {
+    let stripped = Command::new("strip")
+        .arg("--strip-debug")
+        .arg("-o")
+        .arg(staged_binary)
+        .arg(host_test_binary)
+        .status()
+        .await;
+
+    match stripped {
+        Ok(status) if status.success() => return Ok(()),
+        Ok(status) => eprintln!(
+            "strip --strip-debug exited {}, staging the unstripped binary instead",
+            status.code().unwrap_or_default()
+        ),
+        Err(error) => {
+            eprintln!("could not run strip ({error}), staging the unstripped binary instead");
+        }
+    }
+
+    // `strip -o` may have left a partial file behind before failing.
+    let _ = std::fs::remove_file(staged_binary);
+
+    std::fs::copy(host_test_binary, staged_binary).with_context(|| {
+        format!(
+            "failed to copy host test binary from {} to {}",
+            host_test_binary.display(),
+            staged_binary.display()
+        )
+    })?;
+
+    Ok(())
+}
+
 async fn build_image_from_host_binary(
     image_tag: &str,
     host_test_binary: &Path,
@@ -401,13 +452,16 @@ async fn build_image_from_host_binary(
     let dockerfile_path = temp_dir.path().join("Dockerfile.retention-oom");
     let staged_binary = temp_dir.path().join("retention_oom");
 
-    std::fs::copy(host_test_binary, &staged_binary).with_context(|| {
-        format!(
-            "failed to copy host test binary from {} to {}",
-            host_test_binary.display(),
-            staged_binary.display()
-        )
-    })?;
+    stage_test_binary(host_test_binary, &staged_binary).await?;
+
+    // The staged size is what the build context costs, and this step has previously run out
+    // of budget transferring and exporting it rather than running the workload, so report it.
+    if let Ok(metadata) = std::fs::metadata(&staged_binary) {
+        eprintln!(
+            "Staged test binary for the image build context: {} MiB",
+            metadata.len() / (1024 * 1024)
+        );
+    }
 
     std::fs::write(&dockerfile_path, dockerfile_for_host_binary())?;
 

--- a/crates/runtime/tests/retention_oom.rs
+++ b/crates/runtime/tests/retention_oom.rs
@@ -422,8 +422,7 @@ async fn stage_test_binary(
     match stripped {
         Ok(status) if status.success() => return Ok(()),
         Ok(status) => eprintln!(
-            "strip --strip-debug exited {}, staging the unstripped binary instead",
-            status.code().unwrap_or_default()
+            "strip --strip-debug failed ({status}), staging the unstripped binary instead"
         ),
         Err(error) => {
             eprintln!("could not run strip ({error}), staging the unstripped binary instead");


### PR DESCRIPTION
## What

Stage the `retention_oom` test binary into the Docker build context with `strip --strip-debug -o` instead of `std::fs::copy`, and report the staged size.

## Why

`Run retention OOM regression test` has begun timing out and dequeuing PRs from the merge queue, including [#13466](https://github.com/spiceai/spiceai/pull/13466) — the fix for the `Set up cc` failure that is currently killing every other batch.

The step never reaches the workload. In run [32848416252](https://github.com/spiceai/spiceai/actions/runs/32848416252), `test_cayenne_pk_delete_oom_repro` was terminated by nextest at its 360s slow-timeout on **all three** attempts, and each attempt spent that budget inside `docker build`:

```
#6 transferring context: 4.33GB   86.8s done
#7 apt-get install                18.3s
#8 [3/4] COPY retention_oom       21.5s
#9 [4/4] RUN chmod +x             22.3s
#10 exporting layers             188.3s (255.0s on the next attempt)
ERROR: failed to build: failed to solve: Canceled: context canceled
```

`build_image_from_host_binary` copies `current_exe()` into a tempdir and hands that directory to `docker build`, so the **entire build context is the test binary**. An unstripped dev-profile build of this target is 4.33 GB, nearly all of it DWARF — which the container never reads, since it only executes the binary. That is paid twice: once transferring it to the daemon, once exporting it as a layer. The export time varies with runner load, which is why this surfaces as an intermittent timeout rather than a constant one.

The last passing run of this step ([32792934794](https://github.com/spiceai/spiceai/actions/runs/32792934794)) took 246.9s of its 360s budget, so the margin was already thin. Removing ~300s of build overhead is what restores it.

## How

`strip --strip-debug -o <dest> <src>` writes the stripped output directly, so the oversized copy is never materialized at all — the current code writes 4.33 GB to the tempdir before Docker reads it back. `--strip-debug` keeps the ELF symbol table, so a panic inside the container still symbolizes.

Only the ELF path reaches this code, so `strip` is GNU binutils there. `strip` is not guaranteed to be on the host regardless, so any absence, rejected flag, or failure falls back to the plain copy: a slower build is a far better outcome than a test that cannot run.

## What this does not change

The test's assertions, row count, payload size, and `--memory=1280m` container limit are untouched, so what it proves is unchanged. Debug sections are not `SHF_ALLOC` and are never faulted in during execution, so the container's memory behaviour — the thing under test — does not depend on their presence. No built artifact is stripped; only the copy shipped into the container. The `strip = "none"` settings on `release-debug` and `release-profiling` are unrelated and untouched.

## Follow-up filed separately

This fixes the cause of exceeding the 360s cap. It does not address a structural mismatch worth its own change: the step is bounded at `timeout-minutes: 20`, while `retention_oom` inherits the default `retries = 5` and `slow-timeout` of 360s. Six attempts at 360s is 36 minutes, so once this test does exceed the cap the step can only ever die on the action timeout — reporting "the action has timed out" instead of a test verdict, after burning the full 20 minutes. Filed as #13512.

## Review gate

Attests the change in `15aa778e` (the whole PR — I authored it).

- **Adversarial review: `codex` — declared skip.** Probed from the engine before dispatch and it answered `ERROR: Your workspace is out of credits`, exit 1, so no review ran. Recorded as a skip, not a pass.
- **In its place, the reviewer finding was verified empirically rather than by reasoning.** `ExitStatus::code()` was confirmed to return `None` under `kill -9` — the value `unwrap_or_default()` was turning into a false `0` inside the failure arm — and the replacement `{status}` rendering was confirmed to print `signal: 9 (SIGKILL)` and `exit status: N` for the two cases.
- **`/security-review`: declared skip, reason stated.** Not run. This iteration changes one `eprintln!` in a test harness and one comment. The formatted value is a process exit status, not user- or attacker-influenced, and it goes to test stderr; no parsed input, network, auth, or secret surface is touched.
- **Narration sweep:** ran the added-lines grep for old-behavior narration over `origin/trunk...HEAD`. It caught one pre-existing comment in this PR ("this step has previously run out of budget"), rewritten into the conditional form in `15aa778e`; the sweep is now clean.
- **Local checks:** `cargo fmt` clean. The `{status}` form was compiled and executed standalone against real `ExitStatus` values (above) rather than inferred.
- **Sign-off:** dispatched remotely ([32882848878](https://github.com/spiceai/spiceai/actions/runs/32882848878)), pinned to the `fix/13463-setup-cc-skip-brew-when-present` ref. Four prior sign-offs on this branch died in `Set up cc` on runner-01, -02 and -03 under the live `setup-cc` outage; dispatching on the fix branch's ref is what lets the composite action resolve to the repaired version. Remote rather than local because this checkout is a worktree nested inside the parent repo.
