### PR TITLE
ci(search): stage FinanceBench corpus to MinIO before a run

### DIFF
--- a/.github/workflows/testoperator_run_search.yml
+++ b/.github/workflows/testoperator_run_search.yml
@@ -96,6 +96,40 @@ jobs:
           minio_access_key: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
           minio_secret_key: ${{ secrets.TEST_MINIO_SECRET_KEY }}
 
+      # The FinanceBench spicepods read a pre-built corpus and its qrels from the bench MinIO
+      # bucket (s3://benchmarks/financebench/). That data is not committed, so a fresh bucket
+      # leaves the datasets forever unavailable and the run times out waiting for readiness.
+      # Stage it here once per bucket for any FinanceBench spicepod, so every workflow that
+      # runs one finds the data. Both steps no-op for non-FinanceBench runs.
+      - name: Set up Python for FinanceBench staging
+        if: contains(github.event.inputs.spicepod_path, 'financebench')
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Stage FinanceBench corpus to MinIO
+        if: contains(github.event.inputs.spicepod_path, 'financebench')
+        env:
+          S3_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
+          S3_KEY: ${{ secrets.TEST_MINIO_ACCESS_KEY }}
+          S3_SECRET: ${{ secrets.TEST_MINIO_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+          # relevance_data.parquet is the last object financebench_stage.py writes, so its
+          # presence means a prior run staged the corpus in full. Skip the work when it is
+          # already there, so the corpus is built once and reused across every run.
+          if mc stat spice-minio/benchmarks/financebench/relevance_data.parquet >/dev/null 2>&1; then
+            echo "FinanceBench data already staged in MinIO; skipping."
+            exit 0
+          fi
+          echo "FinanceBench data not found in MinIO; staging now."
+          cargo build --release -p pdf-split
+          python3 -m pip install --upgrade boto3 pyarrow
+          # Pin --source to a commit so the corpus cannot change under a staged run.
+          ./scripts/financebench_stage.py \
+            --source https://raw.githubusercontent.com/patronus-ai/financebench/cc39aeb4afdf33909ee1412188bf89035950c2eb \
+            --dest s3://benchmarks/financebench/
+
       - name: Extract spicepod filename path
         id: extract_spicepod_filename
         run: |


### PR DESCRIPTION
## What

The FinanceBench search spicepods read a pre-built, page-level PDF corpus and its two qrel parquet files from the bench MinIO bucket (`s3://benchmarks/financebench/`). That data is not committed to the repo — it must be staged once with `scripts/financebench_stage.py` (added in #12984). On a bucket that has never been staged, the datasets never become available and the run fails only after the full ready-wait timeout.

Example of the old behavior — the run waits ~1 hour, then errors:

```
No data files are yet available for the dataset test_queries (s3) ...
Error: Spiced instance not ready within 3600s. 2/3 datasets not ready ...
```

(from run https://github.com/spiceai/spiceai/actions/runs/33160035568/job/98811998790)

## Change

Add two steps to `testoperator_run_search.yml`, both gated on a FinanceBench spicepod path:

1. Set up Python.
2. Build the `pdf-split` tool and run `scripts/financebench_stage.py` to prepare and upload the corpus and both parquet files to MinIO.

```
run search (financebench spicepod)
  Install MinIO ─► Build Testoperator
       └─► Stage FinanceBench corpus to MinIO
             ├─ relevance_data.parquet already in bucket? ─► skip
             └─ else: cargo build -p pdf-split
                      financebench_stage.py --dest s3://benchmarks/financebench/
       └─► Run the benchmark test
```

- **Stage once, reuse everywhere.** The staging is skipped when `relevance_data.parquet` — the last object the staging job writes — already exists, so the corpus is built once and reused by every workflow that runs a FinanceBench spicepod. Because the search dispatch globs the whole `tools/testoperator/dispatch/search` directory, all three FinanceBench variants pick this up automatically.
- **Pinned source.** `--source` is pinned to a commit of `patronus-ai/financebench` so the corpus cannot change under a staged run.
- **No effect on non-FinanceBench runs.** Both steps `if:`-gate on the spicepod path, so MTEB and custom runs are unchanged.

## Notes

On the very first stage of a fresh bucket, concurrently dispatched FinanceBench variants can each see the bucket as empty and stage in parallel. Staging is deterministic and writes identical bytes to identical keys, so the final state is correct; later runs all hit the skip path.

Closes #12858.