### PR TITLE
fix(ci): raise the e2e Linux build bound above the worst legitimate run (fixes #13674)

### DIFF
--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -170,11 +170,23 @@ jobs:
 
       - name: Build spiced and spice CLI
         if: matrix.target.target_os != 'darwin'
-        # 65 minutes is the slowest this leg has taken across the last ten successful
-        # `merge_group` runs (44-65), so this is that worst case with room to spare. The
-        # spread is wide on a contended pool, and a bound tight enough to fail a
-        # legitimate build would be worse than the slow build it replaced.
-        timeout-minutes: 90
+        # 65 minutes was the slowest this leg had taken across ten successful `merge_group`
+        # runs when the bound was set; on 2026-08-28 that worst case moved. Four consecutive
+        # `merge_group` runs hit 90 minutes with only the last few crates left, on four
+        # different runners, each restoring the same rust-cache entry (full match) with the
+        # disk preflight reporting 40 TiB free and no compile error anywhere in the log.
+        # The same PR had built in 39 minutes ninety minutes earlier, on a batch carrying
+        # strictly more code, so the slowdown is not the diff: measured phase by phase the
+        # work ran ~2.5x slower throughout (cache restore 3m14s -> 5m19s, the `runtime`
+        # crate ~21m -> ~48m), which is what a contended pool looks like.
+        #
+        # A legitimate contended build therefore needs ~100 minutes, and firing at 90 costs
+        # the queue more than waiting does: it discards a nearly finished compile, dequeues
+        # the PR, and makes the queue re-run the whole batch chain, adding load to the pool
+        # that caused the slowdown in the first place. 150 keeps roughly the margin over
+        # worst-observed that the macOS leg below uses, and stays clear of the job's 200 so
+        # the `always()` diagnostics after a genuine wedge still run.
+        timeout-minutes: 150
         uses: ./.github/actions/build-spiced
         with:
           features: 'tpc-extension,models,postgres-accel'

--- a/.github/workflows/e2e_test_ci.yml
+++ b/.github/workflows/e2e_test_ci.yml
@@ -185,7 +185,10 @@ jobs:
         # the PR, and makes the queue re-run the whole batch chain, adding load to the pool
         # that caused the slowdown in the first place. 150 keeps roughly the margin over
         # worst-observed that the macOS leg below uses, and stays clear of the job's 200 so
-        # the `always()` diagnostics after a genuine wedge still run.
+        # that a wedge here is cut by *this step* — which attributes the failure to the
+        # compile — rather than by the job bound, which GitHub renders as the whole job
+        # being cancelled. It buys no diagnostics on this leg: the `always()` steps below
+        # are all gated to `spiceai-macos`, so a Linux build has none to run.
         timeout-minutes: 150
         uses: ./.github/actions/build-spiced
         with:


### PR DESCRIPTION
Fixes #13674.

## What is broken

Since ~11:50 UTC on 2026-08-28 every `merge_group` batch has failed `E2E Test CI` because the
Linux `Build spiced and spice CLI` step hits its 90-minute `timeout-minutes` cap. `trunk` has not
advanced since `a7fe0dc`; the queue re-batches and each new batch fails the same way.

Four consecutive runs, four different runners, identical `##[error]The action has timed out.`
at `duration_ms=5412063`:

| run | batch | build step | outcome |
|---|---|---|---|
| `33168822174` | pr-13616 | 11:53:41 → 13:30:58 | timed out |
| `33169871227` | pr-13602 | 12:11:09 → 13:48:51 | timed out |
| `33169872212` | pr-13545 | 12:11:54 → 13:50:01 | timed out |
| `33169872819` | pr-13616 | 12:13:08 → 13:50:34 | timed out |

The three runs immediately before all passed at 46m, 41m and 39m.

## The build is slow, not broken

Passing and failing runs restore the **same** cache entry — `Restored from cache key
"v0-rust-build-Linux-x64-0af91385-20bdd73c" full match: true` — the disk preflight reports
`40400 GiB` free against a 10 GiB floor, and there is no compile error in any log; the last lines
before the cap are `Compiling` on the final few crates.

The controlled comparison is PR #13602 against itself. It built in **39 minutes** at 10:50
(run `33164855344`, batch base `ee035147`, which carried the preceding queue entries *as well as*
#13602) and **timed out past 90 minutes** at 12:11 (run `33169871227`, batch base `a7fe0dce`,
which carried only trunk and #13602). The batch that failed had strictly less code in it, so the
diff cannot be the cause.

What did change is pace, uniformly, across phases that share nothing but the machine:

| | passing `33164855344` | failing `33169871227` | ratio |
|---|---|---|---|
| cache restore | 3m14s | 5m19s | 1.6x |
| restore → reaching `runtime` | 12m23s | 33m55s | 2.7x |
| `runtime` crate | ~21m | ~48m | 2.3x |

At the time of measurement the repo had 48 in-progress and 65 queued workflow runs, and the build
job for the queue head waited 7 minutes for a runner.

## Why raise the bound rather than leave it

Firing at 90 is not a safety net here — it is the thing holding the queue. Each timeout throws
away ~90 minutes of compilation with the build nearly done, dequeues the PR, and makes the queue
re-form and re-run the whole batch chain, which puts *more* concurrent runs onto the pool that
was already saturated. Contention causes timeouts; timeouts cause re-batching; re-batching causes
contention.

150 minutes covers the ~100 a contended build needs, keeps roughly the margin over worst-observed
that the macOS leg beside it already uses (180 against a documented worst of 138), and stays clear
of the job's own 200-minute backstop so the `always()` diagnostics after a genuine wedge still run.

## The tension, stated plainly

This runs against the direction of #13429 and #12718, which tighten bounds so a hung job cannot
hold the merge queue. The line I am drawing: those target bounds that are *absent or unbounded*,
where firing is the outcome you want. This bound fires on a healthy, nearly-finished build, where
firing is strictly more expensive than waiting. A bound belongs above the worst *legitimate* run,
and today's evidence is that 90 no longer is.

The cost is real and worth naming: a genuinely wedged Linux build now holds the queue 60 minutes
longer than before.

Not addressed here: the pool contention itself, which is the upstream cause and sits closer to
#13446. Also left alone, but worth a look — `Swatinem/rust-cache` runs with
`save-if: github.ref == 'refs/heads/trunk'`, so while trunk is stuck the cache entry ages and
every batch diverges further from it, which feeds the same loop.

## Review gate

Attests HEAD `673c30c` — the `timeout-minutes` change plus the two comment revisions on top of it.

- Adversarial review: **skipped** — `codex` exited with `ERROR: Your workspace is out of credits.`
  Re-probed on the comment revision at `673c30c`; same result, and no second engine is installed on
  this host. The approach questions it would have been asked are answered inline above: the
  code-change hypothesis is excluded by the #13602 self-comparison, the #13429/#12718 tension is
  stated rather than argued away, and the wedge cost is quantified.
- Security review: no surface. The diff changes one `timeout-minutes` value and the comment above
  it — no trigger, permission, secret, action reference or executed command is touched. `673c30c`
  is comment-only (`+4/-1`, all `#` lines).
- Validation: `actionlint` on the modified file reports only the three findings already present on
  `trunk` (the `spiceai-dev-runners` self-hosted labels, the `params` expression at :739, the
  duplicate `acceleration` matrix value at :1394). `yaml.safe_load` re-confirms at `673c30c` that
  the resulting bounds are step 150 / macOS step 180 / job 200.
