### PR TITLE
test(forks): guard the Spice patches carried on our upstream forks

### DIFF
--- a/.github/actions/check-code-changes/action.yml
+++ b/.github/actions/check-code-changes/action.yml
@@ -68,6 +68,8 @@ inputs:
         # The reachability guard's own regression harness runs in `lint-rust`,
         # so a change to it changes what the Rust gate enforces.
         - 'scripts/test_check_module_reachability.py'
+        - 'scripts/check_fork_patches.py'
+        - 'scripts/test_check_fork_patches.py'
         - 'rust-toolchain'
         - 'rust-toolchain.toml'
 

--- a/.github/actions/check-code-changes/action.yml
+++ b/.github/actions/check-code-changes/action.yml
@@ -70,6 +70,7 @@ inputs:
         - 'scripts/test_check_module_reachability.py'
         - 'scripts/check_fork_patches.py'
         - 'scripts/test_check_fork_patches.py'
+        - 'docs/dev/fork_patches.md'
         - 'rust-toolchain'
         - 'rust-toolchain.toml'
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -159,6 +159,8 @@ Git deps in `Cargo.toml`: always a full 40-character SHA (reproducible, unambigu
 duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "<full 40-char sha>" } # branch: spice
 ```
 
+**Moving a fork pin re-audits that fork's patches.** A fork branch is re-cut per upstream major, and a Spice patch not deliberately carried across is lost *silently* — the crate reverts to upstream behaviour and the fork's own tests leave with the patch (it has happened: [#13524](https://github.com/spiceai/spiceai/issues/13524), and a `SIGSEGV` that shipped). `docs/dev/fork_patches.md` records, per fork, every patch and the test **in this repo** that fails if it goes missing; `scripts/check_fork_patches.py` (in `make lint-rust`) fails the build when a pin moves without that ledger being updated. Adding a patch to a fork adds its row and a guard in the same change.
+
 ## Adding a data connector
 
 1. `data_components/src/{connector}.rs` — `TableProvider` impl

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -277,7 +277,7 @@ jobs:
               return;
             }
 
-            const rustAffecting = /(\.rs$|(^|\/)Cargo\.(toml|lock)$|(^|\/)rust-toolchain(\.toml)?$|(^|\/)\.cargo\/|(^|\/)\.?(clippy|rustfmt)\.toml$|(^|\/)nextest\.toml$|(^|\/)layers\.toml$|^scripts\/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability)\.py$|^Makefile$)/;
+            const rustAffecting = /(\.rs$|(^|\/)Cargo\.(toml|lock)$|(^|\/)rust-toolchain(\.toml)?$|(^|\/)\.cargo\/|(^|\/)\.?(clippy|rustfmt)\.toml$|(^|\/)nextest\.toml$|(^|\/)layers\.toml$|^scripts\/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability|fork_patches)\.py$|^Makefile$)/;
             for (const file of files) {
               // A rename off a .rs path changes Rust sources even though the new
               // name doesn't match, so both sides of the rename must be clean.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -277,7 +277,7 @@ jobs:
               return;
             }
 
-            const rustAffecting = /(\.rs$|(^|\/)Cargo\.(toml|lock)$|(^|\/)rust-toolchain(\.toml)?$|(^|\/)\.cargo\/|(^|\/)\.?(clippy|rustfmt)\.toml$|(^|\/)nextest\.toml$|(^|\/)layers\.toml$|^scripts\/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability|fork_patches)\.py$|^Makefile$)/;
+            const rustAffecting = /(\.rs$|(^|\/)Cargo\.(toml|lock)$|(^|\/)rust-toolchain(\.toml)?$|(^|\/)\.cargo\/|(^|\/)\.?(clippy|rustfmt)\.toml$|(^|\/)nextest\.toml$|(^|\/)layers\.toml$|^scripts\/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability|fork_patches)\.py$|^docs\/dev\/fork_patches\.md$|^Makefile$)/;
             for (const file of files) {
               // A rename off a .rs path changes Rust sources even though the new
               // name doesn't match, so both sides of the rename must be clean.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ This section describes the guidelines for contributing code / docs to Spice.ai.
 - [Style Guide](/docs/dev/style_guide.md)
 - [Error Handling](/docs/dev/error_handling.md)
 - [Metrics Naming](/docs/dev/metrics.md)
+- [Fork Patches and Their Guards](/docs/dev/fork_patches.md) — read before moving a `spiceai/*` fork pin
 
 ### Pull Requests
 

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,10 @@ lint-rust:
 	## Its parser is exercised first: the live-tree scan only covers the shapes today's workspace happens to contain, so a parser regression for any other shape would pass unnoticed
 	python3 scripts/test_check_module_reachability.py
 	python3 scripts/check_module_reachability.py
+	## Fork-pin guard (fast, no compile): a moved fork pin must come with a re-audit of that fork's patches. See docs/dev/fork_patches.md
+	## Its parsers are exercised first: with both sides empty the guard would report agreement, so a regex regression would pass unnoticed
+	python3 scripts/test_check_fork_patches.py
+	python3 scripts/check_fork_patches.py
 	## All except metal, cuda, nfs (nfs requires system libnfs library)
 	CLIPPY_CONF_DIR=".ci" cargo clippy $(CARGO_PROFILE) --keep-going $(_LINT_TARGET_FLAGS) $(_FEATURES_FLAGS) $(_LINT_WORKSPACE_FLAGS) -- \
 		-Dwarnings \

--- a/crates/accelerators/accelerator-duckdb/src/lib.rs
+++ b/crates/accelerators/accelerator-duckdb/src/lib.rs
@@ -3711,10 +3711,33 @@ mod tests {
     /// the dataset loads, and the first query touching a time zone fails, in an
     /// environment that may have no network to install the extension from.
     ///
+    /// How the bundled engine says it obtained `name`.
+    ///
+    /// `STATICALLY_LINKED` is the only answer that proves the fork patch is
+    /// present. `DuckDB` installs and loads a known extension automatically, so a
+    /// runner with a network or a warm extension cache satisfies a behavioural
+    /// query either way — which would leave the guards below green on a build that
+    /// had lost the static link, and failing only for whoever runs offline.
+    fn bundled_extension_install_mode(name: &str) -> String {
+        let db = duckdb::Connection::open_in_memory().expect("opens an in-memory DuckDB");
+        db.query_row(
+            "SELECT install_mode FROM duckdb_extensions() WHERE extension_name = ?",
+            [name],
+            |row| row.get(0),
+        )
+        .unwrap_or_else(|e| panic!("the bundled DuckDB does not report an extension `{name}`: {e}"))
+    }
+
     /// New York is five hours behind UTC on this date, which is what makes this a
     /// zone-database lookup rather than a string that happened to parse.
     #[test]
     fn bundled_duckdb_resolves_a_named_time_zone_without_installing_icu() {
+        assert_eq!(
+            bundled_extension_install_mode("icu"),
+            "STATICALLY_LINKED",
+            "ICU has to be compiled in, not installed at runtime"
+        );
+
         let db = duckdb::Connection::open_in_memory().expect("opens an in-memory DuckDB");
         let local: String = db
             .query_row(
@@ -3723,7 +3746,7 @@ mod tests {
                 [],
                 |row| row.get(0),
             )
-            .expect("ICU is statically linked into the bundled DuckDB");
+            .expect("the statically linked ICU resolves a named zone");
         assert_eq!(local, "2025-12-31 19:00");
     }
 
@@ -3738,13 +3761,19 @@ mod tests {
     /// PR #38).
     #[test]
     fn bundled_duckdb_builds_an_hnsw_index_without_installing_vss() {
+        assert_eq!(
+            bundled_extension_install_mode("vss"),
+            "STATICALLY_LINKED",
+            "VSS has to be compiled in, not installed at runtime"
+        );
+
         let db = duckdb::Connection::open_in_memory().expect("opens an in-memory DuckDB");
         db.execute_batch(
             "CREATE TABLE embeddings (v FLOAT[3]);
              INSERT INTO embeddings VALUES ([1.0, 2.0, 3.0]), ([2.0, 3.0, 4.0]);
              CREATE INDEX embeddings_hnsw ON embeddings USING HNSW (v);",
         )
-        .expect("VSS is statically linked into the bundled DuckDB");
+        .expect("the statically linked VSS supplies the HNSW index type");
 
         let nearest: f32 = db
             .query_row(

--- a/crates/accelerators/accelerator-duckdb/src/lib.rs
+++ b/crates/accelerators/accelerator-duckdb/src/lib.rs
@@ -3701,4 +3701,62 @@ mod tests {
             .expect("Should format batches");
         insta::assert_snapshot!("duckdb_upsert_second_update", upsert_pretty);
     }
+
+    /// `ICU` has to be compiled into the bundled `DuckDB`, not installed at runtime.
+    ///
+    /// `DuckDB` resolves a named IANA time zone through `ICU`, and without it every
+    /// query using one fails with `Unknown TimeZone`. Upstream `duckdb-rs` does not
+    /// bundle `ICU`; the `spiceai/duckdb-rs` fork statically links it (fork PR #23).
+    /// If a fork re-cut drops that, nothing here fails to build — `spiced` starts,
+    /// the dataset loads, and the first query touching a time zone fails, in an
+    /// environment that may have no network to install the extension from.
+    ///
+    /// New York is five hours behind UTC on this date, which is what makes this a
+    /// zone-database lookup rather than a string that happened to parse.
+    #[test]
+    fn bundled_duckdb_resolves_a_named_time_zone_without_installing_icu() {
+        let db = duckdb::Connection::open_in_memory().expect("opens an in-memory DuckDB");
+        let local: String = db
+            .query_row(
+                "SELECT strftime(TIMESTAMPTZ '2026-01-01 00:00:00+00' AT TIME ZONE \
+                 'America/New_York', '%Y-%m-%d %H:%M')",
+                [],
+                |row| row.get(0),
+            )
+            .expect("ICU is statically linked into the bundled DuckDB");
+        assert_eq!(local, "2025-12-31 19:00");
+    }
+
+    /// `VSS` has to be compiled into the bundled `DuckDB` too.
+    ///
+    /// It supplies the `HNSW` index type, which is how a `DuckDB`-accelerated dataset
+    /// serves vector search. Without it `CREATE INDEX … USING HNSW` fails, and a
+    /// search either errors or silently degrades to a full scan. Statically linked by
+    /// the `spiceai/duckdb-rs` fork (fork PR #37) for the same reason as `ICU`: a
+    /// runtime `INSTALL` needs a network and a matching engine version, and the fork
+    /// pins the engine to a clean release precisely so those downloads resolve (fork
+    /// PR #38).
+    #[test]
+    fn bundled_duckdb_builds_an_hnsw_index_without_installing_vss() {
+        let db = duckdb::Connection::open_in_memory().expect("opens an in-memory DuckDB");
+        db.execute_batch(
+            "CREATE TABLE embeddings (v FLOAT[3]);
+             INSERT INTO embeddings VALUES ([1.0, 2.0, 3.0]), ([2.0, 3.0, 4.0]);
+             CREATE INDEX embeddings_hnsw ON embeddings USING HNSW (v);",
+        )
+        .expect("VSS is statically linked into the bundled DuckDB");
+
+        let nearest: f32 = db
+            .query_row(
+                "SELECT array_distance(v, [1.0, 2.0, 3.0]::FLOAT[3]) AS d \
+                 FROM embeddings ORDER BY d LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("queries the HNSW-indexed column");
+        assert!(
+            nearest.abs() < f32::EPSILON,
+            "the nearest neighbour of a stored vector is itself, at distance 0, not {nearest}"
+        );
+    }
 }

--- a/crates/data-connector-api/src/listing/connector.rs
+++ b/crates/data-connector-api/src/listing/connector.rs
@@ -3182,4 +3182,206 @@ mod tests {
             "an invalid value falls back to the default"
         );
     }
+
+    /// An `InMemory` store that records the [`object_store::GetOptions`] of every
+    /// read, and reports a version for the object it holds so a reader has something
+    /// to pin to.
+    ///
+    /// `InMemory` itself reports no version, and a reader cannot pin what the store
+    /// does not give it — which would make the guard below pass whether or not the
+    /// pinning worked.
+    #[derive(Debug)]
+    struct VersionRecordingStore {
+        inner: object_store::memory::InMemory,
+        version: String,
+        reads: std::sync::Mutex<Vec<object_store::GetOptions>>,
+    }
+
+    impl VersionRecordingStore {
+        fn new(version: &str) -> Self {
+            Self {
+                inner: object_store::memory::InMemory::new(),
+                version: version.to_string(),
+                reads: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn reads(&self) -> Vec<object_store::GetOptions> {
+            self.reads.lock().expect("reads lock").clone()
+        }
+
+        /// Forget what has been recorded, so a test can set itself up through the
+        /// same store it is about to assert on.
+        fn forget_reads(&self) {
+            self.reads.lock().expect("reads lock").clear();
+        }
+    }
+
+    impl std::fmt::Display for VersionRecordingStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "VersionRecordingStore")
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for VersionRecordingStore {
+        fn list(
+            &self,
+            prefix: Option<&Path>,
+        ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &Path,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            self.reads.lock().expect("reads lock").push(options.clone());
+            let mut result = self.inner.get_opts(location, options).await?;
+            result.meta.version = Some(self.version.clone());
+            Ok(result)
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, object_store::Result<Path>>,
+        ) -> BoxStream<'static, object_store::Result<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// Every read a versioned Parquet scan makes has to name the version it started
+    /// from, and none of them may be a suffix range.
+    ///
+    /// The connectors that set `object_versioning_type` — S3, ABFS, GCS, `SharePoint` —
+    /// do so because the object under a dataset can be replaced while a scan is in
+    /// flight. Pinning makes the reads a consistent view of one version; without it
+    /// the footer comes from the old object and the pages from the new one, and the
+    /// scan returns rows that were never in either.
+    ///
+    /// Both halves of that live on forks. `ListingOptions::with_object_versioning_type`
+    /// is a `spiceai/datafusion` patch, and the `if_match`/`version` it turns into on
+    /// every metadata, byte-range and suffix fetch is a `spiceai/arrow-rs` patch to
+    /// `ParquetObjectReader`. The `arrow-rs` half is the dangerous one: a re-cut that
+    /// keeps the constructor and drops the pinning still compiles, still scans, and
+    /// stops pinning.
+    ///
+    /// The suffix-range assertion guards the other reason `new_with_meta` exists:
+    /// Azure Blob Storage does not serve suffix ranges, so a reader that falls back to
+    /// one cannot read Parquet from ABFS at all.
+    #[tokio::test]
+    async fn a_versioned_parquet_read_pins_every_request_to_one_object_version() {
+        use datafusion::parquet::arrow::ArrowWriter;
+        use datafusion::parquet::arrow::async_reader::{
+            ObjectVersionType, ParquetObjectReader, ParquetRecordBatchStreamBuilder,
+        };
+        use futures::TryStreamExt;
+
+        const VERSION: &str = "the-version-the-scan-started-from";
+
+        // Two columns, so the data reads are plural and go through
+        // `get_byte_ranges` — the override that coalesces them — rather than a
+        // single `get_bytes`.
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("id", arrow::datatypes::DataType::Int32, false),
+            arrow::datatypes::Field::new("name", arrow::datatypes::DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(arrow::array::Int32Array::from(vec![1, 2, 3])),
+                Arc::new(arrow::array::StringArray::from(vec!["a", "b", "c"])),
+            ],
+        )
+        .expect("builds a batch");
+
+        let mut buffer = Vec::new();
+        let mut writer =
+            ArrowWriter::try_new(&mut buffer, Arc::clone(&schema), None).expect("parquet writer");
+        writer.write(&batch).expect("writes the batch");
+        writer.close().expect("closes the file");
+
+        let store = Arc::new(VersionRecordingStore::new(VERSION));
+        let location = Path::from("versioned.parquet");
+        store
+            .put(&location, buffer.into())
+            .await
+            .expect("stores the file");
+        let meta = store.head(&location).await.expect("heads the file");
+        // The write and the `head` are the test's own setup, and the `head` reaches
+        // `get_opts` too. Only what the reader asks for is under assertion.
+        store.forget_reads();
+        let store_handle = Arc::clone(&store);
+
+        let reader = ParquetObjectReader::new_with_meta(store as Arc<dyn ObjectStore>, meta)
+            .with_object_versioning_type(Some(ObjectVersionType::Version));
+        let rows: usize = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .expect("reads the Parquet metadata")
+            .build()
+            .expect("builds the record-batch stream")
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("reads the data")
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum();
+        assert_eq!(
+            rows, 3,
+            "the read has to reach the data, not just the footer"
+        );
+
+        let reads = store_handle.reads();
+        assert!(
+            !reads.is_empty(),
+            "the read issued no request at all, so this asserts nothing"
+        );
+        for options in &reads {
+            assert_eq!(
+                options.version.as_deref(),
+                Some(VERSION),
+                "a read did not pin the object version, so a replacement mid-scan is read as a \
+                 mixture of both versions: {options:?}"
+            );
+            assert!(
+                !matches!(options.range, Some(object_store::GetRange::Suffix(_))),
+                "a read fell back to a suffix range, which Azure Blob Storage does not serve: \
+                 {options:?}"
+            );
+        }
+    }
 }

--- a/crates/data_components/src/federation.rs
+++ b/crates/data_components/src/federation.rs
@@ -139,12 +139,13 @@ mod tests {
 
     use crate::function_support::{FunctionRestriction, FunctionSupport};
     use async_trait::async_trait;
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use datafusion::datasource::TableProvider;
     use datafusion::functions_aggregate::expr_fn::count;
     use datafusion::logical_expr::{
         ColumnarValue, Expr, Extension, JoinType, LogicalPlan, LogicalPlanBuilder, ScalarUDF,
-        TableSource, Volatility, builder::LogicalTableSource, create_udf, expr::ScalarFunction,
+        TableSource, Volatility, builder::LogicalTableSource, cast, create_udf,
+        expr::ScalarFunction,
     };
     use datafusion::prelude::{col, lit};
     use datafusion::sql::unparser::Unparser;
@@ -1051,5 +1052,259 @@ mod tests {
                  for: {sql}"
             );
         }
+    }
+
+    /// The identifier an `AS` at `at` introduces, read back out of the rendered SQL.
+    ///
+    /// Reading the name rather than matching one is what makes the guard below
+    /// dialect-independent: `BigQuery` escapes a `.` in an output name to its
+    /// character code, so the derived table it builds names the same output
+    /// `t_46a + t_46b`. Asserting the logical spelling would fail on a dialect that
+    /// did the right thing.
+    fn alias_introduced_at(sql: &str, at: usize) -> Option<&str> {
+        let rest = sql.get(at + " AS ".len()..)?;
+        let close = match rest.chars().next()? {
+            '"' => '"',
+            '`' => '`',
+            '[' => ']',
+            _ => {
+                let end = rest
+                    .find(|c: char| !c.is_alphanumeric() && c != '_')
+                    .unwrap_or(rest.len());
+                return (end > 0).then(|| &rest[..end]);
+            }
+        };
+        let end = rest[1..].find(close)? + 1;
+        Some(&rest[1..end])
+    }
+
+    /// Regression test for the derived-output naming carried by fork PR #206: a
+    /// projection that becomes a derived table has to name the outputs it does not
+    /// name itself, because the enclosing scope refers to them by their logical name.
+    ///
+    /// Left unnamed, the engine names the column instead — `?column?` on
+    /// `PostgreSQL` — while the statement around it still says `"t.a + t.b"`. The
+    /// remote engine cannot bind that, so the pushdown fails outright
+    /// ([#12751](https://github.com/spiceai/spiceai/issues/12751)).
+    ///
+    /// Both shapes that put a projection in a scope of its own are covered: a filter
+    /// above it, and a row limit above it. Each carries the reference from the
+    /// enclosing scope, which is what makes the missing name observable.
+    #[test]
+    fn a_derived_tables_unnamed_outputs_are_named() {
+        let computed = "t.a + t.b";
+        let shapes: Vec<(&str, LogicalPlan)> = vec![
+            (
+                "filter-above",
+                derived_computed_projection()
+                    .filter(col(computed).gt(lit(1)))
+                    .expect("filter above the projection")
+                    .project(vec![col(computed)])
+                    .expect("outer projection")
+                    .build()
+                    .expect("build"),
+            ),
+            (
+                "limit-above",
+                derived_computed_projection()
+                    .limit(0, Some(5))
+                    .expect("limit above the projection")
+                    .project(vec![col(computed)])
+                    .expect("outer projection")
+                    .build()
+                    .expect("build"),
+            ),
+        ];
+
+        for (shape, plan) in shapes {
+            for (dialect_name, dialect) in federation_dialects() {
+                let sql = unparse_with(dialect_name, dialect.as_ref(), &plan);
+                let alias = sql
+                    .match_indices(" AS ")
+                    .find(|(at, _)| paren_depth_at(&sql, *at) >= 1)
+                    .and_then(|(at, _)| alias_introduced_at(&sql, at));
+                let Some(alias) = alias else {
+                    panic!(
+                        "{dialect_name}/{shape}: the derived table does not name its computed \
+                         output, so the enclosing reference to it binds to a name the engine \
+                         invented instead: {sql}"
+                    );
+                };
+                assert!(
+                    sql.match_indices(alias)
+                        .any(|(at, _)| paren_depth_at(&sql, at) == 0),
+                    "{dialect_name}/{shape}: the enclosing scope refers to something other than \
+                     the name `{alias}` the derived table gives its output, so the statement \
+                     cannot bind: {sql}"
+                );
+            }
+        }
+    }
+
+    /// A projection of `a + b` over `t`, which `DataFusion` names `t.a + t.b` and SQL
+    /// names nothing. The caller stacks whatever puts it in a scope of its own.
+    fn derived_computed_projection() -> LogicalPlanBuilder {
+        LogicalPlanBuilder::scan(
+            "t",
+            table_source(vec![
+                Field::new("a", DataType::Int32, false),
+                Field::new("b", DataType::Int32, false),
+            ]),
+            None,
+        )
+        .expect("scan t")
+        .project(vec![col("t.a") + col("t.b")])
+        .expect("computed projection")
+    }
+
+    /// Regression test for the empty-projection fallback: a `Projection` with no
+    /// output expressions must not unparse to an empty `SELECT` list.
+    ///
+    /// The shape arises on its own — `count(*)` planned over a view or subquery whose
+    /// columns are all pruned leaves `Projection: <empty>` over the scan. Rendered
+    /// literally that is `SELECT FROM t`, which `DuckDB` and others reject outright
+    /// with a parser error, so the federated query fails rather than returning
+    /// anything. The fork emits `SELECT 1` for dialects that refuse an empty list.
+    ///
+    /// This is deliberately not swept over every dialect. The fallback is keyed on
+    /// `Dialect::supports_empty_select_list`, and a dialect that declares it accepts
+    /// an empty list is entitled to keep one — `PostgreSqlDialect` does, and renders
+    /// `SELECT FROM "t"`. The two below are the ones that refuse it, so they are the
+    /// ones the fallback has to reach.
+    #[test]
+    fn an_empty_projection_does_not_unparse_to_an_empty_select_list() {
+        let plan = LogicalPlanBuilder::scan(
+            "t",
+            table_source(vec![Field::new("a", DataType::Int32, false)]),
+            None,
+        )
+        .expect("scan t")
+        .project(Vec::<Expr>::new())
+        .expect("empty projection")
+        .build()
+        .expect("build");
+
+        let refuse_an_empty_list: Vec<(&str, Arc<dyn Dialect>)> = vec![
+            ("default", Arc::new(DefaultDialect {})),
+            ("duckdb", Arc::new(DuckDBDialect::new())),
+        ];
+        for (dialect_name, dialect) in refuse_an_empty_list {
+            let sql = unparse_with(dialect_name, dialect.as_ref(), &plan);
+            let select_list = &sql[..first_offset_of(&sql, "FROM")];
+            assert_ne!(
+                select_list.trim(),
+                "SELECT",
+                "{dialect_name}: an empty select list is not a statement this engine will parse: {sql}"
+            );
+        }
+    }
+
+    /// A projection casting `ts` to a timestamp carrying `tz`, which is the shape
+    /// that reaches the dialect's `AT TIME ZONE` rendering.
+    fn timestamp_cast_to_zone(tz: &str) -> LogicalPlan {
+        LogicalPlanBuilder::scan(
+            "t",
+            table_source(vec![Field::new(
+                "ts",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            )]),
+            None,
+        )
+        .expect("scan t")
+        .project(vec![cast(
+            col("t.ts"),
+            DataType::Timestamp(TimeUnit::Nanosecond, Some(tz.into())),
+        )])
+        .expect("timestamp cast")
+        .build()
+        .expect("build")
+    }
+
+    /// Regression test for the two `AT TIME ZONE` fixes the fork carries: #160 makes
+    /// the unparser emit the timezone at all, and #195 keeps `DuckDB` from receiving a
+    /// fixed *zero* offset it cannot resolve.
+    ///
+    /// Before #160 the timezone was dropped from the SQL entirely, so the remote
+    /// engine evaluated the expression in its own session timezone and returned a
+    /// different instant — silently, for every federated query touching a
+    /// `timestamptz`. #195 is the other direction: Arrow carries a fixed UTC offset
+    /// rather than an IANA name (Iceberg maps every `timestamptz` column to
+    /// `+00:00`), `DuckDB` resolves `AT TIME ZONE` through an ICU zone-name lookup,
+    /// and the result was a permanent `Unknown TimeZone '+00:00'`
+    /// ([#12528](https://github.com/spiceai/spiceai/issues/12528)).
+    ///
+    /// A *non-zero* offset is deliberately still emitted verbatim, and still rejected
+    /// by `DuckDB`: there is no safe total mapping from an offset to a zone name, and
+    /// a clear error beats a possibly-wrong instant. The named-zone arm holds
+    /// `DuckDB` to the faithful rendering so a later fix cannot suppress the zone
+    /// wholesale.
+    ///
+    /// The sweep covers the dialects whose timestamp type carries a zone at all.
+    /// `MySqlDialect` renders the cast as `DATETIME`, which has no zone to carry, so
+    /// dropping it there is the dialect being right rather than the patch being lost.
+    #[test]
+    fn a_timezone_survives_unparsing_except_where_the_engine_cannot_resolve_it() {
+        let named = "America/New_York";
+        let zone_aware: Vec<(&str, Arc<dyn Dialect>)> = vec![
+            ("default", Arc::new(DefaultDialect {})),
+            ("postgres", Arc::new(PostgreSqlDialect {})),
+        ];
+        for (dialect_name, dialect) in zone_aware {
+            let sql = unparse_with(
+                dialect_name,
+                dialect.as_ref(),
+                &timestamp_cast_to_zone(named),
+            );
+            assert!(
+                sql.contains(named),
+                "{dialect_name}: the timezone was dropped, so the remote engine evaluates this in \
+                 its own session timezone and returns a different instant: {sql}"
+            );
+        }
+
+        let duckdb = DuckDBDialect::new();
+        let utc_offset = unparse_with("duckdb", &duckdb, &timestamp_cast_to_zone("+00:00"));
+        assert!(
+            !utc_offset.contains("AT TIME ZONE"),
+            "duckdb: a fixed zero offset reaches DuckDB's ICU zone-name lookup, which knows only \
+             named zones, and fails permanently with `Unknown TimeZone '+00:00'`: {utc_offset}"
+        );
+        let named_zone = unparse_with("duckdb", &duckdb, &timestamp_cast_to_zone(named));
+        assert!(
+            named_zone.contains("AT TIME ZONE") && named_zone.contains(named),
+            "duckdb: a named zone is resolvable and has to keep the faithful rendering, or the \
+             instant changes: {named_zone}"
+        );
+    }
+
+    /// Regression test for the `BigQuery` type spelling carried by fork PR #147:
+    /// `BigQuery` names the 64-bit float type `FLOAT64` and rejects `DOUBLE`.
+    ///
+    /// A cast is the common way this reaches the wire — a federated predicate
+    /// comparing a column to a float literal unparses through it — and the failure is
+    /// the whole query, not a wrong row.
+    #[test]
+    fn bigquery_names_the_float_type_the_way_bigquery_does() {
+        let plan = LogicalPlanBuilder::scan(
+            "t",
+            table_source(vec![Field::new("n", DataType::Int64, false)]),
+            None,
+        )
+        .expect("scan t")
+        .project(vec![cast(col("t.n"), DataType::Float64)])
+        .expect("float cast")
+        .build()
+        .expect("build");
+
+        let sql = unparse_with("bigquery", &BigQueryDialect::new(), &plan);
+        assert!(
+            sql.contains("FLOAT64"),
+            "bigquery: BigQuery has no `DOUBLE` type, so this statement is rejected: {sql}"
+        );
+        assert!(
+            !sql.contains("DOUBLE"),
+            "bigquery: BigQuery has no `DOUBLE` type, so this statement is rejected: {sql}"
+        );
     }
 }

--- a/crates/vortex/src/persistent/mod.rs
+++ b/crates/vortex/src/persistent/mod.rs
@@ -608,11 +608,12 @@ mod tests {
     /// rather than the patch.
     #[test]
     fn test_date_to_timestamp_extension_cast() -> anyhow::Result<()> {
-        use datafusion::arrow::array::Date32Array;
-        use datafusion::arrow::datatypes::{DataType, TimeUnit};
+        use datafusion::arrow::array::{Array as _, AsArray as _, Date32Array};
+        use datafusion::arrow::datatypes::{DataType, Field, TimestampMillisecondType, TimeUnit};
         use vortex::array::ArrayRef as VortexArrayRef;
         use vortex::array::builtins::ArrayBuiltins;
-        use vortex::arrow::{FromArrowArray, FromArrowType};
+        use vortex::array::VortexSessionExecute;
+        use vortex::arrow::{ArrowSessionExt, FromArrowArray, FromArrowType};
         use vortex::dtype::{DType, Nullability};
 
         // 1970-01-01, 2024-01-15, and a NULL, so the cast has to carry validity as
@@ -620,18 +621,37 @@ mod tests {
         let dates = Date32Array::from(vec![Some(0), Some(19_737), None]);
         let source = VortexArrayRef::from_arrow(&dates, true)?;
 
-        let target = DType::from_arrow((
-            &DataType::Timestamp(TimeUnit::Millisecond, None),
-            Nullability::Nullable,
-        ));
+        let millis = DataType::Timestamp(TimeUnit::Millisecond, None);
+        let target = DType::from_arrow((&millis, Nullability::Nullable));
         let cast = source.cast(target.clone())?;
-
         assert_eq!(
             cast.dtype(),
             &target,
             "the cast has to land on the target type"
         );
-        assert_eq!(cast.len(), 3, "the cast has to preserve every row");
+
+        // Read the values back rather than stopping at the type: a cast that lands
+        // on `vortex.timestamp` and puts the wrong instants in it is the failure
+        // this guard is for, and it would pass a type-and-length assertion.
+        let session = VortexSession::default();
+        let arrow = session.arrow().execute_arrow(
+            cast,
+            Some(&Field::new("event_ts", millis, true)),
+            &mut session.create_execution_ctx(),
+        )?;
+        let timestamps = arrow.as_primitive::<TimestampMillisecondType>();
+
+        assert_eq!(timestamps.len(), 3, "the cast has to preserve every row");
+        assert_eq!(timestamps.value(0), 0, "1970-01-01 is the epoch");
+        assert_eq!(
+            timestamps.value(1),
+            1_705_276_800_000,
+            "2024-01-15 is 19_737 days after the epoch, at midnight"
+        );
+        assert!(
+            timestamps.is_null(2),
+            "a NULL date has to stay NULL through the cast, not become the epoch"
+        );
 
         Ok(())
     }

--- a/crates/vortex/src/persistent/mod.rs
+++ b/crates/vortex/src/persistent/mod.rs
@@ -564,4 +564,139 @@ mod tests {
 
         Ok(())
     }
+
+    /// Run `sql` and read the single `Int64` it returns.
+    ///
+    /// The fork guards below assert counts rather than rendered batches on purpose: a
+    /// snapshot can be regenerated, and a guard that a lost patch can be made to pass
+    /// by re-recording it guards nothing.
+    async fn scalar_count(ctx: &TestSessionContext, sql: &str) -> anyhow::Result<i64> {
+        use datafusion::arrow::array::AsArray as _;
+        use datafusion::arrow::datatypes::Int64Type;
+
+        let batches = ctx.session.sql(sql).await?.collect().await?;
+        let total = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_primitive::<Int64Type>()
+                    .iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+            })
+            .sum();
+        Ok(total)
+    }
+
+    /// Vortex has to be able to cast a `vortex.date` column to `vortex.timestamp`.
+    ///
+    /// Vortex stores a `Date32` column as the `vortex.date` extension type, and a
+    /// pushed-down `CAST(date_col AS TIMESTAMP)` is evaluated by Vortex rather than
+    /// by `DataFusion`. Upstream Vortex refuses that cast; the kernel that performs
+    /// it lives in the `spiceai/vortex` fork (fork PR #28), and a re-cut that drops
+    /// it takes no build with it — the plan still pushes the filter down and the
+    /// scan then fails on a cast Vortex no longer knows how to do.
+    ///
+    /// This asserts the kernel directly rather than through a SQL filter, because
+    /// the two are not the same question: the kernel is registered on
+    /// `ExtensionArray`, and the scan also evaluates the pushed-down predicate
+    /// against *constant* arrays built from chunk statistics, which reach a
+    /// different cast path the fork does not patch. That second path fails today
+    /// (`No CastReduce to cast constant array from vortex.date[days] to
+    /// vortex.timestamp[ns]`), so a SQL-level assertion would be pinning a bug
+    /// rather than the patch.
+    #[test]
+    fn test_date_to_timestamp_extension_cast() -> anyhow::Result<()> {
+        use datafusion::arrow::array::Date32Array;
+        use datafusion::arrow::datatypes::{DataType, TimeUnit};
+        use vortex::array::ArrayRef as VortexArrayRef;
+        use vortex::array::builtins::ArrayBuiltins;
+        use vortex::arrow::{FromArrowArray, FromArrowType};
+        use vortex::dtype::{DType, Nullability};
+
+        // 1970-01-01, 2024-01-15, and a NULL, so the cast has to carry validity as
+        // well as values.
+        let dates = Date32Array::from(vec![Some(0), Some(19_737), None]);
+        let source = VortexArrayRef::from_arrow(&dates, true)?;
+
+        let target = DType::from_arrow((
+            &DataType::Timestamp(TimeUnit::Millisecond, None),
+            Nullability::Nullable,
+        ));
+        let cast = source.cast(target.clone())?;
+
+        assert_eq!(
+            cast.dtype(),
+            &target,
+            "the cast has to land on the target type"
+        );
+        assert_eq!(cast.len(), 3, "the cast has to preserve every row");
+
+        Ok(())
+    }
+
+    /// A large `IN` list has to stay evaluable.
+    ///
+    /// An `IN (…)` filter is pushed into the Vortex scan as one `list_contains`
+    /// call, and Vortex evaluates it by OR-ing one equality array per list element.
+    /// Upstream accumulates those into a left-deep chain, so a list of N elements
+    /// builds a tree N deep and evaluating it recurses N frames — a large enough
+    /// `IN` list overflows the stack and takes the process down. The fork balances
+    /// the OR tree to depth `log2(N)` instead (fork PR #37).
+    ///
+    /// Losing the balance is invisible to the compiler: the same call, the same
+    /// results for the small lists every other test uses. This one is sized past the
+    /// point where a left-deep chain is a problem, so if the patch goes missing it
+    /// stops passing — by failing, or by crashing the test binary, which `nextest`
+    /// reports either way.
+    #[tokio::test]
+    async fn test_large_in_list_filter_pushdown_stays_evaluable() -> anyhow::Result<()> {
+        // Deep enough that a left-deep OR chain is thousands of levels, small enough
+        // that the balanced form is a handful of milliseconds.
+        const IN_LIST_LEN: i32 = 8_192;
+        // Rows are 0..ROWS. The IN list starts at ROWS / 2, so half of it matches a
+        // row and half of it matches nothing — a list that matched everything would
+        // pass on a filter that was dropped rather than evaluated.
+        const ROWS: i32 = 2_048;
+
+        let ctx = TestSessionContext::default();
+
+        ctx.session
+            .sql(
+                "CREATE EXTERNAL TABLE ids \
+                    (id INT NOT NULL) \
+                STORED AS vortex \
+                LOCATION '/large_in_list/'",
+            )
+            .await?;
+
+        let values = (0..ROWS)
+            .map(|id| format!("({id})"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        ctx.session
+            .sql(&format!("INSERT INTO ids VALUES {values}"))
+            .await?
+            .collect()
+            .await?;
+
+        let in_list = (0..IN_LIST_LEN)
+            .map(|offset| (ROWS / 2 + offset).to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let matched = scalar_count(
+            &ctx,
+            &format!("SELECT count(*) FROM ids WHERE id IN ({in_list})"),
+        )
+        .await?;
+
+        assert_eq!(
+            matched,
+            i64::from(ROWS / 2),
+            "the IN list covers the upper half of the rows and nothing else"
+        );
+
+        Ok(())
+    }
 }

--- a/crates/vortex/src/persistent/mod.rs
+++ b/crates/vortex/src/persistent/mod.rs
@@ -609,10 +609,10 @@ mod tests {
     #[test]
     fn test_date_to_timestamp_extension_cast() -> anyhow::Result<()> {
         use datafusion::arrow::array::{Array as _, AsArray as _, Date32Array};
-        use datafusion::arrow::datatypes::{DataType, Field, TimestampMillisecondType, TimeUnit};
+        use datafusion::arrow::datatypes::{DataType, Field, TimeUnit, TimestampMillisecondType};
         use vortex::array::ArrayRef as VortexArrayRef;
-        use vortex::array::builtins::ArrayBuiltins;
         use vortex::array::VortexSessionExecute;
+        use vortex::array::builtins::ArrayBuiltins;
         use vortex::arrow::{ArrowSessionExt, FromArrowArray, FromArrowType};
         use vortex::dtype::{DType, Nullability};
 

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -1,0 +1,492 @@
+# Fork patches and their guards
+
+Spice builds against forks of 29 upstream crates. Some of those forks carry Spice
+patches; the rest are pinned for a version or dependency reason and carry no
+behaviour of ours at all.
+
+A patch on a fork exists only as a commit on a fork branch, and every fork branch is
+re-cut when its upstream releases a new major (`spiceai-52` → `-53` → `-54`, …). A
+patch that is not deliberately carried across a re-cut is **lost silently**: nothing
+fails, the crate reverts to upstream behaviour, and the defect the patch fixed
+returns in the next Spice release. The fork's own tests are no protection — they are
+on the branch that was replaced, so they leave with the patch.
+
+This has already happened. Vortex `Map` support shipped on `spiceai-51`, `-52` and
+`-53` and was absent from `-54`; half the patch survived, so it surfaced not as a
+build failure but as `Array encoding not implemented for Arrow data type Map(...)`
+on every write in a released build ([#13524](https://github.com/spiceai/spiceai/issues/13524)).
+A reentrant-waker use-after-free in `vortex-io` was fixed three separate times on
+branches that never reached a shipping one, and shipped as a `SIGSEGV` under
+ordinary task cancellation.
+
+So the protection has to live **here**, in `spiceai/spiceai`, where it survives the
+re-cut. This file is the ledger of what that protection covers.
+
+## How to use this
+
+**At every fork pin bump**, for the fork you moved:
+
+1. Diff the new revision against its upstream merge base and enumerate the Spice
+   commits, or read the fork's own `SPICE_PATCHES.md` / `SPICE_FORK_CHANGES.md`
+   where it has one. Cargo's clone of the fork holds no upstream remote and no
+   tags, so give it one in a scratch repo that borrows its objects rather than
+   re-downloading them:
+
+   ```sh
+   db=~/.cargo/git/db/<fork>-<hash>          # the clone cargo already has
+   git init --bare /tmp/<fork>.git
+   echo "$db/objects" > /tmp/<fork>.git/objects/info/alternates
+   git --git-dir /tmp/<fork>.git fetch --no-tags "$db" '+refs/*:refs/fork/*'
+   git --git-dir /tmp/<fork>.git remote add upstream https://github.com/<owner>/<fork>.git
+   git --git-dir /tmp/<fork>.git fetch --no-tags upstream '+refs/heads/*:refs/remotes/upstream/*'
+
+   base=$(git --git-dir /tmp/<fork>.git merge-base <new-rev> refs/remotes/upstream/<default-branch>)
+   git --git-dir /tmp/<fork>.git log --no-merges --format='%h %an%x09%s' "$base..<new-rev>"
+   git --git-dir /tmp/<fork>.git cherry -v refs/remotes/upstream/<default-branch> <new-rev> "$base"
+   ```
+
+   The `fetch` from `$db` first is what makes the upstream fetch cheap — with no
+   refs to negotiate against, git asks for the entire history. `cherry` marks each
+   commit `+` (ours) or `-` (an upstream commit cherry-picked ahead of a release),
+   which is what separates a Spice patch from a backport on a release branch.
+2. For every patch in that fork's table below, confirm it is still present, or
+   record that it landed upstream and drop the row.
+3. Run the guards named in the **Guard** column. They must pass on the new pin.
+4. Update the fork's revision in the pin table. `scripts/check_fork_patches.py`
+   (run by `make lint-rust`) fails the build until you do, which is the point: the
+   ledger is only true of the revision it names.
+
+**When you add a patch to a fork**, add its row here in the same change, with a
+guard. A patch with no guard is a patch the next re-cut can drop for free.
+
+## What counts as a guard
+
+A guard is a test **in this repo** that fails when the patch is missing. Not a
+comment, not a test in the fork.
+
+The **Loss** column says how a missing patch would surface:
+
+- **silent** — it compiles and runs, and returns different results, hangs, crashes
+  or degrades. These are the rows that need a behaviour test.
+- **build** — the patch adds or changes an API this workspace calls, so losing it
+  fails `cargo check`. The compiler is the guard. Worth recording anyway, because a
+  re-cut that keeps the signature and drops the behaviour turns a **build** row into
+  a **silent** one, and only a reader of this table would notice.
+
+A row whose guard is **GAP** has no repo-side coverage today. Those are listed
+together in [Open gaps](#open-gaps).
+
+## Pinned revisions
+
+Machine-checked against `Cargo.lock` by `scripts/check_fork_patches.py`. One row per
+fork; the revision must be the one cargo resolves. What each fork carries is in its
+own section below — a count here would be one more thing to keep true by hand.
+
+| Fork | Pinned revision | Branch |
+|---|---|---|
+| [arrow-rs](#arrow-rs) | `18a40370d014a0f8eed12ee0d5a914e8cb2070d8` | `lukim/spiceai-58.3.0` |
+| [async-openai](#async-openai) | `6bda5533dd118afcf80aa6f5ef59ad35277627a7` | `spiceai` |
+| [candle](#candle-and-its-kernel-crates) | `efbb9a72e92789eafed0806c3e16f14640c504f6` | `lukim/spiceai-0.11.0` |
+| [candle-cublaslt](#candle-and-its-kernel-crates) | `c41bf9c6e87195749c2262d16ca320af2bbebbfe` | `main` |
+| [candle-index-select-cu](#candle-and-its-kernel-crates) | `75fc0b689b33a327907d36dd479f7d242640ca71` | `master` |
+| [candle-layer-norm](#candle-and-its-kernel-crates) | `dfdbfbb953ceeb0366e5e3b69f2933204309d3dd` | `main` |
+| [candle-rotary](#candle-and-its-kernel-crates) | `e12f91a6c8beec5373ccec91a5ccad80619cf065` | `main` |
+| [clickhouse-rs](#clickhouse-rs) | `7e98394f44cfa33919ebc5a92c06d5bddba708bf` | tag `0.2.2` |
+| [datafusion](#datafusion) | `859621d612511efb93a7f3e020f8baae8e33e3b4` | `spiceai-54` |
+| [datafusion-ballista](#datafusion-ballista) | `f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0` | `spiceai-54` |
+| [datafusion-federation](#datafusion-federation-and-datafusion-table-providers) | `0cb3781608b89f40c6585618ec3071f83345671a` | `spiceai-54` |
+| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `896356c3f7af9db5b6da3f2379196b420eee1b2b` | `spiceai-54` |
+| [delta-kernel-rs](#delta-kernel-rs) | `714d64fd5369efc4835109be0fd718db5a3be0aa` | `spiceai-0.23.0` |
+| [docx-rs](#docx-rs) | `2a85dce57d0128e2cd7c369545516c347cb8c529` | `spiceai` |
+| [duckdb-rs](#duckdb-rs) | `7229b20daf24765c84d294c52cf4b4165ca79073` | `spiceai-1.5.5` |
+| [graph-rs-sdk](#graph-rs-sdk) | `af383410a9c86915263fbd1145b8becfc1e317b5` | `spiceai` |
+| [iceberg-rust](#iceberg-rust) | `351d1bc7b6ac9a835397e248e9c687f305e947d1` | `spiceai-0.10.1-df-54` |
+| [mistral.rs](#mistralrs-and-text-embeddings-inference) | `2d15d171236803481d582a9fbf8a80869bf74d8c` | `spiceai` |
+| [model2vec-rs](#model2vec-rs) | `55fef28a3556895b20204634b788f7c836b610bc` | `spiceai` |
+| [reqwest-eventsource](#dependency-only-forks) | `eb11e695128ce264bf05e4220ce2311c25992c73` | `spiceai` |
+| [rusqlite](#rusqlite-and-tokio-rusqlite) | `e39c9c46dea1f0983cd8d87dabb69b41c9efe1fd` | `master` |
+| [sea-query](#sea-query) | `213b6b876068f58159ebdd5852604a021afaebf9` | `spiceai` |
+| [snowflake-rs](#snowflake-rs) | `744ffd77fe82171a805562ce001a341a94d52541` | `spiceai-58` |
+| [spark-connect-rs](#spark-connect-rs) | `5f7c2452d4202d7496abac0a6f2eaa4bef46a5ad` | `spiceai` |
+| [text-embeddings-inference](#mistralrs-and-text-embeddings-inference) | `ac4e457936bc11c9b4fee453f2be33133d3146d8` | `spiceai` |
+| [text-splitter](#text-splitter) | `58f9c21006e01e5e968c5de80a0398b3f5ec439a` | `spiceai` |
+| [tiberius](#dependency-only-forks) | `9ae93c65222b51b0579945ffce5cba053cb23cca` | `spiceai` |
+| [tokio-rusqlite](#rusqlite-and-tokio-rusqlite) | `b10df82e3bbc4f4700562a14a3a00714cbc2f0c7` | `spiceai` |
+| [vortex](#vortex) | `ba043de0ab6e214e825932210cc336b7ce5e8309` | `spiceai-54` |
+
+`spiceai/spice-rs` and `spiceai/spicebench` are also pinned as git dependencies but
+are not forks — they are Spice repositories with no upstream, so nothing can drop a
+patch from them. They are excluded from the guard.
+
+---
+
+## vortex
+
+Upstream [vortex-data/vortex](https://github.com/vortex-data/vortex). The fork
+carries its own ledger, `SPICE_PATCHES.md`, which tracks the patch set and the
+*fork-side* verification for each. The rows below are the *repo-side* half: what
+fails **here** when a patch goes missing.
+
+The Vortex `vortex-datafusion` crate is vendored into this repo as `crates/vortex`,
+so patches to it are not fork state and are not listed. Only patches to
+`vortex-array`, `vortex-arrow`, `vortex-io`, `vortex-file`, `vortex-layout` and
+`vortex-utils` can be lost by a re-cut.
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| Arrow `Map` alias (`vortex-arrow`), both halves: the `DType` alias and the map-entry recursion in the session importer | Every write of a `Map` column fails with `Array encoding not implemented for Arrow data type Map(...)`. The table is created happily first, so it surfaces only on flush | silent | `crates/vortex/src/persistent/mod.rs::map_column_roundtrips_through_a_vortex_file`, and `crates/cayenne/src/schema.rs::vortex_encodes_exactly_the_types_not_listed_as_unsupported` for the whole type list |
+| Tokio one-shot for the spawned-task result channel (`vortex-io/src/runtime/handle.rs`) | Reentrant waker drop on the cancellation path → `SIGSEGV` under ordinary query cancellation | silent (crash) | `crates/cayenne/tests/vortex_task_cancellation.rs` |
+| Tokio one-shot in `vortex-io/src/runtime/single.rs` | The same hazard on the single-runtime path | silent (crash) | as above |
+| Tokio one-shot for the segment-read result channel (`vortex-file/src/segments/source.rs`) | The same hazard on `ReadFuture`, polled and then dropped on cancellation | silent (crash) | as above |
+| Fixed-offset timezone resolution in timestamp extension types (`vortex-array/src/extension/datetime/timezone.rs`) | Panic `failed to find time zone '+00:00'` reading any `timestamptz` column whose offset is numeric rather than named | silent (panic) | `crates/cayenne/tests/fixed_offset_timezone_test.rs::fixed_offset_timezone_column_survives_a_vortex_file_write` |
+| `set_available_parallelism` (`vortex-utils`) | Vortex sizes encode fan-out and scan lookahead from the machine's core count instead of the process's CPU entitlement, so a limited pod over-subscribes ([#12328](https://github.com/spiceai/spiceai/issues/12328)) | silent | `bin/spiced/tests/cpu_budget.rs::spicepod_cores_size_the_runtime_pools` |
+| `DECIMAL` → floating-point cast applies the scale (fork PR #51) | Decimal columns read back off by a factor of 10^scale | silent (wrong data) | `crates/vortex/src/persistent/mod.rs::test_decimal_to_float_cast_applies_scale` |
+| `UncompressedSizeInBytes` statistic handling | `ColumnStatistics.byte_size` is wrong, so the optimizer mis-sizes joins built over Vortex scans | silent | `crates/vortex/src/persistent/format.rs::propagates_per_column_byte_size` |
+| Target file size respected in the sink (fork PR #33) | The writer ignores `target_file_size_mb` and emits one file per flush regardless of size | silent | `crates/vortex/src/persistent/format.rs::format_plumbs_target_file_size_mb` guards the plumbing only; the sink's own honouring of it is a **GAP** |
+| `vortex.date` → `vortex.timestamp` extension cast (fork PR #28) | Upstream refuses the cast, so a pushed-down `CAST(date_col AS TIMESTAMP)` fails the scan | silent | `crates/vortex/src/persistent/mod.rs::test_date_to_timestamp_extension_cast` guards the kernel. The patch covers `ExtensionArray` only, and the scan reaches a second cast path that it does not patch — see [Open gaps](#open-gaps) |
+| Balanced `list_contains` OR tree for large `IN` lists (fork PR #37) | A large `IN (...)` filter builds a right-leaning OR tree; deep enough and the plan blows the stack during pushdown conversion | silent (crash) | `crates/vortex/src/persistent/mod.rs::test_large_in_list_filter_pushdown_stays_evaluable` |
+| Avoid session lock re-entry in writer init (fork PR #29) | Deadlock in `vortex-file` writer initialisation — the write never completes and the refresh hangs | silent (hang) | **GAP** |
+| Unsupported pushdown node bubbles `TRUE` rather than erroring; empty `IN` list handled (fork PR #8) | A predicate Vortex cannot convert fails the scan instead of degrading to "keep the row" | silent | vendored: the pushdown conversion now lives in `crates/vortex/src/convert/exprs.rs`, guarded by `test_empty_in_list_conversion_produces_boolean_literal` and the `can_be_pushed_down` unsupported-operand cases |
+| Intra-file decode parallelism — sub-split large chunk spans (fork PR #62) | Scan throughput on large chunk spans drops to single-stream decode | silent (perf) | **GAP** — a perf-only row; see [Open gaps](#open-gaps) for why it is deliberately unguarded |
+
+## datafusion
+
+Upstream [apache/datafusion](https://github.com/apache/datafusion), branch
+`spiceai-54`. The branch also carries upstream's own `[branch-52]`/`[branch-53]`/
+`[branch-54]` backports; those are upstream commits and are not Spice patches.
+
+The unparser rows are the highest-consequence set in this file: every one of them
+changes the SQL sent to a federated engine, and every failure mode is *more or fewer
+rows than the plan asked for*, with no error.
+
+Every guard naming `crates/data_components/src/federation.rs` needs the crate's
+`federation` feature, which is **not** in its defaults:
+
+```sh
+cargo test -p data_components --features federation --lib federation::
+```
+
+Without it the module is not compiled and the whole file is skipped — the run is
+green and reports nothing, which is the same shape as the loss these guards exist to
+catch.
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| Unparser: a `fetch` pushed into a join input keeps its own scope (fork PR #197) | The remote engine is asked for the whole table and the join is evaluated over it — more rows than the plan ([#12406](https://github.com/spiceai/spiceai/issues/12406)) | silent (wrong data) | `crates/data_components/src/federation.rs::a_fetch_pushed_into_a_join_input_survives_unparsing` |
+| Unparser: a `Filter` above a `Limit` keeps the limit scoped (fork PR #198) | SQL evaluates `WHERE` before `LIMIT`, so the limit selects from filtered rows instead of bounding them ([#12591](https://github.com/spiceai/spiceai/issues/12591)) | silent (wrong data) | `…::a_filter_above_a_limit_keeps_the_limit_scoped` |
+| Unparser: `ORDER BY` kept out of a derived table when the sort key is computed (fork PR #191) | The ordering is emitted inside a derived table, which SQL does not require the outer query to preserve — rows come back in any order | silent (wrong order) | `…::a_computed_sort_key_keeps_order_by_at_the_top_level` |
+| Unparser: a stacked aggregate is unparsed as a derived table (fork PR #192) | An aggregate over an aggregate is flattened into one query, changing the grouping | silent (wrong data) | `…::a_stacked_aggregate_keeps_its_inner_group_by`, `…::a_grouped_stacked_aggregate_binds_its_outer_clauses_through_the_derived_scope` |
+| Unparser: a bounded `EXISTS` build side is scoped, so its limit selects rows (fork PR #201) | The limit binds to the correlated subquery rather than the build side, so the `EXISTS` matches rows it should not | silent (wrong data) | `…::a_bounded_exists_build_side_is_scoped_outside_the_correlation`, `…::an_offset_only_exists_build_side_is_scoped_outside_the_correlation`, `…::an_unbounded_exists_build_side_is_left_unscoped` |
+| Unparser: refuse an `EXISTS` bound that cannot be scoped, rather than emit wrong rows (fork PR #205) | The unparser silently emits SQL that returns wrong rows for the shapes it cannot scope ([#13277](https://github.com/spiceai/spiceai/issues/13277)) | silent (wrong data) | `…::a_bounded_exists_refuses_a_correlation_naming_two_build_inputs`, `…::a_bounded_exists_refuses_a_correlation_qualified_by_the_probe` |
+| Unparser: name a derived table's unnamed outputs (fork PR #206) | A derived table with an unnamed output column produces SQL the remote engine rejects, or binds the wrong column ([#12751](https://github.com/spiceai/spiceai/issues/12751)) | silent (wrong data / query failure) | `…::a_derived_tables_unnamed_outputs_are_named` |
+| Unparser: empty `Projection` emits `SELECT 1` | A projection with no expressions unparses to `SELECT FROM …`, which is not valid SQL, so the federated query fails outright | silent (query failure) | `…::an_empty_projection_does_not_unparse_to_an_empty_select_list` |
+| Unparser: `AT TIME ZONE` faithfully unparsed (fork PR #160), and suppressed for fixed-offset timezones on DuckDB (fork PR #195) | The timezone is dropped from the SQL, so the remote engine evaluates the expression in its own session timezone | silent (wrong data) | `…::a_timezone_survives_unparsing_except_where_the_engine_cannot_resolve_it` |
+| BigQuery dialect: `FLOAT64` not `DOUBLE`, timestamp literal format, `date_field_extract_style` / `interval_style` overrides, `date_trunc` support, no column alias inside a table alias (fork PRs #144, #146, #147, #148, #169) | Federated BigQuery queries are rejected by BigQuery, or silently coerce types | silent (query failure) | `…::bigquery_names_the_float_type_the_way_bigquery_does` covers the type spelling; the remaining four are a **GAP** |
+| `supports_subquery_in_join_predicate` dialect flag (fork PR #151) | A subquery is emitted inside a `JOIN … ON`, which several engines reject | build (flag) + silent (behaviour) | **GAP** |
+| Metadata columns (`_location`, `_last_modified`, `_size`) on `ListingOptions`/`FileScanConfig`, and their projection, pushdown and statistics handling | Datasets that select file metadata columns lose them, or project the wrong column | build | `crates/data-connector-api/src/listing/connector.rs` (metadata-column tests) |
+| Object-version pinning on `ListingOptions` (`with_object_versioning_type`) | A scan stops pinning the object version, so a file replaced mid-scan is read half-old and half-new | build (API) + silent (behaviour) | `crates/data-connector-api/src/listing/connector.rs::a_versioned_parquet_read_pins_every_request_to_one_object_version` |
+| Placeholder type inference (`Expr::infer_placeholder_types`, incl. `CASE`, `LIMIT`/`OFFSET` `Int64`, name/metadata preservation) (fork PRs #87, #88, #89) | A parameterised query fails to plan, or infers the wrong type for `$1` | silent (query failure) | **GAP** |
+| Eager-aggregation physical optimizer rule (`datafusion/physical-optimizer/src/eager_aggregation.rs`, ~3000 lines, Spice-only) | Aggregations stop being pushed below joins — a large planned regression, not a correctness one | silent (perf) | **GAP** |
+| Pluggable `CollectLeftAccumulator` seam on `HashJoinExec` | Cayenne's custom left-side accumulator cannot be installed | build | compile-guarded by `crates/cayenne` |
+
+## arrow-rs
+
+Upstream [apache/arrow-rs](https://github.com/apache/arrow-rs), branch
+`lukim/spiceai-58.3.0`. The whole patch is one file,
+`parquet/src/arrow/async_reader/store.rs`.
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `ParquetObjectReader::new_with_meta` — take `ObjectMeta` so the file size is known up front | The reader falls back to suffix range requests, which Azure Blob Storage does not support: Parquet reads over ABFS fail or take an extra round trip per file | build (constructor) | `crates/runtime/tests/abfs/mod.rs::test_azure_parquet_reading_with_object_meta` (needs Azurite) |
+| `with_object_versioning_type` — attach `if_match`/`version` to every metadata, byte-range and suffix fetch | The reader stops pinning the object version. A file replaced between the metadata read and the data reads is read as a mixture of both — the footer of one file, the pages of another | build (API) + silent (behaviour) | `crates/data-connector-api/src/listing/connector.rs::a_versioned_parquet_read_pins_every_request_to_one_object_version` |
+| `get_byte_ranges` override — coalesce ranges through `get_opts` rather than `ObjectStore::get_ranges` | Version pinning is dropped for the data reads specifically (the metadata read keeps it), and range coalescing is lost, so a scan issues one request per column chunk | silent | as above |
+
+## datafusion-ballista
+
+Upstream [apache/datafusion-ballista](https://github.com/apache/datafusion-ballista),
+branch `spiceai-54`. The fork carries its own inventory, `SPICE_FORK_CHANGES.md`.
+This fork is heavily Spice-modified — distributed execution is largely our code —
+so the rows below name the contracts, not every commit.
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| Cluster RPC TLS and API-key auth (fork PR #3) | Scheduler/executor traffic falls back to plaintext and unauthenticated | silent (security) | `crates/runtime/tests/tls/mod.rs` (two guards) |
+| Object-store shuffle storage (S3/Azure), `PrefixStore` wrapping, single-stream IPC per partition (fork PRs #9, #18, #40–#43) | Shuffles fall back to local disk, or S3 shuffle paths resolve to the wrong key | silent | `crates/runtime/tests/cluster/distributed_acceleration.rs` and the rest of `crates/runtime/tests/cluster/` |
+| In-memory shuffle storage with remote-fetch fallback (fork PRs #7, #8) | Every shuffle round-trips through storage | silent (perf) | `crates/runtime/tests/cluster/in_memory_shuffle.rs` |
+| Shuffle-fetch resilience: retry on a fresh connection, h2 receive-window sizing, bounded read inactivity, unordered stream consumption (fork PRs #61, #62, #63) | A transient fetch failure fails the whole query; large shuffles stall | silent | **GAP** |
+| Scheduler lock hygiene across persists and awaits (fork PR #60) | Cluster wedge / runtime freeze under load | silent (hang) | **GAP** |
+| Don't swap null-aware anti joins in `JoinSelection` (fork PR #58) | A distributed anti-join returns wrong rows | silent (wrong data) | **GAP** |
+| Vortex columnar shuffle format (fork PR #7) | Shuffles fall back to Arrow IPC | build | compile-guarded |
+| Stuck-query detection and stale `TaskStatus` rejection (fork PRs #39, #53) | A reset partition's stale status is accepted, corrupting the execution graph | silent | **GAP** |
+
+## datafusion-federation and datafusion-table-providers
+
+Upstream `datafusion-contrib/*`. Both are **Spice-maintained in practice** — upstream
+has not moved in a long time and essentially the entire content of these forks is
+ours (`datafusion-federation`: 148 commits ahead; `datafusion-table-providers`: 251).
+
+Their exposure is different in kind, not absent. Both are still re-cut per DataFusion
+major, but the base of the new branch is *our own* previous branch rather than a moved
+upstream, so a patch dropped in a conflict resolution stays visible in our own `git`
+history instead of being replaced by upstream code. That makes the loss recoverable
+and attributable, which is what the per-patch tables above exist to provide, so no
+table is kept for these two.
+
+What does cover them is the federation and SQL-connector integration suites
+(`crates/runtime/tests/{postgres,mysql,sqlite,duckdb,clickhouse,…}` and
+`crates/data_components/src/federation.rs`), which exercise these forks on every run
+rather than patch by patch.
+
+Two things would change that and mean giving each a table here: either fork being
+rebased onto a moved upstream, or upstream resuming releases we track.
+
+## duckdb-rs
+
+Upstream [duckdb/duckdb-rs](https://github.com/duckdb/duckdb-rs), branch
+`spiceai-1.5.5`.
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `duckdb_arrow_scan` support — `register_arrow_scan_view` for Arrow-stream ingestion (fork PR #18) | DuckLake writes and Arrow-stream ingestion have no path in | build | `crates/data_components/src/ducklake/writer.rs` calls it |
+| ICU extension statically linked into bundled DuckDB (fork PR #23) | Any query using a named timezone (`AT TIME ZONE 'America/New_York'`) fails at runtime, and DuckDB tries to download the extension from the network | silent (query failure) | `crates/accelerators/accelerator-duckdb/src/lib.rs::bundled_duckdb_resolves_a_named_time_zone_without_installing_icu` |
+| VSS (HNSW) extension statically linked (fork PR #37) | Vector search over a DuckDB accelerator fails, or silently falls back to a full scan | silent (query failure) | `crates/accelerators/accelerator-duckdb/src/lib.rs::bundled_duckdb_builds_an_hnsw_index_without_installing_vss` |
+| Bundled DuckDB version pinned to the release (fork PR #38) | Extension downloads resolve against a mismatched DuckDB version and fail | silent | covered by the two extension guards above |
+
+## iceberg-rust
+
+Upstream [apache/iceberg-rust](https://github.com/apache/iceberg-rust), branch
+`spiceai-0.10.1-df-54`.
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `RowDeltaAction` for row-level deletes via delete files (fork PR #28) | `DELETE` against an Iceberg table has no commit path | build | `crates/data_components/src/iceberg/delete.rs` calls `tx.row_delta()` |
+| SigV4 signing middleware for REST catalogs on AWS Glue | Glue-backed Iceberg catalogs fail to authenticate | build (module) + silent (signing) | `crates/runtime/src/catalogconnector/iceberg.rs` wires `rest.sigv4-enabled`; end-to-end signing is a **GAP** |
+| Limit push-down for `IcebergTableProvider` (fork PR #19) | `SELECT … LIMIT n` scans the whole table | silent (perf) | partial: `crates/runtime/src/cluster/datafusion/codec/spice_physical_codec.rs` refuses to serialise a scan whose limit it cannot carry, so the distributed path cannot silently drop it. That the single-node scan *applies* the limit is a **GAP** |
+| Pinned snapshot reads in `IcebergTableProvider` (fork PR #45) | A scan reads the current snapshot instead of the pinned one — time-travel and repeatable reads silently return live data | silent (wrong data) | **GAP** |
+| Parallel file scanning with eager task bucketing (fork PR #43) | Iceberg scans lose file-level parallelism | silent (perf) | **GAP** |
+| `IcebergTableProvider::try_new` made public; extended file metadata | No construction path from Spice | build | compile-guarded |
+
+## async-openai
+
+Upstream [64bit/async-openai](https://github.com/64bit/async-openai).
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `reasoning_content` on `ChatCompletionResponseMessage` | Reasoning models' output is dropped from responses | build | every provider in `crates/llms` constructs the field |
+| Azure Entra token auth in `config.rs` | Azure OpenAI with Entra credentials cannot authenticate | build | compile-guarded |
+| `post`/`post_stream` and the GET operation made public | Non-OpenAI providers built on the same client lose their entry point | build | compile-guarded |
+| Don't serialize nulls; hide `usage` when null | Requests carry explicit `null`s that some OpenAI-compatible servers reject | silent (request failure) | **GAP** |
+| `Eq`/`Hash` on `EmbeddingInput` and `CreateEmbeddingRequest` | Embedding request caching cannot key on the request | build | compile-guarded |
+| Aggregated rate-limit retry logging; `retry-after` honoured from the response header (fork PRs #37, #38) | One `WARN` per retried request instead of one per burst; retries ignore the server's back-off hint | silent (log noise, throughput) | **GAP** |
+
+## clickhouse-rs
+
+Upstream [gengteng/clickhouse-rs](https://github.com/gengteng/clickhouse-rs), pinned
+by tag `0.2.2`.
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `Date32` support — `DateConverter for i32`, `Value`/`ValueRef::Date32`, `FromSql for NaiveDate` | ClickHouse `Date32` columns (dates outside 1970–2149) fail to decode | build (variant) + silent (range) | **GAP** — `crates/data-connectors/connector-clickhouse/src/block_to_arrow.rs` covers `Date` only |
+| `ConnectionError::NoPacketReceived` | A dropped connection surfaces as a less specific error | build | compile-guarded |
+
+## rusqlite and tokio-rusqlite
+
+Upstream [rusqlite/rusqlite](https://github.com/rusqlite/rusqlite) and
+[programatik29/tokio-rusqlite](https://github.com/programatik29/tokio-rusqlite).
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `bundled-decimal` — SQLite's `decimal` extension compiled into `libsqlite3-sys` and exposed as `sqlite3_decimal_init` | The SQLite accelerator cannot register the decimal extension, so decimal columns compare and sort as text | build (symbol) + silent (comparison) | `crates/accelerators/accelerator-sqlite/src/lib.rs::test_sqlite_decimal_round_trip` |
+| `tokio-rusqlite`: relaxed `rusqlite` version bound | Version resolution fails | build | compile-guarded |
+
+## sea-query
+
+Upstream [SeaQL/sea-query](https://github.com/SeaQL/sea-query).
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| SQLite backend emits a decimal declared type rather than panicking above 16 digits | `CREATE TABLE` for a `Decimal256(40, 4)` column panics; below that the declared type changes, and the SQLite reader keys value decoding off the declared type | silent (panic / wrong decode) | `crates/accelerators/accelerator-sqlite/src/lib.rs::test_sqlite_decimal_round_trip` |
+
+## snowflake-rs
+
+Upstream [andrusha/snowflake-rs](https://github.com/andrusha/snowflake-rs), branch
+`spiceai-58`.
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| Streaming Arrow batches instead of collecting the whole result | Large Snowflake queries materialise fully in memory — OOM risk | silent (memory) | **GAP** |
+| Async query response support | Long-running Snowflake queries time out | silent | **GAP** |
+| Chunked JSON responses | Large JSON-format results are truncated | silent (wrong data) | **GAP** |
+| Record-batch ordering fix | Result batches come back in the wrong order | silent (wrong order) | **GAP** |
+| Invalid warehouse/account errors surfaced correctly | A misconfigured warehouse produces an opaque error instead of an actionable one | silent (message) | **GAP** |
+
+## graph-rs-sdk
+
+Upstream [sreeise/graph-rs-sdk](https://github.com/sreeise/graph-rs-sdk).
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| Default drive for `Group` | SharePoint group-scoped datasets cannot resolve their drive | build | compile-guarded by `crates/data-connectors/connector-sharepoint` |
+| Tower service setup moved to `RequestHandler` (upstream PR #494) | Middleware (retry, tracing) is not applied to Graph requests | silent | **GAP** |
+
+## docx-rs
+
+Upstream [bokuweb/docx-rs](https://github.com/bokuweb/docx-rs).
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `Render` trait for `Document`/`DocumentChild`, including paragraph newlines and table rendering | `.docx` documents cannot be turned into text — the document parser has no extraction path | build (trait) | `crates/document_parse/src/docx.rs` imports `docx_rs::Render` |
+| Paragraph and table newline placement | Extracted text runs together, changing chunk boundaries and therefore embeddings | silent (wrong text) | **GAP** |
+
+## model2vec-rs
+
+Upstream [MinishLab/model2vec-rs](https://github.com/MinishLab/model2vec-rs).
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| IDs-only fast WordPiece tokenizer for the potion models | Static embedding throughput drops sharply | silent (perf) | **GAP** |
+| `config.json` made optional for sentence-transformers compatibility | Loading a sentence-transformers static model fails | silent (load failure) | **GAP** |
+| HF cache directory read from the environment | Models are re-downloaded instead of reusing the shared cache | silent | **GAP** |
+
+## text-splitter
+
+Upstream [benbrandt/text-splitter](https://github.com/benbrandt/text-splitter).
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| Tokenizer sizing accounts for special characters (`src/chunk_size/huggingface.rs`) | Chunks are sized without the tokenizer's special tokens, so a chunk can exceed the model's context window at embed time | silent (embedding failure / truncation) | **GAP** — `crates/chunking` tests cover the splitter, not the sizing |
+
+## mistral.rs and text-embeddings-inference
+
+Upstream [EricLBuehler/mistral.rs](https://github.com/EricLBuehler/mistral.rs) and
+[huggingface/text-embeddings-inference](https://github.com/huggingface/text-embeddings-inference).
+
+The `mistral.rs` fork's base is `master@2d4ba4f16`, not a release tag, and it carries
+71 commits. Most are Spice-side integration (dependency re-pointing onto
+`spiceai/candle`, logging removal so the loader does not install a global
+subscriber).
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `mistral.rs`: i-quant MoE `index_select` + in-place row dequant | ~34% slower local MoE inference | silent (perf) | **GAP** |
+| `mistral.rs`: assistant messages with `tool_calls` handled in the chat template | Tool-calling conversations render wrong prompts, so the model loses tool context | silent (wrong output) | **GAP** |
+| `mistral.rs`: `tracing_subscriber.init()` removed from the loaders | The loader installs a global subscriber and hijacks `spiced`'s logging | silent (logging) | **GAP** |
+| `mistral.rs`: candle dependency re-pointed at `spiceai/candle` | Two candle versions in the graph | build | compile-guarded |
+| `text-embeddings-inference`: Spice integration + candle re-pointing | Local embedding models fail to load | build | compile-guarded |
+| `text-embeddings-inference`: pooling/model-loading fixes | Embeddings differ from the reference implementation | silent (wrong vectors) | **GAP** |
+
+## candle and its kernel crates
+
+Upstream [huggingface/candle](https://github.com/huggingface/candle) plus the
+`candle-cublaslt`, `candle-layer-norm`, `candle-rotary` and `candle-index-select-cu`
+kernel crates.
+
+The kernel-crate forks are build-only: Windows/MSVC build fixes, `-fPIC`, and
+`cudarc`/`candle` version bounds. They carry no Spice behaviour, so a re-cut cannot
+lose one silently — it fails to build.
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `candle`: i-quant MoE kernels and `slice_assign`/`set_dtype` extensions (carried with the mistral.rs squash) | Local MoE inference regresses in speed, or fails to run quantised MoE models | silent (perf) / build | `crates/llms` model tests cover loading; the kernel behaviour is a **GAP** |
+| `candle`: A10G CUDA header fix | CUDA builds fail on A10G | build | compile-guarded |
+| `candle-index-select-cu`: fallback-only shim | GPU index-select falls back to the slow path silently | silent (perf) | **GAP** |
+
+## spark-connect-rs
+
+Upstream [sjrusso8/spark-connect-rs](https://github.com/sjrusso8/spark-connect-rs).
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| Default to the `http` scheme when `use_ssl` is false | A non-TLS Spark Connect endpoint is dialled over TLS and the connection fails | silent (connection failure) | **GAP** |
+| Edmondo fork changes merged in | Spark Connect features Spice depends on go missing | build | compile-guarded |
+
+## delta-kernel-rs
+
+Upstream [delta-io/delta-kernel-rs](https://github.com/delta-io/delta-kernel-rs),
+branch `spiceai-0.23.0`.
+
+**No Spice patches.** Both patches that existed on the earlier 0.18.x fork line —
+timestamp-column file skipping, and `ParquetObjectReader` Azure suffix-range handling
+— landed upstream and are present unmodified in v0.23.0. The pin is byte-identical to
+upstream v0.23.0 plus the fork's own `SPICE_PATCHES.md`.
+
+Re-confirm this at the next bump rather than assuming it: if a Spice patch becomes
+necessary again, it needs a row here and a guard.
+
+## Dependency-only forks
+
+These forks exist to move a dependency version, not to change behaviour. A lost
+patch is a build failure, so no behaviour guard applies.
+
+| Fork | Why it is forked |
+|---|---|
+| `reqwest-eventsource` | `reqwest` 0.13 bound |
+| `tiberius` | `rustls` 0.23 upgrade, and feature-gating so the TLS modules compile with TLS off |
+| `tokio-rusqlite` | `rusqlite` 0.40 bound |
+| `candle-cublaslt`, `candle-layer-norm`, `candle-rotary` | Windows/MSVC CUDA build fixes and `cudarc`/`candle` version bounds |
+
+---
+
+## Open gaps
+
+The rows above marked **GAP** have no repo-side guard. They are not equal in
+consequence; this is the order to close them in.
+
+**Wrong data, silently.** These change query results:
+
+1. `datafusion` BigQuery dialect: timestamp literal format, `date_field_extract_style`
+   / `interval_style`, `date_trunc`, table-alias column aliases (fork PRs #144, #146,
+   #148, #169).
+2. `datafusion` `supports_subquery_in_join_predicate` (fork PR #151).
+3. `datafusion` placeholder type inference (fork PRs #87, #88, #89).
+4. `iceberg-rust` pinned snapshot reads (fork PR #45) — time travel silently reads live data.
+5. `datafusion-ballista` null-aware anti-join swap (fork PR #58).
+6. `snowflake-rs` chunked JSON responses and record-batch ordering.
+7. `clickhouse-rs` `Date32` range.
+8. `text-splitter` special-character sizing, and `docx-rs` newline placement — both
+   change the text that gets embedded.
+9. `mistral.rs` `tool_calls` chat-template handling.
+
+**Hangs, crashes and failures.** These take a query or the process down:
+
+10. `vortex` session lock re-entry in writer init (fork PR #29).
+11. `datafusion-ballista` scheduler lock hygiene (fork PR #60) and shuffle-fetch
+    resilience (fork PRs #61–#63).
+12. `async-openai` null-suppression in requests.
+13. `spark-connect-rs` `http` scheme when `use_ssl` is false.
+14. `model2vec-rs` optional `config.json`.
+
+**Performance only.** A lost patch here costs throughput, not correctness. These are
+deliberately left to the benchmark suites (`testoperator`, the CH-benCH lab runs and
+the scheduled TPC-H/TPC-DS jobs), which already trend these numbers over time and
+will show the regression as a step change. A unit test cannot assert a speedup
+without becoming a flaky timing test:
+
+15. `vortex` intra-file decode parallelism; `iceberg-rust` parallel file scanning;
+    `datafusion` eager aggregation; `mistral.rs`/`candle` i-quant MoE kernels;
+    `candle-index-select-cu` fallback shim; `model2vec-rs` fast WordPiece;
+    `snowflake-rs` streaming batches (memory, not latency — worth a guard if a
+    cheap one exists); `async-openai` retry-after handling.
+
+**A patch that is present but incomplete.** Found while writing the guard above,
+so it is a defect rather than a coverage gap:
+
+18. `vortex.date` → `vortex.timestamp` (fork PR #28) registers its cast kernel on
+    `ExtensionArray`. A scan also evaluates a pushed-down predicate against
+    *constant* arrays built from chunk statistics, and that path resolves a
+    different kernel, which the fork does not patch. A `SELECT … WHERE
+    CAST(date_col AS TIMESTAMP) > TIMESTAMP '…'` over a Vortex file therefore fails
+    the scan outright with:
+
+    ```
+    No CastReduce to cast constant array from vortex.date[days](i32?) to vortex.timestamp[ns](i64?)
+    ```
+
+    Reproduced on the pin above against a four-row table. The kernel guard passes,
+    so this is not caught by the row above and needs a fix on the fork, not a test
+    here.
+
+**Security posture.** No correctness effect, but a silent downgrade:
+
+16. `iceberg-rust` end-to-end SigV4 signing against a Glue REST catalog.
+17. `graph-rs-sdk` tower middleware application.

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -429,10 +429,13 @@ patch is a build failure, so no behaviour guard applies.
 
 ## Open gaps
 
-The rows above marked **GAP** have no repo-side guard. They are not equal in
-consequence; this is the order to close them in.
+**36 rows above are marked GAP** — they have no repo-side guard. Every one of them
+is accounted for below; `scripts/check_fork_patches.py` fails if that count and this
+sentence disagree, so the list cannot quietly fall behind the tables.
 
-**Wrong data, silently.** These change query results:
+They are not equal in consequence; this is the order to close them in.
+
+**Wrong data or wrong text, silently.** These change what a user gets back:
 
 1. `datafusion` BigQuery dialect: timestamp literal format, `date_field_extract_style`
    / `interval_style`, `date_trunc`, table-alias column aliases (fork PRs #144, #146,
@@ -441,20 +444,45 @@ consequence; this is the order to close them in.
 3. `datafusion` placeholder type inference (fork PRs #87, #88, #89).
 4. `iceberg-rust` pinned snapshot reads (fork PR #45) — time travel silently reads live data.
 5. `datafusion-ballista` null-aware anti-join swap (fork PR #58).
-6. `snowflake-rs` chunked JSON responses and record-batch ordering.
-7. `clickhouse-rs` `Date32` range.
-8. `text-splitter` special-character sizing, and `docx-rs` newline placement — both
+6. `datafusion-ballista` stuck-query detection and stale `TaskStatus` rejection (fork
+   PRs #39, #53) — a reset partition's stale status corrupts the execution graph.
+7. `snowflake-rs` chunked JSON responses and record-batch ordering.
+8. `clickhouse-rs` `Date32` range.
+9. `text-splitter` special-character sizing, and `docx-rs` newline placement — both
    change the text that gets embedded.
-9. `mistral.rs` `tool_calls` chat-template handling.
+10. `mistral.rs` `tool_calls` chat-template handling.
+11. `text-embeddings-inference` pooling and model-loading fixes — embeddings differ
+    from the reference implementation.
 
 **Hangs, crashes and failures.** These take a query or the process down:
 
-10. `vortex` session lock re-entry in writer init (fork PR #29).
-11. `datafusion-ballista` scheduler lock hygiene (fork PR #60) and shuffle-fetch
+12. `vortex` session lock re-entry in writer init (fork PR #29).
+13. `datafusion-ballista` scheduler lock hygiene (fork PR #60) and shuffle-fetch
     resilience (fork PRs #61–#63).
-12. `async-openai` null-suppression in requests.
-13. `spark-connect-rs` `http` scheme when `use_ssl` is false.
-14. `model2vec-rs` optional `config.json`.
+14. `async-openai` null-suppression in requests.
+15. `spark-connect-rs` `http` scheme when `use_ssl` is false.
+16. `model2vec-rs` optional `config.json`.
+17. `snowflake-rs` async query response support — long-running queries time out.
+
+**Wrong shape, but bounded.** Neither wrong rows nor an outage; a knob that stops
+being honoured:
+
+18. `vortex` target file size in the sink (fork PR #33) — the plumbing is guarded,
+    the sink's own honouring of `target_file_size_mb` is not, so the writer can emit
+    one file per flush regardless of size.
+19. `iceberg-rust` single-node limit application (fork PR #19) — the distributed path
+    cannot silently drop the limit, the single-node scan can.
+20. `snowflake-rs` invalid warehouse/account errors surfaced correctly — a
+    misconfigured warehouse produces an opaque error instead of an actionable one.
+21. `model2vec-rs` HF cache directory read from the environment — models are
+    re-downloaded instead of reusing the shared cache.
+22. `mistral.rs` `tracing_subscriber.init()` removed from the loaders — the loader
+    installs a global subscriber and hijacks `spiced`'s logging.
+
+**Security posture.** No correctness effect, but a silent downgrade:
+
+23. `iceberg-rust` end-to-end SigV4 signing against a Glue REST catalog.
+24. `graph-rs-sdk` tower middleware application.
 
 **Performance only.** A lost patch here costs throughput, not correctness. These are
 deliberately left to the benchmark suites (`testoperator`, the CH-benCH lab runs and
@@ -462,31 +490,27 @@ the scheduled TPC-H/TPC-DS jobs), which already trend these numbers over time an
 will show the regression as a step change. A unit test cannot assert a speedup
 without becoming a flaky timing test:
 
-15. `vortex` intra-file decode parallelism; `iceberg-rust` parallel file scanning;
+25. `vortex` intra-file decode parallelism; `iceberg-rust` parallel file scanning;
     `datafusion` eager aggregation; `mistral.rs`/`candle` i-quant MoE kernels;
     `candle-index-select-cu` fallback shim; `model2vec-rs` fast WordPiece;
     `snowflake-rs` streaming batches (memory, not latency — worth a guard if a
     cheap one exists); `async-openai` retry-after handling.
 
-**A patch that is present but incomplete.** Found while writing the guard above,
-so it is a defect rather than a coverage gap:
+## A patch that is present but incomplete
 
-18. `vortex.date` → `vortex.timestamp` (fork PR #28) registers its cast kernel on
-    `ExtensionArray`. A scan also evaluates a pushed-down predicate against
-    *constant* arrays built from chunk statistics, and that path resolves a
-    different kernel, which the fork does not patch. A `SELECT … WHERE
-    CAST(date_col AS TIMESTAMP) > TIMESTAMP '…'` over a Vortex file therefore fails
-    the scan outright with:
+Found while writing the guard for it, so it is a defect rather than a coverage gap,
+and it is not one of the 36 above.
 
-    ```
-    No CastReduce to cast constant array from vortex.date[days](i32?) to vortex.timestamp[ns](i64?)
-    ```
+`vortex.date` → `vortex.timestamp` (fork PR #28) registers its cast kernel on
+`ExtensionArray`. A scan also evaluates a pushed-down predicate against *constant*
+arrays built from chunk statistics, and that path resolves a different kernel, which
+the fork does not patch. A `SELECT … WHERE CAST(date_col AS TIMESTAMP) > TIMESTAMP '…'`
+over a Vortex file therefore fails the scan outright with:
 
-    Reproduced on the pin above against a four-row table. The kernel guard passes,
-    so this is not caught by the row above and needs a fix on the fork, not a test
-    here.
+```
+No CastReduce to cast constant array from vortex.date[days](i32?) to vortex.timestamp[ns](i64?)
+```
 
-**Security posture.** No correctness effect, but a silent downgrade:
-
-16. `iceberg-rust` end-to-end SigV4 signing against a Glue REST catalog.
-17. `graph-rs-sdk` tower middleware application.
+Reproduced on the pin above against a four-row table. The kernel guard passes, so
+this is not caught by the row it belongs to and needs a fix on the fork, not a test
+here.

--- a/scripts/check_fork_patches.py
+++ b/scripts/check_fork_patches.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Fork-pin drift guard.
+#
+# Spice carries patches on forks of upstream crates. Those patches exist only as
+# commits on a fork branch, and every fork branch is re-cut when its upstream
+# releases a new major. A patch that is not deliberately carried across the
+# re-cut is lost silently: nothing fails, the crate reverts to upstream
+# behaviour, and the bug it fixed comes back in the next Spice release. It has
+# happened — twice in the Vortex fork alone (spiceai/spiceai#13524, and the
+# reentrant-waker use-after-free that shipped as a SIGSEGV).
+#
+# `docs/dev/fork_patches.md` is the ledger: every fork, the revision this
+# workspace pins, and for every patch the repo-side test that fails if the patch
+# goes missing. This guard keeps the ledger honest by pinning it to `Cargo.lock`:
+# move a pin without re-auditing the ledger and the build fails here, which is
+# the moment the audit is cheap and the loss is still recoverable.
+#
+# `Cargo.lock` is the authority rather than `Cargo.toml` because it resolves tags
+# and branch specs to the commit cargo actually builds.
+#
+# Usage:
+#   scripts/check_fork_patches.py          # validate (exit 1 on drift)
+#   scripts/check_fork_patches.py --list   # print every fork and its status
+#
+# Pure stdlib; no third-party deps.
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+LEDGER = REPO / "docs" / "dev" / "fork_patches.md"
+LOCK = REPO / "Cargo.lock"
+
+# A `Cargo.lock` source line for a crate that comes from a fork in the spiceai
+# org, e.g.
+#   source = "git+https://github.com/spiceai/vortex.git?rev=ba043de0…#ba043de0…"
+# The fragment after `#` is the resolved commit, which is what a pin means no
+# matter whether the manifest asked for a rev, a tag or a branch.
+LOCK_SOURCE_RE = re.compile(
+    r'^source = "git\+https://github\.com/spiceai/(?P<repo>[^/?#"]+?)(?:\.git)?\?[^#"]*#(?P<rev>[0-9a-f]{40})"$',
+    re.M,
+)
+
+# A ledger pin row:
+#   | [vortex](#vortex) | `ba043de0ab6e214e825932210cc336b7ce5e8309` | `spiceai-54` | … |
+# The repo name is read from the link text so the row stays a working anchor.
+LEDGER_ROW_RE = re.compile(
+    r"^\|\s*\[(?P<repo>[A-Za-z0-9._-]+)\]\([^)]*\)\s*\|\s*`(?P<rev>[0-9a-f]{40})`\s*\|",
+    re.M,
+)
+
+# Repositories in the spiceai org that are not forks: they have no upstream, so
+# nothing can drop a patch from them and there is nothing to audit. Everything
+# else needs a ledger row, including forks that carry no patch today — "no
+# patches" is a finding to re-confirm at the next bump, not a reason to leave a
+# fork undocumented.
+NOT_FORKS = frozenset({"spice-rs", "spicebench"})
+
+
+def pinned_forks(lock_text: str) -> dict[str, set[str]]:
+    """Every spiceai fork in the lockfile, mapped to the revisions pinned for it.
+
+    A repo maps to more than one revision only if the workspace pins two
+    different commits of it at once, which is a mistake in its own right; the
+    caller reports it rather than picking one.
+    """
+    forks: dict[str, set[str]] = {}
+    for match in LOCK_SOURCE_RE.finditer(lock_text):
+        repo = match.group("repo")
+        if repo in NOT_FORKS:
+            continue
+        forks.setdefault(repo, set()).add(match.group("rev"))
+    return forks
+
+
+def ledger_pins(ledger_text: str) -> dict[str, list[str]]:
+    """Every fork the ledger records, mapped to the revisions its rows claim."""
+    pins: dict[str, list[str]] = {}
+    for match in LEDGER_ROW_RE.finditer(ledger_text):
+        pins.setdefault(match.group("repo"), []).append(match.group("rev"))
+    return pins
+
+
+def drift(pinned: dict[str, set[str]], recorded: dict[str, list[str]]) -> list[str]:
+    """Every disagreement between what the workspace builds and what the ledger says."""
+    errors = []
+    for repo in sorted(pinned):
+        revs = pinned[repo]
+        if len(revs) > 1:
+            joined = ", ".join(sorted(rev[:12] for rev in revs))
+            errors.append(
+                f"{repo}: the workspace pins {len(revs)} different revisions at once ({joined}); "
+                f"resolve them to one before recording it"
+            )
+            continue
+        rev = next(iter(revs))
+        if repo not in recorded:
+            errors.append(
+                f"{repo}: pinned at {rev[:12]} but has no row in docs/dev/fork_patches.md. "
+                f"Add one recording what Spice patches this fork carries and which test in this "
+                f"repo fails if each is lost"
+            )
+            continue
+        rows = recorded[repo]
+        if len(rows) > 1:
+            errors.append(f"{repo}: has {len(rows)} rows in docs/dev/fork_patches.md; keep one per fork")
+            continue
+        if rows[0] != rev:
+            errors.append(
+                f"{repo}: pinned at {rev} but docs/dev/fork_patches.md records {rows[0]}. "
+                f"The pin moved: re-audit the fork's patches against the new revision, confirm each "
+                f"one is still present and still guarded, then update the row"
+            )
+    for repo in sorted(recorded):
+        if repo not in pinned:
+            errors.append(
+                f"{repo}: recorded in docs/dev/fork_patches.md but no longer pinned by Cargo.lock. "
+                f"Drop the row, or the pin"
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="print every fork and its recorded revision")
+    args = parser.parse_args()
+
+    for path in (LOCK, LEDGER):
+        if not path.is_file():
+            print(f"error: {path.relative_to(REPO)} not found", file=sys.stderr)
+            return 1
+
+    pinned = pinned_forks(LOCK.read_text(encoding="utf-8"))
+    recorded = ledger_pins(LEDGER.read_text(encoding="utf-8"))
+
+    if args.list:
+        for repo in sorted(set(pinned) | set(recorded)):
+            lock_rev = ", ".join(sorted(pinned.get(repo, set()))) or "-"
+            doc_rev = ", ".join(recorded.get(repo, [])) or "-"
+            status = "ok" if lock_rev == doc_rev else "DRIFT"
+            print(f"{status:6} {repo:28} lock={lock_rev[:12]:14} ledger={doc_rev[:12]}")
+
+    errors = drift(pinned, recorded)
+    if errors:
+        print(
+            f"\n{len(errors)} fork pin(s) disagree with docs/dev/fork_patches.md:\n",
+            file=sys.stderr,
+        )
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        print(
+            "\nThe ledger is what tells us a fork lost a Spice patch. It is only true of the "
+            "revision it names, so it has to move with the pin.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not args.list:
+        print(f"fork-patch ledger: {len(pinned)} pinned forks, all recorded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_fork_patches.py
+++ b/scripts/check_fork_patches.py
@@ -47,6 +47,15 @@ LOCK_SOURCE_RE = re.compile(
     re.M,
 )
 
+# The count of unguarded patches the "Open gaps" section claims to account for,
+# e.g. "**36 rows above are marked GAP**". Pinned against the tables so the
+# prioritised list cannot quietly fall behind them — a row that gets a **GAP**
+# marker and no entry in that list is a patch the ledger hides.
+GAP_CLAIM_RE = re.compile(r"^\*\*(?P<count>\d+) rows above are marked GAP\*\*", re.M)
+
+# A table row whose Guard cell reports no repo-side coverage.
+GAP_ROW_RE = re.compile(r"^\|.*\*\*GAP\*\*.*\|$", re.M)
+
 # A ledger pin row:
 #   | [vortex](#vortex) | `ba043de0ab6e214e825932210cc336b7ce5e8309` | `spiceai-54` | … |
 # The repo name is read from the link text so the row stays a working anchor.
@@ -85,6 +94,28 @@ def ledger_pins(ledger_text: str) -> dict[str, list[str]]:
     for match in LEDGER_ROW_RE.finditer(ledger_text):
         pins.setdefault(match.group("repo"), []).append(match.group("rev"))
     return pins
+
+
+def gap_accounting(ledger_text: str) -> list[str]:
+    """Whether the "Open gaps" list still accounts for every **GAP** row."""
+    body, _, gaps = ledger_text.partition("## Open gaps")
+    if not gaps:
+        return ["docs/dev/fork_patches.md has no `## Open gaps` section"]
+    marked = len(GAP_ROW_RE.findall(body))
+    claim = GAP_CLAIM_RE.search(gaps)
+    if not claim:
+        return [
+            "docs/dev/fork_patches.md: the `Open gaps` section no longer states how many "
+            "rows it accounts for, so nothing pins it to the tables"
+        ]
+    claimed = int(claim.group("count"))
+    if claimed != marked:
+        return [
+            f"docs/dev/fork_patches.md: {marked} table row(s) are marked **GAP** but the "
+            f"`Open gaps` section accounts for {claimed}. Add the missing patch(es) to that "
+            f"list and update the count, or the ledger hides an unguarded patch"
+        ]
+    return []
 
 
 def drift(pinned: dict[str, set[str]], recorded: dict[str, list[str]]) -> list[str]:
@@ -136,8 +167,9 @@ def main() -> int:
             print(f"error: {path.relative_to(REPO)} not found", file=sys.stderr)
             return 1
 
+    ledger_text = LEDGER.read_text(encoding="utf-8")
     pinned = pinned_forks(LOCK.read_text(encoding="utf-8"))
-    recorded = ledger_pins(LEDGER.read_text(encoding="utf-8"))
+    recorded = ledger_pins(ledger_text)
 
     if args.list:
         for repo in sorted(set(pinned) | set(recorded)):
@@ -146,10 +178,10 @@ def main() -> int:
             status = "ok" if lock_rev == doc_rev else "DRIFT"
             print(f"{status:6} {repo:28} lock={lock_rev[:12]:14} ledger={doc_rev[:12]}")
 
-    errors = drift(pinned, recorded)
+    errors = drift(pinned, recorded) + gap_accounting(ledger_text)
     if errors:
         print(
-            f"\n{len(errors)} fork pin(s) disagree with docs/dev/fork_patches.md:\n",
+            f"\n{len(errors)} problem(s) with docs/dev/fork_patches.md:\n",
             file=sys.stderr,
         )
         for error in errors:

--- a/scripts/check_rust_gate_paths.py
+++ b/scripts/check_rust_gate_paths.py
@@ -67,6 +67,12 @@ RUST_SOURCE_PATHS = (
     ".cargo/config.toml",
     # Holds every -Dclippy::… flag the gate enforces.
     "Makefile",
+    # `check_fork_patches.py` validates this file against `Cargo.lock`, so it is
+    # an input the gate reads. Gated by name rather than derived: nothing in the
+    # `lint-rust` recipe names it, only the guard it feeds. Left ungated, a
+    # ledger-only edit skips the very check that would have rejected it, and the
+    # mismatch surfaces on someone else's unrelated Rust PR.
+    "docs/dev/fork_patches.md",
 )
 
 # Paths that must NOT drag in the Rust gate — otherwise the fast-track is dead

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -730,7 +730,7 @@ post_pending_status() {
 # sync with `rustAffecting` in .github/workflows/pr.yml and covered by the
 # check-code-changes filter; `scripts/check_rust_gate_paths.py` enforces both,
 # and docs/dev/ci_signoff.md explains why each path is here.
-RUST_AFFECTING_PATH_PATTERN='(\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)rust-toolchain(\.toml)?$|(^|/)\.cargo/|(^|/)\.?(clippy|rustfmt)\.toml$|(^|/)nextest\.toml$|(^|/)layers\.toml$|^scripts/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability|fork_patches)\.py$|^Makefile$)'
+RUST_AFFECTING_PATH_PATTERN='(\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)rust-toolchain(\.toml)?$|(^|/)\.cargo/|(^|/)\.?(clippy|rustfmt)\.toml$|(^|/)nextest\.toml$|(^|/)layers\.toml$|^scripts/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability|fork_patches)\.py$|^docs/dev/fork_patches\.md$|^Makefile$)'
 
 # True when the branch delta vs trunk can affect Rust lint/build/tests.
 # Prints nothing. Exit 0 = has Rust-affecting changes (or unknown — run checks).

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -730,7 +730,7 @@ post_pending_status() {
 # sync with `rustAffecting` in .github/workflows/pr.yml and covered by the
 # check-code-changes filter; `scripts/check_rust_gate_paths.py` enforces both,
 # and docs/dev/ci_signoff.md explains why each path is here.
-RUST_AFFECTING_PATH_PATTERN='(\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)rust-toolchain(\.toml)?$|(^|/)\.cargo/|(^|/)\.?(clippy|rustfmt)\.toml$|(^|/)nextest\.toml$|(^|/)layers\.toml$|^scripts/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability)\.py$|^Makefile$)'
+RUST_AFFECTING_PATH_PATTERN='(\.rs$|(^|/)Cargo\.(toml|lock)$|(^|/)rust-toolchain(\.toml)?$|(^|/)\.cargo/|(^|/)\.?(clippy|rustfmt)\.toml$|(^|/)nextest\.toml$|(^|/)layers\.toml$|^scripts/(test_)?check_(crate_layers|table_layers|rust_gate_paths|module_reachability|fork_patches)\.py$|^Makefile$)'
 
 # True when the branch delta vs trunk can affect Rust lint/build/tests.
 # Prints nothing. Exit 0 = has Rust-affecting changes (or unknown — run checks).

--- a/scripts/test_check_fork_patches.py
+++ b/scripts/test_check_fork_patches.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Tests for scripts/check_fork_patches.py.
+#
+# The guard's live-tree run only exercises the shapes today's `Cargo.lock` and
+# ledger happen to contain — and while both agree, it reports success whether or
+# not it is still reading either file correctly. A regex that stopped matching
+# would find zero forks, zero rows, and no disagreements, so the guard would pass
+# green on a workspace it had gone blind to. The same reason
+# `test_check_module_reachability.py` runs ahead of its guard.
+#
+# The cases below pin both parsers against the manifest spellings this workspace
+# actually uses (`?rev=`, `?tag=`, `.git` and bare repository names) and pin each
+# drift the guard exists to catch.
+#
+# Run: python3 scripts/test_check_fork_patches.py
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_fork_patches import (  # noqa: E402
+    LEDGER,
+    LOCK,
+    drift,
+    ledger_pins,
+    pinned_forks,
+)
+
+failures = 0
+checks = 0
+
+A = "a" * 40
+B = "b" * 40
+C = "c" * 40
+
+
+def check(name: str, got, want) -> None:
+    global failures, checks
+    checks += 1
+    if got == want:
+        print(f"  ok: {name}")
+    else:
+        failures += 1
+        print(f"  FAIL: {name}\n    got:  {got!r}\n    want: {want!r}")
+
+
+def check_contains(name: str, haystack: list[str], needle: str) -> None:
+    global failures, checks
+    checks += 1
+    if any(needle in item for item in haystack):
+        print(f"  ok: {name}")
+    else:
+        failures += 1
+        print(f"  FAIL: {name}\n    no item contains {needle!r}\n    items: {haystack!r}")
+
+
+print("lockfile parsing")
+
+# The three source spellings this workspace's lockfile uses: a `rev=` pin on a
+# `.git` URL, a `tag=` pin (clickhouse-rs), and a bare repository name with no
+# `.git` suffix (async-openai, tiberius, graph-rs-sdk).
+LOCK_SAMPLE = f"""
+[[package]]
+name = "vortex-array"
+version = "0.79.0"
+source = "git+https://github.com/spiceai/vortex.git?rev={A}#{A}"
+
+[[package]]
+name = "vortex-io"
+version = "0.79.0"
+source = "git+https://github.com/spiceai/vortex.git?rev={A}#{A}"
+
+[[package]]
+name = "clickhouse-rs"
+version = "0.2.2"
+source = "git+https://github.com/spiceai/clickhouse-rs.git?tag=0.2.2#{B}"
+
+[[package]]
+name = "async-openai"
+version = "0.32.0"
+source = "git+https://github.com/spiceai/async-openai?rev={C}#{C}"
+
+[[package]]
+name = "spiceai"
+version = "3.0.0"
+source = "git+https://github.com/spiceai/spice-rs.git?rev={A}#{A}"
+
+[[package]]
+name = "tokio"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "duckdb"
+version = "1.5.5"
+source = "git+https://github.com/duckdb/duckdb-rs.git?rev={B}#{B}"
+"""
+
+parsed = pinned_forks(LOCK_SAMPLE)
+check("a `.git` URL with a rev pin is read once per repo, not once per crate", parsed.get("vortex"), {A})
+check("a tag pin resolves to the commit after the fragment", parsed.get("clickhouse-rs"), {B})
+check("a repository name with no `.git` suffix is read", parsed.get("async-openai"), {C})
+check("a non-spiceai git dependency is not a fork of ours", "duckdb-rs" in parsed, False)
+check("a registry dependency is ignored", "tokio" in parsed, False)
+check("a spiceai repo with no upstream is not audited", "spice-rs" in parsed, False)
+
+print("\nledger parsing")
+
+LEDGER_SAMPLE = f"""
+| Fork | Pinned revision | Branch | Spice patches | Guarded |
+|---|---|---|---|---|
+| [vortex](#vortex) | `{A}` | `spiceai-54` | 14 | 9 |
+| [clickhouse-rs](#clickhouse-rs) | `{B}` | tag `0.2.2` | 2 | 0 |
+
+Prose that mentions `{C}` in passing must not be read as a pin row.
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| Arrow `Map` alias | every write fails | silent | some test |
+"""
+
+recorded = ledger_pins(LEDGER_SAMPLE)
+check("a pin row is read from its link text", recorded.get("vortex"), [A])
+check("a tag-pinned fork is read the same way", recorded.get("clickhouse-rs"), [B])
+check("a revision mentioned in prose is not a pin row", len(recorded), 2)
+check("a patch row is not mistaken for a pin row", "Arrow `Map` alias" in recorded, False)
+
+print("\ndrift detection")
+
+check("agreement is silent", drift({"vortex": {A}}, {"vortex": [A]}), [])
+check_contains(
+    "a moved pin is reported, and says to re-audit",
+    drift({"vortex": {B}}, {"vortex": [A]}),
+    "re-audit",
+)
+check_contains(
+    "a fork with no ledger row is reported",
+    drift({"vortex": {A}}, {}),
+    "no row in docs/dev/fork_patches.md",
+)
+check_contains(
+    "a ledger row for an unpinned fork is reported",
+    drift({}, {"vortex": [A]}),
+    "no longer pinned",
+)
+check_contains(
+    "two rows for one fork is reported",
+    drift({"vortex": {A}}, {"vortex": [A, B]}),
+    "keep one per fork",
+)
+check_contains(
+    "one fork pinned at two revisions at once is reported",
+    drift({"vortex": {A, B}}, {"vortex": [A]}),
+    "different revisions at once",
+)
+
+print("\nshipped tree")
+
+# The parsers have to find something in the real files: a rewrite that broke
+# either regex would leave both sides empty and agreeing.
+lock_forks = pinned_forks(LOCK.read_text(encoding="utf-8"))
+ledger_rows = ledger_pins(LEDGER.read_text(encoding="utf-8"))
+check("the lockfile yields forks", len(lock_forks) > 20, True)
+check("the ledger yields rows", len(ledger_rows) > 20, True)
+check("the shipped tree has no drift", drift(lock_forks, ledger_rows), [])
+
+if failures:
+    print(f"\n{failures} of {checks} checks FAILED")
+    raise SystemExit(1)
+print(f"\nall {checks} checks passed")

--- a/scripts/test_check_fork_patches.py
+++ b/scripts/test_check_fork_patches.py
@@ -27,6 +27,7 @@ from check_fork_patches import (  # noqa: E402
     LEDGER,
     LOCK,
     drift,
+    gap_accounting,
     ledger_pins,
     pinned_forks,
 )
@@ -159,6 +160,37 @@ check_contains(
     "different revisions at once",
 )
 
+print("\ngap accounting")
+
+GAPS_HEAD = """
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| one | a thing | silent | **GAP** |
+| two | another | silent | some test |
+| three | a third | silent | **GAP** |
+
+## Open gaps
+
+**{count} rows above are marked GAP** — they have no repo-side guard.
+"""
+
+check("a count matching the tables is silent", gap_accounting(GAPS_HEAD.format(count=2)), [])
+check_contains(
+    "a count that has fallen behind the tables is reported",
+    gap_accounting(GAPS_HEAD.format(count=1)),
+    "2 table row(s) are marked **GAP** but the `Open gaps` section accounts for 1",
+)
+check_contains(
+    "a section that no longer states a count is reported",
+    gap_accounting("| one | x | silent | **GAP** |\n\n## Open gaps\n\nprose only.\n"),
+    "no longer states how many rows it accounts for",
+)
+check_contains(
+    "a ledger with no Open gaps section at all is reported",
+    gap_accounting("| one | x | silent | **GAP** |\n"),
+    "no `## Open gaps` section",
+)
+
 print("\nshipped tree")
 
 # The parsers have to find something in the real files: a rewrite that broke
@@ -168,6 +200,9 @@ ledger_rows = ledger_pins(LEDGER.read_text(encoding="utf-8"))
 check("the lockfile yields forks", len(lock_forks) > 20, True)
 check("the ledger yields rows", len(ledger_rows) > 20, True)
 check("the shipped tree has no drift", drift(lock_forks, ledger_rows), [])
+ledger_text = LEDGER.read_text(encoding="utf-8")
+check("the shipped tree marks at least one gap", "**GAP**" in ledger_text, True)
+check("the shipped Open gaps list accounts for every gap", gap_accounting(ledger_text), [])
 
 if failures:
     print(f"\n{failures} of {checks} checks FAILED")


### PR DESCRIPTION
## Why

A Spice patch on a fork exists only as a commit on a fork branch, and every fork branch is re-cut when its upstream releases a new major (`spiceai-52` → `-53` → `-54`, …). A patch not deliberately carried across a re-cut is lost **silently**: the crate reverts to upstream behaviour, and the fork's own tests are on the branch that was replaced, so they leave with the patch and nothing here goes red.

That has already shipped twice. Vortex `Map` support was on `spiceai-51`, `-52` and `-53` and absent from `-54`; half the patch survived, so it surfaced not as a build failure but as `Array encoding not implemented for Arrow data type Map(...)` on every write in a release (#13524). A reentrant-waker use-after-free in `vortex-io` was fixed three times on branches that never reached a shipping one, and shipped as a `SIGSEGV` under ordinary query cancellation.

The protection has to live here, where it survives the re-cut.

## What this does

Audits every fork the workspace pins — **29 forks, 86 distinct patches** — by diffing each against its upstream merge base and using `git cherry` to separate our patches from upstream backports carried on release branches. For each patch: what breaks if it goes missing, whether the loss is silent or a build break, and which test in this repo catches it. **50 had coverage; 36 did not.**

- **`docs/dev/fork_patches.md`** — the ledger, including how to enumerate a fork's patches (cargo's clone carries no upstream remote and no tags, which is the non-obvious part).
- **`scripts/check_fork_patches.py`**, run by `make lint-rust` — pins the ledger to `Cargo.lock`. Moving a fork pin now fails the build until that fork's patches are re-audited, which is the moment the audit is cheap and the loss still recoverable. It ships with a self-test, because a regex that stopped matching would find zero forks, zero rows, and report agreement.
- **Nine new guards**, closing the highest-consequence gaps.

Both new scripts are registered in all three Rust-gate path lists. Without that, a branch touching only them would report `Rust Lint` and `Build and Test` green without running a step — `scripts/check_rust_gate_paths.py` caught this.

## The new guards

| Guard | Fork patch | What its loss costs |
|---|---|---|
| `a_derived_tables_unnamed_outputs_are_named` | datafusion #206 | derived-table reference the remote engine cannot bind (#12751) |
| `an_empty_projection_does_not_unparse_to_an_empty_select_list` | datafusion | `SELECT FROM t` — the federated query fails outright |
| `a_timezone_survives_unparsing_except_where_the_engine_cannot_resolve_it` | datafusion #160, #195 | timezone dropped, so the remote engine returns a different instant (#12528) |
| `bigquery_names_the_float_type_the_way_bigquery_does` | datafusion #147 | BigQuery rejects `DOUBLE` |
| `test_date_to_timestamp_extension_cast` | vortex #28 | pushed-down `CAST(date AS TIMESTAMP)` fails the scan |
| `test_large_in_list_filter_pushdown_stays_evaluable` | vortex #37 | a large `IN` list builds an N-deep OR tree and blows the stack |
| `bundled_duckdb_resolves_a_named_time_zone_without_installing_icu` | duckdb-rs #23 | named time zones fail, with a network INSTALL as the only recovery |
| `bundled_duckdb_builds_an_hnsw_index_without_installing_vss` | duckdb-rs #37 | vector search over a DuckDB accelerator fails |
| `a_versioned_parquet_read_pins_every_request_to_one_object_version` | arrow-rs + datafusion | a file replaced mid-scan is read as a mixture of both versions |

The last one covers both halves at once. The `arrow-rs` half is the dangerous one: a re-cut that keeps the constructor and drops the pinning still compiles, still scans, and stops pinning.

Explicit assertions rather than `insta` snapshots throughout — a snapshot can be regenerated blindly, which is the failure mode being guarded against.

## Two findings the guards surfaced

Both recorded in the ledger.

**The Vortex date→timestamp cast is present but incomplete.** Fork PR #28 registers its kernel on `ExtensionArray`. A scan also evaluates pushed-down predicates against *constant* arrays built from chunk statistics, which resolve a kernel the fork does not patch, so a `WHERE CAST(date_col AS TIMESTAMP) > TIMESTAMP '…'` over a Vortex file fails the scan today with `No CastReduce to cast constant array from vortex.date[days](i32?) to vortex.timestamp[ns](i64?)`. Needs a fix on the fork; the guard here pins the kernel the patch does provide.

**`data_components::federation` is behind a non-default feature**, so a scoped `cargo test -p data_components` compiles none of it and skips every guard in that file — including the six pre-existing ones for #12406, #12591 and #13277 — while reporting green. The required invocation is now documented next to those rows.

## Testing

- `cargo test --lib -p vortex-datafusion -p data_components -p accelerator-duckdb -p data-connector-api` — 970 passed, 0 failed
- `cargo test -p data_components --features federation --lib federation::` — 18 passed, 0 failed
- `make lint-rust PACKAGES="vortex-datafusion data_components accelerator-duckdb data-connector-api" FEATURES="federation"` — clean, including both `-Dclippy::pedantic` passes
- `scripts/test_check_fork_patches.py` — 19/19; `scripts/check_rust_gate_paths.py` and its self-test — 28/28

## Not in this PR

The 36 remaining gaps are listed and prioritised in the ledger's *Open gaps* section, ordered by consequence. The performance-only patches (eager aggregation, intra-file decode parallelism, i-quant MoE kernels) are deliberately left to the benchmark suites, which already trend those numbers — a unit test cannot assert a speedup without becoming a flaky timing test.

## Issues filed from this audit

Two defects the guards surfaced:

- #13624 — a pushed-down `CAST(date AS TIMESTAMP)` fails the scan on a Vortex file (needs a fix on `spiceai/vortex`)
- #13625 — a scoped `cargo test -p data_components` skips every federation unparser guard and reports green

The highest-consequence gaps this PR does not close:

- #13627 — four BigQuery dialect unparser fixes unguarded
- #13628 — placeholder type-inference fixes unguarded
- #13629 — Iceberg pinned snapshot reads unguarded
- #13630 — Ballista null-aware anti-join fix unguarded
- #13631 — tracking issue for the rest
