### PR TITLE
fix(duckdb): stop federating the two vector UDFs DuckDB answers differently (fixes #13088)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,6 +4608,7 @@ dependencies = [
  "runtime",
  "runtime-component",
  "runtime-datafusion",
+ "runtime-datafusion-udfs",
  "runtime-parameters",
  "snafu",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "runtime-checkpoint-api",
  "runtime-checkpoint-duckdb",
  "runtime-datafusion",
+ "runtime-datafusion-udfs",
  "runtime-parameters",
  "runtime-table",
  "runtime-table-partition",

--- a/crates/accelerators/accelerator-duckdb/Cargo.toml
+++ b/crates/accelerators/accelerator-duckdb/Cargo.toml
@@ -56,6 +56,11 @@ tokio = { workspace = true, features = ["sync", "rt"] }
 # need this crate's `create_table_provider`.
 runtime-table = { path = "../../runtime-table" }
 spice-table = { path = "../../spice-table" }
+# Test-only: `duckdb_vector_udf_pushdown_matches_local` compares the local vector
+# kernels against the SQL the DuckDB dialect renders for them, so it needs both
+# implementations in one process. `runtime-datafusion-udfs` is shared-utility, so
+# this is a downward edge either way.
+runtime-datafusion-udfs = { path = "../../runtime-datafusion-udfs" }
 insta.workspace = true
 tempfile.workspace = true
 runtime-acceleration = { path = "../../runtime-acceleration", features = ["duckdb", "test-support"] }

--- a/crates/accelerators/accelerator-duckdb/tests/duckdb_vector_udf_pushdown.rs
+++ b/crates/accelerators/accelerator-duckdb/tests/duckdb_vector_udf_pushdown.rs
@@ -33,7 +33,8 @@ limitations under the License.
 
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayRef, AsArray, FixedSizeListArray, Float32Array, RecordBatch};
+use arrow::array::{Array, ArrayRef, AsArray, FixedSizeListArray, Float32Builder, RecordBatch};
+use arrow::buffer::NullBuffer;
 use arrow::datatypes::Float64Type;
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::common::Column;
@@ -46,11 +47,30 @@ use runtime_datafusion::dialect::{duckdb_native_function_names, new_duckdb_diale
 /// Vector width the battery below is written against.
 const DIM: usize = 4;
 
+/// A vector operand: `None` is a NULL row, and a `None` element is a NULL slot
+/// inside an otherwise present vector. Both are legal in an Arrow
+/// `FixedSizeList<Float32>` column and both make the local kernel answer NULL.
+type Operand = Option<[Option<f32>; DIM]>;
+
 /// One `(lhs, rhs)` pair and what makes it worth asking about.
 struct Case {
     label: &'static str,
-    lhs: [f32; DIM],
-    rhs: [f32; DIM],
+    lhs: Operand,
+    rhs: Operand,
+}
+
+/// What one side answered for one case. An engine that raises instead of
+/// answering is its own outcome: it is neither a value nor a NULL, and folding it
+/// into either would hide that a pushdown turns a NULL row into a failed query.
+#[derive(Debug, PartialEq, Clone)]
+enum Outcome {
+    Value(Option<f64>),
+    Error(String),
+}
+
+/// Shorthand for a fully-populated operand.
+fn dense(v: [f32; DIM]) -> Operand {
+    Some(v.map(Some))
 }
 
 /// Every input class where two implementations of the same metric can disagree
@@ -58,25 +78,107 @@ struct Case {
 fn battery() -> Vec<Case> {
     let nan = f32::NAN;
     let inf = f32::INFINITY;
-    vec![
-        Case { label: "identical", lhs: [1.0, 0.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
-        Case { label: "orthogonal", lhs: [1.0, 0.0, 0.0, 0.0], rhs: [0.0, 1.0, 0.0, 0.0] },
-        Case { label: "opposite", lhs: [1.0, 0.0, 0.0, 0.0], rhs: [-1.0, 0.0, 0.0, 0.0] },
-        Case { label: "oblique", lhs: [1.0, 1.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
-        Case { label: "all_nonzero", lhs: [0.25, -0.5, 0.75, 1.5], rhs: [-1.25, 0.5, 2.0, -0.75] },
+    let mut cases = vec![
+        Case {
+            label: "identical",
+            lhs: dense([1.0, 0.0, 0.0, 0.0]),
+            rhs: dense([1.0, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "orthogonal",
+            lhs: dense([1.0, 0.0, 0.0, 0.0]),
+            rhs: dense([0.0, 1.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "opposite",
+            lhs: dense([1.0, 0.0, 0.0, 0.0]),
+            rhs: dense([-1.0, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "oblique",
+            lhs: dense([1.0, 1.0, 0.0, 0.0]),
+            rhs: dense([1.0, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "all_nonzero",
+            lhs: dense([0.25, -0.5, 0.75, 1.5]),
+            rhs: dense([-1.25, 0.5, 2.0, -0.75]),
+        },
         // Undefined direction: a metric that normalizes has to invent an answer,
         // and the two implementations need not invent the same one.
-        Case { label: "zero_lhs", lhs: [0.0, 0.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
-        Case { label: "zero_both", lhs: [0.0; DIM], rhs: [0.0; DIM] },
+        Case {
+            label: "zero_lhs",
+            lhs: dense([0.0, 0.0, 0.0, 0.0]),
+            rhs: dense([1.0, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "zero_both",
+            lhs: dense([0.0; DIM]),
+            rhs: dense([0.0; DIM]),
+        },
         // No defined distance at all: the local contract is NULL, and a pushdown
         // has to reproduce that rather than score the row.
-        Case { label: "nan_lhs", lhs: [nan, 0.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
-        Case { label: "nan_rhs", lhs: [1.0, 0.0, 0.0, 0.0], rhs: [nan, 0.0, 0.0, 0.0] },
-        Case { label: "nan_both", lhs: [nan, 0.0, 0.0, 0.0], rhs: [nan, 0.0, 0.0, 0.0] },
-        Case { label: "pos_inf_lhs", lhs: [inf, 0.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
-        Case { label: "neg_inf_lhs", lhs: [-inf, 0.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
-        Case { label: "nan_deep", lhs: [1.0, 2.0, 3.0, nan], rhs: [1.0, 2.0, 3.0, 4.0] },
-    ]
+        Case {
+            label: "nan_lhs",
+            lhs: dense([nan, 0.0, 0.0, 0.0]),
+            rhs: dense([1.0, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "nan_rhs",
+            lhs: dense([1.0, 0.0, 0.0, 0.0]),
+            rhs: dense([nan, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "nan_both",
+            lhs: dense([nan, 0.0, 0.0, 0.0]),
+            rhs: dense([nan, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "pos_inf_lhs",
+            lhs: dense([inf, 0.0, 0.0, 0.0]),
+            rhs: dense([1.0, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "neg_inf_lhs",
+            lhs: dense([-inf, 0.0, 0.0, 0.0]),
+            rhs: dense([1.0, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "nan_deep",
+            lhs: dense([1.0, 2.0, 3.0, nan]),
+            rhs: dense([1.0, 2.0, 3.0, 4.0]),
+        },
+    ];
+    // NULL is not a variant of "no defined distance" — it is a separate way for a
+    // row to have no answer, and an engine may raise on it rather than return
+    // NULL. `compute_fsl_f32` treats a null outer row and a null inner slot
+    // identically (both append NULL), so a pushdown has to as well.
+    cases.push(Case {
+        label: "null_row_lhs",
+        lhs: None,
+        rhs: dense([1.0, 0.0, 0.0, 0.0]),
+    });
+    cases.push(Case {
+        label: "null_row_rhs",
+        lhs: dense([1.0, 0.0, 0.0, 0.0]),
+        rhs: None,
+    });
+    cases.push(Case {
+        label: "null_row_both",
+        lhs: None,
+        rhs: None,
+    });
+    cases.push(Case {
+        label: "null_element_lhs",
+        lhs: Some([None, Some(0.0), Some(0.0), Some(0.0)]),
+        rhs: dense([1.0, 0.0, 0.0, 0.0]),
+    });
+    cases.push(Case {
+        label: "null_element_rhs",
+        lhs: dense([1.0, 0.0, 0.0, 0.0]),
+        rhs: Some([Some(1.0), Some(0.0), Some(0.0), None]),
+    });
+    cases
 }
 
 /// The Spice vector UDFs, each paired with the fact this test needs about it:
@@ -123,20 +225,45 @@ fn fsl_field() -> Arc<Field> {
     Arc::new(Field::new("item", DataType::Float32, true))
 }
 
-fn fsl_column(rows: &[[f32; DIM]]) -> ArrayRef {
-    let flat: Vec<f32> = rows.iter().flat_map(|r| r.iter().copied()).collect();
-    let values = Arc::new(Float32Array::from(flat));
+fn fsl_column(rows: &[Operand]) -> ArrayRef {
+    let mut values = Float32Builder::new();
+    let mut row_valid = Vec::with_capacity(rows.len());
+    for row in rows {
+        match row {
+            None => {
+                // A null row still occupies DIM child slots in a FixedSizeList.
+                for _ in 0..DIM {
+                    values.append_null();
+                }
+                row_valid.push(false);
+            }
+            Some(elements) => {
+                for element in elements {
+                    match element {
+                        Some(x) => values.append_value(*x),
+                        None => values.append_null(),
+                    }
+                }
+                row_valid.push(true);
+            }
+        }
+    }
     let len = i32::try_from(DIM).expect("DIM fits in i32");
     Arc::new(
-        FixedSizeListArray::try_new(fsl_field(), len, values, None)
-            .expect("equal-length rows form a FixedSizeListArray"),
+        FixedSizeListArray::try_new(
+            fsl_field(),
+            len,
+            Arc::new(values.finish()),
+            Some(NullBuffer::from(row_valid)),
+        )
+        .expect("equal-length rows form a FixedSizeListArray"),
     )
 }
 
-/// The local answer for every case, in battery order. `None` is a NULL row.
-async fn local_values(udf: &ScalarUDF, cases: &[Case]) -> Vec<Option<f64>> {
-    let lhs: Vec<[f32; DIM]> = cases.iter().map(|c| c.lhs).collect();
-    let rhs: Vec<[f32; DIM]> = cases.iter().map(|c| c.rhs).collect();
+/// The local answer for every case, in battery order.
+async fn local_outcomes(udf: &ScalarUDF, cases: &[Case]) -> Vec<Outcome> {
+    let lhs: Vec<Operand> = cases.iter().map(|c| c.lhs).collect();
+    let rhs: Vec<Operand> = cases.iter().map(|c| c.rhs).collect();
     let len = i32::try_from(DIM).expect("DIM fits in i32");
     let list_type = DataType::FixedSizeList(fsl_field(), len);
     let schema = Arc::new(Schema::new(vec![
@@ -155,43 +282,57 @@ async fn local_values(udf: &ScalarUDF, cases: &[Case]) -> Vec<Option<f64>> {
             Expr::Column(Column::new_unqualified("b")),
         ],
     ));
-    let batches = df
+    let collected = df
         .select(vec![call.alias("d")])
         .expect("projection builds")
         .collect()
-        .await
-        .unwrap_or_else(|e| panic!("local {} evaluation failed: {e}", udf.name()));
+        .await;
+    let batches = match collected {
+        Ok(batches) => batches,
+        // The local kernel raising is itself an answer worth comparing: it would
+        // mean neither side can evaluate the row.
+        Err(e) => return vec![Outcome::Error(e.to_string()); cases.len()],
+    };
 
     let mut out = Vec::with_capacity(cases.len());
     for batch in &batches {
         let column = batch.column(0).as_primitive::<Float64Type>();
         for row in 0..column.len() {
-            out.push((!column.is_null(row)).then(|| column.value(row)));
+            out.push(Outcome::Value(
+                (!column.is_null(row)).then(|| column.value(row)),
+            ));
         }
     }
     out
 }
 
-fn duckdb_literal(v: &[f32; DIM]) -> String {
-    let elements: Vec<String> = v
+fn duckdb_literal(operand: &Operand) -> String {
+    let Some(elements) = operand else {
+        return format!("NULL::FLOAT[{DIM}]");
+    };
+    let rendered: Vec<String> = elements
         .iter()
-        .map(|x| {
-            if x.is_nan() {
-                "'nan'::FLOAT".to_string()
-            } else if x.is_infinite() {
+        .map(|element| match element {
+            None => "NULL".to_string(),
+            Some(x) if x.is_nan() => "'nan'::FLOAT".to_string(),
+            Some(x) if x.is_infinite() => {
                 let sign = if *x < 0.0 { "-" } else { "" };
                 format!("'{sign}inf'::FLOAT")
-            } else {
-                format!("CAST({x:?} AS FLOAT)")
             }
+            Some(x) => format!("CAST({x:?} AS FLOAT)"),
         })
         .collect();
-    format!("[{}]::FLOAT[{DIM}]", elements.join(", "))
+    format!("[{}]::FLOAT[{DIM}]", rendered.join(", "))
 }
 
 /// The federated answer for every case: the SQL the dialect renders for this
 /// call, run against a `DuckDB` holding the same rows.
-fn duckdb_values(udf: &ScalarUDF, cases: &[Case]) -> Vec<Option<f64>> {
+///
+/// One statement per case, deliberately. `DuckDB` raising on a row aborts the
+/// whole statement, so a single query would attribute one bad row's failure to
+/// every case in the battery — and the point of the battery is to say *which*
+/// input class diverges.
+fn duckdb_outcomes(udf: &ScalarUDF, cases: &[Case]) -> Vec<Outcome> {
     let dialect = new_duckdb_dialect();
     let unparser = Unparser::new(dialect.as_ref());
     let call = Expr::ScalarFunction(ScalarFunction::new_udf(
@@ -207,35 +348,40 @@ fn duckdb_values(udf: &ScalarUDF, cases: &[Case]) -> Vec<Option<f64>> {
         .to_string();
 
     let conn = Connection::open_in_memory().expect("in-memory DuckDB opens");
-    conn.execute_batch(&format!(
-        "CREATE TABLE t (ord INTEGER, a FLOAT[{DIM}], b FLOAT[{DIM}]);"
-    ))
-    .expect("table creates");
-    for (ord, case) in cases.iter().enumerate() {
-        conn.execute_batch(&format!(
-            "INSERT INTO t VALUES ({ord}, {}, {});",
-            duckdb_literal(&case.lhs),
-            duckdb_literal(&case.rhs)
-        ))
-        .unwrap_or_else(|e| panic!("row {} ({}) inserts: {e}", ord, case.label));
-    }
-
-    let sql = format!("SELECT CAST({rendered} AS DOUBLE) FROM t ORDER BY ord");
-    let mut stmt = conn
-        .prepare(&sql)
-        .unwrap_or_else(|e| panic!("DuckDB rejected the rendered SQL `{sql}`: {e}"));
-    let mut rows = stmt.query([]).expect("rendered query runs");
-    let mut out = Vec::with_capacity(cases.len());
-    while let Some(row) = rows.next().expect("row reads") {
-        out.push(row.get::<_, Option<f64>>(0).expect("column reads"));
-    }
-    out
+    cases
+        .iter()
+        .map(|case| {
+            let sql = format!(
+                "SELECT CAST({rendered} AS DOUBLE) FROM (SELECT {} AS a, {} AS b) t",
+                duckdb_literal(&case.lhs),
+                duckdb_literal(&case.rhs)
+            );
+            match conn
+                .prepare(&sql)
+                .and_then(|mut stmt| stmt.query([])?.next()?.map_or(Ok(None), |r| r.get(0)))
+            {
+                Ok(v) => Outcome::Value(v),
+                Err(e) => Outcome::Error(e.to_string()),
+            }
+        })
+        .collect()
 }
 
-fn describe(v: Option<f64>) -> String {
-    match v {
-        None => "NULL".to_string(),
-        Some(x) => format!("{x}"),
+fn describe(outcome: &Outcome) -> String {
+    match outcome {
+        Outcome::Value(None) => "NULL".to_string(),
+        Outcome::Value(Some(x)) => format!("{x}"),
+        Outcome::Error(e) => format!("an error ({})", e.trim()),
+    }
+}
+
+fn agrees(local: &Outcome, remote: &Outcome) -> bool {
+    match (local, remote) {
+        (Outcome::Value(None), Outcome::Value(None)) => true,
+        (Outcome::Value(Some(l)), Outcome::Value(Some(r))) => {
+            (l - r).abs() <= 1e-6 * l.abs().max(1.0)
+        }
+        _ => false,
     }
 }
 
@@ -253,8 +399,8 @@ async fn duckdb_vector_udf_pushdown_matches_local() {
             continue;
         }
         measured += 1;
-        let local = local_values(&udf, &cases).await;
-        let remote = duckdb_values(&udf, &cases);
+        let local = local_outcomes(&udf, &cases).await;
+        let remote = duckdb_outcomes(&udf, &cases);
         assert_eq!(
             local.len(),
             cases.len(),
@@ -271,28 +417,33 @@ async fn duckdb_vector_udf_pushdown_matches_local() {
         );
 
         for (case, (l, r)) in cases.iter().zip(local.iter().zip(remote.iter())) {
-            let agrees = match (l, r) {
-                (None, None) => true,
-                (Some(l), Some(r)) => (l - r).abs() <= 1e-6 * l.abs().max(1.0),
-                _ => false,
-            };
             assert!(
-                agrees,
+                agrees(l, r),
                 "{name} answers differently depending on where the table lives: case \
                  '{}' is {} locally and {} pushed down to DuckDB. Either the rendering in \
                  runtime-datafusion::dialect::duckdb is not equivalent, or {name} does not \
                  belong in duckdb_scalar_overrides — see #13088.",
                 case.label,
-                describe(*l),
-                describe(*r)
+                describe(l),
+                describe(r)
             );
         }
     }
 
-    assert!(
-        measured > 0,
-        "no vector UDF federates to DuckDB, so this test measured nothing — if that is \
-         intended, delete it rather than leaving it passing vacuously"
+    // No Spice vector UDF federates to DuckDB today, so `measured` is 0 and the
+    // loop above compares nothing. That is deliberate, not dead weight: this is
+    // the gate that fires the moment one is added back. Re-adding either
+    // `cosine_distance` or `inner_product` to `duckdb_scalar_overrides` makes it
+    // fail, naming the input class that diverges — which is how the neuter matrix
+    // for #13088 proved it is armed. The two tests below carry the measured
+    // evidence for each denial, so this file does not rely on an idle loop alone.
+    assert_eq!(
+        measured,
+        native
+            .iter()
+            .filter(|n| vector_udfs().iter().any(|(name, _)| name == *n))
+            .count(),
+        "the loop must measure every vector UDF the dialect advertises"
     );
 }
 
@@ -313,6 +464,34 @@ fn unclassified_overrides_are_a_test_failure() {
              implementations; add it to `vector_udfs()` so its rendering is measured against \
              the local kernel, or to `NON_VECTOR_OVERRIDES` if it carries no Spice contract."
         );
+    }
+}
+
+/// `array_inner_product` raises on a NULL array element where the UDF answers
+/// NULL, which is why `inner_product` no longer federates either (#13088).
+///
+/// This is the finding that ruled out repairing the pushdown in the rendering: an
+/// expression wrapping the call cannot screen an exception raised while
+/// evaluating its own argument, so there is no `nullif` or `CASE` that recovers
+/// the UDF's answer here.
+#[test]
+fn duckdb_array_inner_product_rejects_a_null_element() {
+    let conn = Connection::open_in_memory().expect("in-memory DuckDB opens");
+    let sql = "SELECT array_inner_product([NULL, 1.0]::FLOAT[2], [1.0, 1.0]::FLOAT[2])";
+    let outcome = conn.prepare(sql).and_then(|mut stmt| {
+        stmt.query([])?
+            .next()?
+            .map_or(Ok(None), |r| r.get::<_, Option<f64>>(0))
+    });
+    match outcome {
+        Err(e) => assert!(
+            e.to_string().contains("can not contain NULL"),
+            "expected DuckDB to reject a NULL array element; got a different error: {e}"
+        ),
+        Ok(v) => panic!(
+            "DuckDB answered {v:?} for an array with a NULL element instead of raising. If it \
+             now returns NULL, revisit whether inner_product can federate again — see #13088."
+        ),
     }
 }
 

--- a/crates/accelerators/accelerator-duckdb/tests/duckdb_vector_udf_pushdown.rs
+++ b/crates/accelerators/accelerator-duckdb/tests/duckdb_vector_udf_pushdown.rs
@@ -14,6 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#![expect(
+    clippy::expect_used,
+    reason = "integration-test setup: a failure here is a broken test, not a runtime path"
+)]
+
 //! Does a vector UDF that `DuckDB` is allowed to evaluate answer the same as the
 //! local kernel?
 //!
@@ -68,7 +73,12 @@ enum Outcome {
     Error(String),
 }
 
-/// Shorthand for a fully-populated operand.
+/// Shorthand for a fully-populated operand: a present row whose every element is
+/// present.
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "the Some is the meaning — an Operand's outer layer is row presence"
+)]
 fn dense(v: [f32; DIM]) -> Operand {
     Some(v.map(Some))
 }
@@ -78,7 +88,7 @@ fn dense(v: [f32; DIM]) -> Operand {
 fn battery() -> Vec<Case> {
     let nan = f32::NAN;
     let inf = f32::INFINITY;
-    let mut cases = vec![
+    let cases = vec![
         Case {
             label: "identical",
             lhs: dense([1.0, 0.0, 0.0, 0.0]),
@@ -148,36 +158,36 @@ fn battery() -> Vec<Case> {
             lhs: dense([1.0, 2.0, 3.0, nan]),
             rhs: dense([1.0, 2.0, 3.0, 4.0]),
         },
+        // NULL is not a variant of "no defined distance" — it is a separate way
+        // for a row to have no answer, and an engine may raise on it rather than
+        // return NULL. `compute_fsl_f32` treats a null outer row and a null inner
+        // slot identically (both append NULL), so a pushdown has to as well.
+        Case {
+            label: "null_row_lhs",
+            lhs: None,
+            rhs: dense([1.0, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "null_row_rhs",
+            lhs: dense([1.0, 0.0, 0.0, 0.0]),
+            rhs: None,
+        },
+        Case {
+            label: "null_row_both",
+            lhs: None,
+            rhs: None,
+        },
+        Case {
+            label: "null_element_lhs",
+            lhs: Some([None, Some(0.0), Some(0.0), Some(0.0)]),
+            rhs: dense([1.0, 0.0, 0.0, 0.0]),
+        },
+        Case {
+            label: "null_element_rhs",
+            lhs: dense([1.0, 0.0, 0.0, 0.0]),
+            rhs: Some([Some(1.0), Some(0.0), Some(0.0), None]),
+        },
     ];
-    // NULL is not a variant of "no defined distance" — it is a separate way for a
-    // row to have no answer, and an engine may raise on it rather than return
-    // NULL. `compute_fsl_f32` treats a null outer row and a null inner slot
-    // identically (both append NULL), so a pushdown has to as well.
-    cases.push(Case {
-        label: "null_row_lhs",
-        lhs: None,
-        rhs: dense([1.0, 0.0, 0.0, 0.0]),
-    });
-    cases.push(Case {
-        label: "null_row_rhs",
-        lhs: dense([1.0, 0.0, 0.0, 0.0]),
-        rhs: None,
-    });
-    cases.push(Case {
-        label: "null_row_both",
-        lhs: None,
-        rhs: None,
-    });
-    cases.push(Case {
-        label: "null_element_lhs",
-        lhs: Some([None, Some(0.0), Some(0.0), Some(0.0)]),
-        rhs: dense([1.0, 0.0, 0.0, 0.0]),
-    });
-    cases.push(Case {
-        label: "null_element_rhs",
-        lhs: dense([1.0, 0.0, 0.0, 0.0]),
-        rhs: Some([Some(1.0), Some(0.0), Some(0.0), None]),
-    });
     cases
 }
 
@@ -391,14 +401,23 @@ fn agrees(local: &Outcome, remote: &Outcome) -> bool {
 async fn duckdb_vector_udf_pushdown_matches_local() {
     let native = duckdb_native_function_names();
     let cases = battery();
-    let mut measured = 0_usize;
+    // Only a UDF the dialect advertises has two implementations to compare; the
+    // rest are evaluated locally and have nothing to disagree with.
+    //
+    // No Spice vector UDF is advertised today, so this is empty and the loop
+    // below compares nothing. That is deliberate, not dead weight: it is the gate
+    // that fires the moment one is added back. Re-adding either `cosine_distance`
+    // or `inner_product` to `duckdb_scalar_overrides` makes this test fail,
+    // naming the input class that diverges — which is how the neuter matrix for
+    // #13088 showed it is armed rather than idle. The two tests below carry the
+    // measured evidence for each denial, so this file does not rest on the loop
+    // alone.
+    let federating: Vec<(&str, ScalarUDF)> = vector_udfs()
+        .into_iter()
+        .filter(|(name, _)| native.contains(name))
+        .collect();
 
-    for (name, udf) in vector_udfs() {
-        if !native.contains(&name) {
-            // Denied, so there is only one implementation and nothing to compare.
-            continue;
-        }
-        measured += 1;
+    for (name, udf) in federating {
         let local = local_outcomes(&udf, &cases).await;
         let remote = duckdb_outcomes(&udf, &cases);
         assert_eq!(
@@ -429,22 +448,6 @@ async fn duckdb_vector_udf_pushdown_matches_local() {
             );
         }
     }
-
-    // No Spice vector UDF federates to DuckDB today, so `measured` is 0 and the
-    // loop above compares nothing. That is deliberate, not dead weight: this is
-    // the gate that fires the moment one is added back. Re-adding either
-    // `cosine_distance` or `inner_product` to `duckdb_scalar_overrides` makes it
-    // fail, naming the input class that diverges — which is how the neuter matrix
-    // for #13088 proved it is armed. The two tests below carry the measured
-    // evidence for each denial, so this file does not rely on an idle loop alone.
-    assert_eq!(
-        measured,
-        native
-            .iter()
-            .filter(|n| vector_udfs().iter().any(|(name, _)| name == *n))
-            .count(),
-        "the loop must measure every vector UDF the dialect advertises"
-    );
 }
 
 /// A new entry in the dialect's override list has to be classified here before

--- a/crates/accelerators/accelerator-duckdb/tests/duckdb_vector_udf_pushdown.rs
+++ b/crates/accelerators/accelerator-duckdb/tests/duckdb_vector_udf_pushdown.rs
@@ -1,0 +1,342 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Does a vector UDF that `DuckDB` is allowed to evaluate answer the same as the
+//! local kernel?
+//!
+//! Carving a Spice UDF out of the `DuckDB` federation deny-list means one call
+//! has two implementations, chosen by where the table happens to live. Nothing
+//! else checks that they agree, and a disagreement is not an error — it is a
+//! different number for the same query. Issue #13088 was exactly that:
+//! `cosine_distance` was carved out because `DuckDB` has an
+//! `array_cosine_distance`, which returns `1 - cosine_similarity` over `[0, 2]`
+//! where the UDF returns `(1 - cosine_similarity) / 2` over `[0, 1]` — twice the
+//! distance for every non-identical pair, undetected because the two halves were
+//! only ever tested apart.
+//!
+//! So this drives both halves in one process: the local kernel over an Arrow
+//! batch, and the SQL the `DuckDB` dialect renders for the same call executed
+//! against a real `DuckDB` holding the same rows.
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, AsArray, FixedSizeListArray, Float32Array, RecordBatch};
+use arrow::datatypes::Float64Type;
+use arrow_schema::{DataType, Field, Schema};
+use datafusion::common::Column;
+use datafusion::logical_expr::{Expr, ScalarUDF, expr::ScalarFunction};
+use datafusion::prelude::SessionContext;
+use datafusion::sql::unparser::Unparser;
+use duckdb::Connection;
+use runtime_datafusion::dialect::{duckdb_native_function_names, new_duckdb_dialect};
+
+/// Vector width the battery below is written against.
+const DIM: usize = 4;
+
+/// One `(lhs, rhs)` pair and what makes it worth asking about.
+struct Case {
+    label: &'static str,
+    lhs: [f32; DIM],
+    rhs: [f32; DIM],
+}
+
+/// Every input class where two implementations of the same metric can disagree
+/// without either of them looking wrong on its own.
+fn battery() -> Vec<Case> {
+    let nan = f32::NAN;
+    let inf = f32::INFINITY;
+    vec![
+        Case { label: "identical", lhs: [1.0, 0.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
+        Case { label: "orthogonal", lhs: [1.0, 0.0, 0.0, 0.0], rhs: [0.0, 1.0, 0.0, 0.0] },
+        Case { label: "opposite", lhs: [1.0, 0.0, 0.0, 0.0], rhs: [-1.0, 0.0, 0.0, 0.0] },
+        Case { label: "oblique", lhs: [1.0, 1.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
+        Case { label: "all_nonzero", lhs: [0.25, -0.5, 0.75, 1.5], rhs: [-1.25, 0.5, 2.0, -0.75] },
+        // Undefined direction: a metric that normalizes has to invent an answer,
+        // and the two implementations need not invent the same one.
+        Case { label: "zero_lhs", lhs: [0.0, 0.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
+        Case { label: "zero_both", lhs: [0.0; DIM], rhs: [0.0; DIM] },
+        // No defined distance at all: the local contract is NULL, and a pushdown
+        // has to reproduce that rather than score the row.
+        Case { label: "nan_lhs", lhs: [nan, 0.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
+        Case { label: "nan_rhs", lhs: [1.0, 0.0, 0.0, 0.0], rhs: [nan, 0.0, 0.0, 0.0] },
+        Case { label: "nan_both", lhs: [nan, 0.0, 0.0, 0.0], rhs: [nan, 0.0, 0.0, 0.0] },
+        Case { label: "pos_inf_lhs", lhs: [inf, 0.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
+        Case { label: "neg_inf_lhs", lhs: [-inf, 0.0, 0.0, 0.0], rhs: [1.0, 0.0, 0.0, 0.0] },
+        Case { label: "nan_deep", lhs: [1.0, 2.0, 3.0, nan], rhs: [1.0, 2.0, 3.0, 4.0] },
+    ]
+}
+
+/// The Spice vector UDFs, each paired with the fact this test needs about it:
+/// whether it is currently allowed to federate to `DuckDB`.
+///
+/// `unclassified_overrides_are_a_test_failure` below makes this list exhaustive,
+/// so a vector UDF cannot be added to the dialect's override list without
+/// arriving here and being measured.
+fn vector_udfs() -> Vec<(&'static str, ScalarUDF)> {
+    vec![
+        (
+            runtime_datafusion_udfs::cosine_distance::COSINE_DISTANCE_UDF_NAME,
+            ScalarUDF::from(runtime_datafusion_udfs::cosine_distance::CosineDistance::new()),
+        ),
+        (
+            runtime_datafusion_udfs::inner_product::INNER_PRODUCT_UDF_NAME,
+            ScalarUDF::from(runtime_datafusion_udfs::inner_product::InnerProduct::new()),
+        ),
+        (
+            runtime_datafusion_udfs::l2_distance::L2_DISTANCE_UDF_NAME,
+            ScalarUDF::from(runtime_datafusion_udfs::l2_distance::L2Distance::new()),
+        ),
+        (
+            runtime_datafusion_udfs::l2_distance::L2_SQUARED_DISTANCE_UDF_NAME,
+            ScalarUDF::from(runtime_datafusion_udfs::l2_distance::L2SquaredDistance::new()),
+        ),
+    ]
+}
+
+/// Entries in the dialect's override list that are not Spice vector UDFs, and so
+/// are outside what this test can measure.
+const NON_VECTOR_OVERRIDES: &[&str] = &[
+    // `DataFusion`'s own built-in, not a Spice UDF — it carries no Spice contract
+    // for this test to compare against.
+    "array_distance",
+    "rand",
+    "regexp_like",
+    "regexp_match",
+    "regexp_replace",
+    "regexp_count",
+];
+
+fn fsl_field() -> Arc<Field> {
+    Arc::new(Field::new("item", DataType::Float32, true))
+}
+
+fn fsl_column(rows: &[[f32; DIM]]) -> ArrayRef {
+    let flat: Vec<f32> = rows.iter().flat_map(|r| r.iter().copied()).collect();
+    let values = Arc::new(Float32Array::from(flat));
+    let len = i32::try_from(DIM).expect("DIM fits in i32");
+    Arc::new(
+        FixedSizeListArray::try_new(fsl_field(), len, values, None)
+            .expect("equal-length rows form a FixedSizeListArray"),
+    )
+}
+
+/// The local answer for every case, in battery order. `None` is a NULL row.
+async fn local_values(udf: &ScalarUDF, cases: &[Case]) -> Vec<Option<f64>> {
+    let lhs: Vec<[f32; DIM]> = cases.iter().map(|c| c.lhs).collect();
+    let rhs: Vec<[f32; DIM]> = cases.iter().map(|c| c.rhs).collect();
+    let len = i32::try_from(DIM).expect("DIM fits in i32");
+    let list_type = DataType::FixedSizeList(fsl_field(), len);
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", list_type.clone(), true),
+        Field::new("b", list_type, true),
+    ]));
+    let batch = RecordBatch::try_new(schema, vec![fsl_column(&lhs), fsl_column(&rhs)])
+        .expect("columns match the schema");
+
+    let ctx = SessionContext::new();
+    let df = ctx.read_batch(batch).expect("batch is readable");
+    let call = Expr::ScalarFunction(ScalarFunction::new_udf(
+        Arc::new(udf.clone()),
+        vec![
+            Expr::Column(Column::new_unqualified("a")),
+            Expr::Column(Column::new_unqualified("b")),
+        ],
+    ));
+    let batches = df
+        .select(vec![call.alias("d")])
+        .expect("projection builds")
+        .collect()
+        .await
+        .unwrap_or_else(|e| panic!("local {} evaluation failed: {e}", udf.name()));
+
+    let mut out = Vec::with_capacity(cases.len());
+    for batch in &batches {
+        let column = batch.column(0).as_primitive::<Float64Type>();
+        for row in 0..column.len() {
+            out.push((!column.is_null(row)).then(|| column.value(row)));
+        }
+    }
+    out
+}
+
+fn duckdb_literal(v: &[f32; DIM]) -> String {
+    let elements: Vec<String> = v
+        .iter()
+        .map(|x| {
+            if x.is_nan() {
+                "'nan'::FLOAT".to_string()
+            } else if x.is_infinite() {
+                let sign = if *x < 0.0 { "-" } else { "" };
+                format!("'{sign}inf'::FLOAT")
+            } else {
+                format!("CAST({x:?} AS FLOAT)")
+            }
+        })
+        .collect();
+    format!("[{}]::FLOAT[{DIM}]", elements.join(", "))
+}
+
+/// The federated answer for every case: the SQL the dialect renders for this
+/// call, run against a `DuckDB` holding the same rows.
+fn duckdb_values(udf: &ScalarUDF, cases: &[Case]) -> Vec<Option<f64>> {
+    let dialect = new_duckdb_dialect();
+    let unparser = Unparser::new(dialect.as_ref());
+    let call = Expr::ScalarFunction(ScalarFunction::new_udf(
+        Arc::new(udf.clone()),
+        vec![
+            Expr::Column(Column::new_unqualified("a")),
+            Expr::Column(Column::new_unqualified("b")),
+        ],
+    ));
+    let rendered = unparser
+        .expr_to_sql(&call)
+        .unwrap_or_else(|e| panic!("{} has no DuckDB rendering: {e}", udf.name()))
+        .to_string();
+
+    let conn = Connection::open_in_memory().expect("in-memory DuckDB opens");
+    conn.execute_batch(&format!(
+        "CREATE TABLE t (ord INTEGER, a FLOAT[{DIM}], b FLOAT[{DIM}]);"
+    ))
+    .expect("table creates");
+    for (ord, case) in cases.iter().enumerate() {
+        conn.execute_batch(&format!(
+            "INSERT INTO t VALUES ({ord}, {}, {});",
+            duckdb_literal(&case.lhs),
+            duckdb_literal(&case.rhs)
+        ))
+        .unwrap_or_else(|e| panic!("row {} ({}) inserts: {e}", ord, case.label));
+    }
+
+    let sql = format!("SELECT CAST({rendered} AS DOUBLE) FROM t ORDER BY ord");
+    let mut stmt = conn
+        .prepare(&sql)
+        .unwrap_or_else(|e| panic!("DuckDB rejected the rendered SQL `{sql}`: {e}"));
+    let mut rows = stmt.query([]).expect("rendered query runs");
+    let mut out = Vec::with_capacity(cases.len());
+    while let Some(row) = rows.next().expect("row reads") {
+        out.push(row.get::<_, Option<f64>>(0).expect("column reads"));
+    }
+    out
+}
+
+fn describe(v: Option<f64>) -> String {
+    match v {
+        None => "NULL".to_string(),
+        Some(x) => format!("{x}"),
+    }
+}
+
+/// Every vector UDF the dialect lets `DuckDB` evaluate must answer exactly what
+/// the local kernel answers, on every input class in the battery.
+#[tokio::test(flavor = "multi_thread")]
+async fn duckdb_vector_udf_pushdown_matches_local() {
+    let native = duckdb_native_function_names();
+    let cases = battery();
+    let mut measured = 0_usize;
+
+    for (name, udf) in vector_udfs() {
+        if !native.contains(&name) {
+            // Denied, so there is only one implementation and nothing to compare.
+            continue;
+        }
+        measured += 1;
+        let local = local_values(&udf, &cases).await;
+        let remote = duckdb_values(&udf, &cases);
+        assert_eq!(
+            local.len(),
+            cases.len(),
+            "{name}: local produced {} values for {} cases",
+            local.len(),
+            cases.len()
+        );
+        assert_eq!(
+            remote.len(),
+            cases.len(),
+            "{name}: DuckDB produced {} values for {} cases",
+            remote.len(),
+            cases.len()
+        );
+
+        for (case, (l, r)) in cases.iter().zip(local.iter().zip(remote.iter())) {
+            let agrees = match (l, r) {
+                (None, None) => true,
+                (Some(l), Some(r)) => (l - r).abs() <= 1e-6 * l.abs().max(1.0),
+                _ => false,
+            };
+            assert!(
+                agrees,
+                "{name} answers differently depending on where the table lives: case \
+                 '{}' is {} locally and {} pushed down to DuckDB. Either the rendering in \
+                 runtime-datafusion::dialect::duckdb is not equivalent, or {name} does not \
+                 belong in duckdb_scalar_overrides — see #13088.",
+                case.label,
+                describe(*l),
+                describe(*r)
+            );
+        }
+    }
+
+    assert!(
+        measured > 0,
+        "no vector UDF federates to DuckDB, so this test measured nothing — if that is \
+         intended, delete it rather than leaving it passing vacuously"
+    );
+}
+
+/// A new entry in the dialect's override list has to be classified here before
+/// it can ship, so it cannot skip the equivalence measurement by omission.
+#[test]
+fn unclassified_overrides_are_a_test_failure() {
+    let known: Vec<&str> = vector_udfs()
+        .into_iter()
+        .map(|(name, _)| name)
+        .chain(NON_VECTOR_OVERRIDES.iter().copied())
+        .collect();
+    for name in duckdb_native_function_names() {
+        assert!(
+            known.contains(&name),
+            "`{name}` was added to duckdb_scalar_overrides but is classified nowhere in \
+             this test. Carving a function out of the DuckDB deny-list gives it two \
+             implementations; add it to `vector_udfs()` so its rendering is measured against \
+             the local kernel, or to `NON_VECTOR_OVERRIDES` if it carries no Spice contract."
+        );
+    }
+}
+
+/// The rendering `cosine_distance` used to get, kept as an executable record of
+/// why it no longer federates (#13088).
+#[test]
+fn duckdb_array_cosine_distance_is_not_this_udfs_metric() {
+    let conn = Connection::open_in_memory().expect("in-memory DuckDB opens");
+    // Orthogonal unit vectors: this UDF's contract is (1 - 0) / 2 = 0.5.
+    let sql = "SELECT CAST(array_cosine_distance([1.0, 0.0]::FLOAT[2], [0.0, 1.0]::FLOAT[2]) \
+               AS DOUBLE)";
+    let mut stmt = conn.prepare(sql).expect("prepare");
+    let mut rows = stmt.query([]).expect("query");
+    let duckdb_answer: f64 = rows
+        .next()
+        .expect("row")
+        .expect("one row")
+        .get(0)
+        .expect("column");
+    assert!(
+        (duckdb_answer - 1.0).abs() < 1e-6,
+        "DuckDB's array_cosine_distance is expected to answer 1.0 for orthogonal unit \
+         vectors (it returns 1 - cosine_similarity over [0, 2]); got {duckdb_answer}. If \
+         DuckDB has changed to the [0, 1] convention, revisit whether cosine_distance can \
+         federate again — see #13088."
+    );
+}

--- a/crates/data-connectors/connector-duckdb/src/lib.rs
+++ b/crates/data-connectors/connector-duckdb/src/lib.rs
@@ -78,20 +78,21 @@ impl DuckDB {
     /// `can_execute_plan` refuse such plans so `DataFusion` evaluates the affected
     /// expressions locally instead. We use [`deny_spice_functions_for_duckdb`]
     /// (rather than the generic deny-list) so functions `DuckDB` evaluates to the
-    /// same value — e.g. `inner_product`, which `DuckDB` unparses to
-    /// `array_inner_product` — still federate. See issue #10703.
+    /// same answer — e.g. `rand`, which `DuckDB` unparses to `random()` — still
+    /// federate. See issue #10703.
     ///
-    /// The carve-out is per-function and rests on value equivalence, not on
-    /// `DuckDB` having a function of a similar name: `cosine_distance` stays
-    /// denied because `array_cosine_distance` returns a differently-scaled
-    /// distance (see issue #13088).
+    /// The carve-out is per-function and rests on answering identically, not on
+    /// `DuckDB` having a function of a similar name. Both vector-distance UDFs
+    /// stay denied for that reason: `array_cosine_distance` returns a
+    /// differently-scaled distance, and `array_inner_product` raises on a NULL
+    /// array element where the UDF answers NULL (see issue #13088).
     fn with_spice_deny_list(factory: DuckDBTableFactory) -> DuckDBTableFactory {
         // The spiceai table-providers fork restores the `with_function_support`
         // deny-list seam on DuckDBTableFactory (see issue #10703). Install the
         // DuckDB-aware deny-list so Spice-only UDFs that DuckDB can't run — or
         // runs differently — are evaluated locally, while functions DuckDB's
-        // dialect can rewrite value-for-value (e.g. inner_product ->
-        // array_inner_product) still federate. The factory's seam takes the
+        // dialect can rewrite answer-for-answer (e.g. rand -> random()) still
+        // federate. The factory's seam takes the
         // table-providers FunctionSupport type, so we build the deny-list
         // directly in that type from the runtime's shared name list.
         factory.with_function_support(deny_spice_functions_for_duckdb_table_providers())

--- a/crates/data-connectors/connector-duckdb/src/lib.rs
+++ b/crates/data-connectors/connector-duckdb/src/lib.rs
@@ -77,17 +77,23 @@ impl DuckDB {
     /// function" error from `DuckDB`. Installing the deny-list makes `DuckDB`'s
     /// `can_execute_plan` refuse such plans so `DataFusion` evaluates the affected
     /// expressions locally instead. We use [`deny_spice_functions_for_duckdb`]
-    /// (rather than the generic deny-list) so functions `DuckDB` *does* support
-    /// natively — e.g. `cosine_distance`, which `DuckDB` unparses to
-    /// `array_cosine_distance` — still federate. See issue #10703.
+    /// (rather than the generic deny-list) so functions `DuckDB` evaluates to the
+    /// same value — e.g. `inner_product`, which `DuckDB` unparses to
+    /// `array_inner_product` — still federate. See issue #10703.
+    ///
+    /// The carve-out is per-function and rests on value equivalence, not on
+    /// `DuckDB` having a function of a similar name: `cosine_distance` stays
+    /// denied because `array_cosine_distance` returns a differently-scaled
+    /// distance (see issue #13088).
     fn with_spice_deny_list(factory: DuckDBTableFactory) -> DuckDBTableFactory {
         // The spiceai table-providers fork restores the `with_function_support`
         // deny-list seam on DuckDBTableFactory (see issue #10703). Install the
-        // DuckDB-aware deny-list so Spice-only UDFs that DuckDB can't run are
-        // evaluated locally, while functions DuckDB's dialect can rewrite (e.g.
-        // cosine_distance -> array_cosine_distance) still federate. The factory's
-        // seam takes the table-providers FunctionSupport type, so we build the
-        // deny-list directly in that type from the runtime's shared name list.
+        // DuckDB-aware deny-list so Spice-only UDFs that DuckDB can't run — or
+        // runs differently — are evaluated locally, while functions DuckDB's
+        // dialect can rewrite value-for-value (e.g. inner_product ->
+        // array_inner_product) still federate. The factory's seam takes the
+        // table-providers FunctionSupport type, so we build the deny-list
+        // directly in that type from the runtime's shared name list.
         factory.with_function_support(deny_spice_functions_for_duckdb_table_providers())
     }
 

--- a/crates/data-connectors/connector-ducklake/Cargo.toml
+++ b/crates/data-connectors/connector-ducklake/Cargo.toml
@@ -26,6 +26,10 @@ default = []
 
 [dev-dependencies]
 runtime = { path = "../../runtime" }
+# Test-only: `ducklake_denies_spice_udf_pushdown` needs a real Spice UDF to build
+# the filter whose pushdown must be refused.
+runtime-datafusion-udfs = { path = "../../runtime-datafusion-udfs" }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/data-connectors/connector-ducklake/src/lib.rs
+++ b/crates/data-connectors/connector-ducklake/src/lib.rs
@@ -448,6 +448,7 @@ data_connector_api::register_data_connector!(
 mod tests {
     use std::sync::Arc;
 
+    use datafusion::logical_expr::expr::ScalarFunction;
     use datafusion::logical_expr::{Expr, ScalarUDF, TableProviderFilterPushDown};
     use datafusion::prelude::{col, lit};
     use datafusion::sql::TableReference;
@@ -479,6 +480,11 @@ mod tests {
     ///
     /// It drives `configure_ducklake_factory`, the function production calls, so
     /// dropping `with_function_support` there fails here.
+    ///
+    /// `cosine_distance` is the probe only because it is denied today. If it ever
+    /// federates again (spiceai/spiceai#13506), this test needs a UDF that does
+    /// not — it asserts that the deny-list is *installed*, not which functions it
+    /// happens to contain.
     #[tokio::test]
     async fn ducklake_denies_spice_udf_pushdown() {
         let pool = Arc::new(DuckDbConnectionPool::new_memory().expect("in-memory DuckDB pool"));
@@ -499,13 +505,12 @@ mod tests {
             .await
             .expect("table provider builds for the created table");
 
-        let distance =
-            Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
-                Arc::new(ScalarUDF::from(
-                    runtime_datafusion_udfs::cosine_distance::CosineDistance::new(),
-                )),
-                vec![col("embedding"), col("embedding")],
-            ));
+        let distance = Expr::ScalarFunction(ScalarFunction::new_udf(
+            Arc::new(ScalarUDF::from(
+                runtime_datafusion_udfs::cosine_distance::CosineDistance::new(),
+            )),
+            vec![col("embedding"), col("embedding")],
+        ));
         let filter = distance.lt(lit(0.3));
 
         let pushdown = provider

--- a/crates/data-connectors/connector-ducklake/src/lib.rs
+++ b/crates/data-connectors/connector-ducklake/src/lib.rs
@@ -38,6 +38,7 @@ use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConne
 use duckdb::AccessMode;
 use runtime_component::dataset::DatasetSpec;
 use runtime_datafusion::dialect::new_duckdb_dialect;
+use runtime_datafusion::function_support::deny_spice_functions_for_duckdb_table_providers;
 use runtime_parameters::ParameterSpec;
 use snafu::prelude::*;
 use std::any::Any;
@@ -258,8 +259,29 @@ fn create_ducklake_factory(
             source: Box::new(e),
         })?;
 
-    let factory = DuckDBTableFactory::new(Arc::clone(&pool)).with_dialect(new_duckdb_dialect());
+    let factory = configure_ducklake_factory(Arc::clone(&pool));
     Ok((factory, pool, catalog_name.to_string()))
+}
+
+/// Builds the `DuckDB` table factory `DuckLake` reads through.
+///
+/// The deny-list is what makes `DataFusion` evaluate a Spice UDF locally instead
+/// of pushing it into `DuckLake`'s SQL. Without it the factory's
+/// `function_support` is `None`; the pushdown check is
+/// `is_some_and(..)`, so it is skipped entirely and every filter falls through to
+/// whatever the unparser can render. The unparser can render *any* function call,
+/// so a Spice function the dialect does not rewrite is emitted under its own name
+/// — which `DuckDB` does not have, and the query fails with an unknown function.
+/// `DuckDB`'s own factory has installed this since #10703; this path was missed,
+/// which began to matter as soon as a vector UDF stopped being rewritten (#13088).
+///
+/// A named function rather than a chain inline above, so
+/// `ducklake_denies_spice_udf_pushdown` can assert the policy on the value
+/// production actually builds.
+fn configure_ducklake_factory(pool: Arc<DuckDbConnectionPool>) -> DuckDBTableFactory {
+    DuckDBTableFactory::new(pool)
+        .with_dialect(new_duckdb_dialect())
+        .with_function_support(deny_spice_functions_for_duckdb_table_providers())
 }
 
 impl DataConnectorFactory for DuckLakeFactory {
@@ -424,7 +446,13 @@ data_connector_api::register_data_connector!(
 
 #[cfg(test)]
 mod tests {
-    use super::PARAMETERS;
+    use std::sync::Arc;
+
+    use datafusion::logical_expr::{Expr, ScalarUDF, TableProviderFilterPushDown};
+    use datafusion::prelude::{col, lit};
+    use datafusion::sql::TableReference;
+
+    use super::{DuckDbConnection, DuckDbConnectionPool, PARAMETERS, configure_ducklake_factory};
 
     /// The S3 secret built for `DuckDB` only carries `SESSION_TOKEN` when the parameter is
     /// declared here — otherwise `Parameters::try_new` strips it and temporary (STS)
@@ -436,6 +464,58 @@ mod tests {
                 .iter()
                 .any(|parameter| parameter.name == "aws_session_token"),
             "missing DuckLake data connector parameter aws_session_token"
+        );
+    }
+
+    /// A Spice UDF must not be pushed into `DuckLake`'s SQL.
+    ///
+    /// Regression test for #13088. `DuckLake` builds its own
+    /// `DuckDBTableFactory`, and it was the one that never had the deny-list
+    /// installed. That went unnoticed while the dialect rewrote `cosine_distance`
+    /// into a function `DuckDB` really has — wrong-valued, but it ran. The moment
+    /// the rewrite was removed, the same filter federated under its own name and
+    /// `DuckDB` failed the query with an unknown function, so this asserts the
+    /// policy rather than the rewrite.
+    ///
+    /// It drives `configure_ducklake_factory`, the function production calls, so
+    /// dropping `with_function_support` there fails here.
+    #[tokio::test]
+    async fn ducklake_denies_spice_udf_pushdown() {
+        let pool = Arc::new(DuckDbConnectionPool::new_memory().expect("in-memory DuckDB pool"));
+        {
+            let mut conn = Arc::clone(&pool).connect_sync().expect("sync connection");
+            let duckdb = conn
+                .as_any_mut()
+                .downcast_mut::<DuckDbConnection>()
+                .expect("a DuckDB connection");
+            duckdb
+                .get_underlying_conn_mut()
+                .execute_batch("CREATE TABLE vectors (id INTEGER, embedding FLOAT[2]);")
+                .expect("table creates");
+        }
+
+        let provider = configure_ducklake_factory(Arc::clone(&pool))
+            .table_provider(TableReference::bare("vectors"))
+            .await
+            .expect("table provider builds for the created table");
+
+        let distance =
+            Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
+                Arc::new(ScalarUDF::from(
+                    runtime_datafusion_udfs::cosine_distance::CosineDistance::new(),
+                )),
+                vec![col("embedding"), col("embedding")],
+            ));
+        let filter = distance.lt(lit(0.3));
+
+        let pushdown = provider
+            .supports_filters_pushdown(&[&filter])
+            .expect("pushdown is classifiable");
+        assert_eq!(
+            pushdown,
+            vec![TableProviderFilterPushDown::Unsupported],
+            "a cosine_distance filter must stay in DataFusion; pushing it into DuckLake's SQL \
+             emits a function DuckDB does not have and fails the query (#13088)"
         );
     }
 }

--- a/crates/runtime-datafusion-udfs/src/cosine_distance.rs
+++ b/crates/runtime-datafusion-udfs/src/cosine_distance.rs
@@ -34,10 +34,13 @@ limitations under the License.
 //! `1 - distance`, so any fabricated distance for a failed embedding competes
 //! with real matches, and NULL is what keeps it out of the results.
 //!
-//! The NULL applies to these kernels only. `cosine_distance` is allowed to
-//! federate, where it unparses to the engine's own function (`DuckDB`'s
-//! `array_cosine_distance`) and that engine decides what a non-finite input
-//! scores — see #13088.
+//! These kernels are the only implementation: `cosine_distance` is denied from
+//! federation on every backend, so the value above is what a query gets wherever
+//! the table lives. `DuckDB` was the exception until #13088 — its
+//! `array_cosine_distance` returns `1 - cosine_similarity` over `[0, 2]`, twice
+//! the distance above, and answers `2.0` both for a zero-magnitude vector (0.5
+//! here) and for a non-finite element (NULL here). A backend earns a pushdown by
+//! matching this contract, not by having a function of the same name.
 
 use arrow::array::{
     Array, ArrayRef, Float64Array, Float64Builder, GenericListArray, LargeListArray, ListArray,

--- a/crates/runtime-datafusion-udfs/src/cosine_distance.rs
+++ b/crates/runtime-datafusion-udfs/src/cosine_distance.rs
@@ -40,7 +40,10 @@ limitations under the License.
 //! `array_cosine_distance` returns `1 - cosine_similarity` over `[0, 2]`, twice
 //! the distance above, and answers `2.0` both for a zero-magnitude vector (0.5
 //! here) and for a non-finite element (NULL here). A backend earns a pushdown by
-//! matching this contract, not by having a function of the same name.
+//! matching this contract, not by having a function of the same name — and
+//! matching it is harder than it looks: `inner_product`'s `DuckDB` counterpart
+//! agrees on every dense finite vector and was still withdrawn, because it raises
+//! on a NULL array element.
 
 use arrow::array::{
     Array, ArrayRef, Float64Array, Float64Builder, GenericListArray, LargeListArray, ListArray,

--- a/crates/runtime-datafusion-udfs/src/vector_simd.rs
+++ b/crates/runtime-datafusion-udfs/src/vector_simd.rs
@@ -85,10 +85,11 @@ impl Kernel {
     /// This split governs whether an engine's counterpart could be *repaired* in
     /// the emitted SQL: a propagating function's non-finite result is visible in
     /// its output, where a normalizing one hands back a finite number no screen
-    /// can identify. It was not enough to make either of `DuckDB`'s pushable,
-    /// though — `array_inner_product` propagates as `Dot` does, and still raises
-    /// on a NULL array element, which no wrapping expression can screen (#13088). The shared non-finite test drives all three
-    /// kernels, so if this is ever wrong for `Dot`/`L2Squared` — a simsimd
+    /// can identify. It was not enough to make either of `DuckDB`'s vector
+    /// functions pushable, though — `array_inner_product` propagates as `Dot`
+    /// does, and still raises on a NULL array element, which no wrapping
+    /// expression can screen (#13088). The shared non-finite test drives all
+    /// three kernels, so if this is ever wrong for `Dot`/`L2Squared` — a simsimd
     /// change, a different SIMD dispatch — that test fails rather than the
     /// missing guard going unnoticed.
     fn hides_non_finite_input(self) -> bool {

--- a/crates/runtime-datafusion-udfs/src/vector_simd.rs
+++ b/crates/runtime-datafusion-udfs/src/vector_simd.rs
@@ -80,7 +80,13 @@ impl Kernel {
     /// `Cosine` normalizes, and `simsimd` answers **0** — distance 0, an exact
     /// match — for a row carrying `NaN`. Nothing about the output distinguishes
     /// that from two genuinely parallel vectors, so this kernel is the one that
-    /// has to screen its input. The shared non-finite test drives all three
+    /// has to screen its input.
+    ///
+    /// The same split decides which of these can be pushed down to an engine and
+    /// repaired there: a propagating function's non-finite result is visible in
+    /// its output and a `nullif` over the emitted SQL reaches it, while a
+    /// normalizing one hands back a finite number that no screen over the result
+    /// can identify (#13088). The shared non-finite test drives all three
     /// kernels, so if this is ever wrong for `Dot`/`L2Squared` — a simsimd
     /// change, a different SIMD dispatch — that test fails rather than the
     /// missing guard going unnoticed.

--- a/crates/runtime-datafusion-udfs/src/vector_simd.rs
+++ b/crates/runtime-datafusion-udfs/src/vector_simd.rs
@@ -82,11 +82,12 @@ impl Kernel {
     /// that from two genuinely parallel vectors, so this kernel is the one that
     /// has to screen its input.
     ///
-    /// The same split decides which of these can be pushed down to an engine and
-    /// repaired there: a propagating function's non-finite result is visible in
-    /// its output and a `nullif` over the emitted SQL reaches it, while a
-    /// normalizing one hands back a finite number that no screen over the result
-    /// can identify (#13088). The shared non-finite test drives all three
+    /// This split governs whether an engine's counterpart could be *repaired* in
+    /// the emitted SQL: a propagating function's non-finite result is visible in
+    /// its output, where a normalizing one hands back a finite number no screen
+    /// can identify. It was not enough to make either of `DuckDB`'s pushable,
+    /// though — `array_inner_product` propagates as `Dot` does, and still raises
+    /// on a NULL array element, which no wrapping expression can screen (#13088). The shared non-finite test drives all three
     /// kernels, so if this is ever wrong for `Dot`/`L2Squared` — a simsimd
     /// change, a different SIMD dispatch — that test fails rather than the
     /// missing guard going unnoticed.

--- a/crates/runtime-datafusion/src/dialect/duckdb.rs
+++ b/crates/runtime-datafusion/src/dialect/duckdb.rs
@@ -30,7 +30,7 @@ pub(crate) const REGEXP_COUNT_NAME: &str = "regexp_extract_all";
 
 /// Shared conversion for Spice vector UDFs that have a native `DuckDB` ARRAY
 /// equivalent taking two equal-length `FLOAT[N]` operands (e.g.
-/// `array_cosine_distance`, `array_inner_product`).
+/// `array_inner_product`, `array_distance`).
 ///
 ///  - replaces the `make_array` constructor with a `DuckDB` array literal
 ///    (`make_array` is not supported in `DuckDB`)
@@ -116,24 +116,79 @@ fn spice_array_fn_to_sql(
     Ok(Some(ast_fn))
 }
 
-/// Converts the `cosine_distance` UDF into `DuckDB`'s `array_cosine_distance`:
-/// `https://duckdb.org/docs/sql/functions/array.html#array_cosine_distancearray1-array2`
-pub(crate) fn cosine_distance_to_sql(
-    unparser: &datafusion::sql::unparser::Unparser,
-    args: &[Expr],
-) -> Result<Option<datafusion::sql::sqlparser::ast::Expr>, DataFusionError> {
-    spice_array_fn_to_sql(unparser, args, "array_cosine_distance")
+/// Wraps `expr` so a non-finite result becomes `NULL`, the way the Spice vector
+/// kernels do.
+///
+/// The kernels return `NULL` when a distance is not defined rather than a
+/// fabricated number, because `_score` is `1 - distance` and any number at all
+/// competes with real matches (see `runtime_datafusion_udfs::vector_simd`). A
+/// pushed-down call has to carry that contract too, or the same row scores
+/// differently depending only on whether the table federated.
+///
+/// `nullif` rather than `CASE WHEN isfinite(..)`: `DuckDB` compares `NaN` equal
+/// to `NaN` and each infinity equal to itself, so the chain below reaches every
+/// non-finite value while naming `expr` once. `CASE` would have to repeat the
+/// whole call — operands included — in both arms.
+///
+/// Measured against `DuckDB` v1.5.5: the chain returns `NULL` for `NaN`, `inf`
+/// and `-inf`, passes finite values through unchanged, and leaves the result's
+/// `FLOAT` type alone (a `DOUBLE` sentinel would widen it).
+///
+/// This screens the *result*, so it only reaches an engine function that lets a
+/// non-finite input reach its output. `array_inner_product` accumulates its
+/// operands directly and does propagate — the same reason
+/// `Kernel::hides_non_finite_input` is `false` for `Dot`. A function that
+/// normalizes, and so answers a finite number for a non-finite input, cannot be
+/// repaired this way and does not belong in the pushdown list at all.
+fn null_if_not_finite(expr: ast::Expr) -> ast::Expr {
+    ["nan", "inf", "-inf"]
+        .into_iter()
+        .fold(expr, |acc, sentinel| {
+            ast::Expr::Function(Function {
+                name: ObjectName(vec![ast::ObjectNamePart::Identifier(Ident::new("nullif"))]),
+                args: ast::FunctionArguments::List(ast::FunctionArgumentList {
+                    duplicate_treatment: None,
+                    args: vec![
+                        ast::FunctionArg::Unnamed(FunctionArgExpr::Expr(acc)),
+                        ast::FunctionArg::Unnamed(FunctionArgExpr::Expr(ast::Expr::Cast {
+                            expr: Box::new(ast::Expr::Value(ValueWithSpan {
+                                value: ast::Value::SingleQuotedString(sentinel.to_string()),
+                                span: sqlparser::tokenizer::Span::empty(),
+                            })),
+                            data_type: ast::DataType::Float(ast::ExactNumberInfo::None),
+                            kind: ast::CastKind::DoubleColon,
+                            array: false,
+                            format: None,
+                        })),
+                    ],
+                    clauses: vec![],
+                }),
+                filter: None,
+                null_treatment: None,
+                over: None,
+                within_group: vec![],
+                parameters: ast::FunctionArguments::None,
+                uses_odbc_syntax: false,
+            })
+        })
 }
 
 /// Converts the `inner_product` UDF into `DuckDB`'s `array_inner_product` (dot
-/// product, `sum(a[i] * b[i])`): both compute the same value, so federating the
-/// call to `DuckDB` (>= 1.5.3) is exact.
+/// product, `sum(a[i] * b[i])`), screened so a non-finite result is `NULL`.
+///
+/// The two compute the same value for finite operands, which is what makes the
+/// pushdown sound. They disagreed on a non-finite one — the UDF answers `NULL`,
+/// `DuckDB` propagated the `NaN` or infinity — so [`null_if_not_finite`] closes
+/// that. Numeric precision is a separate axis and unchanged: `DuckDB`
+/// accumulates in `FLOAT` where `simsimd` accumulates wider, so a dot product
+/// that overflows `FLOAT` alone now federates to `NULL` rather than to `inf`,
+/// which is the same direction the local output check takes.
 /// `https://duckdb.org/docs/sql/functions/array.html#array_inner_productarray1-array2`
 pub(crate) fn inner_product_to_sql(
     unparser: &datafusion::sql::unparser::Unparser,
     args: &[Expr],
 ) -> Result<Option<datafusion::sql::sqlparser::ast::Expr>, DataFusionError> {
-    spice_array_fn_to_sql(unparser, args, "array_inner_product")
+    Ok(spice_array_fn_to_sql(unparser, args, "array_inner_product")?.map(null_if_not_finite))
 }
 
 /// Converts `array_distance(query, embed_col)` to `DuckDB` `array_distance` with explicit
@@ -447,62 +502,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cosine_distance_to_sql_scalars() {
-        let dialect = new_duckdb_dialect();
-        let unparser = Unparser::new(dialect.as_ref());
-        let args = vec![
-            // raw values
-            Expr::ScalarFunction(ScalarFunction::new_udf(
-                make_array_udf(),
-                vec![lit(1.0), lit(2.0), lit(3.0)],
-            )),
-            // values wrapped as literals
-            Expr::ScalarFunction(ScalarFunction::new_udf(
-                make_array_udf(),
-                vec![
-                    Expr::Literal(ScalarValue::Float32(Some(4.0)), None),
-                    Expr::Literal(ScalarValue::Float32(Some(5.0)), None),
-                    Expr::Literal(ScalarValue::Float32(Some(6.0)), None),
-                ],
-            )),
-        ];
-        let result = cosine_distance_to_sql(&unparser, &args)
-            .expect("should execute successfully")
-            .expect("should return expression");
-
-        let expected =
-            "array_cosine_distance([1.0, 2.0, 3.0]::FLOAT[3], [4.0, 5.0, 6.0]::FLOAT[3])";
-
-        assert_eq!(result.to_string(), expected);
-    }
-
-    #[test]
-    fn test_cosine_distance_to_sql_column_and_scalar() {
-        let dialect = new_duckdb_dialect();
-        let unparser = Unparser::new(dialect.as_ref());
-        let args = vec![
-            Expr::Column(Column {
-                relation: Some(TableReference::from("table_name")),
-                name: "column_name".to_string(),
-                spans: Spans::new(),
-            }),
-            Expr::ScalarFunction(ScalarFunction::new_udf(
-                make_array_udf(),
-                vec![
-                    Expr::Literal(ScalarValue::Float32(Some(4.0)), None),
-                    Expr::Literal(ScalarValue::Float32(Some(5.0)), None),
-                    Expr::Literal(ScalarValue::Float32(Some(6.0)), None),
-                ],
-            )),
-        ];
-
-        let result = cosine_distance_to_sql(&unparser, &args)
-            .expect("should execute successfully")
-            .expect("should return expression");
-        let expected =
-            r#"array_cosine_distance("table_name"."column_name", [4.0, 5.0, 6.0]::FLOAT[3])"#;
-
-        assert_eq!(result.to_string(), expected);
+    fn cosine_distance_is_not_pushed_down_to_duckdb() {
+        // Regression test for #13088. `array_cosine_distance` is NOT the DuckDB
+        // equivalent of this UDF: measured against DuckDB v1.5.5 it answers
+        // `1 - cosine_similarity` over [0, 2] where the UDF answers
+        // `(1 - cosine_similarity) / 2` over [0, 1] — twice the distance for
+        // every non-identical pair — plus 2.0 where the UDF answers 0.5 (a
+        // zero-magnitude vector) and NULL (a non-finite element). While it was
+        // carved out of the deny-list, the same query returned one number
+        // locally and a different one federated.
+        assert!(
+            !crate::dialect::duckdb_native_function_names()
+                .contains(&runtime_datafusion_udfs::cosine_distance::COSINE_DISTANCE_UDF_NAME),
+            "cosine_distance must stay denied so DataFusion evaluates it locally; \
+             array_cosine_distance returns a differently-scaled distance"
+        );
     }
 
     #[test]
@@ -530,9 +544,70 @@ mod tests {
         let result = inner_product_to_sql(&unparser, &args)
             .expect("should execute successfully")
             .expect("should return expression");
-        let expected =
-            r#"array_inner_product("table_name"."embedding", [4.0, 5.0, 6.0]::FLOAT[3])"#;
+        // The nullif chain is the NULL-for-non-finite contract the local kernel
+        // holds, carried into the pushed-down SQL (#13088). The operands appear
+        // once: `CASE WHEN isfinite(..)` would have to repeat the whole call.
+        let expected = r#"nullif(nullif(nullif(array_inner_product("table_name"."embedding", [4.0, 5.0, 6.0]::FLOAT[3]), 'nan'::FLOAT), 'inf'::FLOAT), '-inf'::FLOAT)"#;
         assert_eq!(result.to_string(), expected);
+    }
+
+    #[test]
+    fn inner_product_screen_names_its_operands_once() {
+        // The screen must not duplicate the operands: a repeated column is
+        // harmless, but a repeated *literal* embedding doubles the size of every
+        // pushed-down vector filter, and a repeated volatile sub-expression would
+        // be evaluated twice.
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        let args = vec![
+            Expr::Column(Column {
+                relation: Some(TableReference::from("t")),
+                name: "embedding".to_string(),
+                spans: Spans::new(),
+            }),
+            Expr::ScalarFunction(ScalarFunction::new_udf(
+                make_array_udf(),
+                vec![lit(4.0), lit(5.0), lit(6.0)],
+            )),
+        ];
+        let rendered = inner_product_to_sql(&unparser, &args)
+            .expect("should execute successfully")
+            .expect("should return expression")
+            .to_string();
+        assert_eq!(
+            rendered.matches("array_inner_product").count(),
+            1,
+            "the screened rendering must call array_inner_product once, got {rendered}"
+        );
+    }
+
+    #[test]
+    fn inner_product_screen_covers_every_non_finite_value() {
+        // Each of the three non-finite values needs its own sentinel: DuckDB
+        // compares NaN equal to NaN and each infinity equal to itself, but an
+        // infinity is not equal to a NaN, so one nullif cannot reach all three.
+        let dialect = new_duckdb_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        let args = vec![
+            Expr::ScalarFunction(ScalarFunction::new_udf(
+                make_array_udf(),
+                vec![lit(1.0), lit(2.0)],
+            )),
+            Expr::ScalarFunction(ScalarFunction::new_udf(
+                make_array_udf(),
+                vec![lit(3.0), lit(4.0)],
+            )),
+        ];
+        let rendered = inner_product_to_sql(&unparser, &args)
+            .expect("should execute successfully")
+            .expect("should return expression")
+            .to_string();
+        for sentinel in ["'nan'::FLOAT", "'inf'::FLOAT", "'-inf'::FLOAT"] {
+            assert!(
+                rendered.contains(sentinel),
+                "screened rendering must nullif against {sentinel}, got {rendered}"
+            );
+        }
     }
 
     #[test]
@@ -590,13 +665,13 @@ mod tests {
 
     #[test]
     fn duckdb_native_function_names_advertises_denylisted_pushables() {
-        // The federation deny-list relies on these names to let `cosine_distance`
+        // The federation deny-list relies on these names to let `inner_product`
         // and `rand` push down to DuckDB, so the dialect must advertise them.
+        // `cosine_distance` used to be asserted here too; it is now asserted
+        // *absent* by `cosine_distance_is_not_pushed_down_to_duckdb`, because
+        // DuckDB's `array_cosine_distance` answers a differently-scaled distance
+        // (#13088).
         let names = crate::dialect::duckdb_native_function_names();
-        assert!(
-            names.contains(&runtime_datafusion_udfs::cosine_distance::COSINE_DISTANCE_UDF_NAME),
-            "duckdb_native_function_names() missing cosine_distance; got {names:?}"
-        );
         assert!(
             names.contains(&runtime_datafusion_udfs::inner_product::INNER_PRODUCT_UDF_NAME),
             "duckdb_native_function_names() missing inner_product; got {names:?}"

--- a/crates/runtime-datafusion/src/dialect/duckdb.rs
+++ b/crates/runtime-datafusion/src/dialect/duckdb.rs
@@ -28,169 +28,6 @@ pub(crate) const REGEXP_MATCH_NAME: &str = "regexp_extract";
 pub(crate) const REGEXP_REPLACE_NAME: &str = "regexp_replace";
 pub(crate) const REGEXP_COUNT_NAME: &str = "regexp_extract_all";
 
-/// Shared conversion for Spice vector UDFs that have a native `DuckDB` ARRAY
-/// equivalent taking two equal-length `FLOAT[N]` operands (e.g.
-/// `array_inner_product`, `array_distance`).
-///
-///  - replaces the `make_array` constructor with a `DuckDB` array literal
-///    (`make_array` is not supported in `DuckDB`)
-///  - applies the required `::FLOAT[N]` cast to array operands (only FLOAT
-///    embeddings are currently supported)
-///  - emits a call to `duckdb_fn`
-fn spice_array_fn_to_sql(
-    unparser: &datafusion::sql::unparser::Unparser,
-    args: &[Expr],
-    duckdb_fn: &str,
-) -> Result<Option<datafusion::sql::sqlparser::ast::Expr>, DataFusionError> {
-    let ast_args: Vec<ast::Expr> = args
-        .iter()
-        .map(|arg| match arg {
-            // embeddings array is wrapped in a make_array function, unwrap it
-            Expr::ScalarFunction(scalar_func)
-                if scalar_func.name().to_lowercase() == "make_array" =>
-            {
-                let num_elements = scalar_func.args.len() as u64;
-
-                let array = ast::Expr::Array(ast::Array {
-                    elem: scalar_func
-                        .args
-                        .iter()
-                        .map(|x| unparser.expr_to_sql(x))
-                        .try_collect()?,
-                    named: false,
-                });
-
-                // Apply required ::FLOAT[] casting. Only FLOAT embeddings are currently supported
-                Ok(ast::Expr::Cast {
-                    expr: Box::new(array),
-                    data_type: ast::DataType::Array(ast::ArrayElemTypeDef::SquareBracket(
-                        Box::new(ast::DataType::Float(ast::ExactNumberInfo::None)),
-                        Some(num_elements),
-                    )),
-                    kind: ast::CastKind::DoubleColon,
-                    array: false,
-                    format: None,
-                })
-            }
-            Expr::Literal(ScalarValue::FixedSizeList(array), None) => {
-                let num_elements = u64::try_from(array.value_length()).map_err(|e| {
-                    DataFusionError::Execution(format!("Cannot cast array length to u64 {e}"))
-                })?;
-                let array = unparser.expr_to_sql(arg)?;
-
-                // Apply required ::FLOAT[] casting. Only FLOAT embeddings are curently supported
-                Ok(ast::Expr::Cast {
-                    expr: Box::new(array),
-                    data_type: ast::DataType::Array(ast::ArrayElemTypeDef::SquareBracket(
-                        Box::new(ast::DataType::Float(ast::ExactNumberInfo::None)),
-                        Some(num_elements),
-                    )),
-                    kind: ast::CastKind::DoubleColon,
-                    array: false,
-                    format: None,
-                })
-            }
-            // For all other expressions, directly convert them to SQL
-            _ => unparser.expr_to_sql(arg),
-        })
-        .try_collect()?;
-
-    let ast_fn = ast::Expr::Function(Function {
-        name: ObjectName(vec![ast::ObjectNamePart::Identifier(Ident::new(duckdb_fn))]),
-        args: ast::FunctionArguments::List(ast::FunctionArgumentList {
-            duplicate_treatment: None,
-            args: ast_args
-                .into_iter()
-                .map(|x| ast::FunctionArg::Unnamed(FunctionArgExpr::Expr(x)))
-                .collect(),
-            clauses: vec![],
-        }),
-        filter: None,
-        null_treatment: None,
-        over: None,
-        within_group: vec![],
-        parameters: ast::FunctionArguments::None,
-        uses_odbc_syntax: false,
-    });
-
-    Ok(Some(ast_fn))
-}
-
-/// Wraps `expr` so a non-finite result becomes `NULL`, the way the Spice vector
-/// kernels do.
-///
-/// The kernels return `NULL` when a distance is not defined rather than a
-/// fabricated number, because `_score` is `1 - distance` and any number at all
-/// competes with real matches (see `runtime_datafusion_udfs::vector_simd`). A
-/// pushed-down call has to carry that contract too, or the same row scores
-/// differently depending only on whether the table federated.
-///
-/// `nullif` rather than `CASE WHEN isfinite(..)`: `DuckDB` compares `NaN` equal
-/// to `NaN` and each infinity equal to itself, so the chain below reaches every
-/// non-finite value while naming `expr` once. `CASE` would have to repeat the
-/// whole call — operands included — in both arms.
-///
-/// Measured against `DuckDB` v1.5.5: the chain returns `NULL` for `NaN`, `inf`
-/// and `-inf`, passes finite values through unchanged, and leaves the result's
-/// `FLOAT` type alone (a `DOUBLE` sentinel would widen it).
-///
-/// This screens the *result*, so it only reaches an engine function that lets a
-/// non-finite input reach its output. `array_inner_product` accumulates its
-/// operands directly and does propagate — the same reason
-/// `Kernel::hides_non_finite_input` is `false` for `Dot`. A function that
-/// normalizes, and so answers a finite number for a non-finite input, cannot be
-/// repaired this way and does not belong in the pushdown list at all.
-fn null_if_not_finite(expr: ast::Expr) -> ast::Expr {
-    ["nan", "inf", "-inf"]
-        .into_iter()
-        .fold(expr, |acc, sentinel| {
-            ast::Expr::Function(Function {
-                name: ObjectName(vec![ast::ObjectNamePart::Identifier(Ident::new("nullif"))]),
-                args: ast::FunctionArguments::List(ast::FunctionArgumentList {
-                    duplicate_treatment: None,
-                    args: vec![
-                        ast::FunctionArg::Unnamed(FunctionArgExpr::Expr(acc)),
-                        ast::FunctionArg::Unnamed(FunctionArgExpr::Expr(ast::Expr::Cast {
-                            expr: Box::new(ast::Expr::Value(ValueWithSpan {
-                                value: ast::Value::SingleQuotedString(sentinel.to_string()),
-                                span: sqlparser::tokenizer::Span::empty(),
-                            })),
-                            data_type: ast::DataType::Float(ast::ExactNumberInfo::None),
-                            kind: ast::CastKind::DoubleColon,
-                            array: false,
-                            format: None,
-                        })),
-                    ],
-                    clauses: vec![],
-                }),
-                filter: None,
-                null_treatment: None,
-                over: None,
-                within_group: vec![],
-                parameters: ast::FunctionArguments::None,
-                uses_odbc_syntax: false,
-            })
-        })
-}
-
-/// Converts the `inner_product` UDF into `DuckDB`'s `array_inner_product` (dot
-/// product, `sum(a[i] * b[i])`), screened so a non-finite result is `NULL`.
-///
-/// The two compute the same value for finite operands, which is what makes the
-/// pushdown sound. They disagreed on a non-finite one — the UDF answers `NULL`,
-/// `DuckDB` propagated the `NaN` or infinity — so [`null_if_not_finite`] closes
-/// that. Numeric precision is a separate axis and unchanged: `DuckDB`
-/// accumulates in `FLOAT` where `simsimd` accumulates wider, so a dot product
-/// that overflows `FLOAT` alone now federates to `NULL` rather than to `inf`,
-/// which is the same direction the local output check takes.
-/// `https://duckdb.org/docs/sql/functions/array.html#array_inner_productarray1-array2`
-pub(crate) fn inner_product_to_sql(
-    unparser: &datafusion::sql::unparser::Unparser,
-    args: &[Expr],
-) -> Result<Option<datafusion::sql::sqlparser::ast::Expr>, DataFusionError> {
-    Ok(spice_array_fn_to_sql(unparser, args, "array_inner_product")?.map(null_if_not_finite))
-}
-
 /// Converts `array_distance(query, embed_col)` to `DuckDB` `array_distance` with explicit
 /// `::FLOAT[N]` casts on both arguments.
 ///
@@ -481,9 +318,7 @@ mod tests {
     use arrow_schema::{DataType, Field};
     use datafusion::{
         common::{Column, Spans},
-        functions_nested::make_array::make_array_udf,
-        logical_expr::expr::ScalarFunction,
-        prelude::{Expr, lit},
+        prelude::Expr,
         scalar::ScalarValue,
         sql::{TableReference, unparser::Unparser},
     };
@@ -520,94 +355,19 @@ mod tests {
     }
 
     #[test]
-    fn test_inner_product_to_sql_column_and_scalar() {
-        // inner_product(column, [4,5,6]) must unparse to DuckDB's native
-        // array_inner_product with the ::FLOAT[N] casts the array functions need.
-        let dialect = new_duckdb_dialect();
-        let unparser = Unparser::new(dialect.as_ref());
-        let args = vec![
-            Expr::Column(Column {
-                relation: Some(TableReference::from("table_name")),
-                name: "embedding".to_string(),
-                spans: Spans::new(),
-            }),
-            Expr::ScalarFunction(ScalarFunction::new_udf(
-                make_array_udf(),
-                vec![
-                    Expr::Literal(ScalarValue::Float32(Some(4.0)), None),
-                    Expr::Literal(ScalarValue::Float32(Some(5.0)), None),
-                    Expr::Literal(ScalarValue::Float32(Some(6.0)), None),
-                ],
-            )),
-        ];
-
-        let result = inner_product_to_sql(&unparser, &args)
-            .expect("should execute successfully")
-            .expect("should return expression");
-        // The nullif chain is the NULL-for-non-finite contract the local kernel
-        // holds, carried into the pushed-down SQL (#13088). The operands appear
-        // once: `CASE WHEN isfinite(..)` would have to repeat the whole call.
-        let expected = r#"nullif(nullif(nullif(array_inner_product("table_name"."embedding", [4.0, 5.0, 6.0]::FLOAT[3]), 'nan'::FLOAT), 'inf'::FLOAT), '-inf'::FLOAT)"#;
-        assert_eq!(result.to_string(), expected);
-    }
-
-    #[test]
-    fn inner_product_screen_names_its_operands_once() {
-        // The screen must not duplicate the operands: a repeated column is
-        // harmless, but a repeated *literal* embedding doubles the size of every
-        // pushed-down vector filter, and a repeated volatile sub-expression would
-        // be evaluated twice.
-        let dialect = new_duckdb_dialect();
-        let unparser = Unparser::new(dialect.as_ref());
-        let args = vec![
-            Expr::Column(Column {
-                relation: Some(TableReference::from("t")),
-                name: "embedding".to_string(),
-                spans: Spans::new(),
-            }),
-            Expr::ScalarFunction(ScalarFunction::new_udf(
-                make_array_udf(),
-                vec![lit(4.0), lit(5.0), lit(6.0)],
-            )),
-        ];
-        let rendered = inner_product_to_sql(&unparser, &args)
-            .expect("should execute successfully")
-            .expect("should return expression")
-            .to_string();
-        assert_eq!(
-            rendered.matches("array_inner_product").count(),
-            1,
-            "the screened rendering must call array_inner_product once, got {rendered}"
+    fn inner_product_is_not_pushed_down_to_duckdb() {
+        // Regression test for #13088. `array_inner_product` agrees with this UDF
+        // on dense finite vectors, which is why it was carved out — but a NULL
+        // element in either operand makes DuckDB *raise* where the UDF answers
+        // NULL, so the pushdown turned a NULL row into a failed query. An
+        // exception cannot be screened by an expression wrapping the call, which
+        // is what rules out repairing this in the rendering.
+        assert!(
+            !crate::dialect::duckdb_native_function_names()
+                .contains(&runtime_datafusion_udfs::inner_product::INNER_PRODUCT_UDF_NAME),
+            "inner_product must stay denied so DataFusion evaluates it locally; \
+             array_inner_product rejects a NULL array element"
         );
-    }
-
-    #[test]
-    fn inner_product_screen_covers_every_non_finite_value() {
-        // Each of the three non-finite values needs its own sentinel: DuckDB
-        // compares NaN equal to NaN and each infinity equal to itself, but an
-        // infinity is not equal to a NaN, so one nullif cannot reach all three.
-        let dialect = new_duckdb_dialect();
-        let unparser = Unparser::new(dialect.as_ref());
-        let args = vec![
-            Expr::ScalarFunction(ScalarFunction::new_udf(
-                make_array_udf(),
-                vec![lit(1.0), lit(2.0)],
-            )),
-            Expr::ScalarFunction(ScalarFunction::new_udf(
-                make_array_udf(),
-                vec![lit(3.0), lit(4.0)],
-            )),
-        ];
-        let rendered = inner_product_to_sql(&unparser, &args)
-            .expect("should execute successfully")
-            .expect("should return expression")
-            .to_string();
-        for sentinel in ["'nan'::FLOAT", "'inf'::FLOAT", "'-inf'::FLOAT"] {
-            assert!(
-                rendered.contains(sentinel),
-                "screened rendering must nullif against {sentinel}, got {rendered}"
-            );
-        }
     }
 
     #[test]
@@ -665,17 +425,12 @@ mod tests {
 
     #[test]
     fn duckdb_native_function_names_advertises_denylisted_pushables() {
-        // The federation deny-list relies on these names to let `inner_product`
-        // and `rand` push down to DuckDB, so the dialect must advertise them.
-        // `cosine_distance` used to be asserted here too; it is now asserted
-        // *absent* by `cosine_distance_is_not_pushed_down_to_duckdb`, because
-        // DuckDB's `array_cosine_distance` answers a differently-scaled distance
-        // (#13088).
+        // The federation deny-list relies on this name to let `rand` push down to
+        // DuckDB, so the dialect must advertise it. `cosine_distance` and
+        // `inner_product` used to be asserted here too; both are now asserted
+        // *absent* by the two tests above, because neither DuckDB counterpart
+        // answers what the UDF answers (#13088).
         let names = crate::dialect::duckdb_native_function_names();
-        assert!(
-            names.contains(&runtime_datafusion_udfs::inner_product::INNER_PRODUCT_UDF_NAME),
-            "duckdb_native_function_names() missing inner_product; got {names:?}"
-        );
         assert!(
             names.contains(&"rand"),
             "duckdb_native_function_names() missing rand; got {names:?}"

--- a/crates/runtime-datafusion/src/dialect/mod.rs
+++ b/crates/runtime-datafusion/src/dialect/mod.rs
@@ -18,8 +18,6 @@ use std::sync::Arc;
 
 use datafusion::sql::unparser::dialect::{Dialect, DuckDBDialect, ScalarFnToSqlHandler};
 
-use runtime_datafusion_udfs::inner_product::INNER_PRODUCT_UDF_NAME;
-
 mod duckdb;
 
 const REGEXP_LIKE_FLAGS_POSITION: usize = 2; // The position of the flags argument in regexp_like function calls
@@ -52,18 +50,26 @@ const REGEXP_COUNT_NAME: &str = "regexp_count";
 /// `DuckDB` for every vector UDF listed here.
 fn duckdb_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
     vec![
-        // `cosine_distance` is deliberately absent. `DuckDB`'s
-        // `array_cosine_distance` returns `1 - cosine_similarity` over `[0, 2]`,
-        // while this UDF returns `(1 - cosine_similarity) / 2` over `[0, 1]`, so
-        // the rewrite reported twice the distance for every non-identical pair.
-        // It also answers `2.0` where the UDF answers `0.5` for a zero-magnitude
-        // vector and `NULL` for a non-finite element — and `2.0` is
-        // simultaneously the legitimate value for opposite vectors, so no screen
-        // over the result can tell the three apart. See issue #13088.
-        (
-            INNER_PRODUCT_UDF_NAME,
-            Box::new(duckdb::inner_product_to_sql) as ScalarFnToSqlHandler,
-        ),
+        // No Spice vector UDF is listed here, and both absences are measured
+        // rather than assumed (see issue #13088 and
+        // `duckdb_vector_udf_pushdown_matches_local`):
+        //
+        // `cosine_distance` — `DuckDB`'s `array_cosine_distance` returns
+        // `1 - cosine_similarity` over `[0, 2]` where the UDF returns
+        // `(1 - cosine_similarity) / 2` over `[0, 1]`, so the rewrite reported
+        // twice the distance for every non-identical pair. It also answers `2.0`
+        // where the UDF answers `0.5` (a zero-magnitude vector) and `NULL` (a
+        // non-finite element) — and `2.0` is simultaneously the legitimate value
+        // for opposite vectors, so no screen over the result can separate them.
+        //
+        // `inner_product` — `array_inner_product` agrees on dense finite vectors,
+        // and a `nullif` chain over its result can even reproduce the
+        // NULL-for-non-finite contract. But a NULL *element* inside either
+        // operand makes it raise `Invalid Input Error: array_inner_product: left
+        // argument can not contain NULL values`, where the UDF answers NULL
+        // (`compute_fsl_f32` treats a null child slot as a null row). An
+        // exception cannot be screened by an expression wrapping the call, so the
+        // pushdown turned a NULL row into a failed query.
         (
             "array_distance",
             Box::new(duckdb::array_distance_to_sql) as ScalarFnToSqlHandler,

--- a/crates/runtime-datafusion/src/dialect/mod.rs
+++ b/crates/runtime-datafusion/src/dialect/mod.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use datafusion::sql::unparser::dialect::{Dialect, DuckDBDialect, ScalarFnToSqlHandler};
 
-use runtime_datafusion_udfs::cosine_distance::COSINE_DISTANCE_UDF_NAME;
 use runtime_datafusion_udfs::inner_product::INNER_PRODUCT_UDF_NAME;
 
 mod duckdb;
@@ -41,12 +40,26 @@ const REGEXP_COUNT_NAME: &str = "regexp_count";
 /// federation deny-list consults to decide what can be pushed down). Keeping
 /// them derived from one list guarantees the dialect's translation capability
 /// and the deny-list carve-out can never drift apart.
+///
+/// **An entry here asserts value equivalence, not just that a similarly-named
+/// `DuckDB` function exists.** Adding one makes the same call answer from two
+/// implementations depending only on where the table lives, so the two have to
+/// agree on every input — including the ones no formula mentions: a zero-
+/// magnitude vector, and an element that is `NaN` or an infinity. A function
+/// whose `DuckDB` counterpart disagrees anywhere belongs out of this list, where
+/// `DataFusion` evaluates it locally. `duckdb_vector_udf_pushdown_matches_local`
+/// in `accelerators/accelerator-duckdb` measures that agreement against a real
+/// `DuckDB` for every vector UDF listed here.
 fn duckdb_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
     vec![
-        (
-            COSINE_DISTANCE_UDF_NAME,
-            Box::new(duckdb::cosine_distance_to_sql) as ScalarFnToSqlHandler,
-        ),
+        // `cosine_distance` is deliberately absent. `DuckDB`'s
+        // `array_cosine_distance` returns `1 - cosine_similarity` over `[0, 2]`,
+        // while this UDF returns `(1 - cosine_similarity) / 2` over `[0, 1]`, so
+        // the rewrite reported twice the distance for every non-identical pair.
+        // It also answers `2.0` where the UDF answers `0.5` for a zero-magnitude
+        // vector and `NULL` for a non-finite element — and `2.0` is
+        // simultaneously the legitimate value for opposite vectors, so no screen
+        // over the result can tell the three apart. See issue #13088.
         (
             INNER_PRODUCT_UDF_NAME,
             Box::new(duckdb::inner_product_to_sql) as ScalarFnToSqlHandler,
@@ -101,11 +114,16 @@ fn duckdb_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
 /// Names of the functions [`new_duckdb_dialect`] rewrites to native `DuckDB`
 /// SQL.
 ///
-/// Any Spice-specific function in this list has a real `DuckDB` equivalent and
-/// can therefore be federated (pushed down) to `DuckDB` rather than denied. The
-/// federation deny-list derives its `DuckDB` carve-out from this list (see
+/// Any Spice-specific function in this list has a `DuckDB` equivalent that
+/// returns the same value for the same input, and can therefore be federated
+/// (pushed down) to `DuckDB` rather than denied. The federation deny-list
+/// derives its `DuckDB` carve-out from this list (see
 /// [`crate::function_support::deny_spice_functions_for_duckdb`]), so the dialect
 /// and the deny-list stay in sync automatically.
+///
+/// "Equivalent" is the load-bearing word: a name `DuckDB` also happens to have
+/// is not enough, because a mismatch here is not an error but a different
+/// answer. See [`duckdb_scalar_overrides`] for what the entry asserts.
 #[must_use]
 pub fn duckdb_native_function_names() -> Vec<&'static str> {
     duckdb_scalar_overrides()

--- a/crates/runtime-datafusion/src/function_support.rs
+++ b/crates/runtime-datafusion/src/function_support.rs
@@ -30,9 +30,9 @@ use runtime_udfs_api::{
 };
 
 /// The [`FunctionSupport`] for `DuckDB` connectors and accelerators: allows
-/// every function the `DuckDB` dialect can rewrite into native SQL that returns
-/// the same value (e.g. `inner_product` → `array_inner_product`, `rand` →
-/// `random()`), derived from the dialect so it tracks it automatically.
+/// every function the `DuckDB` dialect can rewrite into native SQL that answers
+/// identically (e.g. `rand` → `random()`), derived from the dialect so it tracks
+/// it automatically.
 #[must_use]
 pub fn deny_spice_functions_for_duckdb() -> Arc<FunctionSupport> {
     deny_spice_specific_functions_excluding(&crate::dialect::duckdb_native_function_names())

--- a/crates/runtime-datafusion/src/function_support.rs
+++ b/crates/runtime-datafusion/src/function_support.rs
@@ -30,9 +30,9 @@ use runtime_udfs_api::{
 };
 
 /// The [`FunctionSupport`] for `DuckDB` connectors and accelerators: allows
-/// every function the `DuckDB` dialect can rewrite into native SQL (e.g.
-/// `cosine_distance` → `array_cosine_distance`, `rand` → `random()`), derived
-/// from the dialect so it tracks it automatically.
+/// every function the `DuckDB` dialect can rewrite into native SQL that returns
+/// the same value (e.g. `inner_product` → `array_inner_product`, `rand` →
+/// `random()`), derived from the dialect so it tracks it automatically.
 #[must_use]
 pub fn deny_spice_functions_for_duckdb() -> Arc<FunctionSupport> {
     deny_spice_specific_functions_excluding(&crate::dialect::duckdb_native_function_names())

--- a/crates/runtime-udfs-api/src/lib.rs
+++ b/crates/runtime-udfs-api/src/lib.rs
@@ -23,8 +23,12 @@ limitations under the License.
 //! 1. **Spice functions** — the UDFs Spice defines (`bucket`, `cosine_distance`,
 //!    `rerank`, …) plus any the user registers. No remote source knows them, so
 //!    they are denied by default; a backend whose unparser dialect rewrites one
-//!    into a real remote function (`cosine_distance` → `array_cosine_distance`)
-//!    carves it back out by declaring it [`FunctionSupportBuilder::native`].
+//!    into a remote function that returns the *same value* (`inner_product` →
+//!    `array_inner_product`) carves it back out by declaring it
+//!    [`FunctionSupportBuilder::native`]. A same-looking remote function is not
+//!    sufficient: the carve-out makes one call answer from two implementations,
+//!    so a disagreement between them is not an error but a different result for
+//!    the same query (spiceai/spiceai#13088).
 //! 2. **`DataFusion` built-ins a specific backend cannot evaluate** — e.g. the
 //!    nested array/list/map functions relative to `PostgreSQL`. These are
 //!    allowed by default; only the backend knows which subset it lacks, so it

--- a/crates/runtime-udfs-api/src/lib.rs
+++ b/crates/runtime-udfs-api/src/lib.rs
@@ -23,12 +23,14 @@ limitations under the License.
 //! 1. **Spice functions** — the UDFs Spice defines (`bucket`, `cosine_distance`,
 //!    `rerank`, …) plus any the user registers. No remote source knows them, so
 //!    they are denied by default; a backend whose unparser dialect rewrites one
-//!    into a remote function that returns the *same value* (`inner_product` →
-//!    `array_inner_product`) carves it back out by declaring it
-//!    [`FunctionSupportBuilder::native`]. A same-looking remote function is not
-//!    sufficient: the carve-out makes one call answer from two implementations,
-//!    so a disagreement between them is not an error but a different result for
-//!    the same query (spiceai/spiceai#13088).
+//!    into a remote function that answers identically (`rand` → `random()`)
+//!    carves it back out by declaring it [`FunctionSupportBuilder::native`]. A
+//!    same-looking remote function is not sufficient: the carve-out makes one
+//!    call answer from two implementations, so a disagreement between them is not
+//!    an error but a different result for the same query. Both of `DuckDB`'s
+//!    vector-distance functions looked like carve-out candidates and neither
+//!    was — one rescaled the distance, the other raised on a NULL element
+//!    (spiceai/spiceai#13088).
 //! 2. **`DataFusion` built-ins a specific backend cannot evaluate** — e.g. the
 //!    nested array/list/map functions relative to `PostgreSQL`. These are
 //!    allowed by default; only the backend knows which subset it lacks, so it

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -1061,12 +1061,10 @@ mod tests {
         // `rand` is allowed purely by virtue of being in the dialect — no manual
         // carve-out.
         let support = deny_spice_functions_for_duckdb();
-        for name in ["rand"] {
-            assert!(
-                support.supports(&make_named_expr(name)),
-                "{name} has a native DuckDB equivalent and should be pushed down"
-            );
-        }
+        assert!(
+            support.supports(&make_named_expr("rand")),
+            "rand has a native DuckDB equivalent and should be pushed down"
+        );
         // No *equivalent* DuckDB function — must stay denied. The two vector UDFs
         // are here rather than above even though DuckDB has similarly-named
         // functions, because neither answers what the UDF answers (#13088):

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -1056,25 +1056,31 @@ mod tests {
 
     #[test]
     fn duckdb_deny_list_allows_dialect_native_functions() {
-        // The DuckDB unparser dialect rewrites these into native DuckDB SQL
-        // (inner_product -> array_inner_product, rand -> random()), so they must
-        // federate rather than be denied. Note `rand` is allowed purely by virtue
-        // of being in the dialect — no manual carve-out.
+        // The DuckDB unparser dialect rewrites this into native DuckDB SQL
+        // (rand -> random()), so it must federate rather than be denied. Note
+        // `rand` is allowed purely by virtue of being in the dialect — no manual
+        // carve-out.
         let support = deny_spice_functions_for_duckdb();
-        for name in [INNER_PRODUCT_UDF_NAME, "rand"] {
+        for name in ["rand"] {
             assert!(
                 support.supports(&make_named_expr(name)),
                 "{name} has a native DuckDB equivalent and should be pushed down"
             );
         }
-        // No *equivalent* DuckDB function — must stay denied. `cosine_distance`
-        // is here rather than above because DuckDB does have a similarly-named
-        // `array_cosine_distance` and it returns a differently-scaled distance:
-        // `1 - cosine_similarity` over [0, 2] against this UDF's
-        // `(1 - cosine_similarity) / 2` over [0, 1] (#13088). A name is not an
-        // equivalence.
+        // No *equivalent* DuckDB function — must stay denied. The two vector UDFs
+        // are here rather than above even though DuckDB has similarly-named
+        // functions, because neither answers what the UDF answers (#13088):
+        // `array_cosine_distance` returns `1 - cosine_similarity` over [0, 2]
+        // against this UDF's `(1 - cosine_similarity) / 2` over [0, 1], and
+        // `array_inner_product` raises on a NULL array element where the UDF
+        // answers NULL. A name is not an equivalence.
         let json_name = json_get_str_udf().name().to_string();
-        for name in [EMBED_UDF_NAME, COSINE_DISTANCE_UDF_NAME, json_name.as_str()] {
+        for name in [
+            EMBED_UDF_NAME,
+            COSINE_DISTANCE_UDF_NAME,
+            INNER_PRODUCT_UDF_NAME,
+            json_name.as_str(),
+        ] {
             assert!(
                 !support.supports(&make_named_expr(name)),
                 "{name} has no equivalent DuckDB function and must stay denied"
@@ -1139,11 +1145,10 @@ mod tests {
         // can/can't partition explicit: if a dialect change makes another Spice
         // function pushable (or stops one), this test must be updated on purpose.
         //
-        // `inner_product` -> array_inner_product, `rand` -> random(). (Note: l2
-        // distance federates via the non-deny-listed `array_distance` UDF, so it
-        // isn't part of this deny-list carve-out.) `cosine_distance` is
-        // deliberately not in this set — see #13088 and
-        // `duckdb_deny_list_allows_dialect_native_functions` above.
+        // Only `rand` -> random() remains. (Note: l2 distance federates via the
+        // non-deny-listed `array_distance` UDF, so it isn't part of this
+        // deny-list carve-out.) Both vector UDFs are deliberately absent — see
+        // #13088 and `duckdb_deny_list_allows_dialect_native_functions` above.
         use std::collections::BTreeSet;
         let support = deny_spice_functions_for_duckdb();
         let denied_names = builtin_denied_names();
@@ -1154,7 +1159,7 @@ mod tests {
             .collect();
         assert_eq!(
             pushable,
-            BTreeSet::from([INNER_PRODUCT_UDF_NAME, "rand"]),
+            BTreeSet::from(["rand"]),
             "unexpected change to the set of Spice functions pushable to DuckDB"
         );
     }

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -1057,23 +1057,27 @@ mod tests {
     #[test]
     fn duckdb_deny_list_allows_dialect_native_functions() {
         // The DuckDB unparser dialect rewrites these into native DuckDB SQL
-        // (cosine_distance -> array_cosine_distance, inner_product ->
-        // array_inner_product, rand -> random()), so they must federate rather
-        // than be denied. Note `rand` is allowed purely by virtue of being in the
-        // dialect — no manual carve-out.
+        // (inner_product -> array_inner_product, rand -> random()), so they must
+        // federate rather than be denied. Note `rand` is allowed purely by virtue
+        // of being in the dialect — no manual carve-out.
         let support = deny_spice_functions_for_duckdb();
-        for name in [COSINE_DISTANCE_UDF_NAME, INNER_PRODUCT_UDF_NAME, "rand"] {
+        for name in [INNER_PRODUCT_UDF_NAME, "rand"] {
             assert!(
                 support.supports(&make_named_expr(name)),
                 "{name} has a native DuckDB equivalent and should be pushed down"
             );
         }
-        // No native DuckDB equivalent — must stay denied.
+        // No *equivalent* DuckDB function — must stay denied. `cosine_distance`
+        // is here rather than above because DuckDB does have a similarly-named
+        // `array_cosine_distance` and it returns a differently-scaled distance:
+        // `1 - cosine_similarity` over [0, 2] against this UDF's
+        // `(1 - cosine_similarity) / 2` over [0, 1] (#13088). A name is not an
+        // equivalence.
         let json_name = json_get_str_udf().name().to_string();
-        for name in [EMBED_UDF_NAME, json_name.as_str()] {
+        for name in [EMBED_UDF_NAME, COSINE_DISTANCE_UDF_NAME, json_name.as_str()] {
             assert!(
                 !support.supports(&make_named_expr(name)),
-                "{name} has no native DuckDB equivalent and must stay denied"
+                "{name} has no equivalent DuckDB function and must stay denied"
             );
         }
     }
@@ -1135,10 +1139,11 @@ mod tests {
         // can/can't partition explicit: if a dialect change makes another Spice
         // function pushable (or stops one), this test must be updated on purpose.
         //
-        // `cosine_distance` -> array_cosine_distance, `inner_product` ->
-        // array_inner_product, `rand` -> random(). (Note: l2 distance federates
-        // via the non-deny-listed `array_distance` UDF, so it isn't part of this
-        // deny-list carve-out.)
+        // `inner_product` -> array_inner_product, `rand` -> random(). (Note: l2
+        // distance federates via the non-deny-listed `array_distance` UDF, so it
+        // isn't part of this deny-list carve-out.) `cosine_distance` is
+        // deliberately not in this set — see #13088 and
+        // `duckdb_deny_list_allows_dialect_native_functions` above.
         use std::collections::BTreeSet;
         let support = deny_spice_functions_for_duckdb();
         let denied_names = builtin_denied_names();
@@ -1149,7 +1154,7 @@ mod tests {
             .collect();
         assert_eq!(
             pushable,
-            BTreeSet::from([COSINE_DISTANCE_UDF_NAME, INNER_PRODUCT_UDF_NAME, "rand"]),
+            BTreeSet::from([INNER_PRODUCT_UDF_NAME, "rand"]),
             "unexpected change to the set of Spice functions pushable to DuckDB"
         );
     }


### PR DESCRIPTION
## Summary

`cosine_distance` and `inner_product` were carved out of the `DuckDB` federation deny-list on the strength of `DuckDB` having an `array_cosine_distance` and an `array_inner_product`. Measured against the pinned `DuckDB` v1.5.5, neither counterpart answers what the UDF answers, so the same call returned different results depending only on where the table lived.

**`cosine_distance` — wrong on every non-identical row, silently.**

| case | Spice local | pushed to `DuckDB` |
|---|---|---|
| identical | 0.0 | 0.0 |
| orthogonal | 0.5 | 1.0 |
| opposite | 1.0 | 2.0 |
| 45° | 0.1464 | 0.2929 |
| zero-magnitude vector | 0.5 | 2.0 |
| `NaN` / `±inf` element | **NULL** | 2.0 |

`array_cosine_distance` returns `1 - cosine_similarity` over `[0, 2]`; the UDF returns `(1 - cosine_similarity) / 2` over `[0, 1]`. Nothing compensated for the scale anywhere on the path. So a `DuckDB`-accelerated table reported twice the distance, and a threshold predicate such as `WHERE cosine_distance(..) < 0.3` selected a **different row set** than the same query against a non-federated table — no error, no warning.

Halving would not have been enough. `DuckDB` answers `2.0` for a zero-magnitude vector where the UDF answers `0.5`, and `2.0` for a non-finite element where the UDF answers NULL — and `2.0` is simultaneously the legitimate value for opposite vectors, so no screen over the *result* can separate the three causes.

**`inner_product` — a NULL element aborts the query.** This one agrees on every dense finite vector, and a `nullif` chain over its result did reproduce the NULL-for-non-finite contract (that rendering was written and passing). But a NULL element inside either operand makes `DuckDB` raise:

```
Invalid Input Error: array_inner_product: left argument can not contain NULL values
```

where `compute_fsl_f32` answers NULL for a null child slot. An expression wrapping the call cannot screen an exception raised while evaluating its own argument, so unlike the non-finite half this has no rendering-level remedy. The pushdown turned a NULL row into a failed query.

Both are denied; `DataFusion` evaluates them locally. No Spice vector UDF federates to `DuckDB` now — only `rand` (→ `random()`) remains carved out.

**`DuckLake` never had the deny-list at all.** `connector-ducklake` builds its own `DuckDBTableFactory`, where `function_support` defaults to `None` and the pushdown check is `is_some_and(..)` — so it was skipped entirely and every filter fell through to whatever the unparser could render, which is *any* function call. That was latent while the dialect rewrote `cosine_distance` into a function `DuckDB` really has: wrong-valued, but it ran. Removing the rewrite would have made the same filter federate under its own name and fail with an unknown function. It now installs the same deny-list `DuckDB`'s own factory has had since #10703.

## Changes

- `runtime-datafusion::dialect` — remove both vector UDFs from `duckdb_scalar_overrides`, which is the single source for the dialect rewrite *and* the deny-list carve-out, so one edit covers both and they cannot drift. The list now documents that an entry asserts **value equivalence**, not a matching name.
- `connector-ducklake` — install `deny_spice_functions_for_duckdb_table_providers()`; factory construction extracted to `configure_ducklake_factory` so a test can assert the policy on the value production builds.
- Delete `spice_array_fn_to_sql`, unused once both handlers went (`array_distance_to_sql` renders its own casts).
- Doc comments in `runtime-udfs-api`, `connector-duckdb`, `function_support`, `cosine_distance` and `vector_simd` no longer hold up either vector UDF as the example of a sound carve-out.

## Performance impact

A query calling `cosine_distance` or `inner_product` against a `DuckDB`-accelerated or `DuckDB`-federated table now has the embedding column scanned into `DataFusion`, where the local SIMD kernel evaluates it, instead of the distance being computed inside `DuckDB`. For a wide embedding column over many rows that is the difference between shipping one `FLOAT[N]` per row across the connector boundary and shipping one `DOUBLE`.

Spice's own vector search over a `DuckDB` *index* is unaffected — it builds its SQL directly in `crates/search/src/index/duckdb/metric.rs` and never goes through the unparser dialect. The affected surface is a plan that calls one of these UDFs against a table `DuckDB` owns.

Restoring the pushdown with a rendering that matches the UDFs is tracked in #13506, with the measured primitives and the open questions (operand duplication, `CASE` short-circuiting, float accumulation width). This PR chose correctness over the optimization because a silently wrong distance and a differently-selected row set are the worse failure.

## Not fixed here, deliberately

`array_distance` stays in the override list and `DuckDB`'s version very likely rejects a NULL element the same way. It is not reachable by this change: it maps `DataFusion`'s own `array_distance` built-in rather than a Spice UDF, and it is not on the Spice deny-list at all, so it federates by default whether or not the dialect lists it — removing it from the list would drop only the `::FLOAT[N]` cast rendering. Recorded on #13506 so "no vector UDF federates" is not read as covering it.

## Test plan

- `make lint`
- `make test`

New `crates/accelerators/accelerator-duckdb/tests/duckdb_vector_udf_pushdown.rs`:

- `duckdb_vector_udf_pushdown_matches_local` drives **both halves in one process** — the local kernel over an Arrow batch, and the SQL the dialect actually renders, executed against a real `DuckDB` holding the same rows — over 18 input classes: identical / orthogonal / opposite / oblique / dense, zero-magnitude (one side and both), `NaN` and `±inf` in either operand and at depth, NULL rows, and NULL elements. One statement per case: a raise aborts its whole statement, so a single query would blame every case for one bad row. This is the check that was missing — both halves existed and nothing compared them.
- `unclassified_overrides_are_a_test_failure` fails on any *new* override the test classifies nowhere, so the next function cannot skip the measurement by omission.
- `duckdb_array_cosine_distance_is_not_this_udfs_metric` and `duckdb_array_inner_product_rejects_a_null_element` pin the two engine facts the denials rest on, and would go green if `DuckDB` ever changed.
- `ducklake_denies_spice_udf_pushdown` (in `connector-ducklake`) asserts a `cosine_distance` filter reports `Unsupported` through the production factory.
- Dialect-level guards assert each UDF's absence from `duckdb_native_function_names()` with the measured reason in the failure message.

Two pre-existing assertions pinned the old behaviour and were inverted deliberately, not deleted: `duckdb_native_function_names_advertises_denylisted_pushables` asserted `cosine_distance` **is** advertised, and `duckdb_pushable_set_is_exactly_the_dialect_natives` pinned the pushable set — the latter's own comment says it must be updated on purpose, which is what happened. Note `cosine_distance_keeps_spice_zero_to_one_semantics` already guarded the local `[0,1]` convention, calling `1.0` a sign the wrong function had bound; the federated path returned exactly `1.0`.

**Neuter matrix** — every neuter kills at least one test, and every test added here is killed by at least one neuter:

| | re-add cosine | re-add inner_product | unclassified override | drop DuckLake deny-list |
|---|---|---|---|---|
| `cosine_distance_is_not_pushed_down_to_duckdb` | **FAIL** | ok | ok | ok |
| `inner_product_is_not_pushed_down_to_duckdb` | ok | **FAIL** | ok | ok |
| `duckdb_vector_udf_pushdown_matches_local` | **FAIL** | **FAIL** | ok | ok |
| `unclassified_overrides_are_a_test_failure` | ok | ok | **FAIL** | ok |
| `ducklake_denies_spice_udf_pushdown` | **FAIL** | ok | ok | **FAIL** |

The two engine-fact tests pass under every neuter by construction — they guard an external `DuckDB` assumption, so no neuter of this code can fail them. Recorded as assumption guards rather than counted as coverage.

## Review gate

- Adversarial review: `codex` — job `review-mt8sxsb6-wbhblx`, verdict `needs-attention`, scoped to `origin/trunk...a1cbdace58` (the first commit). **Two HIGH findings, both valid, both fixed:**
  - *"Standalone DuckLake still federates cosine_distance after its rewrite is removed."* Confirmed by reading the pinned fork: `function_support` defaults to `None` and the check is `is_some_and(..)`, so it was skipped and the unparser rendered the UDF under its own name. Fixed in `fd0cd24fa7` by installing the deny-list on the `DuckLake` factory, with `ducklake_denies_spice_udf_pushdown` covering it (the neuter that drops the install fails it).
  - *"inner_product pushdown aborts on legal nullable vectors."* Confirmed by measurement, not argument — extending the battery with NULL elements produced `Invalid Input Error: array_inner_product: left argument can not contain NULL values` against a local NULL. Its recommendation (withdraw the pushdown) was taken: an expression wrapping the call cannot screen an exception from its own argument, so there is no rendering-level fix. Fixed in `fd0cd24fa7`; the `nullif` screen and its three tests were removed with it.
- Adversarial re-review of the shipping HEAD `f5f809946e`: **skipped** — `codex` exited 1 with *"Your workspace is out of credits. Ask your workspace owner to refill in order to continue."*, and `grok` is not installed. Receipt reads `engine=none exit=1 verdict=unparsed job=none`, so nothing was mistaken for a clean pass. The delta since the reviewed commit is the two fixes above plus the quality pass in `f5f809946e`; it has **not** been through an adversarial engine and a reviewer should weight it accordingly.
- `/security-review`: no findings. The only executable change generates SQL from compile-time constants through the pre-existing expression-unparsing path and *narrows* what reaches the engine; no new logging, route, deserialization, filesystem or network path, no `unsafe`, and the one dependency added is `dev-dependencies` only. Checked specifically for the hard-stop class — no credential, token, or internal detail reaches a log line, error message, metric label, or this body.
- `/simplify`: applied. Removed a **vacuous** assertion (the `measured` counter compared against a re-derivation of the same predicate its loop filtered on, so it could not fail) by hoisting the filter so coverage is structural; folded the battery's five `push`es into its literal; tidied one fully-qualified path. Verified no reuse opportunity exists — the workspace has no public FixedSizeList test builder, only private per-crate helpers. Skipped one finding: `Outcome` derives `Clone` solely for the `vec![..; n]` local-failure path, which is honest since a local failure is not per-case. Light checks re-run after it, and clippy `--tests` then caught two real lint failures (`expect_used`, `unnecessary_wraps`) that the passing tests had hidden — both fixed with the integration-test suppression forms already used in this workspace.
- Sign-off repair commit `5951f467e2` (this is a fix to an already-reviewed PR, and covers **only** that commit — the bullets above still describe the authored work):
  - Adversarial review: **skipped, declared.** `codex` was probed from the engine and exited with *"Your workspace is out of credits. Ask your workspace owner to refill in order to continue."*; `grok` is not installed. Nothing was read as a clean pass.
  - In place of an engine pass, the change was checked against the gate that rejected the previous HEAD: `make lint-rust` runs clippy with `--keep-going`, and its log reported exactly one error across the whole workspace (`single_element_loop` at `crates/runtime/src/datafusion/udf.rs:1064`), so no second lint failure is queued behind it. A local scoped `cargo clippy -p runtime-datafusion-udfs --lib --tests` is clean.
  - `/security-review`: not run, and it would be vacuous here — the commit changes one test assertion's shape and one doc comment's wording. No production code path, no I/O, no new dependency, no logging or error text.
  - `/simplify`: the commit *is* the simplification — a one-element `for` loop replaced by the assertion it wrapped.

Fixes #13088
