### PR TITLE
fix(search): remove a chunked row's stale chunks when its text goes away (refs #13704)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19031,6 +19031,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "util",
 ]
 

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -55,6 +55,7 @@ text_search = ["dep:tantivy", "dep:tantivy_datafusion_filter"]
 insta = { workspace = true, features = ["json"] }
 tempfile.workspace = true
 tokio.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -1,6 +1,6 @@
 use std::{
     any::Any,
-    collections::HashSet,
+    collections::HashMap,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -354,11 +354,13 @@ impl ChunkedSearchIndex {
     /// the batch the inner index receives, so the inner index never sees that key on this write
     /// and nothing tells it to drop what the row's previous text produced.
     ///
-    /// The subtraction is what keeps the eviction from ever removing a chunk this write just
-    /// produced. It only bites when one batch carries the same key twice — once with text and
-    /// once without — which is already resolved last-write-wins downstream and is not resolved
-    /// here (#13713). Without it, evicting after the writes would delete the chunks the other
-    /// row wrote.
+    /// A key is judged on its **last** row in the batch, which is the one that survives
+    /// downstream: one batch can carry the same key more than once, and the eviction has to
+    /// agree with the row the table will end up holding. So a key whose last row still chunks
+    /// keeps what this write wrote for it, and a key whose last row chunked into nothing loses
+    /// everything under it — including chunks an earlier row of the same batch just produced.
+    /// (A batch carrying one key twice with text *both* times is a different, unresolved
+    /// problem: #13713.)
     ///
     /// `repeats` is parallel to `record`'s rows and holds each row's chunk count.
     fn rows_to_evict(
@@ -368,8 +370,7 @@ impl ChunkedSearchIndex {
     ) -> DataFusionResult<Option<RecordBatch>> {
         // Short-circuit before anything is allocated: on an ordinary write every row chunks into
         // something, and this is the only work that write should pay for.
-        let emptied = repeats.iter().filter(|n| **n == 0).count();
-        if emptied == 0 {
+        if !repeats.contains(&0) {
             return Ok(None);
         }
 
@@ -410,26 +411,27 @@ impl ChunkedSearchIndex {
         )?;
         let rows = converter.convert_columns(keys.columns())?;
 
-        // Keyed on the emptied rows rather than the written ones: the emptied set is the small
-        // one, and it is the side being subtracted from.
-        let mut candidates = HashSet::with_capacity(emptied);
-        for (i, _) in repeats.iter().enumerate().filter(|(_, n)| **n == 0) {
-            candidates.insert(rows.row(i));
-        }
-        for (i, _) in repeats.iter().enumerate().filter(|(_, n)| **n > 0) {
-            candidates.remove(&rows.row(i));
-        }
-        if candidates.is_empty() {
-            return Ok(None);
+        // A key's *last* row in the batch is the one that survives downstream, so that is the
+        // row that decides. Later inserts overwrite earlier ones, leaving each key mapped to its
+        // final occurrence.
+        let mut last_occurrence = HashMap::with_capacity(record.num_rows());
+        for i in 0..record.num_rows() {
+            last_occurrence.insert(rows.row(i), i);
         }
 
-        // Non-nullable by construction, so `filter_record_batch` takes its fast path.
+        // Evict a key exactly once, on its deciding row, and only when that row chunked into
+        // nothing. A key whose last row still has text keeps what this write wrote for it; a key
+        // whose last row is empty loses everything under it, including chunks an earlier row of
+        // the same batch just produced — which is the state the surviving row calls for.
         let evict = BooleanArray::new(
             BooleanBuffer::collect_bool(keys.num_rows(), |i| {
-                repeats[i] == 0 && candidates.contains(&rows.row(i))
+                repeats[i] == 0 && last_occurrence.get(&rows.row(i)) == Some(&i)
             }),
             None,
         );
+        if evict.true_count() == 0 {
+            return Ok(None);
+        }
 
         filter_record_batch(&keys, &evict)
             .map(Some)
@@ -441,7 +443,9 @@ impl ChunkedSearchIndex {
     ///
     /// Runs **after** this write's chunks have landed, not before: the deletion is externally
     /// visible and nothing restores it, so ordering it first would let a failed embedding or
-    /// bulk write leave the row present and its old chunks already gone.
+    /// bulk write leave the row present and its old chunks already gone. That narrows the window
+    /// rather than closing it — the row write itself commits later still, and there is no
+    /// post-commit index hook on the CDC path to hang this on (#13715).
     ///
     /// Skipped inside a [`WriteWindow::ReplaceAll`] window, where it would be destructive: an
     /// index that stages a replacing write keeps serving its *previous* rows until it commits,
@@ -2562,15 +2566,22 @@ mod tests {
         }
     }
 
-    /// The eviction must never remove a chunk this same write produced. One batch can carry the
-    /// same key twice — once with text, once without — and that shape is resolved last-write-wins
-    /// downstream but not here (#13713), so evicting on the emptied row would delete the chunks
-    /// the other row just wrote and leave the row with nothing searchable at all.
+    /// One batch can carry the same key more than once, and the eviction has to agree with the
+    /// row the table will end up holding — the last one. Order therefore decides the outcome:
+    /// text-then-empty leaves nothing searchable under the key, empty-then-text leaves the text.
+    ///
+    /// Getting this wrong in either direction is a wrong search result. Judging the key on *any*
+    /// occurrence rather than the deciding one keeps the superseded text searchable under a row
+    /// the table has emptied; not judging it at all lets the eviction delete chunks the same
+    /// write just produced.
+    ///
+    /// A batch carrying the key twice with text both times is a different, unresolved problem
+    /// (#13713) and is not asserted here.
     #[tokio::test]
-    async fn a_key_this_write_also_chunked_is_not_evicted() {
-        for rows in [
-            vec![(Some("a b"), 1i64), (None, 1)],
-            vec![(None, 1i64), (Some("a b"), 1)],
+    async fn a_duplicated_key_is_judged_on_the_row_that_survives_the_batch() {
+        for (rows, expected) in [
+            (vec![(Some("a b"), 1i64), (None, 1)], vec![]),
+            (vec![(None, 1i64), (Some("a b"), 1)], vec![(1, 0), (1, 1)]),
         ] {
             let inner = Arc::new(StatefulChunkInner::new(&[], false));
             let idx =
@@ -2580,11 +2591,31 @@ mod tests {
 
             assert_eq!(
                 inner.remaining(),
-                vec![(1, 0), (1, 1)],
-                "the chunks this write produced survive it, whichever order the batch carries \
-                 ({rows:?})"
+                expected,
+                "the last row for a key decides what stays searchable under it ({rows:?})"
             );
         }
+    }
+
+    /// The same rule with no duplicate in sight: an emptied key loses its chunks, and a key this
+    /// write chunked keeps them.
+    #[tokio::test]
+    async fn a_write_evicts_only_the_keys_it_emptied() {
+        let inner = Arc::new(StatefulChunkInner::new(&[], false));
+        let idx = ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+
+        idx.write(build_input(&[("a b", 1), ("c", 2)]))
+            .await
+            .expect("first write ok");
+        idx.write(build_input_opt(&[(None, 1), (Some("d e"), 2)]))
+            .await
+            .expect("rewrite ok");
+
+        assert_eq!(
+            inner.remaining(),
+            vec![(2, 0), (2, 1)],
+            "id 1 emptied and went; id 2 was rewritten and kept its new chunks"
+        );
     }
 
     /// The eviction is an externally visible delete that nothing restores, so it must not run

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -1,5 +1,6 @@
 use std::{
     any::Any,
+    collections::HashSet,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -19,6 +20,7 @@ use arrow::{
     },
     buffer::OffsetBuffer,
     compute::{concat, filter_record_batch},
+    row::{RowConverter, SortField},
 };
 
 use crate::index::primary_key_projection;
@@ -344,29 +346,96 @@ impl ChunkedSearchIndex {
         &self.inner
     }
 
-    /// Remove what the inner index still holds for the rows of `record` that this write chunked
-    /// into nothing — a NULL search value, an empty one, or text the chunker yields no chunk for.
+    /// The rows of `record` whose chunks the inner index has to be told to drop, or `None` when
+    /// there are none.
     ///
-    /// Such a row contributes no rows *at all* to the batch the inner index receives: not a row
-    /// the inner index can reject, but no row. The inner index therefore never sees that primary
-    /// key on this write, and nothing tells it to drop the chunks the row's previous text
-    /// produced — they stay searchable at their old vectors, and a search returns content the
-    /// row no longer has. That is a gap only this wrapper can close, because it is the layer
-    /// that decided not to send the row.
+    /// Those are the rows this write chunked into nothing — a NULL search value, an empty one,
+    /// or text the chunker yields no chunk for — **minus** any row whose key this same write
+    /// also produced chunks for. A row that chunked into nothing contributes no rows *at all* to
+    /// the batch the inner index receives, so the inner index never sees that key on this write
+    /// and nothing tells it to drop what the row's previous text produced.
+    ///
+    /// The subtraction is what keeps the eviction from ever removing a chunk this write just
+    /// produced. It only bites when one batch carries the same key twice — once with text and
+    /// once without — which is already resolved last-write-wins downstream and is not resolved
+    /// here (#13713). Without it, evicting after the writes would delete the chunks the other
+    /// row wrote.
     ///
     /// `repeats` is parallel to `record`'s rows and holds each row's chunk count.
+    fn rows_to_evict(
+        &self,
+        record: &RecordBatch,
+        repeats: &[usize],
+    ) -> DataFusionResult<Option<RecordBatch>> {
+        if !repeats.iter().any(|n| *n == 0) {
+            return Ok(None);
+        }
+
+        // A key of no columns addresses nothing, so there is no group to evict.
+        let key_columns = Self::base_key_columns(&self.inner.primary_fields());
+        if key_columns.is_empty() {
+            return Ok(None);
+        }
+
+        let key_arrays: Vec<ArrayRef> = key_columns
+            .iter()
+            .map(|name| record.column_by_name(name).map(Arc::clone))
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "Failed to update the search index on '{}': the rows being written do not \
+                     carry the key column(s) {key_columns:?} the index is addressed by, so a row \
+                     whose value is now empty cannot have its previous entries removed and a \
+                     search would keep returning them.",
+                    self.search_column()
+                ))
+            })?;
+
+        // Compare whole key tuples, whatever their column types, by converting them to Arrow's
+        // comparable row encoding once for the batch.
+        let converter = RowConverter::new(
+            key_arrays
+                .iter()
+                .map(|a| SortField::new(a.data_type().clone()))
+                .collect(),
+        )?;
+        let rows = converter.convert_columns(&key_arrays)?;
+        let written: HashSet<_> = (0..record.num_rows())
+            .filter(|i| repeats[*i] > 0)
+            .map(|i| rows.row(i))
+            .collect();
+
+        let evict: BooleanArray = (0..record.num_rows())
+            .map(|i| Some(repeats[i] == 0 && !written.contains(&rows.row(i))))
+            .collect();
+        if evict.true_count() == 0 {
+            return Ok(None);
+        }
+
+        // `delete_by_keys` reads the key columns out of whatever batch it is handed and ignores
+        // the rest, so the filtered source rows can go straight through.
+        filter_record_batch(record, &evict)
+            .map(Some)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+    }
+
+    /// Tell the inner index to drop what it still holds for [`Self::rows_to_evict`], so a row
+    /// whose text went away stops answering searches with content it no longer has.
     ///
-    /// Skipped inside a [`WriteWindow::ReplaceAll`] window, where it would be both pointless and
-    /// destructive: a replacing write reproduces the table's whole contents, so the inner index
-    /// stages this write and keeps serving its *previous* rows until it commits. An eviction
-    /// resolved against that listing resolves the keys the previous contents hold, and the
-    /// delete it derives from them applies to the staged rows — removing rows this same write
-    /// just wrote.
+    /// Runs **after** this write's chunks have landed, not before: the deletion is externally
+    /// visible and nothing restores it, so ordering it first would let a failed embedding or
+    /// bulk write leave the row present and its old chunks already gone.
+    ///
+    /// Skipped inside a [`WriteWindow::ReplaceAll`] window, where it would be destructive: an
+    /// index that stages a replacing write keeps serving its *previous* rows until it commits,
+    /// so an eviction resolved against that listing resolves the previous contents' keys and
+    /// applies the delete to the staged rows — removing rows this same write just wrote. The
+    /// backends that *don't* stage discard nothing at all for that window, including entries for
+    /// rows the refresh dropped outright, which is #12413 rather than this path.
     ///
     /// An inner index that can neither delete by partial key nor enumerate its own entries has
-    /// no way to reach those chunks; that is reported and the write continues, because failing
-    /// the write would take the row's *new* content with it and leave the stale chunks behind
-    /// anyway.
+    /// no way to reach those chunks; that is reported and the write stands, because failing it
+    /// after the chunks have landed would not remove the stale entries either.
     async fn evict_rows_chunked_to_nothing(
         &self,
         record: &RecordBatch,
@@ -376,15 +445,9 @@ impl ChunkedSearchIndex {
             return Ok(());
         }
 
-        let emptied: BooleanArray = repeats.iter().map(|n| Some(*n == 0)).collect();
-        if emptied.true_count() == 0 {
+        let Some(keys) = self.rows_to_evict(record, repeats)? else {
             return Ok(());
-        }
-
-        // `delete_by_keys` reads the base key columns out of whatever batch it is handed and
-        // ignores the rest, so the filtered source rows can go straight through.
-        let keys = filter_record_batch(record, &emptied)
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        };
 
         match self.delete_by_keys(keys).await {
             Err(DataFusionError::NotImplemented(_)) => {
@@ -655,11 +718,6 @@ impl SearchIndex for ChunkedSearchIndex {
 
         let repeats = offsets.iter().map(Vec::len).collect::<Vec<_>>();
 
-        // A row that chunked into nothing is about to be invisible to the inner index, so drop
-        // what it still holds for that row before writing this batch's replacements.
-        self.evict_rows_chunked_to_nothing(&record, &repeats)
-            .await?;
-
         // Group input rows so that each call to `self.inner.write` sees at most
         // `INNER_WRITE_TARGET_CHUNKS` chunk rows in its intermediate batch. Each group is a
         // contiguous, row-atomic slice of the input. If a single row has more chunks than the
@@ -701,6 +759,12 @@ impl SearchIndex for ChunkedSearchIndex {
                 group_embedding_arrays.push(Arc::clone(arr));
             }
         }
+
+        // Every chunk this write produces has landed, so the rows it chunked into nothing can
+        // now have their previous chunks dropped — see `evict_rows_chunked_to_nothing` for why
+        // this is ordered after the writes rather than before them.
+        self.evict_rows_chunked_to_nothing(&record, &repeats)
+            .await?;
 
         // From the concatenated inner outputs we need {}_embedding and {}_offset, then convert
         // them from `<inner_type>` -> `List(<inner_type>)` (one list per original row, length
@@ -1261,6 +1325,9 @@ mod tests {
         write_complete_fatal: bool,
         /// What this mock reports from [`Index::deletes_by_partial_key`].
         deletes_partial_key: bool,
+        /// Makes [`SearchIndex::write`] fail, for the paths that must not act on a write that
+        /// did not land.
+        write_fails: bool,
         /// What this mock reports from [`SearchIndex::primary_fields`]. A chunked index's inner
         /// index carries [`CHUNKED_INDEX_CHUNK_KEY`] here.
         primary_fields: Vec<Field>,
@@ -1285,6 +1352,7 @@ mod tests {
                 write_start_fatal: false,
                 write_complete_fatal: false,
                 deletes_partial_key: false,
+                write_fails: false,
                 primary_fields: vec![Field::new("id", DataType::Int64, false)],
                 listed: None,
                 deleted: std::sync::Mutex::new(Vec::new()),
@@ -1425,6 +1493,11 @@ mod tests {
             &self,
             record: RecordBatch,
         ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {
+            if self.write_fails {
+                return Err(Box::new(DataFusionError::Execution(
+                    "inner write failed".to_string(),
+                )));
+            }
             self.calls.fetch_add(1, Ordering::SeqCst);
             self.row_counts
                 .lock()
@@ -2488,6 +2561,54 @@ mod tests {
             .await
             .expect("write ok");
         assert_eq!(resolved_ids(&inner.deletes()), vec![1]);
+    }
+
+    /// The eviction must never remove a chunk this same write produced. One batch can carry the
+    /// same key twice — once with text, once without — and that shape is resolved last-write-wins
+    /// downstream but not here (#13713), so evicting on the emptied row would delete the chunks
+    /// the other row just wrote and leave the row with nothing searchable at all.
+    #[tokio::test]
+    async fn a_key_this_write_also_chunked_is_not_evicted() {
+        for rows in [
+            vec![(Some("a b"), 1i64), (None, 1)],
+            vec![(None, 1i64), (Some("a b"), 1)],
+        ] {
+            let inner = Arc::new(StatefulChunkInner::new(&[], false));
+            let idx =
+                ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+
+            idx.write(build_input_opt(&rows)).await.expect("write ok");
+
+            assert_eq!(
+                inner.remaining(),
+                vec![(1, 0), (1, 1)],
+                "the chunks this write produced survive it, whichever order the batch carries \
+                 ({rows:?})"
+            );
+        }
+    }
+
+    /// The eviction is an externally visible delete that nothing restores, so it must not run
+    /// ahead of the write it belongs to. A failed inner write leaves the row's previous chunks
+    /// stale — which is the bug this PR narrows — but stale beats gone: evicting first would
+    /// leave the row present in the table with nothing searchable under it at all.
+    #[tokio::test]
+    async fn a_write_that_fails_evicts_nothing() {
+        let inner = Arc::new(RecordingInner {
+            write_fails: true,
+            ..RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])])
+        });
+        let idx = ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+
+        idx.write(build_input_opt(&[(None, 1), (Some("a b"), 2)]))
+            .await
+            .expect_err("the inner write fails");
+
+        assert!(
+            inner.deletes().is_empty(),
+            "nothing landed, so nothing may be removed: {:?}",
+            inner.deletes()
+        );
     }
 
     /// The warning is the only account a user gets of why a search still returns text a row no

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -1,4 +1,10 @@
-use std::{any::Any, sync::Arc};
+use std::{
+    any::Any,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use crate::{
     SEARCH_SCORE_COLUMN_NAME,
@@ -8,11 +14,11 @@ use crate::{
 
 use arrow::{
     array::{
-        Array, ArrayRef, FixedSizeListArray, FixedSizeListBuilder, Int32Builder, LargeStringArray,
-        ListArray, RecordBatch, StringArray, StringViewArray, UInt64Array,
+        Array, ArrayRef, BooleanArray, FixedSizeListArray, FixedSizeListBuilder, Int32Builder,
+        LargeStringArray, ListArray, RecordBatch, StringArray, StringViewArray, UInt64Array,
     },
     buffer::OffsetBuffer,
-    compute::concat,
+    compute::{concat, filter_record_batch},
 };
 
 use crate::index::primary_key_projection;
@@ -61,6 +67,13 @@ pub struct ChunkedSearchIndex {
     embedding_col_name: String,
     /// Cached `{search_column}_offset` — avoids reallocating the name on every write.
     offset_col_name: String,
+    /// Set for the duration of a [`WriteWindow::ReplaceAll`] window, so
+    /// [`Self::evict_rows_chunked_to_nothing`] can tell a replacing write from every other one.
+    ///
+    /// Shared with the [`ChunkedVectorIndex`] this wrapper hands out and with the temporary
+    /// [`ChunkedSearchIndex`] that index delegates through, so the window one of them opens is
+    /// the window the other one sees.
+    replace_window: Arc<AtomicBool>,
 }
 
 #[async_trait]
@@ -89,15 +102,22 @@ impl Index for ChunkedSearchIndex {
         try_join_all(futs).await
     }
 
+    /// Records whether this window replaces the table's contents before forwarding, so
+    /// [`ChunkedSearchIndex::evict_rows_chunked_to_nothing`] can skip a window where the inner
+    /// index is staging rather than serving what it is about to hold.
     async fn on_write_start(&self, window: WriteWindow) -> Result<(), DataFusionError> {
+        self.replace_window
+            .store(window == WriteWindow::ReplaceAll, Ordering::SeqCst);
         self.inner.on_write_start(window).await
     }
 
     async fn on_write_failed(&self) -> Result<(), DataFusionError> {
+        self.replace_window.store(false, Ordering::SeqCst);
         self.inner.on_write_failed().await
     }
 
     async fn on_write_complete(&self) -> Result<(), DataFusionError> {
+        self.replace_window.store(false, Ordering::SeqCst);
         self.inner.on_write_complete().await
     }
 
@@ -192,6 +212,18 @@ async fn delete_chunked_vector_by_outer_keys(
     }
 
     Ok(())
+}
+
+/// The warning a write emits when a row's search value is now empty and the chunks its previous
+/// text produced cannot be reached — the index can only be addressed by a complete key, and the
+/// chunk ids making up that key are not knowable without listing what it holds.
+///
+/// A pure function so the wording is asserted in a unit test: it is the only account a user gets
+/// of why a search still returns text a row no longer has.
+fn unreachable_chunk_eviction_warning(index: &str, search_column: &str) -> String {
+    format!(
+        "Failed to remove the search index entries for a row whose '{search_column}' value is now empty, so that row's previous text stays searchable and a search can still return content the row no longer has. The `{index}` index can only be addressed by a complete key and cannot list what it holds, so those entries cannot be found to remove them. Re-create the search index to rebuild it from the rows the dataset holds now. See: https://spiceai.org/docs/features/search"
+    )
 }
 
 #[derive(Debug, Snafu)]
@@ -302,6 +334,7 @@ impl ChunkedSearchIndex {
             offset_col_name: Self::chunking_offset_col(search_column.as_str()),
             inner,
             chunker,
+            replace_window: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -309,6 +342,60 @@ impl ChunkedSearchIndex {
     #[must_use]
     pub fn inner(&self) -> &Arc<dyn SearchIndex> {
         &self.inner
+    }
+
+    /// Remove what the inner index still holds for the rows of `record` that this write chunked
+    /// into nothing — a NULL search value, an empty one, or text the chunker yields no chunk for.
+    ///
+    /// Such a row contributes no rows *at all* to the batch the inner index receives: not a row
+    /// the inner index can reject, but no row. The inner index therefore never sees that primary
+    /// key on this write, and nothing tells it to drop the chunks the row's previous text
+    /// produced — they stay searchable at their old vectors, and a search returns content the
+    /// row no longer has. That is a gap only this wrapper can close, because it is the layer
+    /// that decided not to send the row.
+    ///
+    /// `repeats` is parallel to `record`'s rows and holds each row's chunk count.
+    ///
+    /// Skipped inside a [`WriteWindow::ReplaceAll`] window, where it would be both pointless and
+    /// destructive: a replacing write reproduces the table's whole contents, so the inner index
+    /// stages this write and keeps serving its *previous* rows until it commits. An eviction
+    /// resolved against that listing resolves the keys the previous contents hold, and the
+    /// delete it derives from them applies to the staged rows — removing rows this same write
+    /// just wrote.
+    ///
+    /// An inner index that can neither delete by partial key nor enumerate its own entries has
+    /// no way to reach those chunks; that is reported and the write continues, because failing
+    /// the write would take the row's *new* content with it and leave the stale chunks behind
+    /// anyway.
+    async fn evict_rows_chunked_to_nothing(
+        &self,
+        record: &RecordBatch,
+        repeats: &[usize],
+    ) -> DataFusionResult<()> {
+        if self.replace_window.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        let emptied: BooleanArray = repeats.iter().map(|n| Some(*n == 0)).collect();
+        if emptied.true_count() == 0 {
+            return Ok(());
+        }
+
+        // `delete_by_keys` reads the base key columns out of whatever batch it is handed and
+        // ignores the rest, so the filtered source rows can go straight through.
+        let keys = filter_record_batch(record, &emptied)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+        match self.delete_by_keys(keys).await {
+            Err(DataFusionError::NotImplemented(_)) => {
+                tracing::warn!(
+                    "{}",
+                    unreachable_chunk_eviction_warning(self.inner.name(), &self.search_column())
+                );
+                Ok(())
+            }
+            other => other,
+        }
     }
 
     /// Build the intermediate "chunked" [`RecordBatch`] for a contiguous group of input rows
@@ -483,10 +570,12 @@ impl SearchIndex for ChunkedSearchIndex {
 
     fn as_vector_index(self: Arc<Self>) -> Option<Arc<dyn VectorIndex>> {
         let chunker = Arc::clone(&self.chunker);
+        let replace_window = Arc::clone(&self.replace_window);
         let vector_index = Arc::clone(&self.inner).as_vector_index()?;
         Some(Arc::new(ChunkedVectorIndex {
             inner: vector_index,
             chunker,
+            replace_window,
         }))
     }
 
@@ -565,6 +654,11 @@ impl SearchIndex for ChunkedSearchIndex {
             .unzip();
 
         let repeats = offsets.iter().map(Vec::len).collect::<Vec<_>>();
+
+        // A row that chunked into nothing is about to be invisible to the inner index, so drop
+        // what it still holds for that row before writing this batch's replacements.
+        self.evict_rows_chunked_to_nothing(&record, &repeats)
+            .await?;
 
         // Group input rows so that each call to `self.inner.write` sees at most
         // `INNER_WRITE_TARGET_CHUNKS` chunk rows in its intermediate batch. Each group is a
@@ -721,6 +815,33 @@ fn to_offset_array(x: &[Vec<(usize, usize)>], nullable: bool) -> FixedSizeListAr
 pub struct ChunkedVectorIndex {
     inner: Arc<dyn VectorIndex>,
     chunker: Arc<dyn Chunker>,
+    /// See [`ChunkedSearchIndex::replace_window`] — shared with every [`ChunkedSearchIndex`]
+    /// [`Self::as_search_index`] hands out, so a window opened here is visible there.
+    replace_window: Arc<AtomicBool>,
+}
+
+impl ChunkedVectorIndex {
+    #[must_use]
+    pub fn new(inner: Arc<dyn VectorIndex>, chunker: Arc<dyn Chunker>) -> Self {
+        Self {
+            inner,
+            chunker,
+            replace_window: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// The [`ChunkedSearchIndex`] view of this index, which is where the chunking logic lives.
+    /// Shares the write-window flag rather than starting a fresh one: the delegate is what
+    /// decides whether a write may evict, and a private flag would always read "no window open".
+    fn as_search_index(&self) -> ChunkedSearchIndex {
+        ChunkedSearchIndex {
+            replace_window: Arc::clone(&self.replace_window),
+            ..ChunkedSearchIndex::new(
+                Arc::clone(&self.inner) as Arc<dyn SearchIndex>,
+                Arc::clone(&self.chunker),
+            )
+        }
+    }
 }
 
 impl std::fmt::Debug for ChunkedVectorIndex {
@@ -840,11 +961,7 @@ impl Index for ChunkedVectorIndex {
 
     /// Columns that are required for the index to be computed.
     fn required_columns(&self) -> Vec<String> {
-        ChunkedSearchIndex::new(
-            Arc::clone(&self.inner) as Arc<dyn SearchIndex>,
-            Arc::clone(&self.chunker),
-        )
-        .required_columns()
+        self.as_search_index().required_columns()
     }
 
     /// Compute the index - if the index data is represented in the batch itself (i.e. a vector
@@ -853,23 +970,24 @@ impl Index for ChunkedVectorIndex {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        ChunkedSearchIndex::new(
-            Arc::clone(&self.inner) as Arc<dyn SearchIndex>,
-            Arc::clone(&self.chunker),
-        )
-        .compute_index(batches)
-        .await
+        self.as_search_index().compute_index(batches).await
     }
 
+    /// Records the window exactly as [`ChunkedSearchIndex::on_write_start`] does — this index
+    /// delegates its writes to that one, and the delegate reads the flag this sets.
     async fn on_write_start(&self, window: WriteWindow) -> Result<(), DataFusionError> {
+        self.replace_window
+            .store(window == WriteWindow::ReplaceAll, Ordering::SeqCst);
         self.inner.on_write_start(window).await
     }
 
     async fn on_write_failed(&self) -> Result<(), DataFusionError> {
+        self.replace_window.store(false, Ordering::SeqCst);
         self.inner.on_write_failed().await
     }
 
     async fn on_write_complete(&self) -> Result<(), DataFusionError> {
+        self.replace_window.store(false, Ordering::SeqCst);
         self.inner.on_write_complete().await
     }
 
@@ -908,11 +1026,7 @@ impl SearchIndex for ChunkedVectorIndex {
 
     /// All [`Field`]s that define a primary key between the underlying table and the [`SearchIndex`].
     fn primary_fields(&self) -> Vec<Field> {
-        ChunkedSearchIndex::new(
-            Arc::clone(&self.inner) as Arc<dyn SearchIndex>,
-            Arc::clone(&self.chunker),
-        )
-        .primary_fields()
+        self.as_search_index().primary_fields()
     }
 
     /// Update the index based on a [`RecordBatch`] from the underlying table.
@@ -920,23 +1034,14 @@ impl SearchIndex for ChunkedVectorIndex {
         &self,
         record: RecordBatch,
     ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {
-        ChunkedSearchIndex::new(
-            Arc::clone(&self.inner) as Arc<dyn SearchIndex>,
-            Arc::clone(&self.chunker),
-        )
-        .write(record)
-        .await
+        self.as_search_index().write(record).await
     }
 
     /// A [`TableProvider`] containing the [`SearchIndex::primary_fields`], additional metadata
     /// columns, the associated vectors/indexed content of the [`SearchIndex::search_column`] and the
     ///  search score between `query` and the [`SearchIndex::search_column`].
     fn query_table_provider(&self, query: &str) -> Result<Arc<LogicalPlan>, DataFusionError> {
-        ChunkedSearchIndex::new(
-            Arc::clone(&self.inner) as Arc<dyn SearchIndex>,
-            Arc::clone(&self.chunker),
-        )
-        .query_table_provider(query)
+        self.as_search_index().query_table_provider(query)
     }
 
     fn as_vector_index(self: Arc<Self>) -> Option<Arc<dyn VectorIndex>> {
@@ -1165,6 +1270,10 @@ mod tests {
         listed: Option<Vec<RecordBatch>>,
         /// Key batches handed to [`Index::delete_by_keys`].
         deleted: std::sync::Mutex<Vec<RecordBatch>>,
+        /// How many times [`VectorIndex::list_table_provider`] was asked for a plan — the
+        /// enumeration of everything the index holds, which is what resolving a chunked delete
+        /// against an exact-key index costs.
+        listings: AtomicUsize,
     }
 
     impl RecordingInner {
@@ -1179,6 +1288,7 @@ mod tests {
                 primary_fields: vec![Field::new("id", DataType::Int64, false)],
                 listed: None,
                 deleted: std::sync::Mutex::new(Vec::new()),
+                listings: AtomicUsize::new(0),
             }
         }
 
@@ -1208,6 +1318,10 @@ mod tests {
                 listed: Some(listed),
                 ..Self::new("content")
             }
+        }
+
+        fn listings(&self) -> usize {
+            self.listings.load(Ordering::SeqCst)
         }
 
         /// The key batches passed to [`Index::delete_by_keys`], as
@@ -1267,6 +1381,7 @@ mod tests {
     #[async_trait]
     impl VectorIndex for RecordingInner {
         fn list_table_provider(&self) -> Result<LogicalPlan, DataFusionError> {
+            self.listings.fetch_add(1, Ordering::SeqCst);
             let Some(batches) = self.listed.as_ref() else {
                 return Err(DataFusionError::NotImplemented(
                     "RecordingInner stores embeddings in the underlying table".to_string(),
@@ -1372,12 +1487,19 @@ mod tests {
     }
 
     fn build_input(rows: &[(&str, i64)]) -> RecordBatch {
+        let opt: Vec<(Option<&str>, i64)> = rows.iter().map(|(c, id)| (Some(*c), *id)).collect();
+        build_input_opt(&opt)
+    }
+
+    /// [`build_input`] with a nullable search value, for the rewrite cases where a row's text
+    /// goes away entirely.
+    fn build_input_opt(rows: &[(Option<&str>, i64)]) -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),
             Field::new("content", DataType::Utf8, true),
         ]));
         let ids: Vec<i64> = rows.iter().map(|(_, id)| *id).collect();
-        let contents: Vec<&str> = rows.iter().map(|(c, _)| *c).collect();
+        let contents: Vec<Option<&str>> = rows.iter().map(|(c, _)| *c).collect();
         RecordBatch::try_new(
             schema,
             vec![
@@ -1411,17 +1533,16 @@ mod tests {
     fn chunked_vector_index_forwards_write_complete_fatality() {
         let chunker = || Arc::new(DelimChunker { delim: ' ' }) as Arc<dyn Chunker>;
 
-        let best_effort = ChunkedVectorIndex {
-            inner: Arc::new(RecordingInner::new("content")) as Arc<dyn VectorIndex>,
-            chunker: chunker(),
-        };
+        let best_effort = ChunkedVectorIndex::new(
+            Arc::new(RecordingInner::new("content")) as Arc<dyn VectorIndex>,
+            chunker(),
+        );
         assert!(!best_effort.write_complete_failure_is_fatal());
 
-        let fatal = ChunkedVectorIndex {
-            inner: Arc::new(RecordingInner::with_fatal_write_complete("content"))
-                as Arc<dyn VectorIndex>,
-            chunker: chunker(),
-        };
+        let fatal = ChunkedVectorIndex::new(
+            Arc::new(RecordingInner::with_fatal_write_complete("content")) as Arc<dyn VectorIndex>,
+            chunker(),
+        );
         assert!(fatal.write_complete_failure_is_fatal());
     }
 
@@ -1453,17 +1574,16 @@ mod tests {
     fn chunked_vector_index_forwards_write_start_fatality() {
         let chunker = || Arc::new(DelimChunker { delim: ' ' }) as Arc<dyn Chunker>;
 
-        let best_effort = ChunkedVectorIndex {
-            inner: Arc::new(RecordingInner::new("content")) as Arc<dyn VectorIndex>,
-            chunker: chunker(),
-        };
+        let best_effort = ChunkedVectorIndex::new(
+            Arc::new(RecordingInner::new("content")) as Arc<dyn VectorIndex>,
+            chunker(),
+        );
         assert!(!best_effort.write_start_failure_is_fatal());
 
-        let fatal = ChunkedVectorIndex {
-            inner: Arc::new(RecordingInner::with_fatal_write_start("content"))
-                as Arc<dyn VectorIndex>,
-            chunker: chunker(),
-        };
+        let fatal = ChunkedVectorIndex::new(
+            Arc::new(RecordingInner::with_fatal_write_start("content")) as Arc<dyn VectorIndex>,
+            chunker(),
+        );
         assert!(fatal.write_start_failure_is_fatal());
         assert!(
             !fatal.write_complete_failure_is_fatal(),
@@ -1747,11 +1867,10 @@ mod tests {
             (1, 0),
             (1, 1),
         ])]));
-        let idx = ChunkedVectorIndex {
-            inner: compound_inner(&warm, &durable, CompoundReadMode::PrimaryOnly)
-                as Arc<dyn VectorIndex>,
-            chunker: chunker(),
-        };
+        let idx = ChunkedVectorIndex::new(
+            compound_inner(&warm, &durable, CompoundReadMode::PrimaryOnly) as Arc<dyn VectorIndex>,
+            chunker(),
+        );
 
         // The compound inner unions its two halves, so the forward is visible in the plan. Had
         // `ChunkedVectorIndex` inherited the default, this would be the *read* listing — the warm
@@ -1803,10 +1922,7 @@ mod tests {
             let search = ChunkedSearchIndex::new(inner() as Arc<dyn SearchIndex>, chunker());
             assert_eq!(search.deletes_by_partial_key(), partial);
 
-            let vector = ChunkedVectorIndex {
-                inner: inner() as Arc<dyn VectorIndex>,
-                chunker: chunker(),
-            };
+            let vector = ChunkedVectorIndex::new(inner() as Arc<dyn VectorIndex>, chunker());
             assert_eq!(vector.deletes_by_partial_key(), partial);
         }
     }
@@ -2149,19 +2265,268 @@ mod tests {
         fn as_vector_index(self: Arc<Self>) -> Option<Arc<dyn VectorIndex>> {
             Some(self)
         }
+        /// Upserts the `(id, chunk_id)` rows of the chunked batch it is handed, so a test can
+        /// write through [`ChunkedSearchIndex::write`] and then assert what the index holds.
+        /// Returns the input with a synthetic embedding column, which is the shape the chunking
+        /// layer folds back into per-document list columns.
         async fn write(
             &self,
-            _record: RecordBatch,
+            record: RecordBatch,
         ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {
-            Err(Box::new(DataFusionError::NotImplemented(
-                "unused in delete tests".into(),
-            )))
+            let ids = record
+                .column_by_name("id")
+                .expect("chunked batch carries the base key")
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("id is Int64");
+            let chunks = record
+                .column_by_name(CHUNKED_INDEX_CHUNK_KEY)
+                .expect("chunked batch carries the chunk id")
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("chunk id is UInt64");
+
+            {
+                let mut rows = self.rows.lock().expect("mutex");
+                for r in 0..record.num_rows() {
+                    let pair = (ids.value(r), chunks.value(r));
+                    if !rows.contains(&pair) {
+                        rows.push(pair);
+                    }
+                }
+            }
+
+            let n = record.num_rows();
+            let emb_field = Arc::new(Field::new("item", DataType::Float32, true));
+            let emb = FixedSizeListArray::try_new(
+                Arc::clone(&emb_field),
+                4,
+                Arc::new(Float32Array::from(vec![0.0f32; n * 4])),
+                None,
+            )?;
+
+            let mut fields: Vec<Field> = record
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| Arc::unwrap_or_clone(Arc::clone(f)))
+                .collect();
+            let mut cols: Vec<ArrayRef> = record.columns().iter().map(Arc::clone).collect();
+            fields.push(Field::new(
+                embedding_col("content"),
+                DataType::FixedSizeList(Arc::clone(&emb_field), 4),
+                true,
+            ));
+            cols.push(Arc::new(emb) as ArrayRef);
+
+            Ok(RecordBatch::try_new(Arc::new(Schema::new(fields)), cols)?)
         }
         fn query_table_provider(&self, _query: &str) -> Result<Arc<LogicalPlan>, DataFusionError> {
             Err(DataFusionError::NotImplemented(
                 "unused in delete tests".into(),
             ))
         }
+    }
+
+    /// A row rewritten to a value that produces no chunks — NULL, empty, or whitespace the
+    /// chunker yields nothing for — contributes no rows at all to the batch the inner index
+    /// receives. The inner index therefore never sees that key on this write, so unless the
+    /// chunking layer removes them first, every chunk the row's previous text produced stays
+    /// searchable at its old vector and a search returns content the row no longer has.
+    ///
+    /// Regression test for #13704. Run over both inner-index shapes, because the two reach the
+    /// existing chunks by different routes: a partial-key index deletes the whole group from the
+    /// base key, an exact-key index has to enumerate the chunk-keyed rows first.
+    #[tokio::test]
+    async fn a_row_chunked_to_nothing_loses_the_chunks_its_previous_text_produced() {
+        for partial_key in [false, true] {
+            for emptied in [None, Some(""), Some("   ")] {
+                let inner = Arc::new(StatefulChunkInner::new(&[], partial_key));
+                let idx =
+                    ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+
+                idx.write(build_input(&[("a b c", 1), ("d e", 2)]))
+                    .await
+                    .expect("first write ok");
+                assert_eq!(
+                    inner.remaining(),
+                    vec![(1, 0), (1, 1), (1, 2), (2, 0), (2, 1)],
+                    "the text each row started with is indexed chunk by chunk"
+                );
+
+                idx.write(build_input_opt(&[(emptied, 1)]))
+                    .await
+                    .expect("rewrite ok");
+
+                assert_eq!(
+                    inner.remaining(),
+                    vec![(2, 0), (2, 1)],
+                    "id 1 rewritten to {emptied:?} keeps nothing searchable \
+                     (partial-key inner: {partial_key}); id 2 is untouched"
+                );
+            }
+        }
+    }
+
+    /// A row that still chunks into something is written through to the inner index under the
+    /// same key, so there is nothing for the chunking layer to reach around and remove.
+    ///
+    /// Reaching around costs an *enumeration* of everything the inner index holds — a full
+    /// listing of an external store — so paying for it on every write would put that listing on
+    /// the ordinary append and CDC paths. This asserts the listing count, not the delete count:
+    /// a delete resolved from an empty key set issues no delete either way, so counting deletes
+    /// would pass with the guard removed.
+    #[tokio::test]
+    async fn only_a_write_that_empties_a_row_resolves_the_inner_indexs_entries() {
+        let inner = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[
+            (1, 0),
+            (1, 1),
+            (1, 2),
+        ])]));
+        let idx = ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+
+        idx.write(build_input(&[("a", 1), ("b c", 2)]))
+            .await
+            .expect("write ok");
+        assert_eq!(
+            inner.listings(),
+            0,
+            "an ordinary write must not enumerate the inner index"
+        );
+        assert!(
+            inner.deletes().is_empty(),
+            "no row emptied, so no eviction: {:?}",
+            inner.deletes()
+        );
+
+        idx.write(build_input_opt(&[(None, 1)]))
+            .await
+            .expect("write ok");
+        assert_eq!(
+            inner.listings(),
+            1,
+            "emptying a row is what pays for the enumeration, and it pays once"
+        );
+        assert_eq!(resolved_ids(&inner.deletes()), vec![1, 1, 1]);
+    }
+
+    /// A replacing write reproduces the table's whole contents, so the inner index stages it and
+    /// keeps serving its previous rows until it commits. Evicting inside that window would
+    /// resolve the *previous* contents' keys and apply the delete to the *staged* rows, taking
+    /// out rows this same write just wrote — and there is nothing to evict anyway, since the
+    /// commit replaces everything.
+    #[tokio::test]
+    async fn a_replacing_write_does_not_evict_the_rows_it_is_staging() {
+        let inner = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])]));
+        let idx = ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+
+        idx.on_write_start(WriteWindow::ReplaceAll)
+            .await
+            .expect("window opens");
+        idx.write(build_input_opt(&[(None, 1), (Some("a b"), 2)]))
+            .await
+            .expect("write ok");
+
+        assert!(
+            inner.deletes().is_empty(),
+            "a staged replacing write must not delete: {:?}",
+            inner.deletes()
+        );
+
+        // The window closing puts the index back on the evicting path.
+        idx.on_write_complete().await.expect("window closes");
+        idx.write(build_input_opt(&[(None, 1)]))
+            .await
+            .expect("write ok");
+        assert_eq!(
+            resolved_ids(&inner.deletes()),
+            vec![1],
+            "outside the window the emptied row's chunks are resolved and removed"
+        );
+    }
+
+    /// An appending window is not a replacing one — its rows are added to what the index already
+    /// holds, so an emptied row's previous chunks are still there and still have to go.
+    #[tokio::test]
+    async fn an_appending_write_still_evicts() {
+        let inner = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])]));
+        let idx = ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+
+        idx.on_write_start(WriteWindow::Append)
+            .await
+            .expect("window opens");
+        idx.write(build_input_opt(&[(None, 1)]))
+            .await
+            .expect("write ok");
+
+        assert_eq!(resolved_ids(&inner.deletes()), vec![1]);
+    }
+
+    /// `ChunkedVectorIndex` delegates its writes to a `ChunkedSearchIndex` it builds on the spot.
+    /// That delegate is what decides whether a write may evict, so the two have to share the
+    /// window flag — a delegate with a private flag would read "no window open" and evict inside
+    /// a replacing write, deleting the rows that write is staging.
+    #[tokio::test]
+    async fn chunked_vector_index_shares_its_write_window_with_the_delegate_that_evicts() {
+        let inner = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])]));
+        let idx = ChunkedVectorIndex::new(Arc::clone(&inner) as Arc<dyn VectorIndex>, chunker());
+
+        idx.on_write_start(WriteWindow::ReplaceAll)
+            .await
+            .expect("window opens");
+        idx.write(build_input_opt(&[(None, 1)]))
+            .await
+            .expect("write ok");
+        assert!(
+            inner.deletes().is_empty(),
+            "the delegate must see the window this wrapper opened: {:?}",
+            inner.deletes()
+        );
+
+        idx.on_write_complete().await.expect("window closes");
+        idx.write(build_input_opt(&[(None, 1)]))
+            .await
+            .expect("write ok");
+        assert_eq!(resolved_ids(&inner.deletes()), vec![1]);
+    }
+
+    /// The warning is the only account a user gets of why a search still returns text a row no
+    /// longer has, so a reword must not quietly drop the column, the consequence, or the fix.
+    #[test]
+    fn the_unreachable_eviction_warning_says_what_the_user_will_see() {
+        let msg = unreachable_chunk_eviction_warning("SomeIndex", "content");
+        assert!(msg.contains("'content'"), "names the search column: {msg}");
+        assert!(msg.contains("`SomeIndex`"), "names the index: {msg}");
+        assert!(
+            msg.contains("can still return content the row no longer has"),
+            "says what the user will observe: {msg}"
+        );
+        assert!(
+            msg.contains("Re-create the search index"),
+            "gives an actionable fix: {msg}"
+        );
+        assert!(
+            msg.contains("https://spiceai.org/docs/features/search"),
+            "links the docs: {msg}"
+        );
+        assert!(!msg.contains('\n'), "stays on one line: {msg}");
+    }
+
+    /// An inner index that neither deletes by partial key nor lists its own entries cannot be
+    /// reached at all. The write still has to land: failing it would take the rest of the batch's
+    /// new content with it and leave the stale chunks exactly where they are.
+    #[tokio::test]
+    async fn a_write_over_an_unreachable_inner_index_still_lands() {
+        let inner = Arc::new(RecordingInner::new("content"));
+        let idx = ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+
+        let out = idx
+            .write(build_input_opt(&[(None, 1), (Some("a b"), 2)]))
+            .await
+            .expect("the write lands even though the eviction cannot");
+
+        assert_eq!(out.num_rows(), 2);
+        assert!(inner.deletes().is_empty());
     }
 
     #[tokio::test]

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -79,6 +79,12 @@ pub struct ChunkedSearchIndex {
     /// same inner index, so a window opened against either of them is open for both. (Callers do
     /// clone — `runtime-search` clones a borrowed index to hand the search path an owned
     /// `Arc<dyn SearchIndex>`.)
+    ///
+    /// It describes the sink's replacing write, but it is stored on the index, so it is read by
+    /// every caller — including a change-data-capture stream, which drives `compute_index`
+    /// outside the sink write lifecycle. A CDC write that empties a row while a replacing window
+    /// is open therefore evicts nothing and leaves that row's previous chunks searchable; #13727
+    /// owns scoping the suppression to the replacing write's own batches.
     replace_window: Arc<AtomicBool>,
 }
 
@@ -114,7 +120,18 @@ impl Index for ChunkedSearchIndex {
     async fn on_write_start(&self, window: WriteWindow) -> Result<(), DataFusionError> {
         self.replace_window
             .store(window == WriteWindow::ReplaceAll, Ordering::Release);
-        self.inner.on_write_start(window).await
+
+        // Stays set for the duration of the inner call, so a `compute_index` running
+        // alongside it sees the window that is opening. On failure it has to be cleared
+        // here: `prepare_indexes` rolls back only the indexes that *started*, leaving the
+        // index whose start failed to own its own cleanup, so nothing else will ever call
+        // `on_write_failed` on this one. A flag left set outlives the abandoned write and
+        // suppresses eviction on every later append and CDC write, which is the stale-chunk
+        // bug this eviction exists to fix, reintroduced for the life of the index.
+        self.inner
+            .on_write_start(window)
+            .await
+            .inspect_err(|_| self.replace_window.store(false, Ordering::Release))
     }
 
     async fn on_write_failed(&self) -> Result<(), DataFusionError> {
@@ -453,7 +470,8 @@ impl ChunkedSearchIndex {
     /// rather than closing it — the row write itself commits later still, and there is no
     /// post-commit index hook on the CDC path to hang this on (#13715).
     ///
-    /// Skipped inside a [`WriteWindow::ReplaceAll`] window, where it would be destructive: an
+    /// Skipped inside a [`WriteWindow::ReplaceAll`] window (see [`Self::replace_window`] for the
+    /// CDC writes that window also suppresses, #13727), where it would be destructive: an
     /// index that stages a replacing write keeps serving its *previous* rows until it commits,
     /// so an eviction resolved against that listing resolves the previous contents' keys and
     /// applies the delete to the staged rows — removing rows this same write just wrote. The
@@ -478,7 +496,16 @@ impl ChunkedSearchIndex {
         // reporting it as "this index cannot be addressed" would tell the user a story the
         // error never told.
         if !self.deletes_by_partial_key() && Arc::clone(&self.inner).as_vector_index().is_none() {
-            if repeats.contains(&0) {
+            // Warn for an eviction that is actually owed, not merely for a batch that
+            // contains an empty row. A key is judged on its last row, so an `empty -> text`
+            // pair for one key resolves to no eviction at all — and the warning tells the
+            // user their previous text stays searchable and the index must be re-created,
+            // which for that batch is false and asks them to rebuild for nothing.
+            //
+            // `rows_to_evict`'s error is deliberately dropped rather than propagated: an
+            // index that cannot be addressed could not act on the answer either way, so
+            // raising it here would fail writes that this branch has always let through.
+            if matches!(self.rows_to_evict(record, repeats), Ok(Some(_))) {
                 tracing::warn!(
                     "{}",
                     unreachable_chunk_eviction_warning(self.inner.name(), &self.search_column())
@@ -1353,6 +1380,9 @@ mod tests {
         /// Makes [`SearchIndex::write`] fail, for the paths that must not act on a write that
         /// did not land.
         write_fails: bool,
+        /// Makes [`Index::on_write_start`] fail, for the paths that must not be left holding
+        /// state an abandoned write set.
+        start_fails: bool,
         /// Whether [`SearchIndex::as_vector_index`] hands one back. `false` is the shape of a
         /// full-text index: not enumerable, so a chunked index over it can only reach its chunks
         /// if it deletes by partial key.
@@ -1382,6 +1412,7 @@ mod tests {
                 write_complete_fatal: false,
                 deletes_partial_key: false,
                 write_fails: false,
+                start_fails: false,
                 is_vector_index: true,
                 primary_fields: vec![Field::new("id", DataType::Int64, false)],
                 listed: None,
@@ -1464,6 +1495,14 @@ mod tests {
         }
         fn deletes_by_partial_key(&self) -> bool {
             self.deletes_partial_key
+        }
+        async fn on_write_start(&self, _window: WriteWindow) -> Result<(), DataFusionError> {
+            if self.start_fails {
+                return Err(DataFusionError::External(
+                    "RecordingInner was told to fail its start".into(),
+                ));
+            }
+            Ok(())
         }
         fn write_start_failure_is_fatal(&self) -> bool {
             self.write_start_fatal
@@ -2667,6 +2706,155 @@ mod tests {
             "links the docs: {msg}"
         );
         assert!(!msg.contains('\n'), "stays on one line: {msg}");
+    }
+
+    /// A `MakeWriter` that accumulates this thread's log output, so a test can assert on what
+    /// an operator would actually see in `spice.log`.
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl CapturedLogs {
+        fn occurrences_of(&self, needle: &str) -> usize {
+            String::from_utf8_lossy(
+                &self
+                    .0
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner),
+            )
+            .matches(needle)
+            .count()
+        }
+    }
+
+    thread_local! {
+        static CAPTURE_SINK: std::cell::RefCell<Option<CapturedLogs>> =
+            const { std::cell::RefCell::new(None) };
+    }
+
+    /// Routes each event to the buffer registered for the emitting thread, and discards events
+    /// from threads that registered none.
+    #[derive(Clone, Default)]
+    struct ThreadCapture;
+
+    impl std::io::Write for ThreadCapture {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            CAPTURE_SINK.with(|sink| {
+                if let Some(logs) = sink.borrow().as_ref() {
+                    logs.0
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .extend_from_slice(buf);
+                }
+            });
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl tracing_subscriber::fmt::MakeWriter<'_> for ThreadCapture {
+        type Writer = Self;
+
+        fn make_writer(&self) -> Self::Writer {
+            Self
+        }
+    }
+
+    /// Registers a buffer for this thread's log lines and hands it back to be asserted on.
+    ///
+    /// The subscriber is installed **globally**, once per test binary, rather than scoped to the
+    /// calling thread: `tracing` caches each callsite's interest process-wide, so a sibling test
+    /// reaching this callsite without a subscriber would cache it as "never" and the event would
+    /// be dropped before any subscriber saw it. The thread-local sink is what keeps concurrent
+    /// tests from reading each other's lines.
+    fn capture_logs() -> CapturedLogs {
+        static INSTALLED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+        INSTALLED.get_or_init(|| {
+            tracing::subscriber::set_global_default(
+                tracing_subscriber::fmt()
+                    .with_writer(ThreadCapture)
+                    .with_ansi(false)
+                    .with_max_level(tracing::Level::WARN)
+                    .finish(),
+            )
+            .expect("no other global subscriber is installed in this test binary");
+        });
+
+        let logs = CapturedLogs::default();
+        CAPTURE_SINK.with(|sink| *sink.borrow_mut() = Some(logs.clone()));
+        logs
+    }
+
+    /// The warning tells the user that a row's previous text stays searchable and that the index
+    /// has to be re-created to clear it. That is a claim about *this* batch, so it must be made
+    /// only when this batch actually leaves entries behind.
+    ///
+    /// A key is judged on its last row, so an `empty -> text` pair for one key resolves to no
+    /// eviction: the surviving row still chunks and keeps what this write wrote for it. Warning
+    /// on "some row in the batch chunked to nothing" instead reports stale results for a batch
+    /// the code handled correctly, and sends the user to rebuild an index that is fine.
+    #[tokio::test]
+    async fn the_unreachable_warning_fires_only_when_an_eviction_is_owed() {
+        for (rows, expected_warnings) in [
+            // The key's surviving row still chunks: nothing is left behind, nothing to say.
+            (vec![(None, 1i64), (Some("a b"), 1)], 0),
+            // The key's surviving row chunked to nothing, and this index cannot reach what it
+            // left behind — the one case the warning describes.
+            (vec![(Some("a b"), 1i64), (None, 1)], 1),
+        ] {
+            let logs = capture_logs();
+            let inner = Arc::new(RecordingInner {
+                is_vector_index: false,
+                ..RecordingInner::new("content")
+            });
+            let idx =
+                ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+
+            idx.write(build_input_opt(&rows))
+                .await
+                .expect("the write lands even when the eviction cannot");
+
+            assert_eq!(
+                logs.occurrences_of("stays searchable"),
+                expected_warnings,
+                "rows {rows:?} should produce {expected_warnings} warning(s)"
+            );
+            assert!(
+                inner.deletes().is_empty(),
+                "an unreachable index is never asked to delete"
+            );
+        }
+    }
+
+    /// `prepare_indexes` rolls back only the indexes whose start *succeeded*, leaving the one
+    /// whose start failed to clean up after itself. So an `on_write_start` that records the
+    /// window and then fails must put the flag back before it propagates: nothing else will,
+    /// and a flag left set suppresses eviction on every later append and CDC write for the life
+    /// of the index — the stale-chunk bug this eviction exists to fix, made permanent.
+    #[tokio::test]
+    async fn a_failed_write_start_does_not_leave_the_replace_window_open() {
+        let inner = Arc::new(RecordingInner {
+            start_fails: true,
+            ..RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])])
+        });
+        let idx = ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+
+        idx.on_write_start(WriteWindow::ReplaceAll)
+            .await
+            .expect_err("the inner index was told to fail its start");
+
+        // The abandoned write is over. A later write that empties a row must still evict.
+        idx.compute_index(vec![build_input_opt(&[(None, 1)])])
+            .await
+            .expect("write ok");
+
+        assert_eq!(
+            resolved_ids(&inner.deletes()),
+            vec![1],
+            "eviction is still live after a start that failed"
+        );
     }
 
     /// An inner index that neither deletes by partial key nor can be enumerated as a vector

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -61,6 +61,7 @@ pub static CHUNKED_INDEX_FULL_SEARCH_FIELD: &str = "_spice.search_field";
 /// Two new [`FieldRef`]s augment the table:
 ///   1. An index of the chunks position in the underlying search column. This is an additional element in [`SearchIndex::primary_fields`].
 ///   2. The start and end index of the chunk into the underlying search column. This is an additional [`MetadataColumn::NonFilterable`] in  [`SearchIndex::metadata_columns`].
+#[derive(Clone)]
 pub struct ChunkedSearchIndex {
     inner: Arc<dyn SearchIndex>,
     chunker: Arc<dyn Chunker>,
@@ -73,7 +74,12 @@ pub struct ChunkedSearchIndex {
     base_key_names: Vec<String>,
     /// Set for the duration of a [`WriteWindow::ReplaceAll`] window. See
     /// [`Self::evict_rows_chunked_to_nothing`], which is where it is read and why it exists.
-    replace_window: AtomicBool,
+    ///
+    /// Behind an [`Arc`] so a clone of this index observes the same window: a clone wraps the
+    /// same inner index, so a window opened against either of them is open for both. (Callers do
+    /// clone — `runtime-search` clones a borrowed index to hand the search path an owned
+    /// `Arc<dyn SearchIndex>`.)
+    replace_window: Arc<AtomicBool>,
 }
 
 #[async_trait]
@@ -335,7 +341,7 @@ impl ChunkedSearchIndex {
             base_key_names: Self::base_key_columns(&inner.primary_fields()),
             inner,
             chunker,
-            replace_window: AtomicBool::new(false),
+            replace_window: Arc::new(AtomicBool::new(false)),
         }
     }
 

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -18,7 +18,7 @@ use arrow::{
         Array, ArrayRef, BooleanArray, FixedSizeListArray, FixedSizeListBuilder, Int32Builder,
         LargeStringArray, ListArray, RecordBatch, StringArray, StringViewArray, UInt64Array,
     },
-    buffer::OffsetBuffer,
+    buffer::{BooleanBuffer, OffsetBuffer},
     compute::{concat, filter_record_batch},
     row::{RowConverter, SortField},
 };
@@ -61,7 +61,6 @@ pub static CHUNKED_INDEX_FULL_SEARCH_FIELD: &str = "_spice.search_field";
 /// Two new [`FieldRef`]s augment the table:
 ///   1. An index of the chunks position in the underlying search column. This is an additional element in [`SearchIndex::primary_fields`].
 ///   2. The start and end index of the chunk into the underlying search column. This is an additional [`MetadataColumn::NonFilterable`] in  [`SearchIndex::metadata_columns`].
-#[derive(Clone)]
 pub struct ChunkedSearchIndex {
     inner: Arc<dyn SearchIndex>,
     chunker: Arc<dyn Chunker>,
@@ -69,13 +68,12 @@ pub struct ChunkedSearchIndex {
     embedding_col_name: String,
     /// Cached `{search_column}_offset` — avoids reallocating the name on every write.
     offset_col_name: String,
-    /// Set for the duration of a [`WriteWindow::ReplaceAll`] window, so
-    /// [`Self::evict_rows_chunked_to_nothing`] can tell a replacing write from every other one.
-    ///
-    /// Shared with the [`ChunkedVectorIndex`] this wrapper hands out and with the temporary
-    /// [`ChunkedSearchIndex`] that index delegates through, so the window one of them opens is
-    /// the window the other one sees.
-    replace_window: Arc<AtomicBool>,
+    /// Cached names of the base row's primary-key columns — avoids re-deriving them from
+    /// [`SearchIndex::primary_fields`], which clones every `Field`, on every write.
+    base_key_names: Vec<String>,
+    /// Set for the duration of a [`WriteWindow::ReplaceAll`] window. See
+    /// [`Self::evict_rows_chunked_to_nothing`], which is where it is read and why it exists.
+    replace_window: AtomicBool,
 }
 
 #[async_trait]
@@ -109,17 +107,17 @@ impl Index for ChunkedSearchIndex {
     /// index is staging rather than serving what it is about to hold.
     async fn on_write_start(&self, window: WriteWindow) -> Result<(), DataFusionError> {
         self.replace_window
-            .store(window == WriteWindow::ReplaceAll, Ordering::SeqCst);
+            .store(window == WriteWindow::ReplaceAll, Ordering::Release);
         self.inner.on_write_start(window).await
     }
 
     async fn on_write_failed(&self) -> Result<(), DataFusionError> {
-        self.replace_window.store(false, Ordering::SeqCst);
+        self.replace_window.store(false, Ordering::Release);
         self.inner.on_write_failed().await
     }
 
     async fn on_write_complete(&self) -> Result<(), DataFusionError> {
-        self.replace_window.store(false, Ordering::SeqCst);
+        self.replace_window.store(false, Ordering::Release);
         self.inner.on_write_complete().await
     }
 
@@ -334,9 +332,10 @@ impl ChunkedSearchIndex {
         Self {
             embedding_col_name: embedding_col(search_column.as_str()),
             offset_col_name: Self::chunking_offset_col(search_column.as_str()),
+            base_key_names: Self::base_key_columns(&inner.primary_fields()),
             inner,
             chunker,
-            replace_window: Arc::new(AtomicBool::new(false)),
+            replace_window: AtomicBool::new(false),
         }
     }
 
@@ -367,54 +366,72 @@ impl ChunkedSearchIndex {
         record: &RecordBatch,
         repeats: &[usize],
     ) -> DataFusionResult<Option<RecordBatch>> {
-        if !repeats.iter().any(|n| *n == 0) {
+        // Short-circuit before anything is allocated: on an ordinary write every row chunks into
+        // something, and this is the only work that write should pay for.
+        let emptied = repeats.iter().filter(|n| **n == 0).count();
+        if emptied == 0 {
             return Ok(None);
         }
 
         // A key of no columns addresses nothing, so there is no group to evict.
-        let key_columns = Self::base_key_columns(&self.inner.primary_fields());
-        if key_columns.is_empty() {
+        if self.base_key_names.is_empty() {
             return Ok(None);
         }
 
-        let key_arrays: Vec<ArrayRef> = key_columns
+        let key_indices: Vec<usize> = self
+            .base_key_names
             .iter()
-            .map(|name| record.column_by_name(name).map(Arc::clone))
+            .map(|name| record.schema().index_of(name).ok())
             .collect::<Option<Vec<_>>>()
             .ok_or_else(|| {
                 DataFusionError::Plan(format!(
                     "Failed to update the search index on '{}': the rows being written do not \
-                     carry the key column(s) {key_columns:?} the index is addressed by, so a row \
-                     whose value is now empty cannot have its previous entries removed and a \
-                     search would keep returning them.",
-                    self.search_column()
+                     carry the key column(s) {:?} the index is addressed by, so a row whose \
+                     value is now empty cannot have its previous entries removed and a search \
+                     would keep returning them.",
+                    self.search_column(),
+                    self.base_key_names
                 ))
             })?;
 
-        // Compare whole key tuples, whatever their column types, by converting them to Arrow's
-        // comparable row encoding once for the batch.
+        // `delete_by_keys` reads the key columns out of whatever batch it is handed and ignores
+        // the rest, so narrow to them first: `project` re-slices the column vec without copying,
+        // where filtering the whole batch would run a kernel over the search text and the
+        // embedding vectors only to discard them.
+        let keys = record.project(&key_indices)?;
+
+        // Compare whole key tuples, whatever their column types, through Arrow's comparable row
+        // encoding.
         let converter = RowConverter::new(
-            key_arrays
+            keys.columns()
                 .iter()
                 .map(|a| SortField::new(a.data_type().clone()))
                 .collect(),
         )?;
-        let rows = converter.convert_columns(&key_arrays)?;
-        let written: HashSet<_> = (0..record.num_rows())
-            .filter(|i| repeats[*i] > 0)
-            .map(|i| rows.row(i))
-            .collect();
+        let rows = converter.convert_columns(keys.columns())?;
 
-        let evict: BooleanArray = (0..record.num_rows())
-            .map(|i| Some(repeats[i] == 0 && !written.contains(&rows.row(i))))
-            .collect();
-        if evict.true_count() == 0 {
+        // Keyed on the emptied rows rather than the written ones: the emptied set is the small
+        // one, and it is the side being subtracted from.
+        let mut candidates = HashSet::with_capacity(emptied);
+        for (i, _) in repeats.iter().enumerate().filter(|(_, n)| **n == 0) {
+            candidates.insert(rows.row(i));
+        }
+        for (i, _) in repeats.iter().enumerate().filter(|(_, n)| **n > 0) {
+            candidates.remove(&rows.row(i));
+        }
+        if candidates.is_empty() {
             return Ok(None);
         }
 
-        // `delete_by_keys` reads the key columns out of whatever batch it is handed and ignores
-        // the rest, so the filtered source rows can go straight through.
-        filter_record_batch(record, &evict)
+        // Non-nullable by construction, so `filter_record_batch` takes its fast path.
+        let evict = BooleanArray::new(
+            BooleanBuffer::collect_bool(keys.num_rows(), |i| {
+                repeats[i] == 0 && candidates.contains(&rows.row(i))
+            }),
+            None,
+        );
+
+        filter_record_batch(&keys, &evict)
             .map(Some)
             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
     }
@@ -433,15 +450,30 @@ impl ChunkedSearchIndex {
     /// backends that *don't* stage discard nothing at all for that window, including entries for
     /// rows the refresh dropped outright, which is #12413 rather than this path.
     ///
-    /// An inner index that can neither delete by partial key nor enumerate its own entries has
-    /// no way to reach those chunks; that is reported and the write stands, because failing it
-    /// after the chunks have landed would not remove the stale entries either.
+    /// An inner index that can neither delete by partial key nor be enumerated as a vector index
+    /// has no way to reach those chunks at all. That is asked up front, so the write reports it
+    /// and stands — failing it after the chunks have landed would not remove the stale entries
+    /// either — and every error from the delete itself stays an error.
     async fn evict_rows_chunked_to_nothing(
         &self,
         record: &RecordBatch,
         repeats: &[usize],
     ) -> DataFusionResult<()> {
-        if self.replace_window.load(Ordering::SeqCst) {
+        if self.replace_window.load(Ordering::Acquire) {
+            return Ok(());
+        }
+
+        // Ask the capability rather than inferring it from the shape of a failure: a
+        // `NotImplemented` raised deeper down is a real failure of a supported path, and
+        // reporting it as "this index cannot be addressed" would tell the user a story the
+        // error never told.
+        if !self.deletes_by_partial_key() && Arc::clone(&self.inner).as_vector_index().is_none() {
+            if repeats.contains(&0) {
+                tracing::warn!(
+                    "{}",
+                    unreachable_chunk_eviction_warning(self.inner.name(), &self.search_column())
+                );
+            }
             return Ok(());
         }
 
@@ -449,16 +481,7 @@ impl ChunkedSearchIndex {
             return Ok(());
         };
 
-        match self.delete_by_keys(keys).await {
-            Err(DataFusionError::NotImplemented(_)) => {
-                tracing::warn!(
-                    "{}",
-                    unreachable_chunk_eviction_warning(self.inner.name(), &self.search_column())
-                );
-                Ok(())
-            }
-            other => other,
-        }
+        self.delete_by_keys(keys).await
     }
 
     /// Build the intermediate "chunked" [`RecordBatch`] for a contiguous group of input rows
@@ -631,14 +654,13 @@ impl SearchIndex for ChunkedSearchIndex {
             .collect::<Vec<_>>()
     }
 
+    /// The vector view delegates its chunking back to *this* object rather than to a copy, so
+    /// the write window one of them opens is the window the other one reads.
     fn as_vector_index(self: Arc<Self>) -> Option<Arc<dyn VectorIndex>> {
-        let chunker = Arc::clone(&self.chunker);
-        let replace_window = Arc::clone(&self.replace_window);
-        let vector_index = Arc::clone(&self.inner).as_vector_index()?;
+        let inner = Arc::clone(&self.inner).as_vector_index()?;
         Some(Arc::new(ChunkedVectorIndex {
-            inner: vector_index,
-            chunker,
-            replace_window,
+            inner,
+            delegate: self,
         }))
     }
 
@@ -878,33 +900,25 @@ fn to_offset_array(x: &[Vec<(usize, usize)>], nullable: bool) -> FixedSizeListAr
 #[derive(Clone)]
 pub struct ChunkedVectorIndex {
     inner: Arc<dyn VectorIndex>,
-    chunker: Arc<dyn Chunker>,
-    /// See [`ChunkedSearchIndex::replace_window`] — shared with every [`ChunkedSearchIndex`]
-    /// [`Self::as_search_index`] hands out, so a window opened here is visible there.
-    replace_window: Arc<AtomicBool>,
+    /// The chunking itself, which this index is a vector-typed view of. Holding the delegate
+    /// rather than the pieces to rebuild it is what lets the two share one write window: a
+    /// delegate rebuilt per call would carry its own, always reading "no window open".
+    ///
+    /// `delegate.inner` is the same index as [`Self::inner`], reached as a [`SearchIndex`].
+    delegate: Arc<ChunkedSearchIndex>,
 }
 
 impl ChunkedVectorIndex {
-    #[must_use]
-    pub fn new(inner: Arc<dyn VectorIndex>, chunker: Arc<dyn Chunker>) -> Self {
-        Self {
-            inner,
+    /// Builds the vector wrapper and its delegate together. Production reaches this type through
+    /// [`ChunkedSearchIndex::as_vector_index`], which hands over an existing delegate so the two
+    /// share one write window; this constructor is what the tests build a standalone one with.
+    #[cfg(test)]
+    fn new(inner: Arc<dyn VectorIndex>, chunker: Arc<dyn Chunker>) -> Self {
+        let delegate = Arc::new(ChunkedSearchIndex::new(
+            Arc::clone(&inner) as Arc<dyn SearchIndex>,
             chunker,
-            replace_window: Arc::new(AtomicBool::new(false)),
-        }
-    }
-
-    /// The [`ChunkedSearchIndex`] view of this index, which is where the chunking logic lives.
-    /// Shares the write-window flag rather than starting a fresh one: the delegate is what
-    /// decides whether a write may evict, and a private flag would always read "no window open".
-    fn as_search_index(&self) -> ChunkedSearchIndex {
-        ChunkedSearchIndex {
-            replace_window: Arc::clone(&self.replace_window),
-            ..ChunkedSearchIndex::new(
-                Arc::clone(&self.inner) as Arc<dyn SearchIndex>,
-                Arc::clone(&self.chunker),
-            )
-        }
+        ));
+        Self { inner, delegate }
     }
 }
 
@@ -1025,7 +1039,7 @@ impl Index for ChunkedVectorIndex {
 
     /// Columns that are required for the index to be computed.
     fn required_columns(&self) -> Vec<String> {
-        self.as_search_index().required_columns()
+        self.delegate.required_columns()
     }
 
     /// Compute the index - if the index data is represented in the batch itself (i.e. a vector
@@ -1034,25 +1048,21 @@ impl Index for ChunkedVectorIndex {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        self.as_search_index().compute_index(batches).await
+        self.delegate.compute_index(batches).await
     }
 
-    /// Records the window exactly as [`ChunkedSearchIndex::on_write_start`] does — this index
-    /// delegates its writes to that one, and the delegate reads the flag this sets.
+    /// Through the delegate, which records the window and forwards to the same inner index —
+    /// so the object that decides whether a write may evict is the object that was told.
     async fn on_write_start(&self, window: WriteWindow) -> Result<(), DataFusionError> {
-        self.replace_window
-            .store(window == WriteWindow::ReplaceAll, Ordering::SeqCst);
-        self.inner.on_write_start(window).await
+        self.delegate.on_write_start(window).await
     }
 
     async fn on_write_failed(&self) -> Result<(), DataFusionError> {
-        self.replace_window.store(false, Ordering::SeqCst);
-        self.inner.on_write_failed().await
+        self.delegate.on_write_failed().await
     }
 
     async fn on_write_complete(&self) -> Result<(), DataFusionError> {
-        self.replace_window.store(false, Ordering::SeqCst);
-        self.inner.on_write_complete().await
+        self.delegate.on_write_complete().await
     }
 
     /// See [`ChunkedSearchIndex::delete_by_keys`] — same outer-key-to-chunk resolution, with the
@@ -1090,7 +1100,7 @@ impl SearchIndex for ChunkedVectorIndex {
 
     /// All [`Field`]s that define a primary key between the underlying table and the [`SearchIndex`].
     fn primary_fields(&self) -> Vec<Field> {
-        self.as_search_index().primary_fields()
+        self.delegate.primary_fields()
     }
 
     /// Update the index based on a [`RecordBatch`] from the underlying table.
@@ -1098,14 +1108,14 @@ impl SearchIndex for ChunkedVectorIndex {
         &self,
         record: RecordBatch,
     ) -> Result<RecordBatch, Box<dyn std::error::Error + Send + Sync>> {
-        self.as_search_index().write(record).await
+        self.delegate.write(record).await
     }
 
     /// A [`TableProvider`] containing the [`SearchIndex::primary_fields`], additional metadata
     /// columns, the associated vectors/indexed content of the [`SearchIndex::search_column`] and the
     ///  search score between `query` and the [`SearchIndex::search_column`].
     fn query_table_provider(&self, query: &str) -> Result<Arc<LogicalPlan>, DataFusionError> {
-        self.as_search_index().query_table_provider(query)
+        self.delegate.query_table_provider(query)
     }
 
     fn as_vector_index(self: Arc<Self>) -> Option<Arc<dyn VectorIndex>> {
@@ -1315,6 +1325,11 @@ mod tests {
     /// Float32) and an `<col>_offset` column copied from the input. The chunking layer reads
     /// these back and folds them into per-document list columns on the final output.
     #[derive(Debug)]
+    #[expect(
+        clippy::struct_excessive_bools,
+        reason = "a test double's independently-settable knobs; grouping them would obscure the \
+                  `..RecordingInner::new(..)` struct updates every test here is written with"
+    )]
     struct RecordingInner {
         search_column: String,
         calls: AtomicUsize,
@@ -1328,6 +1343,10 @@ mod tests {
         /// Makes [`SearchIndex::write`] fail, for the paths that must not act on a write that
         /// did not land.
         write_fails: bool,
+        /// Whether [`SearchIndex::as_vector_index`] hands one back. `false` is the shape of a
+        /// full-text index: not enumerable, so a chunked index over it can only reach its chunks
+        /// if it deletes by partial key.
+        is_vector_index: bool,
         /// What this mock reports from [`SearchIndex::primary_fields`]. A chunked index's inner
         /// index carries [`CHUNKED_INDEX_CHUNK_KEY`] here.
         primary_fields: Vec<Field>,
@@ -1353,6 +1372,7 @@ mod tests {
                 write_complete_fatal: false,
                 deletes_partial_key: false,
                 write_fails: false,
+                is_vector_index: true,
                 primary_fields: vec![Field::new("id", DataType::Int64, false)],
                 listed: None,
                 deleted: std::sync::Mutex::new(Vec::new()),
@@ -1486,7 +1506,7 @@ mod tests {
         }
 
         fn as_vector_index(self: Arc<Self>) -> Option<Arc<dyn VectorIndex>> {
-            Some(self)
+            self.is_vector_index.then_some(self as Arc<dyn VectorIndex>)
         }
 
         async fn write(
@@ -2483,84 +2503,63 @@ mod tests {
         assert_eq!(resolved_ids(&inner.deletes()), vec![1, 1, 1]);
     }
 
-    /// A replacing write reproduces the table's whole contents, so the inner index stages it and
-    /// keeps serving its previous rows until it commits. Evicting inside that window would
-    /// resolve the *previous* contents' keys and apply the delete to the *staged* rows, taking
-    /// out rows this same write just wrote — and there is nothing to evict anyway, since the
-    /// commit replaces everything.
+    /// The write window decides whether a write may evict, and both chunked wrappers have to
+    /// reach the same answer.
+    ///
+    /// A replacing write reproduces the table's whole contents, so an index that stages it keeps
+    /// serving its previous rows until it commits. Evicting inside that window would resolve the
+    /// previous contents' keys and apply the delete to the staged rows, taking out rows the same
+    /// write just wrote — and there is nothing to evict anyway, since the commit replaces
+    /// everything. An appending window is the opposite: its rows are added to what the index
+    /// already holds, so an emptied row's previous chunks are still there and still have to go.
+    ///
+    /// `ChunkedVectorIndex` is covered by the same table because it delegates its writes to a
+    /// `ChunkedSearchIndex`; were the two not sharing one window, the delegate would read "no
+    /// window open" and evict the rows a replacing write is staging.
     #[tokio::test]
-    async fn a_replacing_write_does_not_evict_the_rows_it_is_staging() {
-        let inner = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])]));
-        let idx = ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
+    async fn the_write_window_decides_whether_a_write_evicts() {
+        for (window, evicts) in [
+            (WriteWindow::ReplaceAll, false),
+            (WriteWindow::Append, true),
+        ] {
+            for vector_wrapper in [false, true] {
+                let inner = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])]));
+                let idx: Arc<dyn Index> = if vector_wrapper {
+                    Arc::new(ChunkedVectorIndex::new(
+                        Arc::clone(&inner) as Arc<dyn VectorIndex>,
+                        chunker(),
+                    ))
+                } else {
+                    Arc::new(ChunkedSearchIndex::new(
+                        Arc::clone(&inner) as Arc<dyn SearchIndex>,
+                        chunker(),
+                    ))
+                };
 
-        idx.on_write_start(WriteWindow::ReplaceAll)
-            .await
-            .expect("window opens");
-        idx.write(build_input_opt(&[(None, 1), (Some("a b"), 2)]))
-            .await
-            .expect("write ok");
+                idx.on_write_start(window).await.expect("window opens");
+                idx.compute_index(vec![build_input_opt(&[(None, 1)])])
+                    .await
+                    .expect("write ok");
 
-        assert!(
-            inner.deletes().is_empty(),
-            "a staged replacing write must not delete: {:?}",
-            inner.deletes()
-        );
+                let expected = if evicts { vec![1] } else { vec![] };
+                assert_eq!(
+                    resolved_ids(&inner.deletes()),
+                    expected,
+                    "{window:?} on {} wrapper",
+                    if vector_wrapper { "vector" } else { "search" }
+                );
 
-        // The window closing puts the index back on the evicting path.
-        idx.on_write_complete().await.expect("window closes");
-        idx.write(build_input_opt(&[(None, 1)]))
-            .await
-            .expect("write ok");
-        assert_eq!(
-            resolved_ids(&inner.deletes()),
-            vec![1],
-            "outside the window the emptied row's chunks are resolved and removed"
-        );
-    }
-
-    /// An appending window is not a replacing one — its rows are added to what the index already
-    /// holds, so an emptied row's previous chunks are still there and still have to go.
-    #[tokio::test]
-    async fn an_appending_write_still_evicts() {
-        let inner = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])]));
-        let idx = ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
-
-        idx.on_write_start(WriteWindow::Append)
-            .await
-            .expect("window opens");
-        idx.write(build_input_opt(&[(None, 1)]))
-            .await
-            .expect("write ok");
-
-        assert_eq!(resolved_ids(&inner.deletes()), vec![1]);
-    }
-
-    /// `ChunkedVectorIndex` delegates its writes to a `ChunkedSearchIndex` it builds on the spot.
-    /// That delegate is what decides whether a write may evict, so the two have to share the
-    /// window flag — a delegate with a private flag would read "no window open" and evict inside
-    /// a replacing write, deleting the rows that write is staging.
-    #[tokio::test]
-    async fn chunked_vector_index_shares_its_write_window_with_the_delegate_that_evicts() {
-        let inner = Arc::new(RecordingInner::chunked(vec![chunk_keyed_rows(&[(1, 0)])]));
-        let idx = ChunkedVectorIndex::new(Arc::clone(&inner) as Arc<dyn VectorIndex>, chunker());
-
-        idx.on_write_start(WriteWindow::ReplaceAll)
-            .await
-            .expect("window opens");
-        idx.write(build_input_opt(&[(None, 1)]))
-            .await
-            .expect("write ok");
-        assert!(
-            inner.deletes().is_empty(),
-            "the delegate must see the window this wrapper opened: {:?}",
-            inner.deletes()
-        );
-
-        idx.on_write_complete().await.expect("window closes");
-        idx.write(build_input_opt(&[(None, 1)]))
-            .await
-            .expect("write ok");
-        assert_eq!(resolved_ids(&inner.deletes()), vec![1]);
+                // Closing the window always puts the index back on the evicting path.
+                idx.on_write_complete().await.expect("window closes");
+                idx.compute_index(vec![build_input_opt(&[(None, 1)])])
+                    .await
+                    .expect("write ok");
+                assert!(
+                    resolved_ids(&inner.deletes()).contains(&1),
+                    "an emptied row evicts once the window is closed"
+                );
+            }
+        }
     }
 
     /// The eviction must never remove a chunk this same write produced. One batch can carry the
@@ -2633,12 +2632,15 @@ mod tests {
         assert!(!msg.contains('\n'), "stays on one line: {msg}");
     }
 
-    /// An inner index that neither deletes by partial key nor lists its own entries cannot be
-    /// reached at all. The write still has to land: failing it would take the rest of the batch's
-    /// new content with it and leave the stale chunks exactly where they are.
+    /// An inner index that neither deletes by partial key nor can be enumerated as a vector
+    /// index cannot be reached at all. The write still has to land: failing it would take the
+    /// rest of the batch's new content with it and leave the stale chunks exactly where they are.
     #[tokio::test]
     async fn a_write_over_an_unreachable_inner_index_still_lands() {
-        let inner = Arc::new(RecordingInner::new("content"));
+        let inner = Arc::new(RecordingInner {
+            is_vector_index: false,
+            ..RecordingInner::new("content")
+        });
         let idx = ChunkedSearchIndex::new(Arc::clone(&inner) as Arc<dyn SearchIndex>, chunker());
 
         let out = idx


### PR DESCRIPTION
## Summary

A chunked search index writes one row per text chunk to the index it wraps, keyed by the source
row's primary key plus a chunk ordinal. A row whose search value chunks into nothing — NULL, empty,
or text the chunker yields no chunk for — contributes **no rows at all** to the batch the inner
index receives. Not a row the inner index can reject: no row. The inner index therefore never sees
that key on the write, and nothing tells it to drop the chunks the row's previous text produced.

They stay searchable at their old vectors. A search over the index returns content the row no
longer has, with no error and no signal that the row changed — a wrong result, not a missing one.
It is a gap only the chunking layer can close, because it is the layer that decided not to send the
row.

## Changes

`ChunkedSearchIndex::write` now removes what the inner index still holds for the rows it chunked
into nothing, through the same `delete_by_keys` bridge the delete path already uses (partial-key
delete where the backend supports one, chunk-key resolution where it does not).

Three properties shape when it runs:

- **After this write's chunks have landed, not before.** The deletion is externally visible and
  nothing restores it, so ordering it first let a failed embedding or bulk write leave the row
  present in the table with its previous chunks already gone — a false negative where the bug being
  fixed is a false positive. This narrows that window rather than closing it; see below.
- **Judged on the row that survives the batch.** One batch can carry the same key more than once,
  and the eviction has to agree with the row the table will end up holding. A key whose last row
  still chunks keeps what this write wrote for it; a key whose last row chunked into nothing loses
  everything under it, including chunks an earlier row of the same batch just produced. Whole key
  tuples are compared through Arrow's row encoding, so this holds for any key column type.
- **Not inside a replacing write window.** An index that stages a `ReplaceAll` write keeps serving
  its previous rows until it commits, so an eviction resolved against that listing would resolve
  the previous contents' keys and apply the delete to the staged rows — removing rows the same
  write just wrote.

An ordinary write — every row still chunks into something — resolves nothing, so the enumeration
this costs stays off the append and CDC paths. A test asserts that by counting enumerations of the
inner index, not deletes: a delete resolved from an empty key set issues no delete either way, so
counting deletes would have passed with the guard removed.

Reachability is asked of the inner index up front rather than inferred from the shape of a failure.
A `NotImplemented` raised deeper down is a real failure of a supported path, and reporting it as
"this index cannot be addressed" would tell the user a story the error never told.

Alongside, `ChunkedVectorIndex` now holds the `ChunkedSearchIndex` it delegates to instead of the
pieces to rebuild one per call. That is what lets the two share one write window without a flag
shared across three objects, and it takes two `format!`s and an allocation off the per-batch path.

## What this does not close

`Refs #13704` rather than `Fixes`, because two of that issue's acceptance criteria survive it:

- **A row rewritten to *fewer* chunks.** Chunk ids `n'..old_n` are still never overwritten and
  never removed. Reaching them needs the row's previous chunk count, which nothing records; the
  only way to learn it is to enumerate the inner index, and doing that on every write would put a
  full listing of an external store on the append and CDC paths. #13704 stays open owning that.
- **A replacing write on a backend that does not stage.** Elasticsearch and the vector tiers
  discard nothing for a `ReplaceAll` window — including entries for rows the refresh dropped
  outright, which is the larger, already-tracked #12413. Evicting only the emptied-row subset there
  would be a partial patch over that hole, so this leaves it to #12413.

Four further limitations were found by the review passes and filed rather than folded in:

- **#13727** — the `ReplaceAll` window is tracked as one flag stored on the index, but CDC drives
  `compute_index` outside the sink write lifecycle, so a CDC write that empties a row while a
  replacing refresh holds the window open evicts nothing. Both settings of a single global flag are
  wrong for a stream-attached index — honored, it leaves stale chunks searchable; ignored, the
  eviction resolves against the staged index's previous contents and deletes rows the refresh just
  wrote — so scoping the suppression to the replacing write's own batches is a design change rather
  than a correction. Not a regression: before this eviction existed a CDC write removed nothing
  either.
- **#13715** — an index's external-store writes are applied before the row write commits, and the
  CDC path has no post-commit hook to defer them to. Ordering the eviction after this write's own
  chunks narrows the window; the row write still commits later.
- **#13714** — on Elasticsearch, the partial-key delete this routes through filters on analyzed key
  columns, so a hyphenated string key can match zero documents and report success. Pre-existing:
  #12267 fixed the whole-key half and explicitly left this one.
- **#13713** — a batch carrying one key twice with text both times still indexes both, so a search
  index disagrees with its table. Pre-existing; the same batch produces the same index contents on
  `trunk`.

## Test plan

- `make lint`
- `make nextest`

New tests in `crates/search/src/index/chunking.rs`, all asserting what the index *holds* after a
write rather than what the write returned:

- a row rewritten to NULL, to empty text, and to whitespace loses the chunks its previous text
  produced — over both inner-index shapes (partial-key delete, and chunk-key resolution)
- a duplicated key is judged on the row that survives the batch, so text-then-empty and
  empty-then-text reach *different* end states
- a write evicts only the keys it emptied
- a write whose inner write fails evicts nothing
- an ordinary write performs no enumeration of the inner index; emptying a row performs exactly one
- the write window decides whether a write evicts, across both window kinds and both chunked
  wrappers
- a write over an inner index that can be neither partial-key-deleted nor enumerated still lands
- the warning that path emits names the column, the consequence, and the fix

Each was verified to fail with the corresponding production change reverted, in both directions
where the rule can be wrong two ways.

## Review gate

Round 3 attests the review fixes in `a41bfcb75` (the two defects raised on this PR's open threads),
not the original work — rounds 1 and 2 below cover that.

- Adversarial review: **`codex`** — job `review-mteyg1lw-89kaz3`, scoped `origin/trunk...a41bfcb75`
  — `needs-attention`, 3 findings, **all three already tracked and none new**:
  - *rewrites that shrink to a nonzero chunk count still orphan the trailing chunk ids* — the
    limitation this PR opens with, which is why it is `Refs #13704` and not `Fixes`
  - *eviction is applied before the row write commits* — #13715, already named in the code comment
    it quotes
  - *the global `ReplaceAll` flag suppresses unrelated CDC maintenance* — #13727, filed earlier in
    this same pass from the identical observation on the review thread, and independently
    corroborated here

  Its "do not ship" verdict is a judgement that the PR should wait until #13704 closes completely;
  this lands as the partial fix it says it is, with each surviving criterion tracked and open.
- `/security-review`: no findings. The harness collected an empty diff (it ran against a different
  worktree), so the diff was reviewed directly rather than let that stand as a clean pass.
  Production surface in `a41bfcb75` is an atomic cleared on an error path, a narrowed `warn!`
  condition whose text is unchanged and interpolates only a `&'static str` and the configured
  column name, and doc comments; everything else is test-only, including the `tracing-subscriber`
  dev-dependency.
- `/simplify`: applied — the flag reset collapsed from an `if let Err` early return to
  `.inspect_err(...)`. Re-ran fmt, clippy, and the chunking tests, and re-checked that the neuter
  still fails afterwards.

Both new tests were neuter-verified: restoring `repeats.contains(&0)` makes the warning test emit 1
where it expects 0, and removing the flag reset makes the start-failure test report `left: []`
against `right: [1]`.

Earlier rounds, on the original work:

- round 1, job `review-mtemmbun-52f3oz`, `needs-attention` — 3 findings: 2 acted on (the eviction
  moved after the write, and the subtraction that makes that ordering safe), 1 filed as #13713
- round 2, job `review-mtenu7yk-pun9l6`, `needs-attention` — 4 findings: 1 acted on (a duplicated
  key is now judged on the row that survives the batch, and the test that codified the wrong
  outcome for one ordering was replaced), 2 filed as #13715 and #13714, 1 declined as #12413's
  territory
- `/simplify` on that work: the delegate restructure, the capability probe, four write-path
  efficiency fixes, and three window tests collapsed into one table. Declined: moving the warning
  into the `Error` enum and dropping its text assertions (CLAUDE.md names the
  pure-function-plus-assertion pattern for warnings specifically), caching the `RowConverter`
  (dictionary-interner state across writes), `spawn_blocking` (pre-existing shape in the same
  function), and a cross-crate key-extractor reuse (changes `layers.toml`).

A trap worth keeping on the record from round 2's retry: job `review-mteof1n2-8ai9hf` stopped 25
tool calls in when the workspace ran out of credits, and the CLI still exited 0 and rendered
`Verdict: approve / No material findings` — the renderer had fallen back to the preliminary message
captured at the start of the turn. The companion's own job state (`failed`) and the log's
`Turn failed.` are what contradict it.

Refs #13704
Refs #13713
Refs #13714
Refs #13715
Refs #13727
Refs #12413

## Checklist

- [x] Regression tests that fail on the old code
- [x] Edge cases covered: NULL, empty, and whitespace-only search values; a duplicated key in both
      orderings; a failed inner write; both write windows on both wrappers; an inner index that
      cannot be reached
- [x] No `.unwrap()` / `.expect()` in production code
- [x] User-facing warning names the resource, the consequence, and an actionable fix
- [x] `cargo clippy --all-targets` clean on the touched crate
