### PR TITLE
fix(ci): stop a CI git push from blocking forever on a credential prompt (fixes #13701)

### DIFF
--- a/.github/actions/push-snap-changes/action.yml
+++ b/.github/actions/push-snap-changes/action.yml
@@ -58,7 +58,13 @@ runs:
         git remote set-url origin "${AUTHENTICATED_REMOTE_URL}"
         git checkout -b "${BRANCH_NAME}"
         git commit -m "${PR_TITLE}"
-        git push origin "HEAD:${BRANCH_NAME}"
+        # Disable any credential helper configured on the (self-hosted) runner so
+        # git authenticates with the URL-embedded token only. Otherwise a helper
+        # (osxkeychain / git-credential-manager) can intercept the push and block on
+        # an interactive credential prompt, hanging the job until the 360-minute
+        # limit and discarding the test result this step was reporting on.
+        git -c credential.helper='' -c credential.interactive=false \
+          push origin "HEAD:${BRANCH_NAME}"
 
         BODY="${PR_DESCRIPTION}"
         if [[ -z "${BODY}" ]]; then
@@ -89,9 +95,15 @@ runs:
         ' "${EXISTING_PR_JSON}" | while IFS=$'\t' read -r OLD_PR_NUMBER OLD_BRANCH; do
           echo "Closing superseded snapshot update PR #${OLD_PR_NUMBER}"
           gh pr close "${OLD_PR_NUMBER}" --comment "Superseded by ${PR_URL} (fresher snapshot diff against current ${BASE_BRANCH})." || true
-          git push origin --delete "${OLD_BRANCH}" || true
+          # `|| true` bounds the exit status, not the wall clock: the same credential
+          # helper can block this push too, so it needs the same guard.
+          git -c credential.helper='' -c credential.interactive=false \
+            push origin --delete "${OLD_BRANCH}" || true
         done
       env:
         GH_TOKEN: ${{ inputs.token }}
         PR_TITLE: ${{ inputs.title }}
+        # Never fall back to an interactive prompt; fail fast if auth is rejected.
+        GIT_TERMINAL_PROMPT: '0'
+        GCM_INTERACTIVE: 'never'
         PR_DESCRIPTION: ${{ inputs.description }}

--- a/.github/actions/push-snap-changes/action.yml
+++ b/.github/actions/push-snap-changes/action.yml
@@ -58,11 +58,9 @@ runs:
         git remote set-url origin "${AUTHENTICATED_REMOTE_URL}"
         git checkout -b "${BRANCH_NAME}"
         git commit -m "${PR_TITLE}"
-        # Disable any credential helper configured on the (self-hosted) runner so
-        # git authenticates with the URL-embedded token only. Otherwise a helper
-        # (osxkeychain / git-credential-manager) can intercept the push and block on
-        # an interactive credential prompt, hanging the job until the 360-minute
-        # limit and discarding the test result this step was reporting on.
+        # Non-interactive: a credential helper on the runner can otherwise intercept
+        # this push and block on a prompt forever. See
+        # scripts/check_ci_git_push_noninteractive.py.
         git -c credential.helper='' -c credential.interactive=false \
           push origin "HEAD:${BRANCH_NAME}"
 
@@ -103,7 +101,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
         PR_TITLE: ${{ inputs.title }}
+        PR_DESCRIPTION: ${{ inputs.description }}
         # Never fall back to an interactive prompt; fail fast if auth is rejected.
         GIT_TERMINAL_PROMPT: '0'
         GCM_INTERACTIVE: 'never'
-        PR_DESCRIPTION: ${{ inputs.description }}

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -520,6 +520,13 @@ jobs:
       - name: Update nightly tag
         run: |
           git tag -f nightly
-          git push origin nightly --force
+          # Disable any credential helper configured on the runner: a helper can
+          # intercept the push and block on an interactive credential prompt,
+          # hanging the job.
+          git -c credential.helper='' -c credential.interactive=false \
+            push origin nightly --force
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Never fall back to an interactive prompt; fail fast if auth is rejected.
+          GIT_TERMINAL_PROMPT: '0'
+          GCM_INTERACTIVE: 'never'

--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -520,9 +520,9 @@ jobs:
       - name: Update nightly tag
         run: |
           git tag -f nightly
-          # Disable any credential helper configured on the runner: a helper can
-          # intercept the push and block on an interactive credential prompt,
-          # hanging the job.
+          # Non-interactive: a credential helper on the runner can otherwise intercept
+          # this push and block on a prompt forever. See
+          # scripts/check_ci_git_push_noninteractive.py.
           git -c credential.helper='' -c credential.interactive=false \
             push origin nightly --force
         env:

--- a/.github/workflows/ci_git_push_guard.yml
+++ b/.github/workflows/ci_git_push_guard.yml
@@ -1,0 +1,65 @@
+---
+name: CI Git-Push Guard
+
+# A `git push` in CI that can consult a credential helper can block on an interactive
+# prompt that never gets an answer on a headless runner. Nothing bounds that wait, so the
+# job runs to GitHub's 360-minute limit -- and when the pushing step exists only to report
+# a result (snapshot updates, generated schemas), the timeout destroys the very test
+# verdict the run had already produced hours earlier.
+#
+# Neither direction is observable until it is already wrong in production: a guarded push
+# and an unguarded one look identical on a runner whose helper happens to stay quiet.
+
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - 'scripts/check_ci_git_push_noninteractive.py'
+      - 'scripts/test_check_ci_git_push_noninteractive.py'
+      # Any workflow or action manifest: a push that can hang is added at a call site, not
+      # in the guard. Composite actions count -- one shared action carried the push for
+      # eight call sites across six workflows.
+      - '.github/workflows/*.yml'
+      - '.github/actions/*/action.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'scripts/check_ci_git_push_noninteractive.py'
+      - 'scripts/test_check_ci_git_push_noninteractive.py'
+      - '.github/workflows/*.yml'
+      - '.github/actions/*/action.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  check-git-push-noninteractive:
+    name: Every CI git push is non-interactive
+    # GitHub-hosted on purpose: this is a sub-second check and must not queue behind the
+    # self-hosted pool whose credential helpers it is about.
+    runs-on: ubuntu-24.04
+    # A checkout plus a local Python script over the manifests -- the job reads the
+    # repository and nothing else.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The guard's parser is exercised first: the live-tree scan only covers the shapes
+      # today's `.github/` happens to contain, so a parser that stopped recognising
+      # `git push` would report a clean tree and pass unnoticed.
+      - name: Test the guard's parser
+        run: python3 scripts/test_check_ci_git_push_noninteractive.py
+
+      - name: Check every CI git push disables interactive credentials
+        run: python3 scripts/check_ci_git_push_noninteractive.py

--- a/.github/workflows/ci_git_push_guard.yml
+++ b/.github/workflows/ci_git_push_guard.yml
@@ -24,7 +24,9 @@ on:
       # in the guard. Composite actions count -- one shared action carried the push for
       # eight call sites across six workflows.
       - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
       - '.github/actions/*/action.yml'
+      - '.github/actions/*/action.yaml'
   push:
     branches:
       - trunk
@@ -32,7 +34,9 @@ on:
       - 'scripts/check_ci_git_push_noninteractive.py'
       - 'scripts/test_check_ci_git_push_noninteractive.py'
       - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
       - '.github/actions/*/action.yml'
+      - '.github/actions/*/action.yaml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -90,7 +90,12 @@ jobs:
           else
             git add .schema/openapi.json
             git commit -m "Update openapi.json"
-            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:openapi/${GITHUB_RUN_ID}
+            # Disable any credential helper configured on the (self-hosted) runner
+            # so git authenticates with the URL-embedded token only. Otherwise a
+            # helper (osxkeychain / git-credential-manager) can intercept the push
+            # and block on an interactive credential prompt, hanging the job.
+            git -c credential.helper='' -c credential.interactive=false \
+              push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:openapi/${GITHUB_RUN_ID}
             gh pr create \
               --title "Update openapi.json" \
               --body $'Updated OpenAPI specification\n\n**Remember**\n- [ ] Updated in [spiceai/docs](https://github.com/spiceai/docs).' \
@@ -100,3 +105,6 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Never fall back to an interactive prompt; fail fast if auth is rejected.
+          GIT_TERMINAL_PROMPT: '0'
+          GCM_INTERACTIVE: 'never'

--- a/.github/workflows/generate-openapi.yml
+++ b/.github/workflows/generate-openapi.yml
@@ -90,10 +90,9 @@ jobs:
           else
             git add .schema/openapi.json
             git commit -m "Update openapi.json"
-            # Disable any credential helper configured on the (self-hosted) runner
-            # so git authenticates with the URL-embedded token only. Otherwise a
-            # helper (osxkeychain / git-credential-manager) can intercept the push
-            # and block on an interactive credential prompt, hanging the job.
+            # Non-interactive: a credential helper on the runner can otherwise intercept
+            # this push and block on a prompt forever. See
+            # scripts/check_ci_git_push_noninteractive.py.
             git -c credential.helper='' -c credential.interactive=false \
               push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:openapi/${GITHUB_RUN_ID}
             gh pr create \

--- a/.github/workflows/generate_acknowledgements.yml
+++ b/.github/workflows/generate_acknowledgements.yml
@@ -41,10 +41,9 @@ jobs:
           if [[ $(git diff --exit-code acknowledgements.md) ]]; then
             git add acknowledgements.md
             git commit -m "Update acknowledgements"
-            # Disable any credential helper configured on the (self-hosted) runner
-            # so git authenticates with the URL-embedded token only. Otherwise a
-            # helper (osxkeychain / git-credential-manager) can intercept the push
-            # and block on an interactive credential prompt, hanging the job.
+            # Non-interactive: a credential helper on the runner can otherwise intercept
+            # this push and block on a prompt forever. See
+            # scripts/check_ci_git_push_noninteractive.py.
             git -c credential.helper='' -c credential.interactive=false \
               push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:acknowledgements/${GITHUB_RUN_ID}
             gh pr create --title "Update acknowledgements" --body "Updated OSS acknowledgements" --base trunk --head acknowledgements/${GITHUB_RUN_ID}

--- a/.github/workflows/generate_acknowledgements.yml
+++ b/.github/workflows/generate_acknowledgements.yml
@@ -41,10 +41,18 @@ jobs:
           if [[ $(git diff --exit-code acknowledgements.md) ]]; then
             git add acknowledgements.md
             git commit -m "Update acknowledgements"
-            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:acknowledgements/${GITHUB_RUN_ID}
+            # Disable any credential helper configured on the (self-hosted) runner
+            # so git authenticates with the URL-embedded token only. Otherwise a
+            # helper (osxkeychain / git-credential-manager) can intercept the push
+            # and block on an interactive credential prompt, hanging the job.
+            git -c credential.helper='' -c credential.interactive=false \
+              push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" HEAD:acknowledgements/${GITHUB_RUN_ID}
             gh pr create --title "Update acknowledgements" --body "Updated OSS acknowledgements" --base trunk --head acknowledgements/${GITHUB_RUN_ID}
           else
             echo "No changes detected"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Never fall back to an interactive prompt; fail fast if auth is rejected.
+          GIT_TERMINAL_PROMPT: '0'
+          GCM_INTERACTIVE: 'never'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -480,6 +480,7 @@ jobs:
 
       - name: Push snapshots to branch
         if: steps.download_snapshots.outcome == 'success'
+        timeout-minutes: 10
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -794,6 +795,7 @@ jobs:
 
       - name: Push snapshots to branch
         if: github.event.inputs.update_snapshots == 'always'
+        timeout-minutes: 10
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_management_api.yml
+++ b/.github/workflows/integration_management_api.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Push snapshots to branch
         if: ${{ !cancelled() && (github.event.inputs.update_snapshots == 'always' || github.event_name == 'schedule') }}
+        timeout-minutes: 10
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_models.yml
+++ b/.github/workflows/integration_models.yml
@@ -348,6 +348,7 @@ jobs:
 
       - name: Push snapshots to branch
         if: ${{ !cancelled() && (github.event.inputs.update_snapshots == 'always' || github.event_name == 'schedule') }}
+        timeout-minutes: 10
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -432,6 +433,7 @@ jobs:
 
       - name: Push snapshots to branch
         if: ${{ !cancelled() && (github.event.inputs.update_snapshots == 'always' || github.event_name == 'schedule') }}
+        timeout-minutes: 10
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -498,6 +500,7 @@ jobs:
 
       - name: Push snapshots to branch
         if: ${{ !cancelled() && (github.event.inputs.update_snapshots == 'always' || github.event_name == 'schedule') }}
+        timeout-minutes: 10
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_search.yml
+++ b/.github/workflows/integration_search.yml
@@ -71,6 +71,7 @@ jobs:
         # `cargo test` will fail if snapshot changes are needed. Always attempt
         #  to make PR if 'always' update snapshots.
         if: ${{ always() && (github.event.inputs.update_snapshots == 'always' || github.event_name == 'schedule') }}
+        timeout-minutes: 10
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -918,6 +918,7 @@ jobs:
 
       - name: Push snapshots to branch
         if: ${{ github.event.inputs.update_snapshots == 'always' && needs.check_changes.outputs.relevant_changes == 'true' }}
+        timeout-minutes: 10
         uses: ./.github/actions/push-snap-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -619,9 +619,9 @@ jobs:
             if git ls-remote --exit-code --heads origin ${BRANCH_NAME}; then
               git pull --rebase origin ${BRANCH_NAME}
             fi
-            # Disable any credential helper configured on the (self-hosted) runner:
-            # a helper (osxkeychain / git-credential-manager) can intercept the push
-            # and block on an interactive credential prompt, hanging the job.
+            # Non-interactive: a credential helper on the runner can otherwise intercept
+            # this push and block on a prompt forever. See
+            # scripts/check_ci_git_push_noninteractive.py.
             git -c credential.helper='' -c credential.interactive=false \
               push origin ${BRANCH_NAME}
 

--- a/.github/workflows/testoperator_run_bench.yml
+++ b/.github/workflows/testoperator_run_bench.yml
@@ -619,7 +619,11 @@ jobs:
             if git ls-remote --exit-code --heads origin ${BRANCH_NAME}; then
               git pull --rebase origin ${BRANCH_NAME}
             fi
-            git push origin ${BRANCH_NAME}
+            # Disable any credential helper configured on the (self-hosted) runner:
+            # a helper (osxkeychain / git-credential-manager) can intercept the push
+            # and block on an interactive credential prompt, hanging the job.
+            git -c credential.helper='' -c credential.interactive=false \
+              push origin ${BRANCH_NAME}
 
             PR_URL="$(gh pr list --head "${BRANCH_NAME}" --state open --json url --jq .[].url)"
             if [[ -n "${PR_URL}" ]]; then
@@ -646,3 +650,6 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Never fall back to an interactive prompt; fail fast if auth is rejected.
+          GIT_TERMINAL_PROMPT: '0'
+          GCM_INTERACTIVE: 'never'

--- a/.github/workflows/testoperator_run_cluster_bench.yml
+++ b/.github/workflows/testoperator_run_cluster_bench.yml
@@ -497,9 +497,9 @@ jobs:
           if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
             git pull --rebase origin "${BRANCH_NAME}"
           fi
-          # Disable any credential helper configured on the (self-hosted) runner:
-          # a helper (osxkeychain / git-credential-manager) can intercept the push
-          # and block on an interactive credential prompt, hanging the job.
+          # Non-interactive: a credential helper on the runner can otherwise intercept
+          # this push and block on a prompt forever. See
+          # scripts/check_ci_git_push_noninteractive.py.
           git -c credential.helper='' -c credential.interactive=false \
             push origin "${BRANCH_NAME}"
 

--- a/.github/workflows/testoperator_run_cluster_bench.yml
+++ b/.github/workflows/testoperator_run_cluster_bench.yml
@@ -439,6 +439,9 @@ jobs:
           EXECUTOR_REPLICAS: ${{ env.CB_EXECUTOR_REPLICAS }}
           CHANNEL: ${{ env.CB_CHANNEL }}
           CUSTOM_IMAGE_TAG: ${{ env.CB_CUSTOM_IMAGE_TAG }}
+          # Never fall back to an interactive prompt; fail fast if auth is rejected.
+          GIT_TERMINAL_PROMPT: '0'
+          GCM_INTERACTIVE: 'never'
         run: |
           set -euo pipefail
           git fetch --unshallow || true
@@ -494,7 +497,11 @@ jobs:
           if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
             git pull --rebase origin "${BRANCH_NAME}"
           fi
-          git push origin "${BRANCH_NAME}"
+          # Disable any credential helper configured on the (self-hosted) runner:
+          # a helper (osxkeychain / git-credential-manager) can intercept the push
+          # and block on an interactive credential prompt, hanging the job.
+          git -c credential.helper='' -c credential.interactive=false \
+            push origin "${BRANCH_NAME}"
 
           PR_URL="$(gh pr list --head "${BRANCH_NAME}" --state open --json url --jq '.[].url')"
           if [ -n "${PR_URL}" ]; then

--- a/.github/workflows/testoperator_run_schema.yml
+++ b/.github/workflows/testoperator_run_schema.yml
@@ -327,8 +327,12 @@ jobs:
           git commit -m "fix: Update schema snapshots for: ${{ github.event.inputs.spicepod_path }}"
           # The checkout persists no credentials, so authenticate the push
           # itself rather than leaving a token in the local git config for the
-          # rest of the job.
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:${BRANCH_NAME}"
+          # rest of the job. Disable any credential helper configured on the
+          # (self-hosted) runner as well, so git uses the URL-embedded token only:
+          # otherwise a helper (osxkeychain / git-credential-manager) can intercept
+          # the push and block on an interactive credential prompt, hanging the job.
+          git -c credential.helper='' -c credential.interactive=false \
+            push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}" "HEAD:${BRANCH_NAME}"
 
           PR_URL="$(gh pr list --head "${BRANCH_NAME}" --state open --json url --jq .[].url)"
           if [[ -n "${PR_URL}" ]]; then
@@ -345,3 +349,6 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Never fall back to an interactive prompt; fail fast if auth is rejected.
+          GIT_TERMINAL_PROMPT: '0'
+          GCM_INTERACTIVE: 'never'

--- a/scripts/check_ci_git_push_noninteractive.py
+++ b/scripts/check_ci_git_push_noninteractive.py
@@ -123,11 +123,18 @@ def violations(path, text):
 
 
 def manifests():
+    """Every workflow and action manifest, in both spellings GitHub accepts.
+
+    `.yaml` is not a stylistic variant to normalise away -- GitHub runs those manifests
+    exactly as it runs `.yml`, and this repository already has three `action.yaml` files. A
+    scan that saw only `.yml` would leave them as a silent hole in a guard whose whole design
+    is to have no exemptions.
+    """
     for root in ROOTS:
         if not root.is_dir():
             continue
-        yield from sorted(root.glob("*.yml"))
-        yield from sorted(root.glob("*/action.yml"))
+        for pattern in ("*.yml", "*.yaml", "*/action.yml", "*/action.yaml"):
+            yield from sorted(root.glob(pattern))
 
 
 def main():

--- a/scripts/check_ci_git_push_noninteractive.py
+++ b/scripts/check_ci_git_push_noninteractive.py
@@ -32,8 +32,9 @@ import sys
 ROOTS = (pathlib.Path(".github/workflows"), pathlib.Path(".github/actions"))
 
 # `git push`, allowing any `-c key=value` / `--flag` between `git` and the subcommand, and
-# tolerating a line continuation before it. `\bgit\b` so `gh` or `legit` never matches.
-GIT_PUSH = re.compile(r"\bgit\b(?P<opts>(?:\s+(?:-c\s+\S+|--?[\w-]+(?:=\S+)?))*)\s*\\?\s*\n?\s*push\b")
+# tolerating a line continuation before it (`\s` already spans the newline it escapes).
+# `\bgit\b` so `gh` or `legit` never matches.
+GIT_PUSH = re.compile(r"\bgit\b(?P<opts>(?:\s+(?:-c\s+\S+|--?[\w-]+(?:=\S+)?))*)\s*\\?\s*push\b")
 
 # `-c credential.helper=` with an empty value: bare, '' or "". A NON-empty value would name
 # a helper to use, which is the opposite of what is wanted, so it must not satisfy this.
@@ -92,7 +93,7 @@ def run_block(step):
                 if nxt.strip() and len(nxt) - len(nxt.lstrip()) <= indent:
                     break
                 body.append(nxt)
-        return "".join(l for l in body if not l.lstrip().startswith("#"))
+        return "".join(b for b in body if not b.lstrip().startswith("#"))
     return ""
 
 

--- a/scripts/check_ci_git_push_noninteractive.py
+++ b/scripts/check_ci_git_push_noninteractive.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Every `git push` in CI must be unable to block on an interactive credential prompt.
+
+A self-hosted runner carries whatever credential helper its host is configured with
+(`osxkeychain`, `git-credential-manager`). When a push's URL-embedded token is rejected --
+or when git decides to consult a helper for any other reason -- the helper is spawned and
+waits for input that never arrives on a headless runner. `git push` then blocks forever.
+
+Nothing bounds that wait. The job runs to GitHub's 360-minute job limit and is killed, so a
+step that exists only to *report* a result instead destroys it: the run's own test verdict,
+already known hours earlier, is replaced by a timed-out job. Observed daily on `integration
+tests (models)`, where `Push snapshots to branch` blocked for 4h15m after the commit it had
+just made, with `git-credential-` and `git-remote-http` still alive at job cleanup.
+
+The invariant, applied to every `run:` block in `.github/workflows` and `.github/actions`:
+
+    a step that runs `git push` must invoke it with an empty `credential.helper`,
+    and must set `GIT_TERMINAL_PROMPT: '0'` in its `env:`
+
+The two halves cover different escapes. `credential.helper=''` stops a *configured* helper
+from being consulted at all; `GIT_TERMINAL_PROMPT=0` stops git's own built-in terminal
+prompt, which needs no helper. Either alone still hangs.
+
+There is deliberately no exemption list. A push that "cannot" hang today is one runner
+migration away from hanging, and an allowlist entry is where the next one would hide.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOTS = (pathlib.Path(".github/workflows"), pathlib.Path(".github/actions"))
+
+# `git push`, allowing any `-c key=value` / `--flag` between `git` and the subcommand, and
+# tolerating a line continuation before it. `\bgit\b` so `gh` or `legit` never matches.
+GIT_PUSH = re.compile(r"\bgit\b(?P<opts>(?:\s+(?:-c\s+\S+|--?[\w-]+(?:=\S+)?))*)\s*\\?\s*\n?\s*push\b")
+
+# `-c credential.helper=` with an empty value: bare, '' or "". A NON-empty value would name
+# a helper to use, which is the opposite of what is wanted, so it must not satisfy this.
+EMPTY_HELPER = re.compile(r"-c\s+credential\.helper=(?:''|\"\"|(?=\s|$))")
+
+TERMINAL_PROMPT = re.compile(r"^\s*GIT_TERMINAL_PROMPT\s*:\s*['\"]?0['\"]?\s*$", re.M)
+
+
+def steps(text):
+    """Yield (line_no, step_text) for each top-level list item in a YAML steps: block.
+
+    Parsed textually rather than with a YAML loader on purpose: the loader resolves
+    `${{ }}` expressions into plain strings and discards the source line numbers this
+    check reports, and a workflow that fails to load would silently check nothing.
+
+    A step starts at a `- ` item whose indentation is the shallowest seen for a list item
+    carrying `run:`/`uses:`, and runs until the next item at that same indentation.
+    """
+    lines = text.splitlines(keepends=True)
+    starts = [
+        (i, len(m.group(1)))
+        for i, ln in enumerate(lines)
+        if (m := re.match(r"^(\s*)-\s+\S", ln))
+    ]
+    if not starts:
+        return
+    # Step items are the ones at the indentation used by `- name:` / `- uses:` entries.
+    depths = [d for i, d in starts if re.match(r"^\s*-\s+(name|uses|run|id|if)\s*:", lines[i])]
+    if not depths:
+        return
+    depth = min(depths)
+    bounds = [i for i, d in starts if d == depth]
+    for n, start in enumerate(bounds):
+        end = bounds[n + 1] if n + 1 < len(bounds) else len(lines)
+        yield start + 1, "".join(lines[start:end])
+
+
+def run_block(step):
+    """The shell body of a step's `run:`, with whole-line comments removed.
+
+    Only the shell body may be scanned for `git push`. A step *named* "…git push", or a
+    comment explaining why a push is guarded, is prose -- matching it would report a
+    violation against a step that runs no push at all.
+    """
+    lines = step.splitlines(keepends=True)
+    for i, ln in enumerate(lines):
+        m = re.match(r"^(\s*)run\s*:\s*(.*)$", ln)
+        if not m:
+            continue
+        indent, inline = len(m.group(1)), m.group(2).strip()
+        if inline and inline not in ("|", ">", "|-", ">-", "|+", ">+"):
+            body = [inline + "\n"]  # `run: git push …` on one line
+        else:
+            body = []
+            for nxt in lines[i + 1:]:
+                if nxt.strip() and len(nxt) - len(nxt.lstrip()) <= indent:
+                    break
+                body.append(nxt)
+        return "".join(l for l in body if not l.lstrip().startswith("#"))
+    return ""
+
+
+def violations(path, text):
+    """Every reason this file's steps could block on a credential prompt."""
+    found = []
+    for line_no, step in steps(text):
+        body = run_block(step)
+        pushes = list(GIT_PUSH.finditer(body))
+        if not pushes:
+            continue
+        where = f"{path}:{line_no}"
+        for m in pushes:
+            if not EMPTY_HELPER.search(m.group("opts")):
+                found.append(
+                    f"{where}: `git push` runs without `-c credential.helper=''`, so a "
+                    f"credential helper on the runner can intercept it and block on an "
+                    f"interactive prompt until the job's 360-minute limit"
+                )
+        if not TERMINAL_PROMPT.search(step):
+            found.append(
+                f"{where}: the step runs `git push` but does not set "
+                f"`GIT_TERMINAL_PROMPT: '0'` in its `env:`, so git's own terminal prompt "
+                f"can still block it"
+            )
+    return found
+
+
+def manifests():
+    for root in ROOTS:
+        if not root.is_dir():
+            continue
+        yield from sorted(root.glob("*.yml"))
+        yield from sorted(root.glob("*/action.yml"))
+
+
+def main():
+    found, checked = [], 0
+    for path in manifests():
+        try:
+            text = path.read_text(encoding="utf8")
+        except OSError as exc:
+            print(f"could not read {path}: {exc}", file=sys.stderr)
+            return 2
+        checked += 1
+        found.extend(violations(path.as_posix(), text))
+
+    if not checked:
+        print("no workflow or action manifests found -- run from the repository root", file=sys.stderr)
+        return 2
+
+    if found:
+        print("CI `git push` invocations that can block on a credential prompt:\n", file=sys.stderr)
+        for v in found:
+            print(f"  {v}", file=sys.stderr)
+        print(
+            "\nPrefix the push with `git -c credential.helper='' -c credential.interactive=false`"
+            "\nand add `GIT_TERMINAL_PROMPT: '0'` to the step's `env:`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"CI git-push guard OK: {checked} manifest(s) checked, no unbounded credential prompts")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_ci_git_push_noninteractive.py
+++ b/scripts/test_check_ci_git_push_noninteractive.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Unit tests for the CI git-push guard's parser.
+
+The live-tree scan only covers the shapes today's `.github/` happens to contain, so a
+parser that stopped recognising `git push` at all would report a clean tree and pass
+unnoticed -- the guard would be silently dead. These pin both directions on fixed inputs.
+"""
+
+import sys
+
+from check_ci_git_push_noninteractive import steps, violations
+
+FAILURES = []
+
+
+def check(name, cond):
+    if not cond:
+        FAILURES.append(name)
+
+
+# The exact pre-fix shape of `.github/actions/push-snap-changes/action.yml`. This is the
+# regression case: the guard MUST reject it, or it would not have caught the hang.
+PRE_FIX = """\
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload snapshots to branch
+      shell: bash
+      run: |
+        git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${R}.git"
+        git push origin "HEAD:${BRANCH_NAME}"
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+"""
+
+POST_FIX = """\
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload snapshots to branch
+      shell: bash
+      run: |
+        git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${R}.git"
+        git -c credential.helper='' -c credential.interactive=false \\
+          push origin "HEAD:${BRANCH_NAME}"
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        GIT_TERMINAL_PROMPT: '0'
+"""
+
+pre = violations("a.yml", PRE_FIX)
+check("pre-fix shape is rejected", len(pre) == 2)
+check("pre-fix names the missing helper flag", any("credential.helper" in v for v in pre))
+check("pre-fix names the missing prompt env", any("GIT_TERMINAL_PROMPT" in v for v in pre))
+check("post-fix shape is accepted", violations("a.yml", POST_FIX) == [])
+
+# Half a fix is still a hang: each half must be required on its own.
+HELPER_ONLY = POST_FIX.replace("        GIT_TERMINAL_PROMPT: '0'\n", "")
+check("helper flag alone is rejected", len(violations("a.yml", HELPER_ONLY)) == 1)
+
+PROMPT_ONLY = POST_FIX.replace(
+    "git -c credential.helper='' -c credential.interactive=false \\\n          push",
+    "git push",
+)
+check("prompt env alone is rejected", len(violations("a.yml", PROMPT_ONLY)) == 1)
+
+# A NON-empty helper names a helper to consult -- the opposite of the fix -- so it must
+# not satisfy the check. Without the empty-value assertion this passed.
+NAMED_HELPER = POST_FIX.replace("credential.helper=''", "credential.helper=osxkeychain")
+check("a named helper is rejected", len(violations("a.yml", NAMED_HELPER)) == 1)
+
+# `"" ` is the same empty value spelled the other way.
+DQUOTED = POST_FIX.replace("credential.helper=''", 'credential.helper=""')
+check("double-quoted empty helper is accepted", violations("a.yml", DQUOTED) == [])
+
+# A step with no push is not this guard's business, however it spells its git calls.
+NO_PUSH = """\
+jobs:
+  b:
+    steps:
+      - name: Fetch
+        run: |
+          git fetch --unshallow || true
+          git status -s
+"""
+check("a step with no push is ignored", violations("a.yml", NO_PUSH) == [])
+
+# `gh` is not `git`, and a word ending in `git` is not `git` either.
+NOT_GIT = """\
+jobs:
+  b:
+    steps:
+      - name: Not a git push
+        run: |
+          gh push-something
+          echo "legit push origin main"
+"""
+check("gh / substring matches are not treated as git push", violations("a.yml", NOT_GIT) == [])
+
+# Several steps in one file: the guard must attribute a violation to the offending step and
+# leave a compliant sibling alone. A parser that fused steps would report one or zero.
+TWO_STEPS = POST_FIX + """\
+    - name: Second, unguarded
+      shell: bash
+      run: |
+        git push origin other
+"""
+two = violations("a.yml", TWO_STEPS)
+check("only the offending sibling step is reported", len(two) == 2)
+
+# Step splitting itself: a parser that found no steps would return no violations and the
+# whole guard would pass vacuously on every file.
+check("steps() splits the two-step document", len(list(steps(TWO_STEPS))) == 2)
+check("steps() splits a workflow job's steps", len(list(steps(NOT_GIT))) == 1)
+
+if FAILURES:
+    print("FAILED:", file=sys.stderr)
+    for f in FAILURES:
+        print(f"  - {f}", file=sys.stderr)
+    sys.exit(1)
+
+print("CI git-push guard parser tests OK")


### PR DESCRIPTION
## Summary

`git push` in CI consults whatever credential helper the runner host is configured with
(`osxkeychain`, `git-credential-manager`). When the URL-embedded token is rejected, the helper
is spawned and waits on stdin — input that never arrives on a headless runner. Nothing bounds
that wait, so the job runs to GitHub's 360-minute limit and is killed.

Because the pushing step exists only to *report* a result, the timeout destroys the verdict the
run had already produced. In run 33223137247, `Test Hugging Face Models` knew its test step had
failed at 03:03:58, then sat in `Push snapshots to branch` until 07:20:10 — 4h15m — and was
reported as `cancelled`. The runner's cleanup names what was still alive after four hours:

```
Terminate orphan process: pid (57648) (git-credential-)
Terminate orphan process: pid (57646) (git-remote-http)
```

Four of the last five scheduled runs hung in at least one job. When it does not hang, the same
step finishes in 1–23 seconds.

This was already fixed once, at a single site: `generate_json_schema.yml` disables the helper
and sets `GIT_TERMINAL_PROMPT`. The shared `push-snap-changes` action — which carries the push
for **8 call sites across 6 workflows** — and six other workflows never received it.

## Changes

- **`.github/actions/push-snap-changes/action.yml`** — both pushes (the branch push and the
  superseded-branch delete) run with an empty `credential.helper`; the step sets
  `GIT_TERMINAL_PROMPT: '0'`. The delete's `|| true` bounded its exit status, not its wall
  clock, so it could hang identically.
- **Six other workflows** with an unguarded push get the same treatment:
  `build_nightly`, `generate-openapi`, `generate_acknowledgements`, `testoperator_run_bench`,
  `testoperator_run_cluster_bench`, `testoperator_run_schema`. The step-level env also covers
  the `git ls-remote` / `git pull` / `git fetch` calls beside those pushes.
- **`timeout-minutes: 10`** on all 8 `push-snap-changes` call sites. `timeout-minutes` is not
  available inside a composite action, so the bound has to live at the call site. This is
  defence in depth: a future hang by some *other* mechanism then costs 10 minutes instead of
  the job's whole 360-minute budget and the test result with it.
- **`scripts/check_ci_git_push_noninteractive.py`** + its parser unit test, run by the new
  `ci_git_push_guard.yml` — the fix above was already made once and did not reach the shared
  action, so the guard is what stops that recurring.

Both halves of the guard are required because they cover different escapes:
`credential.helper=''` stops a *configured* helper being consulted at all, while
`GIT_TERMINAL_PROMPT=0` stops git's own built-in terminal prompt, which needs no helper.

There is deliberately no exemption list — an allowlist entry is where the next unbounded push
would hide.

### Why this cannot break the pushes that authenticate via `origin`

`testoperator_run_bench`, `testoperator_run_cluster_bench` and `build_nightly` push to `origin`
rather than a token URL. None of them sets `persist-credentials: false`, so `actions/checkout`
authenticates them with an `http.https://github.com/.extraheader` entry in the **local** repo
config — visible in the job log's own cleanup (`Removing HTTP extra header`). That mechanism is
independent of `credential.helper`, so disabling the helper cannot affect them. Where a
credential genuinely is bad, git now fails fast instead of blocking for six hours.

## Test plan

- `make lint` and `make nextest` — unaffected; this PR changes no Rust (no path matches the
  `RUST_AFFECTING_PATH_PATTERN`, so `Attestation` fast-tracks).
- `python3 scripts/test_check_ci_git_push_noninteractive.py` — 14 parser assertions, including
  the exact pre-fix shape of `push-snap-changes`, each half of the fix rejected on its own, a
  non-empty `credential.helper=osxkeychain` rejected, and `gh`/`legit` not matched as `git`.
- `python3 scripts/check_ci_git_push_noninteractive.py` — passes on this branch (117 manifests: both the `.yml` and `.yaml` spellings of every workflow and action manifest).
- **Regression check against the unfixed tree**: running the guard over `origin/trunk`'s
  `.github/` reports **15 violations across all 7 push sites** and exits 1. It correctly does
  *not* flag `generate_json_schema.yml`, the one site that was already guarded — so the guard
  discriminates rather than flagging every push.
- All 13 changed YAML manifests parse.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1 with "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` is not installed in this environment. Receipt: `engine=none exit=1 job=none`, base `origin/trunk`.
- `/security-review`: no findings. The diff only *removes* interactive-credential capability and adds a read-only static check. The one new surface — `ci_git_push_guard.yml` executing repo-authored Python — uses `pull_request` (not `pull_request_target`) on a GitHub-hosted ephemeral runner with `permissions: contents: read` and `persist-credentials: false`, matching the existing `sccache_preflight_test.yml` model; it is deliberately not on the self-hosted pool, which is the variant that would have been a real finding.
- Follow-up commit `03076afb1f` (Copilot's `.yaml` finding, below): the adversarial engine was still out of credits, so that pass remains a declared skip. `/security-review` was not re-run for it — the change only widens a read-only scan's file globs and a workflow's `paths:` filter, adding no new surface. Guard, parser tests and the pre-fix regression check were re-run and are green at 117 manifests.
- `/simplify`: applied. Condensed a 4–6 line rationale comment that had been copy-pasted at 7 push sites down to a pointer at the guard's docstring, which now owns the explanation; dropped a redundant `\n?\s*` from the `GIT_PUSH` regex (`\s` already spans newlines); renamed an ambiguous `l` loop variable. Guard, parser tests and the pre-fix regression check were all re-run after the edits, including re-confirming the guard still fails on unfixed `trunk`.

Fixes #13701
Refs #12396

## Checklist

- [x] Root cause identified from run logs, not inferred
- [x] Reproduced across multiple runs (4 of the last 5 scheduled runs)
- [x] Whole bug class fixed — all 7 push sites, not just the one that hung
- [x] Regression guard fails on the pre-fix tree and passes on this one
- [x] Guard's own parser unit-tested, so it cannot pass vacuously
- [x] Verified the change cannot break `origin`-authenticated pushes
- [x] All changed YAML parses
- [x] Copilot's `.yaml`-blind-spot finding verified against the tree, fixed, and the guard's own `paths:` filter widened to match