### PR TITLE
fix(cache): reject plan and search cache entries that straddle an invalidation

### DIFF
--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -453,22 +453,46 @@ impl Caching {
     ///
     /// This is purposely eager, as an invalidated cache is better than a stale one.
     ///
+    /// The caches run concurrently, not in sequence, for two reasons beyond
+    /// latency:
+    ///
+    /// - Every cache stamps its invalidation clock synchronously before its
+    ///   first await, so all stamps land before any (possibly slow) entry
+    ///   removal is waited on. Awaiting one cache's removal before stamping
+    ///   the next would leave the later caches serving pre-write entries for
+    ///   the whole wait — and a stale plan served in that window can feed
+    ///   freshly-stamped stale results into the already-stamped results
+    ///   cache, where they outlive the invalidation.
+    /// - A failure in one cache must not skip the others: a skipped cache
+    ///   never stamps its clock or removes its entries, and serves pre-write
+    ///   data until TTL. Every invalidation runs to completion; the first
+    ///   error is reported after all of them have run.
+    ///
     /// # Errors
     ///
     /// If the cache invalidation fails for any of the caches.
     pub async fn invalidate_for_table(&self, table_ref: TableReference) -> Result<()> {
-        if let Some(results_cache) = &self.results {
-            results_cache
-                .invalidate_for_table(table_ref.clone())
-                .await?;
-        }
-        if let Some(plans_cache) = &self.plans {
-            plans_cache.invalidate_for_table(table_ref.clone()).await?;
-        }
-        if let Some(search_cache) = &self.search {
-            search_cache.invalidate_for_table(table_ref).await?;
-        }
-        Ok(())
+        let (results, plans, search) = futures::join!(
+            async {
+                match &self.results {
+                    Some(cache) => cache.invalidate_for_table(table_ref.clone()).await,
+                    None => Ok(()),
+                }
+            },
+            async {
+                match &self.plans {
+                    Some(cache) => cache.invalidate_for_table(table_ref.clone()).await,
+                    None => Ok(()),
+                }
+            },
+            async {
+                match &self.search {
+                    Some(cache) => cache.invalidate_for_table(table_ref.clone()).await,
+                    None => Ok(()),
+                }
+            },
+        );
+        results.and(plans).and(search)
     }
 
     /// Drives moka housekeeping on every configured cache. `moka::future::Cache`
@@ -517,9 +541,10 @@ impl Caching {
 /// Every table-scoped cache owns its own instance — [`QueryResultsCacheProvider`]
 /// checks it in [`QueryResultsCacheProvider::get_raw_key`]; [`SimpleCache`] and
 /// [`LruCache`] check theirs in [`TabledCacheProvider::get_raw_key_if_fresh`].
-/// The instances need no coordination: each is stamped by its own cache's
-/// invalidation path, and an invalidation fans out to every cache holding
-/// entries for the table.
+/// Each instance is stamped by its own cache's invalidation path, and
+/// [`Caching::invalidate_for_table`] drives the caches concurrently so that no
+/// cache's stamp waits on — or is skipped by a failure of — another cache's
+/// entry removal.
 ///
 /// Memory is bounded at [`MAX_TRACKED_TABLES`] regardless of how many distinct
 /// tables are invalidated over a process lifetime. Table identities are not
@@ -1228,6 +1253,118 @@ mod tests {
         assert!(
             clock.invalidated_since(&tables, base + std::time::Duration::from_millis(1)),
             "folding the map into the floor must keep its newest stamp"
+        );
+    }
+
+    /// A plans cache whose invalidation always fails, standing in for e.g. a
+    /// Pingora scan whose blocking task was cancelled.
+    #[derive(Debug)]
+    struct FailingPlansCache;
+
+    impl Display for FailingPlansCache {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "failing plans cache")
+        }
+    }
+
+    impl HashProvider for FailingPlansCache {
+        fn hasher(&self) -> Box<dyn Hasher> {
+            Box::new(std::hash::DefaultHasher::new())
+        }
+    }
+
+    #[async_trait]
+    impl CacheProvider<CachedLogicalPlan> for FailingPlansCache {
+        async fn get_raw_key(&self, _key: &u64) -> Option<CachedLogicalPlan> {
+            None
+        }
+        async fn get_raw_key_validated(
+            &self,
+            _key: &u64,
+            _is_valid: &(dyn for<'v> Fn(&'v CachedLogicalPlan) -> bool + Send + Sync),
+        ) -> Option<CachedLogicalPlan> {
+            None
+        }
+        async fn put_raw_key(&self, _key: &u64, _value: CachedLogicalPlan) {}
+        async fn invalidate_all(&self) {}
+        async fn size_bytes(&self) -> u64 {
+            0
+        }
+        async fn item_count(&self) -> u64 {
+            0
+        }
+        fn max_size(&self) -> usize {
+            0
+        }
+        async fn checkpoint(&self) {}
+    }
+
+    #[async_trait]
+    impl TabledCacheProvider<CachedLogicalPlan> for FailingPlansCache {
+        async fn invalidate_for_table(&self, table_ref: TableReference) -> Result<()> {
+            Err(Error::FailedToInvalidateCache {
+                source: moka::PredicateError::InvalidationClosuresDisabled,
+                table_name: invalidated_table_name(&table_ref),
+            })
+        }
+        async fn get_raw_key_if_fresh(&self, _key: &u64) -> Option<CachedLogicalPlan> {
+            None
+        }
+    }
+
+    /// One cache's failure must not skip the others: a skipped cache never
+    /// stamps its clock or removes its entries, and would serve pre-write data
+    /// until TTL with nothing but a warning logged at the call site.
+    #[tokio::test]
+    async fn invalidate_for_table_runs_every_cache_despite_a_failure() {
+        use spicepod::component::caching::{CacheEngine, CachingPolicy};
+
+        let search_cache = Arc::new(LruCache::new(
+            1024 * 1024,
+            std::time::Duration::from_mins(10),
+            std::hash::RandomState::default(),
+            CachingPolicy::Lru,
+            CacheEngine::Moka,
+        ));
+        let caching = Caching::new()
+            .with_plans_cache(Arc::new(FailingPlansCache))
+            .with_search_cache(Arc::clone(&search_cache).as_tabled_provider());
+
+        let cached_search_result = |read_started_at: std::time::Instant| CachedSearchResult {
+            results: Arc::new(std::collections::HashMap::new()),
+            input_tables: Arc::new(HashSet::from([TableReference::bare("customer")])),
+            read_started_at,
+        };
+
+        let key = 1u64;
+        search_cache
+            .put_raw_key(&key, cached_search_result(std::time::Instant::now()))
+            .await;
+
+        let pre_invalidation_read = std::time::Instant::now();
+        assert!(
+            caching
+                .invalidate_for_table(TableReference::bare("customer"))
+                .await
+                .is_err(),
+            "the plans-cache failure must surface to the caller"
+        );
+        search_cache.checkpoint().await;
+
+        // The search cache still removed its entry...
+        assert!(
+            search_cache.get_raw_key_if_fresh(&key).await.is_none(),
+            "the search cache must still remove its entries when another cache fails"
+        );
+
+        // ...and still stamped its clock: a result whose read straddled the
+        // invalidation is rejected even though it was stored afterwards.
+        search_cache
+            .put_raw_key(&key, cached_search_result(pre_invalidation_read))
+            .await;
+        assert!(
+            search_cache.get_raw_key_if_fresh(&key).await.is_none(),
+            "the search cache must still stamp its clock when another cache fails"
         );
     }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -592,7 +592,16 @@ impl TableInvalidationClock {
             state.invalidated_at.clear();
         }
 
-        state.invalidated_at.insert(key, at);
+        // Merge with the existing stamp rather than overwrite: concurrent
+        // invalidations of the same table capture their instants *before*
+        // taking this lock, so the older capture can acquire it last, and a
+        // plain insert would move the clock backward — letting a read that
+        // began between the two stamps be served stale.
+        state
+            .invalidated_at
+            .entry(key)
+            .and_modify(|existing| *existing = (*existing).max(at))
+            .or_insert(at);
     }
 
     /// Records that *every* table was invalidated at `at`, folding the map into
@@ -1150,6 +1159,28 @@ mod tests {
         assert!(
             !clock.invalidated_since(&discarded, later),
             "a read beginning after every recorded invalidation must still be cacheable"
+        );
+    }
+
+    /// The per-table stamp is monotonic: concurrent invalidations of the same
+    /// table capture their instants before acquiring the clock's lock, so the
+    /// older capture can be recorded *after* the newer one. It must not move
+    /// the clock backward — a read that began between the two stamps would
+    /// otherwise pass the freshness check and be served stale.
+    #[test]
+    fn table_invalidation_clock_keeps_the_newest_stamp_under_reversed_recording() {
+        let clock = TableInvalidationClock::default();
+        let base = std::time::Instant::now();
+        let newer = base + std::time::Duration::from_millis(2);
+
+        // Recorded newest-first, as when the older caller loses the lock race.
+        clock.mark_invalidated(&TableReference::bare("customer"), newer);
+        clock.mark_invalidated(&TableReference::bare("customer"), base);
+
+        let tables: HashSet<TableReference> = HashSet::from([TableReference::bare("customer")]);
+        assert!(
+            clock.invalidated_since(&tables, base + std::time::Duration::from_millis(1)),
+            "a read that began before the newest invalidation must be rejected"
         );
     }
 

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -53,6 +53,7 @@ pub use backend::PingoraBackend;
 pub use lru_cache::LruCache;
 pub use metrics::CacheMetrics;
 pub use metrics::EvictionReason;
+pub use result::plan::CachedLogicalPlan;
 pub use simple_cache::SimpleCache;
 use spicepod::component::caching::SQLResultsCacheConfig;
 pub use utils::RESPONSE_STATUS_COLUMN;
@@ -148,6 +149,18 @@ impl AsTableRefs for LogicalPlan {
     }
 }
 
+/// A cached value that records when the read that produced it began.
+///
+/// Table-scoped caches use this instant to decide whether the value may still
+/// be served: a value whose tables were invalidated at or after this instant
+/// may describe pre-invalidation state and must be treated as a miss — see
+/// [`TabledCacheProvider::get_raw_key_if_fresh`]. Record the instant *before*
+/// the read starts (before planning, before the first scan): an earlier
+/// instant can only cost a cache entry, never serve a stale one.
+pub trait ReadStartedAt {
+    fn read_started_at(&self) -> std::time::Instant;
+}
+
 /// Default catalog and schema used to resolve table references before comparing
 /// them during cache invalidation.
 ///
@@ -229,7 +242,7 @@ pub trait CacheProvider<V: Clone + Send + Sync + 'static>:
 
 /// A ``TabledCacheProvider`` represents a cache that can invalidate entries based on table references which their values reference.
 #[async_trait]
-pub trait TabledCacheProvider<V: AsTableRefs + Clone + Send + Sync + 'static>:
+pub trait TabledCacheProvider<V: AsTableRefs + ReadStartedAt + Clone + Send + Sync + 'static>:
     CacheProvider<V>
 {
     /// Invalidates all cache entries for the specified table.
@@ -238,10 +251,31 @@ pub trait TabledCacheProvider<V: AsTableRefs + Clone + Send + Sync + 'static>:
     /// worker; the entries are invalidated by the time it returns, so a caller that awaits it
     /// before reporting a write complete keeps the ordering it had when this was synchronous.
     ///
+    /// Implementations must stamp their [`TableInvalidationClock`] *before* removing entries —
+    /// a writer whose read straddles the invalidation must be rejected by
+    /// [`Self::get_raw_key_if_fresh`], and stamping afterwards leaves exactly that gap open.
+    ///
     /// # Errors
     ///
     /// If the cache invalidation fails.
     async fn invalidate_for_table(&self, table_ref: TableReference) -> Result<()>;
+
+    /// Looks up `key`, treating a value whose tables were invalidated at or after its
+    /// [`ReadStartedAt::read_started_at`] as a miss.
+    ///
+    /// This is the lookup every serving path must use. [`CacheProvider::get_raw_key`] alone
+    /// cannot close the write-after-invalidation race: an entry stored *after*
+    /// [`Self::invalidate_for_table`] ran — by a task whose read of the table straddled the
+    /// invalidation — is invisible to that invalidation entirely (`moka` predicates match only
+    /// entries last modified at or before the predicate was registered, and the Pingora scan
+    /// has already walked its shards). Checking at the moment of use is what makes such an
+    /// entry unservable rather than merely short-lived.
+    ///
+    /// Deliberately has no default implementation, for the same reason as
+    /// [`CacheProvider::get_raw_key_validated`]: the check must consult the implementation's
+    /// own invalidation clock, and a default delegating to an unchecked read would silently
+    /// reopen the race in any implementation that forgot to override it.
+    async fn get_raw_key_if_fresh(&self, key: &u64) -> Option<V>;
 }
 
 #[derive(Clone)]
@@ -360,7 +394,7 @@ mod xxhash_compat {
 #[derive(Default)]
 pub struct Caching {
     pub results: Option<Arc<QueryResultsCacheProvider>>,
-    pub plans: Option<Arc<dyn TabledCacheProvider<LogicalPlan> + Send + Sync>>,
+    pub plans: Option<Arc<dyn TabledCacheProvider<CachedLogicalPlan> + Send + Sync>>,
     pub search: Option<Arc<dyn TabledCacheProvider<CachedSearchResult> + Send + Sync>>,
     pub embeddings: Option<Arc<dyn CacheProvider<CachedEmbeddingResult> + Send + Sync>>,
 }
@@ -391,7 +425,7 @@ impl Caching {
     #[must_use]
     pub fn with_plans_cache(
         mut self,
-        plans: Arc<dyn TabledCacheProvider<LogicalPlan> + Send + Sync>,
+        plans: Arc<dyn TabledCacheProvider<CachedLogicalPlan> + Send + Sync>,
     ) -> Self {
         self.plans = Some(plans);
         self
@@ -480,6 +514,13 @@ impl Caching {
 /// `RwLock` rather than a lock-free map, and lookups hash table names directly
 /// rather than building a key string, keeping the hit path allocation-free.
 ///
+/// Every table-scoped cache owns its own instance — [`QueryResultsCacheProvider`]
+/// checks it in [`QueryResultsCacheProvider::get_raw_key`]; [`SimpleCache`] and
+/// [`LruCache`] check theirs in [`TabledCacheProvider::get_raw_key_if_fresh`].
+/// The instances need no coordination: each is stamped by its own cache's
+/// invalidation path, and an invalidation fans out to every cache holding
+/// entries for the table.
+///
 /// Memory is bounded at [`MAX_TRACKED_TABLES`] regardless of how many distinct
 /// tables are invalidated over a process lifetime. Table identities are not
 /// bounded by configuration — where DDL is enabled a client can create and
@@ -493,7 +534,7 @@ impl Caching {
 /// self-healing (later invalidations repopulate per-table entries), at the cost
 /// of some lost cache entries in the moments after a collapse.
 #[derive(Default)]
-struct TableInvalidationClock {
+pub(crate) struct TableInvalidationClock {
     state: parking_lot::RwLock<TableInvalidationState>,
 }
 
@@ -539,7 +580,7 @@ impl TableInvalidationClock {
         hasher.finish()
     }
 
-    fn mark_invalidated(&self, table_ref: &TableReference, at: std::time::Instant) {
+    pub(crate) fn mark_invalidated(&self, table_ref: &TableReference, at: std::time::Instant) {
         let key = Self::resolved_key(table_ref);
         let mut state = self.state.write();
 
@@ -554,12 +595,27 @@ impl TableInvalidationClock {
         state.invalidated_at.insert(key, at);
     }
 
+    /// Records that *every* table was invalidated at `at`, folding the map into
+    /// the conservative `discarded_floor`.
+    ///
+    /// Serves [`CacheProvider::invalidate_all`]: a full clear names no table to
+    /// stamp individually, yet a value whose read straddles the clear must
+    /// still be rejected on its later store — including one reading a table
+    /// this clock has never seen. Folding the per-table entries in keeps the
+    /// floor monotonic even if `at` is somehow older than a recorded stamp.
+    pub(crate) fn mark_all_invalidated(&self, at: std::time::Instant) {
+        let mut state = self.state.write();
+        let newest = state.invalidated_at.values().copied().max();
+        state.discarded_floor = state.discarded_floor.max(newest).max(Some(at));
+        state.invalidated_at.clear();
+    }
+
     /// Returns `true` if any of `tables` was invalidated at or after `since`.
     ///
     /// Ties count as invalidated: an invalidation recorded in the same instant
     /// as the read began must be assumed to have happened first, since serving
     /// stale data is worse than losing a cache entry.
-    fn invalidated_since<S: std::hash::BuildHasher>(
+    pub(crate) fn invalidated_since<S: std::hash::BuildHasher>(
         &self,
         tables: &HashSet<TableReference, S>,
         since: std::time::Instant,
@@ -1094,6 +1150,53 @@ mod tests {
         assert!(
             !clock.invalidated_since(&discarded, later),
             "a read beginning after every recorded invalidation must still be cacheable"
+        );
+    }
+
+    /// A full invalidation (`mark_all_invalidated`) must reject every write
+    /// whose read began at or before it — including for tables the clock never
+    /// saw individually — and must not reject reads that began afterwards.
+    #[test]
+    fn table_invalidation_clock_mark_all_covers_every_table() {
+        let clock = TableInvalidationClock::default();
+        let base = std::time::Instant::now();
+        let cleared_at = base + std::time::Duration::from_millis(1);
+
+        // A table with its own entry, and one the clock has never seen.
+        clock.mark_invalidated(&TableReference::bare("customer"), base);
+        clock.mark_all_invalidated(cleared_at);
+
+        let tracked: HashSet<TableReference> = HashSet::from([TableReference::bare("customer")]);
+        let never_seen: HashSet<TableReference> = HashSet::from([TableReference::bare("orders")]);
+
+        // Reads that began at or before the clear are rejected for any table.
+        assert!(clock.invalidated_since(&tracked, base));
+        assert!(
+            clock.invalidated_since(&never_seen, cleared_at),
+            "the floor must stand in for tables with no individual entry"
+        );
+
+        // Self-healing: reads beginning after the clear are unaffected.
+        let later = cleared_at + std::time::Duration::from_millis(1);
+        assert!(!clock.invalidated_since(&tracked, later));
+        assert!(!clock.invalidated_since(&never_seen, later));
+    }
+
+    /// The floor is monotonic: a full invalidation stamped with an instant
+    /// older than a recorded per-table entry must not weaken that entry.
+    #[test]
+    fn table_invalidation_clock_mark_all_keeps_newer_per_table_stamps() {
+        let clock = TableInvalidationClock::default();
+        let base = std::time::Instant::now();
+        let newer = base + std::time::Duration::from_millis(2);
+
+        clock.mark_invalidated(&TableReference::bare("customer"), newer);
+        clock.mark_all_invalidated(base);
+
+        let tables: HashSet<TableReference> = HashSet::from([TableReference::bare("customer")]);
+        assert!(
+            clock.invalidated_since(&tables, base + std::time::Duration::from_millis(1)),
+            "folding the map into the floor must keep its newest stamp"
         );
     }
 

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -20,8 +20,10 @@ use crate::HashBuilder;
 use crate::HashProvider;
 #[cfg(feature = "pingora")]
 use crate::InvalidationDidNotFinishSnafu;
+use crate::ReadStartedAt;
 use crate::Result;
 use crate::Sizeable;
+use crate::TableInvalidationClock;
 use crate::TabledCacheProvider;
 use crate::backend::{CacheBackend, MokaBackend};
 use crate::key::PassthroughHashBuilder;
@@ -194,6 +196,10 @@ pub struct LruCache<
     initial_instant: Instant,
     hits: AtomicU64,
     total_requests: AtomicU64,
+    /// Closes the write-after-invalidation race for values served through
+    /// [`TabledCacheProvider::get_raw_key_if_fresh`] — see
+    /// [`TableInvalidationClock`].
+    table_invalidations: TableInvalidationClock,
 }
 
 impl<
@@ -391,6 +397,7 @@ impl<
             initial_instant: Instant::now(),
             hits: AtomicU64::new(0),
             total_requests: AtomicU64::new(0),
+            table_invalidations: TableInvalidationClock::default(),
         }
     }
 
@@ -415,7 +422,7 @@ impl<
 }
 
 impl<
-    V: Sizeable + AsTableRefs + CacheMetrics + Clone + Send + Sync + 'static,
+    V: Sizeable + AsTableRefs + ReadStartedAt + CacheMetrics + Clone + Send + Sync + 'static,
     T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
     H: Hasher + Send + Sync + 'static,
 > LruCache<V, T, H>
@@ -519,6 +526,12 @@ impl<
     }
 
     async fn invalidate_all(&self) {
+        // Stamped before clearing, never after: a value whose read straddles
+        // this clear is stored later and must be rejected by
+        // `get_raw_key_if_fresh`, and stamping afterwards leaves exactly that
+        // gap one step earlier.
+        self.table_invalidations
+            .mark_all_invalidated(Instant::now());
         self.backend.clear().await;
 
         let now_seconds = self.initial_instant.elapsed().as_secs();
@@ -563,12 +576,19 @@ impl<
 
 #[async_trait]
 impl<
-    V: Sizeable + AsTableRefs + CacheMetrics + Clone + Send + Sync + 'static,
+    V: Sizeable + AsTableRefs + ReadStartedAt + CacheMetrics + Clone + Send + Sync + 'static,
     T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
     H: Hasher + Send + Sync + 'static,
 > TabledCacheProvider<V> for LruCache<V, T, H>
 {
     async fn invalidate_for_table(&self, table_ref: TableReference) -> Result<()> {
+        // Stamped before removing entries, never after: neither the moka
+        // predicate nor the Pingora scan can reach a value stored later by a
+        // read that straddled this invalidation, so `get_raw_key_if_fresh`
+        // must see the stamp first.
+        self.table_invalidations
+            .mark_invalidated(&table_ref, Instant::now());
+
         match &self.backend {
             CacheBackendEnum::Moka(backend) => {
                 // Moka carries an invalidation predicate that it also applies lazily on
@@ -609,6 +629,33 @@ impl<
                 Ok(())
             }
         }
+    }
+
+    async fn get_raw_key_if_fresh(&self, key: &u64) -> Option<V> {
+        // `Fn`, not `FnMut`, so the outcome comes back through a flag —
+        // mirroring `QueryResultsCacheProvider::get_raw_key`, which records the
+        // same stale-rejection metric for the results cache.
+        let rejected_as_stale = std::sync::atomic::AtomicBool::new(false);
+        // Bound to a local rather than passed as `&|…|`: the borrow has to
+        // outlive the await, and an inline temporary leaves that to how the
+        // async body happens to be lowered.
+        let is_fresh = |value: &V| {
+            if self
+                .table_invalidations
+                .invalidated_since(value.as_table_refs().as_ref(), value.read_started_at())
+            {
+                rejected_as_stale.store(true, Ordering::Relaxed);
+                return false;
+            }
+            true
+        };
+        let result = self.get_raw_key_validated(key, &is_fresh).await;
+
+        if rejected_as_stale.load(Ordering::Relaxed) {
+            V::record_stale_rejection();
+        }
+
+        result
     }
 }
 
@@ -680,6 +727,7 @@ mod tests {
             input_tables: Arc::new(HashSet::from([TableReference::Bare {
                 table: Arc::from("test_table"),
             }])),
+            read_started_at: Instant::now(),
         }
     }
 
@@ -1389,6 +1437,14 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "pingora")]
+    impl ReadStartedAt for ThreadRecordingValue {
+        fn read_started_at(&self) -> Instant {
+            // Freshness is not under test here — only where the scan runs.
+            Instant::now()
+        }
+    }
+
     /// The Pingora invalidation scan must not run on the runtime worker that called it.
     ///
     /// Asserted by observing the thread the scan reads values on rather than by racing a
@@ -1681,6 +1737,12 @@ mod tests {
             impl AsTableRefs for $name {
                 fn as_table_refs(&self) -> Arc<HashSet<TableReference>> {
                     self.0.as_table_refs()
+                }
+            }
+
+            impl ReadStartedAt for $name {
+                fn read_started_at(&self) -> Instant {
+                    self.0.read_started_at()
                 }
             }
 

--- a/crates/cache/src/lru_cache.rs
+++ b/crates/cache/src/lru_cache.rs
@@ -196,9 +196,6 @@ pub struct LruCache<
     initial_instant: Instant,
     hits: AtomicU64,
     total_requests: AtomicU64,
-    /// Closes the write-after-invalidation race for values served through
-    /// [`TabledCacheProvider::get_raw_key_if_fresh`] — see
-    /// [`TableInvalidationClock`].
     table_invalidations: TableInvalidationClock,
 }
 

--- a/crates/cache/src/result/mod.rs
+++ b/crates/cache/src/result/mod.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 pub mod embeddings;
+pub mod plan;
 pub mod query;
 pub mod search;
 

--- a/crates/cache/src/result/plan.rs
+++ b/crates/cache/src/result/plan.rs
@@ -1,0 +1,64 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Instant;
+
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::sql::TableReference;
+
+use crate::{AsTableRefs, ReadStartedAt};
+
+/// A cached logical plan, stamped with when planning began.
+///
+/// The stamp is what lets [`crate::TabledCacheProvider::get_raw_key_if_fresh`]
+/// reject a plan built from pre-invalidation catalog state. Planning that
+/// straddles a refresh, DML write, or schema change stores its plan *after*
+/// the invalidation removed existing entries, where a `moka` predicate cannot
+/// see it. A stale plan is not just a stale artifact: it pins
+/// `Arc<dyn TableSource>` references inside its `TableScan` nodes, so
+/// executing it can read the table state it was planned against — and results
+/// computed from it re-enter the results cache under a fresh
+/// [`ReadStartedAt::read_started_at`], defeating that cache's own staleness
+/// check.
+#[derive(Clone)]
+pub struct CachedLogicalPlan {
+    pub plan: LogicalPlan,
+    /// When planning began — captured before the planner reads any catalog
+    /// state, so an invalidation landing while planning is still running
+    /// orders at or after it and rejects the entry.
+    pub planned_at: Instant,
+}
+
+impl CachedLogicalPlan {
+    #[must_use]
+    pub fn new(plan: LogicalPlan, planned_at: Instant) -> Self {
+        Self { plan, planned_at }
+    }
+}
+
+impl AsTableRefs for CachedLogicalPlan {
+    fn as_table_refs(&self) -> Arc<HashSet<TableReference>> {
+        self.plan.as_table_refs()
+    }
+}
+
+impl ReadStartedAt for CachedLogicalPlan {
+    fn read_started_at(&self) -> Instant {
+        self.planned_at
+    }
+}

--- a/crates/cache/src/result/query.rs
+++ b/crates/cache/src/result/query.rs
@@ -235,6 +235,12 @@ impl AsTableRefs for CachedQueryResult {
     }
 }
 
+impl crate::ReadStartedAt for CachedQueryResult {
+    fn read_started_at(&self) -> Instant {
+        self.read_started_at
+    }
+}
+
 pub struct CachedStream {
     /// Vector of record batches
     data: Arc<Vec<RecordBatch>>,

--- a/crates/cache/src/result/search.rs
+++ b/crates/cache/src/result/search.rs
@@ -85,11 +85,22 @@ impl CachedAggregationResult {
 pub struct CachedSearchResult {
     pub results: Arc<HashMap<TableReference, CachedAggregationResult>>,
     pub input_tables: Arc<HashSet<TableReference>>,
+    /// When the search that produced this result began reading its tables.
+    /// Consulted by [`crate::TabledCacheProvider::get_raw_key_if_fresh`]: a
+    /// result whose tables were invalidated at or after this instant may hold
+    /// pre-invalidation rows and is treated as a miss.
+    pub read_started_at: std::time::Instant,
 }
 
 impl AsTableRefs for CachedSearchResult {
     fn as_table_refs(&self) -> Arc<HashSet<TableReference>> {
         Arc::clone(&self.input_tables)
+    }
+}
+
+impl crate::ReadStartedAt for CachedSearchResult {
+    fn read_started_at(&self) -> std::time::Instant {
+        self.read_started_at
     }
 }
 
@@ -163,6 +174,7 @@ mod tests {
                 result.clone(),
             )])),
             input_tables: Arc::new(HashSet::new()),
+            read_started_at: std::time::Instant::now(),
         };
         assert!(
             cached.get_memory_size() * 100 < scan_batch.get_array_memory_size(),
@@ -197,6 +209,7 @@ mod tests {
                 ),
             )])),
             input_tables: Arc::new(HashSet::from([TableReference::bare("docs")])),
+            read_started_at: std::time::Instant::now(),
         }
     }
 

--- a/crates/cache/src/simple_cache.rs
+++ b/crates/cache/src/simple_cache.rs
@@ -39,9 +39,6 @@ pub struct SimpleCache<
     hasher: T,
     max_size: u64,
     ttl: Duration,
-    /// Closes the write-after-invalidation race for values served through
-    /// [`TabledCacheProvider::get_raw_key_if_fresh`] — see
-    /// [`TableInvalidationClock`].
     table_invalidations: TableInvalidationClock,
 }
 

--- a/crates/cache/src/simple_cache.rs
+++ b/crates/cache/src/simple_cache.rs
@@ -16,8 +16,8 @@ limitations under the License.
 
 use crate::key::PassthroughHashBuilder;
 use crate::{
-    AsTableRefs, CacheProvider, FailedToInvalidateCacheSnafu, HashProvider, Result,
-    TabledCacheProvider,
+    AsTableRefs, CacheProvider, FailedToInvalidateCacheSnafu, HashProvider, ReadStartedAt, Result,
+    TableInvalidationClock, TabledCacheProvider,
 };
 use async_trait::async_trait;
 use byte_unit::Byte;
@@ -39,6 +39,10 @@ pub struct SimpleCache<
     hasher: T,
     max_size: u64,
     ttl: Duration,
+    /// Closes the write-after-invalidation race for values served through
+    /// [`TabledCacheProvider::get_raw_key_if_fresh`] — see
+    /// [`TableInvalidationClock`].
+    table_invalidations: TableInvalidationClock,
 }
 
 impl<
@@ -89,12 +93,13 @@ impl<
             hasher,
             ttl,
             max_size: cache_max_size,
+            table_invalidations: TableInvalidationClock::default(),
         }
     }
 }
 
 impl<
-    V: AsTableRefs + Clone + Send + Sync + 'static,
+    V: AsTableRefs + ReadStartedAt + Clone + Send + Sync + 'static,
     T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
     H: Hasher + Send + Sync + 'static,
 > SimpleCache<V, T, H>
@@ -142,6 +147,12 @@ impl<
     }
 
     async fn invalidate_all(&self) {
+        // Stamped before clearing, never after: a value whose read straddles
+        // this clear is stored later and must be rejected by
+        // `get_raw_key_if_fresh`, and stamping afterwards leaves exactly that
+        // gap one step earlier.
+        self.table_invalidations
+            .mark_all_invalidated(std::time::Instant::now());
         self.cache.invalidate_all();
         self.cache.run_pending_tasks().await;
     }
@@ -167,12 +178,18 @@ impl<
 
 #[async_trait]
 impl<
-    V: AsTableRefs + Clone + Send + Sync + 'static,
+    V: AsTableRefs + ReadStartedAt + Clone + Send + Sync + 'static,
     T: BuildHasher<Hasher = H> + Clone + Send + Sync + 'static,
     H: Hasher + Send + Sync + 'static,
 > TabledCacheProvider<V> for SimpleCache<V, T, H>
 {
     async fn invalidate_for_table(&self, table_ref: TableReference) -> Result<()> {
+        // Stamped before registering the predicate, never after: the predicate
+        // misses a value stored later by a read that straddled this
+        // invalidation, so `get_raw_key_if_fresh` must see the stamp first.
+        self.table_invalidations
+            .mark_invalidated(&table_ref, std::time::Instant::now());
+
         let table_name = crate::invalidated_table_name(&table_ref);
         self.cache
             .invalidate_entries_if(move |_key, value| {
@@ -181,6 +198,18 @@ impl<
             .context(FailedToInvalidateCacheSnafu { table_name })?;
 
         Ok(())
+    }
+
+    async fn get_raw_key_if_fresh(&self, key: &u64) -> Option<V> {
+        // Bound to a local rather than passed as `&|…|`: the borrow has to
+        // outlive the await, and an inline temporary leaves that to how the
+        // async body happens to be lowered.
+        let is_fresh = |value: &V| {
+            !self
+                .table_invalidations
+                .invalidated_since(value.as_table_refs().as_ref(), value.read_started_at())
+        };
+        self.get_raw_key_validated(key, &is_fresh).await
     }
 }
 

--- a/crates/cache/tests/invalidation_orderings.rs
+++ b/crates/cache/tests/invalidation_orderings.rs
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// The value/cache constructors below are shared helpers outside `#[test]`
-// functions, where clippy's `allow-expect-in-tests` cannot see them.
-#![allow(clippy::expect_used)]
+#![expect(
+    clippy::expect_used,
+    reason = "the value/cache constructors below are shared helpers outside `#[test]` functions, where clippy's `allow-expect-in-tests` cannot see them"
+)]
 
 //! Both-orderings invalidation tests for every table-scoped cache.
 //!

--- a/crates/cache/tests/invalidation_orderings.rs
+++ b/crates/cache/tests/invalidation_orderings.rs
@@ -1,0 +1,523 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The value/cache constructors below are shared helpers outside `#[test]`
+// functions, where clippy's `allow-expect-in-tests` cannot see them.
+#![allow(clippy::expect_used)]
+
+//! Both-orderings invalidation tests for every table-scoped cache.
+//!
+//! One invariant, stated once: **a cache entry built from a read of table `T`
+//! must not be servable once `T` has been invalidated.** Whether the store
+//! landed before or after the invalidation is an interleaving, not a licence.
+//!
+//! Two orderings can produce such an entry, and only one of them is covered by
+//! `moka`'s predicate invalidation:
+//!
+//! | Ordering | Sequence | Covered by `invalidate_entries_if`? |
+//! |----------|----------|-------------------------------------|
+//! | A — store, then invalidate | read `T` → store → invalidate `T` | yes — the entry exists when the predicate registers |
+//! | B — invalidate, then store of a pre-read | read `T` → invalidate `T` → store | **no** — the predicate only matches entries last modified at or before it registered |
+//!
+//! Ordering B is not exotic: it is what happens whenever a read outlives a
+//! concurrent refresh or DML, which is every read longer than the gap between
+//! two invalidations of the same table.
+//!
+//! Every cache closes ordering B the same way: the entry records when its read
+//! began, and the serving lookup re-checks that against the per-table
+//! invalidation stamp — `QueryResultsCacheProvider` in its own `get_raw_key`,
+//! the plan and search caches through
+//! [`TabledCacheProvider::get_raw_key_if_fresh`]. These tests hold all three
+//! to the invariant through the lookup each one actually serves from, plus the
+//! full-clear (`invalidate_all`) straddle the plan cache hits on schema
+//! changes, and the counterparts proving none of it over-rejects.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow::array::{Int32Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use cache::key::RawCacheKey;
+use cache::result::query::CachedQueryResult;
+use cache::result::search::{CachedAggregationResult, CachedSearchResult};
+use cache::{
+    CachedLogicalPlan, QueryResultsCacheProvider, SimpleCache, TabledCacheProvider,
+    get_hash_builder, lru_cache,
+};
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::logical_expr::builder::{LogicalPlanBuilder, LogicalTableSource};
+use datafusion::sql::TableReference;
+use spicepod::component::caching::{CacheConfig, SQLResultsCacheConfig};
+
+/// The table every entry in these tests reads, and the one that gets
+/// invalidated.
+const READ_TABLE: &str = "customer";
+
+/// A table nothing under test reads. Invalidating it must leave every entry
+/// alone — without this, a cache that dropped *everything* on any invalidation
+/// would pass the ordering tests for the wrong reason.
+const UNRELATED_TABLE: &str = "supplier";
+
+fn schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]))
+}
+
+fn record_batch() -> RecordBatch {
+    RecordBatch::try_new(schema(), vec![Arc::new(Int32Array::from(vec![1, 2, 3]))])
+        .expect("should build record batch")
+}
+
+// ---------------------------------------------------------------------------
+// Cache constructors — each mirrors how `Runtime::init_caching` builds it, so
+// these exercise the shipped configuration rather than a convenient one.
+// `crates/runtime/src/init/caching.rs`.
+// ---------------------------------------------------------------------------
+
+fn results_cache() -> QueryResultsCacheProvider {
+    QueryResultsCacheProvider::try_new(&SQLResultsCacheConfig::default(), Box::new([]))
+        .expect("should build results cache")
+}
+
+fn search_cache() -> Arc<dyn TabledCacheProvider<CachedSearchResult> + Send + Sync> {
+    lru_cache::build_from_config::<CachedSearchResult>(&CacheConfig {
+        // The shipped default is one second, which would let ordering B pass by
+        // expiry rather than by invalidation. A long TTL keeps the test about
+        // the invalidation path; the default TTL is what bounds the *impact*,
+        // not what decides the correctness.
+        item_ttl: Some("1h".to_string()),
+        ..CacheConfig::default()
+    })
+    .expect("should build search cache")
+    .as_tabled_provider()
+}
+
+/// The plan cache as shipped: 512 entries, one-hour TTL, no `enabled` gate.
+fn plan_cache() -> Arc<dyn TabledCacheProvider<CachedLogicalPlan> + Send + Sync> {
+    Arc::new(SimpleCache::new(
+        512,
+        Duration::from_hours(1),
+        get_hash_builder(SQLResultsCacheConfig::default().hashing_algorithm)
+            .expect("should build hasher"),
+    ))
+    .as_tabled_provider()
+}
+
+// ---------------------------------------------------------------------------
+// Value constructors
+// ---------------------------------------------------------------------------
+
+fn cached_query_result(read_started_at: Instant) -> CachedQueryResult {
+    CachedQueryResult::new_raw(
+        vec![record_batch()],
+        schema(),
+        Arc::new(HashSet::from([TableReference::bare(READ_TABLE)])),
+        Instant::now(),
+        read_started_at,
+    )
+}
+
+fn cached_search_result(read_started_at: Instant) -> CachedSearchResult {
+    let batch = record_batch();
+    let aggregation = CachedAggregationResult::new(
+        vec![batch.clone()],
+        vec!["id".to_string()],
+        Vec::new(),
+        HashMap::new(),
+        batch.schema(),
+    );
+
+    CachedSearchResult {
+        results: Arc::new(HashMap::from([(
+            TableReference::bare(READ_TABLE),
+            aggregation,
+        )])),
+        input_tables: Arc::new(HashSet::from([TableReference::bare(READ_TABLE)])),
+        read_started_at,
+    }
+}
+
+/// A `LogicalPlan` whose only `TableScan` reads [`READ_TABLE`], so
+/// `AsTableRefs` resolves to exactly that table.
+fn logical_plan() -> LogicalPlan {
+    LogicalPlanBuilder::scan(
+        TableReference::bare(READ_TABLE),
+        Arc::new(LogicalTableSource::new(schema())),
+        None,
+    )
+    .expect("should build scan")
+    .build()
+    .expect("should build plan")
+}
+
+fn cached_plan(planned_at: Instant) -> CachedLogicalPlan {
+    CachedLogicalPlan::new(logical_plan(), planned_at)
+}
+
+// ---------------------------------------------------------------------------
+// Preconditions — a passing ordering test means nothing if the entry was never
+// there, or if invalidation is simply dropping the whole cache.
+// ---------------------------------------------------------------------------
+
+/// Every value type must actually name [`READ_TABLE`] as an input, otherwise
+/// the invalidation predicate has nothing to match and ordering A would "pass"
+/// vacuously.
+#[test]
+fn every_value_under_test_names_the_table_it_read() {
+    use cache::AsTableRefs;
+
+    let expected = HashSet::from([TableReference::bare(READ_TABLE)]);
+
+    assert_eq!(
+        cached_query_result(Instant::now())
+            .as_table_refs()
+            .as_ref()
+            .clone(),
+        expected,
+        "the results-cache value must name the table it read"
+    );
+    assert_eq!(
+        cached_search_result(Instant::now())
+            .as_table_refs()
+            .as_ref()
+            .clone(),
+        expected,
+        "the search-cache value must name the table it read"
+    );
+    assert_eq!(
+        cached_plan(Instant::now()).as_table_refs().as_ref().clone(),
+        expected,
+        "the plan-cache value must name the table it scanned"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ordering A — store, then invalidate.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn results_cache_ordering_a_store_then_invalidate() {
+    let cache = results_cache();
+    let key = RawCacheKey::new(1);
+
+    cache
+        .put_raw_key(&key, cached_query_result(Instant::now()))
+        .await
+        .expect("should store");
+    assert!(
+        cache
+            .get_raw_key(&key)
+            .await
+            .expect("get should succeed")
+            .is_some(),
+        "hazard not reached: the entry must be servable before the invalidation"
+    );
+
+    cache
+        .invalidate_for_table(TableReference::bare(READ_TABLE))
+        .await
+        .expect("should invalidate");
+
+    assert!(
+        cache
+            .get_raw_key(&key)
+            .await
+            .expect("get should succeed")
+            .is_none(),
+        "results cache, ordering A: an entry stored before the invalidation must not be served after it"
+    );
+}
+
+#[tokio::test]
+async fn search_cache_ordering_a_store_then_invalidate() {
+    let cache = search_cache();
+    let key = 1u64;
+
+    cache
+        .put_raw_key(&key, cached_search_result(Instant::now()))
+        .await;
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_some(),
+        "hazard not reached: the entry must be servable before the invalidation"
+    );
+
+    cache
+        .invalidate_for_table(TableReference::bare(READ_TABLE))
+        .await
+        .expect("should invalidate");
+    cache.checkpoint().await;
+
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_none(),
+        "search cache, ordering A: an entry stored before the invalidation must not be served after it"
+    );
+}
+
+#[tokio::test]
+async fn plan_cache_ordering_a_store_then_invalidate() {
+    let cache = plan_cache();
+    let key = 1u64;
+
+    cache.put_raw_key(&key, cached_plan(Instant::now())).await;
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_some(),
+        "hazard not reached: the entry must be servable before the invalidation"
+    );
+
+    cache
+        .invalidate_for_table(TableReference::bare(READ_TABLE))
+        .await
+        .expect("should invalidate");
+    cache.checkpoint().await;
+
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_none(),
+        "plan cache, ordering A: an entry stored before the invalidation must not be served after it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ordering B — invalidate, then store a value whose read began earlier.
+//
+// The read start is captured *before* the invalidation in every case, so the
+// stored value provably describes pre-invalidation state. The predicate
+// registered by the invalidation cannot see the later store; only the
+// read-time freshness check can reject it.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn results_cache_ordering_b_invalidate_then_store_of_pre_read() {
+    let cache = results_cache();
+    let key = RawCacheKey::new(1);
+
+    let read_started_at = Instant::now();
+    cache
+        .invalidate_for_table(TableReference::bare(READ_TABLE))
+        .await
+        .expect("should invalidate");
+    cache
+        .put_raw_key(&key, cached_query_result(read_started_at))
+        .await
+        .expect("should store");
+
+    assert!(
+        cache
+            .get_raw_key(&key)
+            .await
+            .expect("get should succeed")
+            .is_none(),
+        "results cache, ordering B: a result read before the invalidation must not be served after it"
+    );
+}
+
+#[tokio::test]
+async fn search_cache_ordering_b_invalidate_then_store_of_pre_read() {
+    let cache = search_cache();
+    let key = 1u64;
+
+    let read_started_at = Instant::now();
+    cache
+        .invalidate_for_table(TableReference::bare(READ_TABLE))
+        .await
+        .expect("should invalidate");
+    cache.checkpoint().await;
+    cache
+        .put_raw_key(&key, cached_search_result(read_started_at))
+        .await;
+
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_none(),
+        "search cache, ordering B: a search result read before the invalidation must not be served after it"
+    );
+}
+
+#[tokio::test]
+async fn plan_cache_ordering_b_invalidate_then_store_of_pre_read() {
+    let cache = plan_cache();
+    let key = 1u64;
+
+    let planned_at = Instant::now();
+    cache
+        .invalidate_for_table(TableReference::bare(READ_TABLE))
+        .await
+        .expect("should invalidate");
+    cache.checkpoint().await;
+    cache.put_raw_key(&key, cached_plan(planned_at)).await;
+
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_none(),
+        "plan cache, ordering B: a plan built before the invalidation must not be served after it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Full-clear straddle — `invalidate_all`, then store a value whose read began
+// earlier. This is the plan cache's schema-change path (`clear_cached_plans`):
+// the clear names no table, so only the clock's global floor can reject the
+// racing store.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn plan_cache_full_clear_rejects_store_of_pre_read() {
+    let cache = plan_cache();
+    let key = 1u64;
+
+    let planned_at = Instant::now();
+    cache.invalidate_all().await;
+    cache.put_raw_key(&key, cached_plan(planned_at)).await;
+
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_none(),
+        "plan cache: a plan built before a full clear must not be served after it"
+    );
+}
+
+#[tokio::test]
+async fn search_cache_full_clear_rejects_store_of_pre_read() {
+    let cache = search_cache();
+    let key = 1u64;
+
+    let read_started_at = Instant::now();
+    cache.invalidate_all().await;
+    cache
+        .put_raw_key(&key, cached_search_result(read_started_at))
+        .await;
+
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_none(),
+        "search cache: a result read before a full clear must not be served after it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Self-healing — a value whose read began *after* the invalidation is fresh
+// and must be served. Without these, rejecting every store would satisfy the
+// ordering tests while permanently disabling the cache for any table that was
+// ever invalidated.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn plan_cache_serves_a_plan_built_after_the_invalidation() {
+    let cache = plan_cache();
+    let key = 1u64;
+
+    cache
+        .invalidate_for_table(TableReference::bare(READ_TABLE))
+        .await
+        .expect("should invalidate");
+    cache.invalidate_all().await;
+
+    // Planning begins after both invalidations, so the plan reflects
+    // post-invalidation state.
+    let planned_at = Instant::now();
+    cache.put_raw_key(&key, cached_plan(planned_at)).await;
+
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_some(),
+        "plan cache: a plan built after the invalidation is fresh and must be served"
+    );
+}
+
+#[tokio::test]
+async fn search_cache_serves_a_result_read_after_the_invalidation() {
+    let cache = search_cache();
+    let key = 1u64;
+
+    cache
+        .invalidate_for_table(TableReference::bare(READ_TABLE))
+        .await
+        .expect("should invalidate");
+    cache.invalidate_all().await;
+
+    let read_started_at = Instant::now();
+    cache
+        .put_raw_key(&key, cached_search_result(read_started_at))
+        .await;
+
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_some(),
+        "search cache: a result read after the invalidation is fresh and must be served"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Counterpart tests — the caches must still cache.
+//
+// Without these, deleting every entry on every invalidation would satisfy the
+// ordering tests above while destroying the feature.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn results_cache_keeps_entries_an_unrelated_invalidation_does_not_touch() {
+    let cache = results_cache();
+    let key = RawCacheKey::new(1);
+
+    cache
+        .put_raw_key(&key, cached_query_result(Instant::now()))
+        .await
+        .expect("should store");
+    cache
+        .invalidate_for_table(TableReference::bare(UNRELATED_TABLE))
+        .await
+        .expect("should invalidate");
+
+    assert!(
+        cache
+            .get_raw_key(&key)
+            .await
+            .expect("get should succeed")
+            .is_some(),
+        "results cache: invalidating an unread table must not drop the entry"
+    );
+}
+
+#[tokio::test]
+async fn search_cache_keeps_entries_an_unrelated_invalidation_does_not_touch() {
+    let cache = search_cache();
+    let key = 1u64;
+
+    cache
+        .put_raw_key(&key, cached_search_result(Instant::now()))
+        .await;
+    cache
+        .invalidate_for_table(TableReference::bare(UNRELATED_TABLE))
+        .await
+        .expect("should invalidate");
+    cache.checkpoint().await;
+
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_some(),
+        "search cache: invalidating an unread table must not drop the entry"
+    );
+}
+
+#[tokio::test]
+async fn plan_cache_keeps_entries_an_unrelated_invalidation_does_not_touch() {
+    let cache = plan_cache();
+    let key = 1u64;
+
+    cache.put_raw_key(&key, cached_plan(Instant::now())).await;
+    cache
+        .invalidate_for_table(TableReference::bare(UNRELATED_TABLE))
+        .await
+        .expect("should invalidate");
+    cache.checkpoint().await;
+
+    assert!(
+        cache.get_raw_key_if_fresh(&key).await.is_some(),
+        "plan cache: invalidating an unread table must not drop the entry"
+    );
+}

--- a/crates/runtime-search/src/search_engine.rs
+++ b/crates/runtime-search/src/search_engine.rs
@@ -480,6 +480,11 @@ impl<E: TableProviderExplorer> SearchEngine<E> {
     ) -> Result<(VectorSearchResult, CacheStatus)> {
         Ok(if let Some(cache_provider) = cache_provider {
             tracing::trace!("Search cache is enabled");
+            // Captured before the search reads anything: the stored entry
+            // carries this stamp so `get_raw_key_if_fresh` can reject it once
+            // any table it read is invalidated — including an invalidation
+            // that lands while this search is still streaming its results.
+            let read_started_at = std::time::Instant::now();
             let search_key = SearchKey::from(req);
             let cache_control = request_context.cache_control();
 
@@ -502,13 +507,20 @@ impl<E: TableProviderExplorer> SearchEngine<E> {
 
             match (
                 cache_control,
-                cache_provider.get_raw_key(&raw_cache_key.as_u64()).await,
+                cache_provider
+                    .get_raw_key_if_fresh(&raw_cache_key.as_u64())
+                    .await,
             ) {
                 (CacheControl::NoCache, _) => {
                     tracing::trace!("Search cache bypass");
                     let results = self.search(req).await?;
                     (
-                        wrap_cache_to_result(raw_cache_key, results, Arc::clone(&cache_provider)),
+                        wrap_cache_to_result(
+                            raw_cache_key,
+                            results,
+                            Arc::clone(&cache_provider),
+                            read_started_at,
+                        ),
                         CacheStatus::CacheBypass,
                     )
                 }
@@ -522,7 +534,12 @@ impl<E: TableProviderExplorer> SearchEngine<E> {
                     tracing::trace!("Search cache miss");
                     let results = self.search(req).await?;
                     (
-                        wrap_cache_to_result(raw_cache_key, results, Arc::clone(&cache_provider)),
+                        wrap_cache_to_result(
+                            raw_cache_key,
+                            results,
+                            Arc::clone(&cache_provider),
+                            read_started_at,
+                        ),
                         CacheStatus::CacheMiss,
                     )
                 }
@@ -749,10 +766,15 @@ fn is_field_not_found_on_unrelated_table(tbl: &TableReference, e: &DataFusionErr
     })
 }
 
+/// `read_started_at` is when the search began reading its tables; the stored
+/// entry carries it so a later lookup can reject the entry if any of those
+/// tables is invalidated at or after that instant — see
+/// [`TabledCacheProvider::get_raw_key_if_fresh`].
 fn wrap_cache_to_result(
     key: RawCacheKey,
     aggregation_result: HashMap<TableReference, AggregationResult>,
     cache_provider: Arc<dyn TabledCacheProvider<CachedSearchResult> + Send + Sync>,
+    read_started_at: std::time::Instant,
 ) -> HashMap<TableReference, AggregationResult> {
     // each hashmap entry is an aggregation result which contains a sendable record batch stream
     // for each table reference, we need to wrap the batch stream in another stream to pull out the record batches
@@ -860,6 +882,7 @@ fn wrap_cache_to_result(
         let result = CachedSearchResult {
             results: Arc::new(results),
             input_tables: Arc::new(expected_keys),
+            read_started_at,
         };
 
         if result.get_memory_size() > cache_provider.max_size() {

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -84,7 +84,9 @@ use cache::TabledCacheProvider;
 use cache::result::embeddings::CachedEmbeddingResult;
 use cache::result::query::QueryResult;
 use cache::result::search::CachedSearchResult;
-use cache::{CacheProvider, Caching, QueryResultsCacheProvider, key::RawCacheKey};
+use cache::{
+    CacheProvider, CachedLogicalPlan, Caching, QueryResultsCacheProvider, key::RawCacheKey,
+};
 use data_components::poly::PolyTableProvider;
 use datafusion::catalog::CatalogProvider;
 use datafusion::catalog::SchemaProvider;
@@ -3966,7 +3968,7 @@ impl DataFusion {
 
     pub fn plans_cache_provider(
         &self,
-    ) -> Option<Arc<dyn TabledCacheProvider<LogicalPlan> + Send + Sync>> {
+    ) -> Option<Arc<dyn TabledCacheProvider<CachedLogicalPlan> + Send + Sync>> {
         self.caching.plans.clone()
     }
 
@@ -4738,14 +4740,26 @@ impl DataFusion {
         cache_key_opt: Option<&RawCacheKey>,
         sql: &str,
     ) -> Result<LogicalPlan, DataFusionError> {
+        // Captured before planning reads any catalog state: the stored plan
+        // carries this stamp so `get_raw_key_if_fresh` can reject it once any
+        // table it scans is invalidated — including an invalidation that lands
+        // while this very planning pass is still running.
+        // `create_logical_plan` can block on pending dataset initializations,
+        // so that window is not negligible; without the stamp, the store below
+        // resurrects a plan the invalidation could never see (`moka`
+        // predicates match only entries that exist when they register), and
+        // the plan pins pre-invalidation table state through the
+        // `Arc<dyn TableSource>` in its scans.
+        let planned_at = std::time::Instant::now();
+
         let plans_cache = if let Some(cache_key) = cache_key_opt {
             let plans_cache = self.plans_cache_provider();
 
             if let Some(cache) = plans_cache.as_ref()
-                && let Some(plan) = cache.get_raw_key(&cache_key.as_u64()).await
+                && let Some(cached) = cache.get_raw_key_if_fresh(&cache_key.as_u64()).await
             {
                 tracing::trace!("using cached plan for {sql}");
-                return Ok(plan);
+                return Ok(cached.plan);
             }
             plans_cache
         } else {
@@ -4758,7 +4772,12 @@ impl DataFusion {
             && let Some(cache_key) = cache_key_opt
         {
             tracing::trace!("caching plan for {sql}");
-            cache.put_raw_key(&cache_key.as_u64(), plan.clone()).await;
+            cache
+                .put_raw_key(
+                    &cache_key.as_u64(),
+                    CachedLogicalPlan::new(plan.clone(), planned_at),
+                )
+                .await;
         }
 
         Ok(plan)
@@ -5894,6 +5913,96 @@ mod tests {
         };
         cache_provider.checkpoint().await; // Ensure entry gets logged
         assert_eq!(cache_provider.item_count().await, 1);
+    }
+
+    /// A plan whose planning straddled an invalidation of its table must not
+    /// be served from the plans cache.
+    ///
+    /// The racing store is simulated directly: the plan is stamped as planned
+    /// *before* the invalidation but stored *after* it, which is exactly what
+    /// a planning pass that outlives a concurrent refresh, DML write, or
+    /// schema change produces — and what the invalidation's own entry removal
+    /// can never reach, since the entry does not exist when it runs. The
+    /// wiring under test is `get_or_create_logical_plan` using the
+    /// freshness-checked lookup: served stale, it would keep the poisoned
+    /// entry; replanning, it overwrites it with a fresh one.
+    #[tokio::test]
+    async fn test_get_or_create_logical_plan_rejects_plan_from_before_invalidation() {
+        static SQL: &str = "SELECT id FROM plans_tbl";
+
+        let runtime = RuntimeBuilder::new().build().await;
+        let plan_cache_provider = Arc::new(SimpleCache::new(
+            512,
+            Duration::from_hours(1),
+            std::hash::BuildHasherDefault::<twox_hash::XxHash3_64>::default(),
+        ));
+        let df = Arc::new(
+            DataFusion::builder(
+                status::RuntimeStatus::new(),
+                runtime.accelerator_engine_registry(),
+                Handle::current(),
+            )
+            .with_caching(Arc::new(
+                Caching::new().with_plans_cache(plan_cache_provider),
+            ))
+            .build(),
+        );
+
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let table = MemTable::try_new(
+            Arc::clone(&schema),
+            vec![vec![arrow::array::RecordBatch::new_empty(schema)]],
+        )
+        .expect("valid mem table");
+        df.ctx
+            .register_table(TableReference::bare("plans_tbl"), Arc::new(table))
+            .expect("should register table");
+
+        let session = df.ctx.state();
+        let raw_cache_key =
+            CacheKey::Query(SQL, None).as_raw_key(Box::new(std::hash::DefaultHasher::new()));
+        let cache_provider = df
+            .plans_cache_provider()
+            .expect("plans cache should be configured");
+
+        // The racing planner began before the invalidation...
+        let stale_planned_at = std::time::Instant::now();
+        df.caching()
+            .invalidate_for_table(TableReference::bare("plans_tbl"))
+            .await
+            .expect("invalidation should succeed");
+
+        // ...and stores its plan afterwards, where the invalidation's entry
+        // removal can no longer reach it.
+        let stale_plan = df
+            .create_logical_plan(&session, SQL)
+            .await
+            .expect("should plan directly");
+        cache_provider
+            .put_raw_key(
+                &raw_cache_key.as_u64(),
+                CachedLogicalPlan::new(stale_plan, stale_planned_at),
+            )
+            .await;
+
+        // The lookup must reject the stale entry and replan.
+        df.get_or_create_logical_plan(&session, Some(&raw_cache_key), SQL)
+            .await
+            .expect("logical plan");
+
+        // Served stale, the poisoned entry would remain and still fail the
+        // freshness check; replanned, the store overwrote it with a fresh one.
+        assert!(
+            cache_provider
+                .get_raw_key_if_fresh(&raw_cache_key.as_u64())
+                .await
+                .is_some(),
+            "the stale plan must be replaced by a freshly planned, servable entry"
+        );
     }
 
     #[cfg(all(feature = "duckdb", feature = "snapshots",))]


### PR DESCRIPTION
## 📝 Summary

The read-time invalidation check added in #12703 covered only the SQL results cache. The logical-plan and search caches relied on moka predicate invalidation alone, which cannot see an entry stored *after* the invalidation ran — so a plan or search result whose read straddled a refresh, DML write, or schema change was resurrected into the cache and served until TTL (a hard-coded hour for plans). A stale cached plan also pins pre-invalidation table state through the `TableSource` references in its scans, and results executed from it re-enter the results cache with a fresh timestamp — defeating that cache's own staleness check.

This PR extends the same clock mechanism to all table-scoped caches:

- Each cache owns a `TableInvalidationClock`, stamped before entries are removed.
- Serving lookups go through a new `TabledCacheProvider::get_raw_key_if_fresh`, which treats an entry whose tables were invalidated at or after its read began as a miss.
- Cached values record when their read began: the plans cache stores `CachedLogicalPlan` (plan + planning start), and `CachedSearchResult` gains `read_started_at`.
- Full clears (`invalidate_all`, e.g. schema-change plan-cache clears) stamp a conservative floor covering every table.

Covered by a new integration suite (`crates/cache/tests/invalidation_orderings.rs`) asserting both orderings on all three caches, full-clear straddles, and no over-rejection, plus a runtime test proving `get_or_create_logical_plan` replans instead of serving a stale racing entry.

## 🔗 Related

- #12703 introduced the clock for the SQL results cache.
