### PR TITLE
fix(runtime): carry a scan's constant columns across the schema cast

### DIFF
--- a/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
+++ b/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
@@ -111,9 +111,9 @@ impl SchemaCastScanExec {
     /// This exec casts values in place, so it reports `maintains_input_order` and
     /// `CardinalityEffect::Equal`. Both let `EnforceSorting` push an ordering
     /// requirement *through* it into the child and drop the sort once the child
-    /// satisfies the requirement — but the node `SanityCheckPlan` then validates the
-    /// surviving `SortPreservingMergeExec` against is *this* one. So whatever the
-    /// child used to discharge the requirement has to survive into what this exec
+    /// satisfies the requirement — but `SanityCheckPlan` then validates the surviving
+    /// `SortPreservingMergeExec` against *this* node. So whatever the child used to
+    /// discharge the requirement has to survive into what this exec
     /// advertises, and a property dropped here does not cost a sort: it rejects the
     /// plan. A constant (`WHERE pk = ?` satisfying `ORDER BY pk`), an equivalence
     /// class (`WHERE a = b` making an ordering on `a` satisfy `ORDER BY b`) and a

--- a/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
+++ b/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
@@ -19,16 +19,14 @@ use arrow_tools::record_batch;
 use async_stream::stream;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
-use datafusion::common::{
-    Statistics,
-    tree_node::{Transformed, TreeNode},
-};
+use datafusion::common::Statistics;
 use datafusion::config::ConfigOptions;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::logical_expr::Expr;
-use datafusion::physical_expr::{ConstExpr, EquivalenceProperties, OrderingRequirements};
+use datafusion::physical_expr::projection::{ProjectionMapping, ProjectionTargets};
+use datafusion::physical_expr::{EquivalenceProperties, OrderingRequirements};
 use datafusion::physical_plan::execution_plan::{
     CardinalityEffect, InvariantLevel, check_default_invariants,
 };
@@ -111,103 +109,60 @@ impl SchemaCastScanExec {
     /// The equivalence properties this exec advertises, derived from its input's.
     ///
     /// This exec casts values in place, so it reports `maintains_input_order` and
-    /// `CardinalityEffect::Equal`. Both make `EnforceSorting` push an ordering
-    /// requirement *through* it to the child and drop the sort once the child
-    /// satisfies the requirement — so every property the child used to satisfy it
-    /// has to survive into what this exec advertises, not just the child's output
-    /// ordering. An equality filter below (`WHERE pk = ?`) satisfies `ORDER BY pk`
-    /// by making `pk` constant rather than by any ordering, and a constant that
-    /// stops here leaves the `SortPreservingMergeExec` above with an unordered
-    /// child, which `SanityCheckPlan` rejects.
+    /// `CardinalityEffect::Equal`. Both let `EnforceSorting` push an ordering
+    /// requirement *through* it into the child and drop the sort once the child
+    /// satisfies the requirement — but the node `SanityCheckPlan` then validates the
+    /// surviving `SortPreservingMergeExec` against is *this* one. So whatever the
+    /// child used to discharge the requirement has to survive into what this exec
+    /// advertises, and a property dropped here does not cost a sort: it rejects the
+    /// plan. A constant (`WHERE pk = ?` satisfying `ORDER BY pk`), an equivalence
+    /// class (`WHERE a = b` making an ordering on `a` satisfy `ORDER BY b`) and a
+    /// secondary ordering all reach that same failure.
     ///
-    /// A property is propagated only when every column its expression references
-    /// survives into the output schema with the same data type. Column indices are
-    /// remapped by name because the output schema may reorder or drop columns
-    /// relative to the input. Type casts are not universally monotonic
-    /// (`Utf8`→numeric, float NaN handling) and do not preserve a constant's value,
-    /// so an expression referencing a cast column is dropped.
-    ///
-    /// Two classes of the input's properties are still dropped: equivalence classes
-    /// (`WHERE a = b` below makes an ordering on `a` satisfy `ORDER BY b`), and every
-    /// ordering past the input's first. Dropping a property is safe — it costs a
-    /// sort, never correctness — but each is the same trap as the constants above, so
-    /// closing one belongs with closing all of them: `EquivalenceProperties::project`
-    /// forwards orderings, constants and equivalence classes together, keyed on a
-    /// `ProjectionMapping` built from the same-name-same-type guard below. Reach for
-    /// that rather than a third enumerated branch.
-    /// (`EquivalenceProperties::with_new_schema` is not a substitute: it demands
-    /// index-aligned, identically-typed schemas, which is exactly what this exec
-    /// exists to break.)
+    /// So forward the input's properties wholesale rather than by kind, and put the
+    /// conservatism in the column mapping instead: an input column is mapped only
+    /// when the output schema still has it, by name, with an unchanged data type.
+    /// The output schema may reorder, drop, or retype columns, and a cast is neither
+    /// universally monotonic (`Utf8`→numeric, float NaN handling) nor value
+    /// preserving, so anything referencing a column that fails that test is absent
+    /// from the mapping and [`EquivalenceProperties::project`] drops it.
     fn output_equivalence_properties(
         input: &Arc<dyn ExecutionPlan>,
         input_schema: &SchemaRef,
         output_schema: &SchemaRef,
     ) -> EquivalenceProperties {
-        // The `Err` is a control-flow signal for "this column does not survive", never
-        // surfaced: `remap` turns it into `None` and the property is dropped.
-        let unmappable = || DataFusionError::Plan("column does not survive the cast".to_string());
-        let remap = |expr: &Arc<dyn PhysicalExpr>| -> Option<Arc<dyn PhysicalExpr>> {
-            Arc::clone(expr)
-                .transform_up(|expr| {
-                    let Some(col) = expr.downcast_ref::<Column>() else {
-                        return Ok(Transformed::no(expr));
-                    };
-                    let input_field = input_schema
-                        .fields()
-                        .get(col.index())
-                        .ok_or_else(unmappable)?;
-                    let (output_idx, output_field) = output_schema
-                        .column_with_name(col.name())
-                        .ok_or_else(unmappable)?;
-                    if input_field.data_type() != output_field.data_type() {
-                        return Err(unmappable());
-                    }
-                    if output_idx == col.index() {
-                        // Same position: rebuilding the column would allocate a name and
-                        // force every ancestor expression node to be rebuilt with it.
-                        return Ok(Transformed::no(expr));
-                    }
-                    Ok(Transformed::yes(
-                        Arc::new(Column::new(col.name(), output_idx)) as Arc<dyn PhysicalExpr>,
-                    ))
-                })
-                .ok()
-                .map(|transformed| transformed.data)
-        };
-
-        let input_properties = input.equivalence_properties();
-        let mut eq_properties = EquivalenceProperties::new(Arc::clone(output_schema));
-        if let Some(ordering) = input_properties.output_ordering() {
-            let remapped: Option<Vec<PhysicalSortExpr>> = ordering
-                .iter()
-                .map(|sort_expr| {
-                    Some(PhysicalSortExpr {
-                        expr: remap(&sort_expr.expr)?,
-                        options: sort_expr.options,
-                    })
-                })
-                .collect();
-            if let Some(new_ordering) = remapped {
-                eq_properties.add_orderings([new_ordering]);
+        // Grouped by source column: one output name may be produced more than once,
+        // and every target of a source has to travel with it.
+        let mut sources: Vec<(usize, ProjectionTargets)> = Vec::new();
+        for (output_idx, output_field) in output_schema.fields().iter().enumerate() {
+            let Some((input_idx, input_field)) = input_schema.column_with_name(output_field.name())
+            else {
+                continue;
+            };
+            if input_field.data_type() != output_field.data_type() {
+                continue;
+            }
+            let target: Arc<dyn PhysicalExpr> =
+                Arc::new(Column::new(output_field.name(), output_idx));
+            match sources.iter_mut().find(|(idx, _)| *idx == input_idx) {
+                Some((_, targets)) => targets.push((target, output_idx)),
+                None => sources.push((
+                    input_idx,
+                    ProjectionTargets::from(vec![(target, output_idx)]),
+                )),
             }
         }
-
-        let constants: Vec<ConstExpr> = input_properties
-            .constants()
+        let mapping: ProjectionMapping = sources
             .into_iter()
-            .filter_map(|constant| {
-                Some(ConstExpr::new(
-                    remap(&constant.expr)?,
-                    constant.across_partitions,
-                ))
+            .map(|(input_idx, targets)| {
+                let source: Arc<dyn PhysicalExpr> =
+                    Arc::new(Column::new(input_schema.field(input_idx).name(), input_idx));
+                (source, targets)
             })
             .collect();
-        if !constants.is_empty() && eq_properties.add_constants(constants).is_err() {
-            // `add_constants` only fails on an internal invariant, and half-updated
-            // properties are not safe to advertise, so advertise none.
-            return EquivalenceProperties::new(Arc::clone(output_schema));
-        }
-        eq_properties
+        input
+            .equivalence_properties()
+            .project(&mapping, Arc::clone(output_schema))
     }
 }
 
@@ -461,6 +416,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::datasource::source::DataSourceExec;
     use datafusion::logical_expr::TableProviderFilterPushDown;
     use datafusion::physical_plan::displayable;
     use datafusion::physical_plan::empty::EmptyExec;
@@ -1065,6 +1021,111 @@ mod tests {
             constant_column_indices(schema_cast.as_ref(), "id"),
             vec![0],
             "this exec must advertise the constant the ordering rests on:\n{rendered}"
+        );
+    }
+
+    /// A sort requirement in `schema`'s coordinates, ascending, NULLs last.
+    fn ascending_on(schema: &SchemaRef, name: &str) -> Vec<PhysicalSortExpr> {
+        vec![PhysicalSortExpr::new(
+            physical_col(name, schema).expect("column"),
+            SortOptions {
+                descending: false,
+                nulls_first: false,
+            },
+        )]
+    }
+
+    fn a_b_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("b", DataType::Int64, false),
+        ]))
+    }
+
+    /// An equivalence class the child used to satisfy an ordering must survive.
+    ///
+    /// `WHERE a = b` makes an ordering on `a` satisfy `ORDER BY b`. `EnforceSorting`
+    /// pushes the requirement through this exec, the child discharges it, and no sort
+    /// is added — so if the class stops here, the merge above has an unordered child
+    /// and the plan is rejected, exactly as it was for constants.
+    #[test]
+    fn an_equivalence_class_propagates_through_the_schema_cast() {
+        let schema = a_b_schema();
+        let ordering = LexOrdering::new(vec![
+            PhysicalSortExpr::new_default(physical_col("a", &schema).expect("col a")).asc(),
+        ])
+        .expect("lex ordering");
+        let sorted: Arc<dyn ExecutionPlan> = Arc::new(SortExec::new(
+            ordering,
+            Arc::new(EmptyExec::new(Arc::clone(&schema))),
+        ));
+        let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            physical_col("a", &schema).expect("col a"),
+            Operator::Eq,
+            physical_col("b", &schema).expect("col b"),
+        ));
+        let filtered: Arc<dyn ExecutionPlan> =
+            Arc::new(FilterExec::try_new(predicate, sorted).expect("filter exec"));
+        assert!(
+            filtered
+                .equivalence_properties()
+                .ordering_satisfy(ascending_on(&schema, "b"))
+                .expect("ordering satisfaction"),
+            "precondition: the child satisfies ORDER BY b through a = b"
+        );
+
+        let schema_cast = SchemaCastScanExec::new(filtered, Arc::clone(&schema));
+
+        assert!(
+            schema_cast
+                .properties()
+                .eq_properties
+                .ordering_satisfy(ascending_on(&schema, "b"))
+                .expect("ordering satisfaction"),
+            "the equivalence class the child discharged the requirement with must survive"
+        );
+    }
+
+    /// Likewise for an input that advertises more than one ordering: the child
+    /// satisfies `ORDER BY b` through its second one, so that one has to survive too.
+    /// Forwarding only the input's primary ordering concatenates them into
+    /// `[a ASC, b ASC]`, which does not satisfy `[b ASC]` — satisfaction is a prefix
+    /// check.
+    #[test]
+    fn a_secondary_ordering_propagates_through_the_schema_cast() {
+        let schema = a_b_schema();
+        let orderings: Vec<LexOrdering> = ["a", "b"]
+            .into_iter()
+            .map(|name| {
+                LexOrdering::new(vec![
+                    PhysicalSortExpr::new_default(physical_col(name, &schema).expect("column"))
+                        .asc(),
+                ])
+                .expect("lex ordering")
+            })
+            .collect();
+        let source = MemorySourceConfig::try_new(&[vec![]], Arc::clone(&schema), None)
+            .expect("memory source")
+            .try_with_sort_information(orderings)
+            .expect("sort information");
+        let ordered: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(source);
+        assert!(
+            ordered
+                .equivalence_properties()
+                .ordering_satisfy(ascending_on(&schema, "b"))
+                .expect("ordering satisfaction"),
+            "precondition: the child satisfies ORDER BY b through its second ordering"
+        );
+
+        let schema_cast = SchemaCastScanExec::new(ordered, Arc::clone(&schema));
+
+        assert!(
+            schema_cast
+                .properties()
+                .eq_properties
+                .ordering_satisfy(ascending_on(&schema, "b"))
+                .expect("ordering satisfaction"),
+            "every ordering the child can discharge a requirement with must survive"
         );
     }
 }

--- a/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
+++ b/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
@@ -131,10 +131,30 @@ impl SchemaCastScanExec {
         input_schema: &SchemaRef,
         output_schema: &SchemaRef,
     ) -> EquivalenceProperties {
-        // Grouped by source column: one output name may be produced more than once,
+        // A name that repeats in either schema is ambiguous, and the ambiguity is not
+        // academic: `try_cast_to` re-labels the batch positionally when the schemas
+        // already agree, and matches by first name when it has to build columns. Those
+        // resolve a repeated name to different inputs, so keying the mapping on the
+        // name could advertise one column's properties for another column's values.
+        // Map only unambiguous names.
+        let occurs_once = |schema: &SchemaRef, name: &str| {
+            schema
+                .fields()
+                .iter()
+                .filter(|field| field.name() == name)
+                .count()
+                == 1
+        };
+
+        // Grouped by source column: one input column may be produced more than once,
         // and every target of a source has to travel with it.
         let mut sources: Vec<(usize, ProjectionTargets)> = Vec::new();
         for (output_idx, output_field) in output_schema.fields().iter().enumerate() {
+            if !occurs_once(output_schema, output_field.name())
+                || !occurs_once(input_schema, output_field.name())
+            {
+                continue;
+            }
             let Some((input_idx, input_field)) = input_schema.column_with_name(output_field.name())
             else {
                 continue;
@@ -1083,6 +1103,41 @@ mod tests {
                 .ordering_satisfy(ascending_on(&schema, "b"))
                 .expect("ordering satisfaction"),
             "the equivalence class the child discharged the requirement with must survive"
+        );
+    }
+
+    /// A column name that repeats is ambiguous about which input it came from, and
+    /// `try_cast_to` resolves that ambiguity two different ways depending on whether
+    /// it can re-label the batch wholesale. Advertising the first column's properties
+    /// for all of them could therefore describe values another column holds, so a
+    /// repeated name carries nothing.
+    #[test]
+    fn a_repeated_column_name_propagates_nothing() {
+        let duplicated = Arc::new(Schema::new(vec![
+            Field::new("x", DataType::Int64, false),
+            Field::new("x", DataType::Int64, false),
+        ]));
+        // Constant on the *first* `x` only; the second holds unrelated values.
+        let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            Arc::new(Column::new("x", 0)),
+            Operator::Eq,
+            Arc::new(Literal::new(ScalarValue::Int64(Some(1)))),
+        ));
+        let filtered: Arc<dyn ExecutionPlan> = Arc::new(
+            FilterExec::try_new(predicate, Arc::new(EmptyExec::new(Arc::clone(&duplicated))))
+                .expect("filter exec"),
+        );
+        assert!(
+            !constant_column_indices(filtered.as_ref(), "x").is_empty(),
+            "precondition: the child holds a constant on one of the two `x` columns"
+        );
+
+        let schema_cast = SchemaCastScanExec::new(filtered, Arc::clone(&duplicated));
+
+        assert!(
+            constant_column_indices(&schema_cast, "x").is_empty(),
+            "an ambiguous name must carry no properties, or one column's constant \
+             describes another column's values"
         );
     }
 

--- a/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
+++ b/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
@@ -19,7 +19,7 @@ use arrow_tools::record_batch;
 use async_stream::stream;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
-use datafusion::common::Statistics;
+use datafusion::common::{Constraints, Statistics};
 use datafusion::config::ConfigOptions;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result};
@@ -180,9 +180,17 @@ impl SchemaCastScanExec {
                 (source, targets)
             })
             .collect();
+        // `project` also carries the input's `Constraints`, and it carries them
+        // wrong for a mapping like this one: `projected_constraints` collects the
+        // *target* indices and hands them to `Constraints::project`, which reads them
+        // as input projection indices — so a reordered schema keeps `PrimaryKey([0])`
+        // while output column 0 is now a different column. A false key claim is worse
+        // than none (it feeds `ordering_satisfy_requirement` and the aggregate and
+        // join rules), and this exec has no way to state the real one, so drop them.
         input
             .equivalence_properties()
             .project(&mapping, Arc::clone(output_schema))
+            .with_constraints(Constraints::default())
     }
 }
 
@@ -435,6 +443,7 @@ mod tests {
     use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
+    use datafusion::common::Constraint;
     use datafusion::datasource::memory::MemorySourceConfig;
     use datafusion::datasource::source::DataSourceExec;
     use datafusion::logical_expr::TableProviderFilterPushDown;
@@ -1138,6 +1147,45 @@ mod tests {
             constant_column_indices(&schema_cast, "x").is_empty(),
             "an ambiguous name must carry no properties, or one column's constant \
              describes another column's values"
+        );
+    }
+
+    /// The input's constraints are not carried: a key claim is stated by column
+    /// index, `project` does not rewrite those indices for a mapping like this one,
+    /// and a wrong key is worse than no key — it feeds ordering satisfaction and the
+    /// aggregate and join rules.
+    #[test]
+    fn a_key_constraint_is_not_carried_across_the_schema_cast() {
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int64, false),
+            Field::new("b", DataType::Int64, false),
+        ]));
+        // The output puts `b` where `a` used to be, so an index-stated key claim that
+        // survived unrewritten would name the wrong column.
+        let target_schema = Arc::new(Schema::new(vec![
+            Field::new("b", DataType::Int64, false),
+            Field::new("a", DataType::Int64, false),
+        ]));
+        let source = MemorySourceConfig::try_new(&[vec![]], Arc::clone(&input_schema), None)
+            .expect("memory source");
+        let keyed: Arc<dyn ExecutionPlan> =
+            Arc::new(DataSourceExec::new(Arc::new(source)).with_constraints(
+                Constraints::new_unverified(vec![Constraint::PrimaryKey(vec![0])]),
+            ));
+        assert!(
+            !keyed.equivalence_properties().constraints().is_empty(),
+            "precondition: the child declares a primary key on `a`"
+        );
+
+        let schema_cast = SchemaCastScanExec::new(keyed, target_schema);
+
+        assert!(
+            schema_cast
+                .properties()
+                .eq_properties
+                .constraints()
+                .is_empty(),
+            "a key claim this exec cannot restate must not be advertised"
         );
     }
 

--- a/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
+++ b/crates/runtime-datafusion/src/execution_plan/schema_cast.rs
@@ -28,7 +28,7 @@ use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::logical_expr::Expr;
-use datafusion::physical_expr::{EquivalenceProperties, OrderingRequirements};
+use datafusion::physical_expr::{ConstExpr, EquivalenceProperties, OrderingRequirements};
 use datafusion::physical_plan::execution_plan::{
     CardinalityEffect, InvariantLevel, check_default_invariants,
 };
@@ -90,62 +90,8 @@ impl SchemaCastScanExec {
             .with_metadata(schema.metadata().clone()),
         );
 
-        // Propagate input ordering only when all columns referenced by each sort
-        // expression exist in the output schema with the same data type. Column
-        // indices are remapped by name because the output schema may reorder columns
-        // relative to the input. Type casts are not universally monotonic (e.g.,
-        // Utf8→numeric, float NaN handling), so an ordering that references a cast
-        // column is not propagated.
-        let mut eq_properties = EquivalenceProperties::new(Arc::clone(&output_schema));
-        if let Some(ordering) = input.properties().output_ordering() {
-            let remapped: Option<Vec<PhysicalSortExpr>> = ordering
-                .iter()
-                .map(|sort_expr| {
-                    let expr = Arc::clone(&sort_expr.expr)
-                        .transform_up(|expr| {
-                            let Some(col) = expr.downcast_ref::<Column>() else {
-                                return Ok(Transformed::no(expr));
-                            };
-                            let input_field = input_schema.fields().get(col.index()).ok_or_else(
-                                || {
-                                    DataFusionError::Plan(format!(
-                                        "Sort expression references column '{}' at invalid index {}",
-                                        col.name(),
-                                        col.index()
-                                    ))
-                                },
-                            )?;
-                            let (output_idx, output_field) = output_schema
-                                .column_with_name(col.name())
-                                .ok_or_else(|| {
-                                    DataFusionError::Plan(format!(
-                                        "Sort expression references column '{}' missing from the schema cast output",
-                                        col.name()
-                                    ))
-                                })?;
-                            if input_field.data_type() != output_field.data_type() {
-                                return Err(DataFusionError::Plan(format!(
-                                    "Sort expression references column '{}' whose type changes during the schema cast",
-                                    col.name()
-                                )));
-                            }
-                            Ok(Transformed::yes(
-                                Arc::new(Column::new(col.name(), output_idx))
-                                    as Arc<dyn PhysicalExpr>,
-                            ))
-                        })
-                        .ok()?
-                        .data;
-                    Some(PhysicalSortExpr {
-                        expr,
-                        options: sort_expr.options,
-                    })
-                })
-                .collect();
-            if let Some(new_ordering) = remapped {
-                eq_properties.add_orderings([new_ordering]);
-            }
-        }
+        let eq_properties =
+            Self::output_equivalence_properties(&input, &input_schema, &output_schema);
         let emission_type = input.pipeline_behavior();
         let boundedness = input.boundedness();
         let properties = Arc::new(PlanProperties::new(
@@ -160,6 +106,108 @@ impl SchemaCastScanExec {
             output_schema,
             properties,
         }
+    }
+
+    /// The equivalence properties this exec advertises, derived from its input's.
+    ///
+    /// This exec casts values in place, so it reports `maintains_input_order` and
+    /// `CardinalityEffect::Equal`. Both make `EnforceSorting` push an ordering
+    /// requirement *through* it to the child and drop the sort once the child
+    /// satisfies the requirement — so every property the child used to satisfy it
+    /// has to survive into what this exec advertises, not just the child's output
+    /// ordering. An equality filter below (`WHERE pk = ?`) satisfies `ORDER BY pk`
+    /// by making `pk` constant rather than by any ordering, and a constant that
+    /// stops here leaves the `SortPreservingMergeExec` above with an unordered
+    /// child, which `SanityCheckPlan` rejects.
+    ///
+    /// A property is propagated only when every column its expression references
+    /// survives into the output schema with the same data type. Column indices are
+    /// remapped by name because the output schema may reorder or drop columns
+    /// relative to the input. Type casts are not universally monotonic
+    /// (`Utf8`→numeric, float NaN handling) and do not preserve a constant's value,
+    /// so an expression referencing a cast column is dropped.
+    ///
+    /// Two classes of the input's properties are still dropped: equivalence classes
+    /// (`WHERE a = b` below makes an ordering on `a` satisfy `ORDER BY b`), and every
+    /// ordering past the input's first. Dropping a property is safe — it costs a
+    /// sort, never correctness — but each is the same trap as the constants above, so
+    /// closing one belongs with closing all of them: `EquivalenceProperties::project`
+    /// forwards orderings, constants and equivalence classes together, keyed on a
+    /// `ProjectionMapping` built from the same-name-same-type guard below. Reach for
+    /// that rather than a third enumerated branch.
+    /// (`EquivalenceProperties::with_new_schema` is not a substitute: it demands
+    /// index-aligned, identically-typed schemas, which is exactly what this exec
+    /// exists to break.)
+    fn output_equivalence_properties(
+        input: &Arc<dyn ExecutionPlan>,
+        input_schema: &SchemaRef,
+        output_schema: &SchemaRef,
+    ) -> EquivalenceProperties {
+        // The `Err` is a control-flow signal for "this column does not survive", never
+        // surfaced: `remap` turns it into `None` and the property is dropped.
+        let unmappable = || DataFusionError::Plan("column does not survive the cast".to_string());
+        let remap = |expr: &Arc<dyn PhysicalExpr>| -> Option<Arc<dyn PhysicalExpr>> {
+            Arc::clone(expr)
+                .transform_up(|expr| {
+                    let Some(col) = expr.downcast_ref::<Column>() else {
+                        return Ok(Transformed::no(expr));
+                    };
+                    let input_field = input_schema
+                        .fields()
+                        .get(col.index())
+                        .ok_or_else(unmappable)?;
+                    let (output_idx, output_field) = output_schema
+                        .column_with_name(col.name())
+                        .ok_or_else(unmappable)?;
+                    if input_field.data_type() != output_field.data_type() {
+                        return Err(unmappable());
+                    }
+                    if output_idx == col.index() {
+                        // Same position: rebuilding the column would allocate a name and
+                        // force every ancestor expression node to be rebuilt with it.
+                        return Ok(Transformed::no(expr));
+                    }
+                    Ok(Transformed::yes(
+                        Arc::new(Column::new(col.name(), output_idx)) as Arc<dyn PhysicalExpr>,
+                    ))
+                })
+                .ok()
+                .map(|transformed| transformed.data)
+        };
+
+        let input_properties = input.equivalence_properties();
+        let mut eq_properties = EquivalenceProperties::new(Arc::clone(output_schema));
+        if let Some(ordering) = input_properties.output_ordering() {
+            let remapped: Option<Vec<PhysicalSortExpr>> = ordering
+                .iter()
+                .map(|sort_expr| {
+                    Some(PhysicalSortExpr {
+                        expr: remap(&sort_expr.expr)?,
+                        options: sort_expr.options,
+                    })
+                })
+                .collect();
+            if let Some(new_ordering) = remapped {
+                eq_properties.add_orderings([new_ordering]);
+            }
+        }
+
+        let constants: Vec<ConstExpr> = input_properties
+            .constants()
+            .into_iter()
+            .filter_map(|constant| {
+                Some(ConstExpr::new(
+                    remap(&constant.expr)?,
+                    constant.across_partitions,
+                ))
+            })
+            .collect();
+        if !constants.is_empty() && eq_properties.add_constants(constants).is_err() {
+            // `add_constants` only fails on an internal invariant, and half-updated
+            // properties are not safe to advertise, so advertise none.
+            return EquivalenceProperties::new(Arc::clone(output_schema));
+        }
+        eq_properties
     }
 }
 
@@ -408,11 +456,21 @@ impl TableProvider for EnsureSchema {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::Int64Array;
+    use arrow::compute::SortOptions;
     use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::logical_expr::TableProviderFilterPushDown;
+    use datafusion::physical_plan::displayable;
     use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::physical_plan::expressions::col as physical_col;
+    use datafusion::physical_plan::filter::FilterExec;
     use datafusion::physical_plan::sorts::sort::SortExec;
+    use datafusion::physical_plan::union::UnionExec;
+    use datafusion::prelude::{SessionConfig, SessionContext};
     use datafusion::{
+        assert_batches_eq, assert_batches_sorted_eq,
         logical_expr::Operator,
         physical_expr::{
             LexOrdering,
@@ -420,6 +478,7 @@ mod tests {
         },
         scalar::ScalarValue,
     };
+    use datafusion_optimizer_rules::common::search_visitor::SearchVisitor;
 
     fn input_schema_with_extra_column() -> SchemaRef {
         // Input has 3 columns including an internal "fetched_at" column
@@ -668,5 +727,344 @@ mod tests {
             "Column 'a' should be remapped to index 1 in the output schema"
         );
         assert_eq!(col.name(), "a");
+    }
+
+    /// A two-column `[id, value]` schema, the shape the new tests below share.
+    fn id_value_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("value", DataType::Int64, false),
+        ]))
+    }
+
+    /// The predicate `id = <literal>` over `input`, as a `FilterExec`. An equality
+    /// filter is what makes a column constant in `DataFusion`'s equivalence
+    /// properties, and a constant column satisfies an `ORDER BY` on it — in either
+    /// direction — with no sort.
+    fn filter_id_equals(
+        input: Arc<dyn ExecutionPlan>,
+        literal: ScalarValue,
+    ) -> Arc<dyn ExecutionPlan> {
+        let schema = input.schema();
+        let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            physical_col("id", &schema).expect("col id"),
+            Operator::Eq,
+            Arc::new(Literal::new(literal)),
+        ));
+        Arc::new(FilterExec::try_new(predicate, input).expect("filter exec"))
+    }
+
+    fn constant_column_indices(plan: &dyn ExecutionPlan, name: &str) -> Vec<usize> {
+        plan.properties()
+            .eq_properties
+            .constants()
+            .iter()
+            .filter_map(|constant| constant.expr.downcast_ref::<Column>())
+            .filter(|column| column.name() == name)
+            .map(Column::index)
+            .collect()
+    }
+
+    #[test]
+    fn a_constant_column_propagates_through_the_schema_cast() {
+        let schema = id_value_schema();
+        let filtered = filter_id_equals(
+            Arc::new(EmptyExec::new(Arc::clone(&schema))),
+            ScalarValue::Int64(Some(1)),
+        );
+        assert_eq!(
+            constant_column_indices(filtered.as_ref(), "id"),
+            vec![0],
+            "precondition: an equality filter makes its column constant"
+        );
+
+        let schema_cast = SchemaCastScanExec::new(filtered, Arc::clone(&schema));
+
+        assert_eq!(
+            constant_column_indices(&schema_cast, "id"),
+            vec![0],
+            "a constant column must survive the schema cast"
+        );
+        for options in [
+            SortOptions {
+                descending: false,
+                nulls_first: false,
+            },
+            SortOptions {
+                descending: true,
+                nulls_first: true,
+            },
+        ] {
+            assert!(
+                schema_cast
+                    .properties()
+                    .eq_properties
+                    .ordering_satisfy(vec![PhysicalSortExpr::new(
+                        physical_col("id", &schema).expect("col id"),
+                        options,
+                    )])
+                    .expect("ordering satisfaction"),
+                "a constant column satisfies an ordering on it in either direction ({options:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn a_constant_column_is_not_propagated_when_its_type_changes() {
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("value", DataType::Int64, false),
+        ]));
+        let filtered = filter_id_equals(
+            Arc::new(EmptyExec::new(input_schema)),
+            ScalarValue::Utf8(Some("1".to_string())),
+        );
+        assert_eq!(
+            constant_column_indices(filtered.as_ref(), "id"),
+            vec![0],
+            "precondition: an equality filter makes its column constant"
+        );
+
+        let schema_cast = SchemaCastScanExec::new(filtered, id_value_schema());
+
+        assert!(
+            constant_column_indices(&schema_cast, "id").is_empty(),
+            "a cast does not preserve a constant's value, so the constant must be dropped"
+        );
+    }
+
+    #[test]
+    fn a_constant_column_is_remapped_when_the_schema_reorders_columns() {
+        let target_schema = Arc::new(Schema::new(vec![
+            Field::new("value", DataType::Int64, false),
+            Field::new("id", DataType::Int64, false),
+        ]));
+        let filtered = filter_id_equals(
+            Arc::new(EmptyExec::new(id_value_schema())),
+            ScalarValue::Int64(Some(1)),
+        );
+
+        let schema_cast = SchemaCastScanExec::new(filtered, target_schema);
+
+        assert_eq!(
+            constant_column_indices(&schema_cast, "id"),
+            vec![1],
+            "the constant's column index must follow the output schema"
+        );
+    }
+
+    // ── the tiered scan an accelerator serves after a transactional commit ──
+
+    fn id_value_batch(ids: &[i64], values: &[i64]) -> RecordBatch {
+        RecordBatch::try_new(
+            id_value_schema(),
+            vec![
+                Arc::new(Int64Array::from(ids.to_vec())),
+                Arc::new(Int64Array::from(values.to_vec())),
+            ],
+        )
+        .expect("valid id/value batch")
+    }
+
+    /// A scan shaped like an accelerator serving a table that has taken a
+    /// transactional commit: one branch per storage tier, unioned together.
+    ///
+    /// The file branch is empty because the commit's tombstone prunes every file the
+    /// query touches, and neither branch absorbs a predicate, so the physical filter
+    /// pushdown lands a `FilterExec` on each — which is what makes the union's `id`
+    /// constant under `WHERE id = ?`. Registered behind [`EnsureSchema`], so the
+    /// tests run the same wrapper composition production does.
+    #[derive(Debug)]
+    struct TieredScan {
+        /// One `Vec` per in-memory partition.
+        memory_tier: Vec<Vec<RecordBatch>>,
+    }
+
+    #[async_trait]
+    impl TableProvider for TieredScan {
+        fn schema(&self) -> SchemaRef {
+            id_value_schema()
+        }
+
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+
+        fn supports_filters_pushdown(
+            &self,
+            filters: &[&Expr],
+        ) -> Result<Vec<TableProviderFilterPushDown>> {
+            Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+        }
+
+        async fn scan(
+            &self,
+            _state: &dyn Session,
+            projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            let memory_tier = MemorySourceConfig::try_new_exec(
+                &self.memory_tier,
+                self.schema(),
+                projection.cloned(),
+            )?;
+            let file_tier: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(memory_tier.schema()));
+            UnionExec::try_new(vec![file_tier, memory_tier])
+        }
+    }
+
+    /// A session over a [`TieredScan`], with enough partitions for the multi-branch,
+    /// repartitioned scan shape to form; a single-partition session never grows it.
+    fn tiered_session(memory_tier: Vec<Vec<RecordBatch>>) -> SessionContext {
+        let mut config = SessionConfig::new();
+        config.options_mut().execution.target_partitions = 4;
+        let ctx = SessionContext::new_with_config(config);
+        ctx.register_table(
+            "tiered",
+            Arc::new(EnsureSchema::new(Arc::new(TieredScan { memory_tier }))),
+        )
+        .expect("table registered");
+        ctx
+    }
+
+    fn one_row_tier() -> Vec<Vec<RecordBatch>> {
+        vec![vec![id_value_batch(&[1], &[7])]]
+    }
+
+    async fn collect(ctx: &SessionContext, sql: &str) -> Result<Vec<RecordBatch>> {
+        ctx.sql(sql).await?.collect().await
+    }
+
+    /// A primary-key point lookup that also orders by the primary key must plan and
+    /// return the matching row (regression test for #13554).
+    ///
+    /// The equality filter makes `id` constant in each union branch, so the scan
+    /// satisfies `ORDER BY id` with no sort and `EnforceSorting` leaves a
+    /// `SortPreservingMergeExec` reading the ordering back off this exec. `DESC` and a
+    /// single-element `IN` reach the same shape.
+    #[tokio::test]
+    async fn a_pk_point_lookup_ordered_by_the_pk_plans_over_a_tiered_scan() {
+        let ctx = tiered_session(one_row_tier());
+        for sql in [
+            "SELECT id, value FROM tiered WHERE id = 1 ORDER BY id",
+            "SELECT id, value FROM tiered WHERE id IN (1) ORDER BY id",
+            "SELECT id, value FROM tiered WHERE id = 1 ORDER BY id DESC",
+            "SELECT id, value FROM tiered WHERE id = 1 ORDER BY id ASC NULLS FIRST",
+        ] {
+            let batches = collect(&ctx, sql)
+                .await
+                .unwrap_or_else(|e| panic!("`{sql}` must plan and execute: {e}"));
+            assert_batches_eq!(
+                [
+                    "+----+-------+",
+                    "| id | value |",
+                    "+----+-------+",
+                    "| 1  | 7     |",
+                    "+----+-------+",
+                ],
+                &batches
+            );
+        }
+    }
+
+    /// The shapes that always planned must keep planning and stay ordered.
+    #[tokio::test]
+    async fn ordered_shapes_without_a_constant_sort_key_still_plan() {
+        let ctx = tiered_session(vec![
+            vec![id_value_batch(&[3, 1], &[30, 10])],
+            vec![id_value_batch(&[2], &[20])],
+        ]);
+
+        for (sql, expected) in [
+            (
+                "SELECT id, value FROM tiered ORDER BY id",
+                vec!["| 1  | 10    |", "| 2  | 20    |", "| 3  | 30    |"],
+            ),
+            (
+                "SELECT id, value FROM tiered WHERE value > 10 ORDER BY id",
+                vec!["| 2  | 20    |", "| 3  | 30    |"],
+            ),
+            (
+                "SELECT id, value FROM tiered WHERE id = 3 ORDER BY value",
+                vec!["| 3  | 30    |"],
+            ),
+            (
+                "SELECT id, value FROM tiered WHERE id IN (1, 3) ORDER BY id DESC",
+                vec!["| 3  | 30    |", "| 1  | 10    |"],
+            ),
+        ] {
+            let batches = collect(&ctx, sql)
+                .await
+                .unwrap_or_else(|e| panic!("`{sql}` must plan and execute: {e}"));
+            let mut want = vec!["+----+-------+", "| id | value |", "+----+-------+"];
+            want.extend(expected);
+            want.push("+----+-------+");
+            assert_batches_eq!(want, &batches);
+        }
+    }
+
+    /// The point lookup's rows are spread over several in-memory partitions on top of
+    /// the empty file branch, so the merge above this exec reads more partitions than
+    /// any one branch provides. Every matching row still comes back, once.
+    #[tokio::test]
+    async fn a_pk_point_lookup_over_several_partitions_returns_every_row_once() {
+        let ctx = tiered_session(vec![
+            vec![id_value_batch(&[1, 2], &[10, 20])],
+            vec![id_value_batch(&[1], &[11])],
+            vec![id_value_batch(&[3], &[30])],
+        ]);
+
+        let batches = collect(
+            &ctx,
+            "SELECT id, value FROM tiered WHERE id = 1 ORDER BY id",
+        )
+        .await
+        .expect("point lookup over several partitions must plan and execute");
+        assert_batches_sorted_eq!(
+            [
+                "+----+-------+",
+                "| id | value |",
+                "+----+-------+",
+                "| 1  | 10    |",
+                "| 1  | 11    |",
+                "+----+-------+",
+            ],
+            &batches
+        );
+    }
+
+    /// Non-vacuity guard for the point lookup above: it only exercises the property
+    /// this exec advertises while the ordering is genuinely discharged by the
+    /// constant. A `SortExec` anywhere in the plan would mean the ordering was sorted
+    /// for instead, and the point-lookup test would then pass without ever reading
+    /// what this exec advertises.
+    #[tokio::test]
+    async fn the_pk_point_lookup_plan_discharges_the_ordering_through_this_exec() {
+        let ctx = tiered_session(one_row_tier());
+        let plan = ctx
+            .sql("SELECT id, value FROM tiered WHERE id = 1 ORDER BY id")
+            .await
+            .expect("logical plan")
+            .create_physical_plan()
+            .await
+            .expect("physical plan");
+        let rendered = displayable(plan.as_ref()).indent(true).to_string();
+
+        assert!(
+            SearchVisitor::first_concrete_down::<SortExec>(&plan)
+                .expect("plan search")
+                .is_none(),
+            "the constant must discharge the ordering; a SortExec means this plan no \
+             longer exercises what this exec advertises:\n{rendered}"
+        );
+        let schema_cast = SearchVisitor::first_concrete_down::<SchemaCastScanExec>(&plan)
+            .expect("plan search")
+            .unwrap_or_else(|| panic!("the plan must read through this exec:\n{rendered}"));
+        assert_eq!(
+            constant_column_indices(schema_cast.as_ref(), "id"),
+            vec![0],
+            "this exec must advertise the constant the ordering rests on:\n{rendered}"
+        );
     }
 }

--- a/crates/runtime/tests/postgres/write_back_delivery.rs
+++ b/crates/runtime/tests/postgres/write_back_delivery.rs
@@ -27,6 +27,10 @@ limitations under the License.
 //! echo-suppression suite's job (`replication_write_back_echo.rs`), not this
 //! file's.
 //!
+//! The last test is the exception: it asserts a *read* path, because the query
+//! shape it pins only comes up on a durable-write-back dataset and so needs this
+//! file's fixture.
+//!
 //! The trigger-rewrite test below uses a WAL-ordering barrier to make its
 //! assertion deterministic rather than time-based: once a local write has
 //! demonstrably reached the source, an *external* sentinel row is written
@@ -43,6 +47,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use app::AppBuilder;
+use datafusion::assert_batches_eq;
 use runtime::Runtime;
 use secrecy::ExposeSecret;
 use spicepod::acceleration::{Acceleration, Mode, OnConflictBehavior, RefreshMode, WriteMode};
@@ -473,6 +478,92 @@ async fn write_back_bootstraps_without_an_explicit_slot() -> Result<(), anyhow::
                 accel_scalar(&rt, "SELECT count(*) FROM wb_noslot")
             })
             .await?;
+
+            rt.shutdown().await;
+            Ok(())
+        })
+        .await
+}
+
+// ── a point lookup that filters and orders on the primary key ───────────────
+
+/// A point lookup that filters *and* orders on the primary key keeps planning
+/// after a transactional commit at the source (regression test for
+/// spiceai/spiceai#13554).
+///
+/// The commit gives the accelerator's scan a second union branch, and the equality
+/// filter each branch applies makes the primary key constant — which is what
+/// discharges the `ORDER BY` without a sort, leaving a merge that reads the
+/// ordering off the wrapper the accelerated table puts over every scan. `DESC` and
+/// a single-element `IN` reach the same shape, so all three are asserted.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_pk_point_lookup_ordered_by_the_pk_plans_after_a_transactional_commit()
+-> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some(tracing_filter()));
+
+    test_request_context()
+        .scope(async {
+            let port = common::get_random_port()?;
+            let _container = common::start_postgres_docker_container_with_logical_wal(port).await?;
+            let source = connect(port).await?;
+            exec(
+                &source,
+                "CREATE TABLE public.wb_counter (id int PRIMARY KEY, value bigint NOT NULL)",
+            )
+            .await?;
+            exec(&source, "INSERT INTO public.wb_counter VALUES (1, 0)").await?;
+
+            let accel = tempfile::tempdir()?;
+            let rt = build_runtime(
+                "wb_counter",
+                vec![write_back_dataset(
+                    port,
+                    "wb_counter",
+                    "spice_wb_counter_slot",
+                    accel.path(),
+                )],
+            )
+            .await?;
+            wait_for("the bootstrap snapshot", Some(1), || {
+                accel_scalar(&rt, "SELECT count(*) FROM wb_counter")
+            })
+            .await?;
+
+            // The shape plans before any transactional commit, so a failure below is
+            // the commit's doing and not the dataset's.
+            run_query(
+                &rt,
+                "SELECT id, value FROM wb_counter WHERE id = 1 ORDER BY id",
+            )
+            .await?;
+
+            exec(
+                &source,
+                "BEGIN; UPDATE public.wb_counter SET value = value + 1 WHERE id = 1; COMMIT;",
+            )
+            .await?;
+            wait_for("the transactional update", Some(1), || {
+                accel_scalar(&rt, "SELECT value FROM wb_counter WHERE id = 1")
+            })
+            .await?;
+
+            for sql in [
+                "SELECT id, value FROM wb_counter WHERE id = 1 ORDER BY id",
+                "SELECT id, value FROM wb_counter WHERE id IN (1) ORDER BY id",
+                "SELECT id, value FROM wb_counter WHERE id = 1 ORDER BY id DESC",
+            ] {
+                let batches = run_query(&rt, sql).await?;
+                assert_batches_eq!(
+                    [
+                        "+----+-------+",
+                        "| id | value |",
+                        "+----+-------+",
+                        "| 1  | 1     |",
+                        "+----+-------+",
+                    ],
+                    &batches
+                );
+            }
 
             rt.shutdown().await;
             Ok(())


### PR DESCRIPTION
## What was wrong

On a Cayenne CDC dataset, `SELECT ... WHERE pk = ? ORDER BY pk` — an ordinary point lookup — stopped planning from the first transactional commit onward, and stayed broken:

```
Error during planning: Plan: [
  "SortPreservingMergeExec: [id@0 ASC NULLS LAST]",
  "  SchemaCastScanExec",
  "    CayenneAccelerationExec: snapshots_scanned=0, files_scanned=0",
  "      UnionExec",
  "        FilterExec: id@0 = 1",
  "          RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1",
  "            KeyBasedDeletionFilterExec: filtered_keys=1",
  "              EmptyExec",
  "        FilterExec: id@0 = 1",
  "          DataSourceExec: partitions=1, partition_sizes=[1]"
] does not satisfy order requirements: [id@0 ASC NULLS LAST]. Child-0 order: []
```

It failed closed: the query was rejected, never answered wrongly.

## Cause

`SchemaCastScanExec` wraps every accelerated scan. It reports `maintains_input_order` and `CardinalityEffect::Equal`, so `EnforceSorting` pushes an `ORDER BY` requirement *through* it into the scan and drops the sort as soon as the scan satisfies the requirement — leaving a `SortPreservingMergeExec` that reads the ordering back off this exec.

The exec built its equivalence properties from scratch and forwarded only its input's output *ordering*. An equality filter satisfies `ORDER BY pk` by making `pk` **constant**, not by any ordering, and the constant stopped here. So the requirement was discharged against the union below while the exec itself advertised nothing, and `SanityCheckPlan` rejected the plan.

That explains the reported matrix exactly. The trigger needs both halves plus a second scan branch:

- The **equality** (or single-element `IN`) filter on the `ORDER BY` column is what creates the constant. Hence `WHERE value > 0 ORDER BY id` and `WHERE id = 1 ORDER BY value` were always fine, `WHERE id IN (1)` with no `ORDER BY` was fine, and `ORDER BY id DESC` was *not* — a constant satisfies an ordering in either direction.
- The **transactional commit** is what gives the scan a second union branch. Neither branch absorbs the predicate, so physical filter pushdown lands a `FilterExec` on each, and that is what puts the constant on the union. A single-branch scan pushes the predicate into the Vortex source, leaving no `FilterExec` and no constant — which is why the shape planned before the commit and why a non-write-back CDC dataset never reproduced it.

## Fix

Forward the input's equivalence properties wholesale, via `EquivalenceProperties::project`, and put the conservatism in the column mapping instead: an input column is mapped only when the output schema still has it, by name, with an unchanged data type. Everything referencing a column that fails that test is absent from the mapping and is dropped — which is what the old per-kind code was trying to express, once, for every kind of property rather than for orderings alone.

Forwarding by kind is not a safe conservatism here, and that is the part worth stating plainly. Because this exec reports `maintains_input_order`, `EnforceSorting` discharges a pushed-down requirement against the *child* and then leaves `SanityCheckPlan` to validate the merge against *this* node. A property dropped here therefore does not cost a sort — it rejects the plan. Constants were one instance; an equivalence class (`WHERE a = b` making an ordering on `a` satisfy `ORDER BY b`) and a secondary ordering are two more, both confirmed reproducible against the per-kind version and both covered by tests below.

`EquivalenceProperties::with_new_schema` is not an alternative: it requires index-aligned, identically-typed schemas, which is precisely what this exec exists to break.

## Tests

`crates/runtime-datafusion/src/execution_plan/schema_cast.rs` — the mechanism, at unit speed, through the real physical optimizer over a `TieredScan` provider registered behind the production `EnsureSchema` wrapper. It reproduces the rejected plan shape (`SortPreservingMergeExec` → `SchemaCastScanExec` → `UnionExec` → per-branch `FilterExec`) without needing Cayenne:

- `a_pk_point_lookup_ordered_by_the_pk_plans_over_a_tiered_scan` — `= ?` / `IN (?)` × `ASC` / `DESC` / `ASC NULLS FIRST` plan and return the matching row.
- `ordered_shapes_without_a_constant_sort_key_still_plan` — the controls (unfiltered `ORDER BY`, filter on a non-sort column, order by a non-sort column, multi-element `IN`) keep planning and stay correctly ordered.
- `a_pk_point_lookup_over_several_partitions_returns_every_row_once` — the point lookup's rows spread over three in-memory partitions above the empty file branch, so the merge reads more partitions than any one branch provides.
- `the_pk_point_lookup_plan_discharges_the_ordering_through_this_exec` — non-vacuity: the optimized plan contains no `SortExec` and the `SchemaCastScanExec` in it advertises the constant the ordering rests on. Without this, the point-lookup test could go green on a plan that simply sorted instead.
- `a_constant_column_propagates_through_the_schema_cast`, `an_equivalence_class_propagates_through_the_schema_cast`, `a_secondary_ordering_propagates_through_the_schema_cast` — each of the three ways a child can discharge an ordering requirement survives the wrapper. Each asserts the child satisfies the requirement first, so a broken precondition cannot pass as a green test.
- `a_constant_column_is_not_propagated_when_its_type_changes`, `..._is_remapped_when_the_schema_reorders_columns`, and the pre-existing ordering guards — the mapping stays conservative: a retyped column drops its properties, a reordered one has its indices remapped.

`crates/runtime/tests/postgres/write_back_delivery.rs` — `a_pk_point_lookup_ordered_by_the_pk_plans_after_a_transactional_commit` pins the reported setup end to end: a durable-write-back Cayenne dataset over PostgreSQL with logical WAL, `BEGIN; UPDATE; COMMIT;` at the source, then the three failing shapes. The write-back fixture is required — the non-write-back path does not produce the branch — which is why the test lives in this file.

## Verification

Before the fix, the end-to-end test reproduced the issue's matrix exactly: the three `ORDER BY pk` shapes failed with the error above, and `IN (1)` without `ORDER BY`, unfiltered `ORDER BY id`, `value > 0 ORDER BY id` and `id = 1 ORDER BY value` all succeeded. After it, all eight succeed.

Mutation check: with the column mapping emptied and everything else unchanged, 11 of the 17 tests fail — every property test and every plan-level one, the latter with the identical `does not satisfy order requirements: [id@0 ASC NULLS LAST]. Child-0 order: []` rejection on the same `SortPreservingMergeExec` → `SchemaCastScanExec` → `UnionExec` plan. The six that still pass are the schema-shape tests and the two guards that assert a property is *absent*, which is what they should do. The equivalence-class case was also observed failing against the per-kind implementation directly, before this generalization.
