### PR TITLE
fix(ci): stop the LLM integration suite passing without running any test (refs #6399)

### DIFF
--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -165,6 +165,10 @@ jobs:
       HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
       TEST_BINARY_OBJECT_KEY: test_binaries/${{ github.run_id }}/llms_integration_test
     strategy:
+      # The two arms cover disjoint model sets — self-hosted local models and the hosted
+      # providers — so one arm's result says nothing about the other's, and cancelling the
+      # sibling on the first failure throws away half the signal this suite exists to give.
+      fail-fast: false
       matrix:
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     permissions: read-all

--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -242,8 +242,37 @@ jobs:
               exit 1
             fi
           fi
-          # `--test-threads` to reduce possible rate limiting/ connection issues for hosted models.
-          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/llms_integration_test --nocapture -- llms::tests --test-threads=2
+          test_binary=./integration_test/llms_integration_test
+          # Every test in this binary lives under `integration.rs`'s only module, `llms`.
+          filter='llms::'
+
+          # A filter that matches nothing makes libtest print `ok. 0 passed` and exit 0, so the
+          # suite reports success having tested nothing. The filter names test-code structure,
+          # which a refactor is free to move, so count the selection and refuse an empty one
+          # rather than trusting a green result. `--list` only enumerates — it runs no test body,
+          # so it costs no model call and needs none of the snapshot environment below. Its exit
+          # status is checked separately from the count, because a harness that cannot run also
+          # produces no output, and reporting that as a stale filter sends the reader to the
+          # wrong file.
+          if ! listed=$("$test_binary" --list "$filter"); then
+            echo "::error::The LLM integration test binary failed to list its tests, so the suite could not run. Check the build and download steps above."
+            exit 1
+          fi
+          # `grep -c` exits 1 on no match, which `-e` would otherwise turn into an abort before
+          # the branch below can report the real problem.
+          selected=$(printf '%s\n' "$listed" | grep -c ': test$' || true)
+          echo "Filter '$filter' selects ${selected} test(s)."
+          if [ "$selected" -eq 0 ]; then
+            echo "::error::The LLM integration filter '$filter' selected no tests, so this suite would report success without exercising any model. Point it at the current test module path under crates/llms/tests/."
+            exit 1
+          fi
+
+          # The binary is itself the libtest harness, so its options are passed directly. A `--`
+          # here would end option parsing, and libtest would read `--test-threads=2` as a second
+          # filter and silently keep its default thread count. `--test-threads` holds concurrent
+          # requests low enough to stay under the hosted providers' rate limits.
+          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" \
+            "$test_binary" --nocapture --test-threads=2 "$filter"
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''


### PR DESCRIPTION
## Summary

`integration tests (llms)` has been reporting success while running **zero tests** since
2025-12-16. The suite ran its test binary as

```
llms_integration_test --nocapture -- llms::tests --test-threads=2
```

The binary *is* the libtest harness, so there is no `cargo`-style `--` separator: `--` ends
option parsing and everything after it is read as a filter. Two defects follow from that one
character.

**The filter names a module that no longer exists.** The tests lived in a `mod tests` block
until #8566 converted them to `rstest`; they are now generated directly under `llms`, so
`llms::tests` matches none of the 79 tests in the binary. libtest prints
`ok. 0 passed; 0 failed; 79 filtered out` and exits **0**, so the job goes green having
exercised no model at all. Measured on the last 100 runs of the workflow: 53 `success`,
47 `cancelled` (merge-queue evictions), **0 `failure`** — and the most recent trunk run,
[32915046757](https://github.com/spiceai/spiceai/actions/runs/32915046757), shows
`running 0 tests` on both matrix arms.

**`--test-threads=2` is swallowed too.** Sitting past the `--`, libtest takes it for a second
filter rather than an option — silently, where the same flag *before* the `--` is rejected as
`error: Unrecognized option` — and keeps its default thread count. The comment above the line
explains the flag as rate-limit protection for the hosted providers; that protection was never
in effect.

This is the prerequisite for #6399 rather than its fix: the flakiness that issue reports cannot
be assessed, let alone refactored away, while nothing runs. #6399 stays open owning the
output-dependent assertions.

## Changes

- Point the filter at the module the tests are actually in, and pass the harness options ahead
  of the filter so `--test-threads` takes effect.
- Check the selection before running it. A filter naming test-code structure can be moved by any
  refactor, and libtest reports an empty selection as a pass, so an empty selection now fails the
  step with a message naming the file to look in. `--list` only enumerates — it runs no test
  body, so the check costs no model call.
- Test the enumeration's exit status separately from its count: a harness that cannot run also
  produces no output, and reporting that as a stale filter would send the reader to the wrong
  file.

- Set `fail-fast: false` on the test matrix. The two arms cover disjoint model sets, so one
  arm's result says nothing about the other's, and the default cancels the sibling on the first
  failure. That was inert while nothing could fail; with the suite running it cost a whole arm —
  the first measurement run below lost the self-hosted arm 19 seconds after the hosted arm failed.

The guard is deliberately inline rather than a shared composite action. The only sibling that
filters by module path is `integration_adbc.yml`, and it is healthy — its most recent run
selected 12 tests and passed 11 — so there is one call site, not a pattern to factor out yet.

## Blast radius

None of this workflow's jobs are required status checks on `trunk` (the required set is
`Attestation`, `enforce-pull-with-spice`, `Rust Lint`, `Build and Test`,
`Build (release profile)`, `Integration Tests (part 1-3)`, `ADBC Integration Tests`,
`Check Rust Licenses`, `E2E Test CI`). Un-muting 79 tests therefore cannot dequeue the merge
queue, and a red-but-honest signal is strictly better than a green vacuous one. What the un-muted suite
actually does was measured on this branch before asking for review — see **Measured result**.

## Measured result

Two `workflow_dispatch` runs on this branch, `run=all`:

| run | arm | result | duration |
|---|---|---|---|
| [32968145550](https://github.com/spiceai/spiceai/actions/runs/32968145550) | hosted | 53 passed, 26 failed | 22.6s |
| | self-hosted | **cancelled** by the hosted failure (before `fail-fast: false`) | — |
| [32968731602](https://github.com/spiceai/spiceai/actions/runs/32968731602) | hosted | 54 passed, 25 failed | 26.2s |
| | self-hosted | 64 passed, 15 failed | 1306s |

Both arms report `Filter 'llms::' selects 79 test(s)` / `running 79 tests`, against
`running 0 tests` on trunk.

**Diffing the failing sets rather than the counts** (26 vs 25 is not one flake plus one fix):
25 tests fail identically in both runs, and exactly one differed —
`llms::test_system_prompt::model_name_3___xai__::as_stream_1_false` failed in the first run and
passed in the second. Two runs is far too small to call a rate, but the split is the useful part:
the great majority of what was hidden is deterministic breakage, not flakiness.

The failures resolve to four independent causes, none of them introduced here, each filed
separately because they need separate fixes:

- **#13557** — `DEFAULT_ANTHROPIC_MODEL` is `claude-3-5-sonnet-latest`, which the API now answers
  with `not_found_error`. 10 hosted failures. This one is user-facing: any Anthropic model
  configured without an explicit model id fails, and the muted suite is why nobody saw it.
- **#13558** — the workflow's Bedrock credentials are rejected (`UnrecognizedClientException`).
  10 hosted failures.
- **#13560** — `hf_phi3` and `local_phi3` are two fixtures over one Hugging Face repo, so they
  race on its blob lock. All 15 self-hosted failures.
- **#6399** — assertions that depend on a model emitting particular text. The residual hosted
  failures are stale `insta` snapshots (`tool_use_openai_valid_function_args`,
  `tool_use_xai_valid_function_args`, and the Anthropic `basic`/`system_prompt`/`usage` snapshots).
  This is the issue's original ask and stays open owning it.

**This PR therefore leaves the workflow red, deliberately.** Quarantining the failures to get a
green tick is how the suite came to be muted in the first place, and #13557 is a real user-facing
defect that the red is correctly reporting. Nothing is gated on it: none of these jobs are
required checks, so red here blocks no merge.

**One cost worth a decision.** `merge_group` has no `paths` filter — GitHub does not support one
for that event — so this suite runs on every queue batch, and the self-hosted arm now takes ~22
minutes where the vacuous job took 25 seconds. That is runner occupancy on the macOS pool per
batch, not merge latency, since the job does not gate. Narrowing what runs in the queue (the
`check_changes` pattern this repo uses elsewhere) is a reasonable follow-up, but it is a
scheduling decision rather than part of this fix, so I have left it alone rather than guess.

## Test plan

- `make lint` — green.
- `make nextest` — green (no Rust source is touched; the diff is one workflow step).
- Filter selection measured against the real test binary built exactly as the workflow builds it
  (`cargo test -p llms --test integration --features metal --no-run`):
  - the shipped filter `llms::tests` -> **0 tests**, matching CI's `79 filtered out`;
  - the corrected filter `llms::` -> **79 tests**;
  - the shipped argument vector verbatim (`--list -- llms::tests --test-threads=2`) -> **0 tests, exit 0**;
  - `--test-threads=2` alone past the `--` -> **0 tests, exit 0** (consumed as a filter), against
    `error: Unrecognized option` for an unknown flag before the `--` — which is what proves it was
    being read as a filter rather than rejected;
  - the corrected vector (`--list --test-threads=2 llms::`) -> **79 tests**.
- Guard exercised in both directions against the real binary, seven cases: `llms::tests` -> exit 1
  (the shipped filter is refused, so this guard would have caught the regression on the day it
  landed), `nonexistent::` -> exit 1, `llms::` -> exit 0 / 79, `llms::streaming_tests::` -> exit 0 / 5
  (a non-empty subset is not refused), a missing binary and a binary exiting 101 -> exit 1 naming the
  *harness*, and a binary that succeeds while listing nothing -> exit 1 naming the *filter*.
- Two `workflow_dispatch` runs of the workflow on this branch with `run=all` — see
  **Measured result** above for per-arm outcomes and the failing-set diff between them.

## Review gate

- Adversarial review: **skipped** — `codex` ran and exited 1: "Your workspace is out of credits. Ask your workspace owner to refill in order to continue." `grok` is not installed (no companion script in the plugin cache), and under `claudespice` it is the only permitted fallback. Receipt: `engine=none exit=1 verdict=unparsed job=none`. Re-run on the `fail-fast` HEAD (`40b14cc`) and refused for the same reason, so the skip attests the code actually shipping rather than an earlier diff.
- `/security-review`: no findings at or above MEDIUM. Every value the diff introduces is a literal defined in the step (`test_binary`, `filter`); nothing derives from a workflow input, `github.event.*`, or any other attacker-influenceable source, and both are quoted at every expansion. The step's secret-bearing environment is untouched, and the two new `echo`s print only the static filter and an integer count. Triggers remain `push`/`merge_group`/`workflow_dispatch` — no `pull_request_target`, so no untrusted fork code reaches these secrets.
- `/simplify`: one finding applied. The `--list` call had inherited the `INSTA_WORKSPACE_ROOT`/`CARGO_MANIFEST_DIR` prefix from the run call, duplicating an environment the enumeration does not need — `--list` executes no test body, so no snapshot is resolved. Dropped it, which removes the duplication rather than hiding it behind an `export`, and keeps the repo's established inline-prefix convention at the one site that needs it. Verified the seven-case guard matrix is unchanged afterward. Skipped: factoring the guard into a composite action (one healthy sibling call site is not yet a pattern — noted under Changes).

Because the adversarial pass could not run, the approach was self-reviewed against the same
questions, which is what produced the split between the "harness failed" and "filter is stale"
branches — a single combined check would have blamed the filter for a broken binary.

Refs #6399

## Checklist

- [x] Root cause identified and stated
- [x] Change verified against the real test binary, not inferred
- [x] Guard exercised in the failing direction (positive control)
- [x] Blast radius on the merge queue established
- [x] `workflow_dispatch` measurement of the un-muted suite reported (both arms)
- [x] Failing set diffed across two runs to separate deterministic breakage from flakiness
- [x] Each independent cause filed separately (#13557, #13558, #13560) rather than folded in here