### PR TITLE
test(chbench): run scheduled HTAP for 30 minutes

### DIFF
--- a/.github/workflows/testoperator_dispatch_htap.yml
+++ b/.github/workflows/testoperator_dispatch_htap.yml
@@ -2,19 +2,25 @@ name: testoperator dispatch htap
 
 on:
   schedule:
-    # htap-sf1000-adaptive, every 6 hours (0000, 0600, 1200, 1800) — the high-value SF1000 adaptive
-    # config for frequent adaptive trend data (spiceai-dev-xlarge-runners).
-    - cron: '0 */6 * * *'
-    # htap-sf1000 (other configs), once daily (0100) — the remaining SF1000 configs
-    # (adaptive-turso, duckdb baseline) on the xlarge pool.
-    - cron: '0 1 * * *'
+    # htap-sf1000-adaptive, every 8 hours (0000, 0800, 1600) — the high-value SF1000 adaptive
+    # config for frequent adaptive trend data (spiceai-dev-xlarge-runners). 8h is the tightest
+    # cadence that still fits the serialized SF1000 xlarge queue in a day at a 30-minute HTAP
+    # window (16 runs/day across adaptive + daily + cold batches, ~20h occupancy with slack
+    # for slow/cold/mysql arms).
+    - cron: '0 */8 * * *'
+    # htap-sf1000 (other configs), once daily (0400) — the remaining SF1000 configs
+    # (adaptive-turso, duckdb baseline) on the xlarge pool. 0400 sits after the 0000 adaptive
+    # batch (~4h) so it usually starts on an idle slot rather than queueing immediately.
+    - cron: '0 4 * * *'
     # htap-sf1, twice daily (0600, 1800) — HTAP CH-benCHmark SF1 (spiceai-dev-large-runners),
     # including adaptive-ivm (lower rate so IVM contribution indexes stay under the safety cap).
+    # SF1 uses a different runner pool and a unique concurrency group, so it does not serialize
+    # with the SF1000 xlarge queue.
     - cron: '0 6,18 * * *'
-    # htap-sf1000-cold, once daily (0800) — HTAP CH-benCHmark SF1000 adaptive cold-object-store tier
-    # (spiceai-dev-xlarge-runners). Lighter once-a-day cadence; it shares the SF1000 serialized run
-    # concurrency group, so it queues, never contends.
-    - cron: '0 8 * * *'
+    # htap-sf1000-cold, once daily (1200) — HTAP CH-benCHmark SF1000 adaptive cold-object-store
+    # tier (spiceai-dev-xlarge-runners). 1200 is between the 0800 and 1600 adaptive slots; it
+    # shares the SF1000 serialized run concurrency group, so it queues, never contends.
+    - cron: '0 12 * * *'
 
   workflow_dispatch:
     inputs:
@@ -107,10 +113,10 @@ jobs:
           SF="${{ github.event.inputs.scale_factor }}"
           if [ -z "$SF" ]; then
             case "${{ github.event.schedule }}" in
-              '0 */6 * * *')                  SF=sf1000-adaptive ;;
-              '0 1 * * *')                    SF=sf1000 ;;
+              '0 */8 * * *')                  SF=sf1000-adaptive ;;
+              '0 4 * * *')                    SF=sf1000 ;;
               '0 6,18 * * *')                 SF=sf1 ;;
-              '0 8 * * *')                    SF=sf1000-cold ;;
+              '0 12 * * *')                   SF=sf1000-cold ;;
               *)                              SF= ;;   # unrecognized cron — dispatch nothing
             esac
           fi

--- a/.github/workflows/testoperator_run_htap.yml
+++ b/.github/workflows/testoperator_run_htap.yml
@@ -29,7 +29,7 @@ on:
         description: 'Duration of the HTAP workload in seconds'
         required: false
         type: string
-        default: '600'
+        default: '1800'
       concurrency:
         description: 'Number of concurrent analytical query clients'
         required: false
@@ -94,7 +94,11 @@ jobs:
   run-htap:
     name: Run CH-BenCHmark
     runs-on: ${{ github.event.inputs.runner_type }}
-    timeout-minutes: 120
+    # 30-minute HTAP window plus ready_wait (up to 30 min on cold SF1000), template
+    # restore, analytical gate, and teardown. SF1000 jobs typically land around 65-90 min
+    # at this duration, so 150 min keeps ~1h of headroom without silently eating a
+    # wedged-seed budget (that path has its own 90-min step timeout).
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -235,7 +239,7 @@ jobs:
         if: steps.set_spicepod_path.outputs.SOURCE_TYPE == 'mysql' && github.event.inputs.runner_type == 'spiceai-dev-xlarge-runners'
         # Backstop so a wedged seed/restore (e.g. a DROP blocked on a stale lock)
         # fails THIS step fast and attributably, instead of silently consuming the
-        # whole 120-min job budget and reporting a confusing "cancelled". A cold
+        # whole 150-min job budget and reporting a confusing "cancelled". A cold
         # SF1000 CSV seed finishes comfortably under this; exceeding it means the
         # seed is stuck.
         timeout-minutes: 90

--- a/tools/testoperator/dispatch/chbench/sf1/mysql-cayenne[file]-adaptive-ivm.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/mysql-cayenne[file]-adaptive-ivm.yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: accelerated/mysql-cayenne[file]-adaptive-ivm.yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 900
+    duration: 1800
     ready_wait: 60
     # Keep q1 + q6 live contribution indexes below the 5M cap during 15 minutes.
     rate: 400

--- a/tools/testoperator/dispatch/chbench/sf1/mysql-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/mysql-cayenne[file]-adaptive.yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/mysql-cayenne[file]-adaptive.yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 900
+    duration: 1800
     ready_wait: 60
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1/mysql-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/mysql-cayenne[file].yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/mysql-cayenne[file].yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 900
+    duration: 1800
     ready_wait: 60
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1/mysql-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/mysql-duckdb[file].yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: accelerated/mysql-duckdb[file].yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 900
+    duration: 1800
     ready_wait: 60
     query_overrides: duckdb
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-adaptive-ivm.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-adaptive-ivm.yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: accelerated/postgres-cayenne[file]-adaptive-ivm.yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 900
+    duration: 1800
     ready_wait: 60
     # Keep q1 + q6 live contribution indexes below the 5M cap during 15 minutes.
     rate: 400

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file]-adaptive.yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/postgres-cayenne[file]-adaptive.yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 900
+    duration: 1800
     ready_wait: 60
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-cayenne[file].yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/postgres-cayenne[file].yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 900
+    duration: 1800
     ready_wait: 60
     rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1/postgres-duckdb[file].yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
     runner_type: spiceai-dev-large-runners
     scale_factor: 1
-    duration: 900
+    duration: 1800
     ready_wait: 60
     query_overrides: duckdb
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-arrow.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-arrow.yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/postgres-arrow.yaml
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 10
-    duration: 600
+    duration: 1800
     ready_wait: 300
     rate: 5000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-adaptive.yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/postgres-cayenne[file]-adaptive.yaml
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 10
-    duration: 600
+    duration: 1800
     ready_wait: 300
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file]-cdc-tuned.yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/postgres-cayenne[file]-cdc-tuned-sf10.yaml
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 10
-    duration: 600
+    duration: 1800
     ready_wait: 300
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-cayenne[file].yaml
@@ -3,6 +3,6 @@ tests:
     spicepod_path: accelerated/postgres-cayenne[file].yaml
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 10
-    duration: 600
+    duration: 1800
     ready_wait: 300
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf10/postgres-duckdb[file].yaml
@@ -3,7 +3,7 @@ tests:
     spicepod_path: accelerated/postgres-duckdb[file].yaml
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 10
-    duration: 600
+    duration: 1800
     ready_wait: 300
     query_overrides: duckdb
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-adaptive.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 100
     terminals: 100
-    duration: 600
+    duration: 1800
     ready_wait: 600
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned-memory.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned-memory.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 100
     terminals: 100
-    duration: 600
+    duration: 1800
     ready_wait: 600
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned-turso.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned-turso.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 100
     terminals: 100
-    duration: 600
+    duration: 1800
     ready_wait: 600
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file]-cdc-tuned.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 100
     terminals: 100
-    duration: 600
+    duration: 1800
     ready_wait: 600
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-cayenne[file].yaml
@@ -4,7 +4,7 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 100
     terminals: 100
-    duration: 600
+    duration: 1800
     ready_wait: 600
     rate: 10000
   bench:

--- a/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf100/postgres-duckdb[file].yaml
@@ -4,7 +4,7 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 100
     terminals: 100
-    duration: 600
+    duration: 1800
     ready_wait: 600
     query_overrides: duckdb
     rate: 10000

--- a/tools/testoperator/dispatch/chbench/sf1000-adaptive/mysql-cayenne[file]-adaptive-split.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-adaptive/mysql-cayenne[file]-adaptive-split.yaml
@@ -4,7 +4,7 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 900
+    duration: 1800
     ready_wait: 900
     query_overrides: chbench-skip-slow
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000-adaptive/mysql-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-adaptive/mysql-cayenne[file]-adaptive.yaml
@@ -4,7 +4,7 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 900
+    duration: 1800
     ready_wait: 900
     query_overrides: chbench-skip-slow
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000-adaptive/postgres-cayenne[file]-adaptive.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-adaptive/postgres-cayenne[file]-adaptive.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 900
+    duration: 1800
     ready_wait: 900
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000-cold/postgres-cayenne[file]-adaptive-cold-auto.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-cold/postgres-cayenne[file]-adaptive-cold-auto.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 900
+    duration: 1800
     ready_wait: 1800
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000-cold/postgres-cayenne[file]-adaptive-cold.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000-cold/postgres-cayenne[file]-adaptive-cold.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 900
+    duration: 1800
     ready_wait: 1800
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000/mysql-cayenne[file]-adaptive-turso.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/mysql-cayenne[file]-adaptive-turso.yaml
@@ -4,7 +4,7 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 900
+    duration: 1800
     ready_wait: 900
     query_overrides: chbench-skip-slow
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000/mysql-cayenne[file]-tuned.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/mysql-cayenne[file]-tuned.yaml
@@ -4,7 +4,7 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 900
+    duration: 1800
     ready_wait: 900
     query_overrides: chbench-skip-slow
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000/mysql-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/mysql-duckdb[file].yaml
@@ -4,7 +4,7 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 900
+    duration: 1800
     ready_wait: 900
     query_overrides: duckdb
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-adaptive-turso.yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-cayenne[file]-adaptive-turso.yaml
@@ -4,6 +4,6 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 900
+    duration: 1800
     ready_wait: 900
     rate: 9250

--- a/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
+++ b/tools/testoperator/dispatch/chbench/sf1000/postgres-duckdb[file].yaml
@@ -4,7 +4,7 @@ tests:
     runner_type: spiceai-dev-xlarge-runners
     scale_factor: 1000
     terminals: 100
-    duration: 900
+    duration: 1800
     ready_wait: 900
     query_overrides: duckdb
     rate: 9250


### PR DESCRIPTION
## Summary

Scheduled CH-benCHmark HTAP runs used a 10-minute window at SF10/SF100 (`duration: 600`) and a 15-minute window everywhere else (`duration: 900`). That is short for CDC lag / QPH to settle, especially at SF1000.

This sets every scheduled dispatch batch — and the HTAP workflow default — to **30 minutes** (`duration: 1800`).

## Schedule

SF100 and SF1000 runs share one xlarge concurrency group, so occupancy has to fit in a day. Recent 15-minute SF1000 jobs already take 50–75 minutes of wall clock (ready wait, template restore, analytical gate, teardown). Adding 15 minutes of workload at the old 6-hour adaptive cadence is ~19 serialized SF1000 runs/day and ~24 hours of xlarge time — the FIFO queue would grow.

`testoperator_dispatch_htap.yml` therefore:

- runs **SF1000 adaptive every 8 hours** (00:00 / 08:00 / 16:00 UTC) instead of every 6 hours
- moves the daily SF1000 (other configs) batch from 01:00 to **04:00**, after the 00:00 adaptive batch
- moves SF1000 cold from 08:00 to **12:00**, between the 08:00 and 16:00 adaptive slots
- leaves SF1 twice daily at 06:00 / 18:00 (large runners, not on the SF1000 queue)

That is 16 serialized SF1000 runs/day, about 20 hours of xlarge occupancy, with slack for slow/cold/MySQL arms.

The HTAP job timeout is **150 minutes** (was 120) so a ~90-minute cold SF1000 run still has ~1 hour of headroom. The MySQL template-seed step timeout stays 90 minutes.

## Test plan

- [x] All 29 `tools/testoperator/dispatch/chbench/**/*.yaml` files have `duration: 1800`
- [x] Cron strings in `on.schedule` match the `Resolve scale factor` case mapping
- [x] `python .github/scripts/check_workflow_yaml.py` — 116 definitions well-formed
- [ ] After merge, confirm the next scheduled `testoperator dispatch htap` run resolves the expected scale factor from the new crons
- [ ] Confirm an SF1000 job completes inside the 150-minute timeout