### PR TITLE
fix(ci): allow '#' in Remote Sign-off branch names

### DIFF
--- a/.github/workflows/signoff.yml
+++ b/.github/workflows/signoff.yml
@@ -185,15 +185,16 @@ jobs:
             fi
             echo "Signing off PR #${PR_NUMBER}: ${checkout_repo}@${checkout_ref}"
           elif [[ -n "${BRANCH// }" ]]; then
-            # Mirror scripts/signoff remote: allow feature/foo, reject whitespace,
-            # quotes, $, `, leading dashes, absolute paths, `..`, and any char
-            # outside [A-Za-z0-9._/-] so dispatch/checkout cannot be broken by the name.
+            # Mirror scripts/signoff remote: allow feature/foo and issue-#123-style
+            # names, reject whitespace, quotes, $, `, leading dashes, absolute
+            # paths, `..`, and any char outside [A-Za-z0-9._/#-] so dispatch/checkout
+            # cannot be broken by the name.
             if [[ "$BRANCH" =~ [[:space:]] || "$BRANCH" == -* || "$BRANCH" == /* || "$BRANCH" == *..* \
                 || "$BRANCH" == *\"* || "$BRANCH" == *\'* || "$BRANCH" == *\$* || "$BRANCH" == *\`* ]]; then
               echo "::error::invalid branch name: '${BRANCH}'"
               exit 1
             fi
-            if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/#-]+$ ]]; then
               echo "::error::invalid branch name: '${BRANCH}'"
               exit 1
             fi
@@ -206,7 +207,11 @@ jobs:
             # this lookup and the checkout therefore signs a commit the SHA
             # group did not pair on — that race is why the coarse branch-keyed
             # workflow-level group above is still worth having.
-            head_sha=$(gh api "repos/${BASE_REPO}/commits/${BRANCH}" --jq '.sha') \
+            # `#` is a legal git ref char but a URL fragment delimiter, so the
+            # commits-API path needs it percent-encoded or gh silently truncates
+            # the ref there (e.g. 'issue-#123-x' -> 'issue-').
+            branch_encoded=$(jq -rn --arg b "$BRANCH" '$b|@uri')
+            head_sha=$(gh api "repos/${BASE_REPO}/commits/${branch_encoded}" --jq '.sha') \
               || { echo "::error::could not resolve branch '${BRANCH}' on ${BASE_REPO} — is it pushed?"; exit 1; }
             if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
               echo "::error::resolved branch '${BRANCH}' to '${head_sha}', which is not a commit SHA"

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -2370,7 +2370,7 @@ cmd_remote() {
       || "$branch" == *\"* || "$branch" == *\'* || "$branch" == *\$* || "$branch" == *\`* ]]; then
     fail "refusing to dispatch Remote Sign-off for unsafe branch name: '${branch}'"
   fi
-  if [[ ! "$branch" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+  if [[ ! "$branch" =~ ^[A-Za-z0-9._/#-]+$ ]]; then
     fail "refusing to dispatch Remote Sign-off for invalid branch name: '${branch}'"
   fi
 

--- a/scripts/test_signoff_resolve_target.sh
+++ b/scripts/test_signoff_resolve_target.sh
@@ -106,6 +106,7 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
 fi
 
 if [[ "${1:-}" == "api" && "${2:-}" == repos/*/commits/* ]]; then
+  printf '%s' "$2" >"${STUB_LOG_API_ENDPOINT:-/dev/null}"
   [[ "${STUB_API_RC:-0}" == "0" ]] || exit "${STUB_API_RC}"
   printf '%s\n' "${STUB_BRANCH_SHA:-}"
   exit 0
@@ -136,6 +137,7 @@ run_step() {
   local outfile="$stub_dir/github_output"
   : >"$outfile"
 
+  : >"$stub_dir/api_endpoint"
   out=$(
     PATH="$stub_dir:$PATH" \
     BRANCH="$branch" \
@@ -146,9 +148,11 @@ run_step() {
     STUB_PR_RC="${STUB_PR_RC:-0}" \
     STUB_BRANCH_SHA="${STUB_BRANCH_SHA:-}" \
     STUB_API_RC="${STUB_API_RC:-0}" \
+    STUB_LOG_API_ENDPOINT="$stub_dir/api_endpoint" \
     bash "$subject" 2>&1
   )
   rc=$?
+  api_endpoint="$(cat "$stub_dir/api_endpoint" 2>/dev/null || true)"
 
   local key
   for key in checkout_repo checkout_ref is_fork head_sha; do
@@ -264,6 +268,20 @@ echo "a lookup that answers with something other than a commit SHA fails"
 STUB_BRANCH_SHA="not-a-sha" run_step "fix/weird" ""
 [[ $rc -ne 0 ]] || fail_test "expected a non-zero exit, got 0: $out"
 grep -q "not a commit SHA" <<<"$out" || fail_test "expected a SHA-shape error in: $out"
+
+# `#` is a legal git ref character (e.g. the issue-#123-* branches this repo's
+# worktree convention produces) but also a URL fragment delimiter — unencoded,
+# gh's commits-API call silently truncates the ref at it and 404s on the wrong
+# thing. checkout_ref (what gets attested and checked out) must stay the raw
+# branch name; only the lookup URL needs encoding.
+tests_run=$((tests_run + 1))
+echo "a branch containing '#' is accepted and percent-encoded for the lookup"
+STUB_BRANCH_SHA="$BRANCH_SHA" run_step "issue-#13038-20260818163736" ""
+[[ $rc -eq 0 ]] || fail_test "exited $rc: $out"
+assert_eq "checkout_ref" "issue-#13038-20260818163736" "$out_checkout_ref"
+assert_eq "head_sha" "$BRANCH_SHA" "$out_head_sha"
+[[ "$api_endpoint" == *"%23"* ]] || fail_test "expected the lookup endpoint to percent-encode '#', got: $api_endpoint"
+[[ "$api_endpoint" != *"#"* ]] || fail_test "raw '#' reached gh api unencoded, would truncate as a URL fragment: $api_endpoint"
 
 # A branch name that would break the dispatch or the checkout must be rejected
 # by the step's own validation, before the stub `gh` is ever reached — the stub


### PR DESCRIPTION
## Summary
- The Remote Sign-off branch-dispatch path (`.github/workflows/signoff.yml`, `scripts/signoff`) rejected any `#` in a branch name, even though `#` is a legal git ref character. This repo's `issue-#<num>-<timestamp>` worktree naming convention produces branches with `#`, so those branches could not sign off via `-f branch=...`.
- The resolve step also passed the branch unencoded into `gh api repos/.../commits/$BRANCH`. `#` is a URL fragment delimiter there, so an unencoded call silently truncates the ref (e.g. `issue-#123-x` becomes `issue-`) and looks up the wrong commit instead of failing loudly.
- Widen the allowlist in both the workflow and `scripts/signoff` to permit `#`, and percent-encode the branch only for the `gh api` lookup — `checkout_ref` (what actually gets attested and checked out) stays the raw branch name.

## Test plan
- [x] `scripts/test_signoff_resolve_target.sh` — added a case for a `#`-containing branch asserting it resolves correctly and that the lookup endpoint is percent-encoded (not raw `#`, which would silently truncate). Full suite: 23/23 groups pass.
- [x] Verified locally that an unencoded `gh api repos/spiceai/spiceai/commits/issue-#13038-...` call truncates to `issue-` and 422s, while the `%23`-encoded form resolves the correct SHA.