### PR TITLE
chore(spicepod): accelerate GitHub datasets with Cayenne instead of DuckDB

### DIFF
--- a/spicepod.yml
+++ b/spicepod.yml
@@ -22,7 +22,8 @@ datasets:
       github_token: ${secrets:GITHUB_PUBLIC_REPO_STARGAZERS_PAT}
     acceleration: &github_acceleration
       enabled: true
-      engine: duckdb
+      engine: cayenne
+      mode: file
       refresh_mode: append
       refresh_append_overlap: 5m
       refresh_check_interval: 1h


### PR DESCRIPTION
## 📝 Summary

Switch the root spicepod's shared GitHub acceleration (`stargazers`, `issues`, `pulls`) from DuckDB to Cayenne in file mode.

DuckDB was running with the default in-memory mode, so GitHub data was re-fetched on every restart. Cayenne stores the acceleration on disk, which is a better fit for hourly append refreshes under GitHub rate limits.

Refresh settings (append, 1h interval, jitter, 5m overlap) are unchanged.

## 🔗 Related

None.

## 👀 Notes for Reviewers

`mode: file` is set because Cayenne is a file-backed accelerator. Without it the engine would default to `memory`, which would still drop the GitHub data on restart.