### PR TITLE
docs(roadmap): re-slot the release timeline after v2.2 shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,8 @@ Spice.ai is designed to be extensible. See [EXTENSIBILITY.md](./docs/EXTENSIBILI
 
 - **[v2.0](https://spiceai.org/releases/v2.0-stable)** (shipped, June 2026) — Spice Cayenne GA, multi-active HA distributed query GA, native CDC (PostgreSQL WAL, MongoDB change streams, Debezium), DML/DDL write-back, mTLS + OIDC, HashiCorp Vault & Azure Key Vault, and SQL/HTTP UDFs. [Read the launch →](https://spice.ai/blog/spice-2-0-is-now-available)
 - **[v2.1](https://spiceai.org/releases/v2.1.0)** (shipped, July 2026) — High-throughput Cayenne CDC (in-memory tier + dedicated compaction runtime), PostgreSQL replication at scale (shared replication slot), distributed Iceberg scans and broadcast joins, DataFusion v54, tensor-parallel GLM inference, and adaptive self-tuning (experimental).
-- **[v2.2](https://github.com/spiceai/spiceai/milestone/99)** (upcoming, targeting September 2026) — MySQL binlog CDC (already on `trunk`), webhooks, and reactive event-driven actions (Drasi-based).
+- **[v2.2](https://spiceai.org/releases/v2.2.0)** (shipped, August 2026) — Cloud Connect for BYOC runtimes, MySQL binlog CDC, PostgreSQL Catalog CDC, warm in-memory search indexes, Cayenne serializable transactions with durable write-back, and reactive event-driven actions (Drasi, alpha).
+- **[v2.3](https://github.com/spiceai/spiceai/milestone/100)** (upcoming, targeting September 2026) — Schema Registry (initial), full UPDATE/DELETE DML on write-through accelerated tables, and DataFusion v55.
 
 ### 🤝 Connect with us
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,30 +15,32 @@ To propose features or report issues, please [file an issue](https://github.com/
 
 ## Release Timeline
 
-### [v2.2](https://github.com/spiceai/spiceai/milestone/99) (July 2026)
+### [v2.2.1](https://github.com/spiceai/spiceai/milestone/111) (August 2026)
 
-**Focus:** Schema Registry, Distributed Search & Event Processing.
+**Focus:** Patch release — write-back durability, Cayenne, and accelerator stability fixes.
+
+### [v2.3](https://github.com/spiceai/spiceai/milestone/100) (September 2026)
+
+**Focus:** Schema Registry & Write-Back Acceleration.
 
 **DataFusion:** v55
 
 - **Schema Registry (Initial)**: Versioning and backward compatibility checks.
-- **Distributed Search (Alpha)**: Federated vector and full-text search across multiple nodes, with FTS indexes available in distributed query mode.
-- **Webhooks & Event Notifications**: Push-based data change alerts for downstream consumers.
-- **Write-Back Acceleration**: Eventually-consistent write-back, with full DML (UPDATE/DELETE) and `spice refresh`/`refresh_check_interval` on write-through accelerated tables.
+- **Write-Back Acceleration DML**: Full UPDATE/DELETE DML on write-through accelerated tables.
 
-### [v2.3](https://github.com/spiceai/spiceai/milestone/100) (September 2026)
+### [v2.4](https://github.com/spiceai/spiceai/milestone/101) (October 2026)
 
-**Focus:** Enterprise Security, Compliance, & Governance.
+**Focus:** Distributed Search, Enterprise Security, Compliance, & Governance.
 
 **DataFusion:** v56
 
+- **Distributed Search (Alpha)**: Federated vector and full-text search across multiple nodes, with FTS indexes available in distributed query mode.
+- **Distributed Search Scale-Out**: Search query partitioning and relative score fusion across distributed nodes.
+- **Distributed Cayenne Catalog**: Cayenne catalog with full distributed query and acceleration support.
 - **Audit Logging**: Persistent, immutable query and access logs for compliance.
 - **Resource Quotas**: Per-user/tenant query limits and throttling.
-- **Actions (Drasi-based)**: Reactive event-driven actions triggered by data changes.
-- **Distributed Cayenne Catalog**: Cayenne catalog with full distributed query and acceleration support.
-- **Distributed Search Scale-Out**: Search query partitioning and relative score fusion across distributed nodes.
 
-### [v2.4](https://github.com/spiceai/spiceai/milestone/101) (October 2026)
+### [v2.5](https://github.com/spiceai/spiceai/milestone/102) (November 2026)
 
 **Focus:** Extensibility & Plugin Architecture.
 
@@ -48,7 +50,7 @@ To propose features or report issues, please [file an issue](https://github.com/
 - **Search at 100B+ Row Scale**: Vector and full-text search benchmarked and tuned for hundred-billion-row deployments, including S3 Vectors throughput improvements.
 - **Unified Connector Rate Control**: Extend the runtime-wide rate-control surface from HTTP connectors to database and file/object-store connectors for consistent per-origin concurrency and request-rate limits.
 
-### [v2.5](https://github.com/spiceai/spiceai/milestone/102) (November 2026)
+### [v2.6](https://github.com/spiceai/spiceai/milestone/103) (December 2026)
 
 **Focus:** Encryption.
 
@@ -56,6 +58,18 @@ To propose features or report issues, please [file an issue](https://github.com/
 
 - **Customer-Managed Keys (BYOK)**: Encryption key management for sensitive workloads.
 - **Data-at-Rest Encryption**: Encrypted storage for accelerated datasets.
+
+### [v2.7](https://github.com/spiceai/spiceai/milestone/104) (January 2027)
+
+**DataFusion:** v59
+
+Scope is being planned. Candidates are drawn from [Features Under Consideration](#features-under-consideration) — tell us which matter most to you.
+
+### [v2.8](https://github.com/spiceai/spiceai/milestone/105) (February 2027)
+
+**DataFusion:** v60
+
+Scope is being planned. Candidates are drawn from [Features Under Consideration](#features-under-consideration) — tell us which matter most to you.
 
 ---
 


### PR DESCRIPTION
## 📝 Summary

v2.2 [shipped on August 24, 2026](https://spiceai.org/releases/v2.2.0), but only part of its planned scope landed, so the roadmap advertised delivered work as upcoming and stale dates for everything behind it.

Drop the v2.2 section and slide the timeline back one release: DataFusion v55 lands in v2.3, and each subsequent release keeps its theme one slot later.

| Release | Date | DataFusion | Contents |
| --- | --- | --- | --- |
| v2.2.1 | August 2026 | — | Patch: write-back durability, Cayenne, accelerator stability |
| v2.3 | September 2026 | v55 | Schema Registry (Initial), Write-Back Acceleration DML |
| v2.4 | October 2026 | v56 | Distributed Search (Alpha), Distributed Search Scale-Out, Distributed Cayenne Catalog, Audit Logging, Resource Quotas |
| v2.5 | November 2026 | v57 | Extensible Middleware, Search at 100B+ Row Scale, Unified Connector Rate Control |
| v2.6 | December 2026 | v58 | Customer-Managed Keys (BYOK), Data-at-Rest Encryption |
| v2.7 | January 2027 | v59 | Scope in planning |
| v2.8 | February 2027 | v60 | Scope in planning |

Removed outright:

- **Actions (Drasi-based)** — shipped in v2.2 as Drasi (Alpha).
- **Webhooks & Event Notifications** — a Spice.ai Cloud feature, not OSS.

**Write-Back Acceleration** shipped in v2.2 except for UPDATE/DELETE DML on write-through accelerated tables (#10121, #10122, both still open), so only that remainder carries forward to v2.3.

The timeline now also covers every milestone that exists on [GitHub](https://github.com/spiceai/spiceai/milestones) — v2.6, v2.7 and v2.8, plus the v2.2.1 patch — so the roadmap and the milestone list agree.

Finally, the README release list still advertised v2.2 as upcoming with webhooks and Drasi actions; it now reflects what shipped and points at v2.3 as next.

## 🔗 Related

- Milestones: [v2.3](https://github.com/spiceai/spiceai/milestone/100), [v2.4](https://github.com/spiceai/spiceai/milestone/101), [v2.5](https://github.com/spiceai/spiceai/milestone/102), [v2.6](https://github.com/spiceai/spiceai/milestone/103), [v2.7](https://github.com/spiceai/spiceai/milestone/104), [v2.8](https://github.com/spiceai/spiceai/milestone/105)
- Remaining write-back DML: #10121, #10122

## 📚 Docs

Docs-only. No runtime, CLI, or configuration change.

## 👀 Notes for Reviewers

Three calls worth a look:

1. **Dates keep the monthly cadence** anchored on v2.3 = September. GitHub milestone due dates run tighter (~3 weeks: v2.4 due Sep 29, v2.8 due Dec 22), so by v2.8 the roadmap reads about two months later than its milestone. Happy to track the due dates exactly instead.
2. **v2.4 and v2.5 contents also slid one release** (Extensibility → v2.5, Encryption → v2.6). Leaving them put would have given v2.4 eight bullets across two unrelated themes while v2.3 carried one.
3. **v2.7 and v2.8 have no committed features.** Their milestones are empty on GitHub, so they carry a date and a DataFusion version and say scope is being planned rather than implying commitments. DataFusion v59/v60 are extrapolated from the one-major-per-release cadence.
