### PR TITLE
Translate the JSON extraction functions into BigQuery SQL, and read negative JSON numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17822,6 +17822,7 @@ dependencies = [
  "object_store 0.13.2",
  "opentelemetry",
  "parking_lot",
+ "regex",
  "runtime-datafusion-index",
  "runtime-datafusion-udfs",
  "runtime-object-store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=b9ea24c3101a24e8b3186a6a552362cf0a91bc03#b9ea24c3101a24e8b3186a6a552362cf0a91bc03"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=0d24a546748b54fd3ff48853739d85a6d351058f#0d24a546748b54fd3ff48853739d85a6d351058f"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4438,6 +4438,7 @@ dependencies = [
  "parking_lot",
  "runtime",
  "runtime-component",
+ "runtime-datafusion",
  "runtime-parameters",
  "runtime-udfs-api",
  "secrecy",
@@ -6933,8 +6934,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-json"
 version = "0.54.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab80590f2e0c240fd14a8178b584941f5ced55ee90cd41a128e6c08176c0f7cc"
+source = "git+https://github.com/spiceai/datafusion-functions-json.git?rev=ca9d4c6e5a0de3bfa9fe20a683a9f7d58e36e2cc#ca9d4c6e5a0de3bfa9fe20a683a9f7d58e36e2cc"
 dependencies = [
  "datafusion",
  "jiter",
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=896356c3f7af9db5b6da3f2379196b420eee1b2b#896356c3f7af9db5b6da3f2379196b420eee1b2b"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=b9ea24c3101a24e8b3186a6a552362cf0a91bc03#b9ea24c3101a24e8b3186a6a552362cf0a91bc03"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,7 +261,7 @@ datafusion-functions = "54.1.0"
 datafusion-functions-aggregate = "54.1.0"
 datafusion-functions-aggregate-common = "54.1.0"
 datafusion-functions-nested = "54.1.0"
-datafusion-functions-json = "0.54"
+datafusion-functions-json = { git = "https://github.com/spiceai/datafusion-functions-json.git", rev = "ca9d4c6e5a0de3bfa9fe20a683a9f7d58e36e2cc" } # branch: spiceai-54
 datafusion-physical-expr = "54.1.0"
 datafusion-physical-expr-adapter = "54.1.0"
 datafusion-physical-expr-common = "54.1.0"
@@ -271,7 +271,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "896356c3f7af9db5b6da3f2379196b420eee1b2b" } # branch: spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "b9ea24c3101a24e8b3186a6a552362cf0a91bc03" } # branch: spiceai-54-expression-aware-function-support
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "b9ea24c3101a24e8b3186a6a552362cf0a91bc03" } # branch: spiceai-54-expression-aware-function-support
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "0d24a546748b54fd3ff48853739d85a6d351058f" } # branch: spiceai-54
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",

--- a/crates/data-connectors/connector-adbc/Cargo.toml
+++ b/crates/data-connectors/connector-adbc/Cargo.toml
@@ -34,6 +34,7 @@ datafusion-table-providers = { workspace = true, features = ["adbc-federation"] 
 futures.workspace = true
 parking_lot.workspace = true
 runtime-component = { path = "../../runtime-component" }
+runtime-datafusion = { path = "../../runtime-datafusion" }
 runtime-parameters = { path = "../../runtime-parameters" }
 runtime-udfs-api = { path = "../../runtime-udfs-api" }
 secrecy.workspace = true

--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -2314,6 +2314,28 @@ mod function_support_tests {
             "the BigQuery dialect rewrites this into JSON_VALUE, so it must push down"
         );
         assert!(
+            federates("bigquery", json_call("json_get_str", vec![lit("a")])).await,
+            "the BigQuery dialect guards JSON_VALUE with JSON_QUERY for the string \
+             form, so it must push down too"
+        );
+        assert!(
+            federates("bigquery", json_call("json_get_bool", vec![lit("a")])).await,
+            "the BigQuery dialect compares JSON_VALUE's rendering for the bool form"
+        );
+        assert!(
+            federates("bigquery", json_call("json_get_float", vec![lit("a")])).await,
+            "BigQuery's SAFE_CAST saturates exactly as Rust's f64::FromStr does, so the \
+             float form is translatable too"
+        );
+        assert!(
+            federates("bigquery", json_call("json_length", vec![lit("a")])).await,
+            "an array's and an object's counts each have a BigQuery equivalent"
+        );
+        assert!(
+            federates("bigquery", json_call("json_object_keys", vec![lit("a")])).await,
+            "JSON_KEYS at depth 1 is the object's own keys, which is what this returns"
+        );
+        assert!(
             federates(
                 "bigquery",
                 json_call("json_get_int", vec![lit("a"), lit(0_i64)])
@@ -2346,19 +2368,30 @@ mod function_support_tests {
             "a key the SQL-literal and JSON-path layers quote differently is left local \
              rather than escaped across both and silently turned into another path"
         );
+        // The check is per call, not per function: every translated name owes
+        // the same refusals, or the newest handler is the one that federates a
+        // shape it cannot render.
+        assert!(
+            !federates("bigquery", json_call("json_get_str", vec![col("val")])).await,
+            "a per-row path has no BigQuery translation for the string form either"
+        );
+        assert!(
+            !federates("bigquery", json_call("json_get_str", vec![lit(r#"a"b"#)])).await,
+            "an unquotable key is left local for the string form too"
+        );
     }
 
     #[tokio::test]
     async fn bigquery_still_denies_the_json_functions_it_has_no_translation_for() {
         for name in [
-            // Rust saturates an out-of-range float to infinity where BigQuery's
-            // SAFE_CAST gives NULL, so pushing this down would change results.
-            "json_get_float",
-            "json_get_str",
-            "json_get_bool",
+            // Returns a union of every JSON scalar type, which has no SQL type
+            // to unparse into.
             "json_get",
+            // Returns the matched node's own bytes; JSON_QUERY re-renders it.
             "json_as_text",
-            "json_length",
+            // A JSON `null` and a missing key are indistinguishable in
+            // BigQuery, and json_contains tells them apart.
+            "json_contains",
         ] {
             assert!(
                 !federates("bigquery", json_call(name, vec![lit("a")])).await,
@@ -2371,7 +2404,12 @@ mod function_support_tests {
     async fn a_driver_without_a_spice_dialect_denies_every_json_function() {
         // The carve-out is BigQuery's, not ADBC's: another driver gets the
         // plain deny-list and evaluates these locally.
-        for name in ["json_get_int", "json_get_float", "json_get_str"] {
+        for name in [
+            "json_get_int",
+            "json_get_float",
+            "json_get_str",
+            "json_get_bool",
+        ] {
             assert!(
                 !federates("sqlite", json_call(name, vec![lit("a")])).await,
                 "{name} must not push down to a driver whose dialect cannot rewrite it"

--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -23,8 +23,6 @@ use data_components::{FieldMetadata, metadata_enriched_table_provider};
 use data_connector_api::ConnectorContext;
 use datafusion::datasource::TableProvider;
 use datafusion::sql::TableReference;
-use datafusion::sql::unparser::dialect::{BigQueryDialect, Dialect};
-use datafusion_table_providers::adbc::AdbcTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::adbcpool::{
     ADBCPool, AdbcConnectionPoolBuilder,
 };
@@ -32,7 +30,6 @@ use datafusion_table_providers::sql::db_connection_pool::dbconnection::query_arr
 use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, JoinPushDown};
 use futures::TryStreamExt;
 use runtime_component::dataset::DatasetSpec;
-use runtime_udfs_api::deny_spice_functions_for_table_providers;
 use sha2::{Digest, Sha256};
 use snafu::prelude::*;
 use std::any::Any;
@@ -47,6 +44,14 @@ use data_connector_api::{
     DataConnectorResult, NewDataConnectorResult,
 };
 use runtime_parameters::{ParameterSpec, Parameters};
+
+mod table_factory;
+use table_factory::{AdbcTableFactoryWithPolicy, dialect_for_driver};
+
+/// The factory this connector holds: the managed-driver ADBC factory, with the
+/// federation policy attached by its type. Named because it appears in the drop
+/// plumbing as well as the connector itself.
+type ManagedAdbcTableFactory = AdbcTableFactoryWithPolicy<adbc_driver_manager::ManagedDatabase>;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -100,7 +105,7 @@ pub struct Adbc {
     /// Wrapped in `Option` so `Drop` can move the factory to a blocking thread
     /// for cleanup. ADBC drivers perform synchronous FFI calls during drop
     /// (e.g. closing network sessions) that must not run on the async runtime.
-    factory: Option<AdbcTableFactory<adbc_driver_manager::ManagedDatabase>>,
+    factory: Option<ManagedAdbcTableFactory>,
     pool: Weak<ADBCPool<adbc_driver_manager::ManagedDatabase>>,
     driver_name: String,
 }
@@ -138,10 +143,7 @@ impl Drop for Adbc {
 
 const ADBC_CLEANUP_QUEUE_CAPACITY: usize = 64;
 
-fn offload_adbc_factory_drop(
-    factory: AdbcTableFactory<adbc_driver_manager::ManagedDatabase>,
-    reason: &str,
-) {
+fn offload_adbc_factory_drop(factory: ManagedAdbcTableFactory, reason: &str) {
     tracing::warn!("{reason}");
     if std::thread::Builder::new()
         .name("adbc-cleanup-overflow".to_string())
@@ -158,15 +160,11 @@ fn offload_adbc_factory_drop(
 /// background thread. The worker thread is created once (on first use) and
 /// processes drop work sequentially with bounded buffering, avoiding both
 /// unbounded thread spawns and unbounded cleanup backlog growth.
-fn adbc_cleanup_sender()
--> &'static std::sync::mpsc::SyncSender<AdbcTableFactory<adbc_driver_manager::ManagedDatabase>> {
-    static SENDER: OnceLock<
-        std::sync::mpsc::SyncSender<AdbcTableFactory<adbc_driver_manager::ManagedDatabase>>,
-    > = OnceLock::new();
+fn adbc_cleanup_sender() -> &'static std::sync::mpsc::SyncSender<ManagedAdbcTableFactory> {
+    static SENDER: OnceLock<std::sync::mpsc::SyncSender<ManagedAdbcTableFactory>> = OnceLock::new();
     SENDER.get_or_init(|| {
-        let (tx, rx) = std::sync::mpsc::sync_channel::<
-            AdbcTableFactory<adbc_driver_manager::ManagedDatabase>,
-        >(ADBC_CLEANUP_QUEUE_CAPACITY);
+        let (tx, rx) =
+            std::sync::mpsc::sync_channel::<ManagedAdbcTableFactory>(ADBC_CLEANUP_QUEUE_CAPACITY);
         if std::thread::Builder::new()
             .name("adbc-cleanup".to_string())
             .spawn(move || {
@@ -533,7 +531,11 @@ impl AdbcFactory {
                 }
             })?;
 
-        let adbc_factory = build_table_factory(Arc::clone(&pool), federation_enabled);
+        let adbc_factory = AdbcTableFactoryWithPolicy::new(
+            Arc::clone(&pool),
+            federation_enabled,
+            &driver_name_owned,
+        );
 
         Ok(Arc::new(Adbc {
             factory: Some(adbc_factory),
@@ -541,26 +543,6 @@ impl AdbcFactory {
             driver_name: driver_name_owned,
         }) as Arc<dyn DataConnector>)
     }
-}
-
-/// Builds the [`AdbcTableFactory`] for a dataset, with the Spice function
-/// deny-list installed and the `query_federation` setting applied.
-///
-/// Without the deny-list, federation pushes Spice-only UDFs (`json_get_str`
-/// and the other JSON functions, the embedding/distance UDFs, etc.) into the
-/// SQL sent to the remote database, where those functions don't exist — the
-/// query then fails with an "unknown function" error from the remote (e.g.
-/// `BigQuery`). Installing the deny-list makes the table's `can_execute_plan`
-/// refuse such plans so `DataFusion` evaluates the affected expressions
-/// locally instead. See issue #10703.
-fn build_table_factory<D>(pool: Arc<ADBCPool<D>>, federation_enabled: bool) -> AdbcTableFactory<D>
-where
-    D: adbc_core::Database + Send + 'static,
-    D::ConnectionType: adbc_core::Connection + Send + Sync,
-{
-    AdbcTableFactory::new(pool)
-        .with_federation_enabled(federation_enabled)
-        .with_function_support(deny_spice_functions_for_table_providers())
 }
 
 async fn enrich_with_bigquery_metadata_from_weak_pool(
@@ -1129,13 +1111,6 @@ fn build_join_context(
         let _ = write!(hash, "{b:02x}");
         hash
     })
-}
-
-pub(crate) fn dialect_for_driver(driver_name: &str) -> Option<Arc<dyn Dialect + Send + Sync>> {
-    match driver_name {
-        "bigquery" => Some(Arc::new(BigQueryDialect::new())),
-        _ => None,
-    }
 }
 
 /// Checks if an error message indicates an authentication or authorization failure.
@@ -1994,7 +1969,7 @@ data_connector_api::register_data_connector!(
 #[cfg(test)]
 mod function_support_tests {
     //! Regression tests for the federation deny-list on the ADBC table
-    //! factory: [`build_table_factory`] must install the Spice function
+    //! factory: [`AdbcTableFactoryWithPolicy`] must install the Spice function
     //! deny-list and honor the `query_federation` setting. Without the
     //! deny-list, Spice-only UDFs like `json_get_str` are unparsed into the
     //! SQL sent to the remote database (e.g. `BigQuery`), which cannot
@@ -2010,17 +1985,21 @@ mod function_support_tests {
     use adbc_core::{Connection, Database, Optionable, PartitionedResult, Statement};
     use arrow::array::{RecordBatch, RecordBatchReader};
     use arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::datasource::TableProvider;
+    use datafusion::common::tree_node::TreeNode;
+    use datafusion::config::ConfigOptions;
+    use datafusion::datasource::{TableProvider, provider_as_source};
     use datafusion::logical_expr::{
         ColumnarValue, Expr, LogicalPlan, LogicalPlanBuilder, TableSource, Volatility,
         builder::LogicalTableSource, create_udf, expr::ScalarFunction,
     };
-    use datafusion::prelude::col;
+    use datafusion::optimizer::AnalyzerRule;
+    use datafusion::prelude::{col, lit};
     use datafusion::sql::TableReference;
+    use datafusion_federation::sql::federation_analyzer_rule;
     use datafusion_federation::{FederatedTableProviderAdaptor, FederationAnalyzerForLogicalPlan};
     use datafusion_table_providers::sql::db_connection_pool::adbcpool::ADBCPool;
 
-    use super::build_table_factory;
+    use super::{AdbcTableFactoryWithPolicy, dialect_for_driver};
 
     fn not_implemented(what: &str) -> AdbcError {
         AdbcError::with_message_and_status(
@@ -2258,17 +2237,22 @@ mod function_support_tests {
         Expr::ScalarFunction(ScalarFunction::new_udf(udf, vec![col("val")]))
     }
 
-    async fn stub_table_provider(federation_enabled: bool) -> Arc<dyn TableProvider> {
+    /// A provider over the stub driver, built the way the connector builds one
+    /// for `driver_name` — same policy, same dialect.
+    async fn stub_table_provider(
+        federation_enabled: bool,
+        driver_name: &str,
+    ) -> Arc<dyn TableProvider> {
         let pool = Arc::new(ADBCPool::new(StubDatabase, None).expect("build the stub ADBC pool"));
-        build_table_factory(pool, federation_enabled)
-            .table_provider(TableReference::bare("t"), None)
+        AdbcTableFactoryWithPolicy::new(pool, federation_enabled, driver_name)
+            .table_provider(TableReference::bare("t"), dialect_for_driver(driver_name))
             .await
             .expect("build the ADBC table provider")
     }
 
     #[tokio::test]
     async fn table_factory_denies_spice_functions_from_federation() {
-        let provider = stub_table_provider(true).await;
+        let provider = stub_table_provider(true, "sqlite").await;
         let adaptor = (provider.as_ref() as &dyn std::any::Any)
             .downcast_ref::<FederatedTableProviderAdaptor>()
             .expect("a federation-enabled factory must produce a federated provider");
@@ -2293,9 +2277,181 @@ mod function_support_tests {
         );
     }
 
+    /// A `json_get_*` call over the stub table's `val` column.
+    fn json_call(name: &str, path: Vec<Expr>) -> Expr {
+        let mut args = vec![col("val")];
+        args.extend(path);
+        let udf = Arc::new(create_udf(
+            name,
+            vec![DataType::Utf8; args.len()],
+            DataType::Int64,
+            Volatility::Immutable,
+            Arc::new(|args: &[ColumnarValue]| Ok(args[0].clone())),
+        ));
+        Expr::ScalarFunction(ScalarFunction::new_udf(udf, args))
+    }
+
+    /// Whether a plan carrying `expr` federates to a provider built for
+    /// `driver_name`.
+    async fn federates(driver_name: &str, expr: Expr) -> bool {
+        let provider = stub_table_provider(true, driver_name).await;
+        let adaptor = (provider.as_ref() as &dyn std::any::Any)
+            .downcast_ref::<FederatedTableProviderAdaptor>()
+            .expect("a federation-enabled factory must produce a federated provider");
+        matches!(
+            adaptor
+                .source
+                .federation_provider()
+                .analyzer(&scan_project(expr)),
+            Some(FederationAnalyzerForLogicalPlan::With(_))
+        )
+    }
+
+    #[tokio::test]
+    async fn bigquery_federates_the_json_calls_its_dialect_can_translate() {
+        assert!(
+            federates("bigquery", json_call("json_get_int", vec![lit("a")])).await,
+            "the BigQuery dialect rewrites this into JSON_VALUE, so it must push down"
+        );
+        assert!(
+            federates(
+                "bigquery",
+                json_call("json_get_float", vec![lit("a"), lit(0_i64)])
+            )
+            .await,
+            "a literal path of any length is translatable"
+        );
+    }
+
+    #[tokio::test]
+    async fn bigquery_refuses_the_json_call_shapes_its_dialect_cannot_translate() {
+        // BigQuery's JSON path argument must be a constant, so a per-row path
+        // has no translation. Federating it would unparse `json_get_int`
+        // verbatim into BigQuery SQL — issue #10703 all over again — so the
+        // plan must stay local instead.
+        assert!(
+            !federates("bigquery", json_call("json_get_int", vec![col("val")])).await,
+            "a per-row path has no BigQuery translation, so the plan must not federate"
+        );
+        assert!(
+            !federates(
+                "bigquery",
+                json_call("json_get_float", vec![lit("a"), col("val")])
+            )
+            .await,
+            "one non-literal element is enough to make the whole path untranslatable"
+        );
+    }
+
+    #[tokio::test]
+    async fn bigquery_still_denies_the_json_functions_it_has_no_translation_for() {
+        for name in [
+            "json_get_str",
+            "json_get_bool",
+            "json_get",
+            "json_as_text",
+            "json_length",
+        ] {
+            assert!(
+                !federates("bigquery", json_call(name, vec![lit("a")])).await,
+                "{name} has no BigQuery translation and must stay denied"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_driver_without_a_spice_dialect_denies_every_json_function() {
+        // The carve-out is BigQuery's, not ADBC's: another driver gets the
+        // plain deny-list and evaluates these locally.
+        for name in ["json_get_int", "json_get_float", "json_get_str"] {
+            assert!(
+                !federates("sqlite", json_call(name, vec![lit("a")])).await,
+                "{name} must not push down to a driver whose dialect cannot rewrite it"
+            );
+        }
+    }
+
+    /// `SELECT id FROM t WHERE <predicate>` over the stub table, run through
+    /// the federation analyzer. The projection keeps the root off the leaf,
+    /// where the analyzer deliberately leaves a bare scan for the provider to
+    /// handle itself.
+    async fn federated_plan(predicate: Expr) -> LogicalPlan {
+        let provider = stub_table_provider(true, "bigquery").await;
+        let plan = LogicalPlanBuilder::scan("t", provider_as_source(provider), None)
+            .expect("scan the stub table")
+            .filter(predicate)
+            .expect("filter on the JSON value")
+            .project(vec![col("id")])
+            .expect("project")
+            .build()
+            .expect("build the plan");
+
+        federation_analyzer_rule()
+            .analyze(plan, &ConfigOptions::default())
+            .expect("federate what can be federated")
+    }
+
+    #[tokio::test]
+    async fn a_translatable_predicate_federates_as_one_node_with_the_predicate_inside_it() {
+        let analyzed =
+            federated_plan(json_call("json_get_int", vec![lit("a")]).eq(lit(1_i64))).await;
+
+        assert!(
+            is_federated_node(&analyzed),
+            "the predicate translates, so the whole plan is one remote statement: {analyzed}"
+        );
+        assert_eq!(
+            federated_node_count(&analyzed),
+            1,
+            "one remote statement, not one per side: {analyzed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_untranslatable_predicate_is_left_above_the_federated_scan() {
+        let analyzed =
+            federated_plan(json_call("json_get_int", vec![col("val")]).eq(lit(1_i64))).await;
+
+        assert!(
+            !is_federated_node(&analyzed),
+            "a per-row path has no translation, so the plan cannot federate whole: {analyzed}"
+        );
+        assert!(
+            analyzed
+                .apply(|node| {
+                    Ok(if matches!(node, LogicalPlan::Filter(_)) {
+                        datafusion::common::tree_node::TreeNodeRecursion::Stop
+                    } else {
+                        datafusion::common::tree_node::TreeNodeRecursion::Continue
+                    })
+                })
+                .map(|recursion| {
+                    recursion == datafusion::common::tree_node::TreeNodeRecursion::Stop
+                })
+                .expect("walk the plan"),
+            "the predicate must be left for the local engine to evaluate: {analyzed}"
+        );
+    }
+
+    fn is_federated_node(plan: &LogicalPlan) -> bool {
+        matches!(plan, LogicalPlan::Extension(extension) if extension.node.name() == "Federated")
+    }
+
+    fn federated_node_count(plan: &LogicalPlan) -> usize {
+        let mut count = 0;
+        plan.apply(|node| {
+            if is_federated_node(node) {
+                count += 1;
+            }
+            Ok(datafusion::common::tree_node::TreeNodeRecursion::Continue)
+        })
+        .expect("walk the plan");
+        count
+    }
+
     #[tokio::test]
     async fn table_factory_disables_federation_when_configured() {
-        let provider = stub_table_provider(false).await;
+        let provider = stub_table_provider(false, "sqlite").await;
         assert!(
             (provider.as_ref() as &dyn std::any::Any)
                 .downcast_ref::<FederatedTableProviderAdaptor>()

--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -2316,7 +2316,7 @@ mod function_support_tests {
         assert!(
             federates(
                 "bigquery",
-                json_call("json_get_float", vec![lit("a"), lit(0_i64)])
+                json_call("json_get_int", vec![lit("a"), lit(0_i64)])
             )
             .await,
             "a literal path of any length is translatable"
@@ -2336,16 +2336,24 @@ mod function_support_tests {
         assert!(
             !federates(
                 "bigquery",
-                json_call("json_get_float", vec![lit("a"), col("val")])
+                json_call("json_get_int", vec![lit("a"), col("val")])
             )
             .await,
             "one non-literal element is enough to make the whole path untranslatable"
+        );
+        assert!(
+            !federates("bigquery", json_call("json_get_int", vec![lit(r#"a"b"#)])).await,
+            "a key the SQL-literal and JSON-path layers quote differently is left local \
+             rather than escaped across both and silently turned into another path"
         );
     }
 
     #[tokio::test]
     async fn bigquery_still_denies_the_json_functions_it_has_no_translation_for() {
         for name in [
+            // Rust saturates an out-of-range float to infinity where BigQuery's
+            // SAFE_CAST gives NULL, so pushing this down would change results.
+            "json_get_float",
             "json_get_str",
             "json_get_bool",
             "json_get",

--- a/crates/data-connectors/connector-adbc/src/table_factory.rs
+++ b/crates/data-connectors/connector-adbc/src/table_factory.rs
@@ -1,0 +1,128 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! The ADBC table factory, with the federation policy attached to its type.
+//!
+//! This module exists for the privacy boundary: [`AdbcTableFactoryWithPolicy`]'s
+//! field is private to it, so [`AdbcTableFactoryWithPolicy::new`] is the only way
+//! to obtain one anywhere else in the crate.
+
+use std::sync::Arc;
+
+use datafusion::datasource::TableProvider;
+use datafusion::sql::TableReference;
+use datafusion::sql::unparser::dialect::Dialect;
+use datafusion_table_providers::adbc::AdbcTableFactory;
+use datafusion_table_providers::sql::db_connection_pool::adbcpool::ADBCPool;
+use datafusion_table_providers::util::supported_functions::FunctionSupport;
+use runtime_datafusion::dialect::new_bigquery_dialect;
+use runtime_datafusion::function_support::deny_spice_functions_for_bigquery_table_providers;
+use runtime_udfs_api::deny_spice_functions_for_table_providers;
+
+type BoxedError = Box<dyn std::error::Error + Send + Sync>;
+
+/// The `BigQuery` driver, as ADBC spells it in the `driver` parameter.
+const BIGQUERY_DRIVER: &str = "bigquery";
+
+/// The unparser dialect for a driver.
+///
+/// This and [`function_support_for_driver`] are deliberately adjacent and keyed
+/// off the same name: a dialect that rewrites a Spice function into native SQL
+/// is only safe when the matching policy — the one that lets that function
+/// federate, and refuses the call shapes the dialect cannot render — is
+/// installed with it. Splitting them is how they come apart.
+pub(crate) fn dialect_for_driver(driver_name: &str) -> Option<Arc<dyn Dialect + Send + Sync>> {
+    match driver_name {
+        BIGQUERY_DRIVER => Some(new_bigquery_dialect()),
+        _ => None,
+    }
+}
+
+/// The federation function-support policy for a driver. Defaults to denying
+/// every Spice function, which is correct for a driver whose dialect rewrites
+/// none of them.
+fn function_support_for_driver(driver_name: &str) -> FunctionSupport {
+    match driver_name {
+        BIGQUERY_DRIVER => deny_spice_functions_for_bigquery_table_providers(),
+        _ => deny_spice_functions_for_table_providers(),
+    }
+}
+
+/// An [`AdbcTableFactory`] that carries Spice's federation policy by
+/// construction.
+///
+/// `AdbcTableFactory::new` defaults to `federation_enabled: true` and
+/// `function_support: None`, and both defaults are silent:
+///
+/// * without `with_function_support`, federation unparses every Spice-only UDF
+///   — the JSON functions, the embedding and distance UDFs, and every
+///   user-registered function — into the SQL sent to the remote database, which
+///   has no such function and answers with an unknown-function error;
+/// * without `with_federation_enabled`, `query_federation: disabled` is parsed,
+///   validated, and then ignored, so the documented way to turn federation off
+///   does nothing.
+///
+/// Both calls have been dropped once already, by a refactor that moved the
+/// construction and compiled without them
+/// ([#10703](https://github.com/spiceai/spiceai/issues/10703)). Requiring this
+/// type wherever a factory is held is what stops that recurring: the policy is
+/// now applied in one function that cannot be bypassed, so dropping it is an
+/// edit to that function rather than an omission a move can make invisible.
+///
+/// The scope is this connector. The ADBC **catalog** connector builds an
+/// `AdbcTableFactory` directly and carries no policy at all —
+/// [#13664](https://github.com/spiceai/spiceai/issues/13664).
+pub(crate) struct AdbcTableFactoryWithPolicy<D>
+where
+    D: adbc_core::Database + Send + 'static,
+    D::ConnectionType: adbc_core::Connection + Send + Sync,
+{
+    factory: AdbcTableFactory<D>,
+}
+
+impl<D> AdbcTableFactoryWithPolicy<D>
+where
+    D: adbc_core::Database + Send + 'static,
+    D::ConnectionType: adbc_core::Connection + Send + Sync,
+{
+    /// Builds the factory with the driver's function-support policy installed
+    /// and the `query_federation` setting applied.
+    pub(crate) fn new(pool: Arc<ADBCPool<D>>, federation_enabled: bool, driver_name: &str) -> Self {
+        Self {
+            factory: AdbcTableFactory::new(pool)
+                .with_federation_enabled(federation_enabled)
+                .with_function_support(function_support_for_driver(driver_name)),
+        }
+    }
+
+    pub(crate) async fn table_provider(
+        &self,
+        table_reference: TableReference,
+        dialect: Option<Arc<dyn Dialect + Send + Sync>>,
+    ) -> Result<Arc<dyn TableProvider + 'static>, BoxedError> {
+        self.factory.table_provider(table_reference, dialect).await
+    }
+
+    pub(crate) async fn read_write_table_provider(
+        &self,
+        table_reference: TableReference,
+        dialect: Option<Arc<dyn Dialect + Send + Sync>>,
+    ) -> Result<Arc<dyn TableProvider + 'static>, BoxedError> {
+        self.factory
+            .read_write_table_provider(table_reference, dialect)
+            .await
+    }
+}

--- a/crates/data_components/src/adbc_helpers.rs
+++ b/crates/data_components/src/adbc_helpers.rs
@@ -78,15 +78,20 @@ pub fn build_db_options(
 /// needed.
 ///
 /// These are the stock `DataFusion` dialects, which rewrite no Spice function.
-/// That is what makes them safe for a caller that installs no federation
-/// function-support policy — the ADBC **catalog** connector, which installs
-/// none at all ([#13664](https://github.com/spiceai/spiceai/issues/13664)).
 ///
-/// The ADBC *dataset* connector has its own, in `connector-adbc`, which
+/// Its only caller today is the ADBC **catalog** connector, which installs no
+/// federation function-support policy at all, so every Spice-only UDF in a
+/// federated plan reaches the unparser and is emitted verbatim into the remote
+/// SQL. That is a live defect, not a safe configuration
+/// ([#13664](https://github.com/spiceai/spiceai/issues/13664)); the fix is to
+/// install the policy, not to change the dialect.
+///
+/// The ADBC *dataset* connector has its own dialect, in `connector-adbc`, which
 /// rewrites the JSON extraction functions into `BigQuery` SQL. **Do not reach
 /// for that one from here.** It renders only the call shapes `BigQuery` can
-/// express, and the policy paired with it is what keeps the rest from reaching
-/// the unparser; without that policy those calls fail the query instead.
+/// express and errors on the rest, and the policy paired with it is what keeps
+/// the rest from reaching the unparser at all; without that policy it turns
+/// #13664's wrong-function error into a failed query.
 #[must_use]
 pub fn dialect_for_driver(driver_name: &str) -> Option<Arc<dyn Dialect + Send + Sync>> {
     match driver_name {

--- a/crates/data_components/src/adbc_helpers.rs
+++ b/crates/data_components/src/adbc_helpers.rs
@@ -74,7 +74,19 @@ pub fn build_db_options(
     opts
 }
 
-/// Returns the SQL dialect for a given ADBC driver name, if a non-default one is needed.
+/// Returns the SQL dialect for a given ADBC driver name, if a non-default one is
+/// needed.
+///
+/// These are the stock `DataFusion` dialects, which rewrite no Spice function.
+/// That is what makes them safe for a caller that installs no federation
+/// function-support policy — the ADBC **catalog** connector, which installs
+/// none at all ([#13664](https://github.com/spiceai/spiceai/issues/13664)).
+///
+/// The ADBC *dataset* connector has its own, in `connector-adbc`, which
+/// rewrites the JSON extraction functions into `BigQuery` SQL. **Do not reach
+/// for that one from here.** It renders only the call shapes `BigQuery` can
+/// express, and the policy paired with it is what keeps the rest from reaching
+/// the unparser; without that policy those calls fail the query instead.
 #[must_use]
 pub fn dialect_for_driver(driver_name: &str) -> Option<Arc<dyn Dialect + Send + Sync>> {
     match driver_name {

--- a/crates/runtime-datafusion/Cargo.toml
+++ b/crates/runtime-datafusion/Cargo.toml
@@ -14,6 +14,7 @@ arrow-schema.workspace = true
 arrow_tools = { path = "../arrow_tools" }
 async-stream.workspace = true
 async-trait.workspace = true
+chrono.workspace = true
 dashmap = "6.1.0"
 datafusion.workspace = true
 datafusion-catalog.workspace = true
@@ -46,7 +47,6 @@ util = { path = "../util", features = ["datafusion"] }
 uuid.workspace = true
 
 [dev-dependencies]
-chrono.workspace = true
 criterion = { version = "0.7", features = ["html_reports"] }
 datafusion-optimizer-rules = { path = "../datafusion-optimizer-rules" }
 datafusion-pruning.workspace = true

--- a/crates/runtime-datafusion/Cargo.toml
+++ b/crates/runtime-datafusion/Cargo.toml
@@ -52,6 +52,7 @@ datafusion-optimizer-rules = { path = "../datafusion-optimizer-rules" }
 datafusion-pruning.workspace = true
 insta.workspace = true
 object_store.workspace = true
+regex.workspace = true
 tokio.workspace = true
 
 [lints]

--- a/crates/runtime-datafusion/src/dialect/bigquery.rs
+++ b/crates/runtime-datafusion/src/dialect/bigquery.rs
@@ -36,8 +36,10 @@ use datafusion::arrow::datatypes::TimeUnit;
 use datafusion::common::{DataFusionError, Result, ScalarValue};
 use datafusion::logical_expr::Expr;
 use datafusion::logical_expr::expr::ScalarFunction;
+use datafusion::sql::sqlparser::ast::helpers::attached_token::AttachedToken;
 use datafusion::sql::sqlparser::ast::{
-    self, BinaryOperator, Function, FunctionArg, FunctionArgExpr, ObjectName, WindowFrameBound,
+    self, BinaryOperator, CaseWhen, Function, FunctionArg, FunctionArgExpr, ObjectName,
+    WindowFrameBound,
 };
 use datafusion::sql::unparser::Unparser;
 use datafusion::sql::unparser::dialect::{
@@ -46,6 +48,28 @@ use datafusion::sql::unparser::dialect::{
 };
 
 pub(crate) const JSON_GET_INT_NAME: &str = "json_get_int";
+pub(crate) const JSON_GET_STR_NAME: &str = "json_get_str";
+pub(crate) const JSON_GET_BOOL_NAME: &str = "json_get_bool";
+pub(crate) const JSON_GET_FLOAT_NAME: &str = "json_get_float";
+pub(crate) const JSON_LENGTH_NAME: &str = "json_length";
+/// `json_length`'s alias. `ScalarUDF::name` returns the canonical name, so a
+/// plan never carries this one — but the federation deny-list is built from
+/// the registry, which does, and a name it denies that this dialect cannot
+/// render would be inconsistent. Both names carry the same handler.
+pub(crate) const JSON_LEN_NAME: &str = "json_len";
+pub(crate) const JSON_OBJECT_KEYS_NAME: &str = "json_object_keys";
+/// `json_object_keys`'s alias, carried for the reason [`JSON_LEN_NAME`] gives.
+pub(crate) const JSON_KEYS_NAME: &str = "json_keys";
+
+/// The first byte of a JSON string node's own token, as `JSON_QUERY` returns it.
+///
+/// `json_get_str` answers only for a JSON **string** — `jiter`'s `Peek::String`
+/// — and NULL for every other node. `JSON_VALUE` cannot express that on its
+/// own: it renders a number as its digits and a bool as `true`/`false`, where
+/// `json_get_str` returns NULL. `JSON_QUERY` returns the node's raw JSON token
+/// instead, and a leading double quote is what distinguishes a string node from
+/// every other type. See [`json_get_str_to_sql`].
+const JSON_STRING_TOKEN_PREFIX: &str = "\"";
 
 /// The grammar Rust's `i64::FromStr` accepts, which is what
 /// `json_get_int` applies to a JSON **string** node.
@@ -57,15 +81,31 @@ pub(crate) const JSON_GET_INT_NAME: &str = "json_get_int";
 ///
 /// It also agrees at the boundaries: an integer too large for `i64` is NULL on
 /// both sides, because Rust's `i64::FromStr` fails rather than saturating.
-/// `json_get_float` is the opposite — Rust saturates an out-of-range magnitude
-/// to infinity where `SAFE_CAST` gives NULL — which is why only the integer
-/// form is translated. See [`SCALAR_OVERRIDES`].
+/// See [`FLOAT64_FROM_STR`] for the float grammar, which agrees for the
+/// opposite reason — both sides saturate.
 ///
 /// Any group must be non-capturing. `REGEXP_EXTRACT` accepts **at most one**
 /// capturing group and errors on more, which would fail every federated call
 /// remotely; with none it returns the whole match, which is what this wants.
 /// [`tests::no_pattern_has_a_capturing_group`] holds the patterns to that.
 const INT64_FROM_STR: &str = r"^[+-]?[0-9]+$";
+
+/// The grammar Rust's `f64::FromStr` accepts, which is what `json_get_float`
+/// applies to a JSON **string** node.
+///
+/// Measured against `BigQuery`: `SAFE_CAST(… AS FLOAT64)` saturates an
+/// out-of-range magnitude to `±Infinity` and underflows to zero, exactly as
+/// Rust does, and reads `inf`, `infinity` and `nan` case-insensitively, exactly
+/// as Rust does. So the boundaries need no special rendering — they already
+/// agree.
+///
+/// What does not agree is the same pair the integer form has: `SAFE_CAST`
+/// reads `0x2A` as 42 and trims `  1.5  `, where `f64::FromStr` fails and
+/// `json_get_float` is NULL. Extracting through this pattern first is what
+/// closes that, and nothing else.
+///
+/// Every group is non-capturing, for the reason [`INT64_FROM_STR`] gives.
+const FLOAT64_FROM_STR: &str = r"^[+-]?(?:(?i:inf|infinity|nan)|(?:[0-9]+\.[0-9]*|[0-9]*\.[0-9]+|[0-9]+)(?:[eE][+-]?[0-9]+)?)$";
 
 /// What `BigQuery` should be asked for, given a `json_get_*` call's path
 /// arguments.
@@ -189,22 +229,92 @@ pub(crate) struct ScalarOverride {
 /// Every function the `BigQuery` dialect rewrites, with what each consumer
 /// needs. [`crate::dialect`] derives the dialect's handlers, the deny-list
 /// carve-out, and the per-call check from this one table.
+pub(crate) const SCALAR_OVERRIDES: &[ScalarOverride] = &[
+    ScalarOverride {
+        name: JSON_GET_INT_NAME,
+        handler: json_get_int_to_sql,
+        can_translate: json_path_is_renderable,
+    },
+    ScalarOverride {
+        name: JSON_GET_STR_NAME,
+        handler: json_get_str_to_sql,
+        can_translate: json_path_is_renderable,
+    },
+    ScalarOverride {
+        name: JSON_GET_BOOL_NAME,
+        handler: json_get_bool_to_sql,
+        can_translate: json_path_is_renderable,
+    },
+    ScalarOverride {
+        name: JSON_GET_FLOAT_NAME,
+        handler: json_get_float_to_sql,
+        can_translate: json_path_is_renderable,
+    },
+    ScalarOverride {
+        name: JSON_LENGTH_NAME,
+        handler: json_length_to_sql,
+        can_translate: json_path_is_renderable,
+    },
+    ScalarOverride {
+        name: JSON_LEN_NAME,
+        handler: json_length_to_sql,
+        can_translate: json_path_is_renderable,
+    },
+    ScalarOverride {
+        name: JSON_OBJECT_KEYS_NAME,
+        handler: json_object_keys_to_sql,
+        can_translate: json_path_is_renderable,
+    },
+    ScalarOverride {
+        name: JSON_KEYS_NAME,
+        handler: json_object_keys_to_sql,
+        can_translate: json_path_is_renderable,
+    },
+];
+
+/// Renders one `json_get_*` call: pulls out the document and the JSON path,
+/// and hands both to `render` as `BigQuery` SQL.
 ///
-/// `json_get_float` is deliberately absent. Rust's `f64::FromStr` saturates an
-/// out-of-range magnitude to infinity and underflows to zero, where
-/// `SAFE_CAST(… AS FLOAT64)` returns NULL for a value it cannot represent — so
-/// a federated plan would answer NULL where the local function answers
-/// infinity, on the same rows. A `CASE` restoring the infinities would rest on
-/// `BigQuery` behaviour at both boundaries that nothing here can verify, so the
-/// float form stays denied until a real `BigQuery` settles it. The integer form
-/// has no such gap: both sides give up on an out-of-range integer.
-/// `json_get_float_saturates_an_out_of_range_magnitude_to_infinity` in
-/// `runtime-udfs-api` measures the local half.
-pub(crate) const SCALAR_OVERRIDES: &[ScalarOverride] = &[ScalarOverride {
-    name: JSON_GET_INT_NAME,
-    handler: json_get_int_to_sql,
-    can_translate: json_path_is_renderable,
-}];
+/// Every handler goes through here so the failure below is written once. It is
+/// unreachable with the deny-list installed, which refuses exactly the calls
+/// [`json_path`] cannot render. Reachable only if this dialect is used without
+/// `deny_spice_functions_for_bigquery_table_providers`, and there the
+/// alternative — returning `Ok(None)` — makes the unparser emit `json_get_*`
+/// verbatim into `BigQuery` SQL, which is the wrong answer dressed as a remote
+/// error. Fail where it can be read instead.
+///
+/// `null_type` is what a path that can never resolve renders as. It carries the
+/// function's own return type: an untyped NULL would leave the federated schema
+/// disagreeing with the plan's.
+fn json_call_to_sql(
+    unparser: &Unparser,
+    args: &[Expr],
+    function: &str,
+    null_type: ast::DataType,
+    render: impl FnOnce(ast::Expr, ast::Expr) -> ast::Expr,
+) -> Result<Option<ast::Expr>> {
+    let (Some(document), Some(path)) = (args.first(), json_path(args)) else {
+        return Err(DataFusionError::Plan(format!(
+            "Failed to run this query against BigQuery: '{function}' was called in a form BigQuery \
+             cannot express, so the query cannot be completed. BigQuery needs a constant JSON path \
+             built only from plain keys: every path argument must be a literal, there must be at \
+             least one, and a key cannot contain a quote, a backslash or a control character. \
+             Rewrite the call to a constant path of plain keys, or set 'query_federation: disabled' \
+             on the dataset to evaluate it locally instead. \
+             See: https://spiceai.org/docs/components/data-connectors/adbc"
+        )));
+    };
+
+    let path = match path {
+        JsonPath::NeverResolves => return Ok(Some(cast_null_to(null_type))),
+        JsonPath::Path(path) => path,
+    };
+
+    Ok(Some(render(
+        unparser.expr_to_sql(document)?,
+        ast::Expr::Value(raw_string(&path).into()),
+    )))
+}
 
 /// `json_get_int(doc, path…)` →
 /// `SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(doc, '<path>'), r'^[+-]?[0-9]+$') AS INT64)`.
@@ -227,6 +337,259 @@ pub(crate) fn json_get_int_to_sql(unparser: &Unparser, args: &[Expr]) -> Result<
     )
 }
 
+/// `json_get_str(doc, path…)` →
+/// `CASE WHEN STARTS_WITH(JSON_QUERY(doc, '<path>'), '"') THEN JSON_VALUE(doc, '<path>') END`.
+///
+/// `json_get_str` answers only for a JSON **string** node and NULL for every
+/// other kind. `JSON_VALUE` alone is wider than that: it renders a number as
+/// its digits and a bool as `true`/`false`, so it would answer a string where
+/// `json_get_str` answers NULL — on rows a `WHERE … IS NOT NULL` then keeps
+/// remotely and drops locally.
+///
+/// `JSON_QUERY` returns the node's own JSON token rather than its value, and
+/// only a string node's token opens with a double quote — a number, a bool, a
+/// JSON `null`, an object and an array all render bare. Testing that first byte
+/// is what narrows `JSON_VALUE` to exactly the nodes the local function
+/// answers for, so the guard is the whole reason this is translatable at all.
+///
+/// Where the two already agree, no guard is needed: `JSON_QUERY` returns SQL
+/// NULL for a missing path, and `STARTS_WITH` over NULL is NULL, so the `CASE`
+/// falls through to its implicit NULL — which is what `json_get_str` returns.
+/// The escape handling agrees too: `JSON_VALUE` unescapes, and so does
+/// `jiter`'s `known_str`, so the guard reads the raw token while the value
+/// comes back decoded.
+pub(crate) fn json_get_str_to_sql(unparser: &Unparser, args: &[Expr]) -> Result<Option<ast::Expr>> {
+    json_call_to_sql(
+        unparser,
+        args,
+        JSON_GET_STR_NAME,
+        ast::DataType::String(None),
+        |document, path| {
+            let is_string_node = call_function(
+                "STARTS_WITH",
+                vec![
+                    call_function("JSON_QUERY", vec![document.clone(), path.clone()]),
+                    ast::Expr::Value(
+                        ast::Value::SingleQuotedString(JSON_STRING_TOKEN_PREFIX.to_string()).into(),
+                    ),
+                ],
+            );
+            ast::Expr::Case {
+                case_token: AttachedToken::empty(),
+                end_token: AttachedToken::empty(),
+                operand: None,
+                conditions: vec![CaseWhen {
+                    condition: is_string_node,
+                    result: call_function("JSON_VALUE", vec![document, path]),
+                }],
+                // No ELSE: a CASE with no matching WHEN is NULL, which is what
+                // `json_get_str` returns for every non-string node.
+                else_result: None,
+            }
+        },
+    )
+}
+
+/// `json_get_bool(doc, path…)` →
+/// `CASE JSON_VALUE(doc, '<path>') WHEN 'true' THEN TRUE WHEN 'false' THEN FALSE END`.
+///
+/// `json_get_bool` answers for a JSON `true`/`false`, and for a JSON **string**
+/// that Rust's `bool::from_str` accepts — which is `"true"` and `"false"`
+/// exactly, case-sensitively. Everything else is NULL.
+///
+/// Comparing `JSON_VALUE`'s rendering is what matches that, and the reason no
+/// cast appears here. Measured against `BigQuery`: `SAFE_CAST('TRUE' AS BOOL)`
+/// and `SAFE_CAST('True' AS BOOL)` both give `true`, where `bool::from_str`
+/// rejects both and the local function returns NULL. A string comparison is
+/// case-sensitive, so the two agree on exactly the same values.
+/// [`tests::no_bool_rendering_casts_to_bool`] is what keeps the cast out.
+///
+/// The single `JSON_VALUE` covers both accepted shapes at once: it renders a
+/// bool node as `true`/`false` and a string node as its decoded contents, so
+/// `"true"` and `true` both arrive as `'true'` — which is what `json_get_bool`
+/// does too. It decodes escapes on the way, so a string written `"tr\u0075e"`
+/// is `true` on both sides. A number renders as its digits and never matches,
+/// and an object, an array, a JSON `null` and a missing path are NULL from
+/// `JSON_VALUE` — NULL from `json_get_bool` as well.
+pub(crate) fn json_get_bool_to_sql(
+    unparser: &Unparser,
+    args: &[Expr],
+) -> Result<Option<ast::Expr>> {
+    json_call_to_sql(
+        unparser,
+        args,
+        JSON_GET_BOOL_NAME,
+        ast::DataType::Bool,
+        |document, path| {
+            let arm = |literal: &str, value: bool| CaseWhen {
+                condition: ast::Expr::Value(
+                    ast::Value::SingleQuotedString(literal.to_string()).into(),
+                ),
+                result: ast::Expr::Value(ast::Value::Boolean(value).into()),
+            };
+            ast::Expr::Case {
+                case_token: AttachedToken::empty(),
+                end_token: AttachedToken::empty(),
+                operand: Some(Box::new(call_function("JSON_VALUE", vec![document, path]))),
+                conditions: vec![arm("true", true), arm("false", false)],
+                // No ELSE: everything `bool::from_str` rejects is NULL on both sides.
+                else_result: None,
+            }
+        },
+    )
+}
+
+/// `json_get_float(doc, path…)` →
+/// `SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(doc, '<path>'), r'<float grammar>') AS FLOAT64)`.
+///
+/// The same shape as [`json_get_int_to_sql`], because the same two things are
+/// true: `JSON_VALUE` renders the node as its own token, and `SAFE_CAST` is
+/// wider than Rust's `FromStr` in ways a pattern can close.
+///
+/// The boundaries need nothing extra. `SAFE_CAST(… AS FLOAT64)` saturates an
+/// out-of-range magnitude to `±Infinity` and underflows to zero exactly as
+/// `f64::FromStr` does, and accepts `inf`/`infinity`/`nan` with the same
+/// case-insensitivity — all measured against `BigQuery`.
+/// `json_get_float_saturates_an_out_of_range_magnitude_to_infinity` in
+/// `runtime-udfs-api` holds the local half of that agreement.
+pub(crate) fn json_get_float_to_sql(
+    unparser: &Unparser,
+    args: &[Expr],
+) -> Result<Option<ast::Expr>> {
+    json_get_number_to_sql(
+        unparser,
+        args,
+        JSON_GET_FLOAT_NAME,
+        FLOAT64_FROM_STR,
+        ast::DataType::Float64,
+    )
+}
+
+/// `json_length(doc, path…)` → a `CASE` counting an array's elements or an
+/// object's keys, and NULL for every other node.
+///
+/// `json_length` answers only for an array and an object. `BigQuery` counts the
+/// two with different functions, so the node's own JSON token picks the branch:
+/// only an array's opens with `[` and only an object's with `{`.
+///
+/// * array — `ARRAY_LENGTH(JSON_QUERY_ARRAY(doc, path))`.
+/// * object — `ARRAY_LENGTH(JSON_KEYS(SAFE.PARSE_JSON(JSON_QUERY(doc, path)), 1))`.
+///   The depth argument is load-bearing: without it `JSON_KEYS` descends,
+///   returning `["b", "c", "c.d"]` for `{"b":1,"c":{"d":2}}` where
+///   `json_length` counts two. `SAFE.PARSE_JSON` cannot fail the query — it is
+///   NULL for anything it will not parse, and `JSON_KEYS` and `ARRAY_LENGTH`
+///   carry that NULL out — so neither `CASE` branch can raise where the local
+///   function returns a number.
+///
+/// An empty array and an empty object are both 0 on both sides, and every
+/// scalar node, a JSON `null`, a missing path and a NULL document are NULL on
+/// both — all measured against `BigQuery`.
+///
+/// The local function returns `UInt64` and `BigQuery` has no unsigned type, so
+/// the count arrives as `INT64` and the scan's schema cast reconciles it. A
+/// count is never negative, so the conversion cannot lose one.
+pub(crate) fn json_length_to_sql(unparser: &Unparser, args: &[Expr]) -> Result<Option<ast::Expr>> {
+    json_call_to_sql(
+        unparser,
+        args,
+        JSON_LENGTH_NAME,
+        ast::DataType::Int64,
+        |document, path| {
+            let token = || call_function("JSON_QUERY", vec![document.clone(), path.clone()]);
+            let opens_with = |brace: &str| {
+                call_function(
+                    "STARTS_WITH",
+                    vec![
+                        token(),
+                        ast::Expr::Value(ast::Value::SingleQuotedString(brace.to_string()).into()),
+                    ],
+                )
+            };
+            ast::Expr::Case {
+                case_token: AttachedToken::empty(),
+                end_token: AttachedToken::empty(),
+                operand: None,
+                conditions: vec![
+                    CaseWhen {
+                        condition: opens_with("["),
+                        result: call_function(
+                            "ARRAY_LENGTH",
+                            vec![call_function(
+                                "JSON_QUERY_ARRAY",
+                                vec![document.clone(), path.clone()],
+                            )],
+                        ),
+                    },
+                    CaseWhen {
+                        condition: opens_with("{"),
+                        result: call_function(
+                            "ARRAY_LENGTH",
+                            vec![call_function(
+                                "JSON_KEYS",
+                                vec![parse_json(token()), depth(1)],
+                            )],
+                        ),
+                    },
+                ],
+                // No ELSE: json_length is NULL for every node that is neither.
+                else_result: None,
+            }
+        },
+    )
+}
+
+/// `json_object_keys(doc, path…)` →
+/// `CASE WHEN STARTS_WITH(JSON_QUERY(doc, '<path>'), '{')
+///  THEN JSON_KEYS(SAFE.PARSE_JSON(JSON_QUERY(doc, '<path>')), 1) END`.
+///
+/// `json_object_keys` answers only for an object, and only with that object's
+/// own keys. The depth argument is what holds `JSON_KEYS` to the same level —
+/// without it `BigQuery` descends and returns `["b", "c", "c.d"]` where the local
+/// function returns `["b", "c"]`. The `{` test is what makes every other node
+/// NULL, matching the local function, since what `JSON_KEYS` does with an array
+/// or a scalar is not something this rests on.
+///
+/// This is the one function here whose element type has to survive the trip:
+/// it returns `List(Field { name: "item", … })`, and `BigQuery` sends back an
+/// `ARRAY<STRING>` whose element field the driver names. A disagreement there
+/// would fail the query rather than answer it differently, so unlike the rest
+/// of this module the risk is loud. Measured against a real `BigQuery` through
+/// the ADBC driver: the array arrives as a `List(Utf8)` the plan accepts.
+pub(crate) fn json_object_keys_to_sql(
+    unparser: &Unparser,
+    args: &[Expr],
+) -> Result<Option<ast::Expr>> {
+    json_call_to_sql(
+        unparser,
+        args,
+        JSON_OBJECT_KEYS_NAME,
+        ast::DataType::Array(ast::ArrayElemTypeDef::AngleBracket(Box::new(
+            ast::DataType::String(None),
+        ))),
+        |document, path| {
+            let token = call_function("JSON_QUERY", vec![document, path]);
+            ast::Expr::Case {
+                case_token: AttachedToken::empty(),
+                end_token: AttachedToken::empty(),
+                operand: None,
+                conditions: vec![CaseWhen {
+                    condition: call_function(
+                        "STARTS_WITH",
+                        vec![
+                            token.clone(),
+                            ast::Expr::Value(
+                                ast::Value::SingleQuotedString("{".to_string()).into(),
+                            ),
+                        ],
+                    ),
+                    result: call_function("JSON_KEYS", vec![parse_json(token), depth(1)]),
+                }],
+                else_result: None,
+            }
+        },
+    )
+}
+
 fn json_get_number_to_sql(
     unparser: &Unparser,
     args: &[Expr],
@@ -234,47 +597,37 @@ fn json_get_number_to_sql(
     pattern: &str,
     cast_to: ast::DataType,
 ) -> Result<Option<ast::Expr>> {
-    let (Some(document), Some(path)) = (args.first(), json_path(args)) else {
-        // Unreachable with the deny-list installed, which refuses exactly the
-        // calls `json_path` cannot render. Reachable only if this dialect is
-        // used without `deny_spice_functions_for_bigquery_table_providers`, and
-        // there the alternative — returning `Ok(None)` — makes the unparser
-        // emit `json_get_*` verbatim into BigQuery SQL, which is the wrong
-        // answer dressed as a remote error. Fail where it can be read instead.
-        return Err(DataFusionError::Plan(format!(
-            "Failed to run this query against BigQuery: '{function}' was called in a form BigQuery \
-             cannot express, so the query cannot be completed. BigQuery needs a constant JSON path \
-             built only from plain keys: every path argument must be a literal, there must be at \
-             least one, and a key cannot contain a quote, a backslash or a control character. \
-             Rewrite the call to a constant path of plain keys, or set 'query_federation: disabled' \
-             on the dataset to evaluate it locally instead. \
-             See: https://spiceai.org/docs/components/data-connectors/adbc"
-        )));
-    };
+    json_call_to_sql(
+        unparser,
+        args,
+        function,
+        cast_to.clone(),
+        |document, path| ast::Expr::Cast {
+            kind: ast::CastKind::SafeCast,
+            expr: Box::new(call_function(
+                "REGEXP_EXTRACT",
+                vec![
+                    call_function("JSON_VALUE", vec![document, path]),
+                    ast::Expr::Value(raw_string(pattern).into()),
+                ],
+            )),
+            data_type: cast_to,
+            array: false,
+            format: None,
+        },
+    )
+}
 
-    let path = match path {
-        JsonPath::NeverResolves => return Ok(Some(cast_null_to(cast_to))),
-        JsonPath::Path(path) => path,
-    };
+/// `SAFE.PARSE_JSON(value)` — SAFE so a document it will not parse is a NULL
+/// carried out through the call rather than a failed query.
+fn parse_json(value: ast::Expr) -> ast::Expr {
+    call_qualified_function("SAFE", "PARSE_JSON", vec![value])
+}
 
-    let document = unparser.expr_to_sql(document)?;
-
-    let json_value = call_function(
-        "JSON_VALUE",
-        vec![document, ast::Expr::Value(raw_string(&path).into())],
-    );
-    let matched = call_function(
-        "REGEXP_EXTRACT",
-        vec![json_value, ast::Expr::Value(raw_string(pattern).into())],
-    );
-
-    Ok(Some(ast::Expr::Cast {
-        kind: ast::CastKind::SafeCast,
-        expr: Box::new(matched),
-        data_type: cast_to,
-        array: false,
-        format: None,
-    }))
+/// A `JSON_KEYS` depth argument. Load-bearing: without it `BigQuery` descends and
+/// returns nested paths, where the local functions see only the top level.
+fn depth(levels: u32) -> ast::Expr {
+    ast::Expr::Value(ast::Value::Number(levels.to_string(), false).into())
 }
 
 fn cast_null_to(data_type: ast::DataType) -> ast::Expr {
@@ -285,6 +638,18 @@ fn cast_null_to(data_type: ast::DataType) -> ast::Expr {
         array: false,
         format: None,
     }
+}
+
+/// A call to a function reached through a prefix, such as `SAFE.PARSE_JSON`.
+fn call_qualified_function(prefix: &str, name: &str, args: Vec<ast::Expr>) -> ast::Expr {
+    let mut call = call_function(name, args);
+    if let ast::Expr::Function(function) = &mut call {
+        function.name = ObjectName(vec![
+            ast::ObjectNamePart::Identifier(ast::Ident::new(prefix)),
+            ast::ObjectNamePart::Identifier(ast::Ident::new(name)),
+        ]);
+    }
+    call
 }
 
 fn call_function(name: &str, args: Vec<ast::Expr>) -> ast::Expr {
@@ -505,7 +870,9 @@ mod tests {
     use datafusion::sql::unparser::Unparser;
 
     use super::{
-        INT64_FROM_STR, JSON_GET_INT_NAME, JsonPath, SpiceBigQueryDialect, can_translate, json_path,
+        FLOAT64_FROM_STR, INT64_FROM_STR, JSON_GET_BOOL_NAME, JSON_GET_FLOAT_NAME,
+        JSON_GET_INT_NAME, JSON_GET_STR_NAME, JSON_KEYS_NAME, JSON_LEN_NAME, JSON_LENGTH_NAME,
+        JSON_OBJECT_KEYS_NAME, JsonPath, SpiceBigQueryDialect, can_translate, json_path,
     };
     use crate::dialect::new_bigquery_dialect;
     use datafusion::common::ScalarValue;
@@ -583,7 +950,7 @@ mod tests {
         // more; with none it returns the whole match. A capturing group added
         // here would fail every federated call at BigQuery, which no local test
         // can see.
-        for pattern in [INT64_FROM_STR] {
+        for pattern in [INT64_FROM_STR, FLOAT64_FROM_STR] {
             let mut chars = pattern.chars().peekable();
             while let Some(c) = chars.next() {
                 match c {
@@ -642,7 +1009,23 @@ mod tests {
             JSON_GET_INT_NAME,
             vec![col("doc"), col("key")]
         )));
-        for name in ["json_get_float", "upper"] {
+        assert!(can_translate(&call(
+            JSON_GET_STR_NAME,
+            vec![col("doc"), lit("a")]
+        )));
+        assert!(!can_translate(&call(
+            JSON_GET_STR_NAME,
+            vec![col("doc"), col("key")]
+        )));
+        assert!(can_translate(&call(
+            JSON_GET_BOOL_NAME,
+            vec![col("doc"), lit("a")]
+        )));
+        assert!(!can_translate(&call(
+            JSON_GET_BOOL_NAME,
+            vec![col("doc"), col("key")]
+        )));
+        for name in ["json_contains", "upper"] {
             assert!(
                 can_translate(&call(name, vec![col("doc"), col("key")])),
                 "{name} has no handler in this dialect, so it is not this check's business — \
@@ -668,13 +1051,152 @@ mod tests {
     }
 
     #[test]
-    fn json_get_float_is_not_translated_at_all() {
-        // Rust saturates an out-of-range float to infinity where SAFE_CAST
-        // gives NULL, so pushing it down would change results. It must not be
-        // in the carve-out, which is what would let it federate.
+    fn json_get_str_renders_as_a_guarded_json_value() {
+        // The STARTS_WITH/JSON_QUERY guard is the whole reason this is
+        // translatable: JSON_VALUE alone renders a JSON number as its digits,
+        // where `json_get_str` returns NULL.
+        assert_eq!(
+            render(JSON_GET_STR_NAME, vec![col("doc"), lit("a")]),
+            r#"CASE WHEN STARTS_WITH(JSON_QUERY(`doc`, R'$."a"'), '"') THEN JSON_VALUE(`doc`, R'$."a"') END"#
+        );
+    }
+
+    #[test]
+    fn json_get_str_never_resolving_renders_as_a_typed_null() {
+        // Utf8, not Int64: a federated schema that disagrees with the local one
+        // is a cast error at best and a wrong column type at worst.
+        assert_eq!(
+            render(JSON_GET_STR_NAME, vec![col("doc"), lit(-1_i64)]),
+            "CAST(NULL AS STRING)"
+        );
+    }
+
+    #[test]
+    fn json_get_bool_renders_as_a_case_over_the_rendered_text() {
+        // A string comparison, not SAFE_CAST(… AS BOOL): the cast is
+        // case-insensitive where Rust's `bool::from_str` is not, so a cast
+        // would answer true for "TRUE" where the local function is NULL.
+        assert_eq!(
+            render(JSON_GET_BOOL_NAME, vec![col("doc"), lit("a")]),
+            r#"CASE JSON_VALUE(`doc`, R'$."a"') WHEN 'true' THEN true WHEN 'false' THEN false END"#
+        );
+    }
+
+    #[test]
+    fn no_bool_rendering_casts_to_bool() {
+        // The whole reason `json_get_bool` is translatable is that it never
+        // reaches BigQuery's BOOL cast. If one appears, the case-sensitivity
+        // agreement is gone and "TRUE" starts answering true remotely only.
+        let sql = render(JSON_GET_BOOL_NAME, vec![col("doc"), lit("a")]);
         assert!(
-            !crate::dialect::bigquery_native_function_names().contains(&"json_get_float"),
-            "json_get_float must stay denied while its boundary behaviour is unverified"
+            !sql.contains("AS BOOL"),
+            "a BOOL cast is case-insensitive and must not appear: {sql}"
+        );
+    }
+
+    #[test]
+    fn json_get_float_renders_as_a_guarded_safe_cast() {
+        assert_eq!(
+            render(JSON_GET_FLOAT_NAME, vec![col("doc"), lit("a")]),
+            concat!(
+                r#"SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(`doc`, R'$."a"'), "#,
+                r#"R'^[+-]?(?:(?i:inf|infinity|nan)|(?:[0-9]+\.[0-9]*|[0-9]*\.[0-9]+|[0-9]+)"#,
+                r#"(?:[eE][+-]?[0-9]+)?)$') AS FLOAT64)"#
+            )
+        );
+    }
+
+    #[test]
+    fn the_float_grammar_accepts_what_rust_accepts_and_nothing_more() {
+        // Every case is asserted against Rust's own parser as well as the
+        // pattern, so the two cannot drift apart while the test still passes.
+        // `regex` and BigQuery's engine are both RE2 lineage, so a pattern this
+        // one accepts is one BigQuery accepts.
+        let pattern = regex::Regex::new(FLOAT64_FROM_STR).expect("the float grammar compiles");
+        for accepted in [
+            "1", "-1", "1.5", "-1.5", "1.", ".5", "1e3", "-1E-3", "0", "inf", "-inf", "Infinity",
+            "INFINITY", "nan", "NaN", "+1.5",
+        ] {
+            assert!(
+                pattern.is_match(accepted),
+                "`{accepted}` parses as f64 in Rust, so the pattern must accept it"
+            );
+            assert!(
+                accepted.parse::<f64>().is_ok(),
+                "`{accepted}` must actually parse in Rust, or this test is asserting the wrong thing"
+            );
+        }
+        for rejected in [
+            "0x2A", "  1.5  ", "1.5f", "", "e3", "1e", "1,5", "true", "--1",
+        ] {
+            assert!(
+                !pattern.is_match(rejected),
+                "`{rejected}` is not an f64 in Rust, so the pattern must reject it"
+            );
+            assert!(
+                rejected.parse::<f64>().is_err(),
+                "`{rejected}` must actually fail in Rust, or this test is asserting the wrong thing"
+            );
+        }
+    }
+
+    #[test]
+    fn json_length_counts_an_array_and_an_object_differently() {
+        // The depth argument on JSON_KEYS is what keeps an object's count to
+        // its own keys: without it BigQuery descends and returns nested paths,
+        // where json_length counts only the top level.
+        assert_eq!(
+            render(JSON_LENGTH_NAME, vec![col("doc"), lit("a")]),
+            concat!(
+                r#"CASE WHEN STARTS_WITH(JSON_QUERY(`doc`, R'$."a"'), '[') "#,
+                r#"THEN ARRAY_LENGTH(JSON_QUERY_ARRAY(`doc`, R'$."a"')) "#,
+                r#"WHEN STARTS_WITH(JSON_QUERY(`doc`, R'$."a"'), '{') "#,
+                r#"THEN ARRAY_LENGTH(JSON_KEYS(SAFE.PARSE_JSON(JSON_QUERY(`doc`, R'$."a"')), 1)) END"#
+            )
+        );
+    }
+
+    #[test]
+    fn json_length_object_keys_are_capped_to_the_top_level() {
+        let sql = render(JSON_LENGTH_NAME, vec![col("doc"), lit("a")]);
+        assert!(
+            sql.contains("JSON_KEYS(SAFE.PARSE_JSON(JSON_QUERY(`doc`, R'$.\"a\"')), 1)"),
+            "JSON_KEYS must carry the depth argument, or it counts nested paths: {sql}"
+        );
+    }
+
+    #[test]
+    fn json_object_keys_renders_as_a_depth_capped_json_keys() {
+        assert_eq!(
+            render(JSON_OBJECT_KEYS_NAME, vec![col("doc"), lit("a")]),
+            concat!(
+                r#"CASE WHEN STARTS_WITH(JSON_QUERY(`doc`, R'$."a"'), '{') "#,
+                r#"THEN JSON_KEYS(SAFE.PARSE_JSON(JSON_QUERY(`doc`, R'$."a"')), 1) END"#
+            )
+        );
+    }
+
+    #[test]
+    fn json_object_keys_never_resolving_keeps_its_element_type() {
+        // An untyped NULL would make the federated schema disagree with the
+        // plan's List(Utf8), which is a failed query rather than a wrong row.
+        assert_eq!(
+            render(JSON_OBJECT_KEYS_NAME, vec![col("doc"), lit(-1_i64)]),
+            "CAST(NULL AS ARRAY<STRING>)"
+        );
+    }
+
+    #[test]
+    fn the_alias_renders_exactly_as_the_canonical_name_does() {
+        assert_eq!(
+            render(JSON_LEN_NAME, vec![col("doc"), lit("a")]),
+            render(JSON_LENGTH_NAME, vec![col("doc"), lit("a")]),
+            "`json_len` is `json_length`; the two must not drift"
+        );
+        assert_eq!(
+            render(JSON_KEYS_NAME, vec![col("doc"), lit("a")]),
+            render(JSON_OBJECT_KEYS_NAME, vec![col("doc"), lit("a")]),
+            "`json_keys` is `json_object_keys`; the two must not drift"
         );
     }
 
@@ -688,7 +1210,14 @@ mod tests {
 
     #[test]
     fn no_rendering_ever_contains_the_function_verbatim() {
-        for name in [JSON_GET_INT_NAME] {
+        for name in [
+            JSON_GET_INT_NAME,
+            JSON_GET_STR_NAME,
+            JSON_GET_BOOL_NAME,
+            JSON_GET_FLOAT_NAME,
+            JSON_LENGTH_NAME,
+            JSON_OBJECT_KEYS_NAME,
+        ] {
             for args in [
                 vec![col("doc"), lit("a")],
                 vec![col("doc"), lit("a"), lit(0_i64)],

--- a/crates/runtime-datafusion/src/dialect/bigquery.rs
+++ b/crates/runtime-datafusion/src/dialect/bigquery.rs
@@ -46,7 +46,6 @@ use datafusion::sql::unparser::dialect::{
 };
 
 pub(crate) const JSON_GET_INT_NAME: &str = "json_get_int";
-pub(crate) const JSON_GET_FLOAT_NAME: &str = "json_get_float";
 
 /// The grammar Rust's `i64::FromStr` accepts, which is what
 /// `json_get_int` applies to a JSON **string** node.
@@ -55,19 +54,18 @@ pub(crate) const JSON_GET_FLOAT_NAME: &str = "json_get_float";
 /// hexadecimal literal, and trims surrounding whitespace — so extracting
 /// through this pattern first is what makes the string case exact. Everything
 /// it rejects, `json_get_int` also rejects, and returns NULL for.
-const INT64_FROM_STR: &str = r"^[+-]?[0-9]+$";
-
-/// The grammar Rust's `f64::FromStr` accepts, which is what `json_get_float`
-/// applies to a JSON **string** node: an optional sign, then `inf`,
-/// `infinity`, `nan` or a decimal with an optional exponent, case-insensitive.
-/// A bare `.5` and a trailing `5.` are both accepted, and whitespace is not.
 ///
-/// Every group is non-capturing. `REGEXP_EXTRACT` accepts **at most one**
+/// It also agrees at the boundaries: an integer too large for `i64` is NULL on
+/// both sides, because Rust's `i64::FromStr` fails rather than saturating.
+/// `json_get_float` is the opposite — Rust saturates an out-of-range magnitude
+/// to infinity where `SAFE_CAST` gives NULL — which is why only the integer
+/// form is translated. See [`SCALAR_OVERRIDES`].
+///
+/// Any group must be non-capturing. `REGEXP_EXTRACT` accepts **at most one**
 /// capturing group and errors on more, which would fail every federated call
 /// remotely; with none it returns the whole match, which is what this wants.
-/// [`tests::no_pattern_has_a_capturing_group`] holds both patterns to that.
-const FLOAT64_FROM_STR: &str =
-    r"(?i)^[+-]?(?:inf(?:inity)?|nan|(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:e[+-]?[0-9]+)?)$";
+/// [`tests::no_pattern_has_a_capturing_group`] holds the patterns to that.
+const INT64_FROM_STR: &str = r"^[+-]?[0-9]+$";
 
 /// What `BigQuery` should be asked for, given a `json_get_*` call's path
 /// arguments.
@@ -191,18 +189,22 @@ pub(crate) struct ScalarOverride {
 /// Every function the `BigQuery` dialect rewrites, with what each consumer
 /// needs. [`crate::dialect`] derives the dialect's handlers, the deny-list
 /// carve-out, and the per-call check from this one table.
-pub(crate) const SCALAR_OVERRIDES: &[ScalarOverride] = &[
-    ScalarOverride {
-        name: JSON_GET_INT_NAME,
-        handler: json_get_int_to_sql,
-        can_translate: json_path_is_renderable,
-    },
-    ScalarOverride {
-        name: JSON_GET_FLOAT_NAME,
-        handler: json_get_float_to_sql,
-        can_translate: json_path_is_renderable,
-    },
-];
+///
+/// `json_get_float` is deliberately absent. Rust's `f64::FromStr` saturates an
+/// out-of-range magnitude to infinity and underflows to zero, where
+/// `SAFE_CAST(… AS FLOAT64)` returns NULL for a value it cannot represent — so
+/// a federated plan would answer NULL where the local function answers
+/// infinity, on the same rows. A `CASE` restoring the infinities would rest on
+/// `BigQuery` behaviour at both boundaries that nothing here can verify, so the
+/// float form stays denied until a real `BigQuery` settles it. The integer form
+/// has no such gap: both sides give up on an out-of-range integer.
+/// `json_get_float_saturates_an_out_of_range_magnitude_to_infinity` in
+/// `runtime-udfs-api` measures the local half.
+pub(crate) const SCALAR_OVERRIDES: &[ScalarOverride] = &[ScalarOverride {
+    name: JSON_GET_INT_NAME,
+    handler: json_get_int_to_sql,
+    can_translate: json_path_is_renderable,
+}];
 
 /// `json_get_int(doc, path…)` →
 /// `SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(doc, '<path>'), r'^[+-]?[0-9]+$') AS INT64)`.
@@ -225,21 +227,6 @@ pub(crate) fn json_get_int_to_sql(unparser: &Unparser, args: &[Expr]) -> Result<
     )
 }
 
-/// `json_get_float(doc, path…)` → the same shape as
-/// [`json_get_int_to_sql`], through [`FLOAT64_FROM_STR`] and `FLOAT64`.
-pub(crate) fn json_get_float_to_sql(
-    unparser: &Unparser,
-    args: &[Expr],
-) -> Result<Option<ast::Expr>> {
-    json_get_number_to_sql(
-        unparser,
-        args,
-        JSON_GET_FLOAT_NAME,
-        FLOAT64_FROM_STR,
-        ast::DataType::Float64,
-    )
-}
-
 fn json_get_number_to_sql(
     unparser: &Unparser,
     args: &[Expr],
@@ -255,8 +242,12 @@ fn json_get_number_to_sql(
         // emit `json_get_*` verbatim into BigQuery SQL, which is the wrong
         // answer dressed as a remote error. Fail where it can be read instead.
         return Err(DataFusionError::Plan(format!(
-            "Cannot push down '{function}' to BigQuery: its path arguments must all be literals. \
-             This plan should not have federated; the BigQuery function-support policy is missing. \
+            "Failed to run this query against BigQuery: '{function}' was called in a form BigQuery \
+             cannot express, so the query cannot be completed. BigQuery needs a constant JSON path \
+             built only from plain keys: every path argument must be a literal, there must be at \
+             least one, and a key cannot contain a quote, a backslash or a control character. \
+             Rewrite the call to a constant path of plain keys, or set 'query_federation: disabled' \
+             on the dataset to evaluate it locally instead. \
              See: https://spiceai.org/docs/components/data-connectors/adbc"
         )));
     };
@@ -514,8 +505,7 @@ mod tests {
     use datafusion::sql::unparser::Unparser;
 
     use super::{
-        FLOAT64_FROM_STR, INT64_FROM_STR, JSON_GET_FLOAT_NAME, JSON_GET_INT_NAME, JsonPath,
-        SpiceBigQueryDialect, can_translate, json_path,
+        INT64_FROM_STR, JSON_GET_INT_NAME, JsonPath, SpiceBigQueryDialect, can_translate, json_path,
     };
     use crate::dialect::new_bigquery_dialect;
     use datafusion::common::ScalarValue;
@@ -593,7 +583,7 @@ mod tests {
         // more; with none it returns the whole match. A capturing group added
         // here would fail every federated call at BigQuery, which no local test
         // can see.
-        for pattern in [INT64_FROM_STR, FLOAT64_FROM_STR] {
+        for pattern in [INT64_FROM_STR] {
             let mut chars = pattern.chars().peekable();
             while let Some(c) = chars.next() {
                 match c {
@@ -648,22 +638,17 @@ mod tests {
             JSON_GET_INT_NAME,
             vec![col("doc"), lit("a")]
         )));
-        assert!(can_translate(&call(
-            JSON_GET_FLOAT_NAME,
-            vec![col("doc"), lit("a")]
-        )));
         assert!(!can_translate(&call(
             JSON_GET_INT_NAME,
             vec![col("doc"), col("key")]
         )));
-        assert!(!can_translate(&call(
-            JSON_GET_FLOAT_NAME,
-            vec![col("doc"), col("key")]
-        )));
-        assert!(
-            can_translate(&call("upper", vec![col("doc"), col("key")])),
-            "a function this dialect has no handler for is not this check's business"
-        );
+        for name in ["json_get_float", "upper"] {
+            assert!(
+                can_translate(&call(name, vec![col("doc"), col("key")])),
+                "{name} has no handler in this dialect, so it is not this check's business — \
+                 the deny-list has not carved it out and it cannot federate at all"
+            );
+        }
     }
 
     #[test]
@@ -675,10 +660,21 @@ mod tests {
     }
 
     #[test]
-    fn json_get_float_renders_as_a_guarded_safe_cast() {
+    fn an_index_in_the_path_renders_after_the_key() {
         assert_eq!(
-            render(JSON_GET_FLOAT_NAME, vec![col("doc"), lit("a"), lit(2_i64)]),
-            r#"SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(`doc`, R'$."a"[2]'), R'(?i)^[+-]?(?:inf(?:inity)?|nan|(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:e[+-]?[0-9]+)?)$') AS FLOAT64)"#
+            render(JSON_GET_INT_NAME, vec![col("doc"), lit("a"), lit(2_i64)]),
+            r#"SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(`doc`, R'$."a"[2]'), R'^[+-]?[0-9]+$') AS INT64)"#
+        );
+    }
+
+    #[test]
+    fn json_get_float_is_not_translated_at_all() {
+        // Rust saturates an out-of-range float to infinity where SAFE_CAST
+        // gives NULL, so pushing it down would change results. It must not be
+        // in the carve-out, which is what would let it federate.
+        assert!(
+            !crate::dialect::bigquery_native_function_names().contains(&"json_get_float"),
+            "json_get_float must stay denied while its boundary behaviour is unverified"
         );
     }
 
@@ -688,15 +684,11 @@ mod tests {
             render(JSON_GET_INT_NAME, vec![col("doc"), lit(-1_i64)]),
             "CAST(NULL AS INT64)"
         );
-        assert_eq!(
-            render(JSON_GET_FLOAT_NAME, vec![col("doc"), lit(-1_i64)]),
-            "CAST(NULL AS FLOAT64)"
-        );
     }
 
     #[test]
     fn no_rendering_ever_contains_the_function_verbatim() {
-        for name in [JSON_GET_INT_NAME, JSON_GET_FLOAT_NAME] {
+        for name in [JSON_GET_INT_NAME] {
             for args in [
                 vec![col("doc"), lit("a")],
                 vec![col("doc"), lit("a"), lit(0_i64)],
@@ -723,9 +715,23 @@ mod tests {
                 vec![col("doc"), col("key")],
             )))
             .expect_err("a dynamic path has no BigQuery translation");
+        let message = error.to_string();
+        for expected in [
+            // The call shape that failed, not the policy that should have
+            // caught it: an internal cause is no help to whoever ran the query.
+            "must be a literal",
+            // The way out, and where to read about it.
+            "query_federation",
+            "https://spiceai.org/docs/components/data-connectors/adbc",
+        ] {
+            assert!(
+                message.contains(expected),
+                "the error must carry {expected:?}: {message}"
+            );
+        }
         assert!(
-            error.to_string().contains("must all be literals"),
-            "the error must say what about the call cannot be pushed down: {error}"
+            !message.contains("policy"),
+            "the error must not name an internal mechanism: {message}"
         );
     }
 

--- a/crates/runtime-datafusion/src/dialect/bigquery.rs
+++ b/crates/runtime-datafusion/src/dialect/bigquery.rs
@@ -61,8 +61,13 @@ const INT64_FROM_STR: &str = r"^[+-]?[0-9]+$";
 /// applies to a JSON **string** node: an optional sign, then `inf`,
 /// `infinity`, `nan` or a decimal with an optional exponent, case-insensitive.
 /// A bare `.5` and a trailing `5.` are both accepted, and whitespace is not.
+///
+/// Every group is non-capturing. `REGEXP_EXTRACT` accepts **at most one**
+/// capturing group and errors on more, which would fail every federated call
+/// remotely; with none it returns the whole match, which is what this wants.
+/// [`tests::no_pattern_has_a_capturing_group`] holds both patterns to that.
 const FLOAT64_FROM_STR: &str =
-    r"(?i)^[+-]?(inf(inity)?|nan|([0-9]+\.?[0-9]*|\.[0-9]+)(e[+-]?[0-9]+)?)$";
+    r"(?i)^[+-]?(?:inf(?:inity)?|nan|(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:e[+-]?[0-9]+)?)$";
 
 /// What `BigQuery` should be asked for, given a `json_get_*` call's path
 /// arguments.
@@ -105,10 +110,12 @@ pub(crate) fn json_path(args: &[Expr]) -> Option<JsonPath> {
             ScalarValue::Utf8(Some(key))
             | ScalarValue::LargeUtf8(Some(key))
             | ScalarValue::Utf8View(Some(key)) => {
-                // BigQuery's JSON_VALUE quotes a key with double quotes, and a
-                // `"` inside one is backslash-escaped.
-                let escaped = key.replace('\\', r"\\").replace('"', r#"\""#);
-                let _ = write!(rendered, r#"."{escaped}""#);
+                if !key_is_renderable(key) {
+                    return None;
+                }
+                // BigQuery quotes a key with double quotes, which is what lets
+                // a key containing `.` stay one key.
+                let _ = write!(rendered, r#"."{key}""#);
             }
             ScalarValue::Int64(Some(index)) if *index >= 0 => {
                 let _ = write!(rendered, "[{index}]");
@@ -131,16 +138,71 @@ pub(crate) fn json_path(args: &[Expr]) -> Option<JsonPath> {
     Some(JsonPath::Path(rendered))
 }
 
+/// Whether a key can be written into the path at all.
+///
+/// The path is emitted as a `BigQuery` **raw** string literal, so what is
+/// written is what the JSON path parser reads: nothing processes backslashes in
+/// between. That holds only while the key contains nothing either layer would
+/// read as structure — `\'` would end the literal, `"` would end the quoted
+/// field name, `\\` is an escape to the JSON path parser, and a control
+/// character has no agreed spelling in either. Escaping across two layers with
+/// different rules is how a key silently becomes a *different* path, so such a
+/// key is left for the local engine instead.
+fn key_is_renderable(key: &str) -> bool {
+    !key.contains(['\'', '"', '\\']) && !key.chars().any(char::is_control)
+}
+
+/// Whether the path arguments of a `json_get_*` call can be rendered. Reads
+/// [`json_path`], so it answers exactly the question the handlers can answer.
+fn json_path_is_renderable(args: &[Expr]) -> bool {
+    json_path(args).is_some()
+}
+
 /// Whether the `BigQuery` dialect can translate this call, for the pushdown
-/// policy to consult. Reads [`json_path`], so it answers exactly the question
-/// the handlers below can answer.
+/// policy to consult.
+///
+/// A function with no entry in [`SCALAR_OVERRIDES`] is not this check's
+/// business: the deny-list has not carved it out, so it is already denied.
 #[must_use]
 pub fn can_translate(call: &ScalarFunction) -> bool {
-    match call.func.name() {
-        JSON_GET_INT_NAME | JSON_GET_FLOAT_NAME => json_path(&call.args).is_some(),
-        _ => true,
-    }
+    let name = call.func.name();
+    SCALAR_OVERRIDES
+        .iter()
+        .find(|entry| entry.name == name)
+        .is_none_or(|entry| (entry.can_translate)(&call.args))
 }
+
+/// A function the `BigQuery` dialect rewrites into native SQL.
+///
+/// The handler and the per-call check are one entry because they are one fact:
+/// a handler that can only render some call shapes is safe only while the
+/// deny-list refuses the rest. Splitting them into a list and a separate match
+/// is what lets a later partial handler be carved out of the deny-list with
+/// nothing to refuse its untranslatable shapes, which puts the function name
+/// verbatim into the remote SQL.
+pub(crate) struct ScalarOverride {
+    pub(crate) name: &'static str,
+    /// Renders the call, or fails if it cannot — see [`json_get_number_to_sql`].
+    pub(crate) handler: fn(&Unparser, &[Expr]) -> Result<Option<ast::Expr>>,
+    /// Whether `handler` can render a call with these arguments.
+    pub(crate) can_translate: fn(&[Expr]) -> bool,
+}
+
+/// Every function the `BigQuery` dialect rewrites, with what each consumer
+/// needs. [`crate::dialect`] derives the dialect's handlers, the deny-list
+/// carve-out, and the per-call check from this one table.
+pub(crate) const SCALAR_OVERRIDES: &[ScalarOverride] = &[
+    ScalarOverride {
+        name: JSON_GET_INT_NAME,
+        handler: json_get_int_to_sql,
+        can_translate: json_path_is_renderable,
+    },
+    ScalarOverride {
+        name: JSON_GET_FLOAT_NAME,
+        handler: json_get_float_to_sql,
+        can_translate: json_path_is_renderable,
+    },
+];
 
 /// `json_get_int(doc, path…)` →
 /// `SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(doc, '<path>'), r'^[+-]?[0-9]+$') AS INT64)`.
@@ -208,7 +270,7 @@ fn json_get_number_to_sql(
 
     let json_value = call_function(
         "JSON_VALUE",
-        vec![document, ast::Expr::Value(single_quoted(&path).into())],
+        vec![document, ast::Expr::Value(raw_string(&path).into())],
     );
     let matched = call_function(
         "REGEXP_EXTRACT",
@@ -254,12 +316,9 @@ fn call_function(name: &str, args: Vec<ast::Expr>) -> ast::Expr {
     })
 }
 
-fn single_quoted(value: &str) -> ast::Value {
-    ast::Value::SingleQuotedString(value.to_string())
-}
-
-/// A `BigQuery` raw string literal, `r'…'`. Raw so a backslash in the pattern
-/// is a regex escape rather than a string escape.
+/// A `BigQuery` raw string literal, `r'…'`. Raw so a backslash in the value is
+/// the value's own, not something the SQL string layer consumes first — which
+/// matters for a regex escape and for a JSON path alike.
 fn raw_string(value: &str) -> ast::Value {
     ast::Value::SingleQuotedRawStringLiteral(value.to_string())
 }
@@ -455,8 +514,8 @@ mod tests {
     use datafusion::sql::unparser::Unparser;
 
     use super::{
-        JSON_GET_FLOAT_NAME, JSON_GET_INT_NAME, JsonPath, SpiceBigQueryDialect, can_translate,
-        json_path,
+        FLOAT64_FROM_STR, INT64_FROM_STR, JSON_GET_FLOAT_NAME, JSON_GET_INT_NAME, JsonPath,
+        SpiceBigQueryDialect, can_translate, json_path,
     };
     use crate::dialect::new_bigquery_dialect;
     use datafusion::common::ScalarValue;
@@ -514,15 +573,42 @@ mod tests {
     }
 
     #[test]
-    fn a_key_containing_a_quote_or_a_backslash_is_escaped() {
-        assert_eq!(
-            json_path(&[col("doc"), lit(r#"a"b"#)]),
-            Some(JsonPath::Path(r#"$."a\"b""#.to_string()))
-        );
-        assert_eq!(
-            json_path(&[col("doc"), lit(r"a\b")]),
-            Some(JsonPath::Path(r#"$."a\\b""#.to_string()))
-        );
+    fn a_key_the_two_quoting_layers_disagree_about_is_not_translated() {
+        // A quote, a backslash or a control character means one of the SQL
+        // literal layer and the JSONPath layer would read the key as structure.
+        // Escaping across both is how a key silently becomes a different path,
+        // so these are left for the local engine.
+        for key in [r#"a"b"#, r"a\b", "a'b", "a\nb", "a\tb"] {
+            assert_eq!(
+                json_path(&[col("doc"), lit(key)]),
+                None,
+                "{key:?} cannot be written into a BigQuery JSON path unambiguously"
+            );
+        }
+    }
+
+    #[test]
+    fn no_pattern_has_a_capturing_group() {
+        // `REGEXP_EXTRACT` accepts at most one capturing group and errors on
+        // more; with none it returns the whole match. A capturing group added
+        // here would fail every federated call at BigQuery, which no local test
+        // can see.
+        for pattern in [INT64_FROM_STR, FLOAT64_FROM_STR] {
+            let mut chars = pattern.chars().peekable();
+            while let Some(c) = chars.next() {
+                match c {
+                    '\\' => {
+                        chars.next();
+                    }
+                    '(' => assert_eq!(
+                        chars.peek(),
+                        Some(&'?'),
+                        "capturing group in {pattern}: every group must be `(?:…)`"
+                    ),
+                    _ => {}
+                }
+            }
+        }
     }
 
     #[test]
@@ -584,7 +670,7 @@ mod tests {
     fn json_get_int_renders_as_a_guarded_safe_cast() {
         assert_eq!(
             render(JSON_GET_INT_NAME, vec![col("doc"), lit("a")]),
-            r#"SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(`doc`, '$."a"'), R'^[+-]?[0-9]+$') AS INT64)"#
+            r#"SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(`doc`, R'$."a"'), R'^[+-]?[0-9]+$') AS INT64)"#
         );
     }
 
@@ -592,7 +678,7 @@ mod tests {
     fn json_get_float_renders_as_a_guarded_safe_cast() {
         assert_eq!(
             render(JSON_GET_FLOAT_NAME, vec![col("doc"), lit("a"), lit(2_i64)]),
-            r#"SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(`doc`, '$."a"[2]'), R'(?i)^[+-]?(inf(inity)?|nan|([0-9]+\.?[0-9]*|\.[0-9]+)(e[+-]?[0-9]+)?)$') AS FLOAT64)"#
+            r#"SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(`doc`, R'$."a"[2]'), R'(?i)^[+-]?(?:inf(?:inity)?|nan|(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:e[+-]?[0-9]+)?)$') AS FLOAT64)"#
         );
     }
 

--- a/crates/runtime-datafusion/src/dialect/bigquery.rs
+++ b/crates/runtime-datafusion/src/dialect/bigquery.rs
@@ -1,0 +1,746 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! `BigQuery` translations for the JSON extraction functions, and the
+//! `BigQuery` dialect that installs them.
+//!
+//! `datafusion-functions-json` takes a **variadic path**, not a `JSONPath`
+//! string: `json_get_int(col, 'a', 'b', 0)` reads key `a`, then key `b`, then
+//! array element 0. A string argument is always an object key — `('a.b')` is
+//! one key literally named `a.b`, not a two-step path — and an integer argument
+//! is always an array index. [`json_path`] is the one place that mapping is
+//! written down, and both the translation and the pushdown policy read it, so
+//! what the dialect can render and what the deny-list lets through cannot
+//! diverge.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::Arc;
+
+use chrono::DateTime;
+use datafusion::arrow::array::timezone::Tz;
+use datafusion::arrow::datatypes::TimeUnit;
+use datafusion::common::{DataFusionError, Result, ScalarValue};
+use datafusion::logical_expr::Expr;
+use datafusion::logical_expr::expr::ScalarFunction;
+use datafusion::sql::sqlparser::ast::{
+    self, BinaryOperator, Function, FunctionArg, FunctionArgExpr, ObjectName, WindowFrameBound,
+};
+use datafusion::sql::unparser::Unparser;
+use datafusion::sql::unparser::dialect::{
+    BigQueryDialect, CharacterLengthStyle, DateFieldExtractStyle, Dialect, IntervalStyle,
+    ScalarFnToSqlHandler,
+};
+
+pub(crate) const JSON_GET_INT_NAME: &str = "json_get_int";
+pub(crate) const JSON_GET_FLOAT_NAME: &str = "json_get_float";
+
+/// The grammar Rust's `i64::FromStr` accepts, which is what
+/// `json_get_int` applies to a JSON **string** node.
+///
+/// `SAFE_CAST(… AS INT64)` on its own is wider than that — `BigQuery` reads a
+/// hexadecimal literal, and trims surrounding whitespace — so extracting
+/// through this pattern first is what makes the string case exact. Everything
+/// it rejects, `json_get_int` also rejects, and returns NULL for.
+const INT64_FROM_STR: &str = r"^[+-]?[0-9]+$";
+
+/// The grammar Rust's `f64::FromStr` accepts, which is what `json_get_float`
+/// applies to a JSON **string** node: an optional sign, then `inf`,
+/// `infinity`, `nan` or a decimal with an optional exponent, case-insensitive.
+/// A bare `.5` and a trailing `5.` are both accepted, and whitespace is not.
+const FLOAT64_FROM_STR: &str =
+    r"(?i)^[+-]?(inf(inity)?|nan|([0-9]+\.?[0-9]*|\.[0-9]+)(e[+-]?[0-9]+)?)$";
+
+/// What `BigQuery` should be asked for, given a `json_get_*` call's path
+/// arguments.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum JsonPath {
+    /// A `BigQuery` JSON path — `$."a"."b"[0]` — reaching the same node the
+    /// variadic path names.
+    Path(String),
+    /// The path can never resolve, so the call is NULL for every row.
+    /// `datafusion-functions-json` maps a negative index and a NULL path
+    /// element to its own `JsonPath::None`, which no lookup ever matches.
+    NeverResolves,
+}
+
+/// Builds the `BigQuery` JSON path for a `json_get_*` call, or `None` when the
+/// call has a shape `BigQuery` cannot be asked for.
+///
+/// The one shape with no translation is a **non-literal** path element:
+/// `json_get_int(doc, key_col)` is legal — the functions are
+/// `Signature::variadic_any` — and `BigQuery`'s JSON path argument must be a
+/// constant, so there is nothing to emit. Such a call must not federate at all;
+/// `crate::function_support` is what stops it, using this same function.
+pub(crate) fn json_path(args: &[Expr]) -> Option<JsonPath> {
+    // The first argument is the document; the rest are the path.
+    let (_document, path) = args.split_first()?;
+    if path.is_empty() {
+        // `json_get_int(col)` reads the document itself. `$` is the JSONPath
+        // for that, but what BigQuery returns for a bare `$` over a scalar
+        // document is not pinned by anything here, so it is left to evaluate
+        // locally rather than guessed at.
+        return None;
+    }
+
+    let mut rendered = String::from("$");
+    for element in path {
+        let Expr::Literal(value, _) = element else {
+            return None;
+        };
+        match value {
+            ScalarValue::Utf8(Some(key))
+            | ScalarValue::LargeUtf8(Some(key))
+            | ScalarValue::Utf8View(Some(key)) => {
+                // BigQuery's JSON_VALUE quotes a key with double quotes, and a
+                // `"` inside one is backslash-escaped.
+                let escaped = key.replace('\\', r"\\").replace('"', r#"\""#);
+                let _ = write!(rendered, r#"."{escaped}""#);
+            }
+            ScalarValue::Int64(Some(index)) if *index >= 0 => {
+                let _ = write!(rendered, "[{index}]");
+            }
+            ScalarValue::UInt64(Some(index)) => {
+                let _ = write!(rendered, "[{index}]");
+            }
+            // A negative index, or a NULL path element of a type the function
+            // accepts, resolves to nothing for every row.
+            ScalarValue::Int64(Some(_) | None)
+            | ScalarValue::UInt64(None)
+            | ScalarValue::Utf8(None)
+            | ScalarValue::LargeUtf8(None)
+            | ScalarValue::Utf8View(None) => return Some(JsonPath::NeverResolves),
+            // Any other literal type is rejected by the function's own
+            // `return_type`, so it cannot reach a plan.
+            _ => return None,
+        }
+    }
+    Some(JsonPath::Path(rendered))
+}
+
+/// Whether the `BigQuery` dialect can translate this call, for the pushdown
+/// policy to consult. Reads [`json_path`], so it answers exactly the question
+/// the handlers below can answer.
+#[must_use]
+pub fn can_translate(call: &ScalarFunction) -> bool {
+    match call.func.name() {
+        JSON_GET_INT_NAME | JSON_GET_FLOAT_NAME => json_path(&call.args).is_some(),
+        _ => true,
+    }
+}
+
+/// `json_get_int(doc, path…)` →
+/// `SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(doc, '<path>'), r'^[+-]?[0-9]+$') AS INT64)`.
+///
+/// `JSON_VALUE` renders the node at the path as a string and returns NULL for
+/// an object, an array, a JSON `null` and a missing path — which is what
+/// `json_get_int` returns for all four. `true` and `false` render as `"true"`
+/// and `"false"`, which the pattern rejects, matching `json_get_int` again. A
+/// number renders as its own token, so a float or an exponent form is rejected
+/// exactly as `json_get_int` rejects it, and an integer outside `INT64` is a
+/// NULL from `SAFE_CAST` exactly as it is a NULL from the `i64` conversion. The
+/// pattern is what makes a JSON **string** node exact — see [`INT64_FROM_STR`].
+pub(crate) fn json_get_int_to_sql(unparser: &Unparser, args: &[Expr]) -> Result<Option<ast::Expr>> {
+    json_get_number_to_sql(
+        unparser,
+        args,
+        JSON_GET_INT_NAME,
+        INT64_FROM_STR,
+        ast::DataType::Int64,
+    )
+}
+
+/// `json_get_float(doc, path…)` → the same shape as
+/// [`json_get_int_to_sql`], through [`FLOAT64_FROM_STR`] and `FLOAT64`.
+pub(crate) fn json_get_float_to_sql(
+    unparser: &Unparser,
+    args: &[Expr],
+) -> Result<Option<ast::Expr>> {
+    json_get_number_to_sql(
+        unparser,
+        args,
+        JSON_GET_FLOAT_NAME,
+        FLOAT64_FROM_STR,
+        ast::DataType::Float64,
+    )
+}
+
+fn json_get_number_to_sql(
+    unparser: &Unparser,
+    args: &[Expr],
+    function: &str,
+    pattern: &str,
+    cast_to: ast::DataType,
+) -> Result<Option<ast::Expr>> {
+    let (Some(document), Some(path)) = (args.first(), json_path(args)) else {
+        // Unreachable with the deny-list installed, which refuses exactly the
+        // calls `json_path` cannot render. Reachable only if this dialect is
+        // used without `deny_spice_functions_for_bigquery_table_providers`, and
+        // there the alternative — returning `Ok(None)` — makes the unparser
+        // emit `json_get_*` verbatim into BigQuery SQL, which is the wrong
+        // answer dressed as a remote error. Fail where it can be read instead.
+        return Err(DataFusionError::Plan(format!(
+            "Cannot push down '{function}' to BigQuery: its path arguments must all be literals. \
+             This plan should not have federated; the BigQuery function-support policy is missing. \
+             See: https://spiceai.org/docs/components/data-connectors/adbc"
+        )));
+    };
+
+    let path = match path {
+        JsonPath::NeverResolves => return Ok(Some(cast_null_to(cast_to))),
+        JsonPath::Path(path) => path,
+    };
+
+    let document = unparser.expr_to_sql(document)?;
+
+    let json_value = call_function(
+        "JSON_VALUE",
+        vec![document, ast::Expr::Value(single_quoted(&path).into())],
+    );
+    let matched = call_function(
+        "REGEXP_EXTRACT",
+        vec![json_value, ast::Expr::Value(raw_string(pattern).into())],
+    );
+
+    Ok(Some(ast::Expr::Cast {
+        kind: ast::CastKind::SafeCast,
+        expr: Box::new(matched),
+        data_type: cast_to,
+        array: false,
+        format: None,
+    }))
+}
+
+fn cast_null_to(data_type: ast::DataType) -> ast::Expr {
+    ast::Expr::Cast {
+        kind: ast::CastKind::Cast,
+        expr: Box::new(ast::Expr::Value(ast::Value::Null.into())),
+        data_type,
+        array: false,
+        format: None,
+    }
+}
+
+fn call_function(name: &str, args: Vec<ast::Expr>) -> ast::Expr {
+    ast::Expr::Function(Function {
+        name: ObjectName(vec![ast::ObjectNamePart::Identifier(ast::Ident::new(name))]),
+        args: ast::FunctionArguments::List(ast::FunctionArgumentList {
+            duplicate_treatment: None,
+            args: args
+                .into_iter()
+                .map(|arg| FunctionArg::Unnamed(FunctionArgExpr::Expr(arg)))
+                .collect(),
+            clauses: vec![],
+        }),
+        filter: None,
+        null_treatment: None,
+        over: None,
+        within_group: vec![],
+        parameters: ast::FunctionArguments::None,
+        uses_odbc_syntax: false,
+    })
+}
+
+fn single_quoted(value: &str) -> ast::Value {
+    ast::Value::SingleQuotedString(value.to_string())
+}
+
+/// A `BigQuery` raw string literal, `r'…'`. Raw so a backslash in the pattern
+/// is a regex escape rather than a string escape.
+fn raw_string(value: &str) -> ast::Value {
+    ast::Value::SingleQuotedRawStringLiteral(value.to_string())
+}
+
+/// [`BigQueryDialect`] plus Spice's own scalar-function handlers.
+///
+/// `BigQueryDialect` does not implement [`Dialect::with_custom_scalar_overrides`]
+/// — it panics — so the handlers cannot be attached to it directly. This wraps
+/// it instead, holding the handler map itself and forwarding every other
+/// [`Dialect`] method to the inner dialect. **Every** method is forwarded
+/// explicitly: inheriting a trait default here would silently unparse
+/// `BigQuery` SQL as if it were the generic dialect, changing quoting, casts
+/// and interval rendering with no error anywhere.
+pub struct SpiceBigQueryDialect {
+    inner: BigQueryDialect,
+    custom_scalar_fn_overrides: HashMap<String, ScalarFnToSqlHandler>,
+}
+
+impl Default for SpiceBigQueryDialect {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SpiceBigQueryDialect {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: BigQueryDialect::new(),
+            custom_scalar_fn_overrides: HashMap::new(),
+        }
+    }
+}
+
+impl Dialect for SpiceBigQueryDialect {
+    fn with_custom_scalar_overrides(mut self, handlers: Vec<(&str, ScalarFnToSqlHandler)>) -> Self {
+        for (name, handler) in handlers {
+            self.custom_scalar_fn_overrides
+                .insert(name.to_string(), handler);
+        }
+        self
+    }
+
+    fn scalar_function_to_sql_overrides(
+        &self,
+        unparser: &Unparser,
+        func_name: &str,
+        args: &[Expr],
+    ) -> Result<Option<ast::Expr>> {
+        if let Some(handler) = self.custom_scalar_fn_overrides.get(func_name) {
+            return handler(unparser, args);
+        }
+        self.inner
+            .scalar_function_to_sql_overrides(unparser, func_name, args)
+    }
+
+    fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
+        self.inner.identifier_quote_style(identifier)
+    }
+
+    fn use_array_keyword_for_array_literals(&self) -> bool {
+        self.inner.use_array_keyword_for_array_literals()
+    }
+
+    fn supports_nulls_first_in_sort(&self) -> bool {
+        self.inner.supports_nulls_first_in_sort()
+    }
+
+    fn use_timestamp_for_date64(&self) -> bool {
+        self.inner.use_timestamp_for_date64()
+    }
+
+    fn interval_style(&self) -> IntervalStyle {
+        self.inner.interval_style()
+    }
+
+    fn float64_ast_dtype(&self) -> ast::DataType {
+        self.inner.float64_ast_dtype()
+    }
+
+    fn utf8_cast_dtype(&self) -> ast::DataType {
+        self.inner.utf8_cast_dtype()
+    }
+
+    fn large_utf8_cast_dtype(&self) -> ast::DataType {
+        self.inner.large_utf8_cast_dtype()
+    }
+
+    fn date_field_extract_style(&self) -> DateFieldExtractStyle {
+        self.inner.date_field_extract_style()
+    }
+
+    fn character_length_style(&self) -> CharacterLengthStyle {
+        self.inner.character_length_style()
+    }
+
+    fn int64_cast_dtype(&self) -> ast::DataType {
+        self.inner.int64_cast_dtype()
+    }
+
+    fn int8_cast_dtype(&self) -> ast::DataType {
+        self.inner.int8_cast_dtype()
+    }
+
+    fn int32_cast_dtype(&self) -> ast::DataType {
+        self.inner.int32_cast_dtype()
+    }
+
+    fn timestamp_cast_dtype(&self, time_unit: &TimeUnit, tz: &Option<Arc<str>>) -> ast::DataType {
+        self.inner.timestamp_cast_dtype(time_unit, tz)
+    }
+
+    fn timestamp_at_time_zone_to_sql(&self, input: ast::Expr, tz: &str) -> Option<ast::Expr> {
+        self.inner.timestamp_at_time_zone_to_sql(input, tz)
+    }
+
+    fn date32_cast_dtype(&self) -> ast::DataType {
+        self.inner.date32_cast_dtype()
+    }
+
+    fn supports_column_alias_in_table_alias(&self) -> bool {
+        self.inner.supports_column_alias_in_table_alias()
+    }
+
+    fn requires_derived_table_alias(&self) -> bool {
+        self.inner.requires_derived_table_alias()
+    }
+
+    fn division_operator(&self) -> BinaryOperator {
+        self.inner.division_operator()
+    }
+
+    fn higher_order_function_to_sql_overrides(
+        &self,
+        unparser: &Unparser,
+        func_name: &str,
+        args: &[Expr],
+    ) -> Result<Option<ast::Expr>> {
+        self.inner
+            .higher_order_function_to_sql_overrides(unparser, func_name, args)
+    }
+
+    fn window_func_support_window_frame(
+        &self,
+        func_name: &str,
+        start_bound: &WindowFrameBound,
+        end_bound: &WindowFrameBound,
+    ) -> bool {
+        self.inner
+            .window_func_support_window_frame(func_name, start_bound, end_bound)
+    }
+
+    fn full_qualified_col(&self) -> bool {
+        self.inner.full_qualified_col()
+    }
+
+    fn unnest_as_table_factor(&self) -> bool {
+        self.inner.unnest_as_table_factor()
+    }
+
+    fn unnest_as_lateral_flatten(&self) -> bool {
+        self.inner.unnest_as_lateral_flatten()
+    }
+
+    fn col_alias_overrides(&self, alias: &str) -> Result<Option<String>> {
+        self.inner.col_alias_overrides(alias)
+    }
+
+    fn supports_qualify(&self) -> bool {
+        self.inner.supports_qualify()
+    }
+
+    fn timestamp_with_tz_to_string(&self, dt: DateTime<Tz>, unit: TimeUnit) -> String {
+        self.inner.timestamp_with_tz_to_string(dt, unit)
+    }
+
+    fn supports_empty_select_list(&self) -> bool {
+        self.inner.supports_empty_select_list()
+    }
+
+    fn string_literal_to_sql(&self, s: &str) -> Option<ast::Expr> {
+        self.inner.string_literal_to_sql(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::DataType;
+    use datafusion::logical_expr::{ColumnarValue, ScalarUDF, Volatility, create_udf};
+    use datafusion::prelude::{col, lit};
+    use datafusion::sql::unparser::Unparser;
+
+    use super::{
+        JSON_GET_FLOAT_NAME, JSON_GET_INT_NAME, JsonPath, SpiceBigQueryDialect, can_translate,
+        json_path,
+    };
+    use crate::dialect::new_bigquery_dialect;
+    use datafusion::common::ScalarValue;
+    use datafusion::logical_expr::Expr;
+    use datafusion::logical_expr::expr::ScalarFunction;
+
+    fn json_udf(name: &str, arity: usize) -> Arc<ScalarUDF> {
+        Arc::new(create_udf(
+            name,
+            vec![DataType::Utf8; arity],
+            DataType::Int64,
+            Volatility::Immutable,
+            Arc::new(|args: &[ColumnarValue]| Ok(args[0].clone())),
+        ))
+    }
+
+    fn call(name: &str, args: Vec<Expr>) -> ScalarFunction {
+        ScalarFunction::new_udf(json_udf(name, args.len()), args)
+    }
+
+    /// The SQL the `BigQuery` dialect renders for one `json_get_*` call.
+    fn render(name: &str, args: Vec<Expr>) -> String {
+        let dialect = new_bigquery_dialect();
+        Unparser::new(dialect.as_ref())
+            .expr_to_sql(&Expr::ScalarFunction(call(name, args)))
+            .expect("the BigQuery dialect renders this call")
+            .to_string()
+    }
+
+    #[test]
+    fn a_literal_key_becomes_a_bigquery_json_path() {
+        assert_eq!(
+            json_path(&[col("doc"), lit("a")]),
+            Some(JsonPath::Path(r#"$."a""#.to_string()))
+        );
+    }
+
+    #[test]
+    fn the_variadic_path_becomes_one_json_path() {
+        assert_eq!(
+            json_path(&[col("doc"), lit("a"), lit("b"), lit(0_i64)]),
+            Some(JsonPath::Path(r#"$."a"."b"[0]"#.to_string()))
+        );
+    }
+
+    #[test]
+    fn a_dotted_key_stays_one_key() {
+        // `json_get_int(doc, 'a.b')` reads a key literally named `a.b`. Quoting
+        // it is what stops BigQuery reading it as two steps, which would return
+        // a different value rather than an error.
+        assert_eq!(
+            json_path(&[col("doc"), lit("a.b")]),
+            Some(JsonPath::Path(r#"$."a.b""#.to_string()))
+        );
+    }
+
+    #[test]
+    fn a_key_containing_a_quote_or_a_backslash_is_escaped() {
+        assert_eq!(
+            json_path(&[col("doc"), lit(r#"a"b"#)]),
+            Some(JsonPath::Path(r#"$."a\"b""#.to_string()))
+        );
+        assert_eq!(
+            json_path(&[col("doc"), lit(r"a\b")]),
+            Some(JsonPath::Path(r#"$."a\\b""#.to_string()))
+        );
+    }
+
+    #[test]
+    fn a_path_that_can_never_resolve_is_recognised_as_such() {
+        // A negative index and a NULL path element both map to
+        // `datafusion-functions-json`'s own `JsonPath::None`, which matches
+        // nothing, so the call is NULL for every row.
+        for element in [
+            lit(-1_i64),
+            Expr::Literal(ScalarValue::Utf8(None), None),
+            Expr::Literal(ScalarValue::Int64(None), None),
+        ] {
+            assert_eq!(
+                json_path(&[col("doc"), element.clone()]),
+                Some(JsonPath::NeverResolves),
+                "{element} names nothing"
+            );
+        }
+    }
+
+    #[test]
+    fn a_non_literal_path_element_has_no_translation() {
+        // BigQuery's JSON path argument must be a constant, so there is nothing
+        // to render for a per-row path.
+        assert_eq!(json_path(&[col("doc"), col("key")]), None);
+        assert_eq!(json_path(&[col("doc"), lit("a"), col("key")]), None);
+    }
+
+    #[test]
+    fn a_call_with_no_path_has_no_translation() {
+        assert_eq!(json_path(&[col("doc")]), None);
+    }
+
+    #[test]
+    fn can_translate_answers_for_the_json_functions_and_defers_on_the_rest() {
+        assert!(can_translate(&call(
+            JSON_GET_INT_NAME,
+            vec![col("doc"), lit("a")]
+        )));
+        assert!(can_translate(&call(
+            JSON_GET_FLOAT_NAME,
+            vec![col("doc"), lit("a")]
+        )));
+        assert!(!can_translate(&call(
+            JSON_GET_INT_NAME,
+            vec![col("doc"), col("key")]
+        )));
+        assert!(!can_translate(&call(
+            JSON_GET_FLOAT_NAME,
+            vec![col("doc"), col("key")]
+        )));
+        assert!(
+            can_translate(&call("upper", vec![col("doc"), col("key")])),
+            "a function this dialect has no handler for is not this check's business"
+        );
+    }
+
+    #[test]
+    fn json_get_int_renders_as_a_guarded_safe_cast() {
+        assert_eq!(
+            render(JSON_GET_INT_NAME, vec![col("doc"), lit("a")]),
+            r#"SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(`doc`, '$."a"'), R'^[+-]?[0-9]+$') AS INT64)"#
+        );
+    }
+
+    #[test]
+    fn json_get_float_renders_as_a_guarded_safe_cast() {
+        assert_eq!(
+            render(JSON_GET_FLOAT_NAME, vec![col("doc"), lit("a"), lit(2_i64)]),
+            r#"SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(`doc`, '$."a"[2]'), R'(?i)^[+-]?(inf(inity)?|nan|([0-9]+\.?[0-9]*|\.[0-9]+)(e[+-]?[0-9]+)?)$') AS FLOAT64)"#
+        );
+    }
+
+    #[test]
+    fn a_path_that_can_never_resolve_renders_as_a_typed_null() {
+        assert_eq!(
+            render(JSON_GET_INT_NAME, vec![col("doc"), lit(-1_i64)]),
+            "CAST(NULL AS INT64)"
+        );
+        assert_eq!(
+            render(JSON_GET_FLOAT_NAME, vec![col("doc"), lit(-1_i64)]),
+            "CAST(NULL AS FLOAT64)"
+        );
+    }
+
+    #[test]
+    fn no_rendering_ever_contains_the_function_verbatim() {
+        for name in [JSON_GET_INT_NAME, JSON_GET_FLOAT_NAME] {
+            for args in [
+                vec![col("doc"), lit("a")],
+                vec![col("doc"), lit("a"), lit(0_i64)],
+                vec![col("doc"), lit(-1_i64)],
+            ] {
+                let sql = render(name, args);
+                assert!(
+                    !sql.contains(name),
+                    "{name} must not reach BigQuery SQL: {sql}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn an_untranslatable_call_fails_rather_than_unparsing_verbatim() {
+        // Unreachable with the deny-list installed. If the dialect is used
+        // without it, the alternative is emitting `json_get_int(...)` into
+        // BigQuery SQL, so this fails where a reader can see it instead.
+        let dialect = new_bigquery_dialect();
+        let error = Unparser::new(dialect.as_ref())
+            .expr_to_sql(&Expr::ScalarFunction(call(
+                JSON_GET_INT_NAME,
+                vec![col("doc"), col("key")],
+            )))
+            .expect_err("a dynamic path has no BigQuery translation");
+        assert!(
+            error.to_string().contains("must all be literals"),
+            "the error must say what about the call cannot be pushed down: {error}"
+        );
+    }
+
+    #[test]
+    fn the_dialect_renders_every_name_the_deny_list_carves_out() {
+        // The carve-out is what lets these names federate. A name in it that
+        // the dialect has no handler for would be unparsed verbatim, so the
+        // list is only safe while the dialect answers for all of it.
+        let dialect = new_bigquery_dialect();
+        let unparser = Unparser::new(dialect.as_ref());
+        for name in crate::dialect::bigquery_native_function_names() {
+            let rendered = dialect
+                .scalar_function_to_sql_overrides(&unparser, name, &[col("doc"), lit("a")])
+                .unwrap_or_else(|error| panic!("the dialect must render `{name}`: {error}"));
+            assert!(
+                rendered.is_some(),
+                "`{name}` is carved out of the deny-list but the dialect has no handler for it, \
+                 so it would be unparsed verbatim into BigQuery SQL"
+            );
+        }
+    }
+
+    #[test]
+    fn a_predicate_over_a_json_function_unparses_into_the_statement() {
+        // The whole statement, not just the expression: this is the SQL a
+        // federated scan sends, so it is where a verbatim `json_get_*` would
+        // show up.
+        let schema = Arc::new(datafusion::arrow::datatypes::Schema::new(vec![
+            datafusion::arrow::datatypes::Field::new("doc", DataType::Utf8, true),
+        ]));
+        let source = Arc::new(datafusion::logical_expr::builder::LogicalTableSource::new(
+            schema,
+        )) as Arc<dyn datafusion::logical_expr::TableSource>;
+        let plan = datafusion::logical_expr::LogicalPlanBuilder::scan("t", source, None)
+            .expect("scan t")
+            .filter(
+                Expr::ScalarFunction(call(JSON_GET_INT_NAME, vec![col("doc"), lit("a")]))
+                    .eq(lit(1_i64)),
+            )
+            .expect("filter")
+            .build()
+            .expect("build");
+
+        let dialect = new_bigquery_dialect();
+        let sql = Unparser::new(dialect.as_ref())
+            .plan_to_sql(&plan)
+            .expect("the BigQuery dialect unparses the plan")
+            .to_string();
+
+        assert!(sql.contains("JSON_VALUE("), "no JSON_VALUE in: {sql}");
+        assert!(sql.contains("SAFE_CAST("), "no SAFE_CAST in: {sql}");
+        assert!(
+            !sql.contains("json_get_"),
+            "a Spice-only function reached BigQuery SQL: {sql}"
+        );
+    }
+
+    #[test]
+    fn the_wrapper_unparses_exactly_as_the_bigquery_dialect_does() {
+        // Every `Dialect` method is forwarded to the inner dialect. Inheriting
+        // a trait default for one instead would change quoting, a cast's type
+        // name or an alias silently — valid SQL that BigQuery rejects, or worse,
+        // accepts differently. Unparsing the same plan through both is what
+        // notices, whichever method was missed.
+        let schema = Arc::new(datafusion::arrow::datatypes::Schema::new(vec![
+            datafusion::arrow::datatypes::Field::new("n", DataType::Int64, false),
+            datafusion::arrow::datatypes::Field::new(
+                "ts",
+                DataType::Timestamp(
+                    datafusion::arrow::datatypes::TimeUnit::Nanosecond,
+                    Some("UTC".into()),
+                ),
+                true,
+            ),
+        ]));
+        let source = Arc::new(datafusion::logical_expr::builder::LogicalTableSource::new(
+            schema,
+        )) as Arc<dyn datafusion::logical_expr::TableSource>;
+        let plan = datafusion::logical_expr::LogicalPlanBuilder::scan("t", source, None)
+            .expect("scan t")
+            .project(vec![
+                datafusion::prelude::cast(col("n"), DataType::Float64).alias("a.b"),
+                datafusion::prelude::cast(col("n"), DataType::Utf8),
+                datafusion::prelude::cast(col("ts"), DataType::Date32),
+                col("ts").alias("raw"),
+            ])
+            .expect("project")
+            .build()
+            .expect("build");
+
+        let unparse = |dialect: &dyn datafusion::sql::unparser::dialect::Dialect| {
+            Unparser::new(dialect)
+                .plan_to_sql(&plan)
+                .expect("unparse the plan")
+                .to_string()
+        };
+
+        assert_eq!(
+            unparse(&SpiceBigQueryDialect::new()),
+            unparse(&datafusion::sql::unparser::dialect::BigQueryDialect::new()),
+            "a `Dialect` method is not forwarded to the inner BigQuery dialect"
+        );
+    }
+}

--- a/crates/runtime-datafusion/src/dialect/mod.rs
+++ b/crates/runtime-datafusion/src/dialect/mod.rs
@@ -16,12 +16,16 @@ limitations under the License.
 
 use std::sync::Arc;
 
+use datafusion::logical_expr::expr::ScalarFunction;
 use datafusion::sql::unparser::dialect::{Dialect, DuckDBDialect, ScalarFnToSqlHandler};
 
 use runtime_datafusion_udfs::cosine_distance::COSINE_DISTANCE_UDF_NAME;
 use runtime_datafusion_udfs::inner_product::INNER_PRODUCT_UDF_NAME;
 
+mod bigquery;
 mod duckdb;
+
+pub use bigquery::SpiceBigQueryDialect;
 
 const REGEXP_LIKE_FLAGS_POSITION: usize = 2; // The position of the flags argument in regexp_like function calls
 const REGEXP_MATCH_FLAGS_POSITION: usize = 2; // The position of the flags argument in regexp_match function calls
@@ -120,4 +124,81 @@ pub fn new_duckdb_dialect() -> Arc<dyn Dialect> {
     let dialect = DuckDBDialect::new().with_custom_scalar_overrides(duckdb_scalar_overrides());
 
     Arc::new(dialect) as Arc<dyn Dialect>
+}
+
+/// The scalar functions the `BigQuery` unparser dialect rewrites to native
+/// `BigQuery` SQL, paired with their handlers.
+///
+/// The same single-source-of-truth rule as [`duckdb_scalar_overrides`], with
+/// one more consumer: [`bigquery_can_translate`] answers from the same path
+/// builder these handlers render with, so what the dialect can render, what the
+/// deny-list lets through, and what the per-call check refuses all come from one
+/// place.
+///
+/// The other JSON functions stay denied. `json_get_str` needs a string-type
+/// guard around `JSON_VALUE`, which renders a JSON number as its digits where
+/// `json_get_str` returns NULL, and `json_get_bool` would diverge because
+/// `BigQuery`'s cast to `BOOL` is case-insensitive and Rust's `bool::from_str`
+/// is not. `json_get` and its relatives return a union that has no SQL surface.
+fn bigquery_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
+    vec![
+        (
+            bigquery::JSON_GET_INT_NAME,
+            Box::new(bigquery::json_get_int_to_sql) as ScalarFnToSqlHandler,
+        ),
+        (
+            bigquery::JSON_GET_FLOAT_NAME,
+            Box::new(bigquery::json_get_float_to_sql) as ScalarFnToSqlHandler,
+        ),
+    ]
+}
+
+/// Names of the functions [`new_bigquery_dialect`] rewrites to native
+/// `BigQuery` SQL. The federation deny-list derives its `BigQuery` carve-out
+/// from this list; see [`crate::function_support::deny_spice_functions_for_bigquery_table_providers`].
+#[must_use]
+pub fn bigquery_native_function_names() -> Vec<&'static str> {
+    bigquery_scalar_overrides()
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect()
+}
+
+/// Whether the `BigQuery` dialect can translate this particular call.
+///
+/// A name in [`bigquery_native_function_names`] is not enough on its own: the
+/// JSON functions take a variadic path, and a path element that is not a
+/// literal has no `BigQuery` equivalent, because its JSON path argument must be
+/// a constant. The deny-list installs this so such a call is left to evaluate
+/// locally instead of being unparsed.
+#[must_use]
+pub fn bigquery_can_translate(call: &ScalarFunction) -> bool {
+    bigquery::can_translate(call)
+}
+
+/// Creates a `BigQuery` dialect that also rewrites the Spice JSON functions
+/// [`bigquery_native_function_names`] lists.
+#[must_use]
+pub fn new_bigquery_dialect() -> Arc<dyn Dialect> {
+    let dialect =
+        SpiceBigQueryDialect::new().with_custom_scalar_overrides(bigquery_scalar_overrides());
+
+    Arc::new(dialect) as Arc<dyn Dialect>
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bigquery_native_function_names;
+
+    #[test]
+    fn every_carved_out_bigquery_name_is_a_function_the_deny_list_knows() {
+        let json = runtime_udfs_api::json_function_names();
+        for name in bigquery_native_function_names() {
+            assert!(
+                json.iter().any(|known| known == name),
+                "`{name}` is not a name `datafusion-functions-json` registers, so carving it out \
+                 of the deny-list does nothing"
+            );
+        }
+    }
 }

--- a/crates/runtime-datafusion/src/dialect/mod.rs
+++ b/crates/runtime-datafusion/src/dialect/mod.rs
@@ -135,11 +135,14 @@ pub fn new_duckdb_dialect() -> Arc<dyn Dialect> {
 /// cannot be allowed to federate that the dialect has no handler for, and a
 /// handler cannot be added without saying which call shapes it can render.
 ///
-/// The other JSON functions stay denied. `json_get_str` needs a string-type
-/// guard around `JSON_VALUE`, which renders a JSON number as its digits where
-/// `json_get_str` returns NULL, and `json_get_bool` would diverge because
-/// `BigQuery`'s cast to `BOOL` is case-insensitive and Rust's `bool::from_str`
-/// is not. `json_get` and its relatives return a union that has no SQL surface.
+/// The rest stay denied, each for something `BigQuery` cannot be talked out of.
+/// `json_get_json` and `json_as_text` return the matched node's own bytes,
+/// spacing and number spelling intact, where `JSON_QUERY` re-renders it — a
+/// document holding `{"b": -1}` comes back as `{"b":-1}`. `json_contains`
+/// counts a JSON `null` as present, and `BigQuery` returns SQL NULL for such a
+/// node exactly as it does for a missing key, so the two cannot be told apart.
+/// `json_get`, `json_get_array` and the union helpers carry the crate's JSON
+/// union, which has no SQL type to unparse into.
 #[must_use]
 pub fn bigquery_native_function_names() -> Vec<&'static str> {
     bigquery::SCALAR_OVERRIDES

--- a/crates/runtime-datafusion/src/dialect/mod.rs
+++ b/crates/runtime-datafusion/src/dialect/mod.rs
@@ -126,41 +126,25 @@ pub fn new_duckdb_dialect() -> Arc<dyn Dialect> {
     Arc::new(dialect) as Arc<dyn Dialect>
 }
 
-/// The scalar functions the `BigQuery` unparser dialect rewrites to native
-/// `BigQuery` SQL, paired with their handlers.
+/// Names of the functions [`new_bigquery_dialect`] rewrites to native
+/// `BigQuery` SQL. The federation deny-list derives its `BigQuery` carve-out
+/// from this list; see [`crate::function_support::deny_spice_functions_for_bigquery_table_providers`].
 ///
-/// The same single-source-of-truth rule as [`duckdb_scalar_overrides`], with
-/// one more consumer: [`bigquery_can_translate`] answers from the same path
-/// builder these handlers render with, so what the dialect can render, what the
-/// deny-list lets through, and what the per-call check refuses all come from one
-/// place.
+/// This, the dialect's handlers and [`bigquery_can_translate`] are all derived
+/// from `bigquery::SCALAR_OVERRIDES`, so the three cannot drift: a function
+/// cannot be allowed to federate that the dialect has no handler for, and a
+/// handler cannot be added without saying which call shapes it can render.
 ///
 /// The other JSON functions stay denied. `json_get_str` needs a string-type
 /// guard around `JSON_VALUE`, which renders a JSON number as its digits where
 /// `json_get_str` returns NULL, and `json_get_bool` would diverge because
 /// `BigQuery`'s cast to `BOOL` is case-insensitive and Rust's `bool::from_str`
 /// is not. `json_get` and its relatives return a union that has no SQL surface.
-fn bigquery_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
-    vec![
-        (
-            bigquery::JSON_GET_INT_NAME,
-            Box::new(bigquery::json_get_int_to_sql) as ScalarFnToSqlHandler,
-        ),
-        (
-            bigquery::JSON_GET_FLOAT_NAME,
-            Box::new(bigquery::json_get_float_to_sql) as ScalarFnToSqlHandler,
-        ),
-    ]
-}
-
-/// Names of the functions [`new_bigquery_dialect`] rewrites to native
-/// `BigQuery` SQL. The federation deny-list derives its `BigQuery` carve-out
-/// from this list; see [`crate::function_support::deny_spice_functions_for_bigquery_table_providers`].
 #[must_use]
 pub fn bigquery_native_function_names() -> Vec<&'static str> {
-    bigquery_scalar_overrides()
-        .into_iter()
-        .map(|(name, _)| name)
+    bigquery::SCALAR_OVERRIDES
+        .iter()
+        .map(|entry| entry.name)
         .collect()
 }
 
@@ -180,10 +164,12 @@ pub fn bigquery_can_translate(call: &ScalarFunction) -> bool {
 /// [`bigquery_native_function_names`] lists.
 #[must_use]
 pub fn new_bigquery_dialect() -> Arc<dyn Dialect> {
-    let dialect =
-        SpiceBigQueryDialect::new().with_custom_scalar_overrides(bigquery_scalar_overrides());
+    let handlers: Vec<(&str, ScalarFnToSqlHandler)> = bigquery::SCALAR_OVERRIDES
+        .iter()
+        .map(|entry| (entry.name, Box::new(entry.handler) as ScalarFnToSqlHandler))
+        .collect();
 
-    Arc::new(dialect) as Arc<dyn Dialect>
+    Arc::new(SpiceBigQueryDialect::new().with_custom_scalar_overrides(handlers)) as Arc<dyn Dialect>
 }
 
 #[cfg(test)]

--- a/crates/runtime-datafusion/src/function_support.rs
+++ b/crates/runtime-datafusion/src/function_support.rs
@@ -47,6 +47,27 @@ pub fn deny_spice_functions_for_duckdb_table_providers() -> FunctionSupport {
         .build()
 }
 
+/// The [`FunctionSupport`] for `BigQuery` over ADBC, as a value for
+/// `AdbcTableFactory::with_function_support`.
+///
+/// Two layers, both derived from [`crate::dialect`] so they cannot drift from
+/// what the dialect can actually render:
+///
+/// 1. the name carve-out, so the JSON extraction functions the `BigQuery`
+///    dialect rewrites into `JSON_VALUE` federate instead of being denied;
+/// 2. a per-call check, because a carved-out *name* is not a carved-out *call*.
+///    `json_get_int(doc, key_col)` is legal and has no `BigQuery` translation —
+///    its JSON path argument must be a constant — and without this check that
+///    call would federate and be unparsed verbatim, which is the
+///    unknown-function failure the deny-list exists to prevent (issue #10703).
+#[must_use]
+pub fn deny_spice_functions_for_bigquery_table_providers() -> FunctionSupport {
+    FunctionSupportBuilder::new()
+        .native(&crate::dialect::bigquery_native_function_names())
+        .build()
+        .with_scalar_call_support(Arc::new(crate::dialect::bigquery_can_translate))
+}
+
 /// `DataFusion`'s nested array/list/map functions that `PostgreSQL` cannot
 /// evaluate are denied for `PostgreSQL` and PostgreSQL-wire backends (e.g.
 /// Redshift). The ones that match `PostgreSQL` exactly are listed here so they

--- a/crates/runtime-udfs-api/tests/json_semantics.rs
+++ b/crates/runtime-udfs-api/tests/json_semantics.rs
@@ -1,0 +1,364 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![expect(
+    clippy::expect_used,
+    reason = "a failed set-up in a test should name itself and stop"
+)]
+
+//! What the JSON extraction functions return, value by value.
+//!
+//! These are the repo-side guards for the `datafusion-functions-json` pin
+//! recorded in `docs/dev/fork_patches.md`. The pin sits ahead of the last
+//! published release for three upstream correctness fixes, and every one of
+//! them is a wrong answer rather than an error: a published
+//! `datafusion-functions-json` returns NULL for every negative JSON number,
+//! panics on an integer outside jiter's `i64` fast path, and reads the wrong
+//! value out of a nested JSON string. Drop back to a published version and
+//! these tests fail; nothing else in the workspace would.
+//!
+//! `runtime-udfs-api` hosts them because it is the crate that owns Spice's
+//! relationship with `datafusion-functions-json` — it derives the federation
+//! deny-list from that crate's registry — and it is small enough that the guard
+//! is cheap to run.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, RecordBatch, StringArray, UnionArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::common::{DFSchema, ScalarValue};
+use datafusion::config::ConfigOptions;
+use datafusion::logical_expr::{ColumnarValue, Expr, ScalarFunctionArgs, ScalarUDF};
+use datafusion::prelude::{SessionContext, col, lit};
+use datafusion_functions_json::functions::json_as_text;
+use datafusion_functions_json::udfs::{json_get_float_udf, json_get_int_udf, json_get_udf};
+use datafusion_functions_json::{JSON_UNION_DATA_TYPE, JsonUnionEncoder, JsonUnionValue};
+
+/// One element of a `json_get_*` path. The functions take a variadic path, not
+/// a `JSONPath` string: a string argument is an object key, an integer argument
+/// an array index.
+#[derive(Clone, Copy)]
+enum Path {
+    Key(&'static str),
+    Index(i64),
+}
+
+/// The single-element path `$.a` every scalar case below reads through.
+const A: &[Path] = &[Path::Key("a")];
+
+fn call(udf: &ScalarUDF, json: &str, path: &[Path], return_type: DataType) -> ScalarValue {
+    let mut args = vec![ColumnarValue::Scalar(ScalarValue::Utf8(Some(
+        json.to_string(),
+    )))];
+    args.extend(path.iter().map(|element| {
+        ColumnarValue::Scalar(match element {
+            Path::Key(key) => ScalarValue::Utf8(Some((*key).to_string())),
+            Path::Index(index) => ScalarValue::Int64(Some(*index)),
+        })
+    }));
+
+    let result = udf
+        .invoke_with_args(ScalarFunctionArgs {
+            args,
+            arg_fields: vec![],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("value", return_type, true)),
+            config_options: Arc::new(ConfigOptions::new()),
+        })
+        .expect("a well-typed json_get_* call never fails; every miss is a NULL");
+
+    match result {
+        ColumnarValue::Scalar(scalar) => scalar,
+        ColumnarValue::Array(_) => panic!("a call with scalar arguments must return a scalar"),
+    }
+}
+
+fn get_int(json: &str, path: &[Path]) -> Option<i64> {
+    match call(&json_get_int_udf(), json, path, DataType::Int64) {
+        ScalarValue::Int64(value) => value,
+        other => panic!("json_get_int returned {other:?}, not an Int64"),
+    }
+}
+
+fn get_float(json: &str, path: &[Path]) -> Option<f64> {
+    match call(&json_get_float_udf(), json, path, DataType::Float64) {
+        ScalarValue::Float64(value) => value,
+        other => panic!("json_get_float returned {other:?}, not a Float64"),
+    }
+}
+
+/// Wraps a JSON value as the sole member of an object under key `a`.
+fn doc(value: &str) -> String {
+    format!(r#"{{"a": {value}}}"#)
+}
+
+#[test]
+fn json_get_int_reads_negative_numbers() {
+    for (value, expected) in [
+        ("-1", Some(-1)),
+        ("-42", Some(-42)),
+        ("-0", Some(0)),
+        (r#""-42""#, Some(-42)),
+        ("1", Some(1)),
+        ("0", Some(0)),
+    ] {
+        assert_eq!(
+            get_int(&doc(value), A),
+            expected,
+            "json_get_int over {value}"
+        );
+    }
+}
+
+#[test]
+fn json_get_float_reads_negative_numbers() {
+    for (value, expected) in [
+        ("-1.5", Some(-1.5)),
+        ("-42", Some(-42.0)),
+        ("-1e3", Some(-1000.0)),
+        (r#""-4.25""#, Some(-4.25)),
+        ("1.5", Some(1.5)),
+        ("0", Some(0.0)),
+    ] {
+        assert_eq!(
+            get_float(&doc(value), A),
+            expected,
+            "json_get_float over {value}"
+        );
+    }
+}
+
+#[test]
+fn json_get_int_rejects_every_non_integer() {
+    for value in [
+        "1.5",  // a float is not an integer
+        "-1.5", // and neither is a negative one
+        "-1e3", // nor an exponent form, whatever it evaluates to
+        "true", "false", "null", "{}", "[]",
+        r#""abc""#, // a string that does not parse as an integer
+        r#""1.5""#, // including one that parses only as a float
+    ] {
+        assert_eq!(get_int(&doc(value), A), None, "json_get_int over {value}");
+    }
+}
+
+#[test]
+fn json_get_float_rejects_every_non_number() {
+    for value in ["true", "false", "null", "{}", "[]", r#""abc""#] {
+        assert_eq!(
+            get_float(&doc(value), A),
+            None,
+            "json_get_float over {value}"
+        );
+    }
+}
+
+#[test]
+fn json_get_int_spans_the_whole_i64_range() {
+    // jiter hands back a `BigInt` for any integer its fast path could not
+    // decode, including values well inside `i64`. Reading it as "too large"
+    // loses them; a released version panics on the same input.
+    for (value, expected) in [
+        ("9223372036854775807", Some(i64::MAX)),
+        ("-9223372036854775808", Some(i64::MIN)),
+        ("1753200000000000000", Some(1_753_200_000_000_000_000)),
+        ("-1753200000000000000", Some(-1_753_200_000_000_000_000)),
+        // genuinely outside i64: no representation, so NULL rather than a
+        // silently truncated or float-rounded answer
+        ("18446744073709551615", None),
+        ("-9223372036854775809", None),
+    ] {
+        assert_eq!(
+            get_int(&doc(value), A),
+            expected,
+            "json_get_int over {value}"
+        );
+    }
+}
+
+#[test]
+fn a_missing_value_is_null_not_an_error() {
+    assert_eq!(get_int(&doc("-1"), &[Path::Key("b")]), None, "wrong key");
+    assert_eq!(
+        get_int(r#"{"a": {"b": -1}}"#, A),
+        None,
+        "value is an object"
+    );
+    assert_eq!(get_int("[-1]", A), None, "key on a non-object");
+    assert_eq!(
+        get_int(&doc("-1"), &[Path::Index(0)]),
+        None,
+        "index on a non-array"
+    );
+    assert_eq!(get_int("[-1]", &[Path::Index(-1)]), None, "negative index");
+    assert_eq!(
+        get_float(&doc("-1.5"), &[Path::Key("b")]),
+        None,
+        "wrong key"
+    );
+}
+
+#[test]
+fn a_malformed_document_is_null_never_an_error() {
+    // Malformed at or before the value the path names.
+    for json in ["not json at all", r#"{"a": -}"#, r#"{"a" -1}"#, "{"] {
+        assert_eq!(get_int(json, A), None, "json_get_int over {json}");
+        assert_eq!(get_float(json, A), None, "json_get_float over {json}");
+    }
+
+    // The parse is incremental and stops at the value the path names, so a
+    // document truncated *after* that value still reads. Pinned because it is
+    // not obvious, and because any translation of these functions into a
+    // backend's own JSON parser has to match it.
+    assert_eq!(get_int(r#"{"a": -1"#, A), Some(-1));
+    assert_eq!(get_float(r#"{"a": -1.5"#, A), Some(-1.5));
+}
+
+#[test]
+fn a_nested_path_reaches_a_negative_number() {
+    let json = r#"{"a": [1, {"b": -7, "c": -0.5}]}"#;
+    assert_eq!(
+        get_int(json, &[Path::Key("a"), Path::Index(1), Path::Key("b")]),
+        Some(-7)
+    );
+    assert_eq!(
+        get_float(json, &[Path::Key("a"), Path::Index(1), Path::Key("c")]),
+        Some(-0.5)
+    );
+}
+
+#[test]
+fn a_key_containing_a_dot_is_one_key_not_a_path() {
+    // The path is variadic, so `a.b` is a literal key. Worth pinning: it is the
+    // assumption any translation of these functions into a backend's JSONPath
+    // has to preserve.
+    let json = r#"{"a.b": -1, "a": {"b": -2}}"#;
+    assert_eq!(get_int(json, &[Path::Key("a.b")]), Some(-1));
+    assert_eq!(get_int(json, &[Path::Key("a"), Path::Key("b")]), Some(-2));
+}
+
+#[test]
+fn json_get_reads_an_integer_outside_the_fast_path_without_panicking() {
+    // `json_get` returns a sparse union, and a released version reaches an
+    // unimplemented arm for any integer jiter's fast path could not decode —
+    // including values well inside `i64`. That is a panic on the query path,
+    // so this test guards liveness as much as the value.
+    for (value, expected) in [
+        (
+            "1753200000000000000",
+            JsonUnionValue::Int(1_753_200_000_000_000_000),
+        ),
+        (
+            "-1753200000000000000",
+            JsonUnionValue::Int(-1_753_200_000_000_000_000),
+        ),
+        ("9223372036854775807", JsonUnionValue::Int(i64::MAX)),
+        ("-9223372036854775808", JsonUnionValue::Int(i64::MIN)),
+        // outside i64 the union has no representation for it, so it is a JSON
+        // null rather than a silently rounded float
+        ("18446744073709551615", JsonUnionValue::JsonNull),
+        ("-9223372036854775809", JsonUnionValue::JsonNull),
+    ] {
+        assert_eq!(get_union(&doc(value)), expected, "json_get over {value}");
+    }
+}
+
+/// `json_get(col, 'a')` over a one-row array, decoded from its sparse union.
+/// The array form is what a real scan takes, and it is the shape the union
+/// encoder reads.
+fn get_union(json: &str) -> JsonUnionValue<'static> {
+    let result = json_get_udf()
+        .invoke_with_args(ScalarFunctionArgs {
+            args: vec![
+                ColumnarValue::Array(Arc::new(StringArray::from(vec![json]))),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some("a".to_string()))),
+            ],
+            arg_fields: vec![],
+            number_rows: 1,
+            return_field: Arc::new(Field::new("value", JSON_UNION_DATA_TYPE.clone(), true)),
+            config_options: Arc::new(ConfigOptions::new()),
+        })
+        .expect("a well-typed json_get call never fails; every miss is a JSON null");
+
+    let ColumnarValue::Array(array) = result else {
+        panic!("a call with an array argument must return an array");
+    };
+    let union = array
+        .as_any()
+        .downcast_ref::<UnionArray>()
+        .expect("json_get returns a sparse union")
+        .clone();
+    let encoder =
+        JsonUnionEncoder::from_union(union).expect("the union is the JSON union encoder's own");
+
+    match encoder.get_value(0) {
+        JsonUnionValue::Int(value) => JsonUnionValue::Int(value),
+        JsonUnionValue::Float(value) => JsonUnionValue::Float(value),
+        JsonUnionValue::Bool(value) => JsonUnionValue::Bool(value),
+        JsonUnionValue::JsonNull => JsonUnionValue::JsonNull,
+        other => panic!("json_get returned {other:?}, which this test does not cover"),
+    }
+}
+
+#[test]
+fn a_json_string_holding_json_is_read_one_level_at_a_time() {
+    // `json_as_text` returns SQL text, so two nested calls are not the same as
+    // one call with a two-element path: the inner call's result is a document
+    // in its own right. Folding them reads the wrong value — NULL here, since
+    // `outer` names a string rather than an object.
+    let doc = r#"{"outer": "{\"inner\": \"value\"}"}"#;
+    let nested = json_as_text(json_as_text(col("doc"), lit("outer")), lit("inner"));
+
+    assert_eq!(
+        evaluate_over(doc, nested),
+        Some("value".to_string()),
+        "nested json_as_text calls must not be folded into one path"
+    );
+}
+
+/// Plans `expr` against a one-column, one-row batch and evaluates it.
+///
+/// Planning is the point: `create_physical_expr` is what applies the crate's
+/// own function rewrites, which is where the folding this guards against
+/// happens. Evaluating the expression by hand would pass either way.
+fn evaluate_over(doc: &str, expr: Expr) -> Option<String> {
+    let mut ctx = SessionContext::new();
+    datafusion_functions_json::register_all(&mut ctx).expect("register the JSON functions");
+
+    let schema = Arc::new(Schema::new(vec![Field::new("doc", DataType::Utf8, true)]));
+    let df_schema = DFSchema::try_from(Arc::clone(&schema)).expect("build the schema");
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(vec![doc]))])
+        .expect("build the batch");
+
+    let physical = ctx
+        .state()
+        .create_physical_expr(expr, &df_schema)
+        .expect("plan the expression");
+
+    match physical.evaluate(&batch).expect("evaluate the expression") {
+        ColumnarValue::Array(array) => {
+            let strings = array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("json_as_text returns a string");
+            strings.is_valid(0).then(|| strings.value(0).to_string())
+        }
+        ColumnarValue::Scalar(ScalarValue::Utf8(value)) => value,
+        ColumnarValue::Scalar(other) => {
+            panic!("json_as_text returned {other:?}, not a string")
+        }
+    }
+}

--- a/crates/runtime-udfs-api/tests/json_semantics.rs
+++ b/crates/runtime-udfs-api/tests/json_semantics.rs
@@ -362,3 +362,37 @@ fn evaluate_over(doc: &str, expr: Expr) -> Option<String> {
         }
     }
 }
+
+/// Rust's `f64::FromStr` saturates an out-of-range magnitude to infinity
+/// rather than failing, so `json_get_float` returns an infinity where a
+/// NULL-on-overflow implementation would return NULL.
+///
+/// This is why `json_get_float` is not carved out for `BigQuery` pushdown:
+/// `SAFE_CAST(… AS FLOAT64)` yields NULL for a value it cannot represent, so a
+/// federated plan would answer NULL where this answers infinity. `json_get_int`
+/// has no such divergence — Rust and `BigQuery` both give up on an
+/// out-of-range integer — which is why only the integer form is pushed down.
+#[test]
+fn json_get_float_saturates_an_out_of_range_magnitude_to_infinity() {
+    for (value, expected) in [
+        (r#""1e400""#, f64::INFINITY),
+        (r#""-1e400""#, f64::NEG_INFINITY),
+        ("1e400", f64::INFINITY),
+        ("-1e400", f64::NEG_INFINITY),
+    ] {
+        assert_eq!(
+            get_float(&doc(value), &[Path::Key("a")]),
+            Some(expected),
+            "{value} must saturate, not become NULL"
+        );
+    }
+
+    // The other end collapses to zero rather than failing, for the same reason.
+    for value in [r#""1e-400""#, "1e-400"] {
+        assert_eq!(
+            get_float(&doc(value), &[Path::Key("a")]),
+            Some(0.0),
+            "{value} must underflow to zero"
+        );
+    }
+}

--- a/crates/runtime-udfs-api/tests/json_semantics.rs
+++ b/crates/runtime-udfs-api/tests/json_semantics.rs
@@ -44,7 +44,9 @@ use datafusion::config::ConfigOptions;
 use datafusion::logical_expr::{ColumnarValue, Expr, ScalarFunctionArgs, ScalarUDF};
 use datafusion::prelude::{SessionContext, col, lit};
 use datafusion_functions_json::functions::json_as_text;
-use datafusion_functions_json::udfs::{json_get_float_udf, json_get_int_udf, json_get_udf};
+use datafusion_functions_json::udfs::{
+    json_get_float_udf, json_get_int_udf, json_get_str_udf, json_get_udf,
+};
 use datafusion_functions_json::{JSON_UNION_DATA_TYPE, JsonUnionEncoder, JsonUnionValue};
 
 /// One element of a `json_get_*` path. The functions take a variadic path, not
@@ -90,6 +92,13 @@ fn get_int(json: &str, path: &[Path]) -> Option<i64> {
     match call(&json_get_int_udf(), json, path, DataType::Int64) {
         ScalarValue::Int64(value) => value,
         other => panic!("json_get_int returned {other:?}, not an Int64"),
+    }
+}
+
+fn get_str(json: &str, path: &[Path]) -> Option<String> {
+    match call(&json_get_str_udf(), json, path, DataType::Utf8) {
+        ScalarValue::Utf8(value) => value,
+        other => panic!("json_get_str returned {other:?}, not a Utf8"),
     }
 }
 
@@ -139,6 +148,60 @@ fn json_get_float_reads_negative_numbers() {
             "json_get_float over {value}"
         );
     }
+}
+
+#[test]
+fn json_get_str_answers_only_for_a_string_node() {
+    // The BigQuery translation guards `JSON_VALUE` with a test for the node's
+    // own JSON token precisely because of this: `JSON_VALUE` renders a number
+    // as its digits and a bool as `true`/`false`, where `json_get_str` is NULL.
+    // If this list ever gains a non-string that answers, that guard is wrong.
+    for value in [
+        "1",
+        "-1",
+        "0",
+        "1.5",
+        "-1e3", // every number shape
+        "true",
+        "false", // and both bools
+        "null",
+        "{}",
+        "[]",
+        r#"{"b": "c"}"#,
+        r#"["a"]"#,
+    ] {
+        assert_eq!(
+            get_str(&doc(value), A),
+            None,
+            "json_get_str over the non-string {value}"
+        );
+    }
+
+    for (value, expected) in [
+        (r#""abc""#, "abc"),
+        (r#""-42""#, "-42"),   // a numeric string is still a string
+        (r#""""#, ""),         // including an empty one
+        (r#""a\"b""#, "a\"b"), // escapes come back decoded
+        (r#""a\\b""#, "a\\b"),
+        (r#""\u00e9""#, "\u{e9}"),
+    ] {
+        assert_eq!(
+            get_str(&doc(value), A).as_deref(),
+            Some(expected),
+            "json_get_str over the string {value}"
+        );
+    }
+}
+
+#[test]
+fn json_get_str_is_null_for_a_miss_not_an_error() {
+    assert_eq!(
+        get_str(&doc(r#""abc""#), &[Path::Key("b")]),
+        None,
+        "wrong key"
+    );
+    assert_eq!(get_str("[1]", A), None, "key on a non-object");
+    assert_eq!(get_str("{", A), None, "malformed document");
 }
 
 #[test]

--- a/crates/search/src/index/duckdb/query_exec.rs
+++ b/crates/search/src/index/duckdb/query_exec.rs
@@ -383,7 +383,7 @@ mod tests {
             "a timezone-aware column must not be rendered through whole milliseconds: {sql}"
         );
         assert!(
-            sql.contains(".000999"),
+            sql.contains("1767225600000999"),
             "the comparison must keep its sub-millisecond digits: {sql}"
         );
     }

--- a/crates/search/src/index/duckdb/sql.rs
+++ b/crates/search/src/index/duckdb/sql.rs
@@ -475,8 +475,33 @@ mod tests {
             "the column must be compared directly: {sql}"
         );
         assert!(
-            sql.contains(".000999"),
+            sql.contains("1767225600000999"),
             "the literal must keep its sub-millisecond digits: {sql}"
+        );
+    }
+
+    /// The microsecond count is rendered as an integer, so it must survive past
+    /// 2^53 — the point beyond which a `f64` can no longer hold consecutive
+    /// integers, and a literal routed through one names a neighbouring
+    /// microsecond instead. A comparison against that literal then keeps or
+    /// drops the wrong boundary row, with well-formed SQL either way.
+    #[test]
+    fn a_microsecond_count_past_the_double_bound_is_rendered_exactly() {
+        // One above 2^53, which is the first count a f64 cannot represent.
+        let micros = 9_007_199_254_740_993_i64;
+        let schema = docs_schema(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            false,
+        )]);
+
+        let sql =
+            flat_sql(&schema, &col("ts").gt(micros_literal(micros))).expect("SQL should build");
+
+        assert!(
+            sql.contains(&micros.to_string()),
+            "the literal must name the microsecond it was given, not the nearest one a \
+             double can hold ({micros}): {sql}"
         );
     }
 

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -246,7 +246,7 @@ build failure:
 
 | Patch | What breaks if it is lost | Loss | Guard |
 |---|---|---|---|
-| DuckDB timestamp literal rendered through microseconds, not a `DOUBLE`, with DuckDB's two infinity sentinels declined (fork PR #57) | `TO_TIMESTAMP` takes a `DOUBLE`, so a timestamp count past 2^53 µs (≈ year 2255, and symmetrically before ≈ 1684) could not be represented exactly: a pushed-down filter names a neighbouring microsecond and keeps or drops the wrong row. Separately, a `TimestampMicrosecond` holding ±`i64::MAX` rendered fine, was reported pushdown-capable, and then failed the statement built from it | silent (wrong rows) | **GAP** — the fork's own execution tests cover it (they build rows one microsecond apart across the 2^53 boundary and assert which one a comparison keeps, under three session time zones); there is no repo-side equivalent. See [Open gaps](#open-gaps) |
+| DuckDB timestamp literal rendered through microseconds, not a `DOUBLE`, with DuckDB's two infinity sentinels declined (fork PR #57) | `TO_TIMESTAMP` takes a `DOUBLE`, so a timestamp count past 2^53 µs (≈ year 2255, and symmetrically before ≈ 1684) could not be represented exactly: a pushed-down filter names a neighbouring microsecond and keeps or drops the wrong row. Separately, a `TimestampMicrosecond` holding ±`i64::MAX` rendered fine, was reported pushdown-capable, and then failed the statement built from it | silent (wrong rows) | `crates/search/src/index/duckdb/sql.rs::a_timezone_aware_timestamp_filter_is_rendered_without_the_millisecond_truncation` and `::a_microsecond_count_past_the_double_bound_is_rendered_exactly`, and `query_exec.rs::scan_renders_filters_against_the_whole_table_schema`. The first and third pin the rendered microsecond count, so a revert to the `DOUBLE` form fails them; the second names a count above 2^53, which is the precision the patch exists for |
 | `FunctionSupport` per-call check (fork PR #61) | A function a backend carves out of the deny-list because its dialect rewrites it federates in *every* call shape, including the ones the dialect cannot render. The unparser then emits the function verbatim into the remote SQL — the unknown-function failure of [#10703](https://github.com/spiceai/spiceai/issues/10703) | build, then silent | `crates/data-connectors/connector-adbc/src/lib.rs::function_support_tests::bigquery_refuses_the_json_call_shapes_its_dialect_cannot_translate` and `::an_untranslatable_predicate_is_left_above_the_federated_scan`. Losing the API fails `cargo check`; a re-cut that keeps `with_scalar_call_support` and drops its use in `contains_unsupported_functions` fails these instead |
 
 ## datafusion-functions-json
@@ -460,7 +460,7 @@ patch is a build failure, so no behaviour guard applies.
 
 ## Open gaps
 
-**37 rows above are marked GAP** — they have no repo-side guard. Every one of them
+**36 rows above are marked GAP** — they have no repo-side guard. Every one of them
 is accounted for below; `scripts/check_fork_patches.py` fails if that count and this
 sentence disagree, so the list cannot quietly fall behind the tables.
 
@@ -484,42 +484,36 @@ They are not equal in consequence; this is the order to close them in.
 10. `mistral.rs` `tool_calls` chat-template handling.
 11. `text-embeddings-inference` pooling and model-loading fixes — embeddings differ
     from the reference implementation.
-12. `datafusion-table-providers` DuckDB timestamp literal exactness (fork PR #57) — a
-    pushed-down timestamp filter past 2^53 µs selects a neighbouring microsecond, so a
-    boundary row is silently kept or dropped. A repo-side guard needs a DuckDB dataset
-    holding two rows one microsecond apart across that boundary and a filter between
-    them; the fork's own execution tests already do exactly that, which is why this is
-    a coverage gap here rather than an unverified patch.
 
 **Hangs, crashes and failures.** These take a query or the process down:
 
-13. `vortex` session lock re-entry in writer init (fork PR #29).
-14. `datafusion-ballista` scheduler lock hygiene (fork PR #60) and shuffle-fetch
+12. `vortex` session lock re-entry in writer init (fork PR #29).
+13. `datafusion-ballista` scheduler lock hygiene (fork PR #60) and shuffle-fetch
     resilience (fork PRs #61–#63).
-15. `async-openai` null-suppression in requests.
-16. `spark-connect-rs` `http` scheme when `use_ssl` is false.
-17. `model2vec-rs` optional `config.json`.
-18. `snowflake-rs` async query response support — long-running queries time out.
+14. `async-openai` null-suppression in requests.
+15. `spark-connect-rs` `http` scheme when `use_ssl` is false.
+16. `model2vec-rs` optional `config.json`.
+17. `snowflake-rs` async query response support — long-running queries time out.
 
 **Wrong shape, but bounded.** Neither wrong rows nor an outage; a knob that stops
 being honoured:
 
-19. `vortex` target file size in the sink (fork PR #33) — the plumbing is guarded,
+18. `vortex` target file size in the sink (fork PR #33) — the plumbing is guarded,
     the sink's own honouring of `target_file_size_mb` is not, so the writer can emit
     one file per flush regardless of size.
-20. `iceberg-rust` single-node limit application (fork PR #19) — the distributed path
+19. `iceberg-rust` single-node limit application (fork PR #19) — the distributed path
     cannot silently drop the limit, the single-node scan can.
-21. `snowflake-rs` invalid warehouse/account errors surfaced correctly — a
+20. `snowflake-rs` invalid warehouse/account errors surfaced correctly — a
     misconfigured warehouse produces an opaque error instead of an actionable one.
-22. `model2vec-rs` HF cache directory read from the environment — models are
+21. `model2vec-rs` HF cache directory read from the environment — models are
     re-downloaded instead of reusing the shared cache.
-23. `mistral.rs` `tracing_subscriber.init()` removed from the loaders — the loader
+22. `mistral.rs` `tracing_subscriber.init()` removed from the loaders — the loader
     installs a global subscriber and hijacks `spiced`'s logging.
 
 **Security posture.** No correctness effect, but a silent downgrade:
 
-24. `iceberg-rust` end-to-end SigV4 signing against a Glue REST catalog.
-25. `graph-rs-sdk` tower middleware application.
+23. `iceberg-rust` end-to-end SigV4 signing against a Glue REST catalog.
+24. `graph-rs-sdk` tower middleware application.
 
 **Performance only.** A lost patch here costs throughput, not correctness. These are
 deliberately left to the benchmark suites (`testoperator`, the CH-benCH lab runs and
@@ -527,7 +521,7 @@ the scheduled TPC-H/TPC-DS jobs), which already trend these numbers over time an
 will show the regression as a step change. A unit test cannot assert a speedup
 without becoming a flaky timing test:
 
-26. `vortex` intra-file decode parallelism; `iceberg-rust` parallel file scanning;
+25. `vortex` intra-file decode parallelism; `iceberg-rust` parallel file scanning;
     `datafusion` eager aggregation; `mistral.rs`/`candle` i-quant MoE kernels;
     `candle-index-select-cu` fallback shim; `model2vec-rs` fast WordPiece;
     `snowflake-rs` streaming batches (memory, not latency — worth a guard if a
@@ -536,7 +530,7 @@ without becoming a flaky timing test:
 ## A patch that is present but incomplete
 
 Found while writing the guard for it, so it is a defect rather than a coverage gap,
-and it is not one of the 37 above.
+and it is not one of the 36 above.
 
 `vortex.date` → `vortex.timestamp` (fork PR #28) registers its cast kernel on
 `ExtensionArray`. A scan also evaluates a pushed-down predicate against *constant*

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -1,6 +1,6 @@
 # Fork patches and their guards
 
-Spice builds against forks of 29 upstream crates. Some of those forks carry Spice
+Spice builds against forks of 30 upstream crates. Some of those forks carry Spice
 patches; the rest are pinned for a version or dependency reason and carry no
 behaviour of ours at all.
 
@@ -95,7 +95,8 @@ own section below — a count here would be one more thing to keep true by hand.
 | [datafusion](#datafusion) | `859621d612511efb93a7f3e020f8baae8e33e3b4` | `spiceai-54` |
 | [datafusion-ballista](#datafusion-ballista) | `f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0` | `spiceai-54` |
 | [datafusion-federation](#datafusion-federation-and-datafusion-table-providers) | `0cb3781608b89f40c6585618ec3071f83345671a` | `spiceai-54` |
-| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `896356c3f7af9db5b6da3f2379196b420eee1b2b` | `spiceai-54` |
+| [datafusion-functions-json](#datafusion-functions-json) | `ca9d4c6e5a0de3bfa9fe20a683a9f7d58e36e2cc` | `spiceai-54` |
+| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `b9ea24c3101a24e8b3186a6a552362cf0a91bc03` | `spiceai-54-expression-aware-function-support` |
 | [delta-kernel-rs](#delta-kernel-rs) | `714d64fd5369efc4835109be0fd718db5a3be0aa` | `spiceai-0.23.0` |
 | [docx-rs](#docx-rs) | `2a85dce57d0128e2cd7c369545516c347cb8c529` | `spiceai` |
 | [duckdb-rs](#duckdb-rs) | `7229b20daf24765c84d294c52cf4b4165ca79073` | `spiceai-1.5.5` |
@@ -239,6 +240,40 @@ rather than patch by patch.
 
 Two things would change that and mean giving each a table here: either fork being
 rebased onto a moved upstream, or upstream resuming releases we track.
+
+`datafusion-table-providers` is pinned to a change branch rather than `spiceai-54`
+because the branch head carries a second patch this workspace has not audited. Fold
+the pin back onto `spiceai-54` at the next bump, which is where that patch gets its
+own audit.
+
+One patch here does have a repo-side guard, because losing it is a wrong answer
+rather than a build failure:
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `FunctionSupport` per-call check (fork PR #61) | A function a backend carves out of the deny-list because its dialect rewrites it federates in *every* call shape, including the ones the dialect cannot render. The unparser then emits the function verbatim into the remote SQL — the unknown-function failure of [#10703](https://github.com/spiceai/spiceai/issues/10703) | build, then silent | `crates/data-connectors/connector-adbc/src/lib.rs::function_support_tests::bigquery_refuses_the_json_call_shapes_its_dialect_cannot_translate` and `::an_untranslatable_predicate_is_left_above_the_federated_scan`. Losing the API fails `cargo check`; a re-cut that keeps `with_scalar_call_support` and drops its use in `contains_unsupported_functions` fails these instead |
+
+## datafusion-functions-json
+
+Upstream
+[datafusion-contrib/datafusion-functions-json](https://github.com/datafusion-contrib/datafusion-functions-json),
+branch `spiceai-54`.
+
+**No Spice patches.** The branch is upstream `main` unmodified. It is pinned rather
+than taken from crates.io because three correctness fixes landed upstream after
+`v0.54.2` and have not been published; the pin exists only to carry them, and should
+be dropped for a plain version requirement as soon as a release contains them.
+
+Every one of the three returns a wrong answer rather than an error, so the loss mode
+if the pin is dropped early is silent. All three guards live in one file, and the
+`json_get_int`/`json_get_float` rows cover the sign and type matrix rather than only
+the case named:
+
+| Patch | What breaks if it is lost | Loss | Guard |
+|---|---|---|---|
+| `json_get_int` / `json_get_float` read negative numbers (upstream PR #125) | Every negative JSON number reads as NULL — `json_get_int('{"a": -1}', 'a')` is NULL, not `-1`. No error, no warning | silent (wrong data) | `crates/runtime-udfs-api/tests/json_semantics.rs::json_get_int_reads_negative_numbers`, `::json_get_float_reads_negative_numbers` |
+| Integers outside jiter's `i64` fast path (upstream PR #124) | `json_get` panics on an in-range integer jiter hands back as a big integer, taking the query down; `json_get_int` reads the same value as NULL | silent (panic, and wrong data) | `crates/runtime-udfs-api/tests/json_semantics.rs::json_get_reads_an_integer_outside_the_fast_path_without_panicking`, `::json_get_int_spans_the_whole_i64_range` |
+| Nested `json_as_text` is not flattened (upstream PR #121) | `json_as_text(json_as_text(x, 'a'), 'b')` folds into one two-element path, which reads the wrong value whenever the inner result is itself a JSON document | silent (wrong data) | `crates/runtime-udfs-api/tests/json_semantics.rs::a_json_string_holding_json_is_read_one_level_at_a_time` |
 
 ## duckdb-rs
 

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -96,7 +96,7 @@ own section below — a count here would be one more thing to keep true by hand.
 | [datafusion-ballista](#datafusion-ballista) | `f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0` | `spiceai-54` |
 | [datafusion-federation](#datafusion-federation-and-datafusion-table-providers) | `0cb3781608b89f40c6585618ec3071f83345671a` | `spiceai-54` |
 | [datafusion-functions-json](#datafusion-functions-json) | `ca9d4c6e5a0de3bfa9fe20a683a9f7d58e36e2cc` | `spiceai-54` |
-| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `b9ea24c3101a24e8b3186a6a552362cf0a91bc03` | `spiceai-54-expression-aware-function-support` |
+| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `0d24a546748b54fd3ff48853739d85a6d351058f` | `spiceai-54` |
 | [delta-kernel-rs](#delta-kernel-rs) | `714d64fd5369efc4835109be0fd718db5a3be0aa` | `spiceai-0.23.0` |
 | [docx-rs](#docx-rs) | `2a85dce57d0128e2cd7c369545516c347cb8c529` | `spiceai` |
 | [duckdb-rs](#duckdb-rs) | `7229b20daf24765c84d294c52cf4b4165ca79073` | `spiceai-1.5.5` |
@@ -241,18 +241,12 @@ rather than patch by patch.
 Two things would change that and mean giving each a table here: either fork being
 rebased onto a moved upstream, or upstream resuming releases we track.
 
-`datafusion-table-providers` is pinned to a change branch rather than `spiceai-54`.
-The branch is the previously pinned `896356c3` plus the one commit below and
-nothing else: `spiceai-54` has since gained a DuckDB timestamp-literal patch that
-this workspace has not audited, and the pin deliberately does **not** reach it.
-Fold the pin back onto `spiceai-54` at the next bump, which is where that patch
-gets its own audit and guard.
-
-One patch here does have a repo-side guard, because losing it is a wrong answer
-rather than a build failure:
+Two patches here have rows, because losing either is a wrong answer rather than a
+build failure:
 
 | Patch | What breaks if it is lost | Loss | Guard |
 |---|---|---|---|
+| DuckDB timestamp literal rendered through microseconds, not a `DOUBLE`, with DuckDB's two infinity sentinels declined (fork PR #57) | `TO_TIMESTAMP` takes a `DOUBLE`, so a timestamp count past 2^53 µs (≈ year 2255, and symmetrically before ≈ 1684) could not be represented exactly: a pushed-down filter names a neighbouring microsecond and keeps or drops the wrong row. Separately, a `TimestampMicrosecond` holding ±`i64::MAX` rendered fine, was reported pushdown-capable, and then failed the statement built from it | silent (wrong rows) | **GAP** — the fork's own execution tests cover it (they build rows one microsecond apart across the 2^53 boundary and assert which one a comparison keeps, under three session time zones); there is no repo-side equivalent. See [Open gaps](#open-gaps) |
 | `FunctionSupport` per-call check (fork PR #61) | A function a backend carves out of the deny-list because its dialect rewrites it federates in *every* call shape, including the ones the dialect cannot render. The unparser then emits the function verbatim into the remote SQL — the unknown-function failure of [#10703](https://github.com/spiceai/spiceai/issues/10703) | build, then silent | `crates/data-connectors/connector-adbc/src/lib.rs::function_support_tests::bigquery_refuses_the_json_call_shapes_its_dialect_cannot_translate` and `::an_untranslatable_predicate_is_left_above_the_federated_scan`. Losing the API fails `cargo check`; a re-cut that keeps `with_scalar_call_support` and drops its use in `contains_unsupported_functions` fails these instead |
 
 ## datafusion-functions-json
@@ -466,7 +460,7 @@ patch is a build failure, so no behaviour guard applies.
 
 ## Open gaps
 
-**36 rows above are marked GAP** — they have no repo-side guard. Every one of them
+**37 rows above are marked GAP** — they have no repo-side guard. Every one of them
 is accounted for below; `scripts/check_fork_patches.py` fails if that count and this
 sentence disagree, so the list cannot quietly fall behind the tables.
 
@@ -490,36 +484,42 @@ They are not equal in consequence; this is the order to close them in.
 10. `mistral.rs` `tool_calls` chat-template handling.
 11. `text-embeddings-inference` pooling and model-loading fixes — embeddings differ
     from the reference implementation.
+12. `datafusion-table-providers` DuckDB timestamp literal exactness (fork PR #57) — a
+    pushed-down timestamp filter past 2^53 µs selects a neighbouring microsecond, so a
+    boundary row is silently kept or dropped. A repo-side guard needs a DuckDB dataset
+    holding two rows one microsecond apart across that boundary and a filter between
+    them; the fork's own execution tests already do exactly that, which is why this is
+    a coverage gap here rather than an unverified patch.
 
 **Hangs, crashes and failures.** These take a query or the process down:
 
-12. `vortex` session lock re-entry in writer init (fork PR #29).
-13. `datafusion-ballista` scheduler lock hygiene (fork PR #60) and shuffle-fetch
+13. `vortex` session lock re-entry in writer init (fork PR #29).
+14. `datafusion-ballista` scheduler lock hygiene (fork PR #60) and shuffle-fetch
     resilience (fork PRs #61–#63).
-14. `async-openai` null-suppression in requests.
-15. `spark-connect-rs` `http` scheme when `use_ssl` is false.
-16. `model2vec-rs` optional `config.json`.
-17. `snowflake-rs` async query response support — long-running queries time out.
+15. `async-openai` null-suppression in requests.
+16. `spark-connect-rs` `http` scheme when `use_ssl` is false.
+17. `model2vec-rs` optional `config.json`.
+18. `snowflake-rs` async query response support — long-running queries time out.
 
 **Wrong shape, but bounded.** Neither wrong rows nor an outage; a knob that stops
 being honoured:
 
-18. `vortex` target file size in the sink (fork PR #33) — the plumbing is guarded,
+19. `vortex` target file size in the sink (fork PR #33) — the plumbing is guarded,
     the sink's own honouring of `target_file_size_mb` is not, so the writer can emit
     one file per flush regardless of size.
-19. `iceberg-rust` single-node limit application (fork PR #19) — the distributed path
+20. `iceberg-rust` single-node limit application (fork PR #19) — the distributed path
     cannot silently drop the limit, the single-node scan can.
-20. `snowflake-rs` invalid warehouse/account errors surfaced correctly — a
+21. `snowflake-rs` invalid warehouse/account errors surfaced correctly — a
     misconfigured warehouse produces an opaque error instead of an actionable one.
-21. `model2vec-rs` HF cache directory read from the environment — models are
+22. `model2vec-rs` HF cache directory read from the environment — models are
     re-downloaded instead of reusing the shared cache.
-22. `mistral.rs` `tracing_subscriber.init()` removed from the loaders — the loader
+23. `mistral.rs` `tracing_subscriber.init()` removed from the loaders — the loader
     installs a global subscriber and hijacks `spiced`'s logging.
 
 **Security posture.** No correctness effect, but a silent downgrade:
 
-23. `iceberg-rust` end-to-end SigV4 signing against a Glue REST catalog.
-24. `graph-rs-sdk` tower middleware application.
+24. `iceberg-rust` end-to-end SigV4 signing against a Glue REST catalog.
+25. `graph-rs-sdk` tower middleware application.
 
 **Performance only.** A lost patch here costs throughput, not correctness. These are
 deliberately left to the benchmark suites (`testoperator`, the CH-benCH lab runs and
@@ -527,7 +527,7 @@ the scheduled TPC-H/TPC-DS jobs), which already trend these numbers over time an
 will show the regression as a step change. A unit test cannot assert a speedup
 without becoming a flaky timing test:
 
-25. `vortex` intra-file decode parallelism; `iceberg-rust` parallel file scanning;
+26. `vortex` intra-file decode parallelism; `iceberg-rust` parallel file scanning;
     `datafusion` eager aggregation; `mistral.rs`/`candle` i-quant MoE kernels;
     `candle-index-select-cu` fallback shim; `model2vec-rs` fast WordPiece;
     `snowflake-rs` streaming batches (memory, not latency — worth a guard if a
@@ -536,7 +536,7 @@ without becoming a flaky timing test:
 ## A patch that is present but incomplete
 
 Found while writing the guard for it, so it is a defect rather than a coverage gap,
-and it is not one of the 36 above.
+and it is not one of the 37 above.
 
 `vortex.date` → `vortex.timestamp` (fork PR #28) registers its cast kernel on
 `ExtensionArray`. A scan also evaluates a pushed-down predicate against *constant*

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -241,10 +241,12 @@ rather than patch by patch.
 Two things would change that and mean giving each a table here: either fork being
 rebased onto a moved upstream, or upstream resuming releases we track.
 
-`datafusion-table-providers` is pinned to a change branch rather than `spiceai-54`
-because the branch head carries a second patch this workspace has not audited. Fold
-the pin back onto `spiceai-54` at the next bump, which is where that patch gets its
-own audit.
+`datafusion-table-providers` is pinned to a change branch rather than `spiceai-54`.
+The branch is the previously pinned `896356c3` plus the one commit below and
+nothing else: `spiceai-54` has since gained a DuckDB timestamp-literal patch that
+this workspace has not audited, and the pin deliberately does **not** reach it.
+Fold the pin back onto `spiceai-54` at the next bump, which is where that patch
+gets its own audit and guard.
 
 One patch here does have a repo-side guard, because losing it is a wrong answer
 rather than a build failure:


### PR DESCRIPTION
## What was wrong

Two independent defects, both on the JSON path.

**`json_get_int` and `json_get_float` returned NULL for every negative JSON number.**
`json_get_int('{"a": -1}', 'a')` was NULL, not `-1`. No error, no warning — a silent wrong
answer, on every shipped version. The published `datafusion-functions-json` lists jiter's
`Peek::Minus` — the first byte of a negative number — in the arm that yields NULL, so a
negative number never reached the number branch at all. The crate's own tests cover only the
*string* form (`'{"a": "-42"}'`), which is why it survived. The same release also panics on an
integer jiter's fast path hands back as a big integer, and folds two nested `json_as_text`
calls into one path, which reads the wrong value out of a JSON string that itself holds JSON.

**No JSON function could be pushed down to BigQuery.** The federation deny-list correctly
refuses to unparse Spice-only UDFs into remote SQL, and the BigQuery dialect translates none of
them, so a predicate like `WHERE json_get_int(doc, 'id') = 1` disqualified the whole node: the
column was streamed to Spice and filtered locally, and a join on a JSON value became two full
remote scans plus a local join. Correct, but expensive — and invisible.

The two are linked. Shipping the translation first would have made the same query return `-1`
when the plan federated and NULL when it did not.

## What this changes

**The negative-number fix, in the dependency that owns it.** All three fixes above landed
upstream after `v0.54.2` and are unreleased, so `datafusion-functions-json` moves from crates.io
to a pin on upstream `main`, mirrored into the spiceai org as fork policy requires. The branch is
upstream unmodified — Spice carries no patch — and `docs/dev/fork_patches.md` records what each
of the three fixes protects, with the repo-side test that fails if the pin is dropped before a
release contains them.

**A per-call check on the federation deny-list.** `FunctionSupport` decided what may federate by
function *name*. That is enough for a deny-list, but not for the carve-out on top of it: a
backend removes a name because its dialect rewrites that function into native SQL, and a dialect
rewrites a *call*, not a name. It can translate `json_get_int(doc, 'a')` and have no equivalent
for `json_get_int(doc, key_col)` — BigQuery's JSON path argument must be a constant. Carving the
name out would federate the second one too, and
`Dialect::scalar_function_to_sql_overrides` returning `Ok(None)` for it makes the unparser emit
`json_get_int` verbatim into BigQuery SQL: the unknown-function failure of #10703, reintroduced
by design. The only other exit, returning `Err`, fails a query that would have succeeded
locally.

So `FunctionSupport` gains an optional per-call check, consulted for every scalar call the name
check allows (spiceai/datafusion-table-providers#61, now merged to `spiceai-54`). It can only
narrow what the name check permits, so a backend that installs none behaves exactly as before,
and a refused call is left for the local engine rather than being pushed down or failed.

**The BigQuery translation**, mirroring the DuckDB precedent: one table in
`runtime-datafusion/src/dialect/bigquery.rs` carries each function's name, its handler *and* its
per-call check as a single entry, and the dialect's handler list, the deny-list carve-out and the
per-call check are all derived from it — so a handler cannot be carved out of the deny-list
without saying which call shapes it can render.

**`json_get_int` only.** The other three JSON extraction functions each diverge from their local
behaviour somewhere BigQuery cannot be talked out of, and the reason is recorded beside the table:

| Function | Why it stays denied |
|---|---|
| `json_get_float` | Rust's `f64::FromStr` saturates an out-of-range magnitude to `±inf` and underflows to zero, where `SAFE_CAST(… AS FLOAT64)` yields NULL. A federated plan would answer NULL where the local function answers infinity, on the same rows. |
| `json_get_str` | Needs a string-type guard around `JSON_VALUE`, which renders a JSON number as its digits where `json_get_str` returns NULL. |
| `json_get_bool` | BigQuery's cast to `BOOL` is case-insensitive; Rust's `bool::from_str` is not. |

`json_get_int` is the one with no such gap: an integer outside `i64` is NULL on both sides,
because Rust's `i64::FromStr` fails rather than saturating.

**A construction seam for the ADBC connector.** `AdbcTableFactory::new` defaults to
`federation_enabled: true` and `function_support: None`, and both defaults are silent — which is
how a refactor dropped them and still compiled. The connector now holds a type that cannot be
obtained without applying the policy, so dropping it is an edit to one function rather than an
omission a move can make invisible.

## Semantics

The mapping replicates what the local function does, rather than the nearest BigQuery
equivalent:

```
json_get_int(doc, p…)  →  SAFE_CAST(REGEXP_EXTRACT(JSON_VALUE(doc, R'<path>'), R'^[+-]?[0-9]+$') AS INT64)
```

The pattern is what makes a JSON **string** node exact: `SAFE_CAST` on its own is wider than
Rust's `FromStr` — BigQuery reads a hexadecimal literal, and trims surrounding whitespace — so
everything the pattern rejects is a NULL on both sides. It carries no capturing group, because
`REGEXP_EXTRACT` accepts at most one and errors on more; with none it returns the whole match.

The path is a **raw** string literal, so what is written is what BigQuery's JSON path parser
reads. A quoted literal would consume backslash escapes first, and a key is then escaped for two
layers with different rules — which is how a key silently becomes a *different* path. Keys
containing a quote, a backslash or a control character are therefore not translated at all;
those calls stay local, which the per-call check makes safe. A path element that can never
resolve (a negative index, a NULL element) renders as a typed NULL, matching the local function.
The variadic path becomes one JSON path, so `('a.b')` stays one key rather than two steps.

**What is not settled here.** The mapping agrees with the local function given that `JSON_VALUE`
over a JSON-formatted STRING returns a number's own token rather than a re-rendered one. That is
what its lenient, textual behaviour implies, but only a real BigQuery can pin it, and the
credential-gated end-to-end test that would is deliberately out of scope for this PR. A document
containing an integer in non-canonical form at the extracted path is where a divergence would
show up if the assumption is wrong.

## Verification

- `runtime-udfs-api`: the sign and type matrix for both functions — negative int and float,
  numeric strings, the `i64` bounds, integers inside and outside `i64`, bools, nulls, objects,
  arrays, missing keys, malformed documents, a dotted key, and a nested path; plus the float
  saturation boundaries that are the reason `json_get_float` is not pushed down. Reverting the
  JSON pin fails 8 of the 12.
- `runtime-datafusion`: the exact rendered SQL for each call shape, the JSON path for dotted
  keys, indexes and never-resolving paths, that a key the two quoting layers disagree about is
  not translated, that no pattern carries a capturing group, that no rendering contains
  `json_get_` in any form, and that unparsing an ordinary plan through the wrapper is
  byte-identical to unparsing it through the stock `BigQueryDialect` — which is what notices a
  `Dialect` method the wrapper forgot to forward.
- `connector-adbc`, over an in-process stub driver: a translatable call federates and an
  untranslatable one does not; the other JSON functions stay denied; another driver denies all of
  them; a translatable predicate federates as one node with the predicate inside it, and an
  untranslatable one is left above the federated scan.

Mutation checks, each confirmed to fail the intended tests and no others:

| Removed | Fails |
|---|---|
| the JSON pin, back to the published release | the sign/type matrix, on values |
| `with_scalar_call_support` | the untranslatable-shape tests, on plan shape |
| the `json_get_int` handler from the override table | the federation tests, on plan shape |
| `with_function_support` from the construction seam | every deny-list test |
| a capturing group reintroduced into the pattern | `no_pattern_has_a_capturing_group` |

## Fork pins

`datafusion-table-providers` moves to `spiceai-54` now that #61 is merged there. That also picks
up the DuckDB timestamp-literal exactness patch (fork PR #57), which the previous pin deliberately
excluded; it is audited and recorded in `docs/dev/fork_patches.md`, and declared as a **GAP** —
the fork's own execution tests cover it, and there is no repo-side equivalent yet. The gap count
and its accounting list move with it, which `scripts/check_fork_patches.py` enforces.

## Not in this change

- #13664 — the ADBC **catalog** connector installs no policy at all and has no `query_federation`
  escape. The dataset connector is what this PR touches; the catalog path keeps the stock
  dialect, and `adbc_helpers::dialect_for_driver` now says why, and that the unpoliced path is a
  live defect rather than a safe configuration.
- #13665 — the per-call mechanism is here and BigQuery uses it, but the DuckDB half of that issue
  is untouched (its four carved-out handlers are total today, so there is nothing to refuse), and
  the row-for-row equality against a real backend is the end-to-end test that is out of scope.
- #13666, #13667 — the ADBC blocking and cancellation defects.

Closes #13590's remaining exposure for the dataset path only; the four issues above stay open.
