### PR TITLE
fix(llms): un-mute the LLM integration suite and make it pass (fixes #6399, #13558, #13560)

### DIFF
--- a/.github/workflows/integration_llms.yml
+++ b/.github/workflows/integration_llms.yml
@@ -165,6 +165,10 @@ jobs:
       HAS_SPICEIO_SECRET: ${{ secrets.UNAS_SMB_PASS != '' }}
       TEST_BINARY_OBJECT_KEY: test_binaries/${{ github.run_id }}/llms_integration_test
     strategy:
+      # The two arms cover disjoint model sets — self-hosted local models and the hosted
+      # providers — so one arm's result says nothing about the other's, and cancelling the
+      # sibling on the first failure throws away half the signal this suite exists to give.
+      fail-fast: false
       matrix:
         target: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     permissions: read-all
@@ -242,8 +246,37 @@ jobs:
               exit 1
             fi
           fi
-          # `--test-threads` to reduce possible rate limiting/ connection issues for hosted models.
-          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" ./integration_test/llms_integration_test --nocapture -- llms::tests --test-threads=2
+          test_binary=./integration_test/llms_integration_test
+          # Every test in this binary lives under `integration.rs`'s only module, `llms`.
+          filter='llms::'
+
+          # A filter that matches nothing makes libtest print `ok. 0 passed` and exit 0, so the
+          # suite reports success having tested nothing. The filter names test-code structure,
+          # which a refactor is free to move, so count the selection and refuse an empty one
+          # rather than trusting a green result. `--list` only enumerates — it runs no test body,
+          # so it costs no model call and needs none of the snapshot environment below. Its exit
+          # status is checked separately from the count, because a harness that cannot run also
+          # produces no output, and reporting that as a stale filter sends the reader to the
+          # wrong file.
+          if ! listed=$("$test_binary" --list "$filter"); then
+            echo "::error::The LLM integration test binary failed to list its tests, so the suite could not run. Check the build and download steps above."
+            exit 1
+          fi
+          # `grep -c` exits 1 on no match, which `-e` would otherwise turn into an abort before
+          # the branch below can report the real problem.
+          selected=$(printf '%s\n' "$listed" | grep -c ': test$' || true)
+          echo "Filter '$filter' selects ${selected} test(s)."
+          if [ "$selected" -eq 0 ]; then
+            echo "::error::The LLM integration filter '$filter' selected no tests, so this suite would report success without exercising any model. Point it at the current test module path under crates/llms/tests/."
+            exit 1
+          fi
+
+          # The binary is itself the libtest harness, so its options are passed directly. A `--`
+          # here would end option parsing, and libtest would read `--test-threads=2` as a second
+          # filter and silently keep its default thread count. `--test-threads` holds concurrent
+          # requests low enough to stay under the hosted providers' rate limits.
+          INSTA_WORKSPACE_ROOT="${PWD}" CARGO_MANIFEST_DIR="${PWD}" \
+            "$test_binary" --nocapture --test-threads=2 "$filter"
 
       - name: Kill spiceio
         if: always() && runner.os == 'macOS' && steps.setup-spiceio.outputs.pid != ''

--- a/crates/llms/tests/llms/mod.rs
+++ b/crates/llms/tests/llms/mod.rs
@@ -25,6 +25,7 @@ use llms::{accumulate::accumulate, chat::Chat};
 use rstest::rstest;
 use serde_json::json;
 use std::{
+    collections::HashMap,
     str::FromStr,
     sync::{Arc, LazyLock, Mutex},
 };
@@ -136,6 +137,34 @@ static MODEL_CACHES: LazyLock<Vec<(&'static str, ModelCache)>> = LazyLock::new(|
         .collect()
 });
 
+/// Hugging Face repos that back more than one fixture. `hf_phi3` and `local_phi3`
+/// are separate fixtures over the same repo, so their per-model caches guard
+/// different entries and do not serialize the artifact download they share.
+/// Creating them concurrently races on the repo's blob lock in the Hugging Face
+/// cache, and the loser fails the test instead of waiting for the download in
+/// flight (regression test for #13560). Serialize creation on the shared repo so
+/// the second fixture reads the warmed cache. Fixtures with no shared repo return
+/// `None` and never contend.
+fn shared_repo(model_name: &str) -> Option<&'static str> {
+    match model_name {
+        "hf_phi3" | "local_phi3" => Some("microsoft/Phi-3-mini-4k-instruct"),
+        _ => None,
+    }
+}
+
+/// One fetch lock per shared repo (see [`shared_repo`]). Held across model
+/// creation so the first fixture over a repo completes its download before the
+/// second starts.
+static REPO_FETCH_LOCKS: LazyLock<HashMap<&'static str, tokio::sync::Mutex<()>>> =
+    LazyLock::new(|| {
+        let mut locks = HashMap::new();
+        locks.insert(
+            "microsoft/Phi-3-mini-4k-instruct",
+            tokio::sync::Mutex::new(()),
+        );
+        locks
+    });
+
 /// Get or create a model instance for the given name
 async fn get_or_create_model(model_name: &str) -> Result<Arc<dyn Chat>, anyhow::Error> {
     let (_, model_cache) = MODEL_CACHES
@@ -144,6 +173,31 @@ async fn get_or_create_model(model_name: &str) -> Result<Arc<dyn Chat>, anyhow::
         .ok_or_else(|| anyhow::anyhow!("model {model_name} not found in MODEL_CACHES"))?;
 
     // Check if model is already cached
+    {
+        let guard = model_cache
+            .lock()
+            .map_err(|_| anyhow::anyhow!("model cache could not be unlocked"))?;
+        if let Some(model) = guard.as_ref() {
+            return Ok(Arc::clone(model));
+        }
+    }
+
+    // Serialize the fetch of fixtures that share a Hugging Face repo, so a
+    // concurrent sibling waits for the download rather than racing on the repo's
+    // blob lock. Held across creation; `None` for fixtures with no shared repo.
+    let _repo_guard = match shared_repo(model_name) {
+        Some(repo) => Some(
+            REPO_FETCH_LOCKS
+                .get(repo)
+                .ok_or_else(|| anyhow::anyhow!("no fetch lock registered for repo {repo}"))?
+                .lock()
+                .await,
+        ),
+        None => None,
+    };
+
+    // Re-check the cache under the repo lock: a sibling over the same model may
+    // have finished creation while this call waited for the lock.
     {
         let guard = model_cache
             .lock()


### PR DESCRIPTION
Un-mutes the `integration tests (llms)` suite and drives it green. This is the
umbrella that re-lands the un-muting reverted by #13652 and carries the fixes for
the failures it exposes. **Draft until both matrix arms run green** — merging
closes every issue below, so it must not merge while any of them still fails.

Tracked by #13653.

## What this PR does

- **Re-lands the un-muting** (#13556, reverted by #13652): repoints the filter to
  `llms::`, moves harness options ahead of `--` so `--test-threads=2` takes
  effect, adds the zero-selection guard that fails the step if the filter matches
  no tests, and sets `fail-fast: false` on the matrix.
- **Fixes #13560** — `hf_phi3` and `local_phi3` are two fixtures over one Hugging
  Face repo. Their per-model caches do not serialize the shared download, so
  concurrent creation races on the repo's blob lock and the loser fails. Adds a
  per-repo fetch lock held across creation, and re-checks the model cache under
  it. All 15 self-hosted failures.

## Blocking before this can go green (and merge)

- **#13558** — the workflow's Bedrock credentials are rejected
  (`UnrecognizedClientException`): the AWS key is present but invalid. Fixed by
  rotating the `SPICE_BEDROCK_ACCESS_KEY` / `SPICE_BEDROCK_SECRET_KEY` repo
  secrets — not a source change. 10 hosted failures.
- **#6399** — assertions that depend on specific model output; the residual
  hosted failures are stale `insta` snapshots. Regenerated from a green run once
  the suite is otherwise passing.

## Depends on

- **#13563** (fixes **#13557**) — retired default Anthropic model. Its 10 hosted
  failures resolve once that merges into `trunk` and this branch picks it up.

## Merge gate

Merge only when both arms report `running 79 tests` and pass. A green run is the
proof that #13558, #6399, and #13560 (and, via #13563, #13557) are all resolved.