### PR TITLE
build(rust): upgrade toolchain to 1.97.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,7 +80,7 @@ make lint-rust-fix      # Auto-fix lint issues
 
 ## Rust standards
 
-Workspace is edition 2024, rust-version 1.96.1 — use stable features and modern std APIs through 1.96; don't code to older subsets. Runtime is 64-bit minimum: assume `usize` is at least (never exactly) 64 bits. New `.rs` files need the copyright header (`Copyright 2024-2026 The Spice.ai OSS Authors`; vendored code in `crates/vendor/` exempt).
+Workspace is edition 2024, rust-version 1.97.1 — use stable features and modern std APIs through 1.97; don't code to older subsets. Runtime is 64-bit minimum: assume `usize` is at least (never exactly) 64 bits. New `.rs` files need the copyright header (`Copyright 2024-2026 The Spice.ai OSS Authors`; vendored code in `crates/vendor/` exempt).
 
 ### Error handling (critical)
 

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -40,9 +40,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust 1.96.1
+      - name: Install Rust 1.97.1
         if: steps.check_pr.outputs.skip != 'true'
-        run: rustup toolchain install 1.96.1 --profile minimal
+        run: rustup toolchain install 1.97.1 --profile minimal
 
       - name: Set up make
         if: runner.os != 'macOS' && steps.check_pr.outputs.skip != 'true'

--- a/.github/workflows/generate_acknowledgements.yml
+++ b/.github/workflows/generate_acknowledgements.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup toolchain install 1.96.1 --profile minimal
+      - run: rustup toolchain install 1.97.1 --profile minimal
 
       - name: Set up make
         if: runner.os != 'macOS'

--- a/.github/workflows/generate_json_schema.yml
+++ b/.github/workflows/generate_json_schema.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup toolchain install 1.96.1 --profile minimal
+      - run: rustup toolchain install 1.97.1 --profile minimal
 
       - name: Set up make
         if: runner.os != 'macOS' && (github.event_name != 'workflow_dispatch' || inputs.run_build)

--- a/.github/workflows/types_check.yml
+++ b/.github/workflows/types_check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set REL_VERSION from version.txt
         run: python3 ./.github/scripts/get_release_version.py
 
-      - run: rustup toolchain install 1.96.1 --profile minimal
+      - run: rustup toolchain install 1.97.1 --profile minimal
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ homepage = "https://spice.ai"
 license-file = "LICENSE"
 publish = false
 repository = "https://github.com/spiceai/spiceai"
-rust-version = "1.96.1"
+rust-version = "1.97.1"
 version = "2.3.0-unstable"
 
 # Clippy lint levels for the workspace. Each member crate opts in with

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.96.1
+ARG RUST_VERSION=1.97.1
 FROM rust:${RUST_VERSION}-slim-trixie as build
 
 # cache mounts below may already exist and owned by root

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.96.1
+ARG RUST_VERSION=1.97.1
 
 FROM nvidia/cuda:13.3.1-cudnn-devel-ubuntu24.04 AS build
 

--- a/crates/cayenne/src/provider/delete/sink/position_based.rs
+++ b/crates/cayenne/src/provider/delete/sink/position_based.rs
@@ -1011,12 +1011,11 @@ fn try_decompose_struct_in_list(
         value_expr.downcast_ref::<datafusion_physical_expr::ScalarFunctionExpr>()
     {
         sf
-    } else if let Some(cast_expr) = value_expr.downcast_ref::<phys_expr::CastExpr>() {
+    } else {
+        let cast_expr = value_expr.downcast_ref::<phys_expr::CastExpr>()?;
         cast_expr
             .expr()
             .downcast_ref::<datafusion_physical_expr::ScalarFunctionExpr>()?
-    } else {
-        return None;
     };
     if struct_fn.name() != "struct" {
         return None;
@@ -1107,12 +1106,11 @@ fn try_decompose_struct_eq(
     let struct_fn =
         if let Some(sf) = lhs.downcast_ref::<datafusion_physical_expr::ScalarFunctionExpr>() {
             sf
-        } else if let Some(cast_expr) = lhs.downcast_ref::<phys_expr::CastExpr>() {
+        } else {
+            let cast_expr = lhs.downcast_ref::<phys_expr::CastExpr>()?;
             cast_expr
                 .expr()
                 .downcast_ref::<datafusion_physical_expr::ScalarFunctionExpr>()?
-        } else {
-            return None;
         };
     if struct_fn.name() != "struct" {
         return None;

--- a/crates/cayenne/src/provider/table.rs
+++ b/crates/cayenne/src/provider/table.rs
@@ -13947,26 +13947,27 @@ impl CayenneTableProvider {
                 // result inline and skips the spawn/join. One entry per shard in
                 // order, so the index alignment steps 3/4 rely on is preserved.
                 std::thread::scope(|scope| {
-                    let handles: Vec<Option<_>> = per_shard_batches
-                        .into_iter()
-                        .enumerate()
-                        .map(|(s, shard_batches)| {
-                            if shard_batches.is_empty() {
-                                None
-                            } else {
-                                Some(scope.spawn(move || {
-                                    self.validate_one_shard(
-                                        s,
-                                        shard_batches,
-                                        index_ref,
-                                        pk_indices,
-                                        converter,
-                                        on_conflict,
-                                    )
-                                }))
-                            }
-                        })
-                        .collect();
+                    // Every shard's thread is spawned before any of them is joined:
+                    // a lazy spawn-then-join iterator chain would start each thread
+                    // only as the join step pulled it, validating the shards one at a
+                    // time instead of together.
+                    let mut handles: Vec<Option<_>> = Vec::with_capacity(n);
+                    for (s, shard_batches) in per_shard_batches.into_iter().enumerate() {
+                        if shard_batches.is_empty() {
+                            handles.push(None);
+                        } else {
+                            handles.push(Some(scope.spawn(move || {
+                                self.validate_one_shard(
+                                    s,
+                                    shard_batches,
+                                    index_ref,
+                                    pk_indices,
+                                    converter,
+                                    on_conflict,
+                                )
+                            })));
+                        }
+                    }
                     handles
                         .into_iter()
                         .map(|handle| match handle {

--- a/crates/cayenne/src/schema.rs
+++ b/crates/cayenne/src/schema.rs
@@ -549,13 +549,10 @@ mod tests {
     #[test]
     fn creation_rewrite_rules_match_vortex_for_all_supported_type_families() {
         // Only the families Cayenne accepts: the rest are refused before any rewrite runs.
-        let types: Vec<DataType> = arrow_type_families()
-            .into_iter()
-            .filter(is_vortex_supported_type)
-            .collect();
         let schema = Schema::new(
-            types
+            arrow_type_families()
                 .into_iter()
+                .filter(is_vortex_supported_type)
                 .enumerate()
                 .map(|(index, data_type)| Field::new(format!("column_{index}"), data_type, true))
                 .collect::<Vec<_>>(),

--- a/crates/data-connectors/connector-nfs/Cargo.toml
+++ b/crates/data-connectors/connector-nfs/Cargo.toml
@@ -17,7 +17,7 @@
 name = "connector-nfs"
 edition = "2024"
 version = "1.11.0-unstable"
-rust-version = "1.96.1"
+rust-version = "1.97.1"
 license = "Apache-2.0"
 description = "NFS data connector for Spice.ai runtime"
 

--- a/crates/data_components/src/debezium/avro.rs
+++ b/crates/data_components/src/debezium/avro.rs
@@ -324,7 +324,7 @@ fn avro_value_to_change_event(value: &AvroValue) -> Result<ChangeEvent> {
     let before = field("before")
         .map(avro_to_json)
         .transpose()?
-        .and_then(|v| if v.is_null() { None } else { Some(v) });
+        .filter(|v| !v.is_null());
 
     let after = field("after")
         .map(avro_to_json)

--- a/crates/data_components/src/elasticsearch/query_table.rs
+++ b/crates/data_components/src/elasticsearch/query_table.rs
@@ -667,10 +667,9 @@ fn parse_timestamp_to_unit(v: &serde_json::Value, unit: TimeUnit) -> Option<i64>
         parse_datetime_to_nanos(s)?
     } else if let Some(ms) = v.as_i64() {
         ms.checked_mul(1_000_000)?
-    } else if let Some(ms) = v.as_u64() {
-        i64::try_from(ms).ok()?.checked_mul(1_000_000)?
     } else {
-        return None;
+        let ms = v.as_u64()?;
+        i64::try_from(ms).ok()?.checked_mul(1_000_000)?
     };
     Some(match unit {
         TimeUnit::Second => nanos.div_euclid(1_000_000_000),

--- a/crates/libnfs/Cargo.toml
+++ b/crates/libnfs/Cargo.toml
@@ -4,7 +4,7 @@
 name = "libnfs"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.96.1"
+rust-version = "1.97.1"
 description = "Safe Rust bindings to libnfs C library for NFS client operations"
 license = "Apache-2.0"
 

--- a/crates/runtime-query-engine/src/allowlist.rs
+++ b/crates/runtime-query-engine/src/allowlist.rs
@@ -125,12 +125,12 @@ impl ResolvedTableAwareAllowlist {
             Token::EOF => {
                 return Err(ParserError::ParserError(
                     "Empty input when parsing identifier".to_string(),
-                ))?;
+                ));
             }
             token => {
                 return Err(ParserError::ParserError(format!(
                     "Unexpected token in identifier: {token}"
-                )))?;
+                )));
             }
         }
 
@@ -143,19 +143,19 @@ impl ResolvedTableAwareAllowlist {
                     Token::EOF => {
                         return Err(ParserError::ParserError(
                             "Trailing period in identifier".to_string(),
-                        ))?;
+                        ));
                     }
                     token => {
                         return Err(ParserError::ParserError(format!(
                             "Unexpected token following period in identifier: {token}"
-                        )))?;
+                        )));
                     }
                 },
                 Token::EOF => break,
                 token => {
                     return Err(ParserError::ParserError(format!(
                         "Unexpected token in identifier: {token}"
-                    )))?;
+                    )));
                 }
             }
         }

--- a/crates/runtime-request-context/src/baggage.rs
+++ b/crates/runtime-request-context/src/baggage.rs
@@ -93,8 +93,7 @@ mod tests {
     #[test]
     fn test_from_headers_empty() {
         let headers = HeaderMap::new();
-        let baggage = from_headers(&headers).collect::<Vec<_>>();
-        assert!(baggage.is_empty());
+        assert!(from_headers(&headers).next().is_none());
     }
 
     #[test]
@@ -104,8 +103,7 @@ mod tests {
             BAGGAGE_HEADER,
             HeaderValue::from_bytes(&[0xFF]).expect("Failed to create header value"),
         );
-        let baggage = from_headers(&headers).collect::<Vec<_>>();
-        assert!(baggage.is_empty());
+        assert!(from_headers(&headers).next().is_none());
     }
 
     #[test]
@@ -165,7 +163,6 @@ mod tests {
     fn test_from_headers_invalid_format() {
         let mut headers = HeaderMap::new();
         headers.insert(BAGGAGE_HEADER, HeaderValue::from_static("invalid_format"));
-        let baggage = from_headers(&headers).collect::<Vec<_>>();
-        assert!(baggage.is_empty());
+        assert!(from_headers(&headers).next().is_none());
     }
 }

--- a/crates/runtime-search/src/search_engine.rs
+++ b/crates/runtime-search/src/search_engine.rs
@@ -667,7 +667,7 @@ impl<E: TableProviderExplorer> SearchEngine<E> {
 
                     Ok((tbl.clone(), agg_result))
                 }
-            }).collect::<Vec<_>>()).await?.into_iter().filter_map(|(tbl, result)| Some((tbl, result?))).collect();
+            })).await?.into_iter().filter_map(|(tbl, result)| Some((tbl, result?))).collect();
 
             Ok(response)
 

--- a/crates/runtime-tools/src/mcp/server.rs
+++ b/crates/runtime-tools/src/mcp/server.rs
@@ -110,7 +110,7 @@ impl RuntimeServer {
     async fn all_tools(&self) -> Vec<Arc<dyn SpiceModelTool>> {
         let tools = self.tools.read().await;
         let mut result = Vec::new();
-        for (_, tooling) in tools.iter() {
+        for tooling in tools.values() {
             match tooling {
                 Tooling::Tool(tool) | Tooling::FunctionTool(tool) => {
                     result.push(Arc::clone(tool));

--- a/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
+++ b/crates/runtime/src/flight/flightsql/prepared_statement_query.rs
@@ -667,12 +667,7 @@ mod tests {
     /// just past the schema message, along with the decoded schema.
     async fn decoder_for(batches: Vec<RecordBatch>) -> (FlightDataDecoder, SchemaRef) {
         use arrow_flight::encode::FlightDataEncoderBuilder;
-        let input = futures::stream::iter(
-            batches
-                .into_iter()
-                .map(Ok::<RecordBatch, FlightError>)
-                .collect::<Vec<_>>(),
-        );
+        let input = futures::stream::iter(batches.into_iter().map(Ok::<RecordBatch, FlightError>));
         let flight_stream = FlightDataEncoderBuilder::new().build(input);
         let mut decoder = FlightDataDecoder::new(flight_stream);
         let schema = decode_schema(&mut decoder).await.expect("schema decoded");

--- a/crates/runtime/src/opentelemetry.rs
+++ b/crates/runtime/src/opentelemetry.rs
@@ -1923,7 +1923,10 @@ mod tests {
         let widened_result =
             metric_data_to_record_batch("svc_requests", &second, &[], Some(first_schema.as_ref()));
         let widened_schema = widened_result.expect("widened batch builds").schema();
-        assert!(detect_added_columns(&first_schema, &widened_schema) == vec!["tier".to_string()]);
+        assert_eq!(
+            detect_added_columns(&first_schema, &widened_schema),
+            vec!["tier".to_string()]
+        );
 
         // Rebuilding the same data against the (evolved) widened schema yields the identical
         // field order — the invariant the OTel pre-flight relies on for the rebuilt batch.

--- a/crates/runtime/src/tracing_util.rs
+++ b/crates/runtime/src/tracing_util.rs
@@ -32,7 +32,7 @@ pub fn dataset_registered_trace(
     ds: &Dataset,
     results_cache_enabled: bool,
 ) -> String {
-    let mut info = format!("Dataset {} registered ({})", &ds.name, &ds.from);
+    let mut info = format!("Dataset {} registered ({})", ds.name, ds.from);
     if let Some(acceleration) = &ds.acceleration
         && acceleration.enabled
     {

--- a/crates/spice-cloud-client/src/client.rs
+++ b/crates/spice-cloud-client/src/client.rs
@@ -815,10 +815,9 @@ fn oauth_host(host: &str) -> Option<String> {
 
     if let Some(api_index) = labels.iter().position(|label| *label == "api") {
         labels.remove(api_index);
-    } else if let Some(label) = labels.iter_mut().find(|label| label.ends_with("-api")) {
-        *label = label.trim_end_matches("-api");
     } else {
-        return None;
+        let label = labels.iter_mut().find(|label| label.ends_with("-api"))?;
+        *label = label.trim_end_matches("-api");
     }
 
     let rewritten_host = labels.join(".");

--- a/crates/spicepod/src/component/runtime.rs
+++ b/crates/spicepod/src/component/runtime.rs
@@ -1513,7 +1513,7 @@ mod tests {
         };
 
         // Test exact match
-        assert!(key == *"secret-api-key-12345");
+        assert_eq!(key, *"secret-api-key-12345");
 
         // Test mismatch at different positions
         assert!(key != *"xecret-api-key-12345"); // First char different
@@ -1529,7 +1529,7 @@ mod tests {
         let rw_key = ApiKey::ReadWrite {
             key: "rw-key".to_string(),
         };
-        assert!(rw_key == *"rw-key");
+        assert_eq!(rw_key, *"rw-key");
         assert!(rw_key != *"rw-key2");
     }
 

--- a/crates/vendor/pgwire-replication/src/protocol/messages.rs
+++ b/crates/vendor/pgwire-replication/src/protocol/messages.rs
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn error_fields_handles_truncated_payload() {
         // Missing null terminator for value
-        let payload = [b'M', b'h', b'e', b'l', b'l', b'o'];
+        let payload = *b"Mhello";
         let fields = ErrorFields::parse(&payload);
         // Should not panic, just skip incomplete field
         assert!(fields.message.is_none());

--- a/crates/yaml/src/lib.rs
+++ b/crates/yaml/src/lib.rs
@@ -400,7 +400,7 @@ three: 3
     #[test]
     fn test_to_string_simple() {
         let yaml = to_string(&42).expect("should serialize 42");
-        assert!(yaml.trim() == "42");
+        assert_eq!(yaml.trim(), "42");
     }
 
     #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.1"
 components = ["rustc", "cargo", "rustfmt", "clippy"]

--- a/scripts/test_signoff_disk_guard.sh
+++ b/scripts/test_signoff_disk_guard.sh
@@ -562,9 +562,9 @@ assert_preflight_lock "quotes what cargo actually said" "$with_lock_dir" 72 \
 # The toolchain matters and is easy to get wrong: rustup picks a toolchain from the
 # *current directory's* rust-toolchain.toml, so a fixture under $TMPDIR gets the
 # runner's default cargo rather than the one this repository pins — measured on one
-# machine as 1.97.1 in the temp directory against the pinned 1.96.1 at the repo
-# root. Testing the wrong cargo's wording is indistinguishable from testing none,
-# so RUSTUP_TOOLCHAIN is set from rust-toolchain.toml explicitly.
+# machine as a newer default in the temp directory against the pinned channel at
+# the repo root. Testing the wrong cargo's wording is indistinguishable from
+# testing none, so RUSTUP_TOOLCHAIN is set from rust-toolchain.toml explicitly.
 #
 # And a skip is not a pass. In CI, being unable to exercise this is fatal: the whole
 # point is that the guard cannot quietly stop working, and "the fixture did not run"

--- a/tools/flightpublisher/src/main.rs
+++ b/tools/flightpublisher/src/main.rs
@@ -81,9 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let flight_descriptor = FlightDescriptor::new_path(vec![args.path]);
     let flight_data_stream = FlightDataEncoderBuilder::new()
         .with_flight_descriptor(Some(flight_descriptor))
-        .build(futures::stream::iter(
-            batches.into_iter().map(Ok).collect::<Vec<_>>(),
-        ));
+        .build(futures::stream::iter(batches.into_iter().map(Ok)));
 
     let _response: Vec<PutResult> = client
         .do_put(flight_data_stream)


### PR DESCRIPTION
## 📝 Summary

Bump the pinned Rust toolchain from 1.96.1 to 1.97.1 across the workspace, Docker images, and the workflows that install the toolchain by version.

1.97.1 backports the LLVM miscompilation fix ([rust-lang/rust#159035](https://github.com/rust-lang/rust/issues/159035)) that 1.97.0 made more likely.

This also covers the four workflows that call `rustup toolchain install <version>` instead of the shared `setup-rust` action, so they do not keep installing 1.96.1 after the `rust-toolchain.toml` bump (the miss that needed a follow-up last time: #11769).

## 🔗 Related

Follow-up to #11743 / #11769 (1.96.1).

## 👀 Notes for Reviewers

Jobs that use `.github/actions/setup-rust` already resolve the channel from `rust-toolchain.toml`. The explicit pins updated here are:

- `generate-openapi.yml` (step label + install)
- `types_check.yml`
- `generate_json_schema.yml`
- `generate_acknowledgements.yml`

`crates/libnfs` and `crates/data-connectors/connector-nfs` pin `rust-version` themselves because they are excluded from the workspace.

Validated locally: `rustc`/`cargo` 1.97.1 active from `rust-toolchain.toml`; `cargo fmt --all --check` passes. Full `make lint-rust` was not run (workspace clippy on 1.97 may surface new pedantic lints such as `manual_assert_eq`).