### PR TITLE
Authenticate the stargazers dataset with a PAT and drop qa_analytics

### DIFF
--- a/spicepod.yml
+++ b/spicepod.yml
@@ -18,10 +18,8 @@ datasets:
     description: github.com/spiceai/spiceai GitHub Stargazers
     time_column: starred_at
     time_format: timestamp
-    params: &github_params
-      github_client_id: ${secrets:GITHUB_CLIENT_ID}
-      github_private_key: ${secrets:GITHUB_PRIVATE_KEY}
-      github_installation_id: ${secrets:GITHUB_INSTALLATION_ID}
+    params:
+      github_token: ${secrets:GITHUB_PUBLIC_REPO_STARGAZERS_PAT}
     acceleration: &github_acceleration
       enabled: true
       engine: duckdb
@@ -31,17 +29,13 @@ datasets:
       refresh_jitter_enabled: true
       refresh_jitter_max: 5m
 
-  - from: https://raw.githubusercontent.com/spiceai/spiceai/refs/heads/trunk/docs/release_notes/qa_analytics.csv
-    name: qa_analytics
-    acceleration:
-      enabled: true
-      engine: duckdb
-      refresh_check_interval: 1d
-
   - from: github:github.com/spiceai/spiceai/issues
     name: issues
     description: github.com/spiceai/spiceai GitHub Issues
-    params: *github_params
+    params: &github_params
+      github_client_id: ${secrets:GITHUB_CLIENT_ID}
+      github_private_key: ${secrets:GITHUB_PRIVATE_KEY}
+      github_installation_id: ${secrets:GITHUB_INSTALLATION_ID}
     time_column: updated_at
     time_format: timestamp
     acceleration: *github_acceleration
@@ -50,9 +44,7 @@ datasets:
   - from: github:github.com/spiceai/spiceai/pulls
     name: pulls
     params:
-      github_client_id: ${secrets:GITHUB_CLIENT_ID}
-      github_private_key: ${secrets:GITHUB_PRIVATE_KEY}
-      github_installation_id: ${secrets:GITHUB_INSTALLATION_ID}
+      <<: *github_params
       github_include_comments: all
     time_column: updated_at
     time_format: timestamp


### PR DESCRIPTION
## 📝 Summary

Three changes to the root `spicepod.yml`:

**`stargazers` now authenticates with a PAT.** It previously shared the GitHub App
installation credentials (`github_client_id` / `github_private_key` /
`github_installation_id`) with `issues` and `pulls`. The connector keys its
concurrency semaphore on the installation ID for App auth, so all three datasets
drew from a single shared budget — a hot `pulls` refresh (which fetches comments)
could starve the hourly stargazers refresh. It now uses
`github_token: ${secrets:GITHUB_PUBLIC_REPO_STARGAZERS_PAT}`.

`GithubFactory::create` matches `token` first, so setting `github_token` selects
`StaticTokenProvider` outright and keys the semaphore on the token instead of the
installation ID. `issues` and `pulls` keep App auth and keep sharing their budget.

**The `&github_params` anchor moved to `issues`.** It was defined on `stargazers`
and aliased by `issues`; since `stargazers` no longer carries App credentials, the
anchor moves with them to `issues`, the first remaining dataset that uses them
(a YAML anchor must precede its aliases). `pulls` merges it with `<<: *github_params`
rather than repeating the three params inline, so the anchor still does real work.
`&github_acceleration` stays on `stargazers`, still the first dataset, so both of
its aliases resolve unchanged.

**Removed the `qa_analytics` dataset** (the `raw.githubusercontent.com` CSV).

## 🔗 Related

None.

## 🚨 Breaking Changes

None. This is the repo's own demo Spicepod, not shipped configuration.

Operationally, `runtime.source_rate_control.github_concurrent_connections_limit: 5`
is now applied across two authentication contexts rather than one — the PAT gets
its own pool of 5 alongside the App installation's 5. Well within the public-repo
rate limit, but worth knowing the ceiling moved.

## 📚 Docs

None required.

## 👀 Notes for Reviewers

`GITHUB_PUBLIC_REPO_STARGAZERS_PAT` needs to exist in the secret store wherever
this pod is run; the PAT only needs public-repo read scope.

Verified by parsing the file and dumping each resolved dataset: `pulls` expands to
all three App params plus `github_include_comments: all`, all three datasets keep
an identical acceleration block, and `qa_analytics` is gone. Merge keys (`<<:`) are
already used throughout `test/spicepods/`, so the spicepod loader handles them.
