### PR TITLE
fix: comment out refresh_append_overlap in the sample spicepod

### DIFF
--- a/spicepod.yml
+++ b/spicepod.yml
@@ -25,7 +25,7 @@ datasets:
       engine: cayenne
       mode: file
       refresh_mode: append
-      refresh_append_overlap: 5m
+      # refresh_append_overlap: 5m  # not yet supported for cayenne
       refresh_check_interval: 1h
       refresh_jitter_enabled: true
       refresh_jitter_max: 5m


### PR DESCRIPTION
## 📝 Summary

Cayenne does not yet support `refresh_append_overlap` and refuses to load a dataset that sets it. The repo-root sample spicepod uses `engine: cayenne` with `refresh_mode: append` for the GitHub datasets, so the 5m overlap window is commented out until that support lands.

Without this, `spice run` from the repo root fails dataset registration on the Cayenne accelerator.

## 🔗 Related

Cayenne currently errors with: `Cayenne data accelerator does not yet support refresh_append_overlap. Please remove this configuration`.

## 👀 Notes for Reviewers

Config-only change to `spicepod.yml`. The setting is left in a comment so it can be restored when Cayenne append overlap is implemented.