### PR TITLE
fix(ci): match the allowed refresh-task warning at its current module path

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -2030,7 +2030,7 @@ jobs:
     # tolerate both variants of that specific transient.
     env:
       PARQUET_RENAME_RACE_ALLOW: |
-        WARN +runtime::accelerated_table::refresh_task: Failed to load data for dataset
+        WARN +runtime_table::accelerated::refresh_task: Failed to load data for dataset
         ^Invalid Error: TProtocolException: Invalid data$
         ^Invalid Error: don't know what type:
 


### PR DESCRIPTION
## What

The graceful-shutdown E2E jobs allow one known transient. `simulate_append_data.sh` rewrites `.spice/service_data.parquet` every 3s, so a refresh tick that races the rename reads a half-published file; the runtime logs a WARN and retries on the next tick. `PARQUET_RENAME_RACE_ALLOW` exists to let that line through, and the comment above it documents exactly that.

Its first pattern still names the pre-crate-split module path:

```
WARN +runtime::accelerated_table::refresh_task: Failed to load data for dataset
```

`refresh_task` now lives in `crates/runtime-table/src/accelerated/`, so the runtime emits it as `runtime_table::accelerated::refresh_task`. The pattern therefore matches nothing, and `Check logs` fails on the very warning the list was written to tolerate.

## Why it matters now

This is not specific to one PR — it fails any run in which the rename race actually occurs. It was blocking the merge-queue head: batch `pr-13489-d99d0ae238` had 65 of 67 jobs green, with the only real failure being `duckdb_append_with_pk_and_indexes.yaml … graceful shutdown on Linux x64`, whose two `Check logs` steps both rejected this line:

```
WARN runtime_table::accelerated::refresh_task: Failed to load data for dataset data_drop (duckdb):
Failed to fetch data from the data connector: External error: Execution error:
Failed to execute DuckDB query: Query execution failed.
```

The second red job in that run is the `E2E Test CI` rollup, i.e. the same cause, not a second one.

## Why this is a repair, not a relaxation

The allow list regains exactly the line it already named, at the path that line is now emitted from. The two `Invalid Error:` patterns beside it are untouched, and no warning becomes tolerated that was not tolerated before the module moved. A stale pattern here fails toward rejecting an expected line, which is why it surfaced as a red job rather than as silently weakened coverage.

## Verification

The action matches extended regular expressions against the ANSI-stripped line, so the pattern was checked the same way, against the line as emitted above:

- old pattern → **0** matches (the bug)
- new pattern → **1** match

## Notes

`.github/actions/check-spice-log/action.yml` mentions `WARN +runtime::...` twice, in its input description and in a shell comment. Both are generic illustrations of the pattern syntax rather than matched patterns, so they are left alone.

No Rust files are touched, so `Attestation` auto-passes for this branch.