### PR TITLE
fix(anthropic): refuse a log-probability request instead of narrowing sampling (fixes #13581)

### DIFF
--- a/crates/llms/src/anthropic/chat.rs
+++ b/crates/llms/src/anthropic/chat.rs
@@ -348,12 +348,57 @@ fn assistant_messages_to_content_blocks(
     Ok(MessageParam::assistant(content_blocks))
 }
 
+/// Refuses a request that asks for per-token log probabilities.
+///
+/// Anthropic's Messages API has no `logprobs` equivalent: it returns no per-token probabilities,
+/// and this adapter's response conversion consequently leaves `ChatChoice::logprobs` empty. A
+/// request for them therefore cannot be served, and answering it with a completion that silently
+/// omits them hides that from the caller, so the parameters are named and refused instead.
+fn refuse_unsupported_logprobs(
+    model: &AnthropicModelVariant,
+    value: &CreateChatCompletionRequest,
+) -> Result<(), OpenAIError> {
+    // `logprobs: Some(false)` asks for nothing and is satisfiable, so only a positive request is
+    // refused. `top_logprobs` is refused on its own: OpenAI documents it as requiring
+    // `logprobs: true`, but a caller setting only `top_logprobs` is still asking for log
+    // probabilities, so leaving that spelling accepted would serve the same request silently.
+    //
+    // `param` reports the more specific field, while `remedy` names every field that has to go:
+    // dropping just `top_logprobs` from a request that also set `logprobs: true` would otherwise
+    // earn a second refusal.
+    let (param, remedy) = match (value.top_logprobs.is_some(), value.logprobs == Some(true)) {
+        (true, true) => ("top_logprobs", "`logprobs` and `top_logprobs`"),
+        (true, false) => ("top_logprobs", "`top_logprobs`"),
+        (false, true) => ("logprobs", "`logprobs`"),
+        (false, false) => return Ok(()),
+    };
+
+    Err(OpenAIError::ApiError(ApiError {
+        // Either field can arrive from the request or from the model's configured defaults, so
+        // the remedy names both origins.
+        message: format!(
+            "Failed to run model '{model}' (anthropic): the `{param}` parameter is not supported. \
+             Anthropic's Messages API returns no per-token log probabilities. \
+             Remove {remedy} from the request and from the model's parameters, \
+             or use a model provider that reports them. \
+             See: https://spiceai.org/docs/components/models/anthropic"
+        ),
+        // The caller sent something this provider cannot serve, so it is their request that is
+        // invalid. `openai_error_to_response` reads `code` to pick the status, and anything it
+        // does not recognize becomes a 500 — which would report a client error as a server fault.
+        r#type: Some("invalid_request_error".to_string()),
+        param: Some(param.to_string()),
+        code: Some("invalid_request_error".to_string()),
+    }))
+}
+
 impl TryFrom<(AnthropicModelVariant, CreateChatCompletionRequest)> for MessageCreateParams {
     type Error = OpenAIError;
     fn try_from(
         pair: (AnthropicModelVariant, CreateChatCompletionRequest),
     ) -> Result<Self, Self::Error> {
         let (model, value) = pair;
+        refuse_unsupported_logprobs(&model, &value)?;
         let cache_control = value
             .prompt_cache_key
             .as_ref()
@@ -367,7 +412,11 @@ impl TryFrom<(AnthropicModelVariant, CreateChatCompletionRequest)> for MessageCr
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(MessageCreateParams {
-            top_k: value.top_logprobs.map(u32::from),
+            // No OpenAI request field corresponds to Anthropic's `top_k`, which restricts which
+            // tokens may be sampled. `top_logprobs` asks how many alternatives to report and
+            // leaves sampling untouched, so carrying one into the other would answer a request to
+            // observe the distribution by narrowing it instead.
+            top_k: None,
             top_p: value.top_p,
             temperature: value.temperature,
             max_tokens: value
@@ -523,5 +572,128 @@ mod tests {
             params.cache_control,
             Some(CacheControlEphemeral::ephemeral())
         );
+    }
+
+    fn request_with(
+        mutate: impl FnOnce(&mut CreateChatCompletionRequest),
+    ) -> CreateChatCompletionRequest {
+        let mut req = CreateChatCompletionRequest {
+            messages: vec![
+                ChatCompletionRequestUserMessageArgs::default()
+                    .content("Rank the alternatives.")
+                    .build()
+                    .expect("user message should build")
+                    .into(),
+            ],
+            ..CreateChatCompletionRequest::default()
+        };
+        mutate(&mut req);
+        req
+    }
+
+    fn convert(req: CreateChatCompletionRequest) -> Result<MessageCreateParams, OpenAIError> {
+        MessageCreateParams::try_from(("claude-sonnet-4-6".to_string(), req))
+    }
+
+    /// Returns the refusal's own fields.
+    ///
+    /// Asserting on `OpenAIError`'s `Display` instead would be vacuous: it appends
+    /// `(param: ...)` and `(code: ...)` to the message, so a check that the rendered string
+    /// mentions a parameter passes even when the human-readable message never names it.
+    fn refusal(err: &OpenAIError) -> &ApiError {
+        match err {
+            OpenAIError::ApiError(api) => api,
+            other => panic!("expected an ApiError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_request_for_log_probabilities_is_refused_rather_than_narrowing_sampling() {
+        for (param, remedy, req) in [
+            (
+                "top_logprobs",
+                "`top_logprobs`",
+                request_with(|r| r.top_logprobs = Some(5)),
+            ),
+            (
+                "logprobs",
+                "`logprobs`",
+                request_with(|r| r.logprobs = Some(true)),
+            ),
+            (
+                // OpenAI's documented pairing: both set together. The more specific field is
+                // reported, but both have to be named as the remedy — removing only the reported
+                // one would earn a second refusal.
+                "top_logprobs",
+                "`logprobs` and `top_logprobs`",
+                request_with(|r| {
+                    r.logprobs = Some(true);
+                    r.top_logprobs = Some(3);
+                }),
+            ),
+            (
+                // Zero alternatives is still a request for log probabilities, and it is the value
+                // an `Option`-vs-truthiness check is most likely to let through.
+                "top_logprobs",
+                "`top_logprobs`",
+                request_with(|r| r.top_logprobs = Some(0)),
+            ),
+        ] {
+            let err = convert(req).expect_err("a request for log probabilities should be refused");
+            let refusal = refusal(&err);
+
+            assert_eq!(refusal.param.as_deref(), Some(param));
+            // `openai_error_to_response` picks the HTTP status from `code`, and maps anything it
+            // does not recognize to 500. This is a client error, so it has to be the code that
+            // maps to 400.
+            assert_eq!(refusal.code.as_deref(), Some("invalid_request_error"));
+            assert_eq!(refusal.r#type.as_deref(), Some("invalid_request_error"));
+
+            // Asserted against the message itself rather than the rendered error, so the
+            // `Display`-appended fields cannot satisfy these on their own.
+            for expected in [
+                "claude-sonnet-4-6",
+                "(anthropic)",
+                remedy,
+                "https://spiceai.org/docs/components/models/anthropic",
+            ] {
+                assert!(
+                    refusal.message.contains(expected),
+                    "refusal should name {expected}, got: {}",
+                    refusal.message
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_request_that_asks_for_no_log_probabilities_still_converts() {
+        // `logprobs: Some(false)` is satisfiable — Anthropic returns none and none were wanted —
+        // so refusing it would reject a request the adapter can serve exactly as asked.
+        for req in [
+            request_with(|_| {}),
+            request_with(|r| r.logprobs = Some(false)),
+        ] {
+            let params = convert(req).expect("a request asking for no log probabilities converts");
+            assert_eq!(
+                params.top_k, None,
+                "no OpenAI field maps to Anthropic's top_k, so it must be left unset"
+            );
+        }
+    }
+
+    #[test]
+    fn a_sampling_control_the_caller_did_set_is_still_forwarded() {
+        // Guards the refusal against over-reaching: the unsupported parameters are refused, and
+        // the controls Anthropic does accept keep reaching it.
+        let params = convert(request_with(|r| {
+            r.temperature = Some(0.25);
+            r.top_p = Some(0.9);
+        }))
+        .expect("supported sampling controls should convert");
+
+        assert_eq!(params.temperature, Some(0.25));
+        assert_eq!(params.top_p, Some(0.9));
+        assert_eq!(params.top_k, None);
     }
 }

--- a/crates/llms/src/anthropic/chat.rs
+++ b/crates/llms/src/anthropic/chat.rs
@@ -687,17 +687,20 @@ mod tests {
         // Guards the refusal against over-reaching: the unsupported parameters are refused, and
         // the controls Anthropic does accept keep reaching it.
         //
-        // One control per request. Setting `temperature` and `top_p` together is a shape every
-        // Claude 4+ model rejects (#13579), so pairing them here would pin a request that cannot
-        // be served as though it were the supported case.
+        // One control per request: #13579 reports that setting `temperature` and `top_p` together
+        // is refused by the models this adapter reaches, so pairing them here would pin a request
+        // that cannot be served as though it were the supported case. Each request is also
+        // asserted to carry only the control it set, so neither can be cross-populated.
         let with_temperature = convert(request_with(|r| r.temperature = Some(0.25)))
             .expect("a supported sampling control should convert");
         assert_eq!(with_temperature.temperature, Some(0.25));
+        assert_eq!(with_temperature.top_p, None);
         assert_eq!(with_temperature.top_k, None);
 
         let with_top_p = convert(request_with(|r| r.top_p = Some(0.9)))
             .expect("a supported sampling control should convert");
         assert_eq!(with_top_p.top_p, Some(0.9));
+        assert_eq!(with_top_p.temperature, None);
         assert_eq!(with_top_p.top_k, None);
     }
 }

--- a/crates/llms/src/anthropic/chat.rs
+++ b/crates/llms/src/anthropic/chat.rs
@@ -686,14 +686,18 @@ mod tests {
     fn a_sampling_control_the_caller_did_set_is_still_forwarded() {
         // Guards the refusal against over-reaching: the unsupported parameters are refused, and
         // the controls Anthropic does accept keep reaching it.
-        let params = convert(request_with(|r| {
-            r.temperature = Some(0.25);
-            r.top_p = Some(0.9);
-        }))
-        .expect("supported sampling controls should convert");
+        //
+        // One control per request. Setting `temperature` and `top_p` together is a shape every
+        // Claude 4+ model rejects (#13579), so pairing them here would pin a request that cannot
+        // be served as though it were the supported case.
+        let with_temperature = convert(request_with(|r| r.temperature = Some(0.25)))
+            .expect("a supported sampling control should convert");
+        assert_eq!(with_temperature.temperature, Some(0.25));
+        assert_eq!(with_temperature.top_k, None);
 
-        assert_eq!(params.temperature, Some(0.25));
-        assert_eq!(params.top_p, Some(0.9));
-        assert_eq!(params.top_k, None);
+        let with_top_p = convert(request_with(|r| r.top_p = Some(0.9)))
+            .expect("a supported sampling control should convert");
+        assert_eq!(with_top_p.top_p, Some(0.9));
+        assert_eq!(with_top_p.top_k, None);
     }
 }


### PR DESCRIPTION
## Summary

`MessageCreateParams::try_from` translated the OpenAI request field `top_logprobs` into Anthropic's
`top_k`. The two are unrelated parameters:

| field | meaning |
|---|---|
| OpenAI `top_logprobs` | how many of the most likely tokens to **report log probabilities for**. An observability request; sampling is untouched. |
| Anthropic `top_k` | only **sample from** the top K tokens at each position. A sampling restriction that changes the output distribution. |

So a request asking to *see* the 5 most likely alternatives per token was served as a request to
*sample only from* the top 5. Two things went wrong silently and in opposite directions: the output
changed — different text than the same request produces against OpenAI, reported as a success — and
the data that was actually asked for never arrived, because the response conversion leaves
`ChatChoice::logprobs` empty.

Anthropic's Messages API returns no per-token log probabilities, so this request cannot be served at
all. Silently dropping the parameter would be the same class of quiet wrong answer on the way back,
so it is refused instead.

## Changes

- `top_k` is left unset. No OpenAI request field corresponds to it, and the comment says why so the
  mapping is not reintroduced.
- A request setting `logprobs: true` or `top_logprobs` is refused with a typed error naming the
  parameter, the model, and the remedy. `logprobs: false` is deliberately still accepted — it asks
  for nothing, which Anthropic can satisfy exactly.
- The refusal carries `code`/`type` of `invalid_request_error`, matching the shape already used in
  `crates/runtime/src/http/v1/responses.rs`. `openai_error_to_response` selects the HTTP status from
  `code` and maps anything it does not recognize to 500, so without this a pure client error would
  be reported as a server fault.
- When both fields are set, the remedy names both. Naming only the reported one would earn a second
  refusal on the next attempt.

### Scope, and what this does not claim

The sibling issues #13564 and #13579 need a model-capability table — which controls each Claude
generation accepts — and that does not exist on `trunk` today (`AnthropicModelVariant` is a `String`
alias). This change is confined to the mistranslation, which is wrong for every model and needs no
such table.

A swept check of the sibling adapters found the mistranslation is unique to Anthropic: Mistral maps
`top_logprobs` onto `top_n_logprobs` correctly and the OpenAI Responses adapter forwards it. Google
and Bedrock ignore the field rather than mistranslating it, so no request to them returns wrong
output; that is a lesser, separate gap and is not widened into here.

## Test plan

- [x] `a_request_for_log_probabilities_is_refused_rather_than_narrowing_sampling` — covers
      `top_logprobs` alone, `logprobs: true` alone, both together, and `top_logprobs: Some(0)`;
      asserts the reported parameter, the `code`/`type` that select a 400, and that the message
      itself names the model, the provider, the full remedy and the docs link
- [x] `a_request_that_asks_for_no_log_probabilities_still_converts` — `logprobs: false` and an
      unset request both convert, so the refusal cannot over-reach
- [x] `a_sampling_control_the_caller_did_set_is_still_forwarded` — `temperature`/`top_p` keep
      reaching Anthropic
- [x] Each test verified against its own neuter, and each neuter fails only the test that owns it:
      restoring the mapping with the refusal removed (i.e. the code on `trunk`); treating
      `top_logprobs: Some(0)` as absent; over-reaching to `logprobs: Some(false)`; naming only the
      reported field in the remedy; and clearing `code`, which is the 500-vs-400 defect
- [ ] `make lint` passes (workspace-wide `cargo fmt --all -- --check` + full clippy — not a
      per-crate scoped invocation)
- [ ] `make test` passes
- [ ] `make signoff` run after the final push (`Attestation` check is green)

### One assertion is deliberately not load-bearing, and this says so

With the refusal in place the `top_logprobs` → `top_k` mapping is unreachable, so
`assert_eq!(params.top_k, None)` **cannot** fail if the mapping were reintroduced — verified by
neutering exactly that. It is kept as a construction check against some *other* field being mapped
onto `top_k` later; the refusal test is what pins the defect this PR fixes. An all-green column
should not be read as coverage it does not provide.

## Review gate

- Adversarial review: `codex` — job `review-13581-a7fe0dce03` (`CODEX_RC=0`, 4 findings, all
  verified against the code before acting):
  - *High — the refusal would return HTTP 500.* **Confirmed and fixed.** `openai_error_to_response`
    (`crates/runtime/src/http/v1/chat.rs:367`) keys the status off `code` and defaults to 500; the
    original `code: None` would have reported a client error as a server fault. Now
    `invalid_request_error`, pinned by a test and its neuter.
  - *Medium — configured defaults are advertised but unserveable.* **Confirmed, and filed as
    #13681** rather than widened into here. `anthropic_logprobs`/`anthropic_top_logprobs` are
    advertised via the shared passthrough set and injected by `with_model_defaults`, so a model
    configured with either loads, passes health, then fails every request. Fixing it means a
    per-provider exclusion in the parameter schema or load-time validation — model construction, not
    this converter.
  - *Low — the remedy named only one of two set fields.* **Confirmed and fixed**; the message now
    names both, with a neuter.
  - *Low — a test assertion was vacuous.* **Confirmed and fixed.** `ApiError`'s `Display` appends
    `(param: …)`, so asserting on the rendered error passed even when the message omitted the
    parameter. Proven rather than assumed: stripping the parameter from the message passes under the
    old `err.to_string()` assertion and fails under the new one, which reads `api.message`.
  - The reviewer independently searched for internal callers setting either field and found none;
    the affected paths are external HTTP callers and configured model defaults.
- `/security-review`: run against the diff — **no findings**. The change adds no logging, I/O,
  deserialization, process execution or `unsafe`; the error interpolates only a regex-validated
  model name and a closed two-literal set, so it exposes no credential, path or internal identifier;
  and it strictly narrows accepted input. The skill's own harness handed it an empty diff (the
  changes were unstaged at that point), so the analysis was performed directly against
  `git diff origin/trunk`.
- `/simplify`: run, one change applied — `param` and `remedy` branched twice over the same two
  booleans and are now derived together in a single `match`, which also removes a `String`
  allocation on the error path. Its four review angles (reuse, simplification, efficiency, altitude)
  were applied inline rather than as parallel agents, because agent dispatch is disabled for this
  session. Reuse: no shared refusal helper exists and inline `ApiError` is this file's established
  idiom. Altitude: per-request validation is the right layer for a request-sourced value; the
  load-time half is #13681. All neuters were re-run after the simplification and still bite.

### Review-fix commits

Two commits after the review gate above, both **test-only** — the production change is unchanged
since `3e22a89c`, which is what the gate above attests.

- `3577bb69` — the forwarding guard set `temperature` and `top_p` on one request, a shape #13579
  reports as refused. Raised by Copilot, and the same slip had already been corrected once on
  #13563. Each control now travels in its own request. It would never have failed, since this is a
  unit test of the converter — which is what makes it worth changing: it would have stood as an
  apparently-passing statement that the pairing is fine, and #13579's own fix would have had to
  argue with it.
- `bc021e56` — from a scoped adversarial pass on that commit: `codex`, job
  `review-13581-3577bb69da` (`CODEX_RC=0`), *"the delta is sound; no blocking findings"*. It
  confirmed the split test is non-vacuous and raised two optional improvements, both taken: each
  request now asserts the *other* control is unset, so a cross-population fails the guard; and the
  comment attributes the rejected-pairing claim to #13579 rather than asserting a breadth
  ("every Claude 4+ model") that a unit test pinned to one model id cannot establish and that
  would go stale.
- `/security-review`: not re-run for these two — neither touches production code, adds a
  dependency, or changes any input path; both are assertions and a comment inside an existing
  `#[cfg(test)]` module.
- `/simplify`: not re-run; the delta is four assertions and a reworded comment.

Fixes #13581

