### PR TITLE
fix(cayenne): close the PK-index checkout window on every exit path (fixes #13267)

### DIFF
--- a/crates/cayenne/src/provider/mutation_writer.rs
+++ b/crates/cayenne/src/provider/mutation_writer.rs
@@ -881,6 +881,11 @@ impl<'a> AppendMutationWriter<'a> {
     /// with the N shard appends joined concurrently. The combined post-validation
     /// state is published for the durable fallback.
     ///
+    /// `prepared.sharded_index` carries the checkout window the index was taken
+    /// under, so the early exits here — a stream error, a spill failure, and the
+    /// sustained-overload diversion to the durable path, which abandons the index
+    /// entirely — close that window on the way out instead of leaving it latched.
+    ///
     /// Engaged only at N>1; the N=1 write path never reaches here, so today's
     /// behavior is byte-identical.
     async fn write_cdc_in_memory_sharded(

--- a/crates/cayenne/src/provider/on_conflict.rs
+++ b/crates/cayenne/src/provider/on_conflict.rs
@@ -23,7 +23,8 @@ limitations under the License.
 
 use super::delete::CayenneDeletionSink;
 use super::pk_index::{
-    CachedPkIndex, PendingPkExistence, PkDigestSet, PkExistenceRef, ShardedPkIndex,
+    CachedPkIndex, CheckedOutShardedPkIndex, PendingPkExistence, PkCheckoutGuard, PkDigestSet,
+    PkExistenceRef,
 };
 use crate::metadata::InlinedData;
 
@@ -763,8 +764,9 @@ impl PreparedInsertStream {
 /// wrapped in an [`OnConflictValidationStream`] — because the sharded path runs
 /// the on-conflict validation PER SHARD after splitting each batch by
 /// `shard_of_pk`. The pre-apply existence snapshot is carried as a
-/// [`ShardedPkIndex`] (one existence view per shard), so a shard validates only
-/// against its own keys (a key's whole history is confined to one shard, §3.1).
+/// [`CheckedOutShardedPkIndex`] (one existence view per shard, plus the checkout
+/// window opened over the cache gap), so a shard validates only against its own
+/// keys (a key's whole history is confined to one shard, §3.1).
 ///
 /// The single-shard (`n == 1`) path never uses this — it takes the existing
 /// `prepare_stream_for_insert` flow unchanged, keeping N=1 byte-identical.
@@ -777,11 +779,12 @@ pub(crate) struct PreparedShardedInsertStream {
     /// so it can be the table's cached `pk_row_converter` (zero per-apply rebuild)
     /// for composite PKs, or a freshly built one for `Int64` PKs (no cache).
     pub(crate) converter: Arc<RowConverter>,
-    /// Pre-apply per-shard existence snapshot. `None` when conflict detection is
-    /// off (`pk_conflict_detection: none`) or the source trusts uniqueness — the
-    /// drain then appends every row with no validation, mirroring the immediate
-    /// path.
-    pub(crate) sharded_index: Option<ShardedPkIndex>,
+    /// Pre-apply per-shard existence snapshot, paired with the checkout window it
+    /// was taken under. `None` when conflict detection is off
+    /// (`pk_conflict_detection: none`) or the source trusts uniqueness — the drain
+    /// then appends every row with no validation, mirroring the immediate path, and
+    /// no window was opened.
+    pub(crate) sharded_index: Option<CheckedOutShardedPkIndex>,
     /// The resolved on-conflict behavior for this table.
     pub(crate) on_conflict: OnConflict,
 }
@@ -1157,13 +1160,19 @@ pub(crate) struct OnConflictValidationStream {
     pub(crate) deleted_inlined_row_keys: Vec<Box<[u8]>>,
     reinserted_over_tombstone: usize,
     post_validation: Arc<ParkingMutex<Option<PostValidationState>>>,
-    /// Whether the validation keyset is stored back into the table's shared PK
-    /// index cache when the stream finishes. `true` for the ordinary write path
-    /// (the keyset was taken from the shared cache and is returned). `false` for
-    /// off-lock conditional-commit staging, which validates against a **private**
-    /// keyset without holding `write_lock` — storing it back would clobber a
-    /// concurrent ordinary writer's cache update and drop committed keys.
-    store_back: bool,
+    /// The checkout window `existing_keys` was taken under, held for the whole
+    /// (lazily consumed) stream and closed by the restore that stores the keyset
+    /// back. Holding it here is what closes the window when the stream is dropped
+    /// or cancelled part-way, rather than only when it finishes (see
+    /// [`PkCheckoutGuard`]).
+    ///
+    /// `None` for off-lock conditional-commit staging, which validates against a
+    /// **private** keyset built without holding `write_lock` and so never opened a
+    /// window: storing that keyset back would clobber a concurrent ordinary
+    /// writer's cache update and drop committed keys. The window itself is what
+    /// records that distinction, so there is no separate flag to fall out of step
+    /// with it.
+    pk_checkout: Option<PkCheckoutGuard>,
     finalized: bool,
 }
 
@@ -1180,7 +1189,7 @@ impl OnConflictValidationStream {
         existing_keys: CachedPkIndex,
         on_conflict: OnConflict,
         post_validation: Arc<ParkingMutex<Option<PostValidationState>>>,
-        store_back: bool,
+        pk_checkout: Option<PkCheckoutGuard>,
     ) -> Self {
         let schema = inner.schema();
         let upsert_options = on_conflict.get_upsert_options();
@@ -1202,7 +1211,7 @@ impl OnConflictValidationStream {
             deleted_inlined_row_keys: Vec::new(),
             reinserted_over_tombstone: 0,
             post_validation,
-            store_back,
+            pk_checkout,
             finalized: false,
         }
     }
@@ -1229,7 +1238,7 @@ impl OnConflictValidationStream {
         // Snapshot per batch, not per stream: `existing` was checked out before the
         // first batch, and this stream is consumed lazily as the encode runs, so a
         // concurrent writer can commit a key between two batches of it.
-        let pending = if self.store_back {
+        let pending = if self.pk_checkout.is_some() {
             self.table.pending_pk_existence()
         } else {
             // Off-lock staging validates against a private keyset it just built —
@@ -1285,12 +1294,11 @@ impl OnConflictValidationStream {
 
     fn store_existing_keyset(&mut self) {
         let existing_keys = self.existing_keys.take();
-        // Off-lock staging validates against a private keyset and must never
-        // publish it to the shared cache (see `store_back`). Drop it instead.
-        if self.store_back
-            && let Some(existing_keys) = existing_keys
-        {
-            self.table.store_cached_pk_index(existing_keys);
+        // Off-lock staging validates against a private keyset and must never publish
+        // it to the shared cache (see `pk_checkout`). With no window there is nothing
+        // to restore into and nothing to close — drop the keyset instead.
+        if let (Some(existing_keys), Some(checkout)) = (existing_keys, self.pk_checkout.take()) {
+            self.table.store_cached_pk_index(existing_keys, checkout);
         }
     }
 

--- a/crates/cayenne/src/provider/pk_index.rs
+++ b/crates/cayenne/src/provider/pk_index.rs
@@ -22,6 +22,7 @@ limitations under the License.
 
 use crate::row_converter::OwnedRow;
 use hash_index::{PrehashedBuildHasher, hash_key_128, hash_key_bytes};
+use parking_lot::Mutex as ParkingMutex;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock};
 
@@ -1256,13 +1257,16 @@ impl PendingPkKeys {
     /// was never stored back, so the next validation rebuilds from the table and
     /// already sees those keys.
     ///
+    /// Private to this module: callers open a window through [`PkCheckoutGuard`],
+    /// which owns closing it again (see there for what a leaked window costs).
+    ///
     /// Opening a SECOND window while one is outstanding puts two independently-aged
     /// indexes over one cache: each was read at a different point, so whichever is
     /// stored last silently reverts the other's keys. Neither is trustworthy, so both
     /// are marked for discard and the cache goes cold — one rebuild instead of a
     /// cache that answers "absent" for a live key. Writers are serialized by the
     /// table write lock, so this is a backstop, not a routine path.
-    pub(crate) fn begin_checkout(&mut self) {
+    fn begin_checkout(&mut self) {
         if self.outstanding == 0 {
             self.overflowed = false;
             self.invalidated = false;
@@ -1325,7 +1329,10 @@ impl PendingPkKeys {
     /// Close the checkout window and hand back everything committed during it. With
     /// several windows outstanding every one of them reports a discard, and the flags
     /// only reset once the last closes.
-    pub(crate) fn end_checkout(&mut self) -> RestoredPkKeys {
+    ///
+    /// Private to this module: reached through [`PkCheckoutGuard::close`] or that
+    /// guard's [`Drop`].
+    fn end_checkout(&mut self) -> RestoredPkKeys {
         let restored = RestoredPkKeys {
             batches: std::mem::take(&mut self.batches),
             discard_index: self.overflowed || self.invalidated,
@@ -1369,6 +1376,96 @@ impl PendingPkKeys {
     /// Bytes currently held, for memory accounting.
     pub(crate) fn approx_bytes(&self) -> usize {
         self.approx_bytes
+    }
+}
+
+/// RAII holder for a [`PendingPkKeys`] checkout window, and the only way to open
+/// one.
+///
+/// The window has to close on EVERY exit path, not just the one that stores an
+/// index back. A window left open latches the log permanently: the next
+/// [`PendingPkKeys::begin_checkout`] finds one already outstanding and sets
+/// `invalidated`, and `outstanding` never returns to zero to clear it again. From
+/// there [`PendingPkKeys::record`] holds nothing and every later
+/// [`PendingPkKeys::end_checkout`] reports a discard — so the cached keyset is
+/// dropped and rebuilt on every write, and, until it is rebuilt, a key committed
+/// during a checkout is no longer held for the restore, reads as absent, and its
+/// row is written a second time under a primary key that already exists.
+///
+/// A guard makes that unrepresentable. `?`, an early return, a panic, and a
+/// dropped or cancelled validation stream all run [`Drop`], and
+/// [`PendingPkKeys::begin_checkout`] is private to this module, so no caller can
+/// open a window it does not also own.
+pub(crate) struct PkCheckoutGuard {
+    pending: Arc<ParkingMutex<PendingPkKeys>>,
+    /// Set by [`Self::close`], which has already closed the window and owns the
+    /// keys it handed back, so [`Drop`] must not close it a second time.
+    closed: bool,
+}
+
+impl PkCheckoutGuard {
+    /// Open a checkout window over `pending`.
+    pub(crate) fn open(pending: &Arc<ParkingMutex<PendingPkKeys>>) -> Self {
+        pending.lock().begin_checkout();
+        Self {
+            pending: Arc::clone(pending),
+            closed: false,
+        }
+    }
+
+    /// Close the window and take the keys committed during it, to replay into the
+    /// index being stored back. Callers hold the matching cache lock across this
+    /// call so no writer can commit a key into the gap between the close and the
+    /// store (see `store_cached_pk_index`).
+    pub(crate) fn close(mut self) -> RestoredPkKeys {
+        self.closed = true;
+        self.pending.lock().end_checkout()
+    }
+}
+
+impl Drop for PkCheckoutGuard {
+    fn drop(&mut self) {
+        if self.closed {
+            return;
+        }
+        // Abandoned: no index is coming back, so the keys held for it have nothing
+        // to replay into. Closing drops them along with the window, and the cache
+        // stays cold — the next validation rebuilds from the table and sees every
+        // committed key.
+        let _ = self.pending.lock().end_checkout();
+    }
+}
+
+/// A per-shard PK existence index together with the checkout window opened over
+/// the gap it leaves in the sharded cache.
+///
+/// The sharded index travels a long way from where it is built
+/// (`build_sharded_pk_index`) to where it is stored back
+/// (`store_sharded_pk_index`): through the prepared insert, the raw-stream drain,
+/// the per-table cap spill, the global byte-budget wait — which can divert the
+/// whole apply to the durable path — and the per-shard validation. Pairing the
+/// index with its window in one value means every one of those exits carries both
+/// or drops both, so there is no shape where the index is abandoned and the window
+/// stays open.
+pub(crate) struct CheckedOutShardedPkIndex {
+    index: ShardedPkIndex,
+    checkout: PkCheckoutGuard,
+}
+
+impl CheckedOutShardedPkIndex {
+    pub(crate) fn new(index: ShardedPkIndex, checkout: PkCheckoutGuard) -> Self {
+        Self { index, checkout }
+    }
+
+    /// The index itself, for the read-only per-shard existence probes.
+    pub(crate) fn index(&self) -> &ShardedPkIndex {
+        &self.index
+    }
+
+    /// Split into index and window, for the restore that stores one and closes the
+    /// other.
+    pub(crate) fn into_parts(self) -> (ShardedPkIndex, PkCheckoutGuard) {
+        (self.index, self.checkout)
     }
 }
 
@@ -1863,11 +1960,13 @@ mod tests {
     use super::{
         BoundedShardedPkIndexBuilder, COLD_PK_BLOOM_PER_FILE_MAX_BYTES, CachedPkKeyset,
         ColdPkExistence, LEGACY_PK_BLOOM_PROBE_FINGERPRINT, PK_BLOOM_FRAME_VERSION_SPLIT_BLOCK,
-        PK_INDEX_SIDECAR_MAGIC, PK_INDEX_SIDECAR_VERSION, PkBloom, PkBloomRepr, PkDigestSet,
-        PkKeysetInsertOutcome, RowLocation, SCATTERED_PROBE_FINGERPRINT, ShardedPkIndex,
-        approx_pk_keyset_entry_bytes, deserialize_pk_bloom_sidecar, deserialize_pk_blooms_sidecar,
-        pk_digest, serialize_pk_blooms_sidecar, shard_of_pk,
+        PK_INDEX_SIDECAR_MAGIC, PK_INDEX_SIDECAR_VERSION, ParkingMutex, PendingPkKeys, PkBloom,
+        PkBloomRepr, PkCheckoutGuard, PkDigestSet, PkKeysetInsertOutcome, RowLocation,
+        SCATTERED_PROBE_FINGERPRINT, ShardedPkIndex, approx_pk_keyset_entry_bytes,
+        deserialize_pk_bloom_sidecar, deserialize_pk_blooms_sidecar, pk_digest,
+        serialize_pk_blooms_sidecar, shard_of_pk,
     };
+    use std::sync::Arc;
 
     /// Degrading after a mid-batch stop must not lose the rest of the batch.
     ///
@@ -2762,6 +2861,115 @@ mod tests {
         assert!(
             keyset.location_by_digest(digest).is_none(),
             "an over-budget key must not be retrievable afterward"
+        );
+    }
+    /// A checkout window abandoned without a restore must not latch the log.
+    ///
+    /// `begin_checkout` reads a window that is still outstanding as two
+    /// independently-aged indexes over one cache and sets `invalidated`, and the
+    /// flags only clear once `outstanding` returns to zero. So a window that is
+    /// never closed makes every LATER checkout invalid for the life of the
+    /// process: `record` holds nothing, `existence` reports nothing to the
+    /// in-flight validation — which then reads a key another writer just
+    /// committed as new and writes a second live row under an existing primary
+    /// key — and every restore discards its index, rebuilding the keyset on every
+    /// write.
+    ///
+    /// [`PkCheckoutGuard`] is what makes the window impossible to abandon; this
+    /// pins the behaviour it buys.
+    #[test]
+    fn an_abandoned_checkout_leaves_the_next_one_usable() {
+        let pending = Arc::new(ParkingMutex::new(PendingPkKeys::default()));
+
+        // A validation that fails, panics, or is cancelled part-way: the window
+        // opened, nothing restored an index, and the guard closed it on the way out.
+        drop(PkCheckoutGuard::open(&pending));
+
+        let checkout = PkCheckoutGuard::open(&pending);
+        let mut keys = PkDigestSet::with_capacity(1);
+        let k = owned_key(&key(7));
+        keys.insert_with_digest(pk_digest(&k), k.clone());
+        pending
+            .lock()
+            .record(&keys, &RowLocation::FileUnlocated, 11, usize::MAX);
+
+        assert!(
+            pending
+                .lock()
+                .existence()
+                .is_some_and(|existence| existence.location_by_digest(pk_digest(&k)).is_some()),
+            "the in-flight validation must see a key committed during its own \
+             checkout — missing it reads the key as new and duplicates the row"
+        );
+
+        let restored = checkout.close();
+        assert!(
+            !restored.index_must_be_discarded(),
+            "a clean checkout must restore its index rather than force a rebuild"
+        );
+        assert_eq!(
+            restored.batches().count(),
+            1,
+            "the key committed during the checkout must be replayed into the index"
+        );
+    }
+
+    /// A window must be closed exactly once. `close` already closed it and owns
+    /// the keys it handed back, so the guard's own `Drop` must not close it a
+    /// second time: that would drive `outstanding` to zero while another window is
+    /// still open, resetting the flags that window's index depends on.
+    #[test]
+    fn closing_a_checkout_does_not_also_close_it_on_drop() {
+        let pending = Arc::new(ParkingMutex::new(PendingPkKeys::default()));
+
+        let outer = PkCheckoutGuard::open(&pending);
+        let inner = PkCheckoutGuard::open(&pending);
+        assert_eq!(pending.lock().outstanding, 2, "two windows are open");
+
+        drop(inner.close());
+        assert_eq!(
+            pending.lock().outstanding,
+            1,
+            "closing one window must decrement the count exactly once"
+        );
+
+        assert!(
+            outer.close().index_must_be_discarded(),
+            "the index `outer` holds was aged against a second checkout, so it must              still be discarded once that sibling closes — a second decrement on drop              would zero the count, clear the flag, and cache an index that silently              reverts the other's keys"
+        );
+        assert_eq!(
+            pending.lock().outstanding,
+            0,
+            "closing every window must return the count to zero exactly"
+        );
+    }
+
+    /// The guard must not soften the deliberate backstop it wraps: two windows
+    /// open at once put two independently-aged indexes over one cache, so BOTH
+    /// must be marked for discard rather than one silently reverting the other's
+    /// keys.
+    #[test]
+    fn two_concurrent_checkouts_are_both_discarded() {
+        let pending = Arc::new(ParkingMutex::new(PendingPkKeys::default()));
+
+        let first = PkCheckoutGuard::open(&pending);
+        let second = PkCheckoutGuard::open(&pending);
+
+        assert!(
+            second.close().index_must_be_discarded(),
+            "an index checked out alongside another must not be cached"
+        );
+        assert!(
+            first.close().index_must_be_discarded(),
+            "the index it was opened over must not be cached either"
+        );
+
+        // ...and the flags clear once the last window closes, so the NEXT
+        // checkout is trusted again.
+        let third = PkCheckoutGuard::open(&pending);
+        assert!(
+            !third.close().index_must_be_discarded(),
+            "the discard must not outlive the overlap that caused it"
         );
     }
 }

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -58,10 +58,10 @@ use super::on_conflict::{
 };
 use super::pk_index::{
     BoundedShardedPkIndexBuilder, COLD_PK_BLOOM_PER_FILE_MAX_BYTES, CachedPkIndex, CachedPkKeyset,
-    ColdPkExistence, PK_INDEX_PERSIST_MAX_BYTES, PendingPkExistence, PendingPkKeys, PkBloom,
-    PkDigestSet, PkExistenceRef, PkKeysetInsertOutcome, RowLocation, ShardedPkIndex,
-    approx_captured_file_bytes, deserialize_pk_bloom_sidecar, pk_digest,
-    serialize_pk_bloom_sidecar, shard_of_pk,
+    CheckedOutShardedPkIndex, ColdPkExistence, PK_INDEX_PERSIST_MAX_BYTES, PendingPkExistence,
+    PendingPkKeys, PkBloom, PkCheckoutGuard, PkDigestSet, PkExistenceRef, PkKeysetInsertOutcome,
+    RowLocation, ShardedPkIndex, approx_captured_file_bytes, deserialize_pk_bloom_sidecar,
+    pk_digest, serialize_pk_bloom_sidecar, shard_of_pk,
 };
 use super::streaming::StreamingExec;
 use crate::bounded_fifo::BoundedFifoSet;
@@ -8847,23 +8847,17 @@ impl CayenneTableProvider {
     /// [`PendingPkKeys`] window over that gap: keys committed meanwhile are held
     /// there and merged back by [`Self::store_cached_pk_index`].
     ///
-    /// Returns `None` when no index is cached — the caller then rebuilds one from
+    /// The window is returned as a [`PkCheckoutGuard`] the caller must carry until
+    /// the store, so a validation that fails or is cancelled closes it on the way
+    /// out instead of latching the log (see [`PkCheckoutGuard`]).
+    ///
+    /// The index is `None` when none is cached — the caller then rebuilds one from
     /// the table, which is equally a checkout: the rebuild reads a snapshot of the
     /// table and every key committed after it must still reach the restored index.
-    fn take_cached_pk_index(&self) -> Option<CachedPkIndex> {
+    fn take_cached_pk_index(&self) -> (Option<CachedPkIndex>, PkCheckoutGuard) {
         let mut guard = self.pk_keyset_cache.lock();
-        self.pk_keyset_pending.lock().begin_checkout();
-        guard.take()
-    }
-
-    /// Close a checkout opened by [`Self::take_cached_pk_index`] without restoring
-    /// an index (the validation never got one — it failed while rebuilding). The
-    /// cache stays empty, so the next validation rebuilds and sees every committed
-    /// key; holding the log open past that point would only accumulate keys nothing
-    /// will replay.
-    fn abandon_cached_pk_index_checkout(&self) {
-        let _guard = self.pk_keyset_cache.lock();
-        let _ = self.pk_keyset_pending.lock().end_checkout();
+        let checkout = PkCheckoutGuard::open(&self.pk_keyset_pending);
+        (guard.take(), checkout)
     }
 
     /// Existence view over the keys committed while the table-wide index has been
@@ -8981,13 +8975,13 @@ impl CayenneTableProvider {
     /// keys are gone, and the index is dropped instead of cached — an index missing
     /// a live key answers "absent" for it, which reads as a new primary key and
     /// duplicates the row.
-    pub(crate) fn store_cached_pk_index(&self, index: CachedPkIndex) {
+    pub(crate) fn store_cached_pk_index(&self, index: CachedPkIndex, checkout: PkCheckoutGuard) {
         let max_bytes = self.effective_single_keyset_budget();
         // Held from closing the checkout window through the store, so no writer can
         // slip a key in between: it would find the cell empty, see no checkout, and
         // drop the key.
         let mut guard = self.pk_keyset_cache.lock();
-        let restored = self.pk_keyset_pending.lock().end_checkout();
+        let restored = checkout.close();
         if restored.index_must_be_discarded() {
             drop(guard);
             tracing::debug!(
@@ -9521,12 +9515,13 @@ impl CayenneTableProvider {
     /// keys committed while the index was out (the sharded twin of
     /// `store_cached_pk_index` — see there for why an index that is missing a live
     /// key must be dropped rather than cached).
-    fn store_sharded_pk_index(&self, index: ShardedPkIndex) {
+    fn store_sharded_pk_index(&self, checked_out: CheckedOutShardedPkIndex) {
+        let (index, checkout) = checked_out.into_parts();
         let max_bytes = self.effective_sharded_keyset_budget();
         // Held from closing the checkout window through the store — see
         // `store_cached_pk_index`.
         let mut guard = self.sharded_pk_keyset_cache.lock();
-        let restored = self.sharded_pk_keyset_pending.lock().end_checkout();
+        let restored = checkout.close();
         if restored.index_must_be_discarded() {
             drop(guard);
             tracing::debug!(
@@ -10950,32 +10945,36 @@ impl CayenneTableProvider {
 
         let converter = self.build_pk_converter(&pk_indices)?;
         // Off-lock staging must NOT take/store the shared cache (it runs without
-        // `write_lock`); it builds a private keyset every time. The ordinary path
-        // reuses the shared cache and stores it back on finish.
-        let existing_keys = if offlock {
-            self.load_pk_index_for_validation(&pk_indices, &converter)
-                .await?
-        } else if let Some(existing_keys) = self.take_cached_pk_index() {
-            tracing::trace!(
-                "prepare_stream_for_insert: reused {} cached existing keys for table {}",
-                existing_keys.len(),
-                self.table_metadata.table_name
-            );
-            existing_keys
+        // `write_lock`); it builds a private keyset every time, and so opens no
+        // checkout window. The ordinary path reuses the shared cache and carries the
+        // window it opened into the validation stream, which stores the keyset back
+        // and closes the window however the stream ends.
+        let (existing_keys, pk_checkout) = if offlock {
+            (
+                self.load_pk_index_for_validation(&pk_indices, &converter)
+                    .await?,
+                None,
+            )
         } else {
-            // `take_cached_pk_index` already opened the checkout window, so close it
-            // if the rebuild fails: nothing will restore an index, and the keys it
-            // would hold are read from the table by the next validation's rebuild.
-            match self
-                .load_pk_index_for_validation(&pk_indices, &converter)
-                .await
-            {
-                Ok(existing_keys) => existing_keys,
-                Err(error) => {
-                    self.abandon_cached_pk_index_checkout();
-                    return Err(error);
+            let (cached, checkout) = self.take_cached_pk_index();
+            let existing_keys = match cached {
+                Some(existing_keys) => {
+                    tracing::trace!(
+                        "prepare_stream_for_insert: reused {} cached existing keys for table {}",
+                        existing_keys.len(),
+                        self.table_metadata.table_name
+                    );
+                    existing_keys
                 }
-            }
+                // Dropping `checkout` on the way out closes the window the take
+                // opened: nothing will restore an index, and the keys it would hold
+                // are read from the table by the next validation's rebuild.
+                None => {
+                    self.load_pk_index_for_validation(&pk_indices, &converter)
+                        .await?
+                }
+            };
+            (existing_keys, Some(checkout))
         };
 
         let on_conflict = self
@@ -10994,9 +10993,7 @@ impl CayenneTableProvider {
             existing_keys,
             on_conflict,
             Arc::clone(&post_validation),
-            // Ordinary path returns the keyset to the shared cache; off-lock
-            // staging drops its private keyset (never publishes it).
-            !offlock,
+            pk_checkout,
         );
 
         Ok(PreparedInsertStream::deferred(
@@ -11188,7 +11185,7 @@ impl CayenneTableProvider {
         pk_indices: &[usize],
         converter: &RowConverter,
         n: usize,
-    ) -> Result<ShardedPkIndex> {
+    ) -> Result<CheckedOutShardedPkIndex> {
         let n = n.max(1);
 
         // Reuse the per-shard cache if present (the sharded analog of
@@ -11196,21 +11193,22 @@ impl CayenneTableProvider {
         // the single source of truth restored after validation by
         // `store_sharded_pk_index` (before the appends), then grown per shard UNDER
         // `locks[s]` by the kept-key insert inside `append_to_shard` (§5 Phase 6).
-        let cached = {
+        // Open the checkout window over the gap this leaves in the cache, so a key
+        // committed before the index is restored is held rather than dropped (see
+        // `take_cached_pk_index`). Opened for the rebuild below too: it reads a
+        // snapshot of the table, and a key committed after that snapshot must still
+        // reach the restored index. Held in a guard so the `?`s below — and every
+        // exit between here and `store_sharded_pk_index` — close it.
+        let (cached, checkout) = {
             let mut guard = self.sharded_pk_keyset_cache.lock();
-            // Open the checkout window over the gap this leaves in the cache, so a
-            // key committed before the index is restored is held rather than dropped
-            // (see `take_cached_pk_index`). Opened for the rebuild below too: it
-            // reads a snapshot of the table, and a key committed after that snapshot
-            // must still reach the restored index.
-            self.sharded_pk_keyset_pending.lock().begin_checkout();
-            guard.take()
+            let checkout = PkCheckoutGuard::open(&self.sharded_pk_keyset_pending);
+            (guard.take(), checkout)
         };
         if let Some(cached) = cached {
             // The stored shard count is fixed at the table's `cdc_mem_tier_shards`
             // and never changes for the table's lifetime, so it always matches `n`.
             if cached.shard_count() == n {
-                return Ok(cached);
+                return Ok(CheckedOutShardedPkIndex::new(cached, checkout));
             }
             // Defensive: a mismatch (shouldn't happen) → rebuild below.
             tracing::debug!(
@@ -11284,7 +11282,7 @@ impl CayenneTableProvider {
                 "keyset_rebuild",
                 keyset_rebuild_start,
             );
-            return Ok(index);
+            return Ok(CheckedOutShardedPkIndex::new(index, checkout));
         }
 
         let index = self
@@ -11295,7 +11293,7 @@ impl CayenneTableProvider {
             "keyset_rebuild",
             keyset_rebuild_start,
         );
-        Ok(index)
+        Ok(CheckedOutShardedPkIndex::new(index, checkout))
     }
 
     pub(crate) fn apply_on_conflict_to_batch(
@@ -11975,7 +11973,7 @@ impl CayenneTableProvider {
     pub(crate) async fn validate_and_append_sharded(
         &self,
         batches: Vec<RecordBatch>,
-        mut sharded_index: Option<ShardedPkIndex>,
+        mut sharded_index: Option<CheckedOutShardedPkIndex>,
         pk_indices: &[usize],
         converter: &RowConverter,
         on_conflict: &OnConflict,
@@ -12049,7 +12047,7 @@ impl CayenneTableProvider {
             // while still eliding the spawn for the small, frequent transactions
             // that dominate the apply rate — and thus replication lag.
             const SMALL_APPLY_INLINE_ROWS: usize = 32;
-            let index_ref = sharded_index.as_ref();
+            let index_ref = sharded_index.as_ref().map(CheckedOutShardedPkIndex::index);
             let non_empty_shards = per_shard_batches.iter().filter(|b| !b.is_empty()).count();
             // Total rows in this apply. Split preserves every row (only empty
             // sub-batches are dropped), so the incoming batches sum to the same
@@ -49239,11 +49237,12 @@ mod tests {
         let pk_converter = provider
             .build_pk_converter(&pk_indices)
             .expect("build pk converter");
+        let (_, checkout) = provider.take_cached_pk_index();
         let index = provider
             .load_existing_pk_index_serial(&pk_indices, &pk_converter, true, None)
             .await
             .expect("cold keyset rebuild");
-        provider.store_cached_pk_index(index);
+        provider.store_cached_pk_index(index, checkout);
         assert!(
             provider.should_capture_positions(),
             "deletion_mode: position on a PK table must enable the position read-back"
@@ -53356,7 +53355,8 @@ mod tests {
         let mut keyset = CachedPkKeyset::with_capacity(1);
         keyset.insert(key.clone(), RowLocation::FileUnlocated);
         keyset.record_sequence(digest, 5);
-        provider.store_cached_pk_index(CachedPkIndex::Exact(keyset));
+        let (_, checkout) = provider.take_cached_pk_index();
+        provider.store_cached_pk_index(CachedPkIndex::Exact(keyset), checkout);
 
         let footprint: HashSet<u128> = HashSet::from([digest]);
         let empty_write_set = crate::provider::pk_index::PkDigestSet::with_capacity(0);
@@ -53403,7 +53403,8 @@ mod tests {
         let mut delta_updated = CachedPkKeyset::with_capacity(1);
         delta_updated.insert(key.clone(), RowLocation::FileUnlocated);
         delta_updated.record_sequence(digest, 5);
-        provider.store_cached_pk_index(CachedPkIndex::Exact(delta_updated));
+        let (_, checkout) = provider.take_cached_pk_index();
+        provider.store_cached_pk_index(CachedPkIndex::Exact(delta_updated), checkout);
         assert!(
             !provider.transaction_has_conflict(
                 stage_seq,
@@ -53427,7 +53428,8 @@ mod tests {
         floor_stamped.insert(key, RowLocation::FileUnlocated);
         floor_stamped.record_sequence(digest, 5);
         floor_stamped.stamp_all_sequences_min(current_high_water);
-        provider.store_cached_pk_index(CachedPkIndex::Exact(floor_stamped));
+        let (_, checkout) = provider.take_cached_pk_index();
+        provider.store_cached_pk_index(CachedPkIndex::Exact(floor_stamped), checkout);
         assert!(
             provider.transaction_has_conflict(
                 stage_seq,
@@ -53489,9 +53491,8 @@ mod tests {
 
         // Seed one row so the table has a live keyset to check out.
         insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[1], &[10])).await;
-        let checked_out = provider
-            .take_cached_pk_index()
-            .expect("the seed insert leaves a cached keyset");
+        let (checked_out, checkout) = provider.take_cached_pk_index();
+        let checked_out = checked_out.expect("the seed insert leaves a cached keyset");
 
         // The concurrent writer commits id=7 while the keyset is out.
         let committed = pk_digest_set_for_ids(&converter, &[7]);
@@ -53513,7 +53514,7 @@ mod tests {
         );
 
         // The writer finishes and returns the keyset.
-        provider.store_cached_pk_index(checked_out);
+        provider.store_cached_pk_index(checked_out, checkout);
 
         let guard = provider.pk_keyset_cache.lock();
         match guard.as_ref() {
@@ -53557,9 +53558,8 @@ mod tests {
             .expect("primary key converter");
 
         insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[1], &[10])).await;
-        let checked_out = provider
-            .take_cached_pk_index()
-            .expect("the seed insert leaves a cached keyset");
+        let (checked_out, _checkout) = provider.take_cached_pk_index();
+        let checked_out = checked_out.expect("the seed insert leaves a cached keyset");
         provider.record_file_pk_keys(&pk_digest_set_for_ids(&converter, &[7]), 11);
 
         let pending = provider.pending_pk_existence();
@@ -53627,15 +53627,14 @@ mod tests {
 
         // A mainline write starts validating: it holds the keyset for its whole
         // lazily-consumed stream.
-        let checked_out = provider
-            .take_cached_pk_index()
-            .expect("the seed insert leaves a cached keyset");
+        let (checked_out, checkout) = provider.take_cached_pk_index();
+        let checked_out = checked_out.expect("the seed insert leaves a cached keyset");
 
         // Another writer commits id=7 in that window.
         insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[7], &[70])).await;
 
         // The first write finishes and returns its keyset.
-        provider.store_cached_pk_index(checked_out);
+        provider.store_cached_pk_index(checked_out, checkout);
 
         // A later upsert of the same key must replace the committed row.
         insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[7], &[71])).await;
@@ -53699,5 +53698,157 @@ mod tests {
                 other.is_some()
             ),
         }
+    }
+    /// A checked-out index that is never restored must not blind the checkout
+    /// mechanism for the rest of the process — regression test for #13267.
+    ///
+    /// `build_sharded_pk_index` opens the window before the fallible work that
+    /// produces the index, and the index then travels through the raw-stream
+    /// drain, the per-table cap spill, and the global byte-budget wait before
+    /// `store_sharded_pk_index` closes it. Every one of those can exit first: an
+    /// error propagates, and sustained overload diverts the whole apply to the
+    /// durable path and abandons the index outright.
+    ///
+    /// A window left open latches the log: the next `begin_checkout` sees one
+    /// already outstanding and marks its index invalid, and `outstanding` never
+    /// returns to zero to clear it. From then on the log records nothing, so every
+    /// restore discards its index — a full keyset rebuild on every write — and an
+    /// in-flight validation stops seeing concurrent commits, reads a live key as
+    /// new, and writes a second row under a primary key that already exists.
+    ///
+    /// Abandoning the index is the cheapest faithful stand-in for those exits: it
+    /// is exactly what each of them does to the window.
+    #[tokio::test]
+    async fn an_abandoned_sharded_checkout_does_not_latch_the_pending_log() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) = create_sharded_cdc_upsert_table_with_cap(
+            "pk_sharded_checkout_abandoned",
+            ctx.runtime_env(),
+            4,
+            0,
+        )
+        .await;
+        let pk_indices = provider
+            .primary_key_indices()
+            .expect("primary key indices resolve")
+            .expect("the table declares a primary key");
+        let converter = provider
+            .build_pk_converter(&pk_indices)
+            .expect("primary key converter");
+        provider.maybe_install_warm_pk_caches().await;
+
+        // An apply that checks the index out and never restores it.
+        drop(
+            provider
+                .build_sharded_pk_index(&pk_indices, &converter, 4)
+                .await
+                .expect("the warm per-shard index is checked out"),
+        );
+
+        // The next apply must be unaffected: it checks the index out, a concurrent
+        // writer commits id=7 into that window, and the restore replays it.
+        provider.maybe_install_warm_pk_caches().await;
+        let checked_out = provider
+            .build_sharded_pk_index(&pk_indices, &converter, 4)
+            .await
+            .expect("the per-shard index is checked out again");
+
+        let committed = pk_digest_set_for_ids(&converter, &[7]);
+        let committed_digest = committed
+            .iter_with_digest()
+            .next()
+            .expect("one committed key")
+            .0;
+        provider.record_file_pk_keys(&committed, 11);
+
+        assert!(
+            provider
+                .pending_sharded_pk_existence()
+                .is_some_and(|pending| pending.location_by_digest(committed_digest).is_some()),
+            "the in-flight validation must still see a key committed while it holds \
+             the per-shard index: missing it reads id=7 as new and leaves two live \
+             rows for one declared primary key"
+        );
+
+        provider.store_sharded_pk_index(checked_out);
+
+        match provider.sharded_pk_keyset_cache.lock().as_ref() {
+            Some(ShardedPkIndex::Exact(keysets)) => {
+                assert!(
+                    keysets
+                        .iter()
+                        .any(|keyset| keyset.location_by_digest(committed_digest).is_some()),
+                    "the restored per-shard index must know id=7"
+                );
+            }
+            other => panic!(
+                "an earlier abandoned checkout must not force this index to be \
+                 discarded (which rebuilds the whole keyset on every later write); \
+                 present={}",
+                other.is_some()
+            ),
+        }
+    }
+
+    /// The table-wide keyset has the same window and the same latch — regression
+    /// test for #13267 on the serial path, where a validation stream dropped or
+    /// cancelled part-way (rather than an error before it starts) is what abandons
+    /// the checkout.
+    #[tokio::test]
+    async fn an_abandoned_serial_checkout_does_not_latch_the_pending_log() {
+        let ctx = SessionContext::new();
+        let (provider, _catalog, _tmp) = create_cdc_upsert_table_with_vortex_config(
+            "pk_checkout_abandoned",
+            ctx.runtime_env(),
+            VortexConfig::default(),
+        )
+        .await;
+        let schema = provider.table_schema();
+        let pk_indices = provider
+            .primary_key_indices()
+            .expect("primary key indices resolve")
+            .expect("the table declares a primary key");
+        let converter = provider
+            .build_pk_converter(&pk_indices)
+            .expect("primary key converter");
+
+        insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[1], &[10])).await;
+
+        // A validation that takes the keyset and is then cancelled: nothing stores
+        // it back, so the cache is left empty and the window has to close here.
+        drop(provider.take_cached_pk_index());
+
+        // The next validation opens its own window over the gap and rebuilds.
+        let (rebuilt, checkout) = provider.take_cached_pk_index();
+        assert!(
+            rebuilt.is_none(),
+            "the abandoned checkout took the cached keyset with it"
+        );
+        let committed = pk_digest_set_for_ids(&converter, &[7]);
+        let committed_digest = committed
+            .iter_with_digest()
+            .next()
+            .expect("one committed key")
+            .0;
+        provider.record_file_pk_keys(&committed, 11);
+
+        assert!(
+            provider
+                .pending_pk_existence()
+                .is_some_and(|pending| pending.location_by_digest(committed_digest).is_some()),
+            "the in-flight validation must still see a key committed while it holds \
+             the keyset: missing it reads id=7 as new and leaves two live rows for \
+             one declared primary key"
+        );
+        drop(checkout);
+
+        // And an ordinary write restores its keyset to the cache rather than
+        // discarding it.
+        insert_batch(&provider, id_value_batch(Arc::clone(&schema), &[2], &[20])).await;
+        assert!(
+            provider.pk_keyset_cache.lock().is_some(),
+            "an earlier abandoned checkout must not force every later restore to \
+             discard its keyset, which rebuilds the whole keyset on every write"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The primary-key existence index is taken out of its cache under a *checkout window*, so a
key another writer commits while the index is out is held in a pending log and replayed into
the index when it is stored back. The window was closed only by that restore. Every other
exit left it open: the three fallible awaits inside `build_sharded_pk_index`, the raw-stream
drain and byte-budget wait between there and `store_sharded_pk_index` — including the
sustained-overload diversion to the durable path, which abandons the index outright — and, on
the serial path, a validation stream dropped or cancelled part-way.

One such exit disables the mechanism for the rest of the process. `begin_checkout` reads a
window that is still outstanding as two independently-aged indexes over one cache and sets
`invalidated`, and the flags clear only once `outstanding` returns to zero — which, after a
leak, it never does. From then on the pending log records nothing, so an in-flight validation
no longer sees a key another writer committed during its own checkout: it reads that key as
new and leaves **two live rows for one declared primary key**. Every later restore also
discards its index, so the whole PK keyset is rebuilt on every write (a single
`keyset_rebuild` on `order_line` measured ~319s on an SF1000 CH-benCHmark run).

It needs a genuine error on the rebuild path — an object-store or metastore failure — so it
does not fire in a healthy run. The cost when it does is a silent correctness regression plus
a throughput collapse, announced only by a `tracing::debug!`.

## Changes

- `PkCheckoutGuard` (`provider/pk_index.rs`) is now the only way to open a window, and it
  closes on every exit: `?`, an early return, a panic, and a dropped or cancelled stream all
  run its `Drop`. `PendingPkKeys::begin_checkout` / `end_checkout` are private to the module,
  so no caller can open a window it does not also own.
- `CheckedOutShardedPkIndex` pairs the sharded index with its window. The index travels from
  `build_sharded_pk_index` through the prepared insert, the raw-stream drain, the per-table cap
  spill and the global byte-budget wait before `store_sharded_pk_index` — pairing them means
  every one of those exits carries both or drops both.
- `OnConflictValidationStream` holds the guard instead of a `store_back: bool`. The two
  encoded the same "did this validation take the shared cache" fact separately and could
  disagree; off-lock staging, which validates against a private keyset and opens no window,
  is now simply the `None` case.
- `abandon_cached_pk_index_checkout` is gone — it closed only the serial window and had to be
  reached explicitly, which is the bug.

## Test plan

- [x] Added regression tests for an abandoned checkout on both the serial and the sharded
      path (`an_abandoned_sharded_checkout_does_not_latch_the_pending_log`,
      `an_abandoned_serial_checkout_does_not_latch_the_pending_log`): the next validation must
      still see a key committed into its own window, and later restores must not be forced to
      discard.
- [x] Added unit tests for the guard itself: an abandoned checkout leaves the next one usable,
      `close` does not also close on `Drop`, and two concurrent checkouts are both discarded.
- [ ] `make lint` passes (workspace-wide `cargo fmt --all -- --check` + full clippy — not a
      per-crate scoped invocation)
- [ ] `make test` passes
- [ ] `make signoff` run after the final push (`Attestation` check is green)

The three unchecked lines are unchecked because they have not run: this branch's build host
has no room for a full workspace build right now, so `make signoff` is still pending and
`Attestation` will be red until it completes. The targeted checks that did run —
`cargo check -p cayenne --all-targets`, `cargo fmt --all -- --check`, and the tests above —
are all green.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits";
  `grok` not installed. An earlier full `codex` pass (job `review-mtc4161r-ydg0tg`) did complete,
  against the immediately preceding commit whose only difference from this one is the wording of
  a single doc comment. It returned one finding — that a PK-keyset rebuild cannot see the keys of
  a pipelined staged write that has recorded them but not yet published its files — which is
  present on `trunk` independently of this change and is filed as #13639 rather than folded in.
  Its recommendation to restore the abandoned index into the cache instead of dropping it is
  deliberately not taken: a cancelled validation may already have inserted its own kept keys, so
  publishing that index would claim keys for rows never written, and under
  `on_conflict: do_nothing` a later genuinely-new row for such a key would be skipped.
- `/security-review`: no findings. The diff adds no input parsing, path handling, deserialization,
  dependency, or `unsafe` block, and no log or error line carrying new data.
- `/simplify`: applied — one doc comment describing the field this change removed was rewritten to
  describe the code as it now is. Light checks re-run green. No other findings.

Fixes #13267

## Checklist

- [x] The change is scoped to the reported defect
- [x] No `.unwrap()` / `.expect()` outside tests
- [x] No behavior change on the healthy path — the window opens and closes exactly where it did