### PR TITLE
fix(spicepod): say which acceleration settings enabled: false discards (fixes #13514)

### DIFF
--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -76,13 +76,20 @@ pub struct DatasetBuilder {
 /// A function rather than an inline `tracing::warn!` so the wording — which is
 /// the whole of this feature for the person reading the log — is assertable.
 ///
+/// Single quotes around the name the operator chose, backticks around the config
+/// keys they are being told to act on, per the repo's message convention.
+///
 /// It names only the fields it was given, and does not say "the rest of the
 /// block": `ready_state` is read out of a disabled block and applied, so a claim
 /// about everything under `enabled` would be untrue for it.
 fn disabled_acceleration_warning(dataset: &str, ignored: &[String]) -> String {
+    let keys = ignored
+        .iter()
+        .map(|field| format!("`{field}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
     format!(
-        "Dataset {dataset} sets `acceleration.enabled: false`, so these settings in its acceleration block are read and then ignored: {}. Remove `enabled: false` to apply them, or remove them to keep the dataset unaccelerated.",
-        ignored.join(", ")
+        "Dataset '{dataset}' sets `acceleration.enabled: false`, so these settings in its acceleration block are read and then ignored: {keys}. Remove `enabled: false` to apply them, or remove them to keep the dataset unaccelerated. See: https://spiceai.org/docs/reference/spicepod/datasets#acceleration"
     )
 }
 
@@ -485,10 +492,14 @@ mod tests {
             "api_data",
             &["engine".to_string(), "refresh_mode".to_string()],
         );
-        assert!(warning.contains("api_data"), "{warning}");
-        assert!(warning.contains("engine, refresh_mode"), "{warning}");
+        // Quoting and backticking are the repo's convention, not decoration: an
+        // unquoted name vanishes when it is empty and reads as prose when it is
+        // a word like `orders`.
+        assert!(warning.contains("'api_data'"), "{warning}");
+        assert!(warning.contains("`engine`, `refresh_mode`"), "{warning}");
         assert!(warning.contains("acceleration.enabled: false"), "{warning}");
         assert!(warning.contains("Remove `enabled: false`"), "{warning}");
+        assert!(warning.contains("https://spiceai.org/docs/"), "{warning}");
     }
 
     #[test]

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -70,35 +70,6 @@ pub struct DatasetBuilder {
     pub check_availability_interval: Option<Duration>,
 }
 
-/// What to tell an operator whose dataset sets `acceleration.enabled: false` and
-/// leaves settings in the block that the runtime will not apply.
-///
-/// A function rather than an inline `tracing::warn!` so the wording — which is
-/// the whole of this feature for the person reading the log — is assertable.
-///
-/// Single quotes around the name the operator chose, backticks around the config
-/// keys they are being told to act on, per the repo's message convention — and
-/// the name escaped, since a quoted Spicepod identifier can carry a newline
-/// through validation and would otherwise forge a second log line.
-///
-/// It names only the fields it was given, and does not say "the rest of the
-/// block": `ready_state` is read out of a disabled block and applied, so a claim
-/// about everything under `enabled` would be untrue for it.
-fn disabled_acceleration_warning(dataset: &str, ignored: &[String]) -> String {
-    let keys = ignored
-        .iter()
-        .map(|field| format!("`{field}`"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    // `escape_debug` rather than the raw name: `validate_identifier` accepts a
-    // *quoted* identifier, and a quoted one may legally contain a newline, so a
-    // validated name can still break this line in two and forge a second one.
-    let dataset = dataset.escape_debug();
-    format!(
-        "Dataset '{dataset}' sets `acceleration.enabled: false`, so these settings in its acceleration block are read and then ignored: {keys}. Remove `enabled: false` to apply them, or remove them to keep the dataset unaccelerated. See: https://spiceai.org/docs/reference/spicepod/datasets#acceleration"
-    )
-}
-
 impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
     type Error = crate::Error;
 
@@ -131,37 +102,12 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
 
         let metadata = dataset.metadata();
 
-        // `enabled: false` turns the whole block off, so anything else set in it
-        // is read, accepted and then never applied — with one exception, which
-        // is above: `ready_state` is pulled out of this block and applied to the
-        // dataset whether or not acceleration is enabled, and
-        // `fields_ignored_when_disabled` leaves it out for exactly that reason.
-        //
-        // Collect the rest here, while the Spicepod block is still in hand and
-        // before the conversion below resolves its defaults away (#13514); it is
-        // reported after the name is validated.
-        let ignored_acceleration_fields = dataset
-            .acceleration
-            .as_ref()
-            .map(spicepod_acceleration::Acceleration::fields_ignored_when_disabled)
-            .unwrap_or_default();
-
         let acceleration = dataset
             .acceleration
             .map(acceleration::Acceleration::try_from)
             .transpose()?;
 
         validate_identifier(&dataset.name).context(crate::ComponentSnafu)?;
-
-        // After the name is validated, deliberately: an identifier that reaches
-        // here has passed the tokenizer, so it holds no newline or other control
-        // character that could forge a second log line out of this one.
-        if !ignored_acceleration_fields.is_empty() {
-            tracing::warn!(
-                "{}",
-                disabled_acceleration_warning(&dataset.name, &ignored_acceleration_fields)
-            );
-        }
 
         let table_reference = Dataset::parse_table_reference(&dataset.name)?;
 
@@ -487,58 +433,4 @@ fn fts_store_from_column_overrides(
         engine: Some(column_engine),
         params: column_params,
     }))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::disabled_acceleration_warning;
-
-    #[test]
-    fn the_warning_names_the_dataset_the_fields_and_the_remedy() {
-        // Everything a reader needs to act, in one line: which dataset, what is
-        // being dropped, and the two ways out. Asserted because the message is
-        // the entire user-visible behaviour of this path (#13514).
-        let warning = disabled_acceleration_warning(
-            "api_data",
-            &["engine".to_string(), "refresh_mode".to_string()],
-        );
-        // Quoting and backticking are the repo's convention, not decoration: an
-        // unquoted name vanishes when it is empty and reads as prose when it is
-        // a word like `orders`.
-        assert!(warning.contains("'api_data'"), "{warning}");
-        assert!(warning.contains("`engine`, `refresh_mode`"), "{warning}");
-        assert!(warning.contains("acceleration.enabled: false"), "{warning}");
-        assert!(warning.contains("Remove `enabled: false`"), "{warning}");
-        assert!(warning.contains("https://spiceai.org/docs/"), "{warning}");
-    }
-
-    #[test]
-    fn a_control_character_in_the_name_cannot_break_the_line_in_two() {
-        // `validate_identifier` accepts a quoted identifier, and a quoted one
-        // may contain a newline — so the name reaching this message is not
-        // guaranteed to be one line, and an unescaped one would let a dataset
-        // name write a second log line of its own choosing.
-        let warning = disabled_acceleration_warning("api\nWARN forged", &["engine".to_string()]);
-        assert!(
-            !warning.contains('\n'),
-            "the message must stay one line: {warning}"
-        );
-        assert!(
-            warning.contains("api\\nWARN forged"),
-            "the name must still be readable, escaped: {warning}"
-        );
-    }
-
-    #[test]
-    fn the_warning_claims_only_the_fields_it_was_given() {
-        // `ready_state` is read out of a disabled block and applied, so this
-        // message must not claim the whole block is ignored — a reader who sees
-        // that goes looking for a `ready_state` that is working correctly.
-        let warning = disabled_acceleration_warning("api_data", &["engine".to_string()]);
-        assert!(
-            !warning.contains("the rest of"),
-            "the message must scope itself to the listed fields: {warning}"
-        );
-        assert!(!warning.contains("ready_state"), "{warning}");
-    }
 }

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -77,7 +77,9 @@ pub struct DatasetBuilder {
 /// the whole of this feature for the person reading the log — is assertable.
 ///
 /// Single quotes around the name the operator chose, backticks around the config
-/// keys they are being told to act on, per the repo's message convention.
+/// keys they are being told to act on, per the repo's message convention — and
+/// the name escaped, since a quoted Spicepod identifier can carry a newline
+/// through validation and would otherwise forge a second log line.
 ///
 /// It names only the fields it was given, and does not say "the rest of the
 /// block": `ready_state` is read out of a disabled block and applied, so a claim
@@ -88,6 +90,10 @@ fn disabled_acceleration_warning(dataset: &str, ignored: &[String]) -> String {
         .map(|field| format!("`{field}`"))
         .collect::<Vec<_>>()
         .join(", ");
+    // `escape_debug` rather than the raw name: `validate_identifier` accepts a
+    // *quoted* identifier, and a quoted one may legally contain a newline, so a
+    // validated name can still break this line in two and forge a second one.
+    let dataset = dataset.escape_debug();
     format!(
         "Dataset '{dataset}' sets `acceleration.enabled: false`, so these settings in its acceleration block are read and then ignored: {keys}. Remove `enabled: false` to apply them, or remove them to keep the dataset unaccelerated. See: https://spiceai.org/docs/reference/spicepod/datasets#acceleration"
     )
@@ -500,6 +506,23 @@ mod tests {
         assert!(warning.contains("acceleration.enabled: false"), "{warning}");
         assert!(warning.contains("Remove `enabled: false`"), "{warning}");
         assert!(warning.contains("https://spiceai.org/docs/"), "{warning}");
+    }
+
+    #[test]
+    fn a_control_character_in_the_name_cannot_break_the_line_in_two() {
+        // `validate_identifier` accepts a quoted identifier, and a quoted one
+        // may contain a newline — so the name reaching this message is not
+        // guaranteed to be one line, and an unescaped one would let a dataset
+        // name write a second log line of its own choosing.
+        let warning = disabled_acceleration_warning("api\nWARN forged", &["engine".to_string()]);
+        assert!(
+            !warning.contains('\n'),
+            "the message must stay one line: {warning}"
+        );
+        assert!(
+            warning.contains("api\\nWARN forged"),
+            "the name must still be readable, escaped: {warning}"
+        );
     }
 
     #[test]

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -102,6 +102,22 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
 
         let metadata = dataset.metadata();
 
+        // `enabled: false` turns the whole block off, so anything else set in it
+        // is read, accepted and then never applied. Say so rather than leaving a
+        // dataset that looks configured to cache serving every query from the
+        // source (#13514). Read from the Spicepod block, before the conversion
+        // below resolves its defaults and the distinction is gone.
+        if let Some(acceleration_block) = dataset.acceleration.as_ref() {
+            let ignored = acceleration_block.fields_ignored_when_disabled();
+            if !ignored.is_empty() {
+                tracing::warn!(
+                    "Dataset {} sets `acceleration.enabled: false`, so the rest of its acceleration block is ignored: {}. Remove `enabled: false` to apply them, or remove them to keep the dataset unaccelerated.",
+                    dataset.name,
+                    ignored.join(", ")
+                );
+            }
+        }
+
         let acceleration = dataset
             .acceleration
             .map(acceleration::Acceleration::try_from)

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -70,6 +70,22 @@ pub struct DatasetBuilder {
     pub check_availability_interval: Option<Duration>,
 }
 
+/// What to tell an operator whose dataset sets `acceleration.enabled: false` and
+/// leaves settings in the block that the runtime will not apply.
+///
+/// A function rather than an inline `tracing::warn!` so the wording — which is
+/// the whole of this feature for the person reading the log — is assertable.
+///
+/// It names only the fields it was given, and does not say "the rest of the
+/// block": `ready_state` is read out of a disabled block and applied, so a claim
+/// about everything under `enabled` would be untrue for it.
+fn disabled_acceleration_warning(dataset: &str, ignored: &[String]) -> String {
+    format!(
+        "Dataset {dataset} sets `acceleration.enabled: false`, so these settings in its acceleration block are read and then ignored: {}. Remove `enabled: false` to apply them, or remove them to keep the dataset unaccelerated.",
+        ignored.join(", ")
+    )
+}
+
 impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
     type Error = crate::Error;
 
@@ -103,20 +119,15 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
         let metadata = dataset.metadata();
 
         // `enabled: false` turns the whole block off, so anything else set in it
-        // is read, accepted and then never applied. Say so rather than leaving a
-        // dataset that looks configured to cache serving every query from the
-        // source (#13514). Read from the Spicepod block, before the conversion
-        // below resolves its defaults and the distinction is gone.
-        if let Some(acceleration_block) = dataset.acceleration.as_ref() {
-            let ignored = acceleration_block.fields_ignored_when_disabled();
-            if !ignored.is_empty() {
-                tracing::warn!(
-                    "Dataset {} sets `acceleration.enabled: false`, so the rest of its acceleration block is ignored: {}. Remove `enabled: false` to apply them, or remove them to keep the dataset unaccelerated.",
-                    dataset.name,
-                    ignored.join(", ")
-                );
-            }
-        }
+        // is read, accepted and then never applied. Collect that here, while the
+        // Spicepod block is still in hand and before the conversion below
+        // resolves its defaults away (#13514); it is reported after the name is
+        // validated.
+        let ignored_acceleration_fields = dataset
+            .acceleration
+            .as_ref()
+            .map(spicepod_acceleration::Acceleration::fields_ignored_when_disabled)
+            .unwrap_or_default();
 
         let acceleration = dataset
             .acceleration
@@ -124,6 +135,16 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
             .transpose()?;
 
         validate_identifier(&dataset.name).context(crate::ComponentSnafu)?;
+
+        // After the name is validated, deliberately: an identifier that reaches
+        // here has passed the tokenizer, so it holds no newline or other control
+        // character that could forge a second log line out of this one.
+        if !ignored_acceleration_fields.is_empty() {
+            tracing::warn!(
+                "{}",
+                disabled_acceleration_warning(&dataset.name, &ignored_acceleration_fields)
+            );
+        }
 
         let table_reference = Dataset::parse_table_reference(&dataset.name)?;
 
@@ -449,4 +470,37 @@ fn fts_store_from_column_overrides(
         engine: Some(column_engine),
         params: column_params,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::disabled_acceleration_warning;
+
+    #[test]
+    fn the_warning_names_the_dataset_the_fields_and_the_remedy() {
+        // Everything a reader needs to act, in one line: which dataset, what is
+        // being dropped, and the two ways out. Asserted because the message is
+        // the entire user-visible behaviour of this path (#13514).
+        let warning = disabled_acceleration_warning(
+            "api_data",
+            &["engine".to_string(), "refresh_mode".to_string()],
+        );
+        assert!(warning.contains("api_data"), "{warning}");
+        assert!(warning.contains("engine, refresh_mode"), "{warning}");
+        assert!(warning.contains("acceleration.enabled: false"), "{warning}");
+        assert!(warning.contains("Remove `enabled: false`"), "{warning}");
+    }
+
+    #[test]
+    fn the_warning_claims_only_the_fields_it_was_given() {
+        // `ready_state` is read out of a disabled block and applied, so this
+        // message must not claim the whole block is ignored — a reader who sees
+        // that goes looking for a `ready_state` that is working correctly.
+        let warning = disabled_acceleration_warning("api_data", &["engine".to_string()]);
+        assert!(
+            !warning.contains("the rest of"),
+            "the message must scope itself to the listed fields: {warning}"
+        );
+        assert!(!warning.contains("ready_state"), "{warning}");
+    }
 }

--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -132,10 +132,14 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
         let metadata = dataset.metadata();
 
         // `enabled: false` turns the whole block off, so anything else set in it
-        // is read, accepted and then never applied. Collect that here, while the
-        // Spicepod block is still in hand and before the conversion below
-        // resolves its defaults away (#13514); it is reported after the name is
-        // validated.
+        // is read, accepted and then never applied — with one exception, which
+        // is above: `ready_state` is pulled out of this block and applied to the
+        // dataset whether or not acceleration is enabled, and
+        // `fields_ignored_when_disabled` leaves it out for exactly that reason.
+        //
+        // Collect the rest here, while the Spicepod block is still in hand and
+        // before the conversion below resolves its defaults away (#13514); it is
+        // reported after the name is validated.
         let ignored_acceleration_fields = dataset
             .acceleration
             .as_ref()

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -35,3 +35,183 @@ pub use runtime_component::{
 pub mod catalog;
 pub mod dataset;
 pub mod view;
+
+/// Which component an acceleration block was written on. A closed set rather than
+/// a `&str`, so a new component that grows an `acceleration:` block cannot reach
+/// [`disabled_acceleration_warning`] without deciding on its noun and its
+/// reference page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AcceleratedComponent {
+    Dataset,
+    View,
+}
+
+impl AcceleratedComponent {
+    /// The component word as the operator's Spicepod spells it, lower case, for
+    /// mid-sentence use.
+    const fn noun(self) -> &'static str {
+        match self {
+            Self::Dataset => "dataset",
+            Self::View => "view",
+        }
+    }
+
+    /// The same word capitalised, to open a log line with.
+    const fn titled_noun(self) -> &'static str {
+        match self {
+            Self::Dataset => "Dataset",
+            Self::View => "View",
+        }
+    }
+
+    /// The `acceleration` section of *this* component's Spicepod reference. A view
+    /// pointed at the datasets page is pointed at a block it does not have.
+    const fn acceleration_reference_url(self) -> &'static str {
+        match self {
+            Self::Dataset => "https://spiceai.org/docs/reference/spicepod/datasets#acceleration",
+            Self::View => "https://spiceai.org/docs/reference/spicepod/views#acceleration",
+        }
+    }
+}
+
+/// What to tell an operator whose dataset or view sets `acceleration.enabled:
+/// false` and leaves settings in the block that the runtime will not apply.
+///
+/// A function rather than an inline `tracing::warn!` so the wording — which is
+/// the whole of this feature for the person reading the log — is assertable,
+/// and shared between the two components rather than written twice: a dataset
+/// and a view discard the same block for the same reason, and an operator who
+/// learns to act on one message should not have to learn a second.
+///
+/// `component` is which component is being reported — it decides both the noun in
+/// the message and which Spicepod reference page the reader is sent to.
+///
+/// Single quotes around the name the operator chose, backticks around the config
+/// keys they are being told to act on, per the repo's message convention — and
+/// the name escaped, since a quoted Spicepod identifier can carry a newline
+/// through validation and would otherwise forge a second log line.
+///
+/// It names only the fields it was given, and does not say "the rest of the
+/// block": `ready_state` is excluded by `CONSUMED_WHEN_DISABLED`, so a claim
+/// about everything under `enabled` would be untrue.
+///
+/// The remedy sentence is load-bearing and constrains what may be passed in
+/// `ignored`: it promises that removing `enabled: false` applies these
+/// settings. Only pass fields for which that is true.
+pub(crate) fn disabled_acceleration_warning(
+    component: AcceleratedComponent,
+    name: &str,
+    ignored: &[String],
+) -> String {
+    let keys = ignored
+        .iter()
+        .map(|field| format!("`{field}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    // `escape_debug` rather than the raw name: `validate_identifier` accepts a
+    // *quoted* identifier, and a quoted one may legally contain a newline, so a
+    // validated name can still break this line in two and forge a second one.
+    let name = name.escape_debug();
+    let noun = component.noun();
+    let reference = component.acceleration_reference_url();
+    format!(
+        "{titled} '{name}' sets `acceleration.enabled: false`, so these settings in its acceleration block are read and then ignored: {keys}. Remove `enabled: false` to apply them, or remove them to keep the {noun} unaccelerated. See: {reference}",
+        titled = component.titled_noun()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AcceleratedComponent, disabled_acceleration_warning};
+
+    #[test]
+    fn the_warning_names_the_component_the_fields_and_the_remedy() {
+        // Everything a reader needs to act, in one line: which dataset, what is
+        // being dropped, and the two ways out. Asserted because the message is
+        // the entire user-visible behaviour of this path (#13514).
+        let warning = disabled_acceleration_warning(
+            AcceleratedComponent::Dataset,
+            "api_data",
+            &["engine".to_string(), "refresh_mode".to_string()],
+        );
+        // Quoting and backticking are the repo's convention, not decoration: an
+        // unquoted name vanishes when it is empty and reads as prose when it is
+        // a word like `orders`.
+        assert!(warning.starts_with("Dataset 'api_data'"), "{warning}");
+        assert!(warning.contains("`engine`, `refresh_mode`"), "{warning}");
+        assert!(warning.contains("acceleration.enabled: false"), "{warning}");
+        assert!(warning.contains("Remove `enabled: false`"), "{warning}");
+        assert!(
+            warning.contains("keep the dataset unaccelerated"),
+            "{warning}"
+        );
+        assert!(
+            warning.contains("/reference/spicepod/datasets#acceleration"),
+            "{warning}"
+        );
+    }
+
+    #[test]
+    fn the_warning_calls_a_view_a_view_and_links_to_the_views_reference() {
+        // An operator greps the log for the component they were editing. A view
+        // reported as a "dataset" sends them to the wrong block of the Spicepod,
+        // the remedy sentence has to agree with the noun, and the link has to
+        // land on a page that documents the block they actually wrote.
+        //
+        // Asserted on the specific phrases rather than `!contains("dataset")`:
+        // the datasets *URL* legitimately contains that substring, so the blunt
+        // form fails on a correct message.
+        let warning = disabled_acceleration_warning(
+            AcceleratedComponent::View,
+            "daily_totals",
+            &["engine".to_string()],
+        );
+        assert!(warning.starts_with("View 'daily_totals'"), "{warning}");
+        assert!(warning.contains("keep the view unaccelerated"), "{warning}");
+        assert!(
+            warning.contains("/reference/spicepod/views#acceleration"),
+            "{warning}"
+        );
+        assert!(!warning.contains("Dataset"), "{warning}");
+        assert!(!warning.contains("the dataset"), "{warning}");
+    }
+
+    #[test]
+    fn a_control_character_in_the_name_cannot_break_the_line_in_two() {
+        // `validate_identifier` accepts a quoted identifier, and a quoted one
+        // may contain a newline — so the name reaching this message is not
+        // guaranteed to be one line, and an unescaped one would let a name
+        // write a second log line of its own choosing.
+        let warning = disabled_acceleration_warning(
+            AcceleratedComponent::Dataset,
+            "api\nWARN forged",
+            &["engine".to_string()],
+        );
+        assert!(
+            !warning.contains('\n'),
+            "the message must stay one line: {warning}"
+        );
+        assert!(
+            warning.contains("api\\nWARN forged"),
+            "the name must still be readable, escaped: {warning}"
+        );
+    }
+
+    #[test]
+    fn the_warning_claims_only_the_fields_it_was_given() {
+        // `ready_state` is never one of the reported fields, so the message must
+        // not claim the whole block is ignored — a reader who saw that would go
+        // looking for a `ready_state` that is not broken in the way implied.
+        // This function must not widen the claim past the list it was handed.
+        let warning = disabled_acceleration_warning(
+            AcceleratedComponent::Dataset,
+            "api_data",
+            &["engine".to_string()],
+        );
+        assert!(
+            !warning.contains("the rest of"),
+            "the message must scope itself to the listed fields: {warning}"
+        );
+        assert!(!warning.contains("ready_state"), "{warning}");
+    }
+}

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -42,6 +42,7 @@ use crate::{
         acceleration::{Acceleration, RefreshMode},
         builder::DatasetBuilder,
     },
+    component::{AcceleratedComponent, disabled_acceleration_warning},
     dataaccelerator::{AccelerationSource, validate_snapshot_consistency, validate_snapshot_paths},
     dataconnector::{
         self, ConnectorComponent, DataConnector, ODBC_DATACONNECTOR,
@@ -81,6 +82,40 @@ use util::{error_spaced, warn_spaced};
 /// bound once per dataset.
 const HOT_RELOAD_INITIAL_REFRESH_TIMEOUT: Duration = Duration::from_mins(5);
 
+/// Warn an operator whose dataset or view sets `acceleration.enabled: false` and leaves
+/// settings in the block that the runtime will not apply (#13514).
+///
+/// Deliberately **not** in `DatasetBuilder`/`ViewBuilder`'s `TryFrom`, where this started.
+/// Those conversions are not the load path: `datasets_iter` runs them on every call to
+/// `get_valid_datasets`, and `GET /v1/datasets` is one of those callers — so a warning
+/// emitted there fires once per misconfigured dataset **per HTTP request**, in a caller
+/// that passes `LogErrors(false)` precisely to say "do not log from here". Emitting it
+/// here instead puts it behind the same `log_errors` gate as the load errors beside it,
+/// so it is tied to a load rather than to a read.
+pub(crate) fn warn_about_discarded_acceleration_settings(
+    component: AcceleratedComponent,
+    name: &str,
+    acceleration: Option<&spicepod::acceleration::Acceleration>,
+    log_errors: LogErrors,
+) {
+    if !log_errors.0 {
+        return;
+    }
+    let Some(acceleration) = acceleration else {
+        return;
+    };
+    let ignored = acceleration.fields_ignored_when_disabled();
+    if ignored.is_empty() {
+        return;
+    }
+    // The name is escaped inside the formatter: a *quoted* Spicepod identifier passes
+    // validation carrying a newline, and would otherwise forge a second log line.
+    tracing::warn!(
+        "{}",
+        disabled_acceleration_warning(component, name, &ignored)
+    );
+}
+
 impl Runtime {
     pub(crate) async fn load_datasets(self: Arc<Self>) {
         let Some(app) = self.read_app().await else {
@@ -93,7 +128,12 @@ impl Runtime {
 
         // Before loading datasets, we must initialize views accelerators (if any).
         // This is required for acceleration federation for some engines (e.g. `DuckDB`).
-        let valid_views = Arc::clone(&self).get_valid_views(&app, LogErrors(true));
+        //
+        // `LogErrors(false)`: this pre-pass exists to initialize view accelerators, and
+        // `load_views` below validates the same views again with `LogErrors(true)`. Passing
+        // `true` here made every view's load error — and its discarded-acceleration
+        // warning — print twice per startup.
+        let valid_views = Arc::clone(&self).get_valid_views(&app, LogErrors(false));
         self.initialize_views_accelerators(&valid_views).await;
 
         let valid_datasets = Arc::clone(&self).get_valid_datasets(&app, LogErrors(true));
@@ -299,7 +339,15 @@ impl Runtime {
         self.datasets_iter(app)
             .zip(&app.datasets)
             .filter_map(|(ds, spicepod_ds)| match ds {
-                Ok(ds) => Some(Arc::new(ds)),
+                Ok(ds) => {
+                    warn_about_discarded_acceleration_settings(
+                        AcceleratedComponent::Dataset,
+                        &spicepod_ds.name,
+                        spicepod_ds.acceleration.as_ref(),
+                        log_errors,
+                    );
+                    Some(Arc::new(ds))
+                }
                 Err(e) => {
                     if log_errors.0 {
                         metrics::datasets::LOAD_ERROR.add(1, &[]);

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -129,11 +129,13 @@ impl Runtime {
         // Before loading datasets, we must initialize views accelerators (if any).
         // This is required for acceleration federation for some engines (e.g. `DuckDB`).
         //
-        // `LogErrors(false)`: this pre-pass exists to initialize view accelerators, and
-        // `load_views` below validates the same views again with `LogErrors(true)`. Passing
-        // `true` here made every view's load error — and its discarded-acceleration
-        // warning — print twice per startup.
-        let valid_views = Arc::clone(&self).get_valid_views(&app, LogErrors(false));
+        // `LogErrors(true)` here, and `LogErrors(false)` in `load_views` below, because
+        // the two validate the same views and only one of them may report: this pre-pass
+        // is the one that always runs. The snapshot validations between here and
+        // `load_views` return early on failure, so reporting from `load_views` instead
+        // loses every view's load error, its status update, and its
+        // discarded-acceleration warning on exactly the startups that already went wrong.
+        let valid_views = Arc::clone(&self).get_valid_views(&app, LogErrors(true));
         self.initialize_views_accelerators(&valid_views).await;
 
         let valid_datasets = Arc::clone(&self).get_valid_datasets(&app, LogErrors(true));

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -130,8 +130,15 @@ impl Runtime {
         let rt_ref = Arc::clone(&self);
         let status = Arc::clone(&self.status);
 
+        // `LogErrors(false)` regardless of this call's own flag: this is a name
+        // lookup, not a dataset load. Both paths that reach here with
+        // `LogErrors(true)` — `load_datasets`, and `apply_dataset_diff` ahead of
+        // `apply_view_diff` — already call `get_valid_datasets(app,
+        // LogErrors(true))` themselves, so nothing is silenced by this; passing
+        // the flag through only made each dataset's load error, and each
+        // dataset's discarded-acceleration warning, print twice per load.
         let datasets = Arc::clone(&self)
-            .get_valid_datasets(app, log_errors)
+            .get_valid_datasets(app, LogErrors(false))
             .iter()
             .map(|ds| ds.name.clone())
             .collect::<HashSet<_>>();
@@ -218,6 +225,23 @@ impl Runtime {
 
                     // Extract dependencies from the validated statement
                     let dependencies = view::get_dependent_table_names(&statement);
+
+                    // `enabled: false` turns the whole acceleration block off, so anything
+                    // else set in it is read, accepted and then never applied — the same for
+                    // a view as for a dataset (#13514). Reported from here — the load path,
+                    // behind `log_errors` — rather than from `ViewBuilder::try_from`, which
+                    // read-only callers run too.
+                    //
+                    // Last, after every rejection above has had its chance: a view that
+                    // collides with a dataset name or fails SQL validation never loads, so
+                    // nothing of its acceleration block is silently discarded and warning
+                    // about it would only add noise to the error that actually matters.
+                    crate::init::dataset::warn_about_discarded_acceleration_settings(
+                        crate::component::AcceleratedComponent::View,
+                        &spicepod_view.name,
+                        spicepod_view.acceleration.as_ref(),
+                        log_errors,
+                    );
 
                     Some(ValidatedView {
                         view: Arc::new(view),

--- a/crates/runtime/src/init/view.rs
+++ b/crates/runtime/src/init/view.rs
@@ -98,7 +98,11 @@ fn order_views_by_dependencies(validated_views: &[ValidatedView]) -> Option<Vec<
 
 impl Runtime {
     pub(crate) fn load_views(self: Arc<Self>, app: &Arc<App>) {
-        let validated_views = Arc::clone(&self).get_valid_views(app, LogErrors(true));
+        // `LogErrors(false)`: `load_datasets` is this function's only caller and it has
+        // already validated the same views with `LogErrors(true)` before its snapshot
+        // checks, so reporting again here only prints each view's load error, and each
+        // view's discarded-acceleration warning, twice per startup.
+        let validated_views = Arc::clone(&self).get_valid_views(app, LogErrors(false));
 
         // Determine the dependency order for views based on their SQL dependencies
         let views_in_dependency_order = order_views_by_dependencies(&validated_views)

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -646,6 +646,50 @@ const fn default_true() -> bool {
     true
 }
 
+impl Acceleration {
+    /// The acceleration fields this block sets that the runtime will ignore
+    /// because `enabled: false` turns the whole block off, in the order they
+    /// should be reported.
+    ///
+    /// Empty for an enabled block, and for a disabled block that sets nothing
+    /// else — `enabled: false` on its own is a deliberate, complete
+    /// configuration.
+    ///
+    /// Derived from the serialized form rather than a hand-written field list,
+    /// so a field added to this struct later is covered without anyone
+    /// remembering to add it here. A field counts as set when it serializes to
+    /// something other than what the same block carries at its default, which
+    /// is what distinguishes `mode: memory` written out by hand — inert either
+    /// way — from `mode: file`.
+    #[must_use]
+    pub fn fields_ignored_when_disabled(&self) -> Vec<String> {
+        if self.enabled {
+            return Vec::new();
+        }
+
+        let disabled_default = Self {
+            enabled: false,
+            ..Self::default()
+        };
+        let (Ok(serde_json::Value::Object(configured)), Ok(serde_json::Value::Object(unset))) = (
+            serde_json::to_value(self),
+            serde_json::to_value(&disabled_default),
+        ) else {
+            // Nothing here is worth failing a load over: this reports on a
+            // configuration, it does not decide one.
+            return Vec::new();
+        };
+
+        let mut ignored: Vec<String> = configured
+            .into_iter()
+            .filter(|(field, value)| field != "enabled" && unset.get(field) != Some(value))
+            .map(|(field, _)| field)
+            .collect();
+        ignored.sort();
+        ignored
+    }
+}
+
 impl Default for Acceleration {
     #[expect(deprecated)]
     fn default() -> Self {
@@ -693,6 +737,109 @@ impl Default for Acceleration {
 mod tests {
     use super::*;
     use yaml;
+
+    fn acceleration_from_yaml(spec: &str) -> Acceleration {
+        yaml::from_str(spec).expect("acceleration should deserialize")
+    }
+
+    #[test]
+    fn a_disabled_acceleration_reports_the_settings_it_discards() {
+        // The reported shape of #13514: everything below `enabled: false` is
+        // read, accepted and then ignored, and the dataset serves federated
+        // queries that look like a working cache.
+        let acceleration = acceleration_from_yaml(
+            r"
+                enabled: false
+                engine: duckdb
+                mode: file
+                refresh_mode: caching
+                primary_key: '(request_query, request_path)'
+                params:
+                  duckdb_file: api_cache.db
+                  caching_ttl: 1s
+            ",
+        );
+        assert_eq!(
+            acceleration.fields_ignored_when_disabled(),
+            vec![
+                "engine".to_string(),
+                "mode".to_string(),
+                "params".to_string(),
+                "primary_key".to_string(),
+                "refresh_mode".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_disabled_acceleration_that_sets_nothing_else_discards_nothing() {
+        // `enabled: false` alone is a complete, deliberate configuration and
+        // must stay silent, or every dataset that turns acceleration off warns.
+        let acceleration = acceleration_from_yaml("enabled: false");
+        assert!(acceleration.fields_ignored_when_disabled().is_empty());
+    }
+
+    #[test]
+    fn a_field_written_out_at_its_default_is_not_reported_as_discarded() {
+        // `mode: memory` is what an omitted `mode` already means, so nothing is
+        // lost by ignoring it and saying otherwise would be noise.
+        let acceleration = acceleration_from_yaml(
+            r"
+                enabled: false
+                mode: memory
+            ",
+        );
+        assert!(acceleration.fields_ignored_when_disabled().is_empty());
+    }
+
+    #[test]
+    fn an_enabled_acceleration_discards_nothing_however_it_is_configured() {
+        // The whole block applies, so there is nothing to report — this is the
+        // direction that would otherwise warn on every accelerated dataset.
+        let acceleration = acceleration_from_yaml(
+            r"
+                engine: duckdb
+                mode: file
+                refresh_mode: full
+            ",
+        );
+        assert!(acceleration.enabled, "enabled defaults to true");
+        assert!(acceleration.fields_ignored_when_disabled().is_empty());
+    }
+
+    #[test]
+    fn enabled_is_never_reported_as_one_of_the_discarded_fields() {
+        // It is the field doing the discarding; naming it in its own list would
+        // read as though turning acceleration off had itself been ignored.
+        let acceleration = acceleration_from_yaml(
+            r"
+                enabled: false
+                engine: duckdb
+            ",
+        );
+        let ignored = acceleration.fields_ignored_when_disabled();
+        assert!(
+            !ignored.iter().any(|field| field == "enabled"),
+            "{ignored:?}"
+        );
+    }
+
+    #[test]
+    fn a_field_added_to_the_block_later_is_covered_without_a_list_to_update() {
+        // The guard against this helper going stale: it is derived from the
+        // serialized form, so a field this test does not know about still shows
+        // up. `retention_period` stands in for "whatever is added next".
+        let acceleration = acceleration_from_yaml(
+            r"
+                enabled: false
+                retention_period: 24h
+            ",
+        );
+        assert_eq!(
+            acceleration.fields_ignored_when_disabled(),
+            vec!["retention_period".to_string()]
+        );
+    }
 
     #[test]
     fn test_deserialize_acceleration_on_conflict_string() {

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -646,6 +646,11 @@ const fn default_true() -> bool {
     true
 }
 
+/// Fields of an acceleration block that a disabled block does not discard: the
+/// switch itself, and the one setting the dataset reads out of the block before
+/// discarding the rest.
+const CONSUMED_WHEN_DISABLED: [&str; 2] = ["enabled", "ready_state"];
+
 impl Acceleration {
     /// The acceleration fields this block sets that the runtime will ignore
     /// because `enabled: false` turns the whole block off, in the order they
@@ -661,6 +666,11 @@ impl Acceleration {
     /// something other than what the same block carries at its default, which
     /// is what distinguishes `mode: memory` written out by hand — inert either
     /// way — from `mode: file`.
+    ///
+    /// Two fields are never reported. `enabled` is the field doing the
+    /// discarding. `ready_state` is read out of this block and applied to the
+    /// dataset before the block is discarded — deprecated, but not ignored —
+    /// so calling it ignored would be untrue.
     #[must_use]
     pub fn fields_ignored_when_disabled(&self) -> Vec<String> {
         if self.enabled {
@@ -682,7 +692,9 @@ impl Acceleration {
 
         let mut ignored: Vec<String> = configured
             .into_iter()
-            .filter(|(field, value)| field != "enabled" && unset.get(field) != Some(value))
+            .filter(|(field, value)| {
+                !CONSUMED_WHEN_DISABLED.contains(&field.as_str()) && unset.get(field) != Some(value)
+            })
             .map(|(field, _)| field)
             .collect();
         ignored.sort();
@@ -804,6 +816,22 @@ mod tests {
             ",
         );
         assert!(acceleration.enabled, "enabled defaults to true");
+        assert!(acceleration.fields_ignored_when_disabled().is_empty());
+    }
+
+    #[test]
+    fn a_ready_state_inside_a_disabled_block_is_not_reported_as_discarded() {
+        // `acceleration.ready_state` is deprecated, but the dataset still reads
+        // it out of this block and applies it whether or not acceleration is
+        // enabled — so it is the one setting here that a disabled block does not
+        // discard, and saying otherwise would send the reader to fix something
+        // that is working.
+        let acceleration = acceleration_from_yaml(
+            r"
+                enabled: false
+                ready_state: on_load
+            ",
+        );
         assert!(acceleration.fields_ignored_when_disabled().is_empty());
     }
 

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -646,9 +646,19 @@ const fn default_true() -> bool {
     true
 }
 
-/// Fields of an acceleration block that a disabled block does not discard: the
-/// switch itself, and the one setting the dataset reads out of the block before
-/// discarding the rest.
+/// Fields an `enabled: false` block does not discard *because it is disabled*,
+/// and so must not be named by a warning whose remedy is "remove
+/// `enabled: false`": the switch itself, and `ready_state`.
+///
+/// `ready_state` is excluded for both components that carry an acceleration
+/// block, but not for the same reason. A dataset reads
+/// `acceleration.ready_state` out of the block and applies it whether or not
+/// acceleration is enabled (deprecated, but honoured) — so it is genuinely not
+/// discarded. `ViewBuilder` never reads it at all, enabled or disabled, so for
+/// a view it *is* dropped — but unconditionally, not because of `enabled:
+/// false`, which makes "remove `enabled: false` to apply them" a false remedy
+/// for it. Either way this warning is the wrong place to raise it; the view
+/// case is #13615.
 const CONSUMED_WHEN_DISABLED: [&str; 2] = ["enabled", "ready_state"];
 
 impl Acceleration {
@@ -667,10 +677,9 @@ impl Acceleration {
     /// is what distinguishes `mode: memory` written out by hand — inert either
     /// way — from `mode: file`.
     ///
-    /// Two fields are never reported. `enabled` is the field doing the
-    /// discarding. `ready_state` is read out of this block and applied to the
-    /// dataset before the block is discarded — deprecated, but not ignored —
-    /// so calling it ignored would be untrue.
+    /// Two fields are never reported, per [`CONSUMED_WHEN_DISABLED`]: `enabled`,
+    /// which is the field doing the discarding, and `ready_state`, which no
+    /// component discards *because of* `enabled: false`.
     #[must_use]
     pub fn fields_ignored_when_disabled(&self) -> Vec<String> {
         if self.enabled {

--- a/crates/spicepod/src/component/dataset.rs
+++ b/crates/spicepod/src/component/dataset.rs
@@ -618,6 +618,49 @@ mod tests {
     use yaml;
 
     #[test]
+    fn a_disabled_acceleration_block_reports_what_the_dataset_will_ignore() {
+        // The shape the runtime reads this through: the whole dataset as
+        // written, its acceleration block still optional. Asserted here so the
+        // caller's expression is exercised against the same types it uses.
+        let yaml = r"
+            name: api_data
+            from: https://api.example.com
+            acceleration:
+              enabled: false
+              engine: duckdb
+              refresh_mode: caching
+        ";
+        let dataset: Dataset = yaml::from_str(yaml).expect("Failed to parse Dataset");
+        let ignored = dataset
+            .acceleration
+            .as_ref()
+            .map(Acceleration::fields_ignored_when_disabled)
+            .unwrap_or_default();
+        assert_eq!(
+            ignored.join(", "),
+            "engine, refresh_mode",
+            "a dataset that turns acceleration off has to say what it dropped"
+        );
+    }
+
+    #[test]
+    fn a_dataset_with_no_acceleration_block_reports_nothing() {
+        let yaml = r"
+            name: api_data
+            from: https://api.example.com
+        ";
+        let dataset: Dataset = yaml::from_str(yaml).expect("Failed to parse Dataset");
+        assert!(
+            dataset
+                .acceleration
+                .as_ref()
+                .map(Acceleration::fields_ignored_when_disabled)
+                .unwrap_or_default()
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn test_invalid_type_action_migration() {
         // Test when only invalid_type_action is present
         let yaml = r"


### PR DESCRIPTION
## Summary

A dataset **or view** that sets `acceleration.enabled: false` and leaves the rest of the
block in place has every other setting read, accepted, and then ignored.
`is_accelerated()` returns `acceleration.enabled` directly and initialization skips
accelerator setup on that basis, so `engine`, `mode`, `refresh_mode`, `primary_key`,
`indexes`, `on_conflict` and everything under `params` are inert — with nothing said
about it.

The component loads, reports healthy, and serves queries federated straight to the source,
which at a glance is indistinguishable from a working accelerator. It is most misleading
under `refresh_mode: caching`, where a configuration that appears to cache with a
one-second freshness window is sending every query to the origin. `enabled: false` reads
as "not enabled *yet*" rather than "discard this whole block", so the mistake is easy to
make and can persist for as long as the origin keeps answering.

Views were added after review on this PR: `View` carries the same
`acceleration: Option<Acceleration>` block and discards it for the same reason, so leaving
them silent left out half the surface of the bug.

## Changes

- `Acceleration::fields_ignored_when_disabled()` in `spicepod` returns the settings a
  disabled block carries that the runtime will not apply.
- `component::disabled_acceleration_warning` renders the message, taking an
  `AcceleratedComponent` — a closed enum, so a third component that grows an
  `acceleration:` block cannot reach the formatter without choosing its noun and its
  Spicepod reference page. A view is told "View", told to "keep the view unaccelerated",
  and linked to `spicepod/views#acceleration` rather than the datasets page.
- `get_valid_datasets` and `get_valid_views` emit it, behind their existing `log_errors`
  gate — **not** the builders' `TryFrom`, where it started. Those conversions are not the
  load path: `datasets_iter` runs them on every call to `get_valid_datasets`, and
  `GET /v1/datasets` is one of those callers, passing `LogErrors(false)` precisely to mean
  "do not log from here". Emitted there, one misconfigured dataset produced one warning
  **per HTTP request**, unbounded and remotely triggerable.
- Two passes that are not loads drop to `LogErrors(false)` so the warning lands exactly
  once per component per load — `get_valid_views`' internal `get_valid_datasets` call (a
  name lookup) and `load_datasets`' view accelerator pre-pass (`load_views` validates the
  same views again straight after). Neither silences anything: both paths already call the
  direct `LogErrors(true)` variant themselves, and this also stops each component's
  *existing* load error printing twice per startup.
- The view warning is emitted last, after every rejection in `get_valid_views`. A view
  that collides with a dataset name or fails SQL validation never loads, so nothing of its
  acceleration block is silently discarded and warning would only add noise to the error
  that matters.

**Derived, not enumerated.** The list comes from diffing the block's serialized form
against the same block at its defaults, rather than from a hand-written field list. Two
things follow, and both are covered by tests: a field added to `Acceleration` later is
reported without anyone remembering this site, and a field written out at its default
(`mode: memory`, which is what omitting `mode` already means) is not reported as lost.

**`ready_state` is excluded for both components, for different reasons** — now recorded on
`CONSUMED_WHEN_DISABLED`. A dataset reads `acceleration.ready_state` out of the block and
applies it (deprecated, but honoured), so it is genuinely not discarded. `ViewBuilder`
never reads it at all, enabled or disabled, so for a view it *is* dropped — but
unconditionally, not because of `enabled: false`, which would make this warning's "remove
`enabled: false` to apply them" a false remedy for it. That defect is **#13615**.

**Nothing fails.** The issue offers warn-or-fail; this warns, which is what the
surrounding code does for configuration that is accepted but inapplicable, and it does not
break a spicepod that loads today.

**One case this does not cover, filed as #13605.** "Carried" is decided by diffing the
block against its defaults, because the deserialized struct does not record which keys the
YAML had — so a field written out *at* its default (`mode: memory`) is not reported, even
though a disabled block discards it just the same. Preserving key presence needs a manual
two-phase `Deserialize` on `Acceleration` plus a decision about `PartialEq`, which is a
change to how a widely-used Spicepod struct deserializes and wants its own review. Every
field in #13514's reproduction differs from its default, so that case is covered here.

## Test plan

- [ ] `make lint` / `make test` on the current HEAD (`f4c9b31`) — sign-off re-dispatched
      after this push; the prior run
      [33041793805](https://github.com/spiceai/spiceai/actions/runs/33041793805) attests
      `4e0a686`, which these two commits supersede, so it does not carry.
- [x] `cargo test -p spicepod --all-features --lib` — **253 passed, 0 failed**.
- [x] `rustfmt --edition 2024 --check` — clean on all five touched files.
- [x] The new constructs compiled standalone with `rustc --edition 2024` under
      `#![deny(warnings)]`, and both `filter_map` closure shapes borrow-checked, because
      **`crates/runtime` cannot be built on this host**: `openssl-sys` needs `perl`,
      `runtime-proto` needs `protoc`, and neither is installed. See the Review gate below
      for exactly what that did and did not establish.

Workspace clippy, and that `crates/runtime` type-checks as a whole, are left to the
sign-off gate and the merge queue.

## Review gate

Re-stated for the current HEAD (`f4c9b31`). This attests the two commits `e675c53`…`f4c9b31`
— extending the warning to views and moving its emission to the load path — not the earlier
work on this branch, which the previous version of this block covered.

- **Adversarial review: `codex` (codex-cli 0.147.0), run as `codex exec --sandbox read-only`, two passes, scoped `origin/trunk...HEAD`.** The companion `.mjs` entry point is unusable on this host — there is no `node` runtime — so the CLI was driven directly; `grok` is not a permitted engine for a Grok-authored diff, so there was no fallback engine.
  - **Pass 1 (complete, ~50 min, on `0141b41`): six findings, all triaged.** Two changed the design. It showed that reporting `acceleration.ready_state` for a view — which the first version of this change did — attaches a *false remedy*: `ViewBuilder` never reads that field, enabled or disabled, so "remove `enabled: false` to apply them" would not apply it. The field is now excluded for both components and the real defect is filed as #13615; the `consumed`-set parameter that existed only to serve that case was removed. It also caught a **deterministic test failure** I had written — `assert!(!warning.contains("dataset"))` fails on a *correct* view message, because the docs URL contains `datasets` — and that a view was being pointed at the datasets reference page; both fixed, and the URL is now per-component. Its duplicate-emission and warn-then-reject findings drove the two `LogErrors(false)` changes and moving the view warning after every rejection. One finding was accepted and **not** fixed: `fields_ignored_when_disabled` compares structural rather than effective defaults, so an explicit `engine: arrow` / `params: {}` is reported while `mode: memory` is not — that predates these commits, is unchanged by them, and is raised in the thread for a maintainer's call rather than widening this PR.
  - **Pass 2 (partial — declared): aborted on `ERROR: Your workspace is out of credits`.** Dispatched as a focused re-review of the reworked diff, it read the module tree, `Cargo.toml`, and both spicepod component definitions before the credit limit stopped it, and never emitted a ranked verdict. Recorded as a partial, not as a clean pass.
- **Compile verification — `crates/runtime` cannot be built on this host.** `openssl-sys` needs `perl`, `runtime-proto` needs `protoc`, and neither is installed (nor `cmake`), so `cargo check -p runtime` fails in a build script before reaching this diff. Rather than let CI be the first compiler to see it, the new constructs were extracted into two standalone programs and compiled with `rustc --edition 2024` under `#![deny(warnings)]`:
  - the `AcceleratedComponent` enum with its three `const fn` methods, and the duplicated-path-prefix `use crate::{component::dataset::{…}, component::{…}}` tree — compiles clean, no dead-code or unused-derive warnings;
  - both `filter_map` closure shapes, modelling the owned-`Result`-zipped-with-`&Spec` pattern and the move of the built value on the line after the helper call — borrow-checks clean, and behaves correctly: `LogErrors(false)` emits nothing, and a view rejected for a name collision emits the collision error and no acceleration warning.
  - all four formatter assertions were executed against the real format string for both the `Dataset` and `View` cases, and hold.
  - `cargo test -p spicepod --all-features --lib`: **253 passed, 0 failed**. `rustfmt --edition 2024 --check`: clean on all five touched files.
  - Still unverified locally, and left to the merge queue: workspace clippy, and that `crates/runtime` type-checks as a whole.
- **`/security-review`: no findings** — audited by hand against the same checklist, since the harness skill diffs the session's own checkout and this change lives in a separate worktree. The relocation was re-checked for the two properties the original placement relied on: the component name still passes `validate_identifier` before it is logged (both call sites warn only in the `Ok(…)` arm, which is reachable only after the builder's validation succeeded), and it is still `escape_debug`-escaped, so a quoted Spicepod identifier carrying a newline cannot forge a second log line. Only the field *keys* leave the helper, never the values — `params` can hold credentials — and nothing is written to disk, interpolated into a query or a path, or sent anywhere. The relocation also *reduces* exposure: the warning no longer fires on unauthenticated-reachable `GET /v1/datasets`.
- **`/simplify`: ran as an inline pass over this diff — one change applied**, and it was a removal: the `consumed: &[&str]` parameter and the two test constants that mirrored it, once pass 1 established that both components exclude the same field. `AcceleratedComponent` was kept over the `&str` it replaced despite being more code, because a closed enum is what stops a third component reaching the formatter without choosing a noun and a reference page.

**Known test gap.** No test drives a `View` through `get_valid_views` with a captured `tracing`
subscriber, so "exactly once per load, and only on a successful load" is argued from the call
graph and from the standalone closure probe rather than asserted in the suite. Noted rather
than papered over; it is the regression test this feature should eventually carry.

### Review gate for the follow-up fix `230f1e9` (claudespice)

Attests **only** the commit `230f1e9` added on top of the above — moving the view
diagnostics back onto the pre-pass — not the authored work this block already covers.

- **Adversarial review: declared skip, no engine available.** `codex` was attempted first and
  failed with `Your workspace is out of credits`; `grok` is not installed on this host, so there
  was no fallback. Receipt: `engine=none exit=1 verdict=unparsed job=none`, scoped
  `origin/trunk...230f1e9`. Recorded as a skip, not as a pass — the run produced no verdict.
- **`/security-review`: no findings.** The change swaps two `LogErrors` literals, so it adds no
  input, parsing, file/network/SQL operation, or authorization decision. It emits no content the
  pre-#13602 code did not already emit through the same formatter with the same `escape_debug`
  escaping, and `fields_ignored_when_disabled` still yields field *keys* only, never `params`
  values.
- **`/simplify`: nothing to apply.** The diff is two boolean literals plus the comments recording
  why each site holds the value it does.
- **Compile surface: none new.** Both `LogErrors(true)` and `LogErrors(false)` are already
  constructed in unchanged code in both touched files, so the swap introduces no new symbol,
  import, or type. Workspace clippy, build and `nextest` are covered by the `signoff` run on this
  HEAD rather than argued from inspection.

**On the test gap above.** It still stands, and it is what let this through: the
duplicate-emission finding was real, but silencing the pre-pass silenced the pass that always
runs, and no test drives a view through a startup that returns early. Reaching that path needs a
Cayenne-backed pod with an inconsistent snapshot setting *and* an invalid view, which is an
integration fixture rather than a unit test — filed as #13617 rather than bolted on here.

Fixes #13514

## Checklist

- [x] Root cause identified and stated
- [x] Both directions tested — reported when discarded, silent when not
- [x] Written so a later field is covered without updating a list
- [x] Copilot's five review comments addressed — three in `8c7d914`: the warning moved after
      identifier validation, its wording scoped to the fields it lists, and the wording
      extracted into a tested function — and two in `5ecc812` (message format) and #13605
      (field presence, deferred with the reason recorded on the thread) and `d821525`
      (the dataset name escaped — a *quoted* Spicepod identifier carries a newline
      through `validate_identifier`, so position alone was not enough) and `4e0a686`
      (the `ready_state` exception recorded where the fields are collected)
- [x] `runtime` half compiled and tested — deferred to the sign-off gate because this host
      has no `protoc`, and confirmed green there: [run 33041793805](https://github.com/spiceai/spiceai/actions/runs/33041793805),
      "lint+test passed in 8848s"


