### PR TITLE
fix(acceleration): stop a refresh already running from answering a later waiter (refs #13544)

### DIFF
--- a/crates/runtime-table/src/accelerated/mod.rs
+++ b/crates/runtime-table/src/accelerated/mod.rs
@@ -82,7 +82,7 @@ pub mod write_back_worker;
 pub(crate) use write::WriteMode;
 
 pub use refresh_completion::{
-    RefreshCompletion, RefreshCompletionOutcome, RefreshCompletionWaiter,
+    RefreshCompletion, RefreshCompletionOutcome, RefreshCompletionWaiter, RefreshRequestId,
 };
 pub use refresh_task_runner::RefreshTaskRunner;
 pub use snapshots::SnapshotCreationConfig;

--- a/crates/runtime-table/src/accelerated/refresh.rs
+++ b/crates/runtime-table/src/accelerated/refresh.rs
@@ -1315,11 +1315,17 @@ mod tests {
         datatypes::{DataType, Field, Fields, Schema},
     };
     use data_components::arrow::write::MemTable;
-    use datafusion::{physical_plan::collect, prelude::SessionContext};
+    use datafusion::{
+        catalog::Session, datasource::TableType, physical_plan::ExecutionPlan,
+        physical_plan::collect, prelude::SessionContext,
+    };
     use opentelemetry::global;
     use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
     use prometheus::proto::MetricType;
-    use tokio::{sync::mpsc, time::timeout};
+    use tokio::{
+        sync::{mpsc, watch},
+        time::timeout,
+    };
 
     use arrow::datatypes::SchemaRef;
     use async_trait::async_trait;
@@ -1534,19 +1540,51 @@ mod tests {
         )
     }
 
-    /// Poll the request counter rather than sleeping, so a waiter taken after
-    /// this is taken while the triggered refresh is in flight.
-    async fn await_request_issued(refresh_completion: &RefreshCompletion) {
-        timeout(Duration::from_secs(5), async {
-            while refresh_completion.issued_requests() == 0 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("the refresher requests the refresh it was triggered for");
+    /// A source that holds its scan open until the test lets it through, and
+    /// reports when a scan has entered.
+    ///
+    /// A refresh over a `MemTable` finishes inside one scheduler pass, so a
+    /// waiter taken "while it runs" is really taken after it: the interleaving
+    /// #13544 needs cannot be produced by timing alone. Gating the scan makes
+    /// the refresh provably in flight instead.
+    #[derive(Debug)]
+    struct GatedSource {
+        inner: Arc<dyn TableProvider>,
+        /// Set once, to release every waiting scan.
+        open: watch::Sender<bool>,
+        /// Scans entered so far, so the test can await one rather than spin.
+        entered: watch::Sender<u32>,
     }
 
-    /// Regression test for #13544. A refresh that was already requested when a
+    #[async_trait]
+    impl TableProvider for GatedSource {
+        fn schema(&self) -> SchemaRef {
+            self.inner.schema()
+        }
+
+        fn table_type(&self) -> TableType {
+            self.inner.table_type()
+        }
+
+        async fn scan(
+            &self,
+            state: &dyn Session,
+            projection: Option<&Vec<usize>>,
+            filters: &[datafusion_expr::Expr],
+            limit: Option<usize>,
+        ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+            self.entered.send_modify(|n| *n = n.saturating_add(1));
+            let mut open = self.open.subscribe();
+            while !*open.borrow_and_update() {
+                if open.changed().await.is_err() {
+                    break;
+                }
+            }
+            self.inner.scan(state, projection, filters, limit).await
+        }
+    }
+
+    /// Regression test for #13544. A refresh that was already running when a
     /// waiter was taken must not answer it: on the partition-assignment path
     /// that completion acked `PartitionsLoaded` for partitions the refresh
     /// carrying their filters had not yet loaded, so the scheduler routed
@@ -1555,29 +1593,42 @@ mod tests {
     /// Both halves are asserted from one refresher, because the property is a
     /// pair: the in-flight refresh must not answer, and the next one must.
     #[tokio::test]
-    async fn test_a_refresh_already_requested_does_not_answer_a_later_waiter() {
-        let (refresher, refresh_completion, trigger, refresh_handle) =
-            started_full_refresher(status::RuntimeStatus::new()).await;
+    async fn test_a_refresh_already_running_does_not_answer_a_later_waiter() {
+        // Held, not used: dropping the refresher aborts the task running the
+        // refreshes this test drives.
+        let (_refresher, refresh_completion, trigger, open, entered, refresh_handle) =
+            started_gated_refresher().await;
 
+        // Trigger the first refresh and wait until it is inside the source scan,
+        // where the gate holds it. It cannot complete from here.
+        let mut entered_rx = entered.subscribe();
         trigger.send(None).await.expect("trigger is accepted");
-        await_request_issued(&refresh_completion).await;
+        timeout(Duration::from_secs(5), entered_rx.changed())
+            .await
+            .expect("the first refresh reaches the source")
+            .expect("the source outlives the scan");
 
-        // Independent waiters, both taken with the first refresh in flight: one
-        // to prove that refresh does not answer them, one left to be answered by
-        // the refresh triggered afterwards.
+        // Independent waiters, both taken with that refresh in flight: one to
+        // prove it does not answer them, one left for the refresh triggered
+        // afterwards. `first_done` is how the test knows the first refresh
+        // finished without polling for it.
         let in_flight_waiter = refresh_completion.next();
         let next_request_waiter = refresh_completion.next();
+        let first_done = refresh_completion.any();
         assert_eq!(
             refresh_completion.completed_requests(),
             0,
-            "the first refresh completed before the waiters were taken, so this run raced past the interleaving it exists to cover"
+            "the gate must hold the first refresh open until its waiters are taken"
         );
 
-        await_initial_load(&refresher).await;
+        open.send_replace(true);
+        timeout(Duration::from_secs(5), first_done.wait())
+            .await
+            .expect("the released refresh completes");
 
         let _ = timeout(Duration::from_millis(500), in_flight_waiter.wait())
             .await
-            .expect_err("a refresh requested before the waiter was taken must not answer it");
+            .expect_err("a refresh already running when the waiter was taken must not answer it");
 
         trigger.send(None).await.expect("trigger is accepted");
         timeout(Duration::from_secs(5), next_request_waiter.wait())
@@ -1585,6 +1636,72 @@ mod tests {
             .expect("the refresh requested after the waiter must answer it");
 
         drop(refresh_handle);
+    }
+
+    /// `started_full_refresher` over a source whose scan the test controls.
+    /// Returns the gate and the scan counter alongside the usual handles.
+    async fn started_gated_refresher() -> (
+        Arc<Refresher>,
+        RefreshCompletion,
+        mpsc::Sender<Option<RefreshOverrides>>,
+        watch::Sender<bool>,
+        watch::Sender<u32>,
+        Option<tokio::task::JoinHandle<()>>,
+    ) {
+        let schema = Arc::new(Schema::new(vec![arrow::datatypes::Field::new(
+            "time_in_string",
+            DataType::Utf8,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringArray::from(vec!["1970-01-01"]))],
+        )
+        .expect("source batch builds");
+        let open = watch::Sender::new(false);
+        let entered = watch::Sender::new(0);
+        let source = Arc::new(GatedSource {
+            inner: Arc::new(
+                MemTable::try_new(Arc::clone(&schema), vec![vec![batch]])
+                    .expect("source table builds"),
+            ),
+            open: open.clone(),
+            entered: entered.clone(),
+        });
+        let federated = Arc::new(FederatedTable::new_unchecked(source));
+        let accelerator =
+            Arc::new(MemTable::try_new(schema, vec![vec![]]).expect("accelerator table builds"))
+                as Arc<dyn TableProvider>;
+
+        let refresh_completion = RefreshCompletion::new();
+        let mut refresher = Refresher::new(
+            status::RuntimeStatus::new(),
+            TableReference::bare("gated"),
+            federated,
+            Some("mem_table".to_string()),
+            Arc::new(RwLock::new(Refresh::new(RefreshMode::Full))),
+            accelerator,
+            None,
+            None,
+            Handle::current(),
+            Arc::new(Mutex::new(())),
+        );
+        refresher.with_refresh_completion(refresh_completion.clone());
+
+        let (trigger, receiver) = mpsc::channel::<Option<RefreshOverrides>>(1);
+        let refresh_handle = refresher
+            .start(AccelerationRefreshMode::Full(receiver))
+            .await
+            .expect("refresh task starts");
+
+        (
+            Arc::new(refresher),
+            refresh_completion,
+            trigger,
+            open,
+            entered,
+            refresh_handle,
+        )
     }
 
     /// Poll `initial_load_completed` rather than sleeping, so the refresh is
@@ -1779,8 +1896,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_refresh_status_change_to_ready() {
+        /// `dataset_load_state` is labelled by dataset and the meter provider is
+        /// global, so the family holds one series per dataset any concurrently
+        /// running test has registered. Select the series by its `dataset`
+        /// label — reading the first one makes this assertion depend on which
+        /// other tests happen to be in flight.
         async fn wait_until_ready_status(
             registry: &prometheus::Registry,
+            dataset: &str,
             desired: status::ComponentStatus,
             max_attempts: usize,
             delay: Duration,
@@ -1791,9 +1914,13 @@ mod tests {
                 };
 
                 let metrics = registry.gather();
-                if let Some(metric) = metrics.iter().find(|m| {
+                if let Some(family) = metrics.iter().find(|m| {
                     m.name() == "dataset_load_state" && m.get_field_type() == MetricType::GAUGE
-                }) && let Some(gauge) = metric.get_metric()[0].get_gauge().as_ref()
+                }) && let Some(series) = family.get_metric().iter().find(|m| {
+                    m.get_label()
+                        .iter()
+                        .any(|l| l.name() == "dataset" && l.value() == dataset)
+                }) && let Some(gauge) = series.get_gauge().as_ref()
                     && gauge.value().is_eq(f64::from(desired_discriminant))
                 {
                     return true;
@@ -1840,6 +1967,7 @@ mod tests {
         assert!(
             wait_until_ready_status(
                 &registry,
+                "test",
                 status::ComponentStatus::Ready,
                 60,
                 Duration::from_millis(50)
@@ -1858,6 +1986,7 @@ mod tests {
         assert!(
             wait_until_ready_status(
                 &registry,
+                "test",
                 status::ComponentStatus::Ready,
                 60,
                 Duration::from_millis(50)

--- a/crates/runtime-table/src/accelerated/refresh.rs
+++ b/crates/runtime-table/src/accelerated/refresh.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use super::refresh_task_runner::RefreshTaskRunner;
 use super::synchronized_table::SynchronizedTable;
 use super::{SnapshotCreateTrigger, SnapshotCreationConfig, metrics};
-use crate::accelerated::refresh_completion::RefreshCompletion;
+use crate::accelerated::refresh_completion::{RefreshCompletion, RefreshRequestId};
 use crate::accelerated::refresh_task::RefreshTask;
 use crate::accelerated::snapshots::{
     SnapshotCallback, canonical_checkpoint_schema, create_checkpoint_and_snapshot,
@@ -1071,7 +1071,8 @@ impl Refresher {
                 select! {
                     () = scheduled_refresh_future => {
                         tracing::debug!("Starting scheduled refresh");
-                        if let Err(err) = start_refresh.send(None).await {
+                        let request_id = issue_refresh_request(refresh_completion.as_ref());
+                        if let Err(err) = start_refresh.send((request_id, None)).await {
                             tracing::error!("Failed to execute refresh: {err}");
                         }
                     },
@@ -1085,12 +1086,17 @@ impl Refresher {
                             sleep(Self::compute_delay(Duration::from_secs(0), Some(max_jitter))).await;
                         }
 
-                        if let Err(err) = start_refresh.send(overrides_opt).await {
+                        // Numbered here rather than at the trigger: a caller
+                        // takes its waiter before triggering, so an id issued
+                        // now is one the waiter has not seen and a refresh
+                        // already running cannot claim.
+                        let request_id = issue_refresh_request(refresh_completion.as_ref());
+                        if let Err(err) = start_refresh.send((request_id, overrides_opt)).await {
                             tracing::error!("Failed to execute refresh: {err}");
                         }
                     },
-                    Some(res) = on_refresh_complete.recv() => {
-                        tracing::debug!("Received refresh task completion callback: {res:?}");
+                    Some((request_id, res)) = on_refresh_complete.recv() => {
+                        tracing::debug!("Received refresh task completion callback for request {request_id}: {res:?}");
 
                         let refresh_succeeded = matches!(&res, Ok(()));
                         // A retention failure can happen after a successful write, so cached
@@ -1104,7 +1110,7 @@ impl Refresher {
                             // this way (`RefreshTask::signal_dataset_ready`).
                             initial_load_completed.store(true, Ordering::Relaxed);
                             if let Some(refresh_completion) = &refresh_completion {
-                                record_refresh_done(&dataset_name, &refresh, refresh_completion).await;
+                                record_refresh_done(&dataset_name, &refresh, refresh_completion, request_id).await;
                             }
                         }
 
@@ -1270,14 +1276,24 @@ fn refresh_result_changed_accelerator(result: &super::Result<()>) -> bool {
     )
 }
 
-/// Records a completed refresh: releases the callers waiting on it, then
-/// publishes the refresh-time metric.
+/// Numbers a refresh about to be requested, so its completion can be told from
+/// that of a refresh already running.
+///
+/// A table with no completion signal has nobody waiting on it, so the id is
+/// unused and any value will do.
+fn issue_refresh_request(refresh_completion: Option<&RefreshCompletion>) -> RefreshRequestId {
+    refresh_completion.map_or(0, RefreshCompletion::issue)
+}
+
+/// Records a completed refresh under the request that started it: releases the
+/// callers waiting on that request, then publishes the refresh-time metric.
 async fn record_refresh_done(
     dataset_name: &TableReference,
     refresh: &Arc<RwLock<Refresh>>,
     refresh_completion: &RefreshCompletion,
+    request_id: RefreshRequestId,
 ) {
-    refresh_completion.record();
+    refresh_completion.record(request_id);
 
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1516,6 +1532,59 @@ mod tests {
             trigger,
             refresh_handle,
         )
+    }
+
+    /// Poll the request counter rather than sleeping, so a waiter taken after
+    /// this is taken while the triggered refresh is in flight.
+    async fn await_request_issued(refresh_completion: &RefreshCompletion) {
+        timeout(Duration::from_secs(5), async {
+            while refresh_completion.issued_requests() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the refresher requests the refresh it was triggered for");
+    }
+
+    /// Regression test for #13544. A refresh that was already requested when a
+    /// waiter was taken must not answer it: on the partition-assignment path
+    /// that completion acked `PartitionsLoaded` for partitions the refresh
+    /// carrying their filters had not yet loaded, so the scheduler routed
+    /// queries to an executor that answered them incompletely.
+    ///
+    /// Both halves are asserted from one refresher, because the property is a
+    /// pair: the in-flight refresh must not answer, and the next one must.
+    #[tokio::test]
+    async fn test_a_refresh_already_requested_does_not_answer_a_later_waiter() {
+        let (refresher, refresh_completion, trigger, refresh_handle) =
+            started_full_refresher(status::RuntimeStatus::new()).await;
+
+        trigger.send(None).await.expect("trigger is accepted");
+        await_request_issued(&refresh_completion).await;
+
+        // Independent waiters, both taken with the first refresh in flight: one
+        // to prove that refresh does not answer them, one left to be answered by
+        // the refresh triggered afterwards.
+        let in_flight_waiter = refresh_completion.next();
+        let next_request_waiter = refresh_completion.next();
+        assert_eq!(
+            refresh_completion.completed_requests(),
+            0,
+            "the first refresh completed before the waiters were taken, so this run raced past the interleaving it exists to cover"
+        );
+
+        await_initial_load(&refresher).await;
+
+        let _ = timeout(Duration::from_millis(500), in_flight_waiter.wait())
+            .await
+            .expect_err("a refresh requested before the waiter was taken must not answer it");
+
+        trigger.send(None).await.expect("trigger is accepted");
+        timeout(Duration::from_secs(5), next_request_waiter.wait())
+            .await
+            .expect("the refresh requested after the waiter must answer it");
+
+        drop(refresh_handle);
     }
 
     /// Poll `initial_load_completed` rather than sleeping, so the refresh is

--- a/crates/runtime-table/src/accelerated/refresh_completion.rs
+++ b/crates/runtime-table/src/accelerated/refresh_completion.rs
@@ -115,6 +115,7 @@ impl RefreshCompletion {
     /// one table in one process — and reaching it would strand waiters rather
     /// than release them early, so the failure direction is a readiness ack that
     /// is never sent rather than one sent for data that was never loaded.
+    #[must_use]
     pub fn issue(&self) -> RefreshRequestId {
         let mut id = 0;
         self.state.send_modify(|state| {

--- a/crates/runtime-table/src/accelerated/refresh_completion.rs
+++ b/crates/runtime-table/src/accelerated/refresh_completion.rs
@@ -175,19 +175,10 @@ impl RefreshCompletion {
         self.waiter(true)
     }
 
-    /// The number of requests issued so far.
-    ///
-    /// Test-only: a test that needs a refresh to be *in flight* has to wait for
-    /// the request rather than sleep for it, and nothing in production asks.
-    #[cfg(test)]
-    pub(crate) fn issued_requests(&self) -> RefreshRequestId {
-        self.state.borrow().issued
-    }
-
     /// The highest request id recorded complete so far.
     ///
-    /// Test-only, and for the same reason: it lets a test assert the refresh it
-    /// is racing against has not finished yet, so a run that loses that race
+    /// Test-only: it lets a test assert that the refresh it is holding open has
+    /// not finished, so a run that fails to reach the interleaving under test
     /// says so instead of passing vacuously.
     #[cfg(test)]
     pub(crate) fn completed_requests(&self) -> RefreshRequestId {

--- a/crates/runtime-table/src/accelerated/refresh_completion.rs
+++ b/crates/runtime-table/src/accelerated/refresh_completion.rs
@@ -139,6 +139,11 @@ impl RefreshCompletion {
     ///
     /// Such a completion answers every waiter taken before it and none taken
     /// after, which is all an uncorrelated signal can honestly claim.
+    ///
+    /// One transition rather than `record(self.issue())`: the intermediate state
+    /// of that pair is a request that has been issued and not completed, and a
+    /// waiter taken there would skip this completion and wait for the following
+    /// apply.
     pub fn record_untriggered(&self) {
         self.state.send_modify(|state| {
             state.issued = state.issued.saturating_add(1);

--- a/crates/runtime-table/src/accelerated/refresh_completion.rs
+++ b/crates/runtime-table/src/accelerated/refresh_completion.rs
@@ -16,13 +16,29 @@ limitations under the License.
 
 //! Level-triggered "a refresh finished" signal for an accelerated table.
 //!
-//! Callers ask two different questions of a refresh, and both are answered from
-//! the same count of completed refreshes:
+//! Callers ask two different questions of a refresh:
 //!
 //! * *"has the initial load landed?"* — [`RefreshCompletion::any`], satisfied by
-//!   a refresh that finished before the caller asked.
+//!   any refresh that has finished, including one that finished before the
+//!   caller asked.
 //! * *"has the refresh I just triggered finished?"* — [`RefreshCompletion::next`],
-//!   satisfied only by a refresh recorded after the waiter was taken.
+//!   satisfied only by the completion of a refresh *requested* after the waiter
+//!   was taken.
+//!
+//! The second question is why a refresh carries a [`RefreshRequestId`]. A
+//! refresh already in flight when the waiter was taken can finish a moment
+//! later, and its completion answers a question nobody asked: it ran against
+//! whatever the table looked like before the caller changed it. Counting
+//! completions cannot tell the two apart, so each request is numbered when it is
+//! issued and its completion is recorded under that number. A `next` waiter
+//! remembers the highest number issued when it was taken and resolves only on a
+//! completion recorded above it.
+//!
+//! Numbering at *issue* rather than at *start* is deliberate: a caller installs
+//! its change, takes the waiter, then triggers, so every id issued after the
+//! waiter belongs to a refresh that will read the change. A refresh issued
+//! between the change and the waiter is merely not credited — conservative, and
+//! never the other way round.
 //!
 //! A waiter is taken up front and awaited later, so a completion landing in
 //! between resolves the wait instead of being dropped. That gap is why this is
@@ -37,14 +53,24 @@ limitations under the License.
 
 use tokio::sync::watch;
 
-/// What every waiter is decided against. Held in one `watch` value so a
-/// completion and a close are each a single atomic transition that also wakes
+/// Identifies one refresh request, so the completion it produces can be told
+/// apart from the completion of a refresh that was already running.
+///
+/// Handed out by [`RefreshCompletion::issue`] and travelling with the request
+/// until [`RefreshCompletion::record`] reports the refresh it started as done.
+pub type RefreshRequestId = u64;
+
+/// What every waiter is decided against. Held in one `watch` value so an issue,
+/// a completion and a close are each a single atomic transition that also wakes
 /// the waiters already registered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CompletionState {
-    /// Refreshes recorded so far. Wrapping, because a waiter is decided by the
-    /// `watch` version it subscribed at rather than by comparing this value.
-    completions: u64,
+    /// Highest [`RefreshRequestId`] handed out so far. Ids start at 1, so 0 is
+    /// "nothing requested yet" and doubles as the threshold a waiter for *any*
+    /// completion is decided against.
+    issued: RefreshRequestId,
+    /// Highest [`RefreshRequestId`] whose refresh has been recorded complete.
+    completed: RefreshRequestId,
     /// Set once no further refresh can be recorded here, so a waiter taken
     /// afterwards resolves instead of blocking on one that cannot arrive.
     closed: bool,
@@ -70,16 +96,54 @@ impl RefreshCompletion {
     pub fn new() -> Self {
         Self {
             state: watch::Sender::new(CompletionState {
-                completions: 0,
+                issued: 0,
+                completed: 0,
                 closed: false,
             }),
         }
     }
 
-    /// Records a completed refresh, resolving every waiter taken before it.
-    pub fn record(&self) {
+    /// Numbers a refresh about to be requested.
+    ///
+    /// Call this once per request, immediately before handing the request to
+    /// whatever runs it, and pass the id back to [`RefreshCompletion::record`]
+    /// when that request's refresh finishes. A [`RefreshCompletion::next`]
+    /// waiter taken beforehand is decided against this number.
+    ///
+    /// Ids saturate rather than wrap so they stay ordered, which is what a
+    /// waiter compares against. The ceiling is unreachable — 2^64 refreshes of
+    /// one table in one process — and reaching it would strand waiters rather
+    /// than release them early, so the failure direction is a readiness ack that
+    /// is never sent rather than one sent for data that was never loaded.
+    pub fn issue(&self) -> RefreshRequestId {
+        let mut id = 0;
+        self.state.send_modify(|state| {
+            state.issued = state.issued.saturating_add(1);
+            id = state.issued;
+        });
+        id
+    }
+
+    /// Records the refresh requested as `id` as complete, resolving every waiter
+    /// that was taken before `id` was issued.
+    pub fn record(&self, id: RefreshRequestId) {
+        // `max` rather than assignment: completions arrive in request order
+        // today, and a reordering must not walk the threshold backwards and
+        // un-answer a waiter that has already been released.
         self.state
-            .send_modify(|state| state.completions = state.completions.wrapping_add(1));
+            .send_modify(|state| state.completed = state.completed.max(id));
+    }
+
+    /// Records a completion for refresh work that no caller requested — the CDC
+    /// apply loop, which streams rather than answering triggers.
+    ///
+    /// Such a completion answers every waiter taken before it and none taken
+    /// after, which is all an uncorrelated signal can honestly claim.
+    pub fn record_untriggered(&self) {
+        self.state.send_modify(|state| {
+            state.issued = state.issued.saturating_add(1);
+            state.completed = state.issued;
+        });
     }
 
     /// Records that no refresh will ever run for this table in this process, so
@@ -111,22 +175,46 @@ impl RefreshCompletion {
         self.waiter(true)
     }
 
-    /// `accept_earlier` selects between the two questions above: whether a
-    /// refresh recorded before this call already answers it.
+    /// The number of requests issued so far.
+    ///
+    /// Test-only: a test that needs a refresh to be *in flight* has to wait for
+    /// the request rather than sleep for it, and nothing in production asks.
+    #[cfg(test)]
+    pub(crate) fn issued_requests(&self) -> RefreshRequestId {
+        self.state.borrow().issued
+    }
+
+    /// The highest request id recorded complete so far.
+    ///
+    /// Test-only, and for the same reason: it lets a test assert the refresh it
+    /// is racing against has not finished yet, so a run that loses that race
+    /// says so instead of passing vacuously.
+    #[cfg(test)]
+    pub(crate) fn completed_requests(&self) -> RefreshRequestId {
+        self.state.borrow().completed
+    }
+
+    /// `accept_earlier` selects between the two questions above, expressed as the
+    /// request id a completion has to exceed to answer this waiter.
+    ///
+    /// For *any* completion that is 0, which every issued id exceeds, so a
+    /// refresh that finished before this call still answers. For the *next*
+    /// completion it is the highest id issued so far, which only a request
+    /// issued after this call exceeds.
     fn waiter(&self, accept_earlier: bool) -> RefreshCompletionWaiter {
-        // `subscribe` marks the receiver as having seen the value current now,
-        // so it resolves on the next transition. The state is then read back
-        // through the receiver rather than the sender: a completion landing
-        // between the two is either seen here or wakes the receiver, never
-        // dropped between them.
-        let mut receiver = self.state.subscribe();
-        let state = *receiver.borrow();
-        if state.closed || (accept_earlier && state.completions > 0) {
-            // Already answered — resolve on the first poll instead of waiting
-            // for a transition that has happened, or can never happen.
-            receiver.mark_changed();
+        // Read the state back through the receiver rather than the sender: a
+        // transition landing between subscribing and reading is either seen here
+        // or wakes the receiver, never dropped between them.
+        let receiver = self.state.subscribe();
+        let threshold = if accept_earlier {
+            0
+        } else {
+            receiver.borrow().issued
+        };
+        RefreshCompletionWaiter {
+            receiver,
+            threshold,
         }
-        RefreshCompletionWaiter { receiver }
     }
 }
 
@@ -139,11 +227,11 @@ impl RefreshCompletion {
 /// readiness, creating a follow-on schedule — must not proceed on
 /// [`RefreshCompletionOutcome::Abandoned`].
 ///
-/// `Answered` is the weaker half of that pair: it says *a* refresh completed, not
-/// that it was the one this waiter's caller triggered, nor that the table is
-/// still the live one. Binding a completion to its request and to a table
-/// generation is tracked in
-/// <https://github.com/spiceai/spiceai/issues/13603>.
+/// `Answered` says the refresh this waiter was taken for completed — a `next`
+/// waiter is bound to its own request by [`RefreshRequestId`] — but not that the
+/// table it was taken from is still the live one. Revalidating a completion
+/// against a table that may have been removed or rebuilt while it ran is tracked
+/// in <https://github.com/spiceai/spiceai/issues/13603>.
 ///
 /// Deliberately not `#[must_use]`: most waits are taken by a caller that acts on
 /// nothing afterwards and only wants to block, and marking the type would make
@@ -178,6 +266,9 @@ impl RefreshCompletionOutcome {
 #[derive(Debug)]
 pub struct RefreshCompletionWaiter {
     receiver: watch::Receiver<CompletionState>,
+    /// The [`RefreshRequestId`] a recorded completion has to exceed to answer
+    /// this waiter. See [`RefreshCompletion::waiter`].
+    threshold: RefreshRequestId,
 }
 
 impl RefreshCompletionWaiter {
@@ -188,16 +279,28 @@ impl RefreshCompletionWaiter {
     /// question was already answered when the waiter was taken, and
     /// [`RefreshCompletionOutcome::Abandoned`] when every recorder is dropped
     /// before it could be. Blocking on the latter would strand the caller rather
-    /// than inform it, but it is not a completed refresh: `changed` reports the
-    /// transition it has already observed ahead of the closed channel, so a
-    /// completion recorded before the last recorder went still reads as
-    /// `Answered`.
+    /// than inform it, but it is not a completed refresh: the state is
+    /// re-examined before each wait, so a completion recorded before the last
+    /// recorder went still reads as `Answered`.
+    ///
+    /// The wait loops because not every transition answers this waiter — an
+    /// issue, or the completion of a refresh already running when the waiter was
+    /// taken, both wake it without deciding it.
     pub async fn wait(mut self) -> RefreshCompletionOutcome {
-        if self.receiver.changed().await.is_ok() {
-            RefreshCompletionOutcome::Answered
-        } else {
-            RefreshCompletionOutcome::Abandoned
+        loop {
+            if self.is_answered() {
+                return RefreshCompletionOutcome::Answered;
+            }
+            if self.receiver.changed().await.is_err() {
+                return RefreshCompletionOutcome::Abandoned;
+            }
         }
+    }
+
+    /// Whether the current state answers the question this waiter was taken for.
+    fn is_answered(&self) -> bool {
+        let state = *self.receiver.borrow();
+        state.closed || state.completed > self.threshold
     }
 }
 
@@ -211,6 +314,13 @@ mod tests {
 
     const SHORT: Duration = Duration::from_millis(200);
 
+    /// Records a refresh nobody was waiting to correlate with, the way a caller
+    /// that only needs *some* completion on the table would produce one.
+    fn record_one(completion: &RefreshCompletion) {
+        let id = completion.issue();
+        completion.record(id);
+    }
+
     /// The lost wakeup this type exists to remove: a completion that lands
     /// between taking the waiter and awaiting it still resolves the wait.
     #[tokio::test]
@@ -218,7 +328,7 @@ mod tests {
         let completion = RefreshCompletion::new();
         let waiter = completion.next();
 
-        completion.record();
+        record_one(&completion);
 
         let outcome = timeout(SHORT, waiter.wait())
             .await
@@ -234,7 +344,7 @@ mod tests {
         let recorder = completion.clone();
         tokio::spawn(async move {
             tokio::task::yield_now().await;
-            recorder.record();
+            record_one(&recorder);
         });
 
         let outcome = timeout(SHORT, waiter.wait())
@@ -248,7 +358,7 @@ mod tests {
     #[tokio::test]
     async fn next_ignores_a_completion_recorded_before_the_waiter_was_taken() {
         let completion = RefreshCompletion::new();
-        completion.record();
+        record_one(&completion);
 
         let waiter = completion.next();
 
@@ -257,16 +367,117 @@ mod tests {
             .expect_err("an earlier completion must not satisfy a waiter taken after it");
     }
 
+    /// The regression this correlation exists for (#13544): a refresh that was
+    /// *already requested* when the waiter was taken can finish a moment later,
+    /// and its completion says nothing about the refresh the caller went on to
+    /// trigger. Before request ids, this released the waiter — which on the
+    /// partition-assignment path acked `PartitionsLoaded` for rows that had not
+    /// been loaded, so the scheduler routed queries to an executor that would
+    /// answer them incompletely.
+    #[tokio::test]
+    async fn next_ignores_the_completion_of_a_refresh_requested_before_it() {
+        let completion = RefreshCompletion::new();
+        // A periodic refresh is already in flight: issued, not yet complete.
+        let periodic = completion.issue();
+
+        let waiter = completion.next();
+
+        // The caller installs its change and triggers its own refresh, which is
+        // still running when the periodic one lands.
+        let _triggered = completion.issue();
+        completion.record(periodic);
+
+        let _ = timeout(SHORT, waiter.wait()).await.expect_err(
+            "a refresh requested before the waiter says nothing about the one it triggered",
+        );
+    }
+
+    /// The other half of the same scenario: once the refresh the caller actually
+    /// triggered lands, its waiter resolves.
+    #[tokio::test]
+    async fn next_is_answered_by_the_refresh_requested_after_it() {
+        let completion = RefreshCompletion::new();
+        let periodic = completion.issue();
+
+        let waiter = completion.next();
+
+        let triggered = completion.issue();
+        completion.record(periodic);
+        completion.record(triggered);
+
+        let outcome = timeout(SHORT, waiter.wait())
+            .await
+            .expect("the triggered refresh must resolve its own waiter");
+        assert_eq!(outcome, RefreshCompletionOutcome::Answered);
+    }
+
+    /// A request arriving mid-refresh cancels the one in flight, which then
+    /// never completes. A waiter must be released by the request that superseded
+    /// it rather than wait forever for a completion that cannot arrive.
+    #[tokio::test]
+    async fn next_is_answered_by_a_later_request_when_the_earlier_one_never_completes() {
+        let completion = RefreshCompletion::new();
+        let _cancelled = completion.issue();
+
+        let waiter = completion.next();
+
+        let triggered = completion.issue();
+        completion.record(triggered);
+
+        let outcome = timeout(SHORT, waiter.wait())
+            .await
+            .expect("a superseded request must not strand the waiters behind it");
+        assert_eq!(outcome, RefreshCompletionOutcome::Answered);
+    }
+
+    /// Completions arrive in request order, but a threshold that could move
+    /// backwards would un-answer a waiter that has already been released.
+    #[tokio::test]
+    async fn record_never_walks_the_threshold_backwards() {
+        let completion = RefreshCompletion::new();
+        let first = completion.issue();
+        let second = completion.issue();
+
+        let waiter = completion.next();
+        let third = completion.issue();
+
+        completion.record(third);
+        completion.record(second);
+        completion.record(first);
+
+        let outcome = timeout(SHORT, waiter.wait())
+            .await
+            .expect("an out-of-order completion must not retract an answered wait");
+        assert_eq!(outcome, RefreshCompletionOutcome::Answered);
+    }
+
     /// `any` answers "has the initial load landed", so it must be satisfied by a
     /// completion that predates the waiter.
     #[tokio::test]
     async fn any_is_satisfied_by_a_completion_recorded_before_the_waiter_was_taken() {
         let completion = RefreshCompletion::new();
-        completion.record();
+        record_one(&completion);
 
         let outcome = timeout(SHORT, completion.any().wait())
             .await
             .expect("an earlier completion must satisfy a waiter for any completion");
+        assert_eq!(outcome, RefreshCompletionOutcome::Answered);
+    }
+
+    /// Correlation narrows `next` only. A caller gating on the initial load is
+    /// asking whether the table has data, not which request produced it, so a
+    /// refresh requested before the waiter still answers.
+    #[tokio::test]
+    async fn any_is_satisfied_by_the_completion_of_a_refresh_requested_before_it() {
+        let completion = RefreshCompletion::new();
+        let periodic = completion.issue();
+
+        let waiter = completion.any();
+        completion.record(periodic);
+
+        let outcome = timeout(SHORT, waiter.wait())
+            .await
+            .expect("any completion answers the initial-load question");
         assert_eq!(outcome, RefreshCompletionOutcome::Answered);
     }
 
@@ -277,6 +488,46 @@ mod tests {
         let _ = timeout(SHORT, completion.any().wait())
             .await
             .expect_err("no completion has been recorded, so there is nothing to observe");
+    }
+
+    /// A request that has been issued but not completed is not a completion, so
+    /// it must not satisfy the initial-load question either.
+    #[tokio::test]
+    async fn any_waits_while_a_request_is_only_issued() {
+        let completion = RefreshCompletion::new();
+        let _issued = completion.issue();
+
+        let _ = timeout(SHORT, completion.any().wait())
+            .await
+            .expect_err("an issued request has loaded nothing yet");
+    }
+
+    /// The CDC apply loop answers no trigger. Its completions keep the
+    /// pre-correlation semantics: everyone waiting when it lands is released.
+    #[tokio::test]
+    async fn an_untriggered_completion_releases_the_waiters_taken_before_it() {
+        let completion = RefreshCompletion::new();
+        let next_waiter = completion.next();
+        let any_waiter = completion.any();
+
+        completion.record_untriggered();
+
+        for (waiter, label) in [(next_waiter, "next"), (any_waiter, "any")] {
+            let outcome = timeout(SHORT, waiter.wait()).await.unwrap_or_else(|_| {
+                panic!("an untriggered completion must release a `{label}` waiter taken before it")
+            });
+            assert_eq!(outcome, RefreshCompletionOutcome::Answered);
+        }
+    }
+
+    #[tokio::test]
+    async fn an_untriggered_completion_does_not_release_a_later_next_waiter() {
+        let completion = RefreshCompletion::new();
+        completion.record_untriggered();
+
+        let _ = timeout(SHORT, completion.next().wait())
+            .await
+            .expect_err("a `next` waiter asks about work that has not happened yet");
     }
 
     #[tokio::test]
@@ -327,6 +578,23 @@ mod tests {
         );
     }
 
+    /// A refresh that was requested but never completed is not a completion
+    /// either: dropping the recorder mid-flight must report the table as gone,
+    /// not the refresh as done.
+    #[tokio::test]
+    async fn a_request_left_in_flight_by_a_drop_is_abandoned() {
+        let completion = RefreshCompletion::new();
+        let waiter = completion.next();
+
+        let _in_flight = completion.issue();
+        drop(completion);
+
+        let outcome = timeout(SHORT, waiter.wait())
+            .await
+            .expect("dropping the recorder must release its waiters");
+        assert_eq!(outcome, RefreshCompletionOutcome::Abandoned);
+    }
+
     /// A completion that landed before the last recorder went is still a
     /// completion: dropping the recorder afterwards must not downgrade an
     /// answered wait into an abandoned one.
@@ -335,7 +603,7 @@ mod tests {
         let completion = RefreshCompletion::new();
         let waiter = completion.next();
 
-        completion.record();
+        record_one(&completion);
         drop(completion);
 
         let outcome = timeout(SHORT, waiter.wait())
@@ -370,7 +638,7 @@ mod tests {
         let completion = RefreshCompletion::new();
         let waiters: Vec<_> = (0..8).map(|_| completion.next()).collect();
 
-        completion.record();
+        record_one(&completion);
 
         for waiter in waiters {
             let outcome = timeout(SHORT, waiter.wait())
@@ -380,22 +648,25 @@ mod tests {
         }
     }
 
-    /// The completion count wraps rather than saturating, and a waiter is
-    /// decided by the `watch` version it subscribed at, so a wrap cannot strand
-    /// it.
+    /// Request ids saturate rather than wrap, because a waiter compares against
+    /// them. The ceiling is unreachable in practice; what must hold is that ids
+    /// stay ordered right up to it, so a waiter taken near the top still
+    /// resolves.
     #[tokio::test]
-    async fn a_waiter_resolves_across_a_generation_wrap() {
+    async fn a_waiter_resolves_at_the_top_of_the_id_range() {
         let completion = RefreshCompletion::new();
         completion
             .state
-            .send_modify(|state| state.completions = u64::MAX);
+            .send_modify(|state| state.issued = u64::MAX - 2);
 
         let waiter = completion.next();
-        completion.record();
+        let id = completion.issue();
+        assert_eq!(id, u64::MAX - 1, "ids must stay ordered near the ceiling");
+        completion.record(id);
 
         let outcome = timeout(SHORT, waiter.wait())
             .await
-            .expect("a wrapping generation must still resolve its waiter");
+            .expect("an id below the ceiling must still resolve its waiter");
         assert_eq!(outcome, RefreshCompletionOutcome::Answered);
     }
 }

--- a/crates/runtime-table/src/accelerated/refresh_task/changes.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task/changes.rs
@@ -1826,7 +1826,10 @@ impl RefreshTask {
             .initial_load_completed
             .store(true, Ordering::Relaxed);
         if let Some(refresh_completion) = context.refresh_completion {
-            refresh_completion.record();
+            // A CDC apply answers no trigger, so it is recorded without a
+            // request id: it releases every waiter taken before it and none
+            // taken after.
+            refresh_completion.record_untriggered();
         }
         self.update_component_status(status::ComponentStatus::Ready)
             .await;

--- a/crates/runtime-table/src/accelerated/refresh_task_runner.rs
+++ b/crates/runtime-table/src/accelerated/refresh_task_runner.rs
@@ -18,8 +18,8 @@ use crate::federated::FederatedTable;
 use runtime_status as status;
 
 use super::{
-    metrics, refresh::RefreshOverrides, refresh_task::RefreshTask,
-    synchronized_table::SynchronizedTable,
+    metrics, refresh::RefreshOverrides, refresh_completion::RefreshRequestId,
+    refresh_task::RefreshTask, synchronized_table::SynchronizedTable,
 };
 use futures::{FutureExt, future::BoxFuture};
 use tokio::{
@@ -233,8 +233,20 @@ pub struct RefreshTaskRunner {
 type RefreshRunFuture =
     BoxFuture<'static, std::result::Result<super::Result<()>, Box<dyn Any + Send>>>;
 
-type RefreshTaskStartSender = Sender<Option<RefreshOverrides>>;
-type RefreshTaskCompletionReceiver = Receiver<super::Result<()>>;
+/// One refresh request: the id it was issued under, and the overrides it
+/// carries.
+///
+/// The id travels with the request so the completion it produces can be
+/// attributed to it. A refresh already running when a request arrives is
+/// cancelled and never completes, so a completion cannot be attributed by
+/// counting requests — see [`RefreshRequestId`].
+pub type RefreshRequest = (RefreshRequestId, Option<RefreshOverrides>);
+
+/// A finished refresh, reported under the id of the request that started it.
+pub type RefreshTaskCompletion = (RefreshRequestId, super::Result<()>);
+
+type RefreshTaskStartSender = Sender<RefreshRequest>;
+type RefreshTaskCompletionReceiver = Receiver<RefreshTaskCompletion>;
 
 impl RefreshTaskRunner {
     #[expect(clippy::too_many_arguments)]
@@ -271,9 +283,10 @@ impl RefreshTaskRunner {
             return Err(super::Error::RefreshTaskAlreadyStarted {});
         }
 
-        let (start_refresh, mut on_start_refresh) = mpsc::channel::<Option<RefreshOverrides>>(1);
+        let (start_refresh, mut on_start_refresh) = mpsc::channel::<RefreshRequest>(1);
 
-        let (notify_refresh_complete, on_refresh_complete) = mpsc::channel::<super::Result<()>>(1);
+        let (notify_refresh_complete, on_refresh_complete) =
+            mpsc::channel::<RefreshTaskCompletion>(1);
 
         let dataset_name = self.dataset_name.clone();
         let notify_refresh_complete = Arc::new(notify_refresh_complete);
@@ -284,6 +297,11 @@ impl RefreshTaskRunner {
 
         self.task = Some(tokio::spawn(async move {
             let mut task_completion: Option<RefreshRunFuture> = None;
+            // The request the in-flight refresh was started for, so its
+            // completion is reported under the id that asked for it. A request
+            // arriving mid-refresh replaces both together: the running future is
+            // dropped by the `select!` below, so it never reports at all.
+            let mut running_request: RefreshRequestId = 0;
 
             loop {
                 if let Some(task) = task_completion.take() {
@@ -292,13 +310,13 @@ impl RefreshTaskRunner {
                             match res {
                                 Ok(Ok(())) => {
                                     tracing::debug!("Dataset {dataset_name} refreshed successfully");
-                                    if let Err(err) = notify_refresh_complete.send(Ok(())).await {
+                                    if let Err(err) = notify_refresh_complete.send((running_request, Ok(()))).await {
                                         tracing::debug!("Failed to send refresh task completion for dataset {dataset_name}: {err}");
                                     }
                                 },
                                 Ok(Err(err)) => {
                                     tracing::debug!("Dataset {dataset_name} failed to refresh with error: {err}");
-                                    if let Err(err) = notify_refresh_complete.send(Err(err)).await {
+                                    if let Err(err) = notify_refresh_complete.send((running_request, Err(err))).await {
                                         tracing::debug!("Failed to send refresh task completion for dataset {dataset_name}: {err}");
                                     }
                                 },
@@ -317,20 +335,22 @@ impl RefreshTaskRunner {
                                         message: panic_message.clone(),
                                     };
 
-                                    if let Err(err) = notify_refresh_complete.send(Err(panic_error)).await {
+                                    if let Err(err) = notify_refresh_complete.send((running_request, Err(panic_error))).await {
                                         tracing::debug!("Failed to send refresh task completion for dataset {dataset_name}: {err}");
                                     }
                                 }
                             }
                         },
-                        Some(overrides_opt) = on_start_refresh.recv() => {
+                        Some((request_id, overrides_opt)) = on_start_refresh.recv() => {
+                            running_request = request_id;
                             let request = Self::create_refresh_from_overrides(Arc::clone(&base_refresh), overrides_opt).await;
                             task_completion = Some(Self::wrap_refresh_future(Arc::clone(&refresh_task), request));
                         }
                     }
                 } else {
                     select! {
-                        Some(overrides_opt) = on_start_refresh.recv() => {
+                        Some((request_id, overrides_opt)) = on_start_refresh.recv() => {
+                            running_request = request_id;
                             let request = Self::create_refresh_from_overrides(Arc::clone(&base_refresh), overrides_opt).await;
                             task_completion = Some(Self::wrap_refresh_future(Arc::clone(&refresh_task), request));
                         }

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -4059,8 +4059,10 @@ impl DataFusion {
             table.as_ref(),
             spice_table::LayerWalk::Read,
         ) {
-            // Taken before the trigger, so the refresh it starts cannot finish
-            // unobserved between here and the caller's wait (#13086).
+            // Taken before the trigger, for both halves of the correlation: the
+            // refresh it starts cannot finish unobserved between here and the
+            // caller's wait (#13086), and a refresh already running when the
+            // caller changed the table cannot answer for it (#13544).
             let notifier = accelerated_table
                 .refresher()
                 .refresh_completion()

--- a/crates/runtime/src/init/dataset.rs
+++ b/crates/runtime/src/init/dataset.rs
@@ -2603,7 +2603,7 @@ mod tests {
             let waiter = completion.any();
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(1)).await;
-                completion.record();
+                completion.record_untriggered();
             });
 
             let started = tokio::time::Instant::now();
@@ -2630,7 +2630,7 @@ mod tests {
         #[tokio::test(start_paused = true)]
         async fn a_completion_that_predates_the_wait_ends_it_immediately() {
             let completion = RefreshCompletion::new();
-            completion.record();
+            completion.record_untriggered();
 
             let started = tokio::time::Instant::now();
             await_hot_reload_initial_refresh(
@@ -2712,7 +2712,7 @@ mod tests {
             let completion = RefreshCompletion::new();
             let waiter = completion.any();
             let records_then_reports_unloaded = move || {
-                completion.record();
+                completion.record_untriggered();
                 false
             };
 

--- a/crates/runtime/tests/refresh_worker_panic/mod.rs
+++ b/crates/runtime/tests/refresh_worker_panic/mod.rs
@@ -166,12 +166,26 @@ async fn refresh_worker_recovers_from_panic() -> Result<(), String> {
     let (start_refresh, mut on_refresh_complete) =
         runner.start().expect("Should start refresh task");
 
-    start_refresh.send(None).await.map_err(|e| e.to_string())?;
+    // Distinct, non-sequential request ids: a completion is reported under the id
+    // of the request that produced it (#13544), so a runner that echoed a
+    // constant, or the wrong one of the two, would still pass with 1 and 2.
+    const PANICKING_REQUEST: u64 = 7;
+    const SUCCEEDING_REQUEST: u64 = 11;
 
-    let first_result = timeout(Duration::from_secs(10), on_refresh_complete.recv())
+    start_refresh
+        .send((PANICKING_REQUEST, None))
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let (first_id, first_result) = timeout(Duration::from_secs(10), on_refresh_complete.recv())
         .await
         .map_err(|_| "timed out waiting for panic result".to_string())?
         .ok_or_else(|| "refresh worker channel closed unexpectedly".to_string())?;
+
+    assert_eq!(
+        first_id, PANICKING_REQUEST,
+        "a panicking refresh must still be reported under the request that started it"
+    );
 
     match first_result {
         Ok(()) => return Err("expected panic error from first refresh".to_string()),
@@ -188,12 +202,20 @@ async fn refresh_worker_recovers_from_panic() -> Result<(), String> {
         Err(other) => return Err(format!("unexpected error from first refresh: {other}")),
     }
 
-    start_refresh.send(None).await.map_err(|e| e.to_string())?;
+    start_refresh
+        .send((SUCCEEDING_REQUEST, None))
+        .await
+        .map_err(|e| e.to_string())?;
 
-    let second_result = timeout(Duration::from_secs(10), on_refresh_complete.recv())
+    let (second_id, second_result) = timeout(Duration::from_secs(10), on_refresh_complete.recv())
         .await
         .map_err(|_| "timed out waiting for successful refresh".to_string())?
         .ok_or_else(|| "refresh worker channel closed unexpectedly".to_string())?;
+
+    assert_eq!(
+        second_id, SUCCEEDING_REQUEST,
+        "the second completion must be reported under the second request, not the first"
+    );
 
     second_result.map_err(|e| format!("second refresh returned error: {e}"))?;
 

--- a/crates/runtime/tests/refresh_worker_panic/mod.rs
+++ b/crates/runtime/tests/refresh_worker_panic/mod.rs
@@ -38,6 +38,13 @@ use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::{Duration, timeout};
 
+/// Distinct, non-sequential request ids: a completion is reported under the id
+/// of the request that produced it (#13544), so a runner that echoed a
+/// constant, or the wrong one of the two in flight, would still pass with 1
+/// and 2.
+const PANICKING_REQUEST: u64 = 7;
+const SUCCEEDING_REQUEST: u64 = 11;
+
 #[derive(Debug)]
 struct PanickingOnceTableProvider {
     inner: Arc<MemTable>,
@@ -165,12 +172,6 @@ async fn refresh_worker_recovers_from_panic() -> Result<(), String> {
 
     let (start_refresh, mut on_refresh_complete) =
         runner.start().expect("Should start refresh task");
-
-    // Distinct, non-sequential request ids: a completion is reported under the id
-    // of the request that produced it (#13544), so a runner that echoed a
-    // constant, or the wrong one of the two, would still pass with 1 and 2.
-    const PANICKING_REQUEST: u64 = 7;
-    const SUCCEEDING_REQUEST: u64 = 11;
 
     start_refresh
         .send((PANICKING_REQUEST, None))

--- a/scripts/check_table_layers.py
+++ b/scripts/check_table_layers.py
@@ -62,6 +62,7 @@ ALLOWED: dict[str, str] = {
     "SlowProvider": "test double",
     "WriteOrderRecordingProvider": "test double",
     "DelayedNativeTableProvider": "test double",
+    "GatedSource": "test double",
 }
 
 STRUCT = re.compile(r"(?:pub(?:\([^)]*\))? )?struct (\w+)\s*\{([^}]*)\}")


### PR DESCRIPTION
## Summary

A refresh-completion waiter was satisfied by the **next completion recorded on the table, whichever refresh produced it**. Nothing correlated the refresh a caller triggered with the completion it was woken by, so a refresh that was *already running* when the caller took its waiter could finish a moment later and release it — reporting on work that started before the caller changed anything.

On the partition-assignment path that is a wrong answer rather than a late one. `Runtime::update_partition_refresh_sql` installs new partition filters, triggers a refresh to load them, and broadcasts `PartitionsLoaded` when the wait returns:

1. A periodic refresh **P** is running.
2. A partition assignment change lands. The executor installs the new filters, takes a completion waiter, and triggers refresh **T** to load the newly assigned partitions.
3. **P** finishes and records a completion. The waiter resolves.
4. `PartitionsLoaded` is broadcast — before **T**, the refresh carrying the new filters, has run.

The scheduler is now told the executor holds partitions whose rows it has not read, and routes queries for them there. The result is silently incomplete query results, not an error.

The window is not hypothetical: the refresher's external-trigger arm sleeps for refresh jitter **before** it hands the request on, and that sleep blocks the same `select!` loop that drains completions — so a completion of **P** landing during the jitter is queued and processed immediately after **T** is dispatched, which is exactly the interleaving above.

### Root cause

`RefreshCompletion` counted completions. A `next()` waiter was decided by the `watch` version it subscribed at, which distinguishes *before the waiter* from *after the waiter* but not *which refresh*. Those are different questions whenever a refresh is in flight.

## Changes

- **`RefreshCompletion` numbers each request.** `issue()` hands out a `RefreshRequestId` and `record(id)` reports that request's refresh complete. A `next()` waiter remembers the highest id issued when it was taken and resolves only above it; `any()` — the initial-load question — keeps its lenient semantics as a threshold of 0.
- **Numbering happens at *issue*, not at start.** A caller installs its change, takes the waiter, then triggers, so every id issued afterwards belongs to a refresh that will read the change. A refresh issued between the change and the waiter is merely not credited — conservative, never the other way round.
- **The id travels with the request through `RefreshTaskRunner` and comes back with the completion.** This is required rather than bookkeeping: a request arriving mid-refresh causes the `select!` to drop the running future, so that refresh is cancelled and never reports. A completion therefore cannot be attributed by counting requests against completions — the counts do not line up.
- **The CDC apply loop records without an id** (`record_untriggered()`). It answers no trigger, so it keeps precisely the semantics it had: every waiter taken before it is released, and none taken after.
- Ids saturate rather than wrap, because a waiter now compares against them. The ceiling — 2^64 refreshes of one table in one process — is unreachable, and reaching it would strand a waiter rather than release one early, so the failure direction stays "a readiness ack that is never sent" rather than "one sent for data that was never loaded".

### Behavioural note

A `next()` waiter can now wait one refresh longer than before in exactly the case this fixes: where an in-flight refresh used to release it, it now waits for the refresh the caller actually triggered. That is the point — the earlier release was the bug. Liveness is preserved because `trigger_refresh` uses `send().await` on the trigger channel, so a successful trigger always produces exactly one issued id, and a superseded request is always followed by one with a higher id.

`#13603` — revalidating a completion against a table that may have been removed or rebuilt while it ran — is a different property of the same signal and stays open; the doc comment on `RefreshCompletionOutcome` is narrowed to reference only that remaining half.

### Why `refs #13544` and not `fixes`

This closes the interleaving #13544 works through — a refresh **already running** when the waiter was taken can no longer answer it — but it does not establish the general property that issue's opening paragraph states, that a waiter is correlated with *the* trigger its caller sent. Two windows survive, both raised by Copilot on this PR:

- A request **enqueued before** the waiter but not yet numbered — the refresher numbers it after its jitter sleep — gets an id above the waiter's threshold, so its completion answers.
- A request enqueued **after** the waiter answers by construction, which is correct for an unrestricted refresh (it runs after the caller's change and reloads it) but wrong for one carrying restrictive `RefreshOverrides`, which may not load what the caller was waiting for.

Numbering at enqueue rather than at dispatch would close the first. It does not close the second, and the second is the one that needs a decision: binding a waiter to exactly one request means a request that is **superseded** — the runner drops the running future when a new request arrives, so it never reports — must resolve its waiters as something other than "answered", and each acting caller has to decide what supersession means for it. That is a design question rather than a bug fix, and worth a maintainer's view, so #13544 stays open owning it rather than being auto-closed by a merge that only narrows it.

## Test plan

- `make lint`
- `make nextest`

New tests in `crates/runtime-table/src/accelerated/refresh_completion.rs`:

- `next_ignores_the_completion_of_a_refresh_requested_before_it` — the regression. A request issued before the waiter completes while the caller's own request is still running; the waiter must not resolve. Fails on the old code, where the completion released it.
- `next_is_answered_by_the_refresh_requested_after_it` — the other half of the same scenario.
- `next_is_answered_by_a_later_request_when_the_earlier_one_never_completes` — liveness for the cancelled in-flight refresh.
- `record_never_walks_the_threshold_backwards` — an out-of-order completion must not retract an answered wait.
- `any_is_satisfied_by_the_completion_of_a_refresh_requested_before_it` — correlation narrows `next` only.
- `any_waits_while_a_request_is_only_issued`, `a_request_left_in_flight_by_a_drop_is_abandoned` — an issued request is not a completion.
- `an_untriggered_completion_releases_the_waiters_taken_before_it`, `an_untriggered_completion_does_not_release_a_later_next_waiter` — the CDC arm.
- `a_waiter_resolves_at_the_top_of_the_id_range` — replaces the wrap test, which measured a property the comparison removed.

End-to-end through the real refresher, in `refresh.rs`:

- `test_a_refresh_already_running_does_not_answer_a_later_waiter` — the interleaving, driven rather than timed. A refresh over a `MemTable` completes inside one scheduler pass, so a waiter taken "while it runs" is really taken after it; a first attempt that polled a request counter tripped its own precondition assertion instead of passing vacuously, which is what sent this to a gate. `GatedSource` holds the source scan open and reports when one is entered, so the waiters are provably taken with the refresh in flight, and the test asserts that precondition (`completed_requests() == 0`) rather than assuming it. It then releases the gate, waits for that refresh to complete, asserts it did *not* answer the waiter, triggers a second refresh and asserts that one does. No sleeps and no spin loops.

The pre-existing `#13086` tests (`test_completion_taken_before_a_trigger_survives_the_window`, `test_initial_load_flag_is_stored_before_the_completion_is_recorded`) are the guard on the wiring: if the runner reported the wrong id, they hang rather than pass.

`scripts/check_table_layers.py` gains one `ALLOWED` entry. `GatedSource` wraps a `TableProvider` and implements one, which the guard refuses because a layer walk stops at such a type silently; it is a test double that holds a scan open rather than part of a dataset's layer stack, so it joins the six test doubles already listed there.

One unrelated test-helper change rides along, and does **not** fix anything on its own: `wait_until_ready_status` read the `dataset_load_state` gauge series positionally (`get_metric()[0]`), and that gauge is labelled by dataset, so the series it reads depends on which datasets other tests in the binary registered. This PR adds one (`gated`), which makes the positional read strictly more fragile than before, so it now selects by the `dataset` label. `test_refresh_status_change_to_ready` **already fails on unmodified `trunk`** under `cargo test -p runtime-table --lib accelerated::refresh` — measured at `4c70e06533` with the working tree reset to `origin/trunk` — for a different reason: the gauge is a process-wide `LazyLock` that binds to whichever meter provider a sibling test installed first. That is filed as #13708 and is not addressed here. The module is green under `cargo nextest run -p runtime-table` (356/356), which is what `make nextest` runs, because nextest gives each test its own process.

## Review gate

- Adversarial review: **skipped** — `codex` ran and exited 1 with `Codex error: Your workspace is out of credits. Ask your workspace owner to refill in order to continue.`; `grok` is not installed in this environment (receipt: `engine=none exit=1 job=none`). No engine was available, so this was not run. In its place the approach was re-examined directly against the failure modes it exists to catch — cancellation liveness, trigger-channel back-pressure, the `any()`/CDC arms, and the saturation ceiling — and each is covered by a test listed above.
- `/security-review`: no findings. The diff adds an in-process `u64` counter and a tuple on two internal `tokio::mpsc` channels; no new parsing, deserialization, path, SQL, or credential surface, and the one new log field is an integer request id on a line that already rendered the refresh result. The change strictly narrows when a readiness ack fires, so both degenerate cases leave a waiter unresolved rather than acking early.
- `/simplify`: run on the resulting diff. One fix applied — `record_untriggered` looks like avoidable duplication of `issue`, so the reason it is a single `send_modify` rather than `record(self.issue())` is now stated in its doc: the intermediate state of that pair is an issued-but-uncompleted request, and a waiter taken there would skip the completion and wait for the following apply. Reviewed and deliberately left: no existing sequence helper to reuse; `issue`'s captured-`mut` is the correct way to read a value out of `send_modify` atomically; moving `issued` to a separate atomic would stop `issue` waking waiters but splits one invariant across two primitives to optimise a cold path. Behaviour unchanged, no test weakened, no snapshot touched.

### Neuters

Each guard was reverted in turn and the suite re-run, to show the tests fail without the fix rather than alongside it:

| Neuter | Result |
| --- | --- |
| The refresher records an uncorrelated completion (`record_untriggered()` in place of `record(request_id)`) — i.e. the pre-fix behaviour | `test_a_refresh_already_running_does_not_answer_a_later_waiter` fails, and only that test |
| `next()` loses its threshold (always 0) | `next_ignores_the_completion_of_a_refresh_requested_before_it`, `next_ignores_a_completion_recorded_before_the_waiter_was_taken` and `an_untriggered_completion_does_not_release_a_later_next_waiter` all fail |
| `record` assigns instead of `max` | `record_never_walks_the_threshold_backwards` fails |
| The CDC arm issues without recording | the pre-existing `test_start_changes_stream_signals_dataset_ready` fails |

The runner's id echo is load-bearing by construction: the integration test sends 7 and 11, so a runner echoing a constant, or the wrong one of two in flight, fails at least one assertion.

Refs #13544

Refs #13708

## Checklist

- [x] Regression test that fails on the old code and passes on the new
- [x] Edge cases: cancelled in-flight request, out-of-order completion, drop mid-request, untriggered (CDC) completion, id ceiling
- [x] No `.unwrap()` outside tests; no new lint suppressions
- [x] `cargo fmt --all`