### PR TITLE
fix(ci): call a test binary the runner cannot load an infrastructure failure (fixes #13518)

### DIFF
--- a/scripts/signoff
+++ b/scripts/signoff
@@ -854,6 +854,21 @@ readonly DISK_FULL_PATTERN='No space left on device|errno=28'
 # an optional `e` while reading as though it were deliberate.
 readonly CACHE_UNUSABLE_PATTERN='sccache: error: Server startup failed|sccache: error: cache storage failed|sccache: error: Timed out waiting for server startup'
 
+# The loader's refusal to execute a test binary, in the two spellings the pool's
+# runners produce: EBADMACHO (88) on the macOS boxes, ENOEXEC on the Linux ones.
+# Both mean the file `nextest` was handed is not a loadable executable — a
+# truncated or clobbered artifact on the shared `target/` volume, which is a
+# statement about the runner and not about the branch.
+readonly CORRUPT_ARTIFACT_PATTERN='Malformed Mach-o file|Exec format error'
+
+# The line that says the loader error above came from `nextest` trying to run a
+# build artifact, rather than from a test asserting on that wording. Both are
+# required, because this repo's own suites do assert error strings, and excusing
+# a genuine test failure as infrastructure is the more expensive mistake of the
+# two. `nextest` prints this when a binary fails to execute during enumeration,
+# which is where a corrupt artifact is met first (#13518).
+readonly TEST_LIST_FAILURE_PATTERN='error: creating test list failed'
+
 # Set to 1 on remote runs, where run_make_step watches build output for the
 # out-of-disk and unusable-cache signatures. Separates "watched, and it was
 # neither" from "nothing watched at all", which failure_kind answers differently.
@@ -880,6 +895,12 @@ SIGNOFF_DISK_HIT="${SIGNOFF_DISK_HIT:-}"
 # test can set up a classification without running a build.
 SIGNOFF_CACHE_HIT="${SIGNOFF_CACHE_HIT:-}"
 
+# Set to 1 by run_make_step when the step it ran could not execute a test binary
+# it built. Same mechanism and the same reason for being a variable rather than
+# a file as the two above, and likewise seeded from the environment so a test
+# can set up a classification without running a build.
+SIGNOFF_ARTIFACT_HIT="${SIGNOFF_ARTIFACT_HIT:-}"
+
 # The statuses the watcher exits with to report each signature. Deliberately
 # not 1 or 2: awk uses those for its own errors, and a watcher that itself died
 # must not be read as a volume that filled. Reserving distinct statuses is also
@@ -887,6 +908,7 @@ SIGNOFF_CACHE_HIT="${SIGNOFF_CACHE_HIT:-}"
 # verdict" (anything else), which it must not conflate — see run_make_step.
 readonly DISK_WATCH_HIT_STATUS=3
 readonly CACHE_WATCH_HIT_STATUS=4
+readonly ARTIFACT_WATCH_HIT_STATUS=5
 
 # The watcher itself, held in one place so the probe below runs exactly the
 # program that will read the build output — a probe of anything else predicts
@@ -904,10 +926,13 @@ readonly CACHE_WATCH_HIT_STATUS=4
 readonly DISK_WATCH_PROGRAM='
     $0 ~ pat { hit = 1 }
     $0 ~ cache_pat { cache_hit = 1 }
+    $0 ~ artifact_pat { artifact_hit = 1 }
+    $0 ~ list_pat { list_failed = 1 }
     { print; fflush() }
     END {
       if (hit) exit (hit_status + 0)
       if (cache_hit) exit (cache_status + 0)
+      if (artifact_hit && list_failed) exit (artifact_status + 0)
     }
   '
 
@@ -918,6 +943,8 @@ readonly DISK_WATCH_PROGRAM='
 disk_watch_probe() {
   awk -v pat="$DISK_FULL_PATTERN" -v hit_status="$DISK_WATCH_HIT_STATUS" \
     -v cache_pat="$CACHE_UNUSABLE_PATTERN" -v cache_status="$CACHE_WATCH_HIT_STATUS" \
+    -v artifact_pat="$CORRUPT_ARTIFACT_PATTERN" -v list_pat="$TEST_LIST_FAILURE_PATTERN" \
+    -v artifact_status="$ARTIFACT_WATCH_HIT_STATUS" \
     "$DISK_WATCH_PROGRAM" </dev/null >/dev/null 2>&1
 }
 
@@ -946,6 +973,7 @@ run_make_step() {
   # steps later.
   SIGNOFF_DISK_HIT=""
   SIGNOFF_CACHE_HIT=""
+  SIGNOFF_ARTIFACT_HIT=""
   # Ask whether the watcher runs before make writes a byte to it, because the
   # only other place to find out is downstream of make — where a watcher that
   # exits at once closes the pipe under a still-writing make, make dies of
@@ -963,6 +991,8 @@ run_make_step() {
   make "$@" 2>&1 | awk \
       -v pat="$DISK_FULL_PATTERN" -v hit_status="$DISK_WATCH_HIT_STATUS" \
       -v cache_pat="$CACHE_UNUSABLE_PATTERN" -v cache_status="$CACHE_WATCH_HIT_STATUS" \
+      -v artifact_pat="$CORRUPT_ARTIFACT_PATTERN" -v list_pat="$TEST_LIST_FAILURE_PATTERN" \
+      -v artifact_status="$ARTIFACT_WATCH_HIT_STATUS" \
       "$DISK_WATCH_PROGRAM"
   # Copy the whole array in one statement: reading PIPESTATUS is itself a command,
   # so a second `x="${PIPESTATUS[1]}"` would be reading the *assignment's* status
@@ -974,6 +1004,8 @@ run_make_step() {
     SIGNOFF_DISK_HIT=1
   elif [[ "$watch_status" -eq "$CACHE_WATCH_HIT_STATUS" ]]; then
     SIGNOFF_CACHE_HIT=1
+  elif [[ "$watch_status" -eq "$ARTIFACT_WATCH_HIT_STATUS" ]]; then
+    SIGNOFF_ARTIFACT_HIT=1
   elif [[ "$watch_status" -ne 0 ]]; then
     # The watcher started, so the probe cleared it, and then died part-way
     # through: killed for memory, or a signal that reached the whole group. Its
@@ -1019,6 +1051,12 @@ build_hit_disk_full() {
 # mislabelling that matters most to avoid.
 build_hit_cache_unusable() {
   [[ -n "$SIGNOFF_CACHE_HIT" ]]
+}
+
+# True when the step that failed could not execute a test binary it built. Read
+# in the same shell that ran the step, for the same reason as its two siblings.
+build_hit_corrupt_artifact() {
+  [[ -n "$SIGNOFF_ARTIFACT_HIT" ]]
 }
 
 # Free space in GiB on the volume holding "$1" (default: the working tree).
@@ -1144,6 +1182,14 @@ failure_kind() {
       echo "disk"
     elif build_hit_cache_unusable; then
       echo "cache"
+    elif build_hit_corrupt_artifact; then
+      # Last of the three, because the other two are upstream of this one: a
+      # volume that fills mid-link and a cache that cannot be reached both
+      # produce short or missing artifacts, and naming the cause is what tells
+      # the reader which remedy applies. Reached only when neither of those
+      # signatures went past, i.e. the artifact is unloadable for a reason this
+      # run cannot see.
+      echo "corrupt-artifact"
     else
       echo "checks"
     fi
@@ -1204,6 +1250,22 @@ describe_check_failure() {
       SIGNOFF_FAILURE_STATUS_DESC="Compiler cache unreachable after ${elapsed}s — checks did not complete, re-dispatch (triggered by ${user})"
       SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — \`sccache\` could not reach its storage endpoint on this runner, so every \`rustc\` invocation failed before compiling anything and **the checks did not complete**. Nothing here is a statement about the branch. Re-dispatch once the runner's cache endpoint is answering; if it stays down, the pool's \`sccache\` service is what needs attention (see \`.github/actions/setup-sccache\`)."$'\n'
       SIGNOFF_FAILURE_MESSAGE="sign-off aborted: sccache could not reach its storage (the checks did not complete)"
+      ;;
+    corrupt-artifact)
+      # Neither a verdict on the code nor a threshold anyone can act on: the
+      # runner handed `nextest` a file the loader will not execute, so
+      # enumeration failed and no test ran. Worded like the other kinds that
+      # reached no verdict, because the alternative — the generic "checks
+      # failed" — sends the author to look for a defect in a diff nothing
+      # judged (#13518, and #12813 before it).
+      #
+      # Hedged rather than asserted: this cannot tell whether the crate whose
+      # binary would not load is one the branch touches. A recurrence on this
+      # branch alone, or one naming a crate whose build script it changes, is
+      # worth suspecting the diff for.
+      SIGNOFF_FAILURE_STATUS_DESC="Sign-off could not complete after ${elapsed}s — a test binary on the runner would not load; re-dispatch (triggered by ${user})"
+      SIGNOFF_FAILURE_SUMMARY="### Sign-off"$'\n'"**Infrastructure failure** after ${elapsed}s — \`nextest\` could not execute a test binary while listing tests, because the runner's copy is not a loadable executable, so **the checks did not complete**. That is a truncated or clobbered artifact on the shared \`target/\` volume rather than a statement about the branch. Re-dispatch the sign-off. If it recurs on this branch alone, or names a crate whose build script this branch changes, the diff is worth suspecting."$'\n'
+      SIGNOFF_FAILURE_MESSAGE="sign-off aborted: a test binary on the runner would not load, so nextest never ran the suite (the checks did not complete) — re-dispatch"
       ;;
     missing-target)
       # Neither of the two readings above: the runner is fine and the code was

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -533,7 +533,7 @@ assert_recorder "records the ELF spelling of the same condition" \
    exit 104' \
   104 no "" no yes
 # Both halves are required, and this is the direction that costs the most if it
-# is wrong: this repo own suites assert on error strings, so a loader message
+# is wrong: this repo's own suites assert on error strings, so a loader message
 # quoted by a failing test must stay a verdict about the branch.
 assert_recorder "leaves a failure unmarked when the loader wording is only quoted" \
   'echo "assertion failed: expected Exec format error (os error 8)"

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -10,11 +10,12 @@
 # credentials: a stub `df` on PATH reports whatever free space a case needs, and a
 # stub `make` prints whatever a case needs the watcher to read.
 #
-# `failure_kind` names two further causes with the same consequence — a run that
-# was signalled and so judged nothing at all, and a branch whose Makefile has no
-# rule for a target the gate invokes, so nothing was compiled — so their cases
-# live here too, alongside `describe_check_failure`, which turns any of them into
-# what the run publishes. The make-target preflight is here for the same reason
+# `failure_kind` names three further causes with the same consequence — a run that
+# was signalled and so judged nothing at all, a branch whose Makefile has no rule
+# for a target the gate invokes, so nothing was compiled, and a test binary the
+# runner's loader will not execute, so nothing was run — so their cases live here
+# too, alongside `describe_check_failure`, which turns any of them into what the
+# run publishes. The make-target preflight is here for the same reason
 # the disk one is: it decides whether a run gets to start, and getting it wrong
 # either way is the bug.
 #
@@ -369,6 +370,9 @@ assert_recorder() {
   # verdicts. Defaulting this to "no" means the existing disk cases now also
   # prove the cache signature does not cross-fire on them.
   local want_cache_marked="${6:-no}"
+  # ...and the same for the unloadable-artifact signature, which the disk and
+  # cache cases above must not trip either.
+  local want_artifact_marked="${7:-no}"
   tests_run=$((tests_run + 1))
 
   local fake_make="$stub_dir/make"
@@ -383,6 +387,7 @@ assert_recorder() {
       if run_make_step some-target; then step_rc=0; else step_rc=$?; fi
       echo "VERDICT=${SIGNOFF_DISK_HIT:+yes}"
       echo "CACHEHIT=${SIGNOFF_CACHE_HIT:+yes}"
+      echo "ARTIFACTHIT=${SIGNOFF_ARTIFACT_HIT:+yes}"
       exit "$step_rc"' _ "$subject" 2>&1)"
   rc=$?
 
@@ -419,6 +424,19 @@ assert_recorder() {
   fi
   if [[ "$cache_marked" != "$want_cache_marked" ]]; then
     fail_test "$name: expected cache_marked=${want_cache_marked}, got ${cache_marked} (output: '${output}')"
+    rm -f "$fake_make"
+    return
+  fi
+
+  local artifact_marked="no"
+  [[ "$output" == *"ARTIFACTHIT=yes"* ]] && artifact_marked="yes"
+  if [[ "$output" != *"ARTIFACTHIT="* ]]; then
+    fail_test "$name: the step never reported an artifact verdict — output: '${output}'"
+    rm -f "$fake_make"
+    return
+  fi
+  if [[ "$artifact_marked" != "$want_artifact_marked" ]]; then
+    fail_test "$name: expected artifact_marked=${want_artifact_marked}, got ${artifact_marked} (output: '${output}')"
     rm -f "$fake_make"
     return
   fi
@@ -496,6 +514,49 @@ assert_recorder "reports disk, not cache, when the volume filled and took sccach
    echo "ld: write() failed, errno=28 (No space left on device)"
    exit 101' \
   101 yes "errno=28" no
+
+# Verbatim from run 32858051094, where a test binary on the shared volume was not
+# a loadable Mach-O and the run reported "Sign-off checks failed" about a branch
+# that never touched the crate. `nextest` fails while *listing*, so no test ran.
+assert_recorder "records a test binary the loader will not execute" \
+  'echo "error: creating test list failed"
+   echo "Caused by:"
+   echo "  for \`runtime-checkpoint-api\`, running command \`target/debug/deps/runtime_checkpoint_api-abc --list --format terse\` failed to execute"
+   echo "Caused by:"
+   echo "  Malformed Mach-o file (os error 88)"
+   exit 104' \
+  104 no "Malformed Mach-o" no yes
+# The Linux runners answer the same condition with ENOEXEC rather than EBADMACHO.
+assert_recorder "records the ELF spelling of the same condition" \
+  'echo "error: creating test list failed"
+   echo "  Exec format error (os error 8)"
+   exit 104' \
+  104 no "" no yes
+# Both halves are required, and this is the direction that costs the most if it
+# is wrong: this repo own suites assert on error strings, so a loader message
+# quoted by a failing test must stay a verdict about the branch.
+assert_recorder "leaves a failure unmarked when the loader wording is only quoted" \
+  'echo "assertion failed: expected Exec format error (os error 8)"
+   echo "error[E0308]: mismatched types"
+   exit 101' \
+  101 no "E0308" no no
+# ...and the other half alone is an ordinary nextest failure, not an artifact one:
+# listing can fail for reasons that are about the branch, e.g. a test binary that
+# panics in a constructor before it can answer --list.
+assert_recorder "leaves a listing failure unmarked without a loader error" \
+  'echo "error: creating test list failed"
+   echo "  process panicked at crates/runtime/src/lib.rs:1:1"
+   exit 104' \
+  104 no "creating test list failed" no no
+# Disk wins over an unloadable artifact, for the same reason it wins over the
+# cache: a volume that filled mid-link is what truncated the binary, and
+# reclaiming space is the remedy that fixes both.
+assert_recorder "reports disk, not the artifact, when the volume filled first" \
+  'echo "ld: write() failed, errno=28 (No space left on device)"
+   echo "error: creating test list failed"
+   echo "  Malformed Mach-o file (os error 88)"
+   exit 104' \
+  104 yes "errno=28" no no
 
 # Stickiness: a step that merely mentions running out of disk and then succeeds
 # must not leave the verdict blaming the volume for a later, genuine failure.
@@ -671,6 +732,26 @@ assert_failure_kind "calls a failure on a roomy volume a check failure" 101 "che
   STUB_FREE_KB="$(gib_to_kb 200)"
 assert_failure_kind "calls a failure with unknown free space a check failure" 101 "checks" \
   STUB_DF_RC=1
+
+# The unloadable-artifact kind: the watch was armed, the artifact signature went
+# past, and neither of the two upstream causes did. Distinct from "checks" for
+# the same reason as the kinds above — nothing about the branch was judged.
+assert_failure_kind "calls an unloadable test binary its own kind, not a check failure" 104 "corrupt-artifact" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_ARTIFACT_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+# The two causes that can produce a short artifact outrank naming the symptom,
+# because each carries a different remedy.
+assert_failure_kind "reports disk when the volume filled and the artifact was short" 104 "disk" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_DISK_HIT=1 SIGNOFF_ARTIFACT_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+assert_failure_kind "reports cache when the cache was unreachable too" 104 "cache" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_CACHE_HIT=1 SIGNOFF_ARTIFACT_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+# ...and a signalled run still outranks all of them: it reached no verdict at all.
+assert_failure_kind "a signalled run stays signalled, not an unloadable artifact" 143 "signalled" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_ARTIFACT_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+# An artifact flag inherited from the environment with nothing watching is not a
+# reading anyone took: with the watch disarmed, classification falls back to free
+# space exactly as on a local run.
+assert_failure_kind "ignores an artifact flag when nothing watched the build" 104 "checks" \
+  SIGNOFF_ARTIFACT_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 
 # The cache verdict, same shape as the disk one: authoritative when the watch was
 # armed, and worth nothing without it.
@@ -851,6 +932,18 @@ assert_describe "still publishes the unreachable-cache verdict" 101 \
   "Compiler cache unreachable after 21195s — checks did not complete, re-dispatch (triggered by someone)" \
   "sccache could not reach its storage" \
   SIGNOFF_DISK_WATCH=1 SIGNOFF_CACHE_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+# An unloadable test binary has to say so in the commit status itself: that
+# description is all most readers see, and worded as a check failure it is
+# indistinguishable from a test that genuinely failed. It also has to name the
+# remedy, since the reader who needs it is not going to open the log.
+assert_describe "says an unloadable test binary could not complete, not that checks failed" 104 \
+  "Sign-off could not complete after 21195s — a test binary on the runner would not load; re-dispatch (triggered by someone)" \
+  "the checks did not complete" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_ARTIFACT_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
+assert_describe "tells the author to re-dispatch rather than to read the log" 104 \
+  "Sign-off could not complete after 21195s — a test binary on the runner would not load; re-dispatch (triggered by someone)" \
+  "re-dispatch" \
+  SIGNOFF_DISK_WATCH=1 SIGNOFF_ARTIFACT_HIT=1 STUB_FREE_KB="$(gib_to_kb 200)"
 assert_describe "still publishes a genuine check failure" 101 \
   "Sign-off checks failed after 21195s (triggered by someone)" \
   "sign-off checks failed" STUB_FREE_KB="$(gib_to_kb 200)"


### PR DESCRIPTION
## Summary

A remote sign-off run whose test binary is not a loadable executable published the
generic verdict — `Sign-off checks failed after 7471s` — so the branch looked guilty
when nothing about it had been evaluated. On run 32858051094 the run died with:

```
error: creating test list failed

Caused by:
  for `runtime-checkpoint-api`, running command `.../runtime_checkpoint_api-<hash> --list --format terse` failed to execute

Caused by:
  Malformed Mach-o file (os error 88)
```

`nextest` never ran a test: it failed while *listing* them, because the file it was
asked to execute is not a valid Mach-O. That is a truncated or clobbered artifact on
the shared `target/` volume — and the crate named is one that branch never touched.

`scripts/signoff` already separates the causes where the branch reached no verdict —
`disk`, `cache`, `missing-target` — from a real one. A corrupt artifact fell through
to `checks`, whose description is indistinguishable from a lint or test denial. The
commit status is all most readers see, so reading that one at face value sends
someone into a 14k-line log looking for a defect that was never there, and the honest
remedy — re-dispatch — is the one thing the status does not suggest. Same failure
shape #12813 fixed for the missing-target case.

## Changes

- The build-output watcher gains the loader's refusal in both spellings the pool
  produces: `Malformed Mach-o file` (EBADMACHO) on the macOS boxes and
  `Exec format error` (ENOEXEC) on the Linux ones.
- **A hit requires `nextest`'s own listing failure alongside it.** This repo's suites
  assert on error strings, so a loader message quoted by a failing test must stay a
  verdict about the branch — excusing a genuine failure as infrastructure is the more
  expensive of the two mistakes, and the test suite pins both directions.
- `failure_kind` gains `corrupt-artifact`, ordered *after* `disk` and `cache`: both of
  those can themselves produce a short artifact, and each carries a different remedy,
  so naming the upstream cause when it is visible stays more useful than naming the
  symptom. A signalled run still outranks all of them.
- `describe_check_failure` publishes it in the register the other no-verdict kinds
  use — the checks did not complete, re-dispatch — and keeps the hedge the classifier
  owes: it cannot tell whether the crate whose binary would not load is one the branch
  touches, so a recurrence on one branch alone, or one naming a crate whose build
  script that branch changes, is worth suspecting the diff for.

## Test plan

- [x] `make lint`
- [x] `make test`

This branch changes two shell scripts and no Rust, so the sign-off gate takes its
no-Rust-changes path: it runs neither lint nor tests, and `Attestation` is green
through that path rather than by skipping a gate.

- [x] `scripts/test_signoff_disk_guard.sh` — the suite this change extends, run locally:
      **108 of 109 pass**, and the one failure (`treats a runner with no make as target
      present`) reproduces identically on unmodified `trunk`. It is a Windows-host
      artifact of the case that builds a PATH containing only a symlinked `bash`; it is
      not caused by, or related to, this diff.
- [x] `shellcheck -S warning` clean on both changed scripts.
- [x] `bash -n` clean on both changed scripts.

Twelve tests added, covering both directions:

- the Mach-O and ELF spellings each recorded, with `nextest`'s listing failure;
- a loader message *quoted by a failing test* left unmarked (the expensive direction);
- a listing failure with no loader error left unmarked;
- disk and cache each still outranking the artifact signature when both appear;
- `failure_kind` returning `corrupt-artifact`, and yielding to `signalled`, `disk` and
  `cache`;
- an inherited artifact flag ignored when nothing watched the build;
- the published description saying the checks did not complete and naming re-dispatch.

The existing disk and cache cases now also assert the artifact signature does *not*
cross-fire on them, which is how the cache signature was added to this harness.

## Review gate

- Adversarial review: **skipped** — receipt `.git/worktrees/13518/spice-review-gate/adversarial-review.txt` records `attempt=codex result=not-installed`, `engine=none`, `exit=1`. This host has no `node` runtime to run the companion `.mjs` entry point (the `codex` CLI itself is present, 0.147.0), and the sandbox denies `/usr/bin/sort`, which the companion-selection step uses. `grok` is not a permitted engine for a Grok-authored diff, so there was no fallback.
- `/security-review`: no findings — audited by hand against the same checklist, because the harness skill diffs the session's own checkout and this change lives in a separate worktree. The new patterns are `readonly` constants matched by `awk` against build output that already streams through this watcher; nothing new is executed, no output is interpolated into a command, and the published strings are fixed text plus the elapsed seconds and the dispatching user the other cases already carry. Build output stays untrusted input that is only ever *matched*, never evaluated.
- `/simplify`: ran against this diff as an inline pass over the four angles (this run cannot spawn the parallel agents the skill uses) — no changes applied. The new kind reuses the watcher, the hit-variable convention and the `describe_check_failure` shape its three siblings already established rather than adding a mechanism of its own, and the test harness was extended in the same way the cache signature extended it.

Fixes #13518

## Checklist

- [x] Root cause identified and stated
- [x] New behaviour covered in both directions, including the false-positive direction
- [x] Pre-existing local test failure verified against unmodified `trunk` before shipping
