### PR TITLE
fix(mysql): assign the binlog dump session's net_write_timeout floor as an integer literal (fixes #13307)

### DIFF
--- a/crates/data_components/src/mysql_replication/binlog.rs
+++ b/crates/data_components/src/mysql_replication/binlog.rs
@@ -89,8 +89,13 @@ pub(super) const MIN_VALID_EVENT_POS: u64 = 4;
 /// A floor rather than an assignment: an operator who already raised
 /// `net_write_timeout` past this — the manual workaround for exactly this
 /// symptom — must not have it lowered by connecting a newer runtime, so the
-/// statement takes the greater of their value and this one.
+/// floor is applied only to a session that inherits something lower.
 const DUMP_NET_WRITE_TIMEOUT_SECS: u32 = 180;
+
+/// What the operator loses whenever the dump session keeps a `net_write_timeout`
+/// below the floor — carried by the statement that raises it, and by the read
+/// that decides whether to raise it.
+const NET_WRITE_TIMEOUT_NOT_RAISED: &str = "the source can still abort the shared binlog connection when one dataset's apply loop stalls, delaying changes for every changes-mode dataset on it. Grant the replication user permission to set session variables, or raise the source's net_write_timeout. See: https://spiceai.org/docs/components/data-connectors/mysql";
 
 /// One statement issued on the dump connection before `COM_BINLOG_DUMP`.
 struct PreDumpStatement {
@@ -104,10 +109,17 @@ struct PreDumpStatement {
 
 /// The session setup a dump connection needs, in the order it is issued.
 ///
+/// `inherited_net_write_timeout` is what this connection already carries, as read
+/// by [`inherited_net_write_timeout`], or `None` when the server did not answer
+/// with a value.
+///
 /// Split out from [`open_binlog_stream`] so the statements — in particular
-/// which of them address a *user* variable versus a *system* one — are
-/// assertable without a `MySQL` server.
-fn pre_dump_session_statements(checkpoint_interval: Duration) -> Vec<PreDumpStatement> {
+/// which of them address a *user* variable versus a *system* one, and which
+/// values they assign — are assertable without a `MySQL` server.
+fn pre_dump_session_statements(
+    checkpoint_interval: Duration,
+    inherited_net_write_timeout: Option<u32>,
+) -> Vec<PreDumpStatement> {
     // Ask the source to send heartbeat events while idle so the stream can
     // detect dead connections and advance its checkpoint. Half the
     // checkpoint interval (min 500ms) keeps idle persists within ~1.5×
@@ -131,18 +143,41 @@ fn pre_dump_session_statements(checkpoint_interval: Duration) -> Vec<PreDumpStat
     // `net_write_timeout` is a system variable, so it needs the `SESSION`
     // form — the `SET @net_write_timeout` spelling the heartbeats use would
     // define an unrelated user variable and leave the server default in place.
-    // `GREATEST` against the inherited value keeps this a floor in one
-    // statement, with no round-trip to read the current setting first.
-    statements.push(PreDumpStatement {
-        sql: format!(
-            "SET SESSION net_write_timeout = \
-             CAST(GREATEST(@@SESSION.net_write_timeout, {DUMP_NET_WRITE_TIMEOUT_SECS}) AS UNSIGNED)"
-        ),
-        rejection_warning: Some(
-            "the source can still abort the shared binlog connection when one dataset's apply loop stalls, delaying changes for every changes-mode dataset on it. Grant the replication user permission to set session variables, or raise the source's net_write_timeout. See: https://spiceai.org/docs/components/data-connectors/mysql",
-        ),
-    });
+    // Its value has to be an integer literal: `MySQL` 8.x answers a function
+    // expression there with `ER_WRONG_TYPE_FOR_VAR` (1232) and keeps the
+    // inherited value, so the floor is resolved against the value read from
+    // this connection rather than by a server-side `GREATEST`.
+    //
+    // Nothing is issued for a session already at or above the floor — there is
+    // nothing to raise — and nothing is issued when the inherited value could
+    // not be read, since assigning the floor blind is what would clamp an
+    // operator's higher setting down. [`open_binlog_stream`] warns in that case.
+    if inherited_net_write_timeout.is_some_and(|inherited| inherited < DUMP_NET_WRITE_TIMEOUT_SECS)
+    {
+        statements.push(PreDumpStatement {
+            sql: format!("SET SESSION net_write_timeout = {DUMP_NET_WRITE_TIMEOUT_SECS}"),
+            rejection_warning: Some(NET_WRITE_TIMEOUT_NOT_RAISED),
+        });
+    }
     statements
+}
+
+/// The `net_write_timeout`, in seconds, this dump connection has inherited, or
+/// `None` when the server did not answer with one.
+///
+/// Read on the connection because the floor cannot be resolved server-side: see
+/// [`pre_dump_session_statements`] for why the assignment has to be a literal.
+/// Typed as `Option<u32>` so a SQL `NULL` answer returns `None` rather than
+/// panicking in `FromRow`.
+async fn inherited_net_write_timeout(conn: &mut Conn) -> Option<u32> {
+    mysql_async::prelude::Queryable::query_first::<Option<u32>, _>(
+        conn,
+        "SELECT @@SESSION.net_write_timeout",
+    )
+    .await
+    .ok()
+    .flatten()
+    .flatten()
 }
 
 pub(super) async fn open_binlog_stream(
@@ -154,10 +189,18 @@ pub(super) async fn open_binlog_stream(
 ) -> std::result::Result<BinlogStream, mysql_async::Error> {
     let mut conn = Conn::new(params.opts.clone()).await?;
 
+    let inherited_timeout = inherited_net_write_timeout(&mut conn).await;
+    if inherited_timeout.is_none() {
+        tracing::warn!(
+            dataset = %dataset_name,
+            "Could not read the MySQL binlog dump session's net_write_timeout for dataset {dataset_name}, so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
+        );
+    }
+
     for PreDumpStatement {
         sql,
         rejection_warning,
-    } in pre_dump_session_statements(params.checkpoint_interval)
+    } in pre_dump_session_statements(params.checkpoint_interval, inherited_timeout)
     {
         if let Err(e) = mysql_async::prelude::Queryable::query_drop(&mut conn, sql.as_str()).await {
             match rejection_warning {
@@ -1032,6 +1075,17 @@ mod tests {
             .map(|statement| statement.sql.as_str())
     }
 
+    /// The value a `SET` statement assigns: everything after its first `=`.
+    ///
+    /// `MySQL` answers an integer system variable assigned a non-integer value
+    /// with `ER_WRONG_TYPE_FOR_VAR` (1232) and keeps the inherited setting, so
+    /// what this returns has to parse as an integer.
+    fn assigned_value(sql: &str) -> &str {
+        sql.split_once('=')
+            .map(|(_, value)| value.trim())
+            .unwrap_or_default()
+    }
+
     /// The warning the statement setting `variable` carries, if it carries one.
     fn statement_rejection_warning(
         statements: &[PreDumpStatement],
@@ -1044,20 +1098,20 @@ mod tests {
     }
 
     #[test]
-    fn the_dump_session_raises_net_write_timeout() {
+    fn the_dump_session_raises_a_lower_net_write_timeout_to_the_floor() {
         // Regression test for #12527: without this the source aborts the shared
         // dump 60s into one dataset's slow apply cycle, and every
         // `refresh_mode: changes` dataset on the connection re-streams from its
         // acked position while already behind.
-        let statements = pre_dump_session_statements(Duration::from_secs(10));
+        let statements = pre_dump_session_statements(
+            Duration::from_secs(10),
+            Some(SERVER_DEFAULT_NET_WRITE_TIMEOUT_SECS),
+        );
         let sql = statement_setting(&statements, "net_write_timeout")
-            .expect("the dump session must raise net_write_timeout");
+            .expect("a session below the floor must have net_write_timeout raised");
         assert_eq!(
             sql,
-            format!(
-                "SET SESSION net_write_timeout = \
-                 CAST(GREATEST(@@SESSION.net_write_timeout, {DUMP_NET_WRITE_TIMEOUT_SECS}) AS UNSIGNED)"
-            ),
+            format!("SET SESSION net_write_timeout = {DUMP_NET_WRITE_TIMEOUT_SECS}"),
             "net_write_timeout is a SYSTEM variable: the `SET @net_write_timeout` spelling the \
              heartbeats use would define an unrelated user variable and silently leave the \
              server default in place"
@@ -1075,18 +1129,59 @@ mod tests {
     }
 
     #[test]
+    fn the_floor_is_assigned_as_an_integer_literal() {
+        // Regression test for #13307. An integer system variable assigned a
+        // function expression — `GREATEST(...)`, cast or not — is answered with
+        // `ER_WRONG_TYPE_FOR_VAR` (1232): the assignment never takes effect, the
+        // session keeps the server default, and the only trace is the rejection
+        // warning. Every statement the dump session issues has to assign a value
+        // the server will accept.
+        let statements = pre_dump_session_statements(
+            Duration::from_secs(10),
+            Some(SERVER_DEFAULT_NET_WRITE_TIMEOUT_SECS),
+        );
+        let sql = statement_setting(&statements, "net_write_timeout")
+            .expect("a session below the floor must have net_write_timeout raised");
+        assert_eq!(
+            assigned_value(sql).parse::<u32>().ok(),
+            Some(DUMP_NET_WRITE_TIMEOUT_SECS),
+            "the assigned value must be the floor as an integer literal, not an expression \
+             the server will refuse: {sql}"
+        );
+    }
+
+    #[test]
     fn the_dump_session_never_lowers_an_operators_higher_net_write_timeout() {
         // Raising `net_write_timeout` on the source is the manual workaround for
         // this symptom, so an operator who has already done it must not have it
-        // lowered by connecting a runtime carrying this fix. `GREATEST` against
-        // the session's inherited value makes the statement a floor; a bare
-        // assignment would clamp their setting down to ours.
-        let statements = pre_dump_session_statements(Duration::from_secs(10));
-        let sql = statement_setting(&statements, "net_write_timeout")
-            .expect("the dump session must raise net_write_timeout");
-        assert!(
-            sql.contains("GREATEST(@@SESSION.net_write_timeout,"),
-            "the statement must take the greater of the inherited value and ours: {sql}"
+        // lowered by connecting a runtime carrying this fix. The floor is
+        // resolved against the value read from the connection, so a session at
+        // or above it is left alone rather than assigned down to ours.
+        for inherited in [
+            DUMP_NET_WRITE_TIMEOUT_SECS,
+            DUMP_NET_WRITE_TIMEOUT_SECS + 1,
+            DUMP_NET_WRITE_TIMEOUT_SECS * 10,
+        ] {
+            let statements = pre_dump_session_statements(Duration::from_secs(10), Some(inherited));
+            assert_eq!(
+                statement_setting(&statements, "net_write_timeout"),
+                None,
+                "a session inheriting {inherited}s already clears the \
+                 {DUMP_NET_WRITE_TIMEOUT_SECS}s floor, so nothing may be assigned to it"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unreadable_net_write_timeout_is_left_as_the_source_set_it() {
+        // With no value read there is no way to tell a server default from an
+        // operator's raised setting, and assigning the floor blind would clamp
+        // the latter down. `open_binlog_stream` warns instead.
+        let statements = pre_dump_session_statements(Duration::from_secs(10), None);
+        assert_eq!(
+            statement_setting(&statements, "net_write_timeout"),
+            None,
+            "an unread net_write_timeout must not be assigned a value"
         );
     }
 
@@ -1095,7 +1190,10 @@ mod tests {
         // The heartbeat spellings are tried in pairs and one is always unknown,
         // so those must stay quiet; a rejected net_write_timeout leaves the
         // reconnect cliff in place and is the one the user can act on.
-        let statements = pre_dump_session_statements(Duration::from_secs(10));
+        let statements = pre_dump_session_statements(
+            Duration::from_secs(10),
+            Some(SERVER_DEFAULT_NET_WRITE_TIMEOUT_SECS),
+        );
         for statement in &statements {
             assert_eq!(
                 statement.rejection_warning.is_some(),
@@ -1115,8 +1213,12 @@ mod tests {
     #[test]
     fn both_heartbeat_spellings_are_set_as_user_variables_in_nanoseconds() {
         // Half the checkpoint interval, in nanoseconds, on both the pre-8.4 and
-        // 8.4 spellings — unchanged by the net_write_timeout addition.
-        let statements = pre_dump_session_statements(Duration::from_secs(10));
+        // 8.4 spellings — independent of whatever net_write_timeout the
+        // session inherited.
+        let statements = pre_dump_session_statements(
+            Duration::from_secs(10),
+            Some(SERVER_DEFAULT_NET_WRITE_TIMEOUT_SECS),
+        );
         for var in ["master_heartbeat_period", "source_heartbeat_period"] {
             assert_eq!(
                 statement_setting(&statements, var),
@@ -1130,7 +1232,7 @@ mod tests {
     fn a_tiny_checkpoint_interval_floors_the_heartbeat_at_500ms() {
         // A sub-second interval would otherwise ask the source to heartbeat
         // continuously.
-        let statements = pre_dump_session_statements(Duration::from_millis(100));
+        let statements = pre_dump_session_statements(Duration::from_millis(100), None);
         assert_eq!(
             statement_setting(&statements, "master_heartbeat_period"),
             Some("SET @master_heartbeat_period = 500000000")

--- a/crates/data_components/src/mysql_replication/binlog.rs
+++ b/crates/data_components/src/mysql_replication/binlog.rs
@@ -162,22 +162,27 @@ fn pre_dump_session_statements(
     statements
 }
 
-/// The `net_write_timeout`, in seconds, this dump connection has inherited, or
-/// `None` when the server did not answer with one.
+/// The `net_write_timeout`, in seconds, this dump connection has inherited.
 ///
 /// Read on the connection because the floor cannot be resolved server-side: see
 /// [`pre_dump_session_statements`] for why the assignment has to be a literal.
-/// Typed as `Option<u32>` so a SQL `NULL` answer returns `None` rather than
-/// panicking in `FromRow`.
-async fn inherited_net_write_timeout(conn: &mut Conn) -> Option<u32> {
-    mysql_async::prelude::Queryable::query_first::<Option<u32>, _>(
-        conn,
-        "SELECT @@SESSION.net_write_timeout",
+///
+/// `Ok(None)` is a server that answered with SQL `NULL`, which is a different
+/// thing from a read that failed and leads to the same floor being skipped for a
+/// different reason — so the error is returned rather than flattened into the
+/// `None`, and the caller says which one happened. Typed as `Option<u32>`
+/// internally so a `NULL` answer decodes instead of panicking in `FromRow`.
+async fn inherited_net_write_timeout(
+    conn: &mut Conn,
+) -> std::result::Result<Option<u32>, mysql_async::Error> {
+    Ok(
+        mysql_async::prelude::Queryable::query_first::<Option<u32>, _>(
+            conn,
+            "SELECT @@SESSION.net_write_timeout",
+        )
+        .await?
+        .flatten(),
     )
-    .await
-    .ok()
-    .flatten()
-    .flatten()
 }
 
 pub(super) async fn open_binlog_stream(
@@ -189,13 +194,24 @@ pub(super) async fn open_binlog_stream(
 ) -> std::result::Result<BinlogStream, mysql_async::Error> {
     let mut conn = Conn::new(params.opts.clone()).await?;
 
-    let inherited_timeout = inherited_net_write_timeout(&mut conn).await;
-    if inherited_timeout.is_none() {
-        tracing::warn!(
-            dataset = %dataset_name,
-            "Could not read the MySQL binlog dump session's net_write_timeout for dataset {dataset_name}, so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
-        );
-    }
+    let inherited_timeout = match inherited_net_write_timeout(&mut conn).await {
+        Ok(Some(inherited)) => Some(inherited),
+        Ok(None) => {
+            tracing::warn!(
+                dataset = %dataset_name,
+                "The MySQL source answered NULL for the binlog dump session's net_write_timeout for dataset {dataset_name}, so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
+            );
+            None
+        }
+        Err(e) => {
+            tracing::warn!(
+                dataset = %dataset_name,
+                error = %e,
+                "Could not read the MySQL binlog dump session's net_write_timeout for dataset {dataset_name}, so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
+            );
+            None
+        }
+    };
 
     for PreDumpStatement {
         sql,

--- a/crates/data_components/src/mysql_replication/binlog.rs
+++ b/crates/data_components/src/mysql_replication/binlog.rs
@@ -95,7 +95,7 @@ const DUMP_NET_WRITE_TIMEOUT_SECS: u32 = 180;
 /// What the operator loses whenever the dump session keeps a `net_write_timeout`
 /// below the floor — carried by the statement that raises it, and by the read
 /// that decides whether to raise it.
-const NET_WRITE_TIMEOUT_NOT_RAISED: &str = "the source can still abort the shared binlog connection when one dataset's apply loop stalls, delaying changes for every changes-mode dataset on it. Grant the replication user permission to set session variables, or raise the source's net_write_timeout. See: https://spiceai.org/docs/components/data-connectors/mysql";
+const NET_WRITE_TIMEOUT_NOT_RAISED: &str = "the source can still abort the shared binlog connection when one dataset's apply loop stalls, delaying changes for every changes-mode dataset on it. Grant the replication user permission to set session variables, or raise the source's `net_write_timeout`. See: https://spiceai.org/docs/components/data-connectors/mysql";
 
 /// One statement issued on the dump connection before `COM_BINLOG_DUMP`.
 struct PreDumpStatement {
@@ -202,7 +202,7 @@ pub(super) async fn open_binlog_stream(
         Ok(None) => {
             tracing::warn!(
                 connection = %connection,
-                "The MySQL source answered NULL for the binlog dump session's net_write_timeout on {connection}, so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
+                "The MySQL source answered NULL for `net_write_timeout` on the binlog dump session for '{connection}', so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
             );
             None
         }
@@ -210,7 +210,7 @@ pub(super) async fn open_binlog_stream(
             tracing::warn!(
                 connection = %connection,
                 error = %e,
-                "Could not read the MySQL binlog dump session's net_write_timeout on {connection}, so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
+                "Could not read `net_write_timeout` on the MySQL binlog dump session for '{connection}', so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
             );
             None
         }
@@ -224,7 +224,7 @@ pub(super) async fn open_binlog_stream(
         if let Err(e) = mysql_async::prelude::Queryable::query_drop(&mut conn, sql.as_str()).await {
             match rejection_warning {
                 Some(consequence) => {
-                    tracing::warn!(connection = %connection, statement = %sql, error = %e, "Failed to configure the MySQL binlog dump session on {connection}: {consequence}");
+                    tracing::warn!(connection = %connection, statement = %sql, error = %e, "Failed to configure the MySQL binlog dump session for '{connection}': {consequence}");
                 }
                 None => {
                     tracing::debug!(connection = %connection, statement = %sql, error = %e, "failed to set a binlog dump session variable");

--- a/crates/data_components/src/mysql_replication/binlog.rs
+++ b/crates/data_components/src/mysql_replication/binlog.rs
@@ -97,6 +97,20 @@ const DUMP_NET_WRITE_TIMEOUT_SECS: u32 = 180;
 /// that decides whether to raise it.
 const NET_WRITE_TIMEOUT_NOT_RAISED: &str = "the source can still abort the shared binlog connection when one dataset's apply loop stalls, delaying changes for every changes-mode dataset on it. Grant the replication user permission to set session variables, or raise the source's `net_write_timeout`. See: https://spiceai.org/docs/components/data-connectors/mysql";
 
+/// What to tell an operator when the floor was not applied to a dump session.
+///
+/// `reason` says which way it went — the source answered `NULL`, or the read
+/// itself failed — because the remedy differs and the consequence does not.
+///
+/// A function rather than two inline `format!`s so both messages are assertable:
+/// this warning is the only account anyone gets of a floor that was skipped, and
+/// the two branches drifted apart the moment they were written separately.
+fn net_write_timeout_left_alone_warning(connection: &str, reason: &str) -> String {
+    format!(
+        "Could not raise `net_write_timeout` on the MySQL binlog dump session for '{connection}' ({reason}), so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
+    )
+}
+
 /// One statement issued on the dump connection before `COM_BINLOG_DUMP`.
 struct PreDumpStatement {
     sql: String,
@@ -202,7 +216,8 @@ pub(super) async fn open_binlog_stream(
         Ok(None) => {
             tracing::warn!(
                 connection = %connection,
-                "The MySQL source answered NULL for `net_write_timeout` on the binlog dump session for '{connection}', so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
+                "{}",
+                net_write_timeout_left_alone_warning(connection, "the source answered NULL")
             );
             None
         }
@@ -210,7 +225,8 @@ pub(super) async fn open_binlog_stream(
             tracing::warn!(
                 connection = %connection,
                 error = %e,
-                "Could not read `net_write_timeout` on the MySQL binlog dump session for '{connection}', so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
+                "{}",
+                net_write_timeout_left_alone_warning(connection, &format!("the read failed: {e}"))
             );
             None
         }
@@ -1202,6 +1218,41 @@ mod tests {
             None,
             "an unread net_write_timeout must not be assigned a value"
         );
+    }
+
+    #[test]
+    fn a_skipped_floor_says_which_connection_why_and_what_it_costs() {
+        // This warning is the only account anyone gets of a floor that was not
+        // applied, so both branches have to carry the same three things: the
+        // connection it is about, why the value was left alone, and what that
+        // costs. Asserted for both, because they are two call sites of one
+        // message and drifted apart when they were two messages.
+        for (reason, expected_reason) in [
+            ("the source answered NULL", "the source answered NULL"),
+            (
+                "the read failed: Access denied",
+                "the read failed: Access denied",
+            ),
+        ] {
+            let warning = net_write_timeout_left_alone_warning("db.internal:3306", reason);
+            assert!(
+                warning.contains("'db.internal:3306'"),
+                "the connection must be named, and quoted: {warning}"
+            );
+            assert!(warning.contains(expected_reason), "{warning}");
+            assert!(
+                warning.contains("`net_write_timeout`"),
+                "the setting is a system identifier: {warning}"
+            );
+            assert!(
+                warning.contains("https://spiceai.org/docs/"),
+                "the warning must point at the fix: {warning}"
+            );
+            assert!(
+                warning.contains("abort the shared binlog connection"),
+                "the warning must say what is lost: {warning}"
+            );
+        }
     }
 
     #[test]

--- a/crates/data_components/src/mysql_replication/binlog.rs
+++ b/crates/data_components/src/mysql_replication/binlog.rs
@@ -185,10 +185,13 @@ async fn inherited_net_write_timeout(
     )
 }
 
+/// `connection` is the shared source's `host:port` label, not a dataset: one dump
+/// serves every `refresh_mode: changes` dataset on the source, so anything this
+/// function reports is about the connection they share.
 pub(super) async fn open_binlog_stream(
     params: &ReplicationParams,
     resume: &BinlogPosition,
-    dataset_name: &str,
+    connection: &str,
     use_gtid: bool,
     gtid: &GtidSet,
 ) -> std::result::Result<BinlogStream, mysql_async::Error> {
@@ -198,16 +201,16 @@ pub(super) async fn open_binlog_stream(
         Ok(Some(inherited)) => Some(inherited),
         Ok(None) => {
             tracing::warn!(
-                dataset = %dataset_name,
-                "The MySQL source answered NULL for the binlog dump session's net_write_timeout for dataset {dataset_name}, so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
+                connection = %connection,
+                "The MySQL source answered NULL for the binlog dump session's net_write_timeout on {connection}, so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
             );
             None
         }
         Err(e) => {
             tracing::warn!(
-                dataset = %dataset_name,
+                connection = %connection,
                 error = %e,
-                "Could not read the MySQL binlog dump session's net_write_timeout for dataset {dataset_name}, so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
+                "Could not read the MySQL binlog dump session's net_write_timeout on {connection}, so it was left as the source set it: {NET_WRITE_TIMEOUT_NOT_RAISED}"
             );
             None
         }
@@ -221,10 +224,10 @@ pub(super) async fn open_binlog_stream(
         if let Err(e) = mysql_async::prelude::Queryable::query_drop(&mut conn, sql.as_str()).await {
             match rejection_warning {
                 Some(consequence) => {
-                    tracing::warn!(dataset = %dataset_name, statement = %sql, error = %e, "Failed to configure the MySQL binlog dump session for dataset {dataset_name}: {consequence}");
+                    tracing::warn!(connection = %connection, statement = %sql, error = %e, "Failed to configure the MySQL binlog dump session on {connection}: {consequence}");
                 }
                 None => {
-                    tracing::debug!(dataset = %dataset_name, statement = %sql, error = %e, "failed to set a binlog dump session variable");
+                    tracing::debug!(connection = %connection, statement = %sql, error = %e, "failed to set a binlog dump session variable");
                 }
             }
         }

--- a/crates/runtime/tests/mysql/replication_e2e.rs
+++ b/crates/runtime/tests/mysql/replication_e2e.rs
@@ -723,6 +723,41 @@ async fn wait_for_binlog_dump_thread(pool: &mysql_async::Pool) -> Result<u64, an
         .ok_or_else(|| anyhow!("the `Binlog Dump` thread vanished between polls"))
 }
 
+/// The floor the pump raises the dump session's `net_write_timeout` to, mirroring
+/// `data_components::mysql_replication::binlog::DUMP_NET_WRITE_TIMEOUT_SECS`
+/// (private to that crate). The server default is 60s, so anything at or above
+/// this proves the raise was accepted and applied.
+const EXPECTED_DUMP_NET_WRITE_TIMEOUT_SECS: u64 = 180;
+
+/// The `net_write_timeout` in force on another session, read back from the
+/// server rather than inferred from the statement Spice sent.
+///
+/// `Ok(None)` when `performance_schema` cannot answer — the instrumentation is
+/// on by default but can be built out or turned off, and a suite that fails for
+/// that reason would be reporting on the image rather than on the runtime.
+async fn session_net_write_timeout(
+    pool: &mysql_async::Pool,
+    processlist_id: u64,
+) -> Result<Option<u64>, anyhow::Error> {
+    let mut conn = pool.get_conn().await?;
+    let sql = format!(
+        "SELECT v.VARIABLE_VALUE FROM performance_schema.variables_by_thread v \
+         JOIN performance_schema.threads t ON t.THREAD_ID = v.THREAD_ID \
+         WHERE t.PROCESSLIST_ID = {processlist_id} \
+           AND v.VARIABLE_NAME = 'net_write_timeout'"
+    );
+    let value: Option<String> = match conn.query_first(sql.as_str()).await {
+        Ok(value) => value,
+        Err(e) => {
+            // Said out loud: a silent `None` here would turn the assertion below
+            // into one that can never fail.
+            eprintln!("performance_schema could not answer `{sql}`: {e}");
+            return Ok(None);
+        }
+    };
+    Ok(value.and_then(|value| value.parse().ok()))
+}
+
 /// Wait for the dump thread id to change, i.e. the pump has reconnected.
 async fn wait_for_dump_thread_change(
     pool: &mysql_async::Pool,
@@ -861,6 +896,25 @@ async fn mysql_binlog_replication_survives_a_dump_reconnect_cayenne() -> Result<
             // The dump thread may register a moment after the first rows land,
             // so wait for it rather than racing it.
             let dump_thread = wait_for_binlog_dump_thread(&pool).await?;
+
+            // Regression test for #13307, and the reason it is here rather than
+            // in a unit test: the floor was expressed as an expression MySQL
+            // refuses for a system variable, and every unit test asserted the
+            // SQL Spice generated rather than what the server did with it, so
+            // they passed while the session kept the 60s default. Read the value
+            // back off the dump session itself.
+            match session_net_write_timeout(&pool, dump_thread).await? {
+                Some(seconds) => assert!(
+                    seconds >= EXPECTED_DUMP_NET_WRITE_TIMEOUT_SECS,
+                    "the dump session must carry the raised net_write_timeout, \
+                     got {seconds}s (the server default is 60s, so this means the \
+                     source rejected or ignored the statement that raises it)"
+                ),
+                None => eprintln!(
+                    "skipped the net_write_timeout assertion: performance_schema \
+                     did not report the dump session's value"
+                ),
+            }
 
             let half = RECONNECT_UPDATES_PER_ROW / 2;
             bump_counter_rows(&pool, half).await?;

--- a/crates/runtime/tests/mysql/replication_e2e.rs
+++ b/crates/runtime/tests/mysql/replication_e2e.rs
@@ -755,7 +755,19 @@ async fn session_net_write_timeout(
             return Ok(None);
         }
     };
-    Ok(value.and_then(|value| value.parse().ok()))
+    // No row is "cannot answer" — the dump session is not instrumented — and
+    // skips the assertion. A row whose value is not a number is a different
+    // thing entirely, and folding it into the same `None` would let this test
+    // pass without ever reading the session it exists to read.
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let seconds = value.parse::<u64>().map_err(|e| {
+        anyhow!(
+            "performance_schema reported net_write_timeout = `{value}`, which is not a number: {e}"
+        )
+    })?;
+    Ok(Some(seconds))
 }
 
 /// Wait for the dump thread id to change, i.e. the pump has reconnected.


### PR DESCRIPTION
## Summary

The shared MySQL binlog dump session raises `net_write_timeout` to a 180s floor so that
one dataset's stalled apply loop cannot get the connection aborted for every other
`refresh_mode: changes` dataset on it (#12527). The floor was expressed server-side, as
`SET SESSION net_write_timeout = CAST(GREATEST(@@SESSION.net_write_timeout, 180) AS UNSIGNED)`.

MySQL 8.x answers an integer *system* variable assigned a function expression with
`ER_WRONG_TYPE_FOR_VAR` (1232). The assignment is refused, the session keeps the server
default of 60s, and the only trace is the rejection warning — so the protection is inert
and the failure it exists to prevent still happens. Field logs show the rejection on every
binlog connection, immediately followed by the stall-then-abort sequence from #12527, with
worst-case data freshness of 200-400s against a clean-run baseline of ~25s.

**Root cause:** the floor was computed by the server, in the one place MySQL will not
evaluate an expression. Nothing in the codebase could have caught it, because both unit
tests asserted the statement's *spelling* rather than its effect — they pass against a
statement the server refuses.

## Changes

- `pre_dump_session_statements` now takes the `net_write_timeout` the connection inherited
  and resolves the floor client-side, assigning `SET SESSION net_write_timeout = 180` — an
  integer literal, which is what MySQL accepts.
- A session already at or above the floor gets no statement at all: an operator who raised
  `net_write_timeout` themselves (the documented manual workaround) must not be clamped back
  down, and there is nothing to raise.
- If the inherited value cannot be read, nothing is assigned — assigning the floor blind is
  what would clamp an operator's higher setting — and `open_binlog_stream` warns with the
  same consequence text the rejection path carries, so a lost floor stays visible.
- The warnings this function emits now name the **connection**, not a dataset: `run_pump`
  passes the shared source's `host:port` label, so the argument called `dataset_name` never
  held one, and the messages read "dataset localhost:3306" while tagging that value as
  `dataset`. Renamed to `connection` across the two warnings added here and the two beside
  them, with a doc comment recording what the argument is. `readiness_heartbeat`, which is
  genuinely per-dataset, is untouched.
- `inherited_net_write_timeout` reads `@@SESSION.net_write_timeout` on the dump connection,
  typed `Option<u32>` so a NULL answer decodes rather than panicking in `FromRow`. One extra
  round-trip per dump connection open. It returns the read error rather than flattening it
  away, so the skip-path warning can name the cause — an access denial and a dropped
  connection are different problems — and a server answering SQL `NULL` is reported
  separately from a read that failed.

**Bug class swept:** this is the only place the runtime assigns a *system* variable on a
source connection with anything other than a literal. `mysql_replication/bootstrap.rs`
(`SET time_zone`, `SET TRANSACTION ISOLATION LEVEL`) uses literals; the remaining
`GREATEST(...)` uses in-tree are in DML, where expressions are fine; the heartbeat
statements set *user* variables, which take expressions.

## Test plan

- [x] `make lint`
- [x] `make test`

Both are the sign-off gate's own steps, run remotely because the workspace cannot be
built on the authoring host — no `protoc`, so `runtime` and `bin/spice` do not compile
at all, and `cayenne`/`turso` do not link on Windows. The `Attestation` check is the
live state of it and these boxes track that check rather than a claim made ahead of it.
While converging, the touched crate's own unit tests and lint were run locally; the
workspace gate is the sign-off run, never a per-crate invocation. The new integration
assertion needs Docker as well, so the merge-queue suite is what exercises it.

- [x] After the review-comment change: the same unit tests and lint re-run locally, both green
      (22 tests).
- [x] The regression test was proven to fail on the pre-fix statement: restoring the
      `CAST(GREATEST(...) AS UNSIGNED)` spelling makes `the_floor_is_assigned_as_an_integer_literal`
      fail with `left: None, right: Some(180)`, and it passes with the fix.

Tests added, all against behaviour rather than SQL text:

- `the_floor_is_assigned_as_an_integer_literal` — the regression test for this issue: the
  assigned value must parse as an integer, which is exactly the property
  `ER_WRONG_TYPE_FOR_VAR` rejects a statement for.
- `the_dump_session_raises_a_lower_net_write_timeout_to_the_floor` — a session at the 60s
  server default is raised to 180s.
- `the_dump_session_never_lowers_an_operators_higher_net_write_timeout` — at 180s, 181s and
  1800s nothing is assigned.
- `an_unreadable_net_write_timeout_is_left_as_the_source_set_it` — an unread value assigns
  nothing.
- `a_rejected_net_write_timeout_is_worth_a_warning` — kept, now exercised against the
  statement that is actually issued.

**And one against a live server**, which is what no unit test here can do and what let the
rejected statement ship: `mysql_binlog_replication_survives_a_dump_reconnect_cayenne` now
reads the dump session's own `net_write_timeout` back out of `performance_schema` — joining
`variables_by_thread` to `threads` on `PROCESSLIST_ID`, on the dump thread it already
locates — and asserts it cleared the floor. That covers the `SELECT` decoding, the server
accepting the `SET`, and the value taking effect. An unanswerable `performance_schema`
skips the assertion and says so on stderr, so a skip cannot read as a pass.

The change is also written so that the server's treatment of *expressions* no longer
matters at all: an integer literal is the form `ER_WRONG_TYPE_FOR_VAR` cannot be raised
for, which is what removes the dependency #13178 was left betting on.

## Performance impact

One `SELECT @@SESSION.net_write_timeout` per dump connection open (once per connection, not
per event), against a connection that is about to issue three session statements anyway.
Sessions already above the floor now issue one statement fewer.

## Review gate

- Adversarial review: **skipped** — receipt `.git/worktrees/13307/spice-review-gate/adversarial-review.txt` records `attempt=codex result=not-installed`, `engine=none`, `exit=1` on each iteration of this branch. This host has no `node` runtime to execute the companion `.mjs` entry point (the `codex` CLI itself is present, 0.147.0), and the sandbox denies `/usr/bin/sort`, which the companion-selection step uses. `grok` is not a permitted engine for a Grok-authored diff, so no fallback was available. Both review-comment fixes were re-checked by hand and locally (22 unit tests, lint clean) before pushing.
- `/security-review`: no findings, re-run over the review-comment change as well. The harness skill initially diffed the session's own checkout rather than this worktree; it was re-run after moving the session into the worktree. Both statements are constants or interpolate a compile-time `u32`, so no caller-controlled value reaches SQL. The warning added for the failed read renders `mysql_async`'s error `Display`, which reports the server's message and code and does not carry the connection options — the password is in `Opts`, which is never rendered.
- `/simplify`: ran against this diff (as an inline pass over the four angles rather than the parallel agents the skill spawns, which this run is not permitted to use) — no changes applied. Reuse: no existing helper reads a session variable this way; the test helper sits beside `statement_setting`, which it complements. Simplification: the read is one expression and the floor one predicate. Efficiency: the added round-trip is once per connection open, and is what removes the server-side expression. Altitude: resolving the floor on the client is the depth the defect is at, not a special case layered over it.

Fixes #13307

## Checklist

- [x] Root cause identified and stated
- [x] Regression test fails on the pre-fix code and passes on the fix
- [x] Bug class swept for sibling occurrences
- [x] Copilot's four review comments addressed: `7eb75d8` (the read error is reported rather
      than discarded), `c4132e3` (the warnings name the shared connection, not a dataset),
      `66a613f` (quoting and backticking per the repo's message convention) and `c3b7288`
      (the floor asserted against a live MySQL session, not against generated SQL) and
      `025295e` (an unparseable server value fails the test instead of skipping it) and
      `5c1061f` (one formatter behind both skip warnings, with the message asserted)
- [ ] `Attestation` green
