### PR TITLE
fix(search): remove the vector a rejected write left behind (fixes #13504)

### DIFF
--- a/crates/search/src/index/elasticsearch/delete.rs
+++ b/crates/search/src/index/elasticsearch/delete.rs
@@ -140,32 +140,93 @@ pub async fn delete_by_keys(
             continue;
         };
 
-        let resp = match client.delete_by_query(es_index, &query).await {
-            Ok(resp) => resp,
-            Err(e) => {
-                // Only a refused connection proves this chunk never reached the index, and so
-                // that no later chunk will either — stopping there costs nothing and spares a
-                // dead node one request per remaining chunk. Every other error leaves the
-                // delete's fate unknown: `JsonParse` is raised *after* a 2xx, so Elasticsearch
-                // ran that delete and only the body was unreadable, and a status error or a
-                // timeout can each land on a request the index already applied in part. Treating
-                // those as "never reached" and returning is what would leave the later chunks
-                // unissued — the same larger divergence a partial body is held open for above.
-                let never_reached = matches!(
-                    &e,
-                    elasticsearch::Error::HttpRequest { source } if source.is_connect()
-                );
-                failure.get_or_insert(DataFusionError::External(Box::new(e)));
-                if never_reached {
-                    break;
-                }
-                continue;
+        let outcome = issue_delete_chunk(client, es_index, &query).await;
+        if let Some(e) = outcome.failure {
+            failure.get_or_insert(e);
+        }
+        if outcome.never_reached {
+            break;
+        }
+    }
+
+    if let Some(e) = failure {
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+/// What issuing one `_delete_by_query` chunk produced: the failure to report, if any, and
+/// whether the rest of the batch has anything to reach.
+struct ChunkOutcome {
+    failure: Option<DataFusionError>,
+    never_reached: bool,
+}
+
+/// Issue one `_delete_by_query` and classify what came back.
+///
+/// Only a refused connection proves this chunk never reached the index, and so that no later
+/// chunk will either — stopping there costs nothing and spares a dead node one request per
+/// remaining chunk. Every other error leaves the delete's fate unknown: `JsonParse` is raised
+/// *after* a 2xx, so Elasticsearch ran that delete and only the body was unreadable, and a
+/// status error or a timeout can each land on a request the index already applied in part.
+/// Treating those as "never reached" is what would leave the later chunks unissued — a larger
+/// divergence than the one being reported.
+async fn issue_delete_chunk(
+    client: &dyn Elasticsearch,
+    es_index: &str,
+    query: &Value,
+) -> ChunkOutcome {
+    match client.delete_by_query(es_index, query).await {
+        Ok(resp) => ChunkOutcome {
+            // Report the first, which is the one whose surrounding state a reconcile starts
+            // from; later chunks fail the same way once the index has diverged.
+            failure: inspect_delete_response(&resp, es_index)
+                .err()
+                .map(|e| DataFusionError::External(Box::new(e))),
+            never_reached: false,
+        },
+        Err(e) => {
+            let never_reached = matches!(
+                &e,
+                elasticsearch::Error::HttpRequest { source } if source.is_connect()
+            );
+            ChunkOutcome {
+                failure: Some(DataFusionError::External(Box::new(e))),
+                never_reached,
             }
-        };
-        if let Err(e) = inspect_delete_response(&resp, es_index) {
-            // Report the first, which is the one whose surrounding state a reconcile starts from;
-            // later chunks fail the same way once the index has diverged.
-            failure.get_or_insert(DataFusionError::External(Box::new(e)));
+        }
+    }
+}
+
+/// Delete the documents stored under `ids`, addressing them by `_id`.
+///
+/// The write path derives each document's `_id` from its row's primary key and holds it while
+/// building the batch, so a write that could not index a row already has the identity of the
+/// document it has to remove — no re-derivation, and no dependence on the key's field mapping
+/// (see [`delete_by_keys`] for why filtering on a key column is not reliable).
+///
+/// Chunked and error-reported exactly as [`delete_by_keys`] is, via [`issue_delete_chunk`].
+pub async fn delete_by_ids(
+    client: &dyn Elasticsearch,
+    es_index: &str,
+    ids: &[String],
+) -> DataFusionResult<()> {
+    let mut failure: Option<DataFusionError> = None;
+
+    for chunk in ids.chunks(DELETE_CHUNK_ROWS) {
+        let values: Vec<Value> = chunk.iter().cloned().map(Value::String).collect();
+        if values.is_empty() {
+            continue;
+        }
+        let query = json!({ "ids": { "values": values } });
+
+        let outcome = issue_delete_chunk(client, es_index, &query).await;
+        if let Some(e) = outcome.failure {
+            failure.get_or_insert(e);
+        }
+        if outcome.never_reached {
+            break;
         }
     }
 
@@ -889,6 +950,96 @@ mod tests {
         .expect("delete should succeed");
 
         assert_eq!(client.present_ids(), vec!["ORDER-1024", "ORDER-1026"]);
+    }
+
+    fn ids(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| (*v).to_string()).collect()
+    }
+
+    /// End-to-end over the modeled store: the write path's eviction removes exactly the
+    /// documents whose rows it could not index, and leaves every other document alone.
+    #[tokio::test]
+    async fn delete_by_ids_removes_only_the_addressed_documents() {
+        let client = RecordingClient::with_ids(&["ORDER-1024", "ORDER-1025", "ORDER-1026"]);
+
+        delete_by_ids(&client, "idx", &ids(&["ORDER-1025"]))
+            .await
+            .expect("delete should succeed");
+
+        assert_eq!(client.present_ids(), vec!["ORDER-1024", "ORDER-1026"]);
+    }
+
+    #[tokio::test]
+    async fn delete_by_ids_addresses_documents_by_id() {
+        let client = RecordingClient::default();
+
+        delete_by_ids(&client, "idx", &ids(&["7", "8"]))
+            .await
+            .expect("delete should succeed");
+
+        assert_eq!(
+            client.queries(),
+            vec![json!({"ids": {"values": ["7", "8"]}})]
+        );
+    }
+
+    /// A write that rejected nothing must not reach Elasticsearch at all — an `ids` query
+    /// with an empty list is not a no-op to send, it is a request that costs a round trip.
+    #[tokio::test]
+    async fn delete_by_ids_issues_no_request_for_an_empty_list() {
+        let client = RecordingClient::default();
+
+        delete_by_ids(&client, "idx", &[])
+            .await
+            .expect("delete should succeed");
+
+        assert!(client.queries().is_empty());
+    }
+
+    /// Chunked exactly as [`delete_by_keys`] is, so a large eviction cannot build an
+    /// unbounded id list in one request.
+    #[tokio::test]
+    async fn delete_by_ids_chunks_a_large_eviction() {
+        let client = RecordingClient::default();
+        let all: Vec<String> = (0..=DELETE_CHUNK_ROWS).map(|i| i.to_string()).collect();
+
+        delete_by_ids(&client, "idx", &all)
+            .await
+            .expect("delete should succeed");
+
+        let queries = client.queries();
+        assert_eq!(queries.len(), 2, "one request per {DELETE_CHUNK_ROWS} ids");
+        let first = queries[0]["ids"]["values"]
+            .as_array()
+            .expect("an ids query carries an array");
+        assert_eq!(first.len(), DELETE_CHUNK_ROWS);
+    }
+
+    /// The eviction reports a partially-applied delete the same way [`delete_by_keys`] does:
+    /// a document left in place is a stale vector still being served.
+    #[tokio::test]
+    async fn delete_by_ids_reports_a_partially_applied_delete() {
+        let client = RecordingClient::answering(json!({
+            "took": 1,
+            "timed_out": false,
+            "total": 2,
+            "deleted": 1,
+            "batches": 1,
+            "version_conflicts": 1,
+            "noops": 0,
+            "retries": {"bulk": 0, "search": 0},
+            "throttled_millis": 0,
+            "failures": [],
+        }));
+
+        let err = delete_by_ids(&client, "idx", &ids(&["7", "8"]))
+            .await
+            .expect_err("a delete that left a document behind must be reported");
+
+        assert!(
+            err.to_string().contains("only partially"),
+            "unexpected error: {err}"
+        );
     }
 
     /// An index with no primary key writes documents under generated `_id`s, so there is no id

--- a/crates/search/src/index/elasticsearch/mod.rs
+++ b/crates/search/src/index/elasticsearch/mod.rs
@@ -122,6 +122,100 @@ pub struct ElasticsearchIndex {
     pub write_maintenance: Arc<ElasticsearchIndexWriteMaintenance>,
 }
 
+/// A client whose every call is a test failure.
+///
+/// Some write-path helpers take the whole [`ElasticsearchIndex`] but touch neither the
+/// cluster nor the embedder — they are handed the embeddings and the `_id`s. Those tests
+/// still have to populate the struct's fields, and this makes an accidental call loud
+/// rather than letting a stub quietly answer one.
+#[cfg(test)]
+pub(super) mod unused_client {
+    use elasticsearch::{
+        Elasticsearch, Error, MappingResponse, Result, SearchRequest, SearchResponse,
+    };
+
+    #[derive(Debug)]
+    pub(crate) struct UnusedClient;
+
+    impl UnusedClient {
+        fn refuse<T>(method: &str) -> Result<T> {
+            Err(Error::ElasticsearchError {
+                status: 500,
+                message: format!("unexpected call to {method}"),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Elasticsearch for UnusedClient {
+        async fn get_mapping(&self, _: &str) -> Result<MappingResponse> {
+            Self::refuse("get_mapping")
+        }
+        async fn search(&self, _: &str, _: &SearchRequest) -> Result<SearchResponse> {
+            Self::refuse("search")
+        }
+        async fn search_raw(&self, _: &str, _: &serde_json::Value) -> Result<SearchResponse> {
+            Self::refuse("search_raw")
+        }
+        async fn open_point_in_time(&self, _: &str, _: &str) -> Result<String> {
+            Self::refuse("open_point_in_time")
+        }
+        async fn search_point_in_time(&self, _: &serde_json::Value) -> Result<SearchResponse> {
+            Self::refuse("search_point_in_time")
+        }
+        async fn close_point_in_time(&self, _: &str) -> Result<()> {
+            Self::refuse("close_point_in_time")
+        }
+        async fn index_exists(&self, _: &str) -> Result<bool> {
+            Self::refuse("index_exists")
+        }
+        async fn create_index(&self, _: &str, _: &serde_json::Value) -> Result<serde_json::Value> {
+            Self::refuse("create_index")
+        }
+        async fn put_mapping(&self, _: &str, _: &serde_json::Value) -> Result<serde_json::Value> {
+            Self::refuse("put_mapping")
+        }
+        async fn get_index_refresh_interval(&self, _: &str) -> Result<Option<String>> {
+            Self::refuse("get_index_refresh_interval")
+        }
+        async fn put_index_settings(
+            &self,
+            _: &str,
+            _: &serde_json::Value,
+        ) -> Result<serde_json::Value> {
+            Self::refuse("put_index_settings")
+        }
+        async fn refresh_index(&self, _: &str) -> Result<serde_json::Value> {
+            Self::refuse("refresh_index")
+        }
+        async fn force_merge(&self, _: &str, _: u32) -> Result<serde_json::Value> {
+            Self::refuse("force_merge")
+        }
+        async fn index_document(
+            &self,
+            _: &str,
+            _: &str,
+            _: &serde_json::Value,
+        ) -> Result<serde_json::Value> {
+            Self::refuse("index_document")
+        }
+        async fn bulk_index(
+            &self,
+            _: &str,
+            _: &[(Option<String>, serde_json::Value)],
+        ) -> Result<serde_json::Value> {
+            Self::refuse("bulk_index")
+        }
+        async fn delete_by_query(
+            &self,
+            _: &str,
+            _: &serde_json::Value,
+        ) -> Result<serde_json::Value> {
+            Self::refuse("delete_by_query")
+        }
+    }
+}
+
 /// Optional Elasticsearch maintenance to run around full/append table-sink writes.
 #[derive(Debug, Clone, Default)]
 pub struct ElasticsearchIndexWriteOptions {

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -36,8 +36,9 @@ use serde_json::Value;
 use snafu::{ResultExt, Snafu};
 use util::{convert_string_arrow_to_iterator, distribute_nulls};
 
-use crate::index::elasticsearch::ElasticsearchIndex;
+use crate::index::elasticsearch::{ElasticsearchIndex, delete};
 use crate::index::embedding_col;
+use crate::index::write_util;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -109,6 +110,14 @@ pub enum Error {
         "Failed to write to Elasticsearch index '{index}': source column '{column}' collides with the configured vector_field name. Rename one of the columns so the embedding vector does not silently overwrite a source value."
     ))]
     VectorFieldCollidesWithSourceColumn { index: String, column: String },
+
+    #[snafu(display(
+        "Failed to update the search index '{index}' (elasticsearch): the documents stored for the records this write could not embed could not be removed, so a search would return them at their previous value. Cause: {source}"
+    ))]
+    CannotEvictRejectedRecords {
+        index: String,
+        source: datafusion::error::DataFusionError,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -160,8 +169,20 @@ pub async fn write(index: &ElasticsearchIndex, record: RecordBatch) -> Result<Re
 
     // Build all documents in a sync block so the arrow-json encoders (which are
     // `!Send`) are dropped before any subsequent `.await`.
-    let docs: Vec<(Option<String>, Value)> =
+    let (docs, evicted): (Vec<(Option<String>, Value)>, Vec<String>) =
         build_documents(index, &record, &embedding_vectors, &primary_keys)?;
+
+    // Before the bulk index, not after it: a key this batch both rejects and indexes is
+    // excluded from `evicted`, so deleting first is what lets the two orders agree.
+    // No rejected row means no extra request at all.
+    if !evicted.is_empty() {
+        delete::delete_by_ids(index.client.as_ref(), es_index, &evicted)
+            .await
+            .map_err(|source| Error::CannotEvictRejectedRecords {
+                index: es_index.to_string(),
+                source,
+            })?;
+    }
 
     if docs.is_empty() {
         tracing::debug!(
@@ -200,14 +221,18 @@ pub async fn write(index: &ElasticsearchIndex, record: RecordBatch) -> Result<Re
 
 /// Build ES `_bulk` documents from a record batch + pre-computed embeddings.
 ///
+/// Returns the documents to index and, beside them, the `_id`s of the rows this batch
+/// could not index and must therefore delete (see [`write_util::keys_to_evict`]).
+///
 /// Kept sync so the arrow-json encoders it uses (which are `!Send`) stay off
 /// the async state machine.
+#[expect(clippy::type_complexity)]
 fn build_documents(
     index: &ElasticsearchIndex,
     record: &RecordBatch,
     embedding_vectors: &[Option<Vec<f32>>],
     primary_keys: &[Option<String>],
-) -> Result<Vec<(Option<String>, Value)>> {
+) -> Result<(Vec<(Option<String>, Value)>, Vec<String>)> {
     // Aggregate per-row skip reasons into batch-level counts (plus a small
     // sample of row indices) to avoid high-volume per-row logs on large
     // batches with many NULLs or invalid embeddings.
@@ -261,16 +286,25 @@ fn build_documents(
 
     let expected_dims = usize::try_from(index.dims.max(0)).unwrap_or(0);
 
+    // The `_id`s of rows this batch could not index. A document already stored under
+    // one of them holds a vector from an earlier value of the row's text, which a
+    // search would go on returning — see [`write_util::keys_to_evict`].
+    let mut rejected: Vec<String> = Vec::new();
+
     for row in 0..record.num_rows() {
         let Some(embedding) = embedding_vectors[row].as_ref() else {
             missing_embedding_skips += 1;
+            if let Some(id) = primary_keys[row].as_ref() {
+                rejected.push(id.clone());
+            }
             continue;
         };
 
         // Skip rows with NULL primary keys when a primary key is configured.
         // Without an `_id`, Elasticsearch would auto-generate one, making
         // re-indexing the same row non-idempotent (producing duplicates on
-        // refresh/CDC writes).
+        // refresh/CDC writes). No `_id` also means no document this write can
+        // address, so there is nothing for it to evict.
         if !index.primary_key.is_empty() && primary_keys[row].is_none() {
             null_pk_skips += 1;
             if null_pk_samples.len() < SAMPLE_LIMIT {
@@ -293,6 +327,9 @@ fn build_documents(
             if zero_or_nan_samples.len() < SAMPLE_LIMIT {
                 zero_or_nan_samples.push(row);
             }
+            if let Some(id) = primary_keys[row].as_ref() {
+                rejected.push(id.clone());
+            }
             continue;
         }
 
@@ -300,6 +337,9 @@ fn build_documents(
             non_finite_skips += 1;
             if non_finite_samples.len() < SAMPLE_LIMIT {
                 non_finite_samples.push(row);
+            }
+            if let Some(id) = primary_keys[row].as_ref() {
+                rejected.push(id.clone());
             }
             continue;
         }
@@ -342,12 +382,12 @@ fn build_documents(
     }
     if zero_or_nan_skips > 0 {
         tracing::warn!(
-            "Skipped {zero_or_nan_skips} record(s) for Elasticsearch index '{es_index}': embedding vector is all zeros or NaN. Sample row indices: {zero_or_nan_samples:?}"
+            "Skipped {zero_or_nan_skips} record(s) for Elasticsearch index '{es_index}': embedding vector is all zeros or NaN. Any document already stored for those records is removed, so a search does not return them at their previous value. Sample row indices: {zero_or_nan_samples:?}"
         );
     }
     if non_finite_skips > 0 {
         tracing::warn!(
-            "Skipped {non_finite_skips} record(s) for Elasticsearch index '{es_index}': embedding vector contains non-finite values (NaN or infinity). Sample row indices: {non_finite_samples:?}"
+            "Skipped {non_finite_skips} record(s) for Elasticsearch index '{es_index}': embedding vector contains non-finite values (NaN or infinity). Any document already stored for those records is removed, so a search does not return them at their previous value. Sample row indices: {non_finite_samples:?}"
         );
     }
     if missing_embedding_skips > 0 {
@@ -356,7 +396,9 @@ fn build_documents(
         );
     }
 
-    Ok(docs)
+    let indexed = docs.iter().filter_map(|(id, _)| id.as_deref());
+    let evicted = write_util::keys_to_evict(rejected, indexed);
+    Ok((docs, evicted))
 }
 
 async fn embed_column(
@@ -940,6 +982,145 @@ mod tests {
             panic!("expected a BulkIndexItemErrors rejection");
         };
         failures
+    }
+
+    mod eviction {
+        use std::sync::Arc;
+
+        use arrow::array::{Int64Array, RecordBatch, StringArray};
+        use arrow_schema::{DataType, Field, Schema};
+
+        use super::super::build_documents;
+        use crate::index::elasticsearch::{
+            ElasticsearchIndex, ElasticsearchIndexWriteMaintenance, unused_client,
+        };
+        use crate::metadata::MetadataColumns;
+
+        const DIMS: i32 = 2;
+
+        /// `build_documents` neither embeds nor talks to Elasticsearch — it is handed the
+        /// embeddings and the `_id`s — so the index's client and embedder only have to exist.
+        #[derive(Debug)]
+        struct Unused;
+
+        #[async_trait::async_trait]
+        impl llms::embeddings::Embed for Unused {
+            async fn embed(
+                &self,
+                _input: llms::embeddings::EmbeddingInput,
+            ) -> llms::embeddings::Result<Vec<Vec<f32>>> {
+                panic!("build_documents must not embed");
+            }
+
+            fn size(&self) -> i32 {
+                DIMS
+            }
+        }
+
+        fn index() -> ElasticsearchIndex {
+            let source_schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("content", DataType::Utf8, true),
+            ]));
+            ElasticsearchIndex {
+                client: Arc::new(unused_client::UnusedClient),
+                es_index: "idx".to_string(),
+                embedded_column: "content".to_string(),
+                vector_field: "content_vector".to_string(),
+                text_fields: vec![],
+                primary_key: vec![Field::new("id", DataType::Int64, false)],
+                compute_query: Arc::new(Unused),
+                dims: DIMS,
+                similarity: "cosine".to_string(),
+                source_schema,
+                metadata_columns: MetadataColumns::none(),
+                batch_write_rows: 100,
+                write_maintenance: Arc::new(ElasticsearchIndexWriteMaintenance::default()),
+            }
+        }
+
+        fn record(ids: &[i64]) -> RecordBatch {
+            let schema = Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int64, false),
+                Field::new("content", DataType::Utf8, true),
+            ]));
+            let contents: Vec<String> = ids.iter().map(|id| format!("row {id}")).collect();
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(Int64Array::from(ids.to_vec())),
+                    Arc::new(StringArray::from(contents)),
+                ],
+            )
+            .expect("valid test batch")
+        }
+
+        fn keys(ids: &[i64]) -> Vec<Option<String>> {
+            ids.iter().map(|id| Some(id.to_string())).collect()
+        }
+
+        fn evicted(ids: &[i64], embeddings: &[Option<Vec<f32>>]) -> Vec<String> {
+            let index = index();
+            let (_docs, evicted) = build_documents(&index, &record(ids), embeddings, &keys(ids))
+                .expect("documents build");
+            let mut evicted = evicted;
+            evicted.sort();
+            evicted
+        }
+
+        /// Regression test for #13503. A row rewritten from an indexable embedding to a
+        /// rejected one is left out of the `_bulk` body, which only ever carries `index`
+        /// actions — so the document stored under its `_id` survives untouched and search
+        /// keeps returning it at the vector its previous text produced.
+        #[test]
+        fn an_all_zero_or_nan_embedding_evicts_its_document() {
+            assert_eq!(
+                evicted(
+                    &[1, 2, 3],
+                    &[
+                        Some(vec![1.0, 2.0]),
+                        Some(vec![0.0, 0.0]),
+                        Some(vec![f32::NAN, f32::NAN]),
+                    ],
+                ),
+                vec!["2".to_string(), "3".to_string()],
+            );
+        }
+
+        /// Elasticsearch is the one backend that already rejected a *partially* non-finite
+        /// vector, so this class is live on it today.
+        #[test]
+        fn a_partially_non_finite_embedding_evicts_its_document() {
+            assert_eq!(
+                evicted(
+                    &[1, 2, 3],
+                    &[
+                        Some(vec![1.0, 2.0]),
+                        Some(vec![1.0, f32::NAN]),
+                        Some(vec![1.0, f32::INFINITY]),
+                    ],
+                ),
+                vec!["2".to_string(), "3".to_string()],
+            );
+        }
+
+        /// No embedding at all — a NULL or empty search text — leaves the same stale
+        /// document behind as a rejected one.
+        #[test]
+        fn a_row_with_no_embedding_evicts_its_document() {
+            assert_eq!(
+                evicted(&[1, 2], &[Some(vec![1.0, 2.0]), None]),
+                vec!["2".to_string()],
+            );
+        }
+
+        #[test]
+        fn a_batch_that_indexes_every_row_evicts_nothing() {
+            assert!(
+                evicted(&[1, 2], &[Some(vec![1.0, 2.0]), Some(vec![3.0, 4.0])]).is_empty(),
+                "the happy path must issue no delete request at all"
+            );
+        }
     }
 
     #[test]

--- a/crates/search/src/index/elasticsearch/write.rs
+++ b/crates/search/src/index/elasticsearch/write.rs
@@ -172,8 +172,13 @@ pub async fn write(index: &ElasticsearchIndex, record: RecordBatch) -> Result<Re
     let (docs, evicted): (Vec<(Option<String>, Value)>, Vec<String>) =
         build_documents(index, &record, &embedding_vectors, &primary_keys)?;
 
-    // Before the bulk index, not after it: a key this batch both rejects and indexes is
-    // excluded from `evicted`, so deleting first is what lets the two orders agree.
+    // Before the bulk index, for two reasons. A key this batch both rejects and indexes is
+    // excluded from `evicted`, so deleting first is what lets the two orders agree. And the
+    // delete and the `_bulk` are separate requests that cannot be made atomic, so one of them
+    // has to be able to land without the other: deleting first fails toward the stale document
+    // being gone, whereas indexing first fails toward it still being searchable — which is the
+    // bug. A retry of the whole batch converges either way, because the delete is idempotent
+    // and the rows it addresses are exactly the ones no `index` action will restore.
     // No rejected row means no extra request at all.
     if !evicted.is_empty() {
         delete::delete_by_ids(index.client.as_ref(), es_index, &evicted)

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -192,14 +192,17 @@ impl MemoryVectorIndex {
 
     /// Project the write-output batch down to the stored schema, dropping
     /// rows that cannot be indexed (null primary key, or a null/invalid
-    /// embedding). Returns the filtered batch and its formatted keys.
+    /// embedding). Returns the filtered batch, its formatted keys, and the keys
+    /// whose row was dropped and so must not keep an earlier entry in the store
+    /// (see [`write_util::keys_to_evict`]).
     fn batch_for_store(
         &self,
         output: &RecordBatch,
         primary_keys: &[Option<String>],
         embedding_vectors: &[Option<Vec<f32>>],
-    ) -> Result<(RecordBatch, Vec<String>), Error> {
+    ) -> Result<(RecordBatch, Vec<String>, Vec<String>), Error> {
         let mut keys = Vec::with_capacity(primary_keys.len());
+        let mut rejected = Vec::new();
         let mask: BooleanArray = primary_keys
             .iter()
             .zip(embedding_vectors.iter())
@@ -212,19 +215,27 @@ impl MemoryVectorIndex {
                         if valid {
                             keys.push(key.clone());
                         } else {
+                            rejected.push(key.clone());
                             tracing::warn!(
-                                "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes or contains only invalid values"
+                                "Skipping record '{key}' for memory vector index '{INDEX_NAME}': Embedding vector is all zeroes or contains only invalid values. Any vector already stored for this record is removed, so it is not returned at its previous value"
                             );
                         }
                         valid
                     }
                     (None, _) => {
+                        // No key to address an earlier entry with, so there is
+                        // nothing this write can evict.
                         tracing::warn!(
                             "Skipping a record for memory vector index '{INDEX_NAME}': the primary key is NULL"
                         );
                         false
                     }
-                    (Some(_), None) => false, // NULL/empty search text — nothing to index.
+                    // NULL/empty search text — nothing to index, and an entry
+                    // stored under this key from an earlier text must go with it.
+                    (Some(key), None) => {
+                        rejected.push(key.clone());
+                        false
+                    }
                 };
                 Some(keep)
             })
@@ -252,7 +263,8 @@ impl MemoryVectorIndex {
                 index: INDEX_NAME.to_string(),
             },
         )?;
-        Ok((batch, keys))
+        let evicted = write_util::keys_to_evict(rejected, keys.iter().map(String::as_str));
+        Ok((batch, keys, evicted))
     }
 }
 
@@ -439,9 +451,9 @@ impl SearchIndex for MemoryVectorIndex {
         let output =
             write_util::sort_columns_alphabetically(updated).map_err(|e| Error::from(*e))?;
 
-        let (store_batch, keys) =
+        let (store_batch, keys, evicted) =
             self.batch_for_store(&output, &primary_keys, &embedding_vectors)?;
-        self.store.write().upsert(store_batch, keys)?;
+        self.store.write().upsert(store_batch, keys, &evicted)?;
 
         Ok(output)
     }
@@ -609,6 +621,111 @@ mod tests {
             .on_write_complete()
             .await
             .expect("the write window closes");
+    }
+
+    /// A batch whose `content` is given per row, so a row can carry text that embeds to a
+    /// vector the write rejects, or no text at all.
+    fn batch_with_contents(ids: &[i64], contents: &[Option<&str>]) -> RecordBatch {
+        assert_eq!(ids.len(), contents.len(), "one content per id");
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("content", DataType::Utf8, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(ids.to_vec())),
+                Arc::new(StringArray::from(contents.to_vec())),
+            ],
+        )
+        .expect("valid test batch")
+    }
+
+    async fn write_batch(index: &MemoryVectorIndex, record: RecordBatch) {
+        index
+            .compute_index(vec![record])
+            .await
+            .expect("the rows are indexed");
+    }
+
+    /// `\0` embeds to an all-zero vector under [`ByteEmbed`] (`0 / 255.0` per component),
+    /// which is exactly what the write path rejects as having no defined direction.
+    const REJECTED_TEXT: &str = "\0";
+
+    #[tokio::test]
+    async fn the_rejected_text_fixture_really_is_rejected() {
+        assert!(
+            byte_vector(REJECTED_TEXT)
+                .iter()
+                .all(|&v| v == 0.0 || v.is_nan()),
+            "the rewrite tests below are vacuous unless this text embeds to a rejected vector"
+        );
+    }
+
+    /// Regression test for #13504. A row rewritten from indexable text to text whose
+    /// embedding the write rejects was dropped from the write but left in the store, so
+    /// vector search kept returning it at the vector its *previous* text produced — while
+    /// the write's own log line said the row was not indexed.
+    #[tokio::test]
+    async fn a_rewrite_to_a_rejected_embedding_removes_the_previous_vector() {
+        let index = memory_index();
+        write_batch(&index, batch(&[1, 2, 3])).await;
+        assert_eq!(indexed_ids(&index), vec![1, 2, 3]);
+
+        write_batch(&index, batch_with_contents(&[2], &[Some(REJECTED_TEXT)])).await;
+
+        assert_eq!(
+            indexed_ids(&index),
+            vec![1, 3],
+            "the write reported row 2 as not indexed, so no vector for it may remain searchable"
+        );
+    }
+
+    /// The same mechanism reached through the other arm: a row whose search text becomes
+    /// NULL produces no embedding at all, and the entry its previous text stored must go
+    /// with it rather than stay searchable under the old value.
+    #[tokio::test]
+    async fn a_rewrite_to_null_text_removes_the_previous_vector() {
+        let index = memory_index();
+        write_batch(&index, batch(&[1, 2, 3])).await;
+
+        write_batch(&index, batch_with_contents(&[2], &[None])).await;
+
+        assert_eq!(indexed_ids(&index), vec![1, 3]);
+    }
+
+    /// The eviction must not reach beyond the rows the write rejected.
+    #[tokio::test]
+    async fn a_rejected_row_does_not_evict_the_rows_written_beside_it() {
+        let index = memory_index();
+        write_batch(&index, batch(&[1, 2, 3])).await;
+
+        write_batch(
+            &index,
+            batch_with_contents(
+                &[1, 2, 3],
+                &[Some("one"), Some(REJECTED_TEXT), Some("three")],
+            ),
+        )
+        .await;
+
+        assert_eq!(
+            indexed_ids(&index),
+            vec![1, 3],
+            "only the rejected row leaves the index; its neighbours are rewritten as usual"
+        );
+    }
+
+    /// A first write for a key that is rejected has nothing to evict, and must not disturb
+    /// the rest of the index.
+    #[tokio::test]
+    async fn a_first_write_that_is_rejected_leaves_the_index_untouched() {
+        let index = memory_index();
+        write_batch(&index, batch(&[1, 3])).await;
+
+        write_batch(&index, batch_with_contents(&[2], &[Some(REJECTED_TEXT)])).await;
+
+        assert_eq!(indexed_ids(&index), vec![1, 3]);
     }
 
     /// The regression test. A `refresh_mode: full` refresh removes a row by not re-sending

--- a/crates/search/src/index/memory/store.rs
+++ b/crates/search/src/index/memory/store.rs
@@ -101,16 +101,28 @@ impl MemoryVectorStore {
     }
 
     /// Replace-on-rewrite insert: drops any stored row whose formatted primary
-    /// key appears in `keys`, then appends the new batch. `keys` must be
-    /// parallel to `batch` rows.
+    /// key appears in `keys` or `evicted`, then appends the new batch. `keys`
+    /// must be parallel to `batch` rows.
+    ///
+    /// `evicted` names keys this write could not index at all, so `batch` carries
+    /// no row for them and only the delete applies. Deleting them here rather
+    /// than in a separate call keeps the store's all-or-nothing delete over the
+    /// whole set, so a failure leaves every row the store held before the call.
     pub(crate) fn upsert(
         &mut self,
         batch: RecordBatch,
         keys: Vec<String>,
+        evicted: &[String],
     ) -> Result<(), DataFusionError> {
         debug_assert_eq!(batch.num_rows(), keys.len());
 
-        self.delete_by_keys(&keys)?;
+        if evicted.is_empty() {
+            self.delete_by_keys(&keys)?;
+        } else {
+            let mut all = keys.clone();
+            all.extend_from_slice(evicted);
+            self.delete_by_keys(&all)?;
+        }
         if batch.num_rows() > 0 {
             self.write_target().push(StoredBatch { batch, keys });
         }
@@ -325,7 +337,7 @@ mod tests {
 
         // `upsert` deletes the superseded rows first, so it inherits the same failure.
         store
-            .upsert(batch(&[5]), keys(&[5]))
+            .upsert(batch(&[5]), keys(&[5]), &[])
             .expect_err("a batch whose mask does not match its rows cannot be filtered");
 
         assert_eq!(
@@ -340,7 +352,7 @@ mod tests {
         let mut store = store_of(&[&[1, 2]]);
         store.begin_replace_window();
         store
-            .upsert(batch(&[3, 4]), keys(&[3, 4]))
+            .upsert(batch(&[3, 4]), keys(&[3, 4]), &[])
             .expect("staging a batch inside a replace window succeeds");
         store.write_target().push(StoredBatch {
             batch: batch(&[5, 6]),

--- a/crates/search/src/index/s3_vectors/mod.rs
+++ b/crates/search/src/index/s3_vectors/mod.rs
@@ -412,11 +412,65 @@ impl S3Vector {
         &self,
         key_strings: Vec<String>,
     ) -> Result<(), DataFusionError> {
+        // Resolving the targets lists indexes in AWS, so nothing to delete must cost nothing.
+        if key_strings.is_empty() {
+            return Ok(());
+        }
+        let tables = self.delete_target_tables().await?;
+        self.delete_key_strings_from(tables, key_strings).await
+    }
+
+    /// Remove the vectors a write could not replace, from the index that write is targeting.
+    ///
+    /// The broadcast [`Self::delete_target_tables`] performs exists because a resolved
+    /// delete-key batch cannot say which physical index a key's vector landed in. A write
+    /// does not have that problem for partitioning: it is *inside* the partition it
+    /// evaluated, and `table` is the very index it is about to `PutVectors` into, so the
+    /// stale vector for a rejected row in that partition is in `table` or nowhere. Routing
+    /// there instead of broadcasting keeps a partitioned write linear — the broadcast is
+    /// issued per chunk *and* per partition, and each one re-lists every partition index, so
+    /// it costs O(partitions²) `DeleteVectors` calls for what one call reaches.
+    ///
+    /// Spill writes are the case a write genuinely cannot resolve: which spill index absorbed
+    /// a key depends on write-time AWS quota state, so those still broadcast.
+    ///
+    /// A row whose *partition value* changed leaves its old vector in the old partition index.
+    /// That is untouched here on purpose: the `PutVectors` beside this delete has the same
+    /// blind spot, so a cross-partition move is a pre-existing gap in the write path rather
+    /// than something eviction can close on its own.
+    pub(super) async fn evict_written_keys(
+        &self,
+        table: &S3VectorsTable,
+        key_strings: Vec<String>,
+    ) -> Result<(), DataFusionError> {
+        if key_strings.is_empty() {
+            return Ok(());
+        }
+        let tables = self.evict_target_tables(table).await?;
+        self.delete_key_strings_from(tables, key_strings).await
+    }
+
+    /// The physical indexes [`Self::evict_written_keys`] must reach for a write targeting
+    /// `table`.
+    async fn evict_target_tables(
+        &self,
+        table: &S3VectorsTable,
+    ) -> Result<Vec<S3VectorsTable>, DataFusionError> {
+        if self.spill_writes {
+            return self.delete_target_tables().await;
+        }
+        Ok(vec![table.clone()])
+    }
+
+    async fn delete_key_strings_from(
+        &self,
+        tables: Vec<S3VectorsTable>,
+        key_strings: Vec<String>,
+    ) -> Result<(), DataFusionError> {
         if key_strings.is_empty() {
             return Ok(());
         }
 
-        let tables = self.delete_target_tables().await?;
         let num_tables = tables.len();
 
         let results = join_all(tables.into_iter().map(|table| {
@@ -683,6 +737,67 @@ mod tests {
                 "virtual-index-01".to_string(),
                 "virtual-index-02".to_string(),
             ]
+        );
+    }
+
+    /// A write already knows which partition index it is writing to, so evicting the rows it
+    /// rejected must go there rather than re-listing and broadcasting to every partition. The
+    /// broadcast is issued per chunk *and* per partition, so leaving it in place costs
+    /// O(partitions²) `DeleteVectors` calls for what one call reaches.
+    #[tokio::test]
+    async fn a_partitioned_write_evicts_only_from_the_index_it_writes_to() {
+        let client = Arc::new(MockClient::new()) as Arc<dyn S3Vectors + Send + Sync>;
+        let mut index = test_s3_vector(Arc::clone(&client)).await;
+        index.partition_by = vec![col("region")];
+
+        for value in ["us", "eu"] {
+            let partitioned_name = PartitionedIndexName::new(
+                "virtual-index",
+                &index.embedded_column,
+                &index.partition_by,
+                &ScalarValue::from(value),
+            )
+            .expect("valid partition name")
+            .to_index_name();
+            create_index(&client, &partitioned_name).await;
+        }
+
+        let broadcast = index
+            .delete_target_tables()
+            .await
+            .expect("should resolve targets");
+        assert_eq!(broadcast.len(), 2, "the key-only delete still broadcasts");
+
+        let targeted = index
+            .evict_target_tables(&index.table)
+            .await
+            .expect("should resolve targets");
+        assert_eq!(
+            index_names(&targeted),
+            vec!["virtual-index".to_string()],
+            "the write's own target, not every partition index"
+        );
+    }
+
+    /// Spill writes are the case a write genuinely cannot resolve: which spill index absorbed
+    /// a key depends on write-time AWS quota state, so eviction must still broadcast.
+    #[tokio::test]
+    async fn a_spilling_write_still_evicts_from_every_spill_index() {
+        let mock_client = Arc::new(MockClient::new());
+        let client = Arc::clone(&mock_client) as Arc<dyn S3Vectors + Send + Sync>;
+        let mut index = test_s3_vector(Arc::clone(&client)).await;
+        index = index.enable_spill_writes();
+
+        create_index(&client, "virtual-index-01").await;
+
+        let targeted = index
+            .evict_target_tables(&index.table)
+            .await
+            .expect("should resolve targets");
+
+        assert_eq!(
+            index_names(&targeted),
+            vec!["virtual-index".to_string(), "virtual-index-01".to_string()],
         );
     }
 

--- a/crates/search/src/index/s3_vectors/mod.rs
+++ b/crates/search/src/index/s3_vectors/mod.rs
@@ -398,6 +398,24 @@ impl Index for S3Vector {
                 .flatten()
                 .collect();
 
+        self.delete_key_strings(key_strings).await
+    }
+}
+
+impl S3Vector {
+    /// Remove every vector stored under `key_strings`, from every physical index a delete
+    /// must reach (see [`Self::delete_target_tables`]).
+    ///
+    /// Shared by [`VectorIndex::delete_by_keys`], which resolves the keys from a batch, and
+    /// by the write path, which already holds them as strings for the rows it rejected.
+    pub(super) async fn delete_key_strings(
+        &self,
+        key_strings: Vec<String>,
+    ) -> Result<(), DataFusionError> {
+        if key_strings.is_empty() {
+            return Ok(());
+        }
+
         let tables = self.delete_target_tables().await?;
         let num_tables = tables.len();
 
@@ -422,9 +440,7 @@ impl Index for S3Vector {
             )))
         }
     }
-}
 
-impl S3Vector {
     /// Every physical S3 Vectors index a delete of `self` must reach.
     ///
     /// Broadcasts to every index that could hold a matching key rather than routing to the exact

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -81,6 +81,14 @@ pub enum Error {
         #[snafu(source(from(data_components::s3_vectors::Error, Box::new)))]
         source: Box<data_components::s3_vectors::Error>,
     },
+
+    #[snafu(display(
+        "Failed to update search index '{index}' (s3_vectors): the vectors stored for the records this write could not embed could not be removed, so a search would return them at their previous value. Check the index's AWS credentials grant s3vectors:DeleteVectors, then write the affected rows again. See: https://spiceai.org/docs/features/search. Cause: {source}"
+    ))]
+    CannotEvictRejectedRecords {
+        index: String,
+        source: datafusion::error::DataFusionError,
+    },
 }
 
 /// Extra index data from the raw table batches, embedded required column and write to [`S3VectorsTable`].
@@ -185,8 +193,20 @@ async fn process_single_batch(
     .map_err(|e| Error::from(*e))?;
 
     // Filter out zero vectors to prevent cosine similarity calculation errors
-    let (filtered_embeddings, filtered_primary_key, filtered_metadata) =
+    let (filtered_embeddings, filtered_primary_key, filtered_metadata, evicted) =
         filter_zero_vectors(embedding_vectors, primary_key, metadata, index.name());
+
+    // Before the put, not after it: a key this batch both rejects and stores is
+    // excluded from `evicted`, so deleting first is what lets the two orders agree.
+    // No rejected row means no extra call at all.
+    if !evicted.is_empty() {
+        index.delete_key_strings(evicted).await.map_err(|source| {
+            Error::CannotEvictRejectedRecords {
+                index: index.name().to_string(),
+                source,
+            }
+        })?;
+    }
 
     let spill_index = index.spill_index().await.context(CannotWriteIndexSnafu {
         index: index.name().to_string(),
@@ -274,6 +294,11 @@ pub fn extract_and_format_metadata(
 /// - `[0.0, NaN]` -> filtered (all values are either zero or NaN)
 /// - `[1.0, 0.0]` -> kept (has a valid non-zero value)
 /// - `[1.0, NaN]` -> kept (has a valid non-NaN value)
+///
+/// The fourth element is the keys this batch will not store a vector for and so must
+/// delete, per [`write_util::keys_to_evict`]. It covers the rows filtered here and the
+/// rows carrying no embedding at all — `write_data` drops a `None` embedding, which
+/// leaves an earlier vector in place just as a filtered row does.
 #[expect(clippy::type_complexity)]
 fn filter_zero_vectors(
     mut embeddings: Vec<Option<Vec<f32>>>,
@@ -284,20 +309,24 @@ fn filter_zero_vectors(
     Vec<Option<Vec<f32>>>,
     Vec<Option<String>>,
     HashMap<String, Vec<Option<Value>>>,
+    Vec<String>,
 ) {
+    let mut rejected: Vec<String> = Vec::new();
     // Filter in reverse order to avoid index shifting when removing elements
     for i in (0..embeddings.len()).rev() {
         if let Some(embedding) = &embeddings[i]
             // Single pass: check if all values are zero or NaN (both are invalid embeddings)
             && embedding.iter().all(|&x| x == 0.0 || x.is_nan())
         {
-            let key_str = primary_keys
-                .get(i)
-                .and_then(|k| k.as_ref().map(String::as_str))
-                .unwrap_or("unknown");
+            let key = primary_keys.get(i).and_then(Option::as_ref);
+            let key_str = key.map_or("unknown", String::as_str);
             tracing::warn!(
-                "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values"
+                "Skipping record '{key_str}' for S3 Vector index '{index_name}': Embedding vector is all zeroes or contains only invalid values. Any vector already stored for this record is removed, so it is not returned at its previous value"
             );
+            // A NULL key addresses no stored vector, so there is nothing to remove.
+            if let Some(key) = key {
+                rejected.push(key.clone());
+            }
 
             embeddings.remove(i);
             primary_keys.remove(i);
@@ -307,7 +336,26 @@ fn filter_zero_vectors(
         }
     }
 
-    (embeddings, primary_keys, metadata)
+    // `write_data` skips a row whose embedding is `None` (a NULL or empty search
+    // text), so those keys keep whatever vector an earlier text stored.
+    let indexed: Vec<&str> = embeddings
+        .iter()
+        .zip(primary_keys.iter())
+        .filter_map(|(embedding, key)| match (embedding, key) {
+            (Some(_), Some(key)) => Some(key.as_str()),
+            _ => None,
+        })
+        .collect();
+    rejected.extend(
+        embeddings
+            .iter()
+            .zip(primary_keys.iter())
+            .filter(|(embedding, _)| embedding.is_none())
+            .filter_map(|(_, key)| key.clone()),
+    );
+
+    let evicted = write_util::keys_to_evict(rejected, indexed);
+    (embeddings, primary_keys, metadata, evicted)
 }
 
 #[cfg(test)]
@@ -344,7 +392,7 @@ mod tests {
             ],
         );
 
-        let (filtered_embeddings, filtered_keys, filtered_metadata) =
+        let (filtered_embeddings, filtered_keys, filtered_metadata, _evicted) =
             filter_zero_vectors(embeddings, keys, metadata, "test_index");
 
         assert_eq!(filtered_embeddings.len(), 3);
@@ -389,7 +437,7 @@ mod tests {
             ],
         );
 
-        let (filtered_embeddings, filtered_keys, filtered_metadata) =
+        let (filtered_embeddings, filtered_keys, filtered_metadata, _evicted) =
             filter_zero_vectors(embeddings, keys, metadata, "test_index");
 
         // Should keep only the 2 valid vectors
@@ -402,6 +450,87 @@ mod tests {
         assert_eq!(filtered_embeddings[1], Some(vec![3.0, 4.0]));
         assert_eq!(filtered_keys[0], Some("key1".to_string()));
         assert_eq!(filtered_keys[1], Some("key4".to_string()));
+    }
+
+    fn keys_of(keys: &[Option<&str>]) -> Vec<Option<String>> {
+        keys.iter().map(|k| k.map(ToString::to_string)).collect()
+    }
+
+    /// Regression test for #13504. A row rewritten from an indexable embedding to a rejected
+    /// one is dropped from the `PutVectors` call, so without a delete beside it the vector
+    /// its previous text produced stays in the index and goes on being returned.
+    #[test]
+    fn a_rejected_row_is_named_for_deletion() {
+        let embeddings = vec![
+            Some(vec![1.0, 2.0]),           // indexed
+            Some(vec![0.0, 0.0]),           // rejected — all zeros
+            Some(vec![f32::NAN, f32::NAN]), // rejected — all NaN
+        ];
+        let keys = keys_of(&[Some("kept"), Some("zeroed"), Some("nan")]);
+
+        let (_, _, _, evicted) =
+            filter_zero_vectors(embeddings, keys, HashMap::new(), "test_index");
+
+        let mut evicted = evicted;
+        evicted.sort();
+        assert_eq!(
+            evicted,
+            vec!["nan".to_string(), "zeroed".to_string()],
+            "every rejected row must be deleted; the row that was indexed must not be"
+        );
+    }
+
+    /// `write_data` drops a `None` embedding as silently as a filtered one, so the same
+    /// stale vector survives a row whose search text became NULL or empty.
+    #[test]
+    fn a_row_with_no_embedding_at_all_is_named_for_deletion() {
+        let embeddings = vec![Some(vec![1.0, 2.0]), None];
+        let keys = keys_of(&[Some("kept"), Some("no_text")]);
+
+        let (_, _, _, evicted) =
+            filter_zero_vectors(embeddings, keys, HashMap::new(), "test_index");
+
+        assert_eq!(evicted, vec!["no_text".to_string()]);
+    }
+
+    /// A NULL primary key addresses no stored vector, so there is nothing to delete for it —
+    /// and inventing a key would delete something else.
+    #[test]
+    fn a_rejected_row_with_a_null_key_names_nothing_for_deletion() {
+        let embeddings = vec![Some(vec![0.0, 0.0]), None];
+        let keys = keys_of(&[None, None]);
+
+        let (_, _, _, evicted) =
+            filter_zero_vectors(embeddings, keys, HashMap::new(), "test_index");
+
+        assert!(evicted.is_empty(), "a NULL key names no stored vector");
+    }
+
+    /// The same key indexed and rejected within one batch: the put re-establishes it, so a
+    /// delete would only cost a round trip.
+    #[test]
+    fn a_key_this_batch_also_stores_is_not_named_for_deletion() {
+        let embeddings = vec![Some(vec![1.0, 2.0]), Some(vec![0.0, 0.0])];
+        let keys = keys_of(&[Some("same"), Some("same")]);
+
+        let (_, _, _, evicted) =
+            filter_zero_vectors(embeddings, keys, HashMap::new(), "test_index");
+
+        assert!(evicted.is_empty());
+    }
+
+    #[test]
+    fn a_batch_that_rejects_nothing_names_nothing_for_deletion() {
+        let embeddings = vec![Some(vec![1.0, 2.0]), Some(vec![3.0, 4.0])];
+        let keys = keys_of(&[Some("a"), Some("b")]);
+
+        let (_, _, _, evicted) =
+            filter_zero_vectors(embeddings, keys, HashMap::new(), "test_index");
+
+        assert!(
+            evicted.is_empty(),
+            "the happy path must issue no delete call at all"
+        );
     }
 
     #[test]

--- a/crates/search/src/index/s3_vectors/write.rs
+++ b/crates/search/src/index/s3_vectors/write.rs
@@ -196,16 +196,21 @@ async fn process_single_batch(
     let (filtered_embeddings, filtered_primary_key, filtered_metadata, evicted) =
         filter_zero_vectors(embedding_vectors, primary_key, metadata, index.name());
 
-    // Before the put, not after it: a key this batch both rejects and stores is
-    // excluded from `evicted`, so deleting first is what lets the two orders agree.
+    // Before the put, for two reasons. A key this batch both rejects and stores is excluded
+    // from `evicted`, so deleting first is what lets the two orders agree. And the delete and
+    // the put cannot be made one atomic operation against S3 Vectors, so one of them has to
+    // be able to land without the other: deleting first fails toward the stale vector being
+    // gone, whereas putting first fails toward it still being served — which is the bug.
+    // A retry of the whole batch converges either way.
     // No rejected row means no extra call at all.
     if !evicted.is_empty() {
-        index.delete_key_strings(evicted).await.map_err(|source| {
-            Error::CannotEvictRejectedRecords {
+        index
+            .evict_written_keys(table, evicted)
+            .await
+            .map_err(|source| Error::CannotEvictRejectedRecords {
                 index: index.name().to_string(),
                 source,
-            }
-        })?;
+            })?;
     }
 
     let spill_index = index.spill_index().await.context(CannotWriteIndexSnafu {
@@ -338,21 +343,15 @@ fn filter_zero_vectors(
 
     // `write_data` skips a row whose embedding is `None` (a NULL or empty search
     // text), so those keys keep whatever vector an earlier text stored.
-    let indexed: Vec<&str> = embeddings
-        .iter()
-        .zip(primary_keys.iter())
-        .filter_map(|(embedding, key)| match (embedding, key) {
-            (Some(_), Some(key)) => Some(key.as_str()),
-            _ => None,
-        })
-        .collect();
-    rejected.extend(
-        embeddings
-            .iter()
-            .zip(primary_keys.iter())
-            .filter(|(embedding, _)| embedding.is_none())
-            .filter_map(|(_, key)| key.clone()),
-    );
+    let mut indexed: Vec<&str> = Vec::with_capacity(embeddings.len());
+    for (embedding, key) in embeddings.iter().zip(primary_keys.iter()) {
+        match (embedding, key) {
+            (Some(_), Some(key)) => indexed.push(key.as_str()),
+            // A NULL key addresses no stored vector, so `None` here evicts nothing.
+            (None, Some(key)) => rejected.push(key.clone()),
+            _ => {}
+        }
+    }
 
     let evicted = write_util::keys_to_evict(rejected, indexed);
     (embeddings, primary_keys, metadata, evicted)

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -371,11 +371,10 @@ pub fn keys_to_evict<'a>(
     indexed: impl IntoIterator<Item = &'a str>,
 ) -> Vec<String> {
     let indexed: std::collections::HashSet<&str> = indexed.into_iter().collect();
-    let mut seen = std::collections::HashSet::new();
     rejected
         .into_iter()
         .filter(|key| !indexed.contains(key.as_str()))
-        .filter(|key| seen.insert(key.clone()))
+        .unique()
         .collect()
 }
 

--- a/crates/search/src/index/write_util.rs
+++ b/crates/search/src/index/write_util.rs
@@ -344,6 +344,41 @@ pub fn create_embedding_array(
     Ok(Arc::new(builder.finish()))
 }
 
+/// The primary keys a write must remove from its index because it could not index
+/// the rows they name.
+///
+/// A vector write drops a row it cannot embed — a NULL or empty search text, or a
+/// vector with no defined direction under any metric the index offers. Dropping it
+/// from the write is not the same as removing it from the index: whatever the index
+/// already holds under that key stays there, so a row rewritten from an indexable
+/// value to a rejected one goes on being returned at its previous vector while the
+/// write's own log line says the row was not indexed.
+///
+/// A stale vector is a wrong search result — the index asserts the row matches text
+/// it no longer contains. An absent one is a correct-by-omission result that agrees
+/// with what the write reported, and it costs nothing that is not recoverable: a
+/// vector index is derived from its source table, so the row itself is untouched and
+/// the next indexable write restores it. Removing the entry is therefore the one
+/// behaviour every backend can implement with the delete primitive it already has,
+/// and it is what these paths do.
+///
+/// `indexed` is what this same write is about to store. A key in both — the batch
+/// carries the key twice, once indexable and once not — is not evicted: the write
+/// that follows re-establishes it, so issuing a delete for it would only cost a round
+/// trip. Callers must still delete before they write, so the two orders agree.
+pub fn keys_to_evict<'a>(
+    rejected: impl IntoIterator<Item = String>,
+    indexed: impl IntoIterator<Item = &'a str>,
+) -> Vec<String> {
+    let indexed: std::collections::HashSet<&str> = indexed.into_iter().collect();
+    let mut seen = std::collections::HashSet::new();
+    rejected
+        .into_iter()
+        .filter(|key| !indexed.contains(key.as_str()))
+        .filter(|key| seen.insert(key.clone()))
+        .collect()
+}
+
 /// Reorder a [`RecordBatch`]'s columns alphabetically by field name.
 ///
 /// Because of limitations of `DFSchema::logically_equivalent_names_and_types` and its use in
@@ -635,6 +670,43 @@ mod tests {
             .map(|f| f.name().clone())
             .collect();
         assert_eq!(names, vec!["alpha".to_string(), "zeta".to_string()]);
+    }
+
+    fn owned(keys: &[&str]) -> Vec<String> {
+        keys.iter().map(|k| (*k).to_string()).collect()
+    }
+
+    #[test]
+    fn keys_to_evict_names_every_rejected_key_the_write_does_not_also_store() {
+        let evicted = keys_to_evict(owned(&["a", "b"]), ["c"]);
+        assert_eq!(
+            evicted,
+            owned(&["a", "b"]),
+            "a rejected key is what leaves a stale vector behind, so it must be evicted"
+        );
+    }
+
+    /// The batch carries one key twice — once indexable, once not. The write that follows
+    /// re-establishes it, so a delete for it would be undone by this same write.
+    #[test]
+    fn keys_to_evict_skips_a_key_the_same_write_also_indexes() {
+        let evicted = keys_to_evict(owned(&["a", "b"]), ["b"]);
+        assert_eq!(evicted, owned(&["a"]));
+    }
+
+    #[test]
+    fn keys_to_evict_deduplicates_a_key_rejected_more_than_once() {
+        let evicted = keys_to_evict(owned(&["a", "a", "b", "a"]), std::iter::empty());
+        assert_eq!(
+            evicted,
+            owned(&["a", "b"]),
+            "one delete per key is enough; repeating it only costs request size"
+        );
+    }
+
+    #[test]
+    fn keys_to_evict_is_empty_when_the_write_rejected_nothing() {
+        assert!(keys_to_evict(Vec::new(), ["a", "b"]).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A vector write drops a row it cannot embed. Dropping it from the write is not the same as
removing it from the index: whatever the index already holds under that row's primary key stays
there. So a row rewritten from an indexable value to a rejected one goes on being returned at
the vector its *previous* text produced, while the write's own log line says the row was not
indexed. The two statements a user gets are in direct conflict, and the index is the one that is
wrong — it asserts the row matches text the row no longer contains.

None of the three external vector backends removed the entry:

- **memory** (`index/memory/mod.rs`) — the rejected row is masked out of the batch *and* its key
  is omitted from `keys`, so `MemoryVectorStore::upsert`'s delete never names it.
- **S3 Vectors** (`index/s3_vectors/write.rs`) — `filter_zero_vectors` removes the row before
  `write_data`, which only issues `PutVectors` for survivors. No `DeleteVectors` was issued.
- **Elasticsearch** (`index/elasticsearch/write.rs`) — the row is skipped before `docs.push`, and
  the `_bulk` body only ever carries `index` actions, so a document already stored under that
  `_id` survives untouched.

## The decision

Both issues ask for one decision applied to every backend, because the remedy is a behaviour
choice rather than a patch. **A rejected row's stale entry is removed.**

A stale vector is a wrong search result. An absent one is a correct-by-omission result that
agrees with what the write reported, and it costs nothing unrecoverable: a vector index is
derived from its source table, so the row itself is untouched and the next indexable write
restores it. Removing the entry is also the one behaviour all three backends can express with a
delete primitive they already have — S3 Vectors is a pure vector store, so "keep the row, null
the embedding" has no representation there at all.

The rationale lives at `write_util::keys_to_evict`, which every backend routes its decision
through, so there is one place to change if the call is ever revisited.

## Changes

- **`write_util::keys_to_evict`** — the shared decision, plus the exclusion rule: a key this same
  write also indexes is not evicted, since the write that follows re-establishes it. Every caller
  deletes *before* it writes, so the two orders agree.
- **memory** — `batch_for_store` reports the keys it rejected; `MemoryVectorStore::upsert` takes
  them and folds them into its existing all-or-nothing delete, so a failure still leaves every
  row the store held before the call.
- **S3 Vectors** — `filter_zero_vectors` reports the rejected keys; the write deletes them before
  its `PutVectors`. `S3Vector::delete_key_strings` is extracted so the write path and
  `VectorIndex::delete_by_keys` share one implementation, and `evict_written_keys` routes a
  write's eviction to the index that write is targeting rather than broadcasting — see
  *Performance impact*.
- **Elasticsearch** — `build_documents` reports the rejected `_id`s; `delete::delete_by_ids`
  removes them by `_id` before the `_bulk`. It reuses the chunking and the partial-delete
  reporting `delete_by_keys` already has (both now share `issue_delete_chunk`), so an eviction
  that only partially applied is reported rather than assumed clean.
- The `zero_or_nan` / `non_finite` warnings now say the stale entry is removed, so the log matches
  what the index does.

### Beyond the two issues

Both issues describe the *invalid embedding* classes. The same mechanism is reached through a
second arm: a row whose search text becomes NULL or empty produces no embedding at all, is
dropped just as silently, and leaves the same stale vector searchable under its old text. That is
the same defect and takes the same remedy, so it is fixed here too rather than left as half the
class. It is called out because it changes a path currently logged as expected — see *Performance
impact*.

## Performance impact

The delete is issued only when a write actually rejected a row, so a batch that indexes every row
makes no extra call at all; that is asserted by a test on each backend.

The cost lands on datasets where rejection is a steady state rather than an anomaly — chiefly a
nullable search column, now that the absent-embedding arm evicts too. Such a write issues one
extra `_delete_by_query` per 512 rejected ids (Elasticsearch) or one broadcast `DeleteVectors`
(S3 Vectors) per batch, on every refresh, for rows that mostly have nothing to delete. The memory
backend is unaffected: its eviction is a local filter with no I/O.

A write's eviction is routed rather than broadcast on S3 Vectors. The broadcast
`delete_target_tables` performs exists because a resolved delete-key batch cannot say which
physical index a key's vector landed in; a write does not have that problem for partitioning,
because it is inside the partition it evaluated. Broadcasting there would have cost
O(partitions²) `DeleteVectors` calls — the broadcast is issued per chunk *and* per partition, and
re-lists every partition index each time. Spill writes still broadcast, since which spill index
absorbed a key depends on write-time AWS quota state.

The delete precedes the write on both external backends, and that ordering is deliberate: the two
cannot be made one atomic operation, so one has to be able to land without the other. Deleting
first fails toward the stale entry being gone; writing first fails toward it still being served,
which is the bug. A retry of the batch converges either way.

A cheaper shape exists for Elasticsearch — `delete` actions inside the same `_bulk` request,
costing extra NDJSON lines instead of a round trip. It is not taken here because it requires a new
method on the `Elasticsearch` client trait, and because a bulk `delete` of a missing document has
response semantics this change would have to get exactly right to avoid turning a first write of a
NULL-text row into a hard failure. `_delete_by_query` with an `ids` query reuses a path this repo
has already reasoned about, including treating `total: 0` as clean.

If a reviewer would rather the absent-embedding arm stay as it was, it is separable: it is the
`(Some(key), None)` arm in `batch_for_store`, the `embedding.is_none()` pass in
`filter_zero_vectors`, and the `missing_embedding_skips` branch in `build_documents`.

## Known limit

On a **chunked** index a NULL search text yields zero chunks, so the row never reaches the inner
index at all and this eviction cannot see it — the row contributes no rows to the batch, rather
than a row the backend can reject. Closing that means changing `ChunkedSearchIndex`'s write
semantics to remove a rewritten outer key's existing chunks first, which is a different change in
a different layer. Filed as #13704.

## Test plan

- `make lint`
- `make nextest`

New tests:

- `write_util` — the shared decision: rejected keys are evicted, a key the same write also indexes
  is not, duplicates collapse, and a write that rejected nothing evicts nothing.
- `memory` — the valid-to-rejected rewrite leaves nothing searchable; the same through the
  NULL-text arm; neighbours written beside a rejected row are untouched; a first write that is
  rejected leaves the index alone. Plus a fixture check that the test's "rejected" text really does
  embed to a rejected vector, so the rewrite tests cannot pass vacuously.
- `s3_vectors` — each rejected class is named for deletion, a NULL primary key names nothing, a key
  the batch also stores is excluded, and a clean batch names nothing.
- `elasticsearch` — the all-zero/NaN, partially-non-finite, and no-embedding classes each evict
  their document; a clean batch evicts nothing. Plus `delete_by_ids` over the modeled document
  store: it removes only the addressed documents, addresses them by `_id`, issues no request for an
  empty list, chunks a large eviction, and reports a partially-applied delete.
- `s3_vectors` routing — a partitioned write evicts only from the index it writes to, while the
  key-only delete beside it still broadcasts; a spilling write still reaches every spill index.

Every one of these was neutered and confirmed to fail: removing the rejected-key recording on each
backend, removing `delete_by_ids`'s request loop, removing each half of `keys_to_evict`, and
reverting the eviction routing to the broadcast. The `keys_to_evict` neuters were re-run after
`/simplify` touched that function.

Note the `elasticsearch` feature is not in the crate's defaults, so a bare
`cargo test -p search` compiles none of the Elasticsearch arm. These were run with
`--features elasticsearch,s3_vectors`, which is what the `make lint-rust` gate's feature set
covers.

## Review gate

- Adversarial review: `codex` — job `01a04cd3-7c98-7a43-8c35-0bec528294be`, verdict
  `needs-attention`. Three findings, all triaged:
  - *Chunked rewrites still leave old vectors searchable* — **valid, out of scope.** It is a
    pre-existing gap in a different layer and this change neither causes nor worsens it. Filed as
    #13704 and recorded under *Known limit*.
  - *Delete-first can commit the eviction after the overall write fails* — **partly valid, kept as
    designed.** There is no atomic delete+write against either backend, so the choice is which way
    the failure falls; deleting first fails toward the stale entry being gone, and the alternative
    it implies fails toward the bug this fixes. The reasoning was missing from the code and is now
    recorded at both call sites. The transient-rejection downside it also gestures at is the
    delete-vs-keep decision itself, taken deliberately above.
  - *Partitioned S3 writes can produce quadratic delete fan-out* — **valid and fixed**, with two
    tests and a neuter. See *Performance impact*.
- `/security-review`: no findings. The new `ids` query is built through `serde_json`, so keys are
  escaped rather than concatenated; the new error paths inherit the existing primary-key-leak
  hardening (`check_status_without_body` on `delete_by_query`, and the allowlist-based
  `describe_delete_failure` from #12370); no new logging of user data.
- `/simplify`: two fixes applied — `keys_to_evict` now uses `itertools::unique()` (already a
  dependency, already imported in that file) instead of a hand-rolled seen-set, and
  `filter_zero_vectors` makes one pass over the filtered vectors instead of two. Two findings
  skipped: the three repetitions of the id-recording line in `build_documents` (extracting it needs
  a closure holding `&mut rejected` across a loop that mutates sibling counters), and the
  `evicted.is_empty()` branch in `MemoryVectorStore::upsert` (a deliberate guard against cloning
  the key vector on the common path).

Fixes #13504
Fixes #13503
Refs #13704