### PR TITLE
fix(bedrock): say which credential AWS rejected instead of "unhandled error" (refs #12396)

### DIFF
--- a/crates/llms/src/bedrock/auth_error.rs
+++ b/crates/llms/src/bedrock/auth_error.rs
@@ -26,15 +26,62 @@ limitations under the License.
 use aws_sdk_bedrockruntime::error::ProvideErrorMetadata;
 use snafu::Snafu;
 
-/// The Bedrock chat docs, which carry the credential parameters for a chat model.
-pub(crate) const CHAT_DOCS_URL: &str = "https://spiceai.org/docs/components/models/bedrock";
-
-/// The Bedrock embeddings docs, which carry the credential parameters for an embedding model.
-pub(crate) const EMBEDDINGS_DOCS_URL: &str =
-    "https://spiceai.org/docs/components/embeddings/bedrock";
-
 /// The model name to report when the request never carried one.
 pub(crate) const UNKNOWN_MODEL: &str = "<unknown>";
+
+/// Which Bedrock call the rejection came from.
+///
+/// A remedy has to get three things right, and they do not vary together: the docs page that
+/// documents the credentials, the credential parameters that component actually accepts, and
+/// the IAM action AWS checks. Carrying the operation rather than any one of them is what keeps
+/// the three consistent at each call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Operation {
+    /// `Converse` — a chat model's non-streaming request.
+    Chat,
+    /// `ConverseStream` — a chat model's streaming request.
+    ChatStream,
+    /// `InvokeModel` — how every Bedrock embedding model is called.
+    Embeddings,
+}
+
+impl Operation {
+    /// The page documenting the credential parameters for the component that made the call.
+    fn docs_url(self) -> &'static str {
+        match self {
+            Self::Chat | Self::ChatStream => "https://spiceai.org/docs/components/models/bedrock",
+            Self::Embeddings => "https://spiceai.org/docs/components/embeddings/bedrock",
+        }
+    }
+
+    /// The IAM action AWS checks for this call. `ConverseStream` is authorized by
+    /// `bedrock:InvokeModelWithResponseStream`, so an identity granted only
+    /// `bedrock:InvokeModel` still has streaming chat denied.
+    fn iam_action(self) -> &'static str {
+        match self {
+            Self::ChatStream => "bedrock:InvokeModelWithResponseStream",
+            Self::Chat | Self::Embeddings => "bedrock:InvokeModel",
+        }
+    }
+
+    /// The credential parameters this component accepts. `aws_profile` is embeddings-only —
+    /// `BedrockModelParams` neither accepts nor forwards it — so a chat remedy that named it
+    /// would send the operator to a setting the chat path ignores.
+    fn credentials_remedy(self) -> &'static str {
+        match self {
+            Self::Chat | Self::ChatStream => {
+                "Set `aws_access_key_id` and `aws_secret_access_key` to an active key pair (and \
+                 `aws_session_token` if the credentials are temporary), or set \
+                 `aws_iam_role_source` to resolve them instead."
+            }
+            Self::Embeddings => {
+                "Set `aws_access_key_id` and `aws_secret_access_key` to an active key pair (and \
+                 `aws_session_token` if the credentials are temporary), or set \
+                 `aws_iam_role_source` or `aws_profile` to resolve them instead."
+            }
+        }
+    }
+}
 
 /// Codes AWS returns when it will not accept the request's credentials at all — the key is
 /// unknown, the signature does not match it, or the session token has expired. Retrying cannot
@@ -50,19 +97,15 @@ const CREDENTIALS_REJECTED_CODES: &[&str] = &[
 ];
 
 /// Codes AWS returns when the credentials are valid but the identity may not make this call —
-/// a missing IAM action, or model access not granted for the model in this region.
+/// a missing IAM action, or the identity not having access to this model in this region.
 const ACCESS_DENIED_CODES: &[&str] = &["AccessDeniedException", "UnauthorizedException"];
-
-/// What the operator should change, chosen by which half of the rejection this is.
-const CREDENTIALS_REJECTED_REMEDY: &str = "Set `aws_access_key_id` and `aws_secret_access_key` to an active key pair (and `aws_session_token` if the credentials are temporary), or set `aws_iam_role_source` or `aws_profile` to resolve them instead.";
-const ACCESS_DENIED_REMEDY: &str = "Grant the identity the `bedrock:InvokeModel` action on this model, and request access to the model in the Amazon Bedrock console for the region in `aws_region`.";
 
 #[derive(Debug, Snafu)]
 #[snafu(display("Failed to call Bedrock model '{model_id}': {detail}. {remedy} See: {docs_url}"))]
 pub struct BedrockAuthError {
     model_id: String,
     detail: String,
-    remedy: &'static str,
+    remedy: String,
     docs_url: &'static str,
 }
 
@@ -74,13 +117,20 @@ fn describe(
     code: Option<&str>,
     message: Option<&str>,
     model_id: &str,
-    docs_url: &'static str,
+    operation: Operation,
 ) -> Option<BedrockAuthError> {
     let code = code?;
     let remedy = if CREDENTIALS_REJECTED_CODES.contains(&code) {
-        CREDENTIALS_REJECTED_REMEDY
+        operation.credentials_remedy().to_string()
     } else if ACCESS_DENIED_CODES.contains(&code) {
-        ACCESS_DENIED_REMEDY
+        // Not "request access in the console": Bedrock grants model access automatically for
+        // most models now, and the ones that don't route through Marketplace or a provider
+        // use-case form. Point at the state to confirm, not at one console flow.
+        format!(
+            "Grant the identity the `{}` action on this model, and confirm the identity has \
+             access to this model in the region set by `aws_region`.",
+            operation.iam_action()
+        )
     } else {
         return None;
     };
@@ -96,25 +146,22 @@ fn describe(
         model_id: model_id.to_string(),
         detail,
         remedy,
-        docs_url,
+        docs_url: operation.docs_url(),
     })
 }
 
 /// Box a Bedrock service error for the caller, substituting the operator-facing explanation
 /// when the rejection was an authentication or authorization failure and leaving every other
 /// error to render exactly as the SDK renders it.
-///
-/// `docs_url` is the page for the component that made the call: a Bedrock client serves both
-/// chat and embedding models, and each has its own configuration page.
 pub(crate) fn explain<E>(
     err: E,
     model_id: &str,
-    docs_url: &'static str,
+    operation: Operation,
 ) -> Box<dyn std::error::Error + Send + Sync>
 where
     E: ProvideErrorMetadata + std::error::Error + Send + Sync + 'static,
 {
-    match describe(err.code(), err.message(), model_id, docs_url) {
+    match describe(err.code(), err.message(), model_id, operation) {
         Some(explained) => Box::new(explained),
         None => Box::new(err),
     }
@@ -123,12 +170,17 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        ACCESS_DENIED_CODES, CHAT_DOCS_URL, CREDENTIALS_REJECTED_CODES, EMBEDDINGS_DOCS_URL,
-        UNKNOWN_MODEL, describe, explain,
+        ACCESS_DENIED_CODES, CREDENTIALS_REJECTED_CODES, Operation, UNKNOWN_MODEL, describe,
+        explain,
     };
     use aws_smithy_types::error::metadata::{ErrorMetadata, ProvideErrorMetadata};
 
     const MODEL: &str = "amazon.titan-embed-text-v2:0";
+    const EVERY_OPERATION: [Operation; 3] = [
+        Operation::Chat,
+        Operation::ChatStream,
+        Operation::Embeddings,
+    ];
 
     /// Stands in for a Bedrock operation error: the SDK's own types carry both of these
     /// impls, and `explain` needs both to box the error it was handed.
@@ -157,61 +209,134 @@ mod tests {
         FakeServiceError(ErrorMetadata::builder().code(code).message(message).build())
     }
 
+    fn rendered(code: &str, message: Option<&str>, operation: Operation) -> String {
+        describe(Some(code), message, MODEL, operation)
+            .unwrap_or_else(|| panic!("{code} must be classified"))
+            .to_string()
+    }
+
     #[test]
     fn credential_rejection_names_the_model_the_keys_and_the_docs() {
-        let err = describe(
-            Some("UnrecognizedClientException"),
+        let out = rendered(
+            "UnrecognizedClientException",
             Some("The security token included in the request is invalid."),
-            MODEL,
-            EMBEDDINGS_DOCS_URL,
-        )
-        .expect("UnrecognizedClientException is a credential rejection");
-        let rendered = err.to_string();
+            Operation::Embeddings,
+        );
 
-        assert!(rendered.contains(MODEL), "must name the model: {rendered}");
+        assert!(out.contains(MODEL), "must name the model: {out}");
         assert!(
-            rendered.contains("UnrecognizedClientException"),
-            "must keep the AWS code: {rendered}"
+            out.contains("UnrecognizedClientException"),
+            "must keep the AWS code: {out}"
         );
         assert!(
-            rendered.contains("The security token included in the request is invalid."),
-            "must keep the AWS message: {rendered}"
+            out.contains("The security token included in the request is invalid."),
+            "must keep the AWS message: {out}"
         );
         assert!(
-            rendered.contains("`aws_access_key_id`")
-                && rendered.contains("`aws_secret_access_key`"),
-            "must name the parameters to change: {rendered}"
+            out.contains("`aws_access_key_id`") && out.contains("`aws_secret_access_key`"),
+            "must name the parameters to change: {out}"
         );
         assert!(
-            rendered.contains(EMBEDDINGS_DOCS_URL),
-            "must link the docs: {rendered}"
+            out.contains(Operation::Embeddings.docs_url()),
+            "must link the docs: {out}"
         );
         // The whole point of the rewrite: the SDK's own rendering said only this.
         assert!(
-            !rendered.contains("unhandled error"),
-            "must not read as an unhandled error: {rendered}"
+            !out.contains("unhandled error"),
+            "must not read as an unhandled error: {out}"
         );
     }
 
     #[test]
     fn access_denial_asks_for_the_grant_not_for_new_keys() {
-        let rendered = describe(
-            Some("AccessDeniedException"),
+        let out = rendered(
+            "AccessDeniedException",
             Some("You don't have access to the model with the specified model ID."),
-            MODEL,
-            EMBEDDINGS_DOCS_URL,
-        )
-        .expect("AccessDeniedException is an authorization rejection")
-        .to_string();
+            Operation::Embeddings,
+        );
 
         assert!(
-            rendered.contains("bedrock:InvokeModel"),
-            "must name the IAM action: {rendered}"
+            out.contains("bedrock:InvokeModel"),
+            "must name the IAM action: {out}"
         );
         assert!(
-            !rendered.contains("`aws_access_key_id`"),
-            "credentials that AWS accepted must not be blamed: {rendered}"
+            !out.contains("`aws_access_key_id`"),
+            "credentials that AWS accepted must not be blamed: {out}"
         );
+    }
+
+    #[test]
+    fn a_streaming_chat_denial_asks_for_the_streaming_iam_action() {
+        // AWS authorizes `ConverseStream` with `bedrock:InvokeModelWithResponseStream`. An
+        // identity granted only `bedrock:InvokeModel` still has streaming chat denied, so a
+        // shared remedy would send the operator to a grant that does not lift the denial.
+        let streaming = rendered("AccessDeniedException", None, Operation::ChatStream);
+        assert!(
+            streaming.contains("`bedrock:InvokeModelWithResponseStream`"),
+            "streaming chat must ask for the streaming action: {streaming}"
+        );
+
+        for operation in [Operation::Chat, Operation::Embeddings] {
+            let out = rendered("AccessDeniedException", None, operation);
+            assert!(
+                out.contains("`bedrock:InvokeModel`")
+                    && !out.contains("InvokeModelWithResponseStream"),
+                "{operation:?} is authorized by bedrock:InvokeModel alone: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_chat_credential_remedy_names_only_parameters_chat_accepts() {
+        // `aws_profile` is an embeddings-only parameter: `BedrockModelParams` neither accepts
+        // nor forwards it, so a chat operator who followed that advice would stay
+        // unauthenticated while believing they had acted on the message.
+        for operation in [Operation::Chat, Operation::ChatStream] {
+            let out = rendered("UnrecognizedClientException", None, operation);
+            assert!(
+                !out.contains("aws_profile"),
+                "{operation:?} does not accept `aws_profile`: {out}"
+            );
+            assert!(
+                out.contains("`aws_iam_role_source`"),
+                "{operation:?} does accept `aws_iam_role_source`: {out}"
+            );
+        }
+
+        let embeddings = rendered("UnrecognizedClientException", None, Operation::Embeddings);
+        assert!(
+            embeddings.contains("`aws_profile`"),
+            "embeddings do accept `aws_profile`: {embeddings}"
+        );
+
+        // The two remedies differ only in `aws_profile`, so the rest is duplicated prose that
+        // one arm could lose in an edit without the assertions above noticing.
+        for operation in EVERY_OPERATION {
+            let out = rendered("UnrecognizedClientException", None, operation);
+            for param in [
+                "`aws_access_key_id`",
+                "`aws_secret_access_key`",
+                "`aws_session_token`",
+            ] {
+                assert!(
+                    out.contains(param),
+                    "{operation:?} must name {param}: {out}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn chat_and_embeddings_are_sent_to_their_own_docs_page() {
+        assert_ne!(Operation::Chat.docs_url(), Operation::Embeddings.docs_url());
+        assert_eq!(Operation::Chat.docs_url(), Operation::ChatStream.docs_url());
+        for operation in EVERY_OPERATION {
+            let out = rendered("ExpiredTokenException", None, operation);
+            assert!(
+                out.ends_with(operation.docs_url()),
+                "{operation:?} must link its own page: {out}"
+            );
+        }
     }
 
     #[test]
@@ -220,14 +345,14 @@ mod tests {
             .iter()
             .chain(ACCESS_DENIED_CODES.iter())
         {
-            let rendered = describe(Some(code), None, MODEL, EMBEDDINGS_DOCS_URL)
-                .unwrap_or_else(|| panic!("{code} is listed, so it must be described"))
-                .to_string();
-            assert!(rendered.contains(code), "{code} must appear in {rendered}");
-            assert!(
-                rendered.contains(EMBEDDINGS_DOCS_URL),
-                "{code} must link the docs: {rendered}"
-            );
+            for operation in EVERY_OPERATION {
+                let out = rendered(code, None, operation);
+                assert!(out.contains(code), "{code} must appear in {out}");
+                assert!(
+                    out.contains(operation.docs_url()),
+                    "{code}/{operation:?} must link the docs: {out}"
+                );
+            }
         }
     }
 
@@ -253,7 +378,7 @@ mod tests {
             "InternalServerException",
         ] {
             assert!(
-                describe(Some(code), Some("some detail"), MODEL, EMBEDDINGS_DOCS_URL).is_none(),
+                describe(Some(code), Some("some detail"), MODEL, Operation::Chat).is_none(),
                 "{code} is not an auth failure and must render as the SDK renders it"
             );
         }
@@ -266,7 +391,7 @@ mod tests {
                 None,
                 Some("a message but no code"),
                 MODEL,
-                EMBEDDINGS_DOCS_URL
+                Operation::Embeddings
             )
             .is_none(),
             "a rejection AWS did not label cannot be classified"
@@ -276,38 +401,35 @@ mod tests {
     #[test]
     fn an_empty_aws_message_does_not_leave_a_dangling_separator() {
         for message in [Some(""), Some("   "), None] {
-            let rendered = describe(
-                Some("UnrecognizedClientException"),
+            let out = rendered(
+                "UnrecognizedClientException",
                 message,
-                MODEL,
-                EMBEDDINGS_DOCS_URL,
-            )
-            .expect("still a credential rejection")
-            .to_string();
-            assert!(
-                rendered.contains("(UnrecognizedClientException)"),
-                "an absent AWS message must leave the code alone: {rendered}"
+                Operation::Embeddings,
             );
             assert!(
-                !rendered.contains(": )"),
-                "must not render an empty message: {rendered}"
+                out.contains("(UnrecognizedClientException)"),
+                "an absent AWS message must leave the code alone: {out}"
+            );
+            assert!(
+                !out.contains(": )"),
+                "must not render an empty message: {out}"
             );
         }
     }
 
     #[test]
     fn a_request_with_no_model_id_still_renders() {
-        let rendered = describe(
+        let out = describe(
             Some("ExpiredTokenException"),
             None,
             UNKNOWN_MODEL,
-            EMBEDDINGS_DOCS_URL,
+            Operation::Chat,
         )
         .expect("still a credential rejection")
         .to_string();
         assert!(
-            rendered.contains(UNKNOWN_MODEL),
-            "must be explicit that the model is unknown: {rendered}"
+            out.contains(UNKNOWN_MODEL),
+            "must be explicit that the model is unknown: {out}"
         );
     }
 
@@ -323,49 +445,29 @@ mod tests {
             "the SDK rendering this replaces"
         );
 
-        let rendered = explain(err, MODEL, EMBEDDINGS_DOCS_URL).to_string();
-        assert!(rendered.contains(MODEL), "must name the model: {rendered}");
+        let out = explain(err, MODEL, Operation::Embeddings).to_string();
+        assert!(out.contains(MODEL), "must name the model: {out}");
         assert!(
-            rendered.contains("The security token included in the request is invalid."),
-            "must carry AWS's own message through: {rendered}"
+            out.contains("The security token included in the request is invalid."),
+            "must carry AWS's own message through: {out}"
         );
         assert!(
-            rendered.contains("`aws_access_key_id`"),
-            "must name the parameter to change: {rendered}"
+            out.contains("`aws_access_key_id`"),
+            "must name the parameter to change: {out}"
         );
         assert!(
-            !rendered.contains("unhandled error"),
-            "the SDK rendering must not survive: {rendered}"
+            !out.contains("unhandled error"),
+            "the SDK rendering must not survive: {out}"
         );
     }
 
     #[test]
     fn explain_passes_a_non_auth_error_through_unchanged() {
         // Every other Bedrock failure must keep rendering exactly as the SDK renders it.
-        let err = service_error("ValidationException", "input too long");
-        let sdk_rendering = err.to_string();
-        assert_eq!(
-            explain(err, MODEL, EMBEDDINGS_DOCS_URL).to_string(),
-            sdk_rendering
-        );
-    }
-
-    #[test]
-    fn explain_links_the_docs_page_of_the_calling_component() {
-        // A Bedrock client serves chat and embeddings, and the credential parameters are
-        // documented on a different page for each.
-        assert_ne!(CHAT_DOCS_URL, EMBEDDINGS_DOCS_URL);
-        for docs_url in [CHAT_DOCS_URL, EMBEDDINGS_DOCS_URL] {
-            let rendered = explain(
-                service_error("AccessDeniedException", "no access to the model"),
-                MODEL,
-                docs_url,
-            )
-            .to_string();
-            assert!(
-                rendered.ends_with(docs_url),
-                "{rendered} must end with {docs_url}"
-            );
+        for operation in EVERY_OPERATION {
+            let err = service_error("ValidationException", "input too long");
+            let sdk_rendering = err.to_string();
+            assert_eq!(explain(err, MODEL, operation).to_string(), sdk_rendering);
         }
     }
 }

--- a/crates/llms/src/bedrock/auth_error.rs
+++ b/crates/llms/src/bedrock/auth_error.rs
@@ -1,0 +1,371 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Turning a Bedrock authentication or authorization rejection into a message the operator
+//! can act on.
+//!
+//! AWS models only some of these rejections on the Bedrock operation error enums.
+//! `UnrecognizedClientException` — what AWS returns for an access key it does not know — is not
+//! one of them, so the SDK renders it as `unhandled error (UnrecognizedClientException)`: a
+//! string that names neither the model that failed nor anything to change. The modelled
+//! `AccessDeniedException` reads better but still names no model and no Spice parameter.
+
+use aws_sdk_bedrockruntime::error::ProvideErrorMetadata;
+use snafu::Snafu;
+
+/// The Bedrock chat docs, which carry the credential parameters for a chat model.
+pub(crate) const CHAT_DOCS_URL: &str = "https://spiceai.org/docs/components/models/bedrock";
+
+/// The Bedrock embeddings docs, which carry the credential parameters for an embedding model.
+pub(crate) const EMBEDDINGS_DOCS_URL: &str =
+    "https://spiceai.org/docs/components/embeddings/bedrock";
+
+/// The model name to report when the request never carried one.
+pub(crate) const UNKNOWN_MODEL: &str = "<unknown>";
+
+/// Codes AWS returns when it will not accept the request's credentials at all — the key is
+/// unknown, the signature does not match it, or the session token has expired. Retrying cannot
+/// help; the credentials themselves have to change.
+const CREDENTIALS_REJECTED_CODES: &[&str] = &[
+    "UnrecognizedClientException",
+    "InvalidSignatureException",
+    "InvalidClientTokenId",
+    "MissingAuthenticationToken",
+    "IncompleteSignature",
+    "ExpiredToken",
+    "ExpiredTokenException",
+];
+
+/// Codes AWS returns when the credentials are valid but the identity may not make this call —
+/// a missing IAM action, or model access not granted for the model in this region.
+const ACCESS_DENIED_CODES: &[&str] = &["AccessDeniedException", "UnauthorizedException"];
+
+/// What the operator should change, chosen by which half of the rejection this is.
+const CREDENTIALS_REJECTED_REMEDY: &str = "Set `aws_access_key_id` and `aws_secret_access_key` to an active key pair (and `aws_session_token` if the credentials are temporary), or set `aws_iam_role_source` or `aws_profile` to resolve them instead.";
+const ACCESS_DENIED_REMEDY: &str = "Grant the identity the `bedrock:InvokeModel` action on this model, and request access to the model in the Amazon Bedrock console for the region in `aws_region`.";
+
+#[derive(Debug, Snafu)]
+#[snafu(display("Failed to call Bedrock model '{model_id}': {detail}. {remedy} See: {docs_url}"))]
+pub struct BedrockAuthError {
+    model_id: String,
+    detail: String,
+    remedy: &'static str,
+    docs_url: &'static str,
+}
+
+/// Build the operator-facing message for a rejection AWS has already labelled with `code`.
+///
+/// Returns `None` for any code that is not an authentication or authorization rejection, which
+/// leaves every other error rendering exactly as the SDK renders it.
+fn describe(
+    code: Option<&str>,
+    message: Option<&str>,
+    model_id: &str,
+    docs_url: &'static str,
+) -> Option<BedrockAuthError> {
+    let code = code?;
+    let remedy = if CREDENTIALS_REJECTED_CODES.contains(&code) {
+        CREDENTIALS_REJECTED_REMEDY
+    } else if ACCESS_DENIED_CODES.contains(&code) {
+        ACCESS_DENIED_REMEDY
+    } else {
+        return None;
+    };
+
+    // Keep whatever AWS said alongside its code: the code is what the remedy is chosen from, and
+    // the message is often the only thing distinguishing two causes behind one code.
+    let detail = match message.map(str::trim).filter(|m| !m.is_empty()) {
+        Some(message) => format!("AWS rejected the request ({code}: {message})"),
+        None => format!("AWS rejected the request ({code})"),
+    };
+
+    Some(BedrockAuthError {
+        model_id: model_id.to_string(),
+        detail,
+        remedy,
+        docs_url,
+    })
+}
+
+/// Box a Bedrock service error for the caller, substituting the operator-facing explanation
+/// when the rejection was an authentication or authorization failure and leaving every other
+/// error to render exactly as the SDK renders it.
+///
+/// `docs_url` is the page for the component that made the call: a Bedrock client serves both
+/// chat and embedding models, and each has its own configuration page.
+pub(crate) fn explain<E>(
+    err: E,
+    model_id: &str,
+    docs_url: &'static str,
+) -> Box<dyn std::error::Error + Send + Sync>
+where
+    E: ProvideErrorMetadata + std::error::Error + Send + Sync + 'static,
+{
+    match describe(err.code(), err.message(), model_id, docs_url) {
+        Some(explained) => Box::new(explained),
+        None => Box::new(err),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ACCESS_DENIED_CODES, CHAT_DOCS_URL, CREDENTIALS_REJECTED_CODES, EMBEDDINGS_DOCS_URL,
+        UNKNOWN_MODEL, describe, explain,
+    };
+    use aws_smithy_types::error::metadata::{ErrorMetadata, ProvideErrorMetadata};
+
+    const MODEL: &str = "amazon.titan-embed-text-v2:0";
+
+    /// Stands in for a Bedrock operation error: the SDK's own types carry both of these
+    /// impls, and `explain` needs both to box the error it was handed.
+    #[derive(Debug)]
+    struct FakeServiceError(ErrorMetadata);
+
+    impl std::fmt::Display for FakeServiceError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            // How the SDK renders a code it does not model.
+            match ProvideErrorMetadata::code(self) {
+                Some(code) => write!(f, "unhandled error ({code})"),
+                None => f.write_str("unhandled error"),
+            }
+        }
+    }
+
+    impl std::error::Error for FakeServiceError {}
+
+    impl ProvideErrorMetadata for FakeServiceError {
+        fn meta(&self) -> &ErrorMetadata {
+            &self.0
+        }
+    }
+
+    fn service_error(code: &str, message: &str) -> FakeServiceError {
+        FakeServiceError(ErrorMetadata::builder().code(code).message(message).build())
+    }
+
+    #[test]
+    fn credential_rejection_names_the_model_the_keys_and_the_docs() {
+        let err = describe(
+            Some("UnrecognizedClientException"),
+            Some("The security token included in the request is invalid."),
+            MODEL,
+            EMBEDDINGS_DOCS_URL,
+        )
+        .expect("UnrecognizedClientException is a credential rejection");
+        let rendered = err.to_string();
+
+        assert!(rendered.contains(MODEL), "must name the model: {rendered}");
+        assert!(
+            rendered.contains("UnrecognizedClientException"),
+            "must keep the AWS code: {rendered}"
+        );
+        assert!(
+            rendered.contains("The security token included in the request is invalid."),
+            "must keep the AWS message: {rendered}"
+        );
+        assert!(
+            rendered.contains("`aws_access_key_id`")
+                && rendered.contains("`aws_secret_access_key`"),
+            "must name the parameters to change: {rendered}"
+        );
+        assert!(
+            rendered.contains(EMBEDDINGS_DOCS_URL),
+            "must link the docs: {rendered}"
+        );
+        // The whole point of the rewrite: the SDK's own rendering said only this.
+        assert!(
+            !rendered.contains("unhandled error"),
+            "must not read as an unhandled error: {rendered}"
+        );
+    }
+
+    #[test]
+    fn access_denial_asks_for_the_grant_not_for_new_keys() {
+        let rendered = describe(
+            Some("AccessDeniedException"),
+            Some("You don't have access to the model with the specified model ID."),
+            MODEL,
+            EMBEDDINGS_DOCS_URL,
+        )
+        .expect("AccessDeniedException is an authorization rejection")
+        .to_string();
+
+        assert!(
+            rendered.contains("bedrock:InvokeModel"),
+            "must name the IAM action: {rendered}"
+        );
+        assert!(
+            !rendered.contains("`aws_access_key_id`"),
+            "credentials that AWS accepted must not be blamed: {rendered}"
+        );
+    }
+
+    #[test]
+    fn every_listed_code_is_described_and_carries_a_remedy() {
+        for code in CREDENTIALS_REJECTED_CODES
+            .iter()
+            .chain(ACCESS_DENIED_CODES.iter())
+        {
+            let rendered = describe(Some(code), None, MODEL, EMBEDDINGS_DOCS_URL)
+                .unwrap_or_else(|| panic!("{code} is listed, so it must be described"))
+                .to_string();
+            assert!(rendered.contains(code), "{code} must appear in {rendered}");
+            assert!(
+                rendered.contains(EMBEDDINGS_DOCS_URL),
+                "{code} must link the docs: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_two_code_lists_are_disjoint() {
+        // A code in both lists would take whichever remedy is tested first, so the operator
+        // could be told to rotate credentials AWS had already accepted.
+        for code in CREDENTIALS_REJECTED_CODES {
+            assert!(
+                !ACCESS_DENIED_CODES.contains(code),
+                "{code} is classified as both a credential rejection and an access denial"
+            );
+        }
+    }
+
+    #[test]
+    fn a_non_auth_code_is_left_to_the_sdk() {
+        for code in [
+            "ThrottlingException",
+            "ValidationException",
+            "ModelTimeoutException",
+            "ServiceUnavailableException",
+            "InternalServerException",
+        ] {
+            assert!(
+                describe(Some(code), Some("some detail"), MODEL, EMBEDDINGS_DOCS_URL).is_none(),
+                "{code} is not an auth failure and must render as the SDK renders it"
+            );
+        }
+    }
+
+    #[test]
+    fn an_error_with_no_code_is_left_to_the_sdk() {
+        assert!(
+            describe(
+                None,
+                Some("a message but no code"),
+                MODEL,
+                EMBEDDINGS_DOCS_URL
+            )
+            .is_none(),
+            "a rejection AWS did not label cannot be classified"
+        );
+    }
+
+    #[test]
+    fn an_empty_aws_message_does_not_leave_a_dangling_separator() {
+        for message in [Some(""), Some("   "), None] {
+            let rendered = describe(
+                Some("UnrecognizedClientException"),
+                message,
+                MODEL,
+                EMBEDDINGS_DOCS_URL,
+            )
+            .expect("still a credential rejection")
+            .to_string();
+            assert!(
+                rendered.contains("(UnrecognizedClientException)"),
+                "an absent AWS message must leave the code alone: {rendered}"
+            );
+            assert!(
+                !rendered.contains(": )"),
+                "must not render an empty message: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_request_with_no_model_id_still_renders() {
+        let rendered = describe(
+            Some("ExpiredTokenException"),
+            None,
+            UNKNOWN_MODEL,
+            EMBEDDINGS_DOCS_URL,
+        )
+        .expect("still a credential rejection")
+        .to_string();
+        assert!(
+            rendered.contains(UNKNOWN_MODEL),
+            "must be explicit that the model is unknown: {rendered}"
+        );
+    }
+
+    #[test]
+    fn explain_replaces_an_auth_rejection_with_the_actionable_message() {
+        let err = service_error(
+            "UnrecognizedClientException",
+            "The security token included in the request is invalid.",
+        );
+        assert_eq!(
+            err.to_string(),
+            "unhandled error (UnrecognizedClientException)",
+            "the SDK rendering this replaces"
+        );
+
+        let rendered = explain(err, MODEL, EMBEDDINGS_DOCS_URL).to_string();
+        assert!(rendered.contains(MODEL), "must name the model: {rendered}");
+        assert!(
+            rendered.contains("The security token included in the request is invalid."),
+            "must carry AWS's own message through: {rendered}"
+        );
+        assert!(
+            rendered.contains("`aws_access_key_id`"),
+            "must name the parameter to change: {rendered}"
+        );
+        assert!(
+            !rendered.contains("unhandled error"),
+            "the SDK rendering must not survive: {rendered}"
+        );
+    }
+
+    #[test]
+    fn explain_passes_a_non_auth_error_through_unchanged() {
+        // Every other Bedrock failure must keep rendering exactly as the SDK renders it.
+        let err = service_error("ValidationException", "input too long");
+        let sdk_rendering = err.to_string();
+        assert_eq!(
+            explain(err, MODEL, EMBEDDINGS_DOCS_URL).to_string(),
+            sdk_rendering
+        );
+    }
+
+    #[test]
+    fn explain_links_the_docs_page_of_the_calling_component() {
+        // A Bedrock client serves chat and embeddings, and the credential parameters are
+        // documented on a different page for each.
+        assert_ne!(CHAT_DOCS_URL, EMBEDDINGS_DOCS_URL);
+        for docs_url in [CHAT_DOCS_URL, EMBEDDINGS_DOCS_URL] {
+            let rendered = explain(
+                service_error("AccessDeniedException", "no access to the model"),
+                MODEL,
+                docs_url,
+            )
+            .to_string();
+            assert!(
+                rendered.ends_with(docs_url),
+                "{rendered} must end with {docs_url}"
+            );
+        }
+    }
+}

--- a/crates/llms/src/bedrock/auth_error.rs
+++ b/crates/llms/src/bedrock/auth_error.rs
@@ -67,17 +67,27 @@ impl Operation {
     /// The credential parameters this component accepts. `aws_profile` is embeddings-only —
     /// `BedrockModelParams` neither accepts nor forwards it — so a chat remedy that named it
     /// would send the operator to a setting the chat path ignores.
+    ///
+    /// The precedence in the remedy is real and load-bearing:
+    /// `aws_sdk_credential_bridge::initiate_config_with_credentials` installs a static
+    /// credentials provider whenever both key parameters are set and never consults
+    /// `aws_iam_role_source`, and a later `profile_name` does not displace it. An operator who
+    /// adds the fallback while leaving the rejected keys in place keeps sending those keys.
     fn credentials_remedy(self) -> &'static str {
         match self {
             Self::Chat | Self::ChatStream => {
-                "Set `aws_access_key_id` and `aws_secret_access_key` to an active key pair (and \
-                 `aws_session_token` if the credentials are temporary), or set \
-                 `aws_iam_role_source` to resolve them instead."
+                "Replace `aws_access_key_id` and `aws_secret_access_key` with an active key pair \
+                 (and `aws_session_token` if the credentials are temporary). To resolve \
+                 credentials some other way, remove both of those parameters first and then set \
+                 `aws_iam_role_source` — an explicit key pair takes precedence and is sent even \
+                 when a role source is configured."
             }
             Self::Embeddings => {
-                "Set `aws_access_key_id` and `aws_secret_access_key` to an active key pair (and \
-                 `aws_session_token` if the credentials are temporary), or set \
-                 `aws_iam_role_source` or `aws_profile` to resolve them instead."
+                "Replace `aws_access_key_id` and `aws_secret_access_key` with an active key pair \
+                 (and `aws_session_token` if the credentials are temporary). To resolve \
+                 credentials some other way, remove both of those parameters first and then set \
+                 `aws_iam_role_source` or `aws_profile` — an explicit key pair takes precedence \
+                 and is sent even when a role source or profile is configured."
             }
         }
     }
@@ -117,11 +127,22 @@ const SIGNATURE_REMEDY: &str = concat!(
 );
 
 /// Codes AWS returns when it knows the identity but will not let this call through — a missing
-/// IAM action, or the account or identity not having access to this model in this region.
+/// IAM action, or the identity not having access to this model in this region.
 ///
-/// `NotAuthorized` and `OptInRequired` are from AWS's common-error set rather than Bedrock's own
-/// modelled errors, so they arrive unmodelled exactly as the credential codes do.
-const ACCESS_DENIED_CODES: &[&str] = &["AccessDeniedException", "NotAuthorized", "OptInRequired"];
+/// `NotAuthorized` is from AWS's common-error set rather than Bedrock's own modelled errors, so
+/// it arrives unmodelled exactly as the credential codes do.
+const ACCESS_DENIED_CODES: &[&str] = &["AccessDeniedException", "NotAuthorized"];
+
+/// The code AWS returns when the *account* is not subscribed to the service, rather than the
+/// identity lacking a permission. An IAM grant cannot resolve it, and suggesting one would
+/// broaden access while Bedrock stays unavailable — so it is deliberately not an access denial.
+const NOT_SUBSCRIBED_CODES: &[&str] = &["OptInRequired"];
+
+const NOT_SUBSCRIBED_REMEDY: &str = concat!(
+    "Amazon Bedrock is not enabled for this AWS account in the region set by `aws_region`. ",
+    "Enable Bedrock for the account in that region and request access to this model there; ",
+    "no IAM grant on the identity can resolve this."
+);
 
 #[derive(Debug, Snafu)]
 #[snafu(display("Failed to call Bedrock model '{model_id}': {detail}. {remedy} See: {docs_url}"))]
@@ -167,6 +188,8 @@ fn describe(
         operation.credentials_remedy().to_string()
     } else if SIGNATURE_REJECTED_CODES.contains(&code) {
         SIGNATURE_REMEDY.to_string()
+    } else if NOT_SUBSCRIBED_CODES.contains(&code) {
+        NOT_SUBSCRIBED_REMEDY.to_string()
     } else if ACCESS_DENIED_CODES.contains(&code) {
         // Naming one action is not enough on its own: a request carrying a guardrail also needs
         // `bedrock:ApplyGuardrail`, and an inference profile needs its own actions, so an
@@ -244,8 +267,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        ACCESS_DENIED_CODES, CREDENTIALS_REJECTED_CODES, Operation, SIGNATURE_REJECTED_CODES,
-        UNKNOWN_MODEL, explain,
+        ACCESS_DENIED_CODES, CREDENTIALS_REJECTED_CODES, NOT_SUBSCRIBED_CODES, Operation,
+        SIGNATURE_REJECTED_CODES, UNKNOWN_MODEL, explain,
     };
     use aws_sdk_bedrockruntime::error::ErrorMetadata;
     use aws_sdk_bedrockruntime::operation::{
@@ -369,7 +392,6 @@ mod tests {
                 "AccessDeniedException",
                 Some("You don't have access to the model with the specified model ID."),
             ),
-            ("OptInRequired", None),
             ("NotAuthorized", None),
         ] {
             for operation in EVERY_OPERATION {
@@ -478,7 +500,7 @@ mod tests {
                     "{code} must name the causes a key rotation cannot fix: {out}"
                 );
                 assert!(
-                    !out.contains("to an active key pair"),
+                    !out.contains("with an active key pair"),
                     "{code} must not be reported as a credential replacement: {out}"
                 );
                 assert!(
@@ -486,6 +508,54 @@ mod tests {
                     "{code} is not an authorization failure: {out}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn an_unsubscribed_account_is_not_reported_as_a_missing_iam_grant() {
+        // AWS defines `OptInRequired` as the account needing the service enabled, not the
+        // identity needing a permission. Advising an IAM grant broadens access and leaves
+        // Bedrock exactly as unavailable as it was.
+        assert_eq!(NOT_SUBSCRIBED_CODES, ["OptInRequired"]);
+        assert!(
+            !ACCESS_DENIED_CODES.contains(&"OptInRequired"),
+            "account enablement is not an authorization failure"
+        );
+
+        for operation in EVERY_OPERATION {
+            let out = rendered("OptInRequired", None, operation);
+            assert!(
+                out.contains("not enabled for this AWS account"),
+                "{operation:?} must name account enablement: {out}"
+            );
+            assert!(
+                out.contains("no IAM grant"),
+                "{operation:?} must say an IAM grant cannot resolve it: {out}"
+            );
+            assert!(
+                !out.contains("Grant the identity"),
+                "{operation:?} must not ask for an IAM grant: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_credential_fallback_says_the_rejected_keys_must_be_removed() {
+        // `aws_sdk_credential_bridge::initiate_config_with_credentials` installs a static
+        // credentials provider whenever both key parameters are set, and never reaches
+        // `aws_iam_role_source`; a later `profile_name` does not displace it. So "set a role
+        // source instead" without "remove the keys first" is advice that changes nothing — the
+        // operator keeps sending the very keys AWS rejected.
+        for operation in EVERY_OPERATION {
+            let out = rendered("UnrecognizedClientException", None, operation);
+            assert!(
+                out.contains("remove both of those parameters first"),
+                "{operation:?} must say the keys have to go first: {out}"
+            );
+            assert!(
+                out.contains("takes precedence"),
+                "{operation:?} must say why: {out}"
+            );
         }
     }
 
@@ -520,6 +590,7 @@ mod tests {
         CREDENTIALS_REJECTED_CODES
             .iter()
             .chain(SIGNATURE_REJECTED_CODES.iter())
+            .chain(NOT_SUBSCRIBED_CODES.iter())
             .chain(ACCESS_DENIED_CODES.iter())
             .copied()
     }
@@ -532,6 +603,7 @@ mod tests {
         let lists = [
             ("credentials", CREDENTIALS_REJECTED_CODES),
             ("signature", SIGNATURE_REJECTED_CODES),
+            ("not subscribed", NOT_SUBSCRIBED_CODES),
             ("access denied", ACCESS_DENIED_CODES),
         ];
         for (i, (name, codes)) in lists.iter().enumerate() {

--- a/crates/llms/src/bedrock/auth_error.rs
+++ b/crates/llms/src/bedrock/auth_error.rs
@@ -105,7 +105,7 @@ const SIGNATURE_REJECTED_CODES: &[&str] = &[
     "RequestExpired",
 ];
 
-/// AWS's own message distinguishes the causes behind these two codes ("Signature expired…" vs
+/// AWS's own message distinguishes the causes behind these codes ("Signature expired…" vs
 /// "…does not match the signature you provided"), and [`describe`] carries it through, so the
 /// remedy names every cause rather than guessing at one.
 const SIGNATURE_REMEDY: &str = concat!(
@@ -136,6 +136,21 @@ pub struct BedrockAuthError {
     source: Box<dyn std::error::Error + Send + Sync>,
 }
 
+/// Squeeze every run of whitespace — including the newlines AWS's own message may carry — down
+/// to a single space, so an error stays on one line as the repository requires.
+fn collapse_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Whether AWS's message names the action it refused.
+///
+/// This is IAM's standard denial phrasing across services ("User: arn:… is not authorized to
+/// perform: bedrock:ApplyGuardrail on resource: …"), and it is the only thing that makes
+/// "the action named in AWS's message" refer to anything.
+fn names_a_denied_action(message: Option<&str>) -> bool {
+    message.is_some_and(|m| m.contains("not authorized to perform"))
+}
+
 /// Build the `(detail, remedy)` halves of the operator-facing message for a rejection AWS has
 /// already labelled with `code`.
 ///
@@ -155,18 +170,29 @@ fn describe(
     } else if ACCESS_DENIED_CODES.contains(&code) {
         // Naming one action is not enough on its own: a request carrying a guardrail also needs
         // `bedrock:ApplyGuardrail`, and an inference profile needs its own actions, so an
-        // identity that already holds the invoke action can still be denied. AWS's message
-        // names the action it actually refused, and `detail` carries it, so lead with that and
-        // give the invoke action as the floor rather than as the whole answer.
+        // identity that already holds the invoke action can still be denied. When AWS names the
+        // action it refused, `detail` carries it and the remedy points there.
+        //
+        // But it does not always name one — `OptInRequired`, and an `AccessDeniedException`
+        // about model access rather than IAM, name none. Referring the operator to an action
+        // that is not in the message points them at nothing, so ask for the invoke action
+        // outright in that case.
+        //
         // Not "request access in the console" either: Bedrock grants model access automatically
         // for most models now, and the rest route through Marketplace or a provider use-case
         // form. Point at the state to confirm, not at one console flow.
+        let action = operation.iam_action();
+        let grant = if names_a_denied_action(message) {
+            format!(
+                "Grant the identity the action named in AWS's message — this call needs at least `{action}`"
+            )
+        } else {
+            format!("Grant the identity `{action}` on this model")
+        };
         format!(
-            "Grant the identity the action named in AWS's message — this call needs at \
-             least `{}`, and a request using a guardrail or an inference profile needs the \
-             further actions those require. Then confirm the account and the identity have \
-             access to this model in the region set by `aws_region`.",
-            operation.iam_action()
+            "{grant}, and a request using a guardrail or an inference profile needs the further \
+             actions those require. Then confirm the account and the identity have access to \
+             this model in the region set by `aws_region`."
         )
     } else {
         return None;
@@ -176,7 +202,7 @@ fn describe(
     // the message is often the only thing distinguishing two causes behind one code. The request
     // ID goes in too — it is what AWS support and the service logs are searched by, and this
     // rendering is all an operator sees.
-    let mut detail = match message.map(str::trim).filter(|m| !m.is_empty()) {
+    let mut detail = match message.map(collapse_whitespace).filter(|m| !m.is_empty()) {
         Some(message) => format!("AWS rejected the request ({code}: {message}"),
         None => format!("AWS rejected the request ({code}"),
     };
@@ -314,8 +340,10 @@ mod tests {
         // action — a guardrail also needs `bedrock:ApplyGuardrail`, and this chat client
         // supports guardrails — so an identity holding only the invoke action is still denied.
         // AWS names the action it refused; the message has to point there, not assert one.
+        const IAM_DENIAL: &str = "User: arn:aws:iam::123456789012:user/svc is not authorized to \
+                                  perform: bedrock:ApplyGuardrail on resource: *";
         for operation in EVERY_OPERATION {
-            let out = rendered("AccessDeniedException", Some("not authorized"), operation);
+            let out = rendered("AccessDeniedException", Some(IAM_DENIAL), operation);
             assert!(
                 out.contains("the action named in AWS's message"),
                 "{operation:?} must defer to AWS's own named action: {out}"
@@ -328,6 +356,37 @@ mod tests {
                 out.contains("at least"),
                 "{operation:?} must give the invoke action as a floor, not the whole answer: {out}"
             );
+        }
+    }
+
+    #[test]
+    fn access_denial_asks_outright_when_aws_named_no_action() {
+        // `OptInRequired`, and a model-access denial rather than an IAM one, name no action.
+        // Referring the operator to "the action named in AWS's message" then points them at
+        // something that is not there, so the remedy has to ask for the action outright.
+        for (code, message) in [
+            (
+                "AccessDeniedException",
+                Some("You don't have access to the model with the specified model ID."),
+            ),
+            ("OptInRequired", None),
+            ("NotAuthorized", None),
+        ] {
+            for operation in EVERY_OPERATION {
+                let out = rendered(code, message, operation);
+                assert!(
+                    !out.contains("named in AWS's message"),
+                    "{code}/{operation:?} names no action, so must not point at one: {out}"
+                );
+                assert!(
+                    out.contains(&format!("Grant the identity `{}`", operation.iam_action())),
+                    "{code}/{operation:?} must ask for the action outright: {out}"
+                );
+                assert!(
+                    out.contains("`aws_region`"),
+                    "{code}/{operation:?} must still ask for the access check: {out}"
+                );
+            }
         }
     }
 
@@ -660,17 +719,26 @@ mod tests {
         // These messages are assembled from wrapped source, and `rustfmt` joins a continued
         // top-level `const` onto one line while keeping the indentation the continuation was
         // meant to swallow — which put runs of spaces inside the rendered text.
-        for code in every_code() {
-            for operation in EVERY_OPERATION {
-                let out = rendered(code, Some("an AWS message"), operation);
-                assert!(
-                    !out.contains("  "),
-                    "{code}/{operation:?} renders a run of spaces: {out}"
-                );
-                assert!(
-                    !out.contains('\n'),
-                    "{code}/{operation:?} must stay on one line: {out}"
-                );
+        // AWS's message is service text, and `trim` only reaches the ends: a message with an
+        // embedded newline or an internal run of spaces would pass straight through into the
+        // rendered line. Feed one that has both.
+        for message in [
+            "an AWS message",
+            "first line\nsecond line",
+            "  padded  and\t\ttabbed \r\n wrapped  ",
+        ] {
+            for code in every_code() {
+                for operation in EVERY_OPERATION {
+                    let out = rendered(code, Some(message), operation);
+                    assert!(
+                        !out.contains("  "),
+                        "{code}/{operation:?} renders a run of spaces: {out}"
+                    );
+                    assert!(
+                        !out.chars().any(|c| c == '\n' || c == '\r' || c == '\t'),
+                        "{code}/{operation:?} must stay on one line: {out}"
+                    );
+                }
             }
         }
     }

--- a/crates/llms/src/bedrock/auth_error.rs
+++ b/crates/llms/src/bedrock/auth_error.rs
@@ -83,18 +83,33 @@ impl Operation {
     }
 }
 
-/// Codes AWS returns when it will not accept the request's credentials at all — the key is
-/// unknown, the signature does not match it, or the session token has expired. Retrying cannot
-/// help; the credentials themselves have to change.
+/// Codes AWS returns when it does not accept the identity behind the request at all — the
+/// access key is unknown to AWS, no key reached it, or the session token has expired. Retrying
+/// cannot help; the credentials themselves have to change.
 const CREDENTIALS_REJECTED_CODES: &[&str] = &[
     "UnrecognizedClientException",
-    "InvalidSignatureException",
     "InvalidClientTokenId",
     "MissingAuthenticationToken",
-    "IncompleteSignature",
     "ExpiredToken",
     "ExpiredTokenException",
 ];
+
+/// Codes AWS returns when it could not verify the request's *signature*. This is deliberately
+/// not the credential class: a signature can fail to verify with a perfectly valid key pair —
+/// a host clock more than a few minutes out makes the signature expire, and a signature scoped
+/// to the wrong region is rejected as mismatched. Telling those operators to replace their keys
+/// is advice that cannot work, which is worse than saying nothing.
+const SIGNATURE_REJECTED_CODES: &[&str] = &["InvalidSignatureException", "IncompleteSignature"];
+
+/// AWS's own message distinguishes the causes behind these two codes ("Signature expired…" vs
+/// "…does not match the signature you provided"), and [`describe`] carries it through, so the
+/// remedy names every cause rather than guessing at one.
+const SIGNATURE_REMEDY: &str = concat!(
+    "AWS could not verify the request signature, which a valid key pair can still fail: ",
+    "check that the host clock is accurate (a signature expires minutes after it is made), ",
+    "that `aws_region` names the region serving this model, ",
+    "and that `aws_secret_access_key` belongs with `aws_access_key_id`."
+);
 
 /// Codes AWS returns when the credentials are valid but the identity may not make this call —
 /// a missing IAM action, or the identity not having access to this model in this region.
@@ -122,6 +137,8 @@ fn describe(
     let code = code?;
     let remedy = if CREDENTIALS_REJECTED_CODES.contains(&code) {
         operation.credentials_remedy().to_string()
+    } else if SIGNATURE_REJECTED_CODES.contains(&code) {
+        SIGNATURE_REMEDY.to_string()
     } else if ACCESS_DENIED_CODES.contains(&code) {
         // Not "request access in the console": Bedrock grants model access automatically for
         // most models now, and the ones that don't route through Marketplace or a provider
@@ -170,8 +187,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        ACCESS_DENIED_CODES, CREDENTIALS_REJECTED_CODES, Operation, UNKNOWN_MODEL, describe,
-        explain,
+        ACCESS_DENIED_CODES, CREDENTIALS_REJECTED_CODES, Operation, SIGNATURE_REJECTED_CODES,
+        UNKNOWN_MODEL, describe, explain,
     };
     use aws_smithy_types::error::metadata::{ErrorMetadata, ProvideErrorMetadata};
 
@@ -343,6 +360,7 @@ mod tests {
     fn every_listed_code_is_described_and_carries_a_remedy() {
         for code in CREDENTIALS_REJECTED_CODES
             .iter()
+            .chain(SIGNATURE_REJECTED_CODES.iter())
             .chain(ACCESS_DENIED_CODES.iter())
         {
             for operation in EVERY_OPERATION {
@@ -357,14 +375,56 @@ mod tests {
     }
 
     #[test]
-    fn the_two_code_lists_are_disjoint() {
-        // A code in both lists would take whichever remedy is tested first, so the operator
-        // could be told to rotate credentials AWS had already accepted.
-        for code in CREDENTIALS_REJECTED_CODES {
-            assert!(
-                !ACCESS_DENIED_CODES.contains(code),
-                "{code} is classified as both a credential rejection and an access denial"
-            );
+    fn the_code_lists_are_pairwise_disjoint() {
+        // A code in two lists takes whichever remedy is tested first, so the operator could be
+        // told to rotate credentials AWS had already accepted, or to fix a clock when the key
+        // is simply unknown.
+        let lists = [
+            ("credentials", CREDENTIALS_REJECTED_CODES),
+            ("signature", SIGNATURE_REJECTED_CODES),
+            ("access denied", ACCESS_DENIED_CODES),
+        ];
+        for (i, (name, codes)) in lists.iter().enumerate() {
+            for (other_name, other) in &lists[i + 1..] {
+                for code in *codes {
+                    assert!(
+                        !other.contains(code),
+                        "{code} is classified as both a {name} and an {other_name} rejection"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_signature_failure_is_not_reported_as_a_bad_key_pair() {
+        // A signature can fail to verify with a valid key pair — a skewed host clock expires
+        // it, and a signature scoped to the wrong region is rejected as mismatched. An operator
+        // told to replace their keys would rotate a working key pair and still be broken.
+        // Pin the membership, not just the wording: emptying the list would leave the loop
+        // below with nothing to iterate and the test would pass with the defect restored.
+        assert_eq!(
+            SIGNATURE_REJECTED_CODES,
+            ["InvalidSignatureException", "IncompleteSignature"],
+            "a signature code moved out of this class silently takes the credential remedy"
+        );
+
+        for code in SIGNATURE_REJECTED_CODES {
+            for operation in EVERY_OPERATION {
+                let out = rendered(code, None, operation);
+                assert!(
+                    out.contains("clock") && out.contains("`aws_region`"),
+                    "{code} must name the causes a key rotation cannot fix: {out}"
+                );
+                assert!(
+                    !out.contains("to an active key pair"),
+                    "{code} must not be reported as a credential replacement: {out}"
+                );
+                assert!(
+                    !out.contains("bedrock:InvokeModel"),
+                    "{code} is not an authorization failure: {out}"
+                );
+            }
         }
     }
 
@@ -459,6 +519,30 @@ mod tests {
             !out.contains("unhandled error"),
             "the SDK rendering must not survive: {out}"
         );
+    }
+
+    #[test]
+    fn no_message_renders_with_broken_spacing() {
+        // These messages are assembled from wrapped source, and `rustfmt` joins a continued
+        // top-level `const` onto one line while keeping the indentation the continuation was
+        // meant to swallow — which put runs of spaces inside the rendered text.
+        for code in CREDENTIALS_REJECTED_CODES
+            .iter()
+            .chain(SIGNATURE_REJECTED_CODES.iter())
+            .chain(ACCESS_DENIED_CODES.iter())
+        {
+            for operation in EVERY_OPERATION {
+                let out = rendered(code, Some("an AWS message"), operation);
+                assert!(
+                    !out.contains("  "),
+                    "{code}/{operation:?} renders a run of spaces: {out}"
+                );
+                assert!(
+                    !out.contains('\n'),
+                    "{code}/{operation:?} must stay on one line: {out}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/llms/src/bedrock/auth_error.rs
+++ b/crates/llms/src/bedrock/auth_error.rs
@@ -99,7 +99,11 @@ const CREDENTIALS_REJECTED_CODES: &[&str] = &[
 /// a host clock more than a few minutes out makes the signature expire, and a signature scoped
 /// to the wrong region is rejected as mismatched. Telling those operators to replace their keys
 /// is advice that cannot work, which is worse than saying nothing.
-const SIGNATURE_REJECTED_CODES: &[&str] = &["InvalidSignatureException", "IncompleteSignature"];
+const SIGNATURE_REJECTED_CODES: &[&str] = &[
+    "InvalidSignatureException",
+    "IncompleteSignature",
+    "RequestExpired",
+];
 
 /// AWS's own message distinguishes the causes behind these two codes ("Signature expired…" vs
 /// "…does not match the signature you provided"), and [`describe`] carries it through, so the
@@ -108,12 +112,16 @@ const SIGNATURE_REMEDY: &str = concat!(
     "AWS could not verify the request signature, which a valid key pair can still fail: ",
     "check that the host clock is accurate (a signature expires minutes after it is made), ",
     "that `aws_region` names the region serving this model, ",
-    "and that `aws_secret_access_key` belongs with `aws_access_key_id`."
+    "that `aws_secret_access_key` belongs with `aws_access_key_id`, ",
+    "and that nothing between this host and AWS is rewriting the request."
 );
 
-/// Codes AWS returns when the credentials are valid but the identity may not make this call —
-/// a missing IAM action, or the identity not having access to this model in this region.
-const ACCESS_DENIED_CODES: &[&str] = &["AccessDeniedException", "UnauthorizedException"];
+/// Codes AWS returns when it knows the identity but will not let this call through — a missing
+/// IAM action, or the account or identity not having access to this model in this region.
+///
+/// `NotAuthorized` and `OptInRequired` are from AWS's common-error set rather than Bedrock's own
+/// modelled errors, so they arrive unmodelled exactly as the credential codes do.
+const ACCESS_DENIED_CODES: &[&str] = &["AccessDeniedException", "NotAuthorized", "OptInRequired"];
 
 #[derive(Debug, Snafu)]
 #[snafu(display("Failed to call Bedrock model '{model_id}': {detail}. {remedy} See: {docs_url}"))]
@@ -122,29 +130,41 @@ pub struct BedrockAuthError {
     detail: String,
     remedy: String,
     docs_url: &'static str,
+    /// The SDK error this explains, kept as the source so nothing the replacement does not
+    /// render is lost with it: the operation error stays downcastable and its own source chain
+    /// stays walkable. Only [`Display`](std::fmt::Display) changes.
+    source: Box<dyn std::error::Error + Send + Sync>,
 }
 
-/// Build the operator-facing message for a rejection AWS has already labelled with `code`.
+/// Build the `(detail, remedy)` halves of the operator-facing message for a rejection AWS has
+/// already labelled with `code`.
 ///
 /// Returns `None` for any code that is not an authentication or authorization rejection, which
 /// leaves every other error rendering exactly as the SDK renders it.
 fn describe(
     code: Option<&str>,
     message: Option<&str>,
-    model_id: &str,
+    request_id: Option<&str>,
     operation: Operation,
-) -> Option<BedrockAuthError> {
+) -> Option<(String, String)> {
     let code = code?;
     let remedy = if CREDENTIALS_REJECTED_CODES.contains(&code) {
         operation.credentials_remedy().to_string()
     } else if SIGNATURE_REJECTED_CODES.contains(&code) {
         SIGNATURE_REMEDY.to_string()
     } else if ACCESS_DENIED_CODES.contains(&code) {
-        // Not "request access in the console": Bedrock grants model access automatically for
-        // most models now, and the ones that don't route through Marketplace or a provider
-        // use-case form. Point at the state to confirm, not at one console flow.
+        // Naming one action is not enough on its own: a request carrying a guardrail also needs
+        // `bedrock:ApplyGuardrail`, and an inference profile needs its own actions, so an
+        // identity that already holds the invoke action can still be denied. AWS's message
+        // names the action it actually refused, and `detail` carries it, so lead with that and
+        // give the invoke action as the floor rather than as the whole answer.
+        // Not "request access in the console" either: Bedrock grants model access automatically
+        // for most models now, and the rest route through Marketplace or a provider use-case
+        // form. Point at the state to confirm, not at one console flow.
         format!(
-            "Grant the identity the `{}` action on this model, and confirm the identity has \
+            "Grant the identity the action named in AWS's message — this call needs at \
+             least `{}`, and a request using a guardrail or an inference profile needs the \
+             further actions those require. Then confirm the account and the identity have \
              access to this model in the region set by `aws_region`.",
             operation.iam_action()
         )
@@ -153,18 +173,20 @@ fn describe(
     };
 
     // Keep whatever AWS said alongside its code: the code is what the remedy is chosen from, and
-    // the message is often the only thing distinguishing two causes behind one code.
-    let detail = match message.map(str::trim).filter(|m| !m.is_empty()) {
-        Some(message) => format!("AWS rejected the request ({code}: {message})"),
-        None => format!("AWS rejected the request ({code})"),
+    // the message is often the only thing distinguishing two causes behind one code. The request
+    // ID goes in too — it is what AWS support and the service logs are searched by, and this
+    // rendering is all an operator sees.
+    let mut detail = match message.map(str::trim).filter(|m| !m.is_empty()) {
+        Some(message) => format!("AWS rejected the request ({code}: {message}"),
+        None => format!("AWS rejected the request ({code}"),
     };
+    if let Some(request_id) = request_id.map(str::trim).filter(|id| !id.is_empty()) {
+        detail.push_str("; AWS request ID ");
+        detail.push_str(request_id);
+    }
+    detail.push(')');
 
-    Some(BedrockAuthError {
-        model_id: model_id.to_string(),
-        detail,
-        remedy,
-        docs_url: operation.docs_url(),
-    })
+    Some((detail, remedy))
 }
 
 /// Box a Bedrock service error for the caller, substituting the operator-facing explanation
@@ -178,8 +200,17 @@ pub(crate) fn explain<E>(
 where
     E: ProvideErrorMetadata + std::error::Error + Send + Sync + 'static,
 {
-    match describe(err.code(), err.message(), model_id, operation) {
-        Some(explained) => Box::new(explained),
+    // The key AWS's own SDK files the request ID under (`aws_types::request_id`); read from the
+    // metadata directly rather than taking a dependency on that crate for one accessor.
+    let request_id = err.meta().extra("aws_request_id").map(ToOwned::to_owned);
+    match describe(err.code(), err.message(), request_id.as_deref(), operation) {
+        Some((detail, remedy)) => Box::new(BedrockAuthError {
+            model_id: model_id.to_string(),
+            detail,
+            remedy,
+            docs_url: operation.docs_url(),
+            source: Box::new(err),
+        }),
         None => Box::new(err),
     }
 }
@@ -188,9 +219,13 @@ where
 mod tests {
     use super::{
         ACCESS_DENIED_CODES, CREDENTIALS_REJECTED_CODES, Operation, SIGNATURE_REJECTED_CODES,
-        UNKNOWN_MODEL, describe, explain,
+        UNKNOWN_MODEL, explain,
     };
-    use aws_smithy_types::error::metadata::{ErrorMetadata, ProvideErrorMetadata};
+    use aws_sdk_bedrockruntime::error::ErrorMetadata;
+    use aws_sdk_bedrockruntime::operation::{
+        converse::ConverseError, converse_stream::ConverseStreamError,
+        invoke_model::InvokeModelError,
+    };
 
     const MODEL: &str = "amazon.titan-embed-text-v2:0";
     const EVERY_OPERATION: [Operation; 3] = [
@@ -199,37 +234,33 @@ mod tests {
         Operation::Embeddings,
     ];
 
-    /// Stands in for a Bedrock operation error: the SDK's own types carry both of these
-    /// impls, and `explain` needs both to box the error it was handed.
-    #[derive(Debug)]
-    struct FakeServiceError(ErrorMetadata);
-
-    impl std::fmt::Display for FakeServiceError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            // How the SDK renders a code it does not model.
-            match ProvideErrorMetadata::code(self) {
-                Some(code) => write!(f, "unhandled error ({code})"),
-                None => f.write_str("unhandled error"),
-            }
+    fn metadata(code: &str, message: Option<&str>, request_id: Option<&str>) -> ErrorMetadata {
+        let mut builder = ErrorMetadata::builder().code(code);
+        if let Some(message) = message {
+            builder = builder.message(message);
         }
-    }
-
-    impl std::error::Error for FakeServiceError {}
-
-    impl ProvideErrorMetadata for FakeServiceError {
-        fn meta(&self) -> &ErrorMetadata {
-            &self.0
+        if let Some(request_id) = request_id {
+            builder = builder.custom("aws_request_id", request_id);
         }
+        builder.build()
     }
 
-    fn service_error(code: &str, message: &str) -> FakeServiceError {
-        FakeServiceError(ErrorMetadata::builder().code(code).message(message).build())
-    }
-
+    /// Render through the real SDK error type an unmodelled code actually arrives as, so these
+    /// assertions exercise the same `ProvideErrorMetadata` path the call sites do.
     fn rendered(code: &str, message: Option<&str>, operation: Operation) -> String {
-        describe(Some(code), message, MODEL, operation)
-            .unwrap_or_else(|| panic!("{code} must be classified"))
-            .to_string()
+        let err = InvokeModelError::generic(metadata(code, message, None));
+        let out = explain(err, MODEL, operation).to_string();
+        assert!(
+            !out.contains("unhandled error"),
+            "{code} must be classified, not left to the SDK: {out}"
+        );
+        out
+    }
+
+    /// What the SDK renders for a code it does not model — the string this whole module exists
+    /// to replace, and the one every unclassified error must still get.
+    fn sdk_rendering(code: &str) -> String {
+        format!("unhandled error ({code})")
     }
 
     #[test]
@@ -257,11 +288,6 @@ mod tests {
             out.contains(Operation::Embeddings.docs_url()),
             "must link the docs: {out}"
         );
-        // The whole point of the rewrite: the SDK's own rendering said only this.
-        assert!(
-            !out.contains("unhandled error"),
-            "must not read as an unhandled error: {out}"
-        );
     }
 
     #[test]
@@ -280,6 +306,29 @@ mod tests {
             !out.contains("`aws_access_key_id`"),
             "credentials that AWS accepted must not be blamed: {out}"
         );
+    }
+
+    #[test]
+    fn access_denial_defers_to_the_action_aws_named() {
+        // Naming one action would be wrong whenever the request needs more than the invoke
+        // action — a guardrail also needs `bedrock:ApplyGuardrail`, and this chat client
+        // supports guardrails — so an identity holding only the invoke action is still denied.
+        // AWS names the action it refused; the message has to point there, not assert one.
+        for operation in EVERY_OPERATION {
+            let out = rendered("AccessDeniedException", Some("not authorized"), operation);
+            assert!(
+                out.contains("the action named in AWS's message"),
+                "{operation:?} must defer to AWS's own named action: {out}"
+            );
+            assert!(
+                out.contains("guardrail"),
+                "{operation:?} must say further actions can be required: {out}"
+            );
+            assert!(
+                out.contains("at least"),
+                "{operation:?} must give the invoke action as a floor, not the whole answer: {out}"
+            );
+        }
     }
 
     #[test]
@@ -344,6 +393,44 @@ mod tests {
     }
 
     #[test]
+    fn a_signature_failure_is_not_reported_as_a_bad_key_pair() {
+        // A signature can fail to verify with a valid key pair — a skewed host clock expires
+        // it, a signature scoped to the wrong region is rejected as mismatched, and something
+        // rewriting the request in flight breaks it. An operator told to replace their keys
+        // would rotate a working key pair and still be broken.
+        //
+        // Pin the membership, not just the wording: emptying the list would leave the loop
+        // below with nothing to iterate and this test would pass with the defect restored.
+        assert_eq!(
+            SIGNATURE_REJECTED_CODES,
+            [
+                "InvalidSignatureException",
+                "IncompleteSignature",
+                "RequestExpired"
+            ],
+            "a signature code moved out of this class silently takes the credential remedy"
+        );
+
+        for code in SIGNATURE_REJECTED_CODES {
+            for operation in EVERY_OPERATION {
+                let out = rendered(code, None, operation);
+                assert!(
+                    out.contains("clock") && out.contains("`aws_region`"),
+                    "{code} must name the causes a key rotation cannot fix: {out}"
+                );
+                assert!(
+                    !out.contains("to an active key pair"),
+                    "{code} must not be reported as a credential replacement: {out}"
+                );
+                assert!(
+                    !out.contains("bedrock:InvokeModel"),
+                    "{code} is not an authorization failure: {out}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn chat_and_embeddings_are_sent_to_their_own_docs_page() {
         assert_ne!(Operation::Chat.docs_url(), Operation::Embeddings.docs_url());
         assert_eq!(Operation::Chat.docs_url(), Operation::ChatStream.docs_url());
@@ -358,11 +445,7 @@ mod tests {
 
     #[test]
     fn every_listed_code_is_described_and_carries_a_remedy() {
-        for code in CREDENTIALS_REJECTED_CODES
-            .iter()
-            .chain(SIGNATURE_REJECTED_CODES.iter())
-            .chain(ACCESS_DENIED_CODES.iter())
-        {
+        for code in every_code() {
             for operation in EVERY_OPERATION {
                 let out = rendered(code, None, operation);
                 assert!(out.contains(code), "{code} must appear in {out}");
@@ -372,6 +455,14 @@ mod tests {
                 );
             }
         }
+    }
+
+    fn every_code() -> impl Iterator<Item = &'static str> {
+        CREDENTIALS_REJECTED_CODES
+            .iter()
+            .chain(SIGNATURE_REJECTED_CODES.iter())
+            .chain(ACCESS_DENIED_CODES.iter())
+            .copied()
     }
 
     #[test]
@@ -397,35 +488,46 @@ mod tests {
     }
 
     #[test]
-    fn a_signature_failure_is_not_reported_as_a_bad_key_pair() {
-        // A signature can fail to verify with a valid key pair — a skewed host clock expires
-        // it, and a signature scoped to the wrong region is rejected as mismatched. An operator
-        // told to replace their keys would rotate a working key pair and still be broken.
-        // Pin the membership, not just the wording: emptying the list would leave the loop
-        // below with nothing to iterate and the test would pass with the defect restored.
-        assert_eq!(
-            SIGNATURE_REJECTED_CODES,
-            ["InvalidSignatureException", "IncompleteSignature"],
-            "a signature code moved out of this class silently takes the credential remedy"
+    fn the_aws_request_id_survives_into_the_message() {
+        // It is what AWS support and the service logs are searched by, and the rendered message
+        // is all an operator sees, so losing it here loses it entirely.
+        let err = InvokeModelError::generic(metadata(
+            "UnrecognizedClientException",
+            Some("The security token included in the request is invalid."),
+            Some("11111111-2222-3333-4444-555555555555"),
+        ));
+        let out = explain(err, MODEL, Operation::Embeddings).to_string();
+        assert!(
+            out.contains("AWS request ID 11111111-2222-3333-4444-555555555555"),
+            "must carry the request ID: {out}"
         );
 
-        for code in SIGNATURE_REJECTED_CODES {
-            for operation in EVERY_OPERATION {
-                let out = rendered(code, None, operation);
-                assert!(
-                    out.contains("clock") && out.contains("`aws_region`"),
-                    "{code} must name the causes a key rotation cannot fix: {out}"
-                );
-                assert!(
-                    !out.contains("to an active key pair"),
-                    "{code} must not be reported as a credential replacement: {out}"
-                );
-                assert!(
-                    !out.contains("bedrock:InvokeModel"),
-                    "{code} is not an authorization failure: {out}"
-                );
-            }
-        }
+        // And its absence must not leave a dangling separator.
+        let without = rendered("UnrecognizedClientException", Some("nope"), Operation::Chat);
+        assert!(
+            !without.contains("request ID"),
+            "no request ID means no mention of one: {without}"
+        );
+        assert!(
+            without.contains("(UnrecognizedClientException: nope)"),
+            "the detail must still close cleanly: {without}"
+        );
+    }
+
+    #[test]
+    fn the_sdk_error_is_kept_as_the_source() {
+        // The replacement changes how the failure reads, not what is reachable behind it: the
+        // operation error must stay downcastable and its own chain walkable.
+        let err = InvokeModelError::generic(metadata("AccessDeniedException", Some("no"), None));
+        let boxed = explain(err, MODEL, Operation::Chat);
+
+        let source =
+            std::error::Error::source(boxed.as_ref()).expect("the SDK error is the source");
+        assert!(
+            source.downcast_ref::<InvokeModelError>().is_some(),
+            "the original operation error must stay downcastable: {source}"
+        );
+        assert_eq!(source.to_string(), sdk_rendering("AccessDeniedException"));
     }
 
     #[test]
@@ -437,23 +539,23 @@ mod tests {
             "ServiceUnavailableException",
             "InternalServerException",
         ] {
-            assert!(
-                describe(Some(code), Some("some detail"), MODEL, Operation::Chat).is_none(),
-                "{code} is not an auth failure and must render as the SDK renders it"
-            );
+            for operation in EVERY_OPERATION {
+                let err = InvokeModelError::generic(metadata(code, Some("some detail"), None));
+                assert_eq!(
+                    explain(err, MODEL, operation).to_string(),
+                    sdk_rendering(code),
+                    "{code} is not an auth failure and must render as the SDK renders it"
+                );
+            }
         }
     }
 
     #[test]
     fn an_error_with_no_code_is_left_to_the_sdk() {
-        assert!(
-            describe(
-                None,
-                Some("a message but no code"),
-                MODEL,
-                Operation::Embeddings
-            )
-            .is_none(),
+        let err = InvokeModelError::generic(ErrorMetadata::builder().message("no code").build());
+        assert_eq!(
+            explain(err, MODEL, Operation::Embeddings).to_string(),
+            "unhandled error",
             "a rejection AWS did not label cannot be classified"
         );
     }
@@ -461,11 +563,9 @@ mod tests {
     #[test]
     fn an_empty_aws_message_does_not_leave_a_dangling_separator() {
         for message in [Some(""), Some("   "), None] {
-            let out = rendered(
-                "UnrecognizedClientException",
-                message,
-                Operation::Embeddings,
-            );
+            let err =
+                InvokeModelError::generic(metadata("UnrecognizedClientException", message, None));
+            let out = explain(err, MODEL, Operation::Embeddings).to_string();
             assert!(
                 out.contains("(UnrecognizedClientException)"),
                 "an absent AWS message must leave the code alone: {out}"
@@ -479,14 +579,8 @@ mod tests {
 
     #[test]
     fn a_request_with_no_model_id_still_renders() {
-        let out = describe(
-            Some("ExpiredTokenException"),
-            None,
-            UNKNOWN_MODEL,
-            Operation::Chat,
-        )
-        .expect("still a credential rejection")
-        .to_string();
+        let err = InvokeModelError::generic(metadata("ExpiredTokenException", None, None));
+        let out = explain(err, UNKNOWN_MODEL, Operation::Chat).to_string();
         assert!(
             out.contains(UNKNOWN_MODEL),
             "must be explicit that the model is unknown: {out}"
@@ -494,14 +588,54 @@ mod tests {
     }
 
     #[test]
+    fn each_operations_own_sdk_error_type_is_classified() {
+        // The three call sites hand `explain` three different SDK error enums. They share a
+        // `ProvideErrorMetadata` impl, but nothing in the type system says so — assert each
+        // one, through the type that call site actually produces.
+        let code = "UnrecognizedClientException";
+        let converse = explain(
+            ConverseError::generic(metadata(code, None, None)),
+            MODEL,
+            Operation::Chat,
+        )
+        .to_string();
+        let stream = explain(
+            ConverseStreamError::generic(metadata(code, None, None)),
+            MODEL,
+            Operation::ChatStream,
+        )
+        .to_string();
+        let invoke = explain(
+            InvokeModelError::generic(metadata(code, None, None)),
+            MODEL,
+            Operation::Embeddings,
+        )
+        .to_string();
+
+        for (name, out) in [
+            ("Converse", &converse),
+            ("ConverseStream", &stream),
+            ("InvokeModel", &invoke),
+        ] {
+            assert!(
+                out.contains(code) && !out.contains("unhandled error"),
+                "{name} must be classified: {out}"
+            );
+        }
+        assert_eq!(converse, stream, "both chat calls share the chat remedy");
+        assert_ne!(converse, invoke, "embeddings has its own remedy and page");
+    }
+
+    #[test]
     fn explain_replaces_an_auth_rejection_with_the_actionable_message() {
-        let err = service_error(
+        let err = InvokeModelError::generic(metadata(
             "UnrecognizedClientException",
-            "The security token included in the request is invalid.",
-        );
+            Some("The security token included in the request is invalid."),
+            None,
+        ));
         assert_eq!(
             err.to_string(),
-            "unhandled error (UnrecognizedClientException)",
+            sdk_rendering("UnrecognizedClientException"),
             "the SDK rendering this replaces"
         );
 
@@ -526,11 +660,7 @@ mod tests {
         // These messages are assembled from wrapped source, and `rustfmt` joins a continued
         // top-level `const` onto one line while keeping the indentation the continuation was
         // meant to swallow — which put runs of spaces inside the rendered text.
-        for code in CREDENTIALS_REJECTED_CODES
-            .iter()
-            .chain(SIGNATURE_REJECTED_CODES.iter())
-            .chain(ACCESS_DENIED_CODES.iter())
-        {
+        for code in every_code() {
             for operation in EVERY_OPERATION {
                 let out = rendered(code, Some("an AWS message"), operation);
                 assert!(
@@ -542,16 +672,6 @@ mod tests {
                     "{code}/{operation:?} must stay on one line: {out}"
                 );
             }
-        }
-    }
-
-    #[test]
-    fn explain_passes_a_non_auth_error_through_unchanged() {
-        // Every other Bedrock failure must keep rendering exactly as the SDK renders it.
-        for operation in EVERY_OPERATION {
-            let err = service_error("ValidationException", "input too long");
-            let sdk_rendering = err.to_string();
-            assert_eq!(explain(err, MODEL, operation).to_string(), sdk_rendering);
         }
     }
 }

--- a/crates/llms/src/bedrock/mod.rs
+++ b/crates/llms/src/bedrock/mod.rs
@@ -15,9 +15,12 @@ limitations under the License.
 */
 #![allow(clippy::missing_errors_doc)]
 
+mod auth_error;
 pub mod chat;
 pub mod embed;
 mod list_models;
+
+pub use auth_error::BedrockAuthError;
 
 pub use list_models::BedrockModelLister;
 
@@ -78,8 +81,13 @@ impl BedrockClient {
         &self,
         converse_build: ConverseStreamFluentBuilder,
     ) -> Result<ConverseStreamOutput, Box<dyn std::error::Error + Send + Sync>> {
+        let model_id = converse_build
+            .get_model_id()
+            .clone()
+            .unwrap_or_else(|| auth_error::UNKNOWN_MODEL.to_string());
         self.rate_limit_request_with_retry(move |_client| {
             let value = converse_build.clone();
+            let model_id = model_id.clone();
             async move {
                 match value.send().await {
                     Ok(response) => Ok(response),
@@ -92,9 +100,11 @@ impl BedrockClient {
                                 Box::new(throttle_e) as Box<dyn std::error::Error + Send + Sync>
                             ))
                         }
-                        e => Err(RetryError::permanent(
-                            Box::new(e) as Box<dyn std::error::Error + Send + Sync>
-                        )),
+                        e => Err(RetryError::permanent(auth_error::explain(
+                            e,
+                            &model_id,
+                            auth_error::CHAT_DOCS_URL,
+                        ))),
                     },
                     Err(e) => Err(RetryError::permanent(
                         Box::new(e) as Box<dyn std::error::Error + Send + Sync>
@@ -110,8 +120,13 @@ impl BedrockClient {
         &self,
         converse_build: ConverseFluentBuilder,
     ) -> Result<ConverseOutput, Box<dyn std::error::Error + Send + Sync>> {
+        let model_id = converse_build
+            .get_model_id()
+            .clone()
+            .unwrap_or_else(|| auth_error::UNKNOWN_MODEL.to_string());
         self.rate_limit_request_with_retry(move |_client| {
             let value = converse_build.clone();
+            let model_id = model_id.clone();
             async move {
                 match value.send().await {
                     Ok(response) => Ok(response),
@@ -124,9 +139,11 @@ impl BedrockClient {
                                 Box::new(throttle_e) as Box<dyn std::error::Error + Send + Sync>
                             ))
                         }
-                        e => Err(RetryError::permanent(
-                            Box::new(e) as Box<dyn std::error::Error + Send + Sync>
-                        )),
+                        e => Err(RetryError::permanent(auth_error::explain(
+                            e,
+                            &model_id,
+                            auth_error::CHAT_DOCS_URL,
+                        ))),
                     },
                     Err(e) => Err(RetryError::permanent(
                         Box::new(e) as Box<dyn std::error::Error + Send + Sync>
@@ -151,7 +168,7 @@ impl BedrockClient {
             async move {
             match client
                 .invoke_model()
-                .model_id(m)
+                .model_id(m.clone())
                 .body(Blob::new(b))
                 .content_type("application/json")
                 .send()
@@ -167,9 +184,11 @@ impl BedrockClient {
                             Box::new(throttle_e) as Box<dyn std::error::Error + Send + Sync>
                         ))
                     }
-                    e => Err(RetryError::permanent(
-                        Box::new(e) as Box<dyn std::error::Error + Send + Sync>
-                    )),
+                    e => Err(RetryError::permanent(auth_error::explain(
+                        e,
+                        &m,
+                        auth_error::EMBEDDINGS_DOCS_URL,
+                    ))),
                 },
                 Err(e) => Err(RetryError::permanent(
                     Box::new(e) as Box<dyn std::error::Error + Send + Sync>

--- a/crates/llms/src/bedrock/mod.rs
+++ b/crates/llms/src/bedrock/mod.rs
@@ -103,7 +103,7 @@ impl BedrockClient {
                         e => Err(RetryError::permanent(auth_error::explain(
                             e,
                             &model_id,
-                            auth_error::CHAT_DOCS_URL,
+                            auth_error::Operation::ChatStream,
                         ))),
                     },
                     Err(e) => Err(RetryError::permanent(
@@ -142,7 +142,7 @@ impl BedrockClient {
                         e => Err(RetryError::permanent(auth_error::explain(
                             e,
                             &model_id,
-                            auth_error::CHAT_DOCS_URL,
+                            auth_error::Operation::Chat,
                         ))),
                     },
                     Err(e) => Err(RetryError::permanent(
@@ -187,7 +187,7 @@ impl BedrockClient {
                     e => Err(RetryError::permanent(auth_error::explain(
                         e,
                         &m,
-                        auth_error::EMBEDDINGS_DOCS_URL,
+                        auth_error::Operation::Embeddings,
                     ))),
                 },
                 Err(e) => Err(RetryError::permanent(


### PR DESCRIPTION
## Summary

`integration tests (models)` has been red on every scheduled trunk run for weeks, and the `Test Bedrock Models` job fails the same way each time: four embedding tests each burn 121s and then panic on the readiness wait. [#12396](https://github.com/spiceai/spiceai/issues/12396) proposed adding a `HAS_*_SECRET` guard to that job, on the theory that the AWS credentials were absent — every sibling job in the workflow gates on one, and `test-bedrock` does not.

Re-reading today's run ([33030011779](https://github.com/spiceai/spiceai/actions/runs/33030011779)) shows the premise does not hold. The job log carries `AWS_BEDROCK_KEY: ***` and `AWS_BEDROCK_SECRET: ***`, so both secrets are present and non-empty; a `HAS_*_SECRET` guard would not skip. What the runtime actually reports is:

```
embedding:cohere-english: Error(Some("Failed to initialize embedding model: Embedding health
check failed. Failed to create embedding: unhandled error (UnrecognizedClientException).
Verify the embedding configuration."))
```

`UnrecognizedClientException` is what AWS returns for an access key it does not recognise. The credentials are present and rejected — an ops rotation, not a workflow-config change. That part of #12396 stays open and is noted on the issue.

What *is* a defect in this repository is the message. AWS does not model its credential-rejection codes on the Bedrock operation error enums, so the SDK renders the rejection as `unhandled error (UnrecognizedClientException)` — a string that names neither the model that failed nor anything the operator can change, and which carries no docs link. The modelled `AccessDeniedException` reads better but still names no model and no Spice parameter. That string is the entire explanation an operator with a bad AWS key gets, from the embedding health check and from chat alike, and it is what made this CI failure read as "the runtime never becomes ready" for weeks.

## Changes

- New `crates/llms/src/bedrock/auth_error.rs`. It classifies a Bedrock rejection by the code AWS labelled it with — following the SDK's own guidance for unmodelled codes — into four classes, because they have genuinely different remedies and being confidently wrong about which is worse than the SDK's silence:
  - **credentials rejected** (`UnrecognizedClientException`, `InvalidClientTokenId`, `MissingAuthenticationToken`, `ExpiredToken`, `ExpiredTokenException`) — AWS does not know this identity → name `aws_access_key_id` / `aws_secret_access_key` / `aws_session_token`, or `aws_iam_role_source` / `aws_profile`;
  - **signature not verified** (`InvalidSignatureException`, `IncompleteSignature`, `RequestExpired`) — which a *valid* key pair can still hit → name the host clock, `aws_region`, the key-pair pairing, and anything rewriting the request in flight. AWS's own message distinguishes them ("Signature expired…" vs "…does not match the signature you provided"), and it is carried through;
  - **account not subscribed** (`OptInRequired`) — the *account* does not have Bedrock enabled, not the identity missing a permission → ask for account enablement and model access in the region, and say outright that no IAM grant resolves it. Routing this through the access-denial remedy would ask an operator to broaden IAM access while leaving Bedrock exactly as unavailable;
  - **access denied** (`AccessDeniedException`, `NotAuthorized`) — the identity is known but this call is refused → when AWS's message names the action it refused, point **there** and give the operation's invoke action as a floor rather than the whole answer; when it names none (`OptInRequired`, or a model-access rather than IAM denial), ask for the invoke action outright instead of referring the operator to something absent. Either way, confirm account and identity access in the region, and do *not* blame credentials AWS just accepted.
- The credential remedy says the rejected keys must be **removed** before a role source or profile takes effect, and says why. `aws_sdk_credential_bridge::initiate_config_with_credentials` installs a static credentials provider whenever both key parameters are set and never consults `aws_iam_role_source`, and a later `profile_name` does not displace it — so "set a role source instead" on its own is advice that changes nothing: the operator keeps sending the very keys AWS rejected.
- AWS's message is service text this code does not control, so every whitespace run in it — newlines included, which `trim` does not reach — is collapsed before interpolation, keeping the error on one line as the repository requires.
- The error **keeps the SDK error as its source**, so the operation error stays downcastable and its chain walkable; only `Display` changes. The **AWS request ID** is lifted into the rendered text, because that rendering is all an operator sees and the request ID is what AWS support and the service logs are searched by.
- The message names the model, keeps AWS's own code and message, states the remedy, and links the docs page **of the component that made the call**.
- Wired into all three Bedrock operations, not just the one the CI failure came through: `do_converse`, `do_converse_stream` (chat) and `do_invoke` (embeddings). All three had the identical `e => RetryError::permanent(Box::new(e))` arm.
- The remedy is derived from the **operation**, not from one shared string, because three things a remedy has to get right do not vary together:
  - the **docs page** follows the component (chat vs embeddings);
  - the **credential parameters** follow the component too, but not identically — `aws_profile` is embeddings-only, since `BedrockModelParams` neither accepts nor forwards it, so naming it in a chat remedy would send an operator to a setting the chat path ignores;
  - the **IAM action** follows the *call*: AWS authorizes `ConverseStream` with `bedrock:InvokeModelWithResponseStream`, so an identity granted only `bedrock:InvokeModel` still has streaming chat denied.
- The access-denial remedy does not prescribe the Bedrock console's "request access" flow: Bedrock now grants model access automatically for most models, and the rest route through Marketplace or a provider use-case form. It asks for the state to confirm instead of one console action.
- Retry classification is unchanged — these were permanent before and stay permanent. Every non-auth Bedrock failure keeps rendering exactly as the SDK renders it.

Before:

```
Failed to create embedding: unhandled error (UnrecognizedClientException)
```

After:

```
Failed to call Bedrock model 'amazon.titan-embed-text-v2:0': AWS rejected the request
(UnrecognizedClientException: The security token included in the request is invalid.). Set
`aws_access_key_id` and `aws_secret_access_key` to an active key pair (and `aws_session_token`
if the credentials are temporary), or set `aws_iam_role_source` or `aws_profile` to resolve
them instead. See: https://spiceai.org/docs/components/embeddings/bedrock
```

## Test plan

21 unit tests in `crates/llms/src/bedrock/auth_error.rs`:

- **Regression test** — `explain_replaces_an_auth_rejection_with_the_actionable_message` first asserts the SDK's own rendering is exactly `unhandled error (UnrecognizedClientException)`, then asserts the rewrite replaces it and that the SDK string does not survive. It pins the old behaviour and the new one in the same test.
- Each remedy is bound to its own half: the credential test asserts the parameter names appear, the access-denial test asserts `bedrock:InvokeModel` appears **and** that credentials AWS accepted are not blamed.
- Every listed code is covered, and the two code lists are asserted disjoint — a code in both would take whichever remedy is tested first.
- Non-auth codes and an unlabelled error are asserted to pass through unchanged, so the rewrite cannot swallow an unrelated Bedrock failure.
- Edge cases: empty/whitespace/absent AWS message (no dangling separator), and a request carrying no model id.
- `chat_and_embeddings_are_sent_to_their_own_docs_page` asserts the two pages differ, that streaming and non-streaming chat share one, and that each operation renders its own.
- `a_streaming_chat_denial_asks_for_the_streaming_iam_action` and `a_chat_credential_remedy_names_only_parameters_chat_accepts` pin the two asymmetries above, each from both sides — streaming asks for the streaming action *and* the other two do not; chat omits `aws_profile` *and* embeddings names it.
- The chat and embeddings credential remedies differ only in `aws_profile`, so a final loop asserts every operation still names the parameters they share — otherwise an edit to one arm could silently drop them from the other.
- `a_signature_failure_is_not_reported_as_a_bad_key_pair` pins the signature class: the clock and `aws_region` appear, the credential-replacement wording does not, and no IAM action is suggested. It asserts the *list membership* before looping, because the first version was vacuous — emptying the list restored the defect and the empty loop still passed.
- `no_message_renders_with_broken_spacing` asserts no message renders a run of spaces or a newline, for every code × operation. This caught a real defect while writing the signature remedy: `rustfmt` joins a continued top-level `const` onto one line while keeping the indentation the `\` was meant to swallow, so the message shipped with space runs inside it. `concat!` is stable under that.
- The disjointness check covers all three lists pairwise — a code in two takes whichever remedy is tested first.
- `access_denial_defers_to_the_action_aws_named` asserts the remedy points at AWS's own named action and gives the invoke action only as a floor. This is what makes a guardrail denial actionable: an identity holding `bedrock:InvokeModel` but not `bedrock:ApplyGuardrail` is denied, and a remedy asserting the invoke action could not restore service.
- `the_aws_request_id_survives_into_the_message` and `the_sdk_error_is_kept_as_the_source` pin the two things the replacement could silently lose — the latter downcasts through `Error::source()` back to `InvokeModelError`.
- `each_operations_own_sdk_error_type_is_classified` drives all three call-site error enums (`ConverseError`, `ConverseStreamError`, `InvokeModelError`). They share a `ProvideErrorMetadata` impl but nothing in the type system says so.
- `access_denial_asks_outright_when_aws_named_no_action` covers the three denials that name no action, asserting the message does not refer the operator to one.
- The spacing guard feeds three messages per code per operation, including one with an embedded newline and one with tabs, a CR and internal runs.
- `an_unsubscribed_account_is_not_reported_as_a_missing_iam_grant` and `the_credential_fallback_says_the_rejected_keys_must_be_removed` pin the last two, the latter with the provider-precedence reasoning recorded at the assertion.

Every test drives `explain` through the **real SDK error type** an unmodelled code arrives as (`InvokeModelError::generic(ErrorMetadata)`), not a stand-in, so they exercise the same metadata path the call sites do — and each "left to the SDK" case asserts equality with the exact SDK rendering rather than merely that classification declined.

Every claim was neuter-verified rather than assumed — thirteen neuters, each restoring one specific defect, each killing exactly the test that owns it and nothing else: classifier returns `None` (6 tests); the two remedies swapped (2); the streaming IAM action collapsed back to the shared one; `aws_profile` put back into the chat remedy; the signature codes folded back into the credential class; a space run reintroduced into a remedy; the SDK error dropped instead of kept as the source; the request ID not read off the metadata; the access-denial remedy asserting one action again; the newline normalization reverted to `trim`; the action deferral made unconditional again; `OptInRequired` folded back into the access-denied class; and the removal requirement dropped from the credential fallback.

One of those neuters caught a **vacuous test**: the first version of the signature guard looped over `SIGNATURE_REJECTED_CODES`, so emptying the list restored the defect *and the empty loop still passed*. It now pins the list membership before looping.

Full gate: `make signoff` (= `make lint-rust` + `make build-cli nextest`).

## Review gate

Run on each successive diff — five rounds in all — because each round's findings changed the code the next round had to see. The receipt binds to the HEAD being shipped.

- Adversarial review: `codex`, run twice, `exit=0`, verdict **needs-attention** both times — **five findings, all five valid and all five fixed**:
  - round one: the SDK error (and with it the AWS request ID and the ability to downcast) being dropped; the access-denial remedy asserting one IAM action where guardrails and inference profiles need more; the code lists diverging from AWS's documented common errors. Its further suggestion — driving the tests through the real SDK error types rather than a stand-in — was taken too.
  - round two, on the result: `OptInRequired` misdiagnosed as a missing IAM grant when it is account enablement; and the role/profile fallback being unreachable while the rejected keys remain set. The second was verified in `aws-sdk-credential-bridge` before acting, not taken on the reviewer's word.

  (Two earlier attempts, on the two earlier diffs, receipted `engine=none exit=1` — "Your workspace is out of credits", with `grok` not installed. The engine had credits from the third attempt on.)
- `/security-review`: ran on each diff; no findings at or above the reporting bar. The change adds no input parsing, no filesystem or network path, and no auth logic; the only new data reaching a message is AWS's own error code and message, and the message names credential *parameters*, never their values. The IAM action interpolated into the access-denial remedy is a compile-time constant.
- `/simplify`: ran on each. First pass folded a one-line `classify` adapter into `explain` (two layers instead of three), moved `UNKNOWN_MODEL` in with the other constants, and dropped two tests whose coverage the `explain` tests already carried — after adding the one assertion they made that `explain`'s did not. Second pass found the duplicated prose shared by the two credential remedies and pinned it with an assertion rather than splitting the sentence to dedupe it. Light checks re-run green after each.

**Copilot review**: seven comments across three rounds, all seven valid and all seven fixed rather than deferred — the streaming IAM action, the chat/`aws_profile` mismatch, the stale console instruction, signature failures reported as bad credentials, an embedded newline in AWS's message escaping the one-line rule, the action deferral assuming AWS always names an action, and a stale doc comment. Each was verified against the tree or against AWS's own semantics before acting (`BedrockModelParams` in `crates/runtime/src/model/params/bedrock.rs` has no `aws_profile` field and its `runtime_params()` does not forward one), and each now has a test that fails if the defect is reintroduced.

Two are worth calling out. The signature one was the most consequential: the others misdirected an operator, that one would have had them rotate a working key pair and still be broken. And the conditional-action one was a **regression this PR introduced** while fixing the adversarial review's second finding — an over-correction from "assert one action" into "assume AWS always names one".

Refs #12396