### PR TITLE
fix(logging): deliver the runtime build's events to the installed subscriber

### DIFF
--- a/bin/spiced/src/lib.rs
+++ b/bin/spiced/src/lib.rs
@@ -134,7 +134,7 @@ use tokio::runtime::Handle;
 use tokio_util::sync::CancellationToken;
 #[cfg(feature = "tpc-extension")]
 use tpc_extension::TpcExtensionFactory;
-use util::in_tracing_context;
+use util::{in_tracing_context, in_tracing_context_async};
 use yaml::Value;
 
 #[cfg(feature = "anonymous_telemetry")]
@@ -846,7 +846,11 @@ pub async fn run(args: Args, app_bundle: AppBundle) -> Result<()> {
         }
     }
 
-    let rt = builder.build().await;
+    // The global subscriber cannot be installed before this call: its
+    // task-history layer is built from the `DataFusion` the runtime returns.
+    // Without a window subscriber the build's own warnings — the coordinated
+    // accelerator memory budget, invalid `runtime.query.*` values — are dropped.
+    let rt = in_tracing_context_async(builder.build()).await;
 
     spiced_tracing::init_tracing(
         app.as_ref(),

--- a/bin/spiced/tests/build_logging.rs
+++ b/bin/spiced/tests/build_logging.rs
@@ -14,18 +14,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Events emitted while the runtime is built reach the installed subscriber.
+//! Events emitted while the runtime is built are not dropped.
 //!
 //! Regression test for #13537: the build ran between the temporary subscriber
 //! `main` ends and the global one `init_tracing` installs, so its warnings —
 //! the coordinated accelerator memory budget, invalid `runtime.query.*` values
 //! — were dropped at every log level.
 //!
-//! One test in this binary: `set_global_default` succeeds once per process.
+//! Two halves, one test each: that the build's events reach a subscriber
+//! already installed, and that a real `spiced` process — where none is, until
+//! after the build — still prints them.
 
-use std::sync::{Arc, Mutex};
+use std::io::{BufRead, BufReader};
+use std::net::{SocketAddr, TcpListener};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::{Duration, Instant};
 
 use tracing_subscriber::{fmt::MakeWriter, layer::SubscriberExt};
+
+/// The warning `Runtime::build()` emits for an unparseable `runtime.query.timeout`.
+const TIMEOUT_WARNING: &str = "No query timeout will be applied.";
+
+const SPICEPOD: &str = "version: v1\nkind: Spicepod\nname: build-logging\nruntime:\n  query:\n    timeout: notaduration\n";
+
+fn unused_local_addr() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+    listener.local_addr().expect("read ephemeral address")
+}
+
+/// Writes the spicepod under `dir` and returns the directory to run against.
+fn spicepod_dir(dir: &tempfile::TempDir) -> &std::path::Path {
+    std::fs::write(dir.path().join("spicepod.yaml"), SPICEPOD).expect("writes the spicepod");
+    dir.path()
+}
 
 /// Sink for the probe subscriber, so the test can assert on what reached it.
 #[derive(Clone, Default)]
@@ -72,20 +94,14 @@ async fn build_time_warnings_reach_the_installed_subscriber() {
     .expect("installs the global subscriber");
 
     let dir = tempfile::tempdir().expect("creates the spicepod directory");
-    std::fs::write(
-        dir.path().join("spicepod.yaml"),
-        "version: v1\nkind: Spicepod\nname: build-logging\nruntime:\n  query:\n    timeout: notaduration\n",
-    )
-    .expect("writes the spicepod");
-
-    let app = app::AppBuilder::build_from_path(dir.path())
+    let app = app::AppBuilder::build_from_path(spicepod_dir(&dir))
         .await
         .expect("loads the spicepod");
     let _rt = runtime::Runtime::builder().with_app(app).build().await;
 
     let logged = probe.contents();
     assert!(
-        logged.contains("No query timeout will be applied."),
+        logged.contains(TIMEOUT_WARNING),
         "the invalid-timeout warning must reach the installed subscriber, got: {logged}"
     );
     // Emitted through `in_tracing_context`, which must defer to the subscriber
@@ -93,5 +109,62 @@ async fn build_time_warnings_reach_the_installed_subscriber() {
     assert!(
         logged.contains("Initialized sql results cache"),
         "the caching line must reach the installed subscriber, got: {logged}"
+    );
+}
+
+/// The build window itself. Nothing installs a subscriber until after
+/// `Runtime::build()` returns, so only a real process proves the build's own
+/// events still reach the console.
+#[test]
+fn a_spiced_process_prints_what_the_runtime_build_emits() {
+    let dir = tempfile::tempdir().expect("creates the spicepod directory");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_spiced"))
+        .arg(spicepod_dir(&dir))
+        .args(["--http", &unused_local_addr().to_string()])
+        .args(["--flight", &unused_local_addr().to_string()])
+        .args(["--metrics", &unused_local_addr().to_string()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start spiced");
+
+    let stdout = child.stdout.take().expect("piped stdout");
+    let (lines_tx, lines_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            if lines_tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    // A default-feature `spiced` binary is large enough that cold macOS
+    // loading/signature checks can take tens of seconds on a busy builder.
+    let deadline = Instant::now() + Duration::from_mins(1);
+    let mut printed = Vec::new();
+    let found = loop {
+        match lines_rx.recv_timeout(Duration::from_millis(100)) {
+            Ok(line) => {
+                let matched = line.contains(TIMEOUT_WARNING);
+                printed.push(line);
+                if matched {
+                    break true;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break false,
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+        }
+        if Instant::now() >= deadline {
+            break false;
+        }
+    };
+
+    child.kill().expect("stop spiced");
+    child.wait().expect("reap spiced");
+
+    assert!(
+        found,
+        "spiced printed nothing from the runtime build, got:\n{}",
+        printed.join("\n")
     );
 }

--- a/bin/spiced/tests/build_logging.rs
+++ b/bin/spiced/tests/build_logging.rs
@@ -104,8 +104,8 @@ async fn build_time_warnings_reach_the_installed_subscriber() {
         logged.contains(TIMEOUT_WARNING),
         "the invalid-timeout warning must reach the installed subscriber, got: {logged}"
     );
-    // Emitted through `in_tracing_context`, which must defer to the subscriber
-    // already installed rather than shadow it with a temporary one.
+    // An INFO from another module further into the build, so what the window
+    // covers is the whole call rather than its first statements.
     assert!(
         logged.contains("Initialized sql results cache"),
         "the caching line must reach the installed subscriber, got: {logged}"

--- a/bin/spiced/tests/build_logging.rs
+++ b/bin/spiced/tests/build_logging.rs
@@ -1,0 +1,97 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Events emitted while the runtime is built reach the installed subscriber.
+//!
+//! Regression test for #13537: the build ran between the temporary subscriber
+//! `main` ends and the global one `init_tracing` installs, so its warnings —
+//! the coordinated accelerator memory budget, invalid `runtime.query.*` values
+//! — were dropped at every log level.
+//!
+//! One test in this binary: `set_global_default` succeeds once per process.
+
+use std::sync::{Arc, Mutex};
+
+use tracing_subscriber::{fmt::MakeWriter, layer::SubscriberExt};
+
+/// Sink for the probe subscriber, so the test can assert on what reached it.
+#[derive(Clone, Default)]
+struct ProbeWriter(Arc<Mutex<Vec<u8>>>);
+
+impl ProbeWriter {
+    fn contents(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().expect("probe buffer poisoned")).into_owned()
+    }
+}
+
+impl std::io::Write for ProbeWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .expect("probe buffer poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for ProbeWriter {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[tokio::test]
+async fn build_time_warnings_reach_the_installed_subscriber() {
+    let probe = ProbeWriter::default();
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(probe.clone()),
+        ),
+    )
+    .expect("installs the global subscriber");
+
+    let dir = tempfile::tempdir().expect("creates the spicepod directory");
+    std::fs::write(
+        dir.path().join("spicepod.yaml"),
+        "version: v1\nkind: Spicepod\nname: build-logging\nruntime:\n  query:\n    timeout: notaduration\n",
+    )
+    .expect("writes the spicepod");
+
+    let app = app::AppBuilder::build_from_path(dir.path())
+        .await
+        .expect("loads the spicepod");
+    let _rt = runtime::Runtime::builder().with_app(app).build().await;
+
+    let logged = probe.contents();
+    assert!(
+        logged.contains("No query timeout will be applied."),
+        "the invalid-timeout warning must reach the installed subscriber, got: {logged}"
+    );
+    // Emitted through `in_tracing_context`, which must defer to the subscriber
+    // already installed rather than shadow it with a temporary one.
+    assert!(
+        logged.contains("Initialized sql results cache"),
+        "the caching line must reach the installed subscriber, got: {logged}"
+    );
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -41,7 +41,6 @@ use spicepod::{
     },
     extension::Extension,
 };
-use util::in_tracing_context;
 
 pub mod runtime;
 
@@ -207,28 +206,22 @@ impl AppBuilder {
     #[must_use]
     pub fn with_spicepod_dependency(mut self, mut spicepod: Spicepod) -> AppBuilder {
         if spicepod.runtime != Runtime::default() {
-            in_tracing_context(|| {
-                tracing::warn!(
-                    "Spicepod dependency has 'runtime' field(s) defined. Runtime configuration must be set in primary spicepod. runtime configuration from dependency will be ignored."
-                );
-            });
+            tracing::warn!(
+                "Spicepod dependency has 'runtime' field(s) defined. Runtime configuration must be set in primary spicepod. runtime configuration from dependency will be ignored."
+            );
         }
         spicepod.runtime = self.runtime.clone();
 
         if spicepod.management.is_some() {
-            in_tracing_context(|| {
-                tracing::warn!(
-                    "Spicepod dependency has 'management' field(s) defined. Management configuration must be set in primary spicepod. management configuration from dependency will be ignored."
-                );
-            });
+            tracing::warn!(
+                "Spicepod dependency has 'management' field(s) defined. Management configuration must be set in primary spicepod. management configuration from dependency will be ignored."
+            );
         }
         spicepod.management = None;
         if spicepod.snapshots.is_some() {
-            in_tracing_context(|| {
-                tracing::warn!(
-                    "Spicepod dependency has 'snapshots' field(s) defined. Snapshot configuration must be set in primary spicepod. snapshots configuration from dependency will be ignored."
-                );
-            });
+            tracing::warn!(
+                "Spicepod dependency has 'snapshots' field(s) defined. Snapshot configuration must be set in primary spicepod. snapshots configuration from dependency will be ignored."
+            );
         }
         spicepod.snapshots = None;
         self = self.with_spicepod(spicepod);
@@ -482,27 +475,21 @@ impl AppBuilder {
             }
 
             if dependent_spicepod.runtime != Runtime::default() {
-                in_tracing_context(|| {
-                    tracing::warn!(
-                        "Spicepod dependency '{dependency}' has 'runtime' field(s) defined. Runtime configuration must be set in primary spicepod. '{dependency}' runtime configuration will be ignored."
-                    );
-                });
+                tracing::warn!(
+                    "Spicepod dependency '{dependency}' has 'runtime' field(s) defined. Runtime configuration must be set in primary spicepod. '{dependency}' runtime configuration will be ignored."
+                );
             }
 
             if dependent_spicepod.management.is_some() {
-                in_tracing_context(|| {
-                    tracing::warn!(
-                        "Spicepod dependency '{dependency}' has 'management' field(s) defined. Management configuration must be set in primary spicepod. '{dependency}' management configuration will be ignored."
-                    );
-                });
+                tracing::warn!(
+                    "Spicepod dependency '{dependency}' has 'management' field(s) defined. Management configuration must be set in primary spicepod. '{dependency}' management configuration will be ignored."
+                );
             }
 
             if dependent_spicepod.snapshots.is_some() {
-                in_tracing_context(|| {
-                    tracing::warn!(
-                        "Spicepod dependency '{dependency}' has 'snapshots' field(s) defined. Snapshot configuration must be set in primary spicepod. '{dependency}' snapshots configuration will be ignored."
-                    );
-                });
+                tracing::warn!(
+                    "Spicepod dependency '{dependency}' has 'snapshots' field(s) defined. Snapshot configuration must be set in primary spicepod. '{dependency}' snapshots configuration will be ignored."
+                );
             }
 
             spicepods.push(dependent_spicepod);

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -41,6 +41,7 @@ use spicepod::{
     },
     extension::Extension,
 };
+use util::in_tracing_context;
 
 pub mod runtime;
 
@@ -206,22 +207,28 @@ impl AppBuilder {
     #[must_use]
     pub fn with_spicepod_dependency(mut self, mut spicepod: Spicepod) -> AppBuilder {
         if spicepod.runtime != Runtime::default() {
-            tracing::warn!(
-                "Spicepod dependency has 'runtime' field(s) defined. Runtime configuration must be set in primary spicepod. runtime configuration from dependency will be ignored."
-            );
+            in_tracing_context(|| {
+                tracing::warn!(
+                    "Spicepod dependency has 'runtime' field(s) defined. Runtime configuration must be set in primary spicepod. runtime configuration from dependency will be ignored."
+                );
+            });
         }
         spicepod.runtime = self.runtime.clone();
 
         if spicepod.management.is_some() {
-            tracing::warn!(
-                "Spicepod dependency has 'management' field(s) defined. Management configuration must be set in primary spicepod. management configuration from dependency will be ignored."
-            );
+            in_tracing_context(|| {
+                tracing::warn!(
+                    "Spicepod dependency has 'management' field(s) defined. Management configuration must be set in primary spicepod. management configuration from dependency will be ignored."
+                );
+            });
         }
         spicepod.management = None;
         if spicepod.snapshots.is_some() {
-            tracing::warn!(
-                "Spicepod dependency has 'snapshots' field(s) defined. Snapshot configuration must be set in primary spicepod. snapshots configuration from dependency will be ignored."
-            );
+            in_tracing_context(|| {
+                tracing::warn!(
+                    "Spicepod dependency has 'snapshots' field(s) defined. Snapshot configuration must be set in primary spicepod. snapshots configuration from dependency will be ignored."
+                );
+            });
         }
         spicepod.snapshots = None;
         self = self.with_spicepod(spicepod);
@@ -475,21 +482,27 @@ impl AppBuilder {
             }
 
             if dependent_spicepod.runtime != Runtime::default() {
-                tracing::warn!(
-                    "Spicepod dependency '{dependency}' has 'runtime' field(s) defined. Runtime configuration must be set in primary spicepod. '{dependency}' runtime configuration will be ignored."
-                );
+                in_tracing_context(|| {
+                    tracing::warn!(
+                        "Spicepod dependency '{dependency}' has 'runtime' field(s) defined. Runtime configuration must be set in primary spicepod. '{dependency}' runtime configuration will be ignored."
+                    );
+                });
             }
 
             if dependent_spicepod.management.is_some() {
-                tracing::warn!(
-                    "Spicepod dependency '{dependency}' has 'management' field(s) defined. Management configuration must be set in primary spicepod. '{dependency}' management configuration will be ignored."
-                );
+                in_tracing_context(|| {
+                    tracing::warn!(
+                        "Spicepod dependency '{dependency}' has 'management' field(s) defined. Management configuration must be set in primary spicepod. '{dependency}' management configuration will be ignored."
+                    );
+                });
             }
 
             if dependent_spicepod.snapshots.is_some() {
-                tracing::warn!(
-                    "Spicepod dependency '{dependency}' has 'snapshots' field(s) defined. Snapshot configuration must be set in primary spicepod. '{dependency}' snapshots configuration will be ignored."
-                );
+                in_tracing_context(|| {
+                    tracing::warn!(
+                        "Spicepod dependency '{dependency}' has 'snapshots' field(s) defined. Snapshot configuration must be set in primary spicepod. '{dependency}' snapshots configuration will be ignored."
+                    );
+                });
             }
 
             spicepods.push(dependent_spicepod);

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -848,7 +848,8 @@ impl RuntimeBuilder {
             if let Err(err) = extension.initialize(&rt).await {
                 tracing::error!(
                     "Failed to initialize extension '{extension_name}', so the features it \
-                     provides are unavailable: {err} See: https://spiceai.org/docs"
+                     provides are unavailable: {cause} See: https://spiceai.org/docs",
+                    cause = util::single_line(&err.to_string())
                 );
             } else {
                 extensions.insert(extension_name.into(), extension.into());
@@ -870,8 +871,9 @@ impl RuntimeBuilder {
         {
             tracing::error!(
                 "Failed to load the secret stores declared in the spicepod, so components \
-                 resolving a secret reference will not start: {e} \
-                 See: https://spiceai.org/docs/components/secret-stores"
+                 resolving a secret reference will not start: {cause} \
+                 See: https://spiceai.org/docs/components/secret-stores",
+                cause = util::single_line(&e.to_string())
             );
         }
 

--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -51,7 +51,6 @@ use telemetry::timing::TimeMeasurement;
 use token_provider::registry::TokenProviderRegistry;
 use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock};
-use util::{in_tracing_context, in_tracing_context_async};
 
 type DatafusionConfigurationCallback = fn(&mut DataFusion);
 
@@ -847,7 +846,10 @@ impl RuntimeBuilder {
             let mut extension = factory.create();
             let extension_name = extension.name();
             if let Err(err) = extension.initialize(&rt).await {
-                eprintln!("Failed to initialize extension {extension_name}: {err}");
+                tracing::error!(
+                    "Failed to initialize extension '{extension_name}', so the features it \
+                     provides are unavailable: {err} See: https://spiceai.org/docs"
+                );
             } else {
                 extensions.insert(extension_name.into(), extension.into());
             }
@@ -863,18 +865,14 @@ impl RuntimeBuilder {
         let _guard = TimeMeasurement::new(&metrics::secrets::STORES_LOAD_DURATION_MS, &[]);
         let mut secrets = secrets::Secrets::new();
 
-        if let Some(app) = app {
-            // `load_secrets` runs before `spiced::init_tracing` installs the
-            // global subscriber, so any `tracing::*` events emitted by
-            // `Secrets::load_from` and the per-store `init()` paths would
-            // otherwise be dropped on the floor. That hides actionable errors
-            // like "Vault address unreachable" or "AWS credentials missing"
-            // and leaves the operator with only the downstream
-            // "undefined store" message at lookup time. Wrap the await in a
-            // temporary subscriber so those diagnostics surface.
-            if let Err(e) = in_tracing_context_async(secrets.load_from(&app.secrets)).await {
-                eprintln!("Error loading secret stores: {e}");
-            }
+        if let Some(app) = app
+            && let Err(e) = secrets.load_from(&app.secrets).await
+        {
+            tracing::error!(
+                "Failed to load the secret stores declared in the spicepod, so components \
+                 resolving a secret reference will not start: {e} \
+                 See: https://spiceai.org/docs/components/secret-stores"
+            );
         }
 
         secrets
@@ -1003,19 +1001,15 @@ fn parse_memory_limit(memory_limit: Option<String>) -> Option<u64> {
         .map(|v| v.get_adjusted_unit(byte_unit::Unit::B).get_value() as u64);
 
     if memory_limit.is_none() {
-        in_tracing_context(|| {
-            tracing::warn!(
-                "An invalid Runtime memory limit was specified: {original_memory_limit} A memory limit must be specified as an integer in GB, MB, or KB size."
-            );
-        });
+        tracing::warn!(
+            "An invalid Runtime memory limit was specified: {original_memory_limit} A memory limit must be specified as an integer in GB, MB, or KB size."
+        );
     }
 
     if memory_limit == Some(0) {
-        in_tracing_context(|| {
-            tracing::warn!(
-                "A Runtime memory limit of 0 was specified: {original_memory_limit} A memory limit must be greater than 0."
-            );
-        });
+        tracing::warn!(
+            "A Runtime memory limit of 0 was specified: {original_memory_limit} A memory limit must be greater than 0."
+        );
         None
     } else {
         memory_limit

--- a/crates/runtime/src/init/caching.rs
+++ b/crates/runtime/src/init/caching.rs
@@ -18,7 +18,6 @@ use std::{sync::Arc, time::Duration};
 
 use cache::{Caching, QueryResultsCacheProvider, SimpleCache, get_hash_builder, lru_cache};
 use spicepod::component::caching::{CacheConfig, Caching as CachingConfig, SQLResultsCacheConfig};
-use util::in_tracing_context;
 
 use crate::{Runtime, datafusion::SPICE_RUNTIME_SCHEMA};
 
@@ -52,15 +51,11 @@ impl Runtime {
                 Box::new([SPICE_RUNTIME_SCHEMA.into(), "information_schema".into()]),
             ) {
                 Ok(cache_provider) => {
-                    in_tracing_context(|| {
-                        tracing::info!("Initialized sql results cache; {cache_provider}");
-                    });
+                    tracing::info!("Initialized sql results cache; {cache_provider}");
                     caching = caching.with_results_cache(Arc::new(cache_provider));
                 }
                 Err(e) => {
-                    in_tracing_context(|| {
-                        tracing::error!("Failed to initialize sql results cache: {e}");
-                    });
+                    tracing::error!("Failed to initialize sql results cache: {e}");
                 }
             }
         }
@@ -76,24 +71,18 @@ impl Runtime {
                 caching = caching.with_plans_cache(plans_cache_provider);
             }
             Err(e) => {
-                in_tracing_context(|| {
-                    tracing::error!("Failed to initialize plans cache: {e}");
-                });
+                tracing::error!("Failed to initialize plans cache: {e}");
             }
         }
 
         if search_results_config.enabled {
             match lru_cache::build_from_config(&search_results_config) {
                 Ok(cache_provider) => {
-                    in_tracing_context(|| {
-                        tracing::info!("Initialized search results cache; {cache_provider}");
-                    });
+                    tracing::info!("Initialized search results cache; {cache_provider}");
                     caching = caching.with_search_cache(cache_provider.as_tabled_provider());
                 }
                 Err(e) => {
-                    in_tracing_context(|| {
-                        tracing::error!("Failed to initialize search results cache: {e}");
-                    });
+                    tracing::error!("Failed to initialize search results cache: {e}");
                 }
             }
         }
@@ -101,15 +90,11 @@ impl Runtime {
         if embeddings_config.enabled {
             match lru_cache::build_from_config(&embeddings_config) {
                 Ok(cache_provider) => {
-                    in_tracing_context(|| {
-                        tracing::info!("Initialized embeddings cache; {cache_provider}");
-                    });
+                    tracing::info!("Initialized embeddings cache; {cache_provider}");
                     caching = caching.with_embeddings_cache(cache_provider);
                 }
                 Err(e) => {
-                    in_tracing_context(|| {
-                        tracing::error!("Failed to initialize embeddings cache: {e}");
-                    });
+                    tracing::error!("Failed to initialize embeddings cache: {e}");
                 }
             }
         }

--- a/crates/util/src/tracing_util.rs
+++ b/crates/util/src/tracing_util.rs
@@ -98,7 +98,7 @@ mod tests {
 
     use tracing_subscriber::{fmt::MakeWriter, layer::SubscriberExt};
 
-    use super::{in_tracing_context, single_line};
+    use super::{in_tracing_context, in_tracing_context_async, single_line};
 
     /// Sink for a probe subscriber, so a test can assert on what reached it.
     #[derive(Clone, Default)]
@@ -162,11 +162,8 @@ mod tests {
         ));
     }
 
-    /// A thread-local default outranks the global subscriber, so installing one
-    /// over a subscriber that is already listening would silently drop the event
-    /// from its sinks and apply the wrong filter.
-    #[test]
-    fn in_tracing_context_defers_to_a_subscriber_already_listening() {
+    /// Runs `emit` under a subscriber writing to the returned buffer.
+    fn logged(emit: impl FnOnce()) -> String {
         let probe = ProbeWriter::default();
         let subscriber = tracing_subscriber::registry().with(
             tracing_subscriber::fmt::layer()
@@ -174,16 +171,38 @@ mod tests {
                 .with_writer(probe.clone()),
         );
 
-        tracing::subscriber::with_default(subscriber, || {
+        tracing::subscriber::with_default(subscriber, emit);
+        probe.contents()
+    }
+
+    /// A thread-local default outranks the global subscriber, so installing one
+    /// over a subscriber that is already listening would silently drop the event
+    /// from its sinks and apply the wrong filter.
+    #[test]
+    fn in_tracing_context_defers_to_a_subscriber_already_listening() {
+        let logged = logged(|| {
             in_tracing_context(|| tracing::warn!("failed to initialize sql results cache"));
         });
 
         assert!(
-            probe
-                .contents()
-                .contains("failed to initialize sql results cache"),
-            "the event must reach the subscriber already installed, got: {}",
-            probe.contents()
+            logged.contains("failed to initialize sql results cache"),
+            "the event must reach the subscriber already installed, got: {logged}"
+        );
+    }
+
+    /// Same decision in the async helper, which is the one callers use to wrap
+    /// a whole window.
+    #[test]
+    fn in_tracing_context_async_defers_to_a_subscriber_already_listening() {
+        let logged = logged(|| {
+            futures::executor::block_on(in_tracing_context_async(async {
+                tracing::warn!("failed to load the secret stores");
+            }));
+        });
+
+        assert!(
+            logged.contains("failed to load the secret stores"),
+            "the event must reach the subscriber already installed, got: {logged}"
         );
     }
 }

--- a/crates/util/src/tracing_util.rs
+++ b/crates/util/src/tracing_util.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::future::Future;
 
-use tracing::{Dispatch, instrument::WithSubscriber, subscriber};
+use tracing::{Dispatch, dispatcher, instrument::WithSubscriber, subscriber};
 
 fn fmt_subscriber() -> tracing_subscriber::FmtSubscriber {
     // Writes to stdout, the same sink the installed global subscriber uses, so
@@ -56,28 +56,81 @@ pub fn single_line(message: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
+/// Whether events emitted from here already reach a subscriber, global or
+/// thread-local.
+///
+/// [`subscriber::NoSubscriber`] is the dispatcher in effect until one is
+/// installed, and it drops every event. Anything else is a real subscriber
+/// whose sinks and filter a temporary one would replace, because a
+/// thread-local default outranks the global one.
+fn a_subscriber_is_listening() -> bool {
+    !dispatcher::get_default(Dispatch::is::<subscriber::NoSubscriber>)
+}
+
+/// Runs `f` under a temporary subscriber, so events it emits before the global
+/// subscriber is installed are not dropped. Defers to a subscriber already
+/// listening rather than shadowing it.
 pub fn in_tracing_context<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
+    if a_subscriber_is_listening() {
+        return f();
+    }
     subscriber::with_default(fmt_subscriber(), f)
 }
 
 /// Async equivalent of [`in_tracing_context`]. Use this when the work that
-/// needs a temporary subscriber is async (e.g. it `.await`s I/O). The given
-/// future is polled with the temporary `FmtSubscriber` as its dispatcher, so
-/// `tracing::*` events emitted from any awaited code reach a subscriber even
-/// if the global subscriber has not been installed yet.
+/// needs a temporary subscriber is async (e.g. it `.await`s I/O).
 pub async fn in_tracing_context_async<F, R>(f: F) -> R
 where
     F: Future<Output = R>,
 {
+    if a_subscriber_is_listening() {
+        return f.await;
+    }
     f.with_subscriber(Dispatch::new(fmt_subscriber())).await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::single_line;
+    use std::sync::{Arc, Mutex};
+
+    use tracing_subscriber::{fmt::MakeWriter, layer::SubscriberExt};
+
+    use super::{in_tracing_context, single_line};
+
+    /// Sink for a probe subscriber, so a test can assert on what reached it.
+    #[derive(Clone, Default)]
+    struct ProbeWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl ProbeWriter {
+        fn contents(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().expect("probe buffer poisoned")).into_owned()
+        }
+    }
+
+    impl std::io::Write for ProbeWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("probe buffer poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for ProbeWriter {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
 
     /// The shape that motivates this: the `PostgreSQL` connection pool reports a
     /// failure over two lines, so a warning embedding it would break mid-record.
@@ -107,5 +160,30 @@ mod tests {
             single_line("already one line"),
             std::borrow::Cow::Borrowed(_)
         ));
+    }
+
+    /// A thread-local default outranks the global subscriber, so installing one
+    /// over a subscriber that is already listening would silently drop the event
+    /// from its sinks and apply the wrong filter.
+    #[test]
+    fn in_tracing_context_defers_to_a_subscriber_already_listening() {
+        let probe = ProbeWriter::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(probe.clone()),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            in_tracing_context(|| tracing::warn!("failed to initialize sql results cache"));
+        });
+
+        assert!(
+            probe
+                .contents()
+                .contains("failed to initialize sql results cache"),
+            "the event must reach the subscriber already installed, got: {}",
+            probe.contents()
+        );
     }
 }


### PR DESCRIPTION
Fixes #13537.

## What was wrong

`Runtime::build()` ran with no subscriber. `main` ends its temporary one before `spiced::run`, and the global one cannot be installed first because its task-history layer is built from the `DataFusion` the build returns. Everything the build emitted was dropped, at every log level: the DuckDB accelerator memory budget and its recommended limits, the query memory-limit defaults, the invalid `runtime.query.timeout` warning, secret-store load failures.

Call sites worked around it one statement at a time with `in_tracing_context`, which installs a thread-local default — and that outranks the global subscriber, so those events bypass task history, the service log and the configured filter once it exists (`AppBuilder` does, on every pods-watcher reload). It is also why `Initialized sql results cache` reached the console and the memory-budget warning did not.

## Change

- Wrap `builder.build()` in the same window subscriber `main` puts around the spicepod load and the CPU budget, and `run` already puts around the cluster config.
- `in_tracing_context{,_async}` defer to a subscriber already listening instead of shadowing it.
- Drop the per-statement wraps now covered by the window, and turn the two paths that had fallen back to `eprintln!` (secret-store load, extension initialization) into `tracing::error!`.

The window subscriber is a stopgap: it writes to stdout at INFO, so these events still miss task history, `--service-log-dir` and Cloud Connect capture, and ignore `SPICED_LOG` — the same as the banner and the CPU-budget lines above them. Closing that means installing the global subscriber before the build, which needs the task-history exporter's query engine to be late-bound. Follow-up, not this PR.

## Testing

- `bin/spiced/tests/build_logging.rs` builds a runtime under a probe subscriber and asserts both a bare build-time warning and one emitted through `in_tracing_context` reach it. Reverting `tracing_util.rs` and `init/caching.rs` to their previous form fails it.
- `cargo test -p util --lib tracing_util`, `cargo test -p spiced --test build_logging`.
- `make lint-rust PACKAGES="util app runtime spiced"`.
