### PR TITLE
fix(ci): exempt every App account from the assignee gate, not just Dependabot (fixes #13115)

### DIFF
--- a/.github/workflows/enforce-pulls-with-spice.yml
+++ b/.github/workflows/enforce-pulls-with-spice.yml
@@ -79,14 +79,22 @@ jobs:
           required_label_prefixes: 'kind/,area/'
           banned_labels: 'invalid,wontfix,nomerge,duplicate'
           # GitHub's assignees API silently drops App accounts, so `auto_assign_author`
-          # below cannot satisfy `require_assignee` on a Dependabot PR — the required
-          # check is then red forever with nothing any author or reviewer can do about
-          # it. #12358 is the shape: every other gate green, blocked solely on
+          # below cannot satisfy `require_assignee` on a PR opened by an App — the
+          # required check is then red forever with nothing any author or reviewer can
+          # do about it. #12358 is the shape: every other gate green, blocked solely on
           # `❌ At least one assignee is required`, until a maintainer hand-assigned
           # themselves. `pr.yml` already fast-tracks Dependabot for the same reason.
+          #
+          # Keyed on the author's account *type* rather than its login, because the
+          # dropped assignment is a property of App accounts generally: `dependabot[bot]`
+          # and `github-actions[bot]` both report `type: Bot` and both hit it, and any
+          # App installed later would too. Our own bot identities (`claudespice`,
+          # `grokspice`) are ordinary `User` accounts, so they still have to carry an
+          # assignee.
+          #
           # This exempts nothing else — the title-length, `kind/`/`area/` label and
-          # banned-label gates still apply to dependency bumps exactly as before.
-          require_assignee: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && 'false' || 'true' }}
+          # banned-label gates still apply to an App's PRs exactly as before.
+          require_assignee: ${{ github.event.pull_request.user.type == 'Bot' && 'false' || 'true' }}
           auto_label: 'true'
           # No auto_label_size: GitHub applies size labels natively now, and the
           # action's input defaults to false, so leaving it out is the whole


### PR DESCRIPTION
## Summary

`enforce-pull-with-spice` is a required check on `trunk`, and its `require_assignee`
gate cannot be satisfied by a PR opened by a GitHub App: the assignees API silently
drops App accounts, so `auto_assign_author` cannot give the PR an assignee and the
check stays red with nothing the author or a reviewer can do about it. The workflow
already documents that mechanism — the exemption added for it just named one App by
login:

```yaml
require_assignee: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && 'false' || 'true' }}
```

`github-actions[bot]` is an App account too and hits the identical behaviour, so every
`Update openapi.json` PR the schema workflow opens is structurally unmergeable. Six were
open at the time #13115 was filed, all carrying the same 101-line diff, one of them
approved by a core maintainer — so the published schema has been missing a live route
for weeks because of a metadata gate, not a review decision.

## Changes

- Key the exemption on the author's account **type** rather than its login:

  ```yaml
  require_assignee: ${{ github.event.pull_request.user.type == 'Bot' && 'false' || 'true' }}
  ```

  The dropped assignment is a property of App accounts generally, so keying on the
  property fixes it for `dependabot[bot]`, `github-actions[bot]`, and any App installed
  later, instead of collecting one login per App.
- Update the comment above it to say what the exemption keys on and why, and to record
  that our own bot identities stay covered.

Every other gate — title length, `kind/`/`area/` label prefixes, banned labels — is
untouched and still applies to an App's PRs.

## Verification

- `github-actions[bot]` and `dependabot[bot]` both report `"type": "Bot"` from the API;
  `claudespice` and `grokspice` both report `"type": "User"`, so our own bots still have
  to carry an assignee. Checked against the live API and against the `user` object of a
  real PR from each account (#12945, #13400, #12837), which is the same object the
  `pull_request_target` payload carries.
- `actionlint` passes on the workflow, and the file still parses as YAML with the
  expression intact.

Note this does not by itself turn the six stuck PRs green: a `pull_request_target` event
raised by `GITHUB_TOKEN` starts no run at all, so those PRs have never reported this check
and will need a label toggle (or a fresh PR) once this is on `trunk`. That half is the
event-suppression behaviour described in #13115, not the assignee gate.

## Test plan

- [x] `make lint`
- [x] `make test`

This branch changes one workflow file and no Rust, so the sign-off gate takes its
no-Rust-changes path: it runs neither lint nor tests. `Attestation` is green on this HEAD
without them, which is that path working as designed rather than a gate being skipped.

- [x] `actionlint .github/workflows/enforce-pulls-with-spice.yml` — clean

## Review gate

- Adversarial review: **skipped** — receipt `.git/worktrees/13115/spice-review-gate/adversarial-review.txt` records `attempt=codex result=not-installed`, `engine=none`, `exit=1`. This host has no `node` runtime to execute the companion `.mjs` entry point (the `codex` CLI itself is present, 0.147.0), and the sandbox denies `/usr/bin/sort`, which the companion-selection step uses. `grok` is not a permitted engine for a Grok-authored diff, so there was no fallback.
- `/security-review`: no findings — audited by hand against the same checklist, because the harness skill diffs the session's own checkout and this change lives in a separate worktree. The expression is interpolated into an action *input*, not a `run:` shell, and `user.type` is a GitHub-assigned enum, so there is no injection surface. `require_assignee` is a PR-hygiene gate rather than a security control: widening its exemption from one App to all Apps grants no permission, bypasses no review requirement, and leaves the title, label and banned-label gates in force. Making `user.type` read `Bot` requires authoring the PR from a GitHub App, which buys only the exemption itself.
- `/simplify`: ran against this diff as an inline pass over the four angles (this run cannot spawn the parallel agents the skill uses) — no changes applied. The diff is one expression and the comment that explains it; there is nothing to reuse, simplify or defer.

Fixes #13115

## Checklist

- [x] Root cause identified and stated
- [x] The premise (`user.type` for App vs. our bot accounts) verified against the API
- [x] No other gate weakened
