### PR TITLE
fix(tools): forward strict() and as_mcp_proxy() from a renamed tool (fixes #13443)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22095,6 +22095,7 @@ dependencies = [
  "async-trait",
  "rmcp",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -11,8 +11,17 @@ version.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-rmcp = { workspace = true, optional = true }
+# `client` gates `rmcp::service`, which `mcp::McpProxy` names in its own
+# signature — without it this crate does not compile under its own `mcp`
+# feature, and only compiled at all because `runtime` enables `rmcp/client`
+# for the whole graph. `client` rather than `server` because the proxy calls
+# out to an MCP server rather than serving one.
+rmcp = { workspace = true, optional = true, features = ["client"] }
 serde_json.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true
+
 [features]
 mcp = ["dep:rmcp"]
 

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -28,6 +28,13 @@ use serde_json::Value;
 use std::borrow::Cow;
 
 /// Tools that implement the [`SpiceModelTool`] trait can automatically be used by LLMs in the runtime.
+///
+/// **A method added here has to be forwarded in `rename::RenamedTool`.** That wrapper
+/// re-exposes a tool under a catalog-qualified name and must answer for the tool it wraps on
+/// everything but `name`. A method carrying a default impl is inherited there silently — it
+/// compiles, and the wrapper then answers with the trait's fallback rather than the wrapped
+/// tool's real value (spiceai/spiceai#13443). Its `assert_answers_for_inner` test asserts the
+/// methods below as they stand and cannot fail for one that is added, so extend that too.
 #[async_trait]
 pub trait SpiceModelTool: Sync + Send {
     fn name(&self) -> Cow<'_, str>;

--- a/crates/tools/src/rename.rs
+++ b/crates/tools/src/rename.rs
@@ -36,9 +36,14 @@ pub fn with_name(tool: &Arc<dyn SpiceModelTool>, name: &str) -> Arc<dyn SpiceMod
 /// Every method other than [`SpiceModelTool::name`] must forward to the wrapped
 /// tool. Inheriting a trait default here answers for the inner tool with the
 /// trait's fallback instead of the inner tool's real value, which compiles
-/// cleanly and is wrong at runtime; `renamed_tool_forwards_every_method`
-/// pins the forwarding so a method added to the trait fails a test here rather
-/// than silently defaulting.
+/// cleanly and is wrong at runtime.
+///
+/// `assert_answers_for_inner` holds that for the methods [`SpiceModelTool`]
+/// exposes today, and cannot hold it for one added later: a new method with a
+/// default impl is inherited here, asserted by nothing, and the test still
+/// passes. Adding a method to the trait therefore means forwarding it here and
+/// extending that helper — which is why the requirement is also recorded on
+/// the trait, where someone adding one would be looking.
 struct RenamedTool {
     name: String,
     tool: Arc<dyn SpiceModelTool>,
@@ -151,12 +156,14 @@ mod tests {
         }
     }
 
-    /// Assert `renamed` answers for `inner` on every method of the trait but
-    /// [`SpiceModelTool::name`].
+    /// Assert `renamed` answers for `inner` on every method [`SpiceModelTool`]
+    /// exposes today, other than [`SpiceModelTool::name`].
     ///
-    /// Kept in one place deliberately: a method added to [`SpiceModelTool`] has
-    /// to be forwarded for every wrapping shape at once, so it should have to be
-    /// asserted in only one.
+    /// This records the current trait surface; it does not grow with it. A
+    /// method added to the trait is inherited by the wrapper and checked by
+    /// nothing below, so extend this whenever the trait gains one. Keeping the
+    /// per-method assertions here rather than in each test is what makes that a
+    /// single edit instead of one per wrapping shape.
     async fn assert_answers_for_inner(
         renamed: &Arc<dyn SpiceModelTool>,
         inner: &Arc<dyn SpiceModelTool>,

--- a/crates/tools/src/rename.rs
+++ b/crates/tools/src/rename.rs
@@ -32,6 +32,13 @@ pub fn with_name(tool: &Arc<dyn SpiceModelTool>, name: &str) -> Arc<dyn SpiceMod
 /// Wraps [`SpiceModelTool`]s to enable renaming them.
 ///
 /// Not intended for broad use, solely [`with_name`].
+///
+/// Every method other than [`SpiceModelTool::name`] must forward to the wrapped
+/// tool. Inheriting a trait default here answers for the inner tool with the
+/// trait's fallback instead of the inner tool's real value, which compiles
+/// cleanly and is wrong at runtime; `renamed_tool_forwards_every_method`
+/// pins the forwarding so a method added to the trait fails a test here rather
+/// than silently defaulting.
 struct RenamedTool {
     name: String,
     tool: Arc<dyn SpiceModelTool>,
@@ -47,11 +54,184 @@ impl SpiceModelTool for RenamedTool {
         self.tool.description()
     }
 
+    fn strict(&self) -> Option<bool> {
+        self.tool.strict()
+    }
+
     fn parameters(&self) -> Option<Value> {
         self.tool.parameters()
     }
 
     async fn call(&self, arg: &str) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
         self.tool.call(arg).await
+    }
+
+    #[cfg(feature = "mcp")]
+    async fn as_mcp_proxy(&self) -> Option<&dyn crate::McpProxy> {
+        self.tool.as_mcp_proxy().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SpiceModelTool, with_name};
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use std::{borrow::Cow, sync::Arc};
+
+    #[cfg(feature = "mcp")]
+    struct StubProxy;
+
+    #[cfg(feature = "mcp")]
+    #[async_trait]
+    impl crate::McpProxy for StubProxy {
+        async fn call_tool(
+            &self,
+            _arguments: Option<rmcp::model::JsonObject>,
+        ) -> Result<rmcp::model::CallToolResult, rmcp::service::ServiceError> {
+            Ok(rmcp::model::CallToolResult::success(vec![]))
+        }
+    }
+
+    struct InnerTool {
+        strict: Option<bool>,
+        #[cfg(feature = "mcp")]
+        proxy: Option<StubProxy>,
+    }
+
+    impl InnerTool {
+        /// A tool answering every optional method with a value the trait default
+        /// cannot produce, so a wrapper that inherits a default rather than
+        /// forwarding disagrees with it.
+        fn answering(strict: bool) -> Arc<dyn SpiceModelTool> {
+            Arc::new(Self {
+                strict: Some(strict),
+                #[cfg(feature = "mcp")]
+                proxy: Some(StubProxy),
+            })
+        }
+
+        /// A tool that answers every optional method exactly as the trait default
+        /// does, so forwarding must reproduce the absence rather than invent a
+        /// value of the wrapper's own.
+        fn silent() -> Arc<dyn SpiceModelTool> {
+            Arc::new(Self {
+                strict: None,
+                #[cfg(feature = "mcp")]
+                proxy: None,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl SpiceModelTool for InnerTool {
+        fn name(&self) -> Cow<'_, str> {
+            Cow::Borrowed("inner")
+        }
+
+        fn description(&self) -> Option<Cow<'_, str>> {
+            Some(Cow::Borrowed("the inner tool"))
+        }
+
+        fn strict(&self) -> Option<bool> {
+            self.strict
+        }
+
+        fn parameters(&self) -> Option<Value> {
+            Some(serde_json::json!({ "type": "object" }))
+        }
+
+        async fn call(&self, arg: &str) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(Value::String(format!("inner called with {arg}")))
+        }
+
+        #[cfg(feature = "mcp")]
+        async fn as_mcp_proxy(&self) -> Option<&dyn crate::McpProxy> {
+            self.proxy.as_ref().map(|p| p as &dyn crate::McpProxy)
+        }
+    }
+
+    /// Assert `renamed` answers for `inner` on every method of the trait but
+    /// [`SpiceModelTool::name`].
+    ///
+    /// Kept in one place deliberately: a method added to [`SpiceModelTool`] has
+    /// to be forwarded for every wrapping shape at once, so it should have to be
+    /// asserted in only one.
+    async fn assert_answers_for_inner(
+        renamed: &Arc<dyn SpiceModelTool>,
+        inner: &Arc<dyn SpiceModelTool>,
+    ) {
+        assert_eq!(renamed.description(), inner.description());
+        assert_eq!(renamed.parameters(), inner.parameters());
+        assert_eq!(
+            renamed.strict(),
+            inner.strict(),
+            "strict() must forward the inner tool's value, not the trait's None"
+        );
+        assert_eq!(
+            renamed.call("x").await.expect("the inner call succeeds"),
+            inner.call("x").await.expect("the inner call succeeds")
+        );
+        #[cfg(feature = "mcp")]
+        assert_eq!(
+            renamed.as_mcp_proxy().await.is_some(),
+            inner.as_mcp_proxy().await.is_some(),
+            "as_mcp_proxy() must forward the inner tool's proxy, not the trait's None"
+        );
+    }
+
+    /// Renaming replaces the name and nothing else.
+    #[tokio::test]
+    async fn renamed_tool_forwards_every_method() {
+        let inner = InnerTool::answering(true);
+        let renamed = with_name(&inner, "catalog__inner");
+
+        assert_eq!(renamed.name(), "catalog__inner");
+        assert_eq!(inner.name(), "inner", "the wrapped tool is not modified");
+
+        // The comparison in `assert_answers_for_inner` is only a regression guard
+        // while the fixture's answers differ from the defaults a non-forwarding
+        // wrapper would return; assert that here so it cannot pass vacuously.
+        assert_eq!(inner.strict(), Some(true));
+        #[cfg(feature = "mcp")]
+        assert!(inner.as_mcp_proxy().await.is_some());
+
+        assert_answers_for_inner(&renamed, &inner).await;
+    }
+
+    /// `Some(false)` and the trait default `None` mean different things to the
+    /// callers that read `strict()` into an outgoing function definition, so a
+    /// wrapper that collapses one into the other is not forwarding.
+    #[tokio::test]
+    async fn renamed_tool_forwards_a_false_strict_rather_than_absence() {
+        let inner = InnerTool::answering(false);
+        let renamed = with_name(&inner, "catalog__inner");
+
+        assert_eq!(renamed.strict(), Some(false));
+    }
+
+    /// Forwarding must carry an *absent* answer through unchanged too — a wrapper
+    /// that supplies a value of its own is as wrong as one that drops the inner
+    /// tool's.
+    #[tokio::test]
+    async fn renamed_tool_forwards_absent_answers() {
+        let inner = InnerTool::silent();
+        let renamed = with_name(&inner, "catalog__inner");
+
+        assert_eq!(renamed.strict(), None);
+        #[cfg(feature = "mcp")]
+        assert!(renamed.as_mcp_proxy().await.is_none());
+        assert_answers_for_inner(&renamed, &inner).await;
+    }
+
+    /// Renames compose: each layer forwards to the one below, so a tool wrapped
+    /// twice still answers for itself on every method but its name.
+    #[tokio::test]
+    async fn nested_renames_forward_through_every_layer() {
+        let inner = InnerTool::answering(true);
+        let renamed = with_name(&with_name(&inner, "once"), "twice");
+
+        assert_eq!(renamed.name(), "twice");
+        assert_answers_for_inner(&renamed, &inner).await;
     }
 }


### PR DESCRIPTION
## 📝 Summary

`RenamedTool` — the wrapper `tools::rename::with_name` builds to re-expose a tool under a catalog-qualified name — implemented three of `SpiceModelTool`'s five methods. It forwarded `description`, `parameters` and `call`, and inherited the trait defaults for the other two, so it answered `None` for `strict()` and reported the wrapped tool as not an MCP proxy. That is the defaulted-trait-method-in-a-wrapper shape `CLAUDE.md` names under *Trait evolution & wrapper delegation*: it compiles, and the wrapper answers for the inner tool with the trait's fallback instead of the inner tool's real value.

Neither drop is observable on current `trunk`, which is why the issue was filed as a hazard rather than a defect with a repro:

- **`strict()` is reachable but inert.** `Tooling::tools()` wraps every tool of a non-default catalog with `with_name`, and those wrappers reach all three sites that read `t.strict()` into an outgoing function definition (`runtime/src/model/tool_use.rs`, `runtime/src/model/tool_use_responses.rs`, `runtime-tools/src/catalog.rs`). No tool in the repo overrides `strict()` today, so the value dropped is always `None` — the first one that does would silently lose the override when exposed through a catalog.
- **`as_mcp_proxy()` is currently unreachable.** Its only caller is the `/v1/mcp` gateway, which resolves through `RuntimeServer::get_tool`; that returns the catalog's tool unwrapped, so the proxy check never sees a `RenamedTool`.

`RenamedTool` is the only delegating `SpiceModelTool` wrapper in the tree — every other impl is a leaf tool or a leaf adapter over something that is not a `SpiceModelTool` — so this bug class has exactly one instance and it is fixed here.

## Changes

- Forward `strict()` and `as_mcp_proxy()` to the wrapped tool.
- Record the requirement in the two places someone would meet it: on `RenamedTool`, and on `SpiceModelTool` itself, where a method would be added.
- Pin the forwarding with tests that assert a renamed tool answers for its inner tool on every method the trait exposes today — for a present answer, for an absent one, for a `Some(false)` that must not collapse into the trait's `None`, and through nested renames. The per-method assertions live in one helper, so extending them when the trait grows is a single edit rather than one per wrapping shape. That helper records the current trait surface; it is deliberately *not* described as a guard that fails for a newly added method, because it cannot be one — a new method carrying a default impl is inherited by the wrapper and asserted by nothing. That is why the requirement is also stated on the trait.
- Enable `rmcp/client` on this crate's optional `rmcp` dependency. `rmcp::service`, which `mcp::McpProxy` names in its own signature, is gated behind it, so `crates/tools` did not build under its own `mcp` feature and only ever compiled with `mcp` on because `runtime` enables that feature for the whole graph. Without this the `mcp`-gated half of the new test cannot be run at all. Nothing changes in a shipped binary — `runtime` already enables `rmcp`'s `client` *and* `server`.

Each forwarding method was reverted in turn to confirm the tests catch it: `strict()` and `as_mcp_proxy()` are each independently caught, and the absent-answer test correctly still passes under both (it asserts the wrapper does not invent a value, which a non-forwarding wrapper also satisfies).

## 🔗 Related

Fixes #13443

Refs #13648 — `runtime-tools` has the same latent defect one crate up, on a larger feature set: its `mcp` feature enables neither `tools/mcp` nor `rmcp`'s own features, so `cargo check -p runtime-tools --features mcp` does not compile. Filed rather than folded in; it is a separate crate and a separate feature set.

## 🚨 Breaking Changes

None. Both forwarded methods previously returned the trait default, and no tool in the tree overrides `strict()` or is reachable as a `RenamedTool` through the MCP gateway today, so no shipped behaviour changes.

## 📚 Docs

None required — no user-facing configuration, API, or error message changes.

## 👀 Notes for Reviewers

The `rmcp/client` line is the one change beyond the issue's ask. It is load-bearing rather than incidental: without it the `mcp`-gated assertions cannot compile in a scoped run, so the regression test for half the fix would only ever be built by a workspace-wide command and never executed by `make nextest` (which resolves default features, leaving `tools/mcp` off). `client` rather than `server` because this crate proxies out to an MCP server rather than serving one.

## Test plan

- `make lint`
- `make nextest`
- `make signoff`

## Review gate

- Adversarial review: `codex` — job `review-mtcjd7yj-wy9ql3` — verdict approve, no material findings. It traced the delegation callers, checked the `rmcp` feature graph and lockfile, and ran the crate's test binaries. (Two earlier attempts on the first commit returned `exit=1`, "Your workspace is out of credits"; this one ran against the current HEAD.)
- `/security-review`: no findings — the only change with a security-relevant control-flow effect is `as_mcp_proxy()` forwarding, which selects the MCP passthrough branch of `call_tool`; that branch applies its own argument depth check, and the path is unreachable today because `get_tool` returns catalog tools unwrapped
- Copilot review: one finding, valid and fixed in `f92df3c` — the `RenamedTool` comment claimed the test would fail for a method added to the trait, which it cannot do. Reworded to state what the test holds, and the requirement moved onto the trait as well.
- `/simplify`: applied — removed `#[cfg(feature = "mcp")]` attributes from a shared constructor's parameters in favour of two plain constructors, and factored the duplicated per-method assertions into one helper; light checks re-run green