### PR TITLE
fix(ci): let the E2E macOS build share the fleet's Cargo home (fixes #13299)

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -135,14 +135,6 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1 # Shallow clone for faster checkout
 
-      - name: Configure Cargo directories (self-hosted macOS)
-        if: matrix.target.builder == 'spiceai-macos'
-        run: |
-          set -euo pipefail
-          cargo_home="${{ runner.temp }}/cargo-${{ github.run_id }}-${{ github.job }}"
-          mkdir -p "$cargo_home/bin"
-          echo "CARGO_HOME=$cargo_home" >> "$GITHUB_ENV"
-
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
 


### PR DESCRIPTION
## Summary

The E2E macOS build leg pointed `CARGO_HOME` at `${{ runner.temp }}/cargo-<run_id>-<job>`,
so the value was different on every run. sccache hashes every non-excluded `CARGO_*`
environment variable into its Rust cache key, and dependency sources live under
`$CARGO_HOME/registry/src/...`, whose absolute paths are hashed too — so the key changed
run to run and every Rust lookup missed.

Measured on `Build spiced and spice CLI (macOS)` (run 32295877592):

```
Compile requests        4080
Cache hits (Rust)          2      Cache hits rate (Rust)    0.14 %
Cache misses (Rust)     1410      Cache hits rate (C/C++)  88.20 %
Non-cacheable              0      Cache errors                 0
```

C/C++ sits at 88% in the same job because sccache hashes preprocessed output rather than
paths, which is what isolates the cause to the path-derived Rust key. `CARGO_INCREMENTAL=0`
is already set and the non-cacheable count is zero, so these were real lookups that missed.

The control is in this repo: `integration.yml` sets no `CARGO_HOME`, runs on the same
self-hosted pool, and gets ~71% on the same bucket.

## Changes

- Remove the `Configure Cargo directories (self-hosted macOS)` step, so the leg uses the
  default `CARGO_HOME` like every other workflow in the repo.

That is the whole diff. `setup-rust` and `setup-nextest` already resolve `CARGO_HOME` with
a `${CARGO_HOME:-$HOME/.cargo}` default, so nothing else needs to change, and the step's
`mkdir -p "$cargo_home/bin"` is unnecessary against a home rustup already populated.

**Why the default rather than a stable per-runner path.** A stable-but-job-specific path
would restore reuse across runs of this job, but its entries still could not be shared with
the jobs that use the default path, because the hashed value would differ. Sharing the
default is what puts this leg on the same entries as `integration.yml` and the rest of the
fleet.

**On the isolation the per-run directory provided.** It arrived in #7627, which was fixing
sporadic macOS failures and in the same change removed an `rsync`-ed shared `target/`
directory — a mutable shared build output, which is the part that cannot be concurrently
shared. A Cargo home can: cargo takes a file lock on its package cache, and every other
workflow on these same runners already shares one.

**On trust.** This leg's builds run only on `merge_group`, `push` and `workflow_dispatch` —
`check_changes` and `setup-matrix` are both `if: github.event_name != 'pull_request'` and
`build` needs them — so nothing a fork PR controls ever writes to the shared path through
this workflow.

## Test plan

- [x] `make lint`
- [x] `make test`

This branch changes one workflow file and no Rust, so the sign-off gate takes its
no-Rust-changes path: it runs neither lint nor tests and attests the branch directly.

- [x] `actionlint .github/workflows/e2e_test_ci.yml` — identical finding count before and
      after the change (40 pre-existing, all custom-runner-label and shellcheck-style
      notes elsewhere in the file), so the removal introduces none.
- [ ] The measurement that closes this: the Rust hit rate reported by the sccache stats
      step on the next `merge_group` run of this leg should move from ~0% toward
      `integration.yml`'s ~71%. It cannot be observed from a PR, since this leg does not
      run on `pull_request`.

## Review gate

- Adversarial review: **skipped** — receipt `.git/worktrees/13299/spice-review-gate/adversarial-review.txt` records `attempt=codex result=not-installed`, `engine=none`, `exit=1`. This host has no `node` runtime to run the companion `.mjs` entry point (the `codex` CLI itself is present, 0.147.0), and the sandbox denies `/usr/bin/sort`, which the companion-selection step uses. `grok` is not a permitted engine for a Grok-authored diff, so there was no fallback.
- `/security-review`: no findings — audited by hand against the same checklist, because the harness skill diffs the session's own checkout and this change lives in a separate worktree. The change removes a step and adds nothing. The one property worth stating is the trust boundary on the now-shared path: this leg's builds never run on `pull_request` (both `check_changes` and `setup-matrix` are gated on the event, and `build` needs them), so only `merge_group`, `push` and `workflow_dispatch` — all post-approval — write to it, and every other workflow on these runners already shares that same default path.
- `/simplify`: ran against this diff as an inline pass over the four angles (this run cannot spawn the parallel agents the skill uses) — no changes applied. The diff is a deletion.

Fixes #13299

## Checklist

- [x] Root cause identified and stated, with the mechanism and the in-repo control
- [x] The original reason for the per-run directory traced (#7627) and addressed
- [x] Swept for other `CARGO_*` overrides — this was the only one in the repo
