### PR TITLE
fix(runtime-request-context): remove infallible Windows OS version result

### DIFF
--- a/crates/runtime-request-context/src/user_agent.rs
+++ b/crates/runtime-request-context/src/user_agent.rs
@@ -200,22 +200,23 @@ fn get_os_version_internal() -> Result<String, GenericError> {
 }
 
 #[cfg(target_family = "windows")]
-fn get_os_version_internal() -> Result<String, GenericError> {
+fn get_os_version_internal() -> String {
     use winver::WindowsVersion;
     if let Some(version) = WindowsVersion::detect() {
-        Ok(version.to_string())
+        version.to_string()
     } else {
-        Ok("unknown".to_string())
+        "unknown".to_string()
     }
 }
 
 #[must_use]
 fn get_runtime_os_string() -> String {
     let os_type = os_type();
-    let os_version = get_os_version_internal()
-        .unwrap_or_else(|_| "unknown".to_string())
-        .trim()
-        .to_string();
+    #[cfg(target_family = "unix")]
+    let os_version = get_os_version_internal().unwrap_or_else(|_| "unknown".to_string());
+    #[cfg(target_family = "windows")]
+    let os_version = get_os_version_internal();
+    let os_version = os_version.trim().to_string();
     let os_arch = os_arch();
 
     format!("{os_type}/{os_version} {os_arch}")


### PR DESCRIPTION
## 📝 Summary

On Windows, `get_os_version_internal` had no error path but returned `Result`, causing the workspace's pedantic Clippy gate to fail on unmodified `trunk`. Return `String` from the Windows implementation and retain the Unix error fallback at the shared caller.

## 🔗 Related

Closes #13687

## 👀 Notes for Reviewers

Validated on Windows with Rust 1.96.1:

- `cargo +1.96.1 clippy -p runtime-request-context --tests --no-deps`
- `cargo +1.96.1 test -p runtime-request-context --lib` (56 passed)
- `cargo +1.96.1 fmt -p runtime-request-context --check`

`cargo +1.96.1 fmt --all --check` could not complete because pre-existing snapshot paths exceed the Windows path limit (OS error 206); the touched crate's format check passed. Repository sign-off for a fork contribution must be posted by a maintainer.
