### PR TITLE
fix(tests): reap zombies in test containers so their names are released (fixes #13646)

### DIFF
--- a/crates/runtime/tests/docker/mod.rs
+++ b/crates/runtime/tests/docker/mod.rs
@@ -51,7 +51,7 @@ const CLEANUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// How long a container name is waited on before it is reused, once its
 /// removal has been requested.
-const NAME_RELEASE_TIMEOUT: Duration = Duration::from_secs(60);
+const NAME_RELEASE_TIMEOUT: Duration = Duration::from_mins(1);
 
 /// How often the name is re-checked while waiting for it to be released.
 const NAME_RELEASE_POLL_INTERVAL: Duration = Duration::from_millis(250);

--- a/crates/runtime/tests/docker/mod.rs
+++ b/crates/runtime/tests/docker/mod.rs
@@ -71,6 +71,40 @@ fn is_removal_already_in_progress(error: &anyhow::Error) -> bool {
     )
 }
 
+/// Whether a removal failed because there is no such container, which is the
+/// end state this wanted rather than a failure to reach it.
+///
+/// Reachable between the existence check and the removal below: the previous
+/// test's `Drop` cleanup can finish in that window, and the daemon then answers
+/// the second removal with a 404 rather than the 409 above.
+fn is_already_gone(error: &anyhow::Error) -> bool {
+    matches!(
+        error.downcast_ref::<bollard::errors::Error>(),
+        Some(bollard::errors::Error::DockerResponseServerError {
+            status_code: 404,
+            ..
+        })
+    )
+}
+
+/// Whether a creation failed because the name is still taken.
+///
+/// The daemon frees a name as the last step of removing a container, *after* it
+/// has dropped it from the list [`ContainerRunner::container_exist`] reads, so
+/// the name can still be reserved when that check says it is gone. Matched on
+/// the status code, as above: 409 is the only conflict `create_container`
+/// reports, and a reworded daemon message must not turn a retryable creation
+/// into a hard failure.
+fn is_name_still_taken(error: &bollard::errors::Error) -> bool {
+    matches!(
+        error,
+        bollard::errors::Error::DockerResponseServerError {
+            status_code: 409,
+            ..
+        }
+    )
+}
+
 pub struct RunningContainer<'a> {
     name: &'a str,
     docker: Docker,
@@ -404,7 +438,35 @@ impl<'a> ContainerRunner<'a> {
             ..Default::default()
         };
 
-        let _ = self.docker.create_container(Some(options), config).await?;
+        // `wait_for_name_release` polls the container list, and the daemon drops
+        // a container from that list before it releases the name — so the list
+        // can report the name free while it is still reserved, and creation
+        // answers 409. Retry on exactly that, under the same bound, rather than
+        // failing the test for a window that closes on its own.
+        let create_deadline = std::time::Instant::now() + NAME_RELEASE_TIMEOUT;
+        loop {
+            match self
+                .docker
+                .create_container(Some(options.clone()), config.clone())
+                .await
+            {
+                Ok(_) => break,
+                Err(e) if is_name_still_taken(&e) => {
+                    if std::time::Instant::now() >= create_deadline {
+                        return Err(anyhow::Error::new(e).context(format!(
+                            "the name of test container {} was still reserved {NAME_RELEASE_TIMEOUT:?} after its removal completed",
+                            self.name
+                        )));
+                    }
+                    tracing::debug!(
+                        "Docker still holds the name {}; retrying the creation",
+                        self.name
+                    );
+                    tokio::time::sleep(NAME_RELEASE_POLL_INTERVAL).await;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
 
         // The container exists from here on, so hold it in the guard before
         // anything else can fail. Starting it, inspecting it, or waiting for it
@@ -491,11 +553,39 @@ impl<'a> ContainerRunner<'a> {
     /// accepts. That reports the end state this method wants, so it is waited
     /// out rather than raised as a failure.
     async fn wait_for_name_release(&self) -> Result<(), anyhow::Error> {
+        // Bounded around the whole operation, not just between polls. Checking
+        // the elapsed time after each Docker call only bounds a daemon that
+        // keeps answering; one that accepts the connection and then stops
+        // replying leaves any single `list_containers` or `remove_container`
+        // outstanding forever, and the stated bound would never be reached.
+        // `Drop` guards its own cleanup the same way.
+        tokio::time::timeout(NAME_RELEASE_TIMEOUT, self.release_name())
+            .await
+            .unwrap_or_else(|_| {
+                Err(anyhow::anyhow!(
+                    "test container {} still held its name {NAME_RELEASE_TIMEOUT:?} after its removal was requested, so a new one cannot take it. Either the container cannot be killed or the Docker daemon stopped answering",
+                    self.name
+                ))
+            })
+    }
+
+    /// The body of [`Self::wait_for_name_release`], which supplies the deadline.
+    async fn release_name(&self) -> Result<(), anyhow::Error> {
         if !self.container_exist().await? {
             return Ok(());
         }
 
         if let Err(e) = remove(&self.docker, self.name).await {
+            // A 404 says the container is gone, which is the end state wanted;
+            // a 409 says someone else is removing it, which reaches that state.
+            // Anything else is a real failure.
+            if is_already_gone(&e) {
+                tracing::debug!(
+                    "Docker container {} was removed between the check and the removal",
+                    self.name
+                );
+                return Ok(());
+            }
             if !is_removal_already_in_progress(&e) {
                 return Err(e);
             }
@@ -505,16 +595,9 @@ impl<'a> ContainerRunner<'a> {
             );
         }
 
-        let start_time = std::time::Instant::now();
+        // No elapsed check here: the caller's timeout covers this loop and the
+        // requests inside it.
         while self.container_exist().await? {
-            // An unkillable container never releases its name, so this reports
-            // that rather than waiting on it for the job's whole budget.
-            if start_time.elapsed() > NAME_RELEASE_TIMEOUT {
-                return Err(anyhow::anyhow!(
-                    "test container {} was still present {NAME_RELEASE_TIMEOUT:?} after its removal was requested, so a new one cannot take its name",
-                    self.name
-                ));
-            }
             tokio::time::sleep(NAME_RELEASE_POLL_INTERVAL).await;
         }
 
@@ -586,7 +669,7 @@ pub async fn wait_for_tcp_port(
 
 #[cfg(test)]
 mod tests {
-    use super::is_removal_already_in_progress;
+    use super::{is_already_gone, is_name_still_taken, is_removal_already_in_progress};
 
     fn docker_error(status_code: u16, message: &str) -> anyhow::Error {
         anyhow::Error::new(bollard::errors::Error::DockerResponseServerError {
@@ -619,5 +702,56 @@ mod tests {
         assert!(!is_removal_already_in_progress(&anyhow::anyhow!(
             "the daemon is not reachable"
         )));
+    }
+
+    #[test]
+    fn a_container_removed_between_the_check_and_the_removal_is_already_released() {
+        // The previous test's `Drop` cleanup finishing in that window: the name
+        // is free, which is what the caller wanted, so this is not a failure.
+        assert!(is_already_gone(&docker_error(
+            404,
+            "No such container: runtime-integration-test-mysql-13306"
+        )));
+    }
+
+    #[test]
+    fn a_removal_that_fails_for_any_other_reason_is_not_already_gone() {
+        assert!(!is_already_gone(&docker_error(
+            409,
+            "removal of container runtime-integration-test-mysql-13306 is already in progress"
+        )));
+        assert!(!is_already_gone(&anyhow::anyhow!(
+            "the daemon is not reachable"
+        )));
+    }
+
+    #[test]
+    fn a_creation_refused_for_the_name_is_retried() {
+        // The window the container list cannot see: the daemon has dropped the
+        // container but not yet released its name.
+        assert!(is_name_still_taken(
+            &bollard::errors::Error::DockerResponseServerError {
+                status_code: 409,
+                message: "Conflict. The container name \"/runtime-integration-test-mysql-13306\" is already in use".to_string(),
+            }
+        ));
+    }
+
+    #[test]
+    fn a_creation_refused_for_any_other_reason_is_not_retried() {
+        // Retrying these would spend the whole name-release budget and then
+        // report the same failure, so they have to surface immediately.
+        assert!(!is_name_still_taken(
+            &bollard::errors::Error::DockerResponseServerError {
+                status_code: 404,
+                message: "No such image: mysql:9".to_string(),
+            }
+        ));
+        assert!(!is_name_still_taken(
+            &bollard::errors::Error::DockerResponseServerError {
+                status_code: 500,
+                message: "server error".to_string(),
+            }
+        ));
     }
 }

--- a/crates/runtime/tests/docker/mod.rs
+++ b/crates/runtime/tests/docker/mod.rs
@@ -49,6 +49,28 @@ static CONTAINER_SEMAPHORE: LazyLock<Arc<Semaphore>> =
 /// Cleanup is best-effort, and a test process must never hang in it.
 const CLEANUP_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// How long a container name is waited on before it is reused, once its
+/// removal has been requested.
+const NAME_RELEASE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How often the name is re-checked while waiting for it to be released.
+const NAME_RELEASE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Whether a removal failed only because the daemon is already removing that
+/// container, which reaches the same end state this wanted.
+///
+/// Matched on the status code rather than the message, so a reworded daemon
+/// error cannot silently turn this back into a hard failure.
+fn is_removal_already_in_progress(error: &anyhow::Error) -> bool {
+    matches!(
+        error.downcast_ref::<bollard::errors::Error>(),
+        Some(bollard::errors::Error::DockerResponseServerError {
+            status_code: 409,
+            ..
+        })
+    )
+}
+
 pub struct RunningContainer<'a> {
     name: &'a str,
     docker: Docker,
@@ -301,9 +323,7 @@ impl<'a> ContainerRunner<'a> {
         self,
         start_timeout: Option<Duration>,
     ) -> Result<RunningContainer<'a>, anyhow::Error> {
-        if self.container_exist().await? {
-            remove(&self.docker, self.name).await?;
-        }
+        self.wait_for_name_release().await?;
 
         let permit = tokio::time::timeout(
             std::time::Duration::from_mins(5), // Timeout after 5min
@@ -347,6 +367,20 @@ impl<'a> ContainerRunner<'a> {
 
         let host_config = Some(HostConfig {
             port_bindings,
+            // Reap zombies inside the container, so it stays killable and its
+            // name and host port are actually released.
+            //
+            // Several of these images fork children that their PID 1 never
+            // reaps (mongod, the DynamoDB local JVM, the Kafka broker). Once a
+            // zombie accumulates, Docker cannot kill the container -- removal
+            // fails with `could not kill container: ... is zombie and can not
+            // be killed`, whose own remedy is this flag. The container then
+            // leaks under a name derived from a fixed port, so every later test
+            // reusing that name fails on a 409 (`name already in use`, or
+            // `removal ... already in progress`) and every later test needing
+            // that host port fails with it -- one unkillable container spraying
+            // failures across unrelated connectors.
+            init: Some(true),
             ..Default::default()
         });
 
@@ -442,6 +476,51 @@ impl<'a> ContainerRunner<'a> {
         Ok(())
     }
 
+    /// Frees `self.name` so a fresh container can take it, waiting out a
+    /// removal that the daemon has accepted but not yet finished.
+    ///
+    /// `remove_container` returns once the removal is *accepted*, not once it is
+    /// done, and the name stays taken until it is. Creating inside that window
+    /// fails with a 409 (`Conflict. The container name ... is already in use`),
+    /// so the name is polled until it is genuinely gone rather than assumed free
+    /// the moment the call returns.
+    ///
+    /// A concurrent remover answers a second removal with a 409 (`removal of
+    /// container ... is already in progress`) -- the previous test's `Drop`
+    /// cleanup is the usual one, since it joins its thread as soon as the daemon
+    /// accepts. That reports the end state this method wants, so it is waited
+    /// out rather than raised as a failure.
+    async fn wait_for_name_release(&self) -> Result<(), anyhow::Error> {
+        if !self.container_exist().await? {
+            return Ok(());
+        }
+
+        if let Err(e) = remove(&self.docker, self.name).await {
+            if !is_removal_already_in_progress(&e) {
+                return Err(e);
+            }
+            tracing::debug!(
+                "Docker container {} is already being removed; waiting for its name",
+                self.name
+            );
+        }
+
+        let start_time = std::time::Instant::now();
+        while self.container_exist().await? {
+            // An unkillable container never releases its name, so this reports
+            // that rather than waiting on it for the job's whole budget.
+            if start_time.elapsed() > NAME_RELEASE_TIMEOUT {
+                return Err(anyhow::anyhow!(
+                    "test container {} was still present {NAME_RELEASE_TIMEOUT:?} after its removal was requested, so a new one cannot take its name",
+                    self.name
+                ));
+            }
+            tokio::time::sleep(NAME_RELEASE_POLL_INTERVAL).await;
+        }
+
+        Ok(())
+    }
+
     async fn container_exist(&self) -> Result<bool, anyhow::Error> {
         let containers = self
             .docker
@@ -503,4 +582,42 @@ pub async fn wait_for_tcp_port(
         timeout.as_secs(),
         last_error.unwrap_or_else(|| "none".to_string())
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_removal_already_in_progress;
+
+    fn docker_error(status_code: u16, message: &str) -> anyhow::Error {
+        anyhow::Error::new(bollard::errors::Error::DockerResponseServerError {
+            status_code,
+            message: message.to_string(),
+        })
+    }
+
+    #[test]
+    fn a_concurrent_removal_is_waited_out() {
+        assert!(is_removal_already_in_progress(&docker_error(
+            409,
+            "removal of container runtime-integration-test-mysql-13306 is already in progress"
+        )));
+    }
+
+    #[test]
+    fn an_unkillable_container_stays_a_failure() {
+        // The zombie-reap case: nothing will release this name, so waiting on it
+        // would spend the whole poll budget and then fail anyway. It has to
+        // surface as the error it is.
+        assert!(!is_removal_already_in_progress(&docker_error(
+            500,
+            "cannot remove container: could not kill container: PID 4291 is zombie and can not be killed"
+        )));
+    }
+
+    #[test]
+    fn an_unrelated_error_stays_a_failure() {
+        assert!(!is_removal_already_in_progress(&anyhow::anyhow!(
+            "the daemon is not reachable"
+        )));
+    }
 }


### PR DESCRIPTION
Fixes #13646

The merge-queue-only `integration tests` job — a required check — has been failing repo-wide, taking a batch with it each time.

## What was wrong

The integration suite's containers were created with no init process, so a child their PID 1 never reaps left a zombie behind. Docker then could not kill the container, and removal failed with a 500 whose message names its own remedy:

```
could not kill container: container c246cbb8e89c PID 4246 is zombie and can not
be killed. Use the --init option when creating containers to run an init inside
the container that forwards signals and reaps processes
```

The `Drop` cleanup timed out after 30s and the container leaked, still holding a name derived from a fixed port and still holding that host port. Every later test reusing that name then failed on a 409, and every later test needing the port failed with it — one unkillable container spraying failures across unrelated connectors.

A single `merge_group` run showed **88** such 409s, 19–22 flaky tests, and 7 tests that exhausted all six retries, spanning kafka, mongo, mysql, dynamodb and s3 — a spread no single PR's diff reaches. Across the last 200 `merge_group` runs the job failed 9 times on 7 different PRs, none of whose diffs touch container teardown.

A second shape is independent of zombies: `remove_container` returns once the daemon has *accepted* the removal, not once it has finished, so recreating the name inside that window hits a 409 on a container merely on its way out.

## What this changes

- **`init: Some(true)`** on the shared `HostConfig`, so every connector's container gets an init that reaps zombies and stays killable. Set in the shared builder rather than per-connector, so no image is left out.
- **`wait_for_name_release`** polls until the name is genuinely gone before reusing it, instead of assuming `remove_container` returning means the name is free. A concurrent remover — typically the previous test's `Drop` cleanup, which joins as soon as the daemon accepts — answers a second removal with a 409 reporting that same end state, so that is waited out rather than raised.

An unkillable container is still a hard failure: nothing will release its name, so it surfaces with a message saying so instead of silently consuming the wait. `an_unkillable_container_stays_a_failure` pins that, so a future widening of the tolerated case cannot quietly swallow it.

This is complementary to #13612, which is the same job failing for an unrelated reason (a hosted Spice Cloud dependency).

## Test plan
- [x] Added regression tests for the 409-tolerated, unkillable, and unrelated-error cases (`docker::tests`, 3 passed)
- [x] `make lint`
- [x] `make test`

## Review gate

Attests the review-fix commit `66346a0` (bounding the name release and closing the two races around it), not the original change on this PR.

- Adversarial review: **declared skip** — `codex` returned `ERROR: Your workspace is out of credits` partway through this run, and the `grok` plugin is not installed on this host. No engine was available, so this diff has not had an independent pass. It is the largest of this run's review fixes; a second look is worth having before merge.
- Security review: not run — `/security-review` needs a repository working directory and this run's session cwd is not one. The change is confined to the integration-test Docker harness: no new external input, no logging of anything but the container's own name.
- `/simplify`: not run, same constraints.
- Local verification: **not run.** A `crates/runtime` integration build did not complete on this host — the disk filled at 476G/100% during an earlier build in this run — so the three changes have not been compiled locally. Sign-off's workspace build is the first compile.
