### PR TITLE
fix(llms): keep cached test clients on a runtime that outlives each test (fixes #13575)

### DIFF
--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -271,12 +271,6 @@ async fn run_test(
     Ok(Some(actual_resp))
 }
 
-/// How long the background task in [`spawned_work_outlives_per_test_runtime`] stays alive after
-/// reporting that it started. Long enough that the per-test runtime is always dropped first, and
-/// short enough to keep the surviving-work case quick — the dying case does not wait for it, it
-/// observes the dropped sender instead.
-const BACKGROUND_TASK_LIFETIME: Duration = Duration::from_millis(500);
-
 /// Drives a body that spawns a background task, drops the runtime the test itself owns, and
 /// reports whether the task then ran to completion.
 ///
@@ -291,11 +285,17 @@ fn spawned_work_outlives_per_test_runtime(via_shared_runtime: bool) -> bool {
         .build()
         .expect("failed to build the per-test runtime");
 
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+
     let body = async move {
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
         tokio::spawn(async move {
             let _ = started_tx.send(());
-            tokio::time::sleep(BACKGROUND_TASK_LIFETIME).await;
+            // Wait to be released rather than for a fixed time. The release is sent only after
+            // the per-test runtime is dropped, so the drop always happens first however the test
+            // thread is scheduled; a timer here would let a preempted thread finish the task
+            // early and report the control case as surviving.
+            let _ = release_rx.await;
             let _ = finished_tx.send(());
         });
         // Both cases must measure survival rather than whether the task ever got going, so let
@@ -309,6 +309,9 @@ fn spawned_work_outlives_per_test_runtime(via_shared_runtime: bool) -> bool {
         per_test.block_on(body);
     }
     drop(per_test);
+    // Released only now: a task that died with the runtime can never observe this, so the two
+    // cases are separated by what survives the drop rather than by elapsed time.
+    let _ = release_tx.send(());
 
     // Dropping a runtime drops its tasks, which drops `finished_tx` and disconnects the channel,
     // so a task that died is reported immediately rather than by waiting out the timeout.

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -25,9 +25,12 @@ use llms::{accumulate::accumulate, chat::Chat};
 use rstest::rstest;
 use serde_json::json;
 use std::{
+    future::Future,
     str::FromStr,
     sync::{Arc, LazyLock, Mutex},
+    time::Duration,
 };
+use tokio::runtime::Runtime;
 
 use crate::{TEST_ARGS, init_tracing};
 
@@ -44,6 +47,40 @@ type AsyncModelCreator = Box<
 
 /// A given model to test - cached after first creation
 type ModelCache = Mutex<Option<Arc<dyn Chat>>>;
+
+/// A multi-thread runtime that lives for as long as the test binary.
+///
+/// Every test here is a `#[tokio::test]`, so each owns a runtime that is dropped when that test
+/// ends, while [`MODEL_CACHES`] hands the same model — and so the same HTTP client — to later
+/// tests. A client's connection task is spawned by whichever runtime first drove a request over
+/// it, so once that runtime is gone the pooled connection is dead and the next test to reuse the
+/// client fails with `hyper::Error(User(DispatchGone), "runtime dropped the dispatch task")`.
+/// Building and driving every cached client here keeps those connection tasks alive for as long
+/// as the cache that hands them out.
+static SHARED_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build the shared test runtime")
+});
+
+/// Drives `future` on [`SHARED_RUNTIME`] and awaits its result from the caller's runtime.
+///
+/// A panic inside `future` is re-raised here, so a failing request still reports the message
+/// [`run_test`] panicked with rather than an opaque join error.
+async fn on_shared_runtime<F>(future: F) -> F::Output
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    match SHARED_RUNTIME.spawn(future).await {
+        Ok(output) => output,
+        Err(err) => match err.try_into_panic() {
+            Ok(payload) => std::panic::resume_unwind(payload),
+            Err(err) => panic!("shared test runtime task did not complete: {err}"),
+        },
+    }
+}
 
 /// Loads `.env` once per process; repeated loads would re-run `set_var` while
 /// other test threads are active.
@@ -187,28 +224,37 @@ async fn run_test(
         return Ok(None);
     }
 
-    let model = get_or_create_model(model_name)
-        .await
-        .unwrap_or_else(|e| panic!("failed to get or create model {model_name}: {e}"));
+    let model = on_shared_runtime({
+        let model_name = model_name.to_string();
+        async move { get_or_create_model(&model_name).await }
+    })
+    .await
+    .unwrap_or_else(|e| panic!("failed to get or create model {model_name}: {e}"));
 
     tracing::info!("Running test {test_name}/{model_name} with {req:?}");
 
-    let actual_resp = if as_stream {
-        let mut req = req;
-        req.stream = Some(true);
-        req.stream_options = Some(ChatCompletionStreamOptions {
-            include_usage: Some(true),
-            include_obfuscation: None,
-        });
-        accumulate(model.chat_stream(req).await.unwrap_or_else(|e| {
-            panic!("For test {test_name}/{model_name}, chat_stream failed. Error: {e:#?}")
-        }))
-        .await
-    } else {
-        model.chat_request(req).await.unwrap_or_else(|e| {
-            panic!("For test {test_name}/{model_name}, chat_request failed. Error: {e:#?}")
-        })
-    };
+    let actual_resp = on_shared_runtime({
+        let (test_name, model_name) = (test_name.to_string(), model_name.to_string());
+        async move {
+            if as_stream {
+                let mut req = req;
+                req.stream = Some(true);
+                req.stream_options = Some(ChatCompletionStreamOptions {
+                    include_usage: Some(true),
+                    include_obfuscation: None,
+                });
+                accumulate(model.chat_stream(req).await.unwrap_or_else(|e| {
+                    panic!("For test {test_name}/{model_name}, chat_stream failed. Error: {e:#?}")
+                }))
+                .await
+            } else {
+                model.chat_request(req).await.unwrap_or_else(|e| {
+                    panic!("For test {test_name}/{model_name}, chat_request failed. Error: {e:#?}")
+                })
+            }
+        }
+    })
+    .await;
     tracing::debug!("Response for {test_name}/{model_name}: {actual_resp:?}");
 
     let resp_value =
@@ -223,6 +269,96 @@ async fn run_test(
         );
     }
     Ok(Some(actual_resp))
+}
+
+/// How long the background task in [`spawned_work_outlives_per_test_runtime`] stays alive after
+/// reporting that it started. Long enough that the per-test runtime is always dropped first, and
+/// short enough to keep the surviving-work case quick — the dying case does not wait for it, it
+/// observes the dropped sender instead.
+const BACKGROUND_TASK_LIFETIME: Duration = Duration::from_millis(500);
+
+/// Drives a body that spawns a background task, drops the runtime the test itself owns, and
+/// reports whether the task then ran to completion.
+///
+/// The background task stands in for a connection task: spawned as a side effect of driving a
+/// request, and needed again by whichever test reuses the cached client next. With
+/// `via_shared_runtime` the body runs on [`SHARED_RUNTIME`], as [`run_test`] now drives every
+/// request; otherwise it runs on the per-test runtime, which is what produced #13575.
+fn spawned_work_outlives_per_test_runtime(via_shared_runtime: bool) -> bool {
+    let (finished_tx, finished_rx) = std::sync::mpsc::channel::<()>();
+    let per_test = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build the per-test runtime");
+
+    let body = async move {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let _ = started_tx.send(());
+            tokio::time::sleep(BACKGROUND_TASK_LIFETIME).await;
+            let _ = finished_tx.send(());
+        });
+        // Both cases must measure survival rather than whether the task ever got going, so let
+        // it start before the runtime that spawned it can go away.
+        started_rx.await.expect("the background task never started");
+    };
+
+    if via_shared_runtime {
+        per_test.block_on(on_shared_runtime(body));
+    } else {
+        per_test.block_on(body);
+    }
+    drop(per_test);
+
+    // Dropping a runtime drops its tasks, which drops `finished_tx` and disconnects the channel,
+    // so a task that died is reported immediately rather than by waiting out the timeout.
+    finished_rx.recv_timeout(Duration::from_secs(30)).is_ok()
+}
+
+/// Work driven through [`on_shared_runtime`] must survive the test that started it, because the
+/// model cache hands the same client to a later test whose own runtime did not create it.
+///
+/// Regression test for #13575.
+#[test]
+fn shared_runtime_keeps_spawned_work_alive_past_the_test_that_started_it() {
+    // Control first: on the per-test runtime the task does not survive. Without this the
+    // assertion below would pass even if `on_shared_runtime` did nothing at all.
+    assert!(
+        !spawned_work_outlives_per_test_runtime(false),
+        "a task spawned on the per-test runtime outlived it, so this test can no longer tell whether the shared runtime is doing anything"
+    );
+
+    assert!(
+        spawned_work_outlives_per_test_runtime(true),
+        "work driven through `on_shared_runtime` died with the per-test runtime; a cached client's connection task would die with it too, failing the next test with `DispatchGone` (#13575)"
+    );
+}
+
+/// [`run_test`] reports a provider failure by panicking with the test and model names, so
+/// [`on_shared_runtime`] has to re-raise that panic rather than replace it with a join error.
+#[test]
+fn on_shared_runtime_re_raises_the_original_panic() {
+    let per_test = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build the per-test runtime");
+
+    let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        per_test.block_on(on_shared_runtime(async {
+            panic!("For test basic/xai, chat_request failed.");
+        }));
+    }))
+    .expect_err("the panic did not propagate out of `on_shared_runtime`");
+
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .unwrap_or_else(|| panic!("the propagated panic carried no string payload"));
+    assert!(
+        message.contains("For test basic/xai, chat_request failed."),
+        "the panic reached the test as {message:?}, losing the diagnostic `run_test` panicked with"
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
## Summary

The LLM integration suite caches one model per provider for the life of the test binary
(`MODEL_CACHES` / `get_or_create_model`), while every test is a `#[tokio::test]` and so owns a
runtime that is dropped when that test ends. A cached model owns an HTTP client, and a client's
connection task is spawned by whichever runtime first drove a request over it. Once that runtime
is gone the pooled connection is dead, and the next test to reuse the client fails before its
request leaves the process:

```
hyper::Error(User(DispatchGone), "runtime dropped the dispatch task")
```

The suite runs as a **single process** — `integration_llms.yml` invokes the test binary directly
with `--test-threads=2` — so the cache really is shared across runtimes, and tests overlap, which
is why the casualty moves between runs and the failure reads as flakiness rather than as a
harness defect.

This is the mechanism behind one of the varying failures in #6399: diffing two otherwise-identical
failing sets left exactly one test that changed between runs, and it was a `DispatchGone` casualty.

## Changes

- Add `SHARED_RUNTIME`, a multi-thread runtime held in a `static` so it lives for the whole test
  binary, and `on_shared_runtime`, which drives a future there and awaits it from the caller's
  runtime.
- Route both halves of `run_test` through it — model creation and the `chat_request` /
  `chat_stream` + `accumulate` request path — so every connection task a cached client depends on
  is spawned on a runtime that outlives the cache's consumers.
- `on_shared_runtime` re-raises a panic from the spawned future with `resume_unwind` rather than
  letting it surface as a join error, because `run_test` reports provider failures by panicking
  with the test and model names and that diagnostic is the whole value of the message.

`run_test` is the single entry point for every live test in the suite, so wrapping it covers the
cached clients completely. Converting the tests themselves to `SHARED_RUNTIME.block_on(...)` would
remove per-test runtimes outright and was considered, but it rewrites six `#[rstest]` signatures
and their bodies for the same property this gets at the one choke point everything already passes
through.

## Test plan

- `make lint` — clean
- `make nextest` — via `make signoff` after the push
- Both new tests exercise the harness directly and need no provider credentials.

Two things worth stating plainly about coverage:

- **The suite's own test binary is outside the merge gate's filterset.** `NEXTEST_FILTER` selects
  `kind(=lib)` plus a named list of test binaries, and `llms`'s `integration` binary is not on it,
  so `make nextest` builds these tests but does not run them. They run in
  `integration_llms.yml`, and locally with
  `cargo test -p llms --test integration -- shared_runtime`. That command was run on this branch:
  both tests pass in 0.51s.
- **The regression test was verified to fail without the fix.** Neutering `on_shared_runtime` to a
  plain `future.await` makes
  `shared_runtime_keeps_spawned_work_alive_past_the_test_that_started_it` fail with its own
  message; restoring the helper makes it pass. The test also asserts the control case first — that
  work spawned on the per-test runtime does *not* survive it — so it cannot silently become
  vacuous if the mechanism it models ever changes.

## Review gate

- Adversarial review: `codex` — scoped `origin/trunk`...`c4a73828`; verdict **approve**, "no substantive correctness, isolation, or failure-path issue is supported by the branch diff". This supersedes the earlier skip: the previous attempt exited 1 out of credits, and the engine has since run the full pass, including executing the regression test binary and reading `tokio`'s `oneshot` source.
- `/security-review`: no findings on the original diff — confined to a test target, adds no input flow, no new secret handling, no `unsafe`, and no new dependency; the provider-error panic strings are moved verbatim, not widened. **Not re-run** for `c4a73828`, which only swaps two test-local channels and reaches no production code.
- `/simplify`: applied to the original diff — collapsed the duplicated spawn and `to_string` pair across the streaming and non-streaming arms into one `on_shared_runtime` call. **Not re-run** for `c4a73828`: ten lines inside one function, already at its simplest form.

`c4a73828` is a follow-up to reviewer feedback, not part of the original fix — it replaces the
control case's 500 ms timer with a release channel fired after `drop(per_test)`, so the two
cases are separated by what survives the drop rather than by elapsed time.

## Related

A pre-fix sweep for the same shape found one sibling: `crates/runtime/tests/tpcds_postgres/mod.rs`
shares a `Runtime` across three `#[tokio::test]`s through a `OnceCell`. Filed as #13610 rather
than fixed here — it needs Docker, `MinIO` and a ~10 minute dataset load to verify, and an
unverified change to that suite is worse than the latent hazard.

Fixes #13575

## Checklist

- [x] Root cause identified and stated
- [x] Regression test added, and verified to fail without the fix
- [x] Control assertion added so the regression test cannot become vacuous
- [x] Bug-class swept for siblings; the one found is filed as #13610
- [x] `cargo fmt --all` clean, scoped clippy clean
- [ ] `make signoff` green and `Attestation` re-run