### PR TITLE
docs(v2.2.0): `spice cloud link` is what enrolls, not `spice connect`

### DIFF
--- a/docs/release_notes/v2.2.0.md
+++ b/docs/release_notes/v2.2.0.md
@@ -4,7 +4,7 @@ Spice v2.2.0 focuses on real-time data, performance, and stability. **Cloud Conn
 
 Highlights in v2.2.0 include:
 
-- **[Cloud Connect](#cloud-connect)** — link self-hosted runtimes to Spice.ai Cloud for management and observability
+- **[Cloud Connect](#cloud-connect)** — link self-hosted runtimes for BYOC (Bring Your Own Cloud) to Spice.ai Cloud for management and observability
 - **[MySQL CDC](#mysql-change-data-capture)** — MySQL tables now stay in sync in real time using MySQL binlog replication, with no Kafka or Debezium infrastructure and no scheduled refreshes
 - **[PostgreSQL Catalog CDC](#postgresql-catalog-cdc)** — accelerate an entire PostgreSQL database in real time with a few lines of configuration and no per-table setup
 - **[Faster Search](#faster-search-with-warm-in-memory-indexes)** — vector and full-text search can now serve from an in-memory index by default, with no configuration change
@@ -15,7 +15,7 @@ Highlights in v2.2.0 include:
 
 > Spice Cloud Connect is a feature of [Spice.ai Cloud](https://spice.ai/).
 
-[Spice Cloud Connect](https://spiceai.org/docs/deployment/cloud/cloud-connect) links self-hosted runtimes to Spice.ai Cloud for management and observability, while their data stays on the hosts that run them. Enroll a standalone runtime with [`spice cloud link`](https://spiceai.org/docs/cli/reference/cloud#link), or start it with [`spiced --token <enrollment-key>`](https://spiceai.org/docs/cli/reference/spiced#spice-cloud-connect-flags) for unattended enrollment.
+[Spice Cloud Connect](https://spiceai.org/docs/deployment/cloud/cloud-connect) links self-hosted runtimes for BYOC (Bring Your Own Cloud) to Spice.ai Cloud for management and observability. Run [`spice cloud link`](https://spiceai.org/docs/cli/reference/cloud#link) to enroll a standalone runtime.
 
 Try it with the [Cloud Connect on a Development Machine](https://github.com/spiceai/cookbook/tree/trunk/cloud-connect-dev) recipe.
 

--- a/docs/release_notes/v2.2.0.md
+++ b/docs/release_notes/v2.2.0.md
@@ -4,7 +4,7 @@ Spice v2.2.0 focuses on real-time data, performance, and stability. **Cloud Conn
 
 Highlights in v2.2.0 include:
 
-- **[Cloud Connect](#cloud-connect)** — link self-hosted runtimes for BYOC (Bring Your Own Cloud) to Spice.ai Cloud for management and observability
+- **[Cloud Connect](#cloud-connect)** — link self-hosted runtimes to Spice.ai Cloud for management and observability
 - **[MySQL CDC](#mysql-change-data-capture)** — MySQL tables now stay in sync in real time using MySQL binlog replication, with no Kafka or Debezium infrastructure and no scheduled refreshes
 - **[PostgreSQL Catalog CDC](#postgresql-catalog-cdc)** — accelerate an entire PostgreSQL database in real time with a few lines of configuration and no per-table setup
 - **[Faster Search](#faster-search-with-warm-in-memory-indexes)** — vector and full-text search can now serve from an in-memory index by default, with no configuration change
@@ -15,7 +15,7 @@ Highlights in v2.2.0 include:
 
 > Spice Cloud Connect is a feature of [Spice.ai Cloud](https://spice.ai/).
 
-[Spice Cloud Connect](https://spiceai.org/docs/next/deployment/cloud/cloud-connect) links self-hosted runtimes for BYOC (Bring Your Own Cloud) to Spice.ai Cloud for management and observability. Run `spice connect` to enroll a standalone runtime.
+[Spice Cloud Connect](https://spiceai.org/docs/deployment/cloud/cloud-connect) links self-hosted runtimes to Spice.ai Cloud for management and observability, while their data stays on the hosts that run them. Enroll a standalone runtime with [`spice cloud link`](https://spiceai.org/docs/cli/reference/cloud#link), or start it with [`spiced --token <enrollment-key>`](https://spiceai.org/docs/cli/reference/spiced#spice-cloud-connect-flags) for unattended enrollment.
 
 Try it with the [Cloud Connect on a Development Machine](https://github.com/spiceai/cookbook/tree/trunk/cloud-connect-dev) recipe.
 


### PR DESCRIPTION
Fixes the enrollment command — `spice connect` errors out and points at `spice cloud link` — plus the `/docs/next/` link path, and drops the duplicated BYOC mention from the highlights bullet. Companion: spiceai/docs#2126