### PR TITLE
fix(search): index only the last change a batch carries for a row (fixes #13713)

### DIFF
--- a/crates/search/src/generation/text_search/index.rs
+++ b/crates/search/src/generation/text_search/index.rs
@@ -49,6 +49,7 @@ use crate::generation::text_search::{
 };
 use crate::generation::util::get_primary_keys;
 use crate::index::SearchIndex;
+use crate::index::coalesce;
 
 /// The heap budget for the [`tantivy::IndexWriter`] (150 MiB).
 /// A larger budget reduces the number of segment flushes and subsequent merges,
@@ -263,7 +264,15 @@ impl Index for FullTextDatabaseIndex {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        if let Err(e) = self.update_index(batches.as_slice()).await {
+        // A batch can carry more than one change for the same primary key, which the table this
+        // indexes resolves to the last one. `update_index` deletes each key's existing terms and
+        // then adds every document it was given, so without this the collection would hold a
+        // second document for the superseded content — see [`coalesce`]. Only what is indexed is
+        // reduced; the caller's batches are handed back untouched.
+        let primary_key = self.primary_fields();
+        let reduced = coalesce::reduce_batches(&primary_key, batches.as_slice())?;
+        let indexed = reduced.as_deref().unwrap_or(batches.as_slice());
+        if let Err(e) = self.update_index(indexed).await {
             tracing::error!("Failed to update full text search index: {e}");
             return Err(DataFusionError::External(Box::new(e)));
         }
@@ -1210,6 +1219,64 @@ mod tests {
             .expect("Failed to collect search results");
 
         format!("{}", pretty_format_batches(&rb).expect("failed to format"))
+    }
+
+    /// How many documents a query matches.
+    async fn search_hits(idx: &FullTextSearchFieldIndex, query: &str) -> usize {
+        let rb: Vec<RecordBatch> = idx
+            .search(query.to_string(), vec![], 1000)
+            .expect("Failed to search")
+            .try_collect()
+            .await
+            .expect("Failed to collect search results");
+        rb.iter().map(RecordBatch::num_rows).sum()
+    }
+
+    /// Regression test for #13713. A CDC change envelope carries every change the source
+    /// produced in one poll, so one batch can hold two changes for the same row. Indexing is a
+    /// delete of each key's existing terms followed by an add of every document handed over, so
+    /// both changes became documents and the row stayed findable by words its current content
+    /// does not contain.
+    ///
+    /// Asserts what the collection holds after the write, not what the write returned.
+    #[tokio::test]
+    async fn a_row_changed_twice_in_one_batch_is_indexed_once_as_its_last_change() {
+        let index = new_test_index();
+
+        index
+            .compute_index(vec![
+                record_batch!(
+                    ("id", Int32, [1, 2, 1]),
+                    (
+                        "content",
+                        Utf8,
+                        ["apple superseded", "banana", "cherry current"]
+                    )
+                )
+                .expect("Failed to create test batch"),
+            ])
+            .await
+            .expect("failed to compute_index");
+
+        let search_index = index
+            .full_text_search_field_index("content")
+            .expect("Failed to create FullTextSearchFieldIndex");
+
+        assert_eq!(
+            search_hits(&search_index, "apple").await,
+            0,
+            "row 1's superseded content must not be searchable"
+        );
+        assert_eq!(
+            search_hits(&search_index, "cherry").await,
+            1,
+            "row 1 must be one document, carrying the change that supersedes the other"
+        );
+        assert_eq!(
+            search_hits(&search_index, "banana").await,
+            1,
+            "the row the batch changed once is untouched"
+        );
     }
 
     /// Verifies that an exact filter is included in the tantivy query before the top-K limit is

--- a/crates/search/src/index/chunking.rs
+++ b/crates/search/src/index/chunking.rs
@@ -15,7 +15,7 @@ use arrow::{
     compute::concat,
 };
 
-use crate::index::primary_key_projection;
+use crate::index::{coalesce, primary_key_projection};
 use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use chunking::Chunker;
@@ -83,9 +83,13 @@ impl Index for ChunkedSearchIndex {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        let futs = batches
-            .into_iter()
-            .map(|rb| async { self.write(rb).await.map_err(DataFusionError::External) });
+        // Duplicate primary keys in one batch resolve to the last change — see [`coalesce`].
+        let primary_key = self.primary_fields();
+        let futs = batches.into_iter().map(|rb| {
+            coalesce::write_last_write_wins(&primary_key, rb, |b| async {
+                self.write(b).await.map_err(DataFusionError::External)
+            })
+        });
         try_join_all(futs).await
     }
 
@@ -1165,6 +1169,8 @@ mod tests {
         listed: Option<Vec<RecordBatch>>,
         /// Key batches handed to [`Index::delete_by_keys`].
         deleted: std::sync::Mutex<Vec<RecordBatch>>,
+        /// The chunk rows handed to [`SearchIndex::write`] — what this index would hold.
+        written: std::sync::Mutex<Vec<RecordBatch>>,
     }
 
     impl RecordingInner {
@@ -1179,6 +1185,7 @@ mod tests {
                 primary_fields: vec![Field::new("id", DataType::Int64, false)],
                 listed: None,
                 deleted: std::sync::Mutex::new(Vec::new()),
+                written: std::sync::Mutex::new(Vec::new()),
             }
         }
 
@@ -1208,6 +1215,48 @@ mod tests {
                 listed: Some(listed),
                 ..Self::new("content")
             }
+        }
+
+        /// The chunk rows this index was asked to hold, as `(primary key, chunk id, text)`
+        /// across every [`SearchIndex::write`] call.
+        fn holds(&self) -> Vec<(i64, u64, String)> {
+            self.written
+                .lock()
+                .expect("mutex")
+                .iter()
+                .flat_map(|batch| {
+                    let ids = batch
+                        .column_by_name("id")
+                        .expect("the chunked batch carries the base key")
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .expect("id is Int64")
+                        .values()
+                        .to_vec();
+                    let chunk_ids = batch
+                        .column_by_name(CHUNKED_INDEX_CHUNK_KEY)
+                        .expect("the chunked batch carries the chunk key")
+                        .as_any()
+                        .downcast_ref::<UInt64Array>()
+                        .expect("chunk id is UInt64")
+                        .values()
+                        .to_vec();
+                    let text = batch
+                        .column_by_name(&self.search_column)
+                        .expect("the chunked batch carries the search column")
+                        .as_any()
+                        .downcast_ref::<StringArray>()
+                        .expect("the search column is Utf8")
+                        .iter()
+                        .map(|v| v.unwrap_or_default().to_string())
+                        .collect::<Vec<_>>();
+                    ids.into_iter()
+                        .zip(chunk_ids)
+                        .zip(text)
+                        .map(|((id, chunk), text)| (id, chunk, text))
+                        .collect::<Vec<_>>()
+                })
+                .collect()
         }
 
         /// The key batches passed to [`Index::delete_by_keys`], as
@@ -1315,6 +1364,7 @@ mod tests {
                 .lock()
                 .expect("mutex")
                 .push(record.num_rows());
+            self.written.lock().expect("mutex").push(record.clone());
 
             // Build a synthetic embedding column matching the row count. The first element
             // encodes the row's position within this call so tests can verify ordering
@@ -1386,6 +1436,86 @@ mod tests {
             ],
         )
         .expect("valid batch")
+    }
+
+    /// Regression test for #13713. A CDC change envelope carries every change the source
+    /// produced in one poll, so one batch can hold two changes for the same row. Chunking each
+    /// row independently then put two rows under the chunk-keyed primary key `(1, 0)` and left
+    /// the superseded text's `(1, 1)` chunk in the index, where it kept the row searchable by a
+    /// word its current text does not contain.
+    ///
+    /// Asserts what the inner index was asked to hold, not what the write returned.
+    #[tokio::test]
+    async fn a_row_changed_twice_in_one_batch_is_chunked_only_from_its_last_change() {
+        let inner = Arc::new(RecordingInner::new("content"));
+        let chunked = ChunkedSearchIndex::new(
+            Arc::clone(&inner) as Arc<dyn SearchIndex>,
+            Arc::new(DelimChunker { delim: ' ' }) as Arc<dyn Chunker>,
+        );
+
+        let out = chunked
+            .compute_index(vec![build_input(&[("aaa bbb", 1), ("ddd", 2), ("ccc", 1)])])
+            .await
+            .expect("the batch is indexed");
+
+        assert_eq!(
+            inner.holds(),
+            vec![(2, 0, "ddd".to_string()), (1, 0, "ccc".to_string()),],
+            "only the last change for row 1 may be chunked: 'aaa'/'bbb' belong to the text it \
+             superseded, and 'bbb' would never be overwritten by the shorter 'ccc'"
+        );
+
+        let held = inner.holds();
+        let mut keys: Vec<(i64, u64)> = held.iter().map(|(id, chunk, _)| (*id, *chunk)).collect();
+        let before = keys.len();
+        keys.sort_unstable();
+        keys.dedup();
+        assert_eq!(
+            keys.len(),
+            before,
+            "the chunk-keyed primary key must be unique in what the inner index holds"
+        );
+
+        assert_eq!(
+            out.iter().map(RecordBatch::num_rows).sum::<usize>(),
+            3,
+            "the batch handed back keeps every change, so the accelerator still applies all three"
+        );
+    }
+
+    /// The same shape without the duplicate: the last change clears the search value, so the
+    /// superseded text must not be chunked into the index either.
+    #[tokio::test]
+    async fn a_search_value_cleared_later_in_the_batch_is_not_chunked_from_its_old_text() {
+        let inner = Arc::new(RecordingInner::new("content"));
+        let chunked = ChunkedSearchIndex::new(
+            Arc::clone(&inner) as Arc<dyn SearchIndex>,
+            Arc::new(DelimChunker { delim: ' ' }) as Arc<dyn Chunker>,
+        );
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("content", DataType::Utf8, true),
+        ]));
+        let input = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1_i64, 1])),
+                Arc::new(StringArray::from(vec![Some("value"), None])),
+            ],
+        )
+        .expect("valid batch");
+
+        chunked
+            .compute_index(vec![input])
+            .await
+            .expect("the batch is indexed");
+
+        assert!(
+            inner.holds().is_empty(),
+            "row 1 ends the batch with no search value, so nothing may be indexed for it: {:?}",
+            inner.holds()
+        );
     }
 
     /// The chunking layer must not downgrade a fatal inner index to best-effort — a

--- a/crates/search/src/index/coalesce.rs
+++ b/crates/search/src/index/coalesce.rs
@@ -1,0 +1,529 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Last-write-wins coalescing of the rows a single index write is given.
+//!
+//! A write batch can carry more than one change for the same primary key: a CDC change envelope
+//! holds every change the source produced in one poll, so two updates to one row inside that
+//! window arrive as two rows of one batch. The accelerated table resolves such a key to the last
+//! change; an index that writes every row does not, and then disagrees with the table it indexes.
+//!
+//! The disagreement takes a different shape per index but has one cause, so the repair is applied
+//! once here and shared by every [`crate::index::SearchIndex`] that maintains a store keyed by
+//! primary key:
+//!
+//! - a store whose upsert deletes the batch's keys and appends the batch keeps *both* rows, so one
+//!   primary key ends up with two entries;
+//! - a chunked index chunks each row independently, so the superseded text contributes chunks the
+//!   winning text never overwrites — the row stays searchable by words it no longer contains.
+//!
+//! Row identity is the primary key's [`arrow::row`] encoding of the declared
+//! [`crate::index::SearchIndex::primary_fields`], which is the same notion of identity the stores'
+//! upsert and `delete_by_keys` paths already assume. A row whose key is NULL has no identity to
+//! resolve — SQL never treats NULL as equal to NULL — so it is never coalesced with anything.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::{
+    array::{Array, ArrayRef, RecordBatch, UInt32Array},
+    compute::take_record_batch,
+    row::{Row, RowConverter, SortField},
+};
+use arrow_schema::Field;
+use datafusion::error::DataFusionError;
+
+/// Coordinates of a row within a slice of batches: `(batch, row)`.
+type RowRef = (usize, usize);
+
+/// For every row of every batch, the coordinates of the row that supersedes it — itself when it
+/// is the last change for its key.
+type Winners = Vec<Vec<RowRef>>;
+
+fn as_u32(index: usize) -> Result<u32, DataFusionError> {
+    u32::try_from(index).map_err(|_| {
+        DataFusionError::Execution(format!(
+            "Row index {index} does not fit in a 32-bit take index"
+        ))
+    })
+}
+
+/// The primary-key columns of every batch, or `None` when there is no key to resolve rows by:
+/// no declared primary key, or a batch that does not carry one of its columns.
+fn primary_key_columns(
+    primary_key: &[Field],
+    batches: &[RecordBatch],
+) -> Option<Vec<Vec<ArrayRef>>> {
+    if primary_key.is_empty() {
+        return None;
+    }
+    batches
+        .iter()
+        .map(|batch| {
+            primary_key
+                .iter()
+                .map(|field| batch.column_by_name(field.name()).map(Arc::clone))
+                .collect::<Option<Vec<_>>>()
+        })
+        .collect()
+}
+
+/// Resolve every row to the last change carrying the same primary key.
+///
+/// `None` when nothing repeats, so the common case pays only for the key encoding and callers
+/// can hand the batches on untouched.
+fn winners(
+    primary_key: &[Field],
+    batches: &[RecordBatch],
+) -> Result<Option<Winners>, DataFusionError> {
+    let Some(key_columns) = primary_key_columns(primary_key, batches) else {
+        return Ok(None);
+    };
+    if batches.iter().map(RecordBatch::num_rows).sum::<usize>() < 2 {
+        return Ok(None);
+    }
+
+    // The encoding is only ever compared for equality, so the sort options are irrelevant; the
+    // fields come from the batch rather than the declared key so a widened column still encodes.
+    let Some(first) = key_columns.first() else {
+        return Ok(None);
+    };
+    let converter = RowConverter::new(
+        first
+            .iter()
+            .map(|c| SortField::new(c.data_type().clone()))
+            .collect(),
+    )
+    .map_err(|e| {
+        DataFusionError::Execution(format!(
+            "Cannot resolve rows by primary key ({}): {e}",
+            primary_key
+                .iter()
+                .map(Field::name)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    })?;
+
+    let mut encoded = Vec::with_capacity(key_columns.len());
+    for columns in &key_columns {
+        encoded.push(
+            converter
+                .convert_columns(columns)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+        );
+    }
+
+    // A NULL anywhere in the key leaves the row without an identity to resolve, so it stands
+    // alone rather than joining a group.
+    let unresolvable: Vec<Vec<bool>> = key_columns
+        .iter()
+        .zip(batches)
+        .map(|(columns, batch)| {
+            if columns.iter().all(|c| c.null_count() == 0) {
+                return vec![false; batch.num_rows()];
+            }
+            (0..batch.num_rows())
+                .map(|row| columns.iter().any(|c| c.is_null(row)))
+                .collect()
+        })
+        .collect();
+
+    let mut last: HashMap<Row<'_>, RowRef> = HashMap::new();
+    for (b, rows) in encoded.iter().enumerate() {
+        for row in 0..rows.num_rows() {
+            if unresolvable[b][row] {
+                continue;
+            }
+            last.insert(rows.row(row), (b, row));
+        }
+    }
+
+    let mut winners: Winners = Vec::with_capacity(encoded.len());
+    let mut superseded = false;
+    for (b, rows) in encoded.iter().enumerate() {
+        let mut batch_winners = Vec::with_capacity(rows.num_rows());
+        for row in 0..rows.num_rows() {
+            let winner = if unresolvable[b][row] {
+                (b, row)
+            } else {
+                *last.get(&rows.row(row)).unwrap_or(&(b, row))
+            };
+            superseded |= winner != (b, row);
+            batch_winners.push(winner);
+        }
+        winners.push(batch_winners);
+    }
+
+    Ok(superseded.then_some(winners))
+}
+
+/// Reduce `batches` to one row per primary key — the last change for that key across the whole
+/// slice — dropping any batch left with no rows.
+///
+/// `None` when no key repeats. For a caller that indexes the batches as a set and returns its
+/// input unchanged (there is no per-row output to map back), which is why this has no counterpart
+/// to [`LastWriteWins::expand`].
+pub(crate) fn reduce_batches(
+    primary_key: &[Field],
+    batches: &[RecordBatch],
+) -> Result<Option<Vec<RecordBatch>>, DataFusionError> {
+    let Some(winners) = winners(primary_key, batches)? else {
+        return Ok(None);
+    };
+
+    let mut reduced = Vec::with_capacity(batches.len());
+    for (b, (batch, batch_winners)) in batches.iter().zip(&winners).enumerate() {
+        let mut keep = Vec::new();
+        for (row, winner) in batch_winners.iter().enumerate() {
+            if *winner == (b, row) {
+                keep.push(as_u32(row)?);
+            }
+        }
+        if keep.is_empty() {
+            continue;
+        }
+        reduced.push(
+            take_record_batch(batch, &UInt32Array::from(keep))
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+        );
+    }
+    Ok(Some(reduced))
+}
+
+/// One batch's rows reduced to the last change per primary key, and the map back to the batch's
+/// original shape.
+struct LastWriteWins {
+    keep: UInt32Array,
+    expand: UInt32Array,
+}
+
+impl LastWriteWins {
+    /// `None` when no key repeats within `record`.
+    fn plan(primary_key: &[Field], record: &RecordBatch) -> Result<Option<Self>, DataFusionError> {
+        let Some(winners) = winners(primary_key, std::slice::from_ref(record))? else {
+            return Ok(None);
+        };
+        let Some(batch_winners) = winners.first() else {
+            return Ok(None);
+        };
+
+        let mut keep = Vec::new();
+        let mut position = vec![u32::MAX; batch_winners.len()];
+        for (row, winner) in batch_winners.iter().enumerate() {
+            if *winner == (0, row) {
+                position[row] = as_u32(keep.len())?;
+                keep.push(as_u32(row)?);
+            }
+        }
+
+        let mut expand = Vec::with_capacity(batch_winners.len());
+        for (_, winner_row) in batch_winners {
+            // Every winner kept itself in the loop above, so its position is assigned.
+            expand.push(position[*winner_row]);
+        }
+
+        Ok(Some(Self {
+            keep: UInt32Array::from(keep),
+            expand: UInt32Array::from(expand),
+        }))
+    }
+
+    fn reduce(&self, record: &RecordBatch) -> Result<RecordBatch, DataFusionError> {
+        take_record_batch(record, &self.keep)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+    }
+
+    fn expand(&self, written: &RecordBatch) -> Result<RecordBatch, DataFusionError> {
+        if written.num_rows() != self.keep.len() {
+            return Err(DataFusionError::Execution(format!(
+                "An index write returned {} rows for the {} rows it was given, so its output \
+                 cannot be mapped back onto the batch it came from",
+                written.num_rows(),
+                self.keep.len()
+            )));
+        }
+        take_record_batch(written, &self.expand)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+    }
+}
+
+/// Write `record` to an index, indexing only the last change carried for each primary key.
+///
+/// `write` sees one row per key; the batch handed back has `record`'s original rows in their
+/// original order, each carrying the columns the write derived for the change that supersedes it.
+/// A superseded row's own derived values are never observable — the accelerated table resolves
+/// that key to the same winning change — so taking the winner's is what keeps the two agreeing.
+pub(crate) async fn write_last_write_wins<F, Fut>(
+    primary_key: &[Field],
+    record: RecordBatch,
+    write: F,
+) -> Result<RecordBatch, DataFusionError>
+where
+    F: FnOnce(RecordBatch) -> Fut,
+    Fut: Future<Output = Result<RecordBatch, DataFusionError>>,
+{
+    let Some(plan) = LastWriteWins::plan(primary_key, &record)? else {
+        return write(record).await;
+    };
+    let written = write(plan.reduce(&record)?).await?;
+    plan.expand(&written)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow_schema::{DataType, Schema};
+
+    fn pk() -> Vec<Field> {
+        vec![Field::new("id", DataType::Int64, false)]
+    }
+
+    /// `id` nullable so a NULL key can be expressed; `content` carries the change.
+    fn batch(rows: &[(Option<i64>, &str)]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("content", DataType::Utf8, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|(_, c)| *c).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .expect("valid batch")
+    }
+
+    fn contents(record: &RecordBatch) -> Vec<Option<String>> {
+        record
+            .column_by_name("content")
+            .expect("content column")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("content is Utf8")
+            .iter()
+            .map(|v| v.map(str::to_string))
+            .collect()
+    }
+
+    async fn written_and_returned(
+        primary_key: &[Field],
+        record: RecordBatch,
+    ) -> (Vec<Option<String>>, Vec<Option<String>>) {
+        let seen = std::sync::Mutex::new(Vec::new());
+        let returned = write_last_write_wins(primary_key, record, |b| async {
+            seen.lock().expect("mutex").extend(contents(&b));
+            Ok(b)
+        })
+        .await
+        .expect("write succeeds");
+        let seen = seen.lock().expect("mutex").clone();
+        (seen, contents(&returned))
+    }
+
+    #[tokio::test]
+    async fn a_repeated_key_is_written_once_as_its_last_change() {
+        let (written, returned) = written_and_returned(
+            &pk(),
+            batch(&[(Some(1), "aaa"), (Some(2), "bbb"), (Some(1), "ccc")]),
+        )
+        .await;
+
+        assert_eq!(
+            written,
+            vec![Some("bbb".to_string()), Some("ccc".to_string())],
+            "the index must see one row per key, carrying the last change for that key"
+        );
+        // The batch handed back keeps every input row so the caller's row-for-row contract with
+        // the change batch still holds; a superseded row carries its winner's derived values.
+        assert_eq!(
+            returned,
+            vec![
+                Some("ccc".to_string()),
+                Some("bbb".to_string()),
+                Some("ccc".to_string())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_batch_with_no_repeated_key_is_handed_over_untouched() {
+        let (written, returned) =
+            written_and_returned(&pk(), batch(&[(Some(1), "aaa"), (Some(2), "bbb")])).await;
+
+        assert_eq!(
+            written,
+            vec![Some("aaa".to_string()), Some("bbb".to_string())]
+        );
+        assert_eq!(
+            returned,
+            vec![Some("aaa".to_string()), Some("bbb".to_string())]
+        );
+    }
+
+    /// The last change for a key is what the index must hold even when it is the shorter or
+    /// empty one — the NULL case in #13713, where the superseded text otherwise stays searchable.
+    #[tokio::test]
+    async fn a_key_superseded_by_a_null_search_value_is_written_as_the_null() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("content", DataType::Utf8, true),
+        ]));
+        let record = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1_i64, 1])),
+                Arc::new(StringArray::from(vec![Some("value"), None])),
+            ],
+        )
+        .expect("valid batch");
+
+        let (written, _) = written_and_returned(&pk(), record).await;
+        assert_eq!(written, vec![None]);
+    }
+
+    /// SQL never treats NULL as equal to NULL, so two NULL-keyed rows are two rows.
+    #[tokio::test]
+    async fn null_keys_are_not_coalesced_with_each_other() {
+        let (written, _) = written_and_returned(
+            &pk(),
+            batch(&[(None, "aaa"), (None, "bbb"), (Some(1), "ccc")]),
+        )
+        .await;
+
+        assert_eq!(
+            written,
+            vec![
+                Some("aaa".to_string()),
+                Some("bbb".to_string()),
+                Some("ccc".to_string())
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn an_index_with_no_declared_primary_key_writes_every_row() {
+        let (written, _) =
+            written_and_returned(&[], batch(&[(Some(1), "aaa"), (Some(1), "ccc")])).await;
+
+        assert_eq!(
+            written,
+            vec![Some("aaa".to_string()), Some("ccc".to_string())]
+        );
+    }
+
+    /// A key column the batch does not carry leaves nothing to resolve rows by, so the write is
+    /// handed the batch as it stands rather than failing it.
+    #[tokio::test]
+    async fn a_primary_key_column_missing_from_the_batch_writes_every_row() {
+        let absent = vec![Field::new("missing", DataType::Int64, false)];
+        let (written, _) =
+            written_and_returned(&absent, batch(&[(Some(1), "aaa"), (Some(1), "ccc")])).await;
+
+        assert_eq!(
+            written,
+            vec![Some("aaa".to_string()), Some("ccc".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_multi_column_key_resolves_on_the_whole_key() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("tenant", DataType::Utf8, false),
+            Field::new("id", DataType::Int64, false),
+            Field::new("content", DataType::Utf8, true),
+        ]));
+        let record = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b", "a"])),
+                Arc::new(Int64Array::from(vec![1_i64, 1, 1])),
+                Arc::new(StringArray::from(vec!["first", "other tenant", "last"])),
+            ],
+        )
+        .expect("valid batch");
+
+        let key = vec![
+            Field::new("tenant", DataType::Utf8, false),
+            Field::new("id", DataType::Int64, false),
+        ];
+        let (written, _) = written_and_returned(&key, record).await;
+        assert_eq!(
+            written,
+            vec![Some("other tenant".to_string()), Some("last".to_string())],
+            "(a, 1) is superseded but (b, 1) is a different key"
+        );
+    }
+
+    /// The mapping back is by key, not by position: an index that reorders nothing still has to
+    /// survive the reduced batch being shorter than the one the caller handed in.
+    #[tokio::test]
+    async fn a_write_returning_the_wrong_row_count_is_refused() {
+        let record = batch(&[(Some(1), "aaa"), (Some(1), "ccc")]);
+        let err = write_last_write_wins(&pk(), record, |b| async move { Ok(b.slice(0, 0)) })
+            .await
+            .expect_err("a row count the map cannot be applied to must fail the write");
+        assert!(
+            err.to_string().contains("cannot be mapped back"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn reduce_batches_resolves_a_key_repeated_across_batches() {
+        let batches = vec![
+            batch(&[(Some(1), "aaa"), (Some(2), "bbb")]),
+            batch(&[(Some(1), "ccc")]),
+        ];
+        let reduced = reduce_batches(&pk(), &batches)
+            .expect("reduce succeeds")
+            .expect("a repeated key must reduce");
+
+        assert_eq!(
+            reduced.iter().flat_map(contents).collect::<Vec<_>>(),
+            vec![Some("bbb".to_string()), Some("ccc".to_string())]
+        );
+    }
+
+    /// A batch every one of whose rows is superseded later carries nothing to index.
+    #[test]
+    fn reduce_batches_drops_a_batch_left_with_no_rows() {
+        let batches = vec![batch(&[(Some(1), "aaa")]), batch(&[(Some(1), "ccc")])];
+        let reduced = reduce_batches(&pk(), &batches)
+            .expect("reduce succeeds")
+            .expect("a repeated key must reduce");
+
+        assert_eq!(reduced.len(), 1);
+        assert_eq!(contents(&reduced[0]), vec![Some("ccc".to_string())]);
+    }
+
+    #[test]
+    fn reduce_batches_reports_nothing_to_do_when_no_key_repeats() {
+        let batches = vec![batch(&[(Some(1), "aaa")]), batch(&[(Some(2), "bbb")])];
+        assert!(
+            reduce_batches(&pk(), &batches)
+                .expect("reduce succeeds")
+                .is_none()
+        );
+    }
+}

--- a/crates/search/src/index/compound/search_index.rs
+++ b/crates/search/src/index/compound/search_index.rs
@@ -26,7 +26,7 @@ use datafusion::{
 use futures::future::try_join_all;
 use spice_table::{Index, WriteWindow};
 
-use crate::index::{SearchIndex, VectorIndex};
+use crate::index::{SearchIndex, VectorIndex, coalesce};
 
 use super::{
     COMPOUND_WRITE_COMPLETE_FAILURE_IS_FATAL, COMPOUND_WRITE_START_FAILURE_IS_FATAL,
@@ -98,9 +98,13 @@ impl Index for CompoundSearchIndex {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        let futs = batches
-            .into_iter()
-            .map(|rb| async { self.write(rb).await.map_err(DataFusionError::External) });
+        // Duplicate primary keys in one batch resolve to the last change — see [`coalesce`].
+        let primary_key = self.primary_fields();
+        let futs = batches.into_iter().map(|rb| {
+            coalesce::write_last_write_wins(&primary_key, rb, |b| async {
+                self.write(b).await.map_err(DataFusionError::External)
+            })
+        });
         try_join_all(futs).await
     }
 

--- a/crates/search/src/index/compound/vector_index.rs
+++ b/crates/search/src/index/compound/vector_index.rs
@@ -26,7 +26,7 @@ use datafusion::{
 use futures::future::try_join_all;
 use spice_table::{Index, WriteWindow};
 
-use crate::index::{SearchIndex, VectorIndex, primary_key_projection};
+use crate::index::{SearchIndex, VectorIndex, coalesce, primary_key_projection};
 
 use super::{
     COMPOUND_WRITE_COMPLETE_FAILURE_IS_FATAL, COMPOUND_WRITE_START_FAILURE_IS_FATAL,
@@ -165,9 +165,13 @@ impl Index for CompoundVectorIndex {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        let futs = batches
-            .into_iter()
-            .map(|rb| async { self.write(rb).await.map_err(DataFusionError::External) });
+        // Duplicate primary keys in one batch resolve to the last change — see [`coalesce`].
+        let primary_key = self.primary_fields();
+        let futs = batches.into_iter().map(|rb| {
+            coalesce::write_last_write_wins(&primary_key, rb, |b| async {
+                self.write(b).await.map_err(DataFusionError::External)
+            })
+        });
         try_join_all(futs).await
     }
 

--- a/crates/search/src/index/elasticsearch/mod.rs
+++ b/crates/search/src/index/elasticsearch/mod.rs
@@ -44,7 +44,9 @@ use spice_table::{Index, WriteWindow};
 use tokio::sync::Mutex;
 
 use crate::SEARCH_SCORE_COLUMN_NAME;
-use crate::index::{MAX_CONCURRENT_INDEX_WRITES, SearchIndex, VectorIndex, embedding_col};
+use crate::index::{
+    MAX_CONCURRENT_INDEX_WRITES, SearchIndex, VectorIndex, coalesce, embedding_col,
+};
 use crate::metadata::MetadataColumns;
 use data_components::elasticsearch::search_table::{
     ElasticsearchKnnTable, ElasticsearchTextSearchTable, QueryEmbedder,
@@ -463,10 +465,14 @@ impl Index for ElasticsearchIndex {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        let futs = batches.into_iter().map(|rb| async move {
-            write::write(self, rb)
-                .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))
+        // Duplicate primary keys in one batch resolve to the last change — see [`coalesce`].
+        let primary_key = self.primary_fields();
+        let futs = batches.into_iter().map(|rb| {
+            coalesce::write_last_write_wins(&primary_key, rb, |b| async {
+                write::write(self, b)
+                    .await
+                    .map_err(|e| DataFusionError::External(Box::new(e)))
+            })
         });
         futures::stream::iter(futs)
             .buffered(MAX_CONCURRENT_INDEX_WRITES)
@@ -725,9 +731,13 @@ impl Index for ElasticsearchTextIndex {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        let futs = batches
-            .into_iter()
-            .map(|rb| async move { self.write(rb).await.map_err(DataFusionError::External) });
+        // Duplicate primary keys in one batch resolve to the last change — see [`coalesce`].
+        let primary_key = self.primary_fields();
+        let futs = batches.into_iter().map(|rb| {
+            coalesce::write_last_write_wins(&primary_key, rb, |b| async {
+                self.write(b).await.map_err(DataFusionError::External)
+            })
+        });
         futures::stream::iter(futs)
             .buffered(MAX_CONCURRENT_INDEX_WRITES)
             .try_collect()

--- a/crates/search/src/index/memory/mod.rs
+++ b/crates/search/src/index/memory/mod.rs
@@ -44,7 +44,7 @@ use snafu::{ResultExt, Snafu, ensure};
 use spice_table::{Index, WriteWindow};
 
 use crate::index::{
-    SearchIndex, VectorIndex, embedding_col,
+    SearchIndex, VectorIndex, coalesce, embedding_col,
     memory::{
         provider::{MemoryVectorListTable, MemoryVectorQueryTable},
         store::MemoryVectorStore,
@@ -321,9 +321,13 @@ impl Index for MemoryVectorIndex {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        let futs = batches
-            .into_iter()
-            .map(|rb| async { self.write(rb).await.map_err(DataFusionError::External) });
+        // Duplicate primary keys in one batch resolve to the last change — see [`coalesce`].
+        let primary_key = self.primary_fields();
+        let futs = batches.into_iter().map(|rb| {
+            coalesce::write_last_write_wins(&primary_key, rb, |b| async {
+                self.write(b).await.map_err(DataFusionError::External)
+            })
+        });
         try_join_all(futs).await
     }
 
@@ -492,7 +496,7 @@ impl VectorIndex for MemoryVectorIndex {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Int64Array, StringArray};
+    use arrow::array::{FixedSizeListArray, Float32Array, Int64Array, StringArray};
     use datafusion_expr::{Volatility, create_udf};
     use llms::embeddings::EmbeddingInput;
 
@@ -609,6 +613,94 @@ mod tests {
             .on_write_complete()
             .await
             .expect("the write window closes");
+    }
+
+    /// The embeddings the store holds, paired with their primary key, ascending by key.
+    fn indexed_vectors(index: &MemoryVectorIndex) -> Vec<(i64, Vec<f32>)> {
+        let mut rows: Vec<(i64, Vec<f32>)> = index
+            .store
+            .read()
+            .batches()
+            .iter()
+            .flat_map(|b| {
+                let (id_idx, _) = b
+                    .schema()
+                    .column_with_name("id")
+                    .expect("the stored schema carries the primary key");
+                let ids = b
+                    .column(id_idx)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("id is Int64")
+                    .values()
+                    .to_vec();
+                let (emb_idx, _) = b
+                    .schema()
+                    .column_with_name(&embedding_col("content"))
+                    .expect("the stored schema carries the embedding");
+                let embeddings = b
+                    .column(emb_idx)
+                    .as_any()
+                    .downcast_ref::<FixedSizeListArray>()
+                    .expect("the embedding is a FixedSizeList");
+                ids.into_iter()
+                    .enumerate()
+                    .map(|(row, id)| {
+                        let values = embeddings.value(row);
+                        let values = values
+                            .as_any()
+                            .downcast_ref::<Float32Array>()
+                            .expect("the embedding is Float32");
+                        (id, values.values().to_vec())
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        rows.sort_by_key(|(id, _)| *id);
+        rows
+    }
+
+    /// Regression test for #13713. A CDC change envelope carries every change the source
+    /// produced in one poll, so one batch can hold two changes for the same row. The store's
+    /// upsert deletes the batch's keys and then appends the batch, so both changes survived and
+    /// one primary key ended up with two stored rows — one of them the superseded content.
+    ///
+    /// Asserts what the store holds after the write, not what the write returned.
+    #[tokio::test]
+    async fn a_row_changed_twice_in_one_batch_is_stored_once_as_its_last_change() {
+        let index = memory_index();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("content", DataType::Utf8, false),
+        ]));
+        let record = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1_i64, 2, 1])),
+                Arc::new(StringArray::from(vec![
+                    "superseded",
+                    "other row",
+                    "current",
+                ])),
+            ],
+        )
+        .expect("valid test batch");
+
+        index
+            .compute_index(vec![record])
+            .await
+            .expect("the rows are indexed");
+
+        assert_eq!(
+            indexed_ids(&index),
+            vec![1, 2],
+            "one primary key must have one entry, whatever the batch carried for it"
+        );
+        assert_eq!(
+            indexed_vectors(&index),
+            vec![(1, byte_vector("current")), (2, byte_vector("other row")),],
+            "row 1 must be stored as the change that supersedes the other, not the one it replaced"
+        );
     }
 
     /// The regression test. A `refresh_mode: full` refresh removes a row by not re-sending

--- a/crates/search/src/index/mod.rs
+++ b/crates/search/src/index/mod.rs
@@ -26,6 +26,7 @@ use datafusion::{
 use spice_table::Index;
 
 pub mod chunking;
+pub(crate) mod coalesce;
 pub mod compound;
 #[cfg(feature = "duckdb")]
 pub mod duckdb;

--- a/crates/search/src/index/s3_vectors/mod.rs
+++ b/crates/search/src/index/s3_vectors/mod.rs
@@ -54,7 +54,9 @@ use spice_table::Index;
 use crate::SEARCH_SCORE_COLUMN_NAME;
 use crate::index::s3_vectors::compute_query::EmbedQuery;
 use crate::index::write_util::extract_and_format_primary_key;
-use crate::index::{MAX_CONCURRENT_INDEX_WRITES, SearchIndex, VectorIndex, embedding_col};
+use crate::index::{
+    MAX_CONCURRENT_INDEX_WRITES, SearchIndex, VectorIndex, coalesce, embedding_col,
+};
 use crate::metadata::MetadataColumns;
 use datafusion::{
     common::Column,
@@ -381,9 +383,13 @@ impl Index for S3Vector {
         &self,
         batches: Vec<RecordBatch>,
     ) -> Result<Vec<RecordBatch>, DataFusionError> {
-        let futs = batches
-            .into_iter()
-            .map(|rb| async { self.write(rb).await.map_err(DataFusionError::External) });
+        // Duplicate primary keys in one batch resolve to the last change — see [`coalesce`].
+        let primary_key = self.primary_fields();
+        let futs = batches.into_iter().map(|rb| {
+            coalesce::write_last_write_wins(&primary_key, rb, |b| async {
+                self.write(b).await.map_err(DataFusionError::External)
+            })
+        });
         futures::stream::iter(futs)
             .buffered(MAX_CONCURRENT_INDEX_WRITES)
             .try_collect()


### PR DESCRIPTION
## Summary

A write batch can carry more than one change for the same primary key. A CDC change envelope holds
every change the source produced in one poll, so two updates to one row inside that window arrive
as two rows of one batch. The accelerated table resolves such a key to the last change; every
search index wrote all of them, and then disagreed with the table it is an index of — with no
error, and needing only a source that emits two changes for a row in one poll.

The disagreement takes a different shape per index but has one cause, so it is repaired once:

- **A store whose upsert deletes the batch's keys and then appends the batch keeps both rows.** One
  primary key ends up with two entries, one of them the superseded content.
- **A chunked index chunks each row independently and concatenates.** For `(id=1, 'aaa bbb')`
  followed by `(id=1, 'ccc')` the inner index is handed
  `[(1,0)='aaa', (1,1)='bbb', (1,0)='ccc']` — two entries under the chunk-keyed primary key
  `(1,0)`, and a `(1,1)='bbb'` chunk belonging to text the row no longer has, which the shorter
  winning text never overwrites. The row stays searchable by a word its current text does not
  contain.
- **The full-text index deletes each key's existing terms and then adds every document it was
  given**, so the superseded content becomes a second document.

## Changes

`crates/search/src/index/coalesce.rs` (new) resolves a write batch to one row per primary key —
the last change for that key — and maps the write's output back onto the batch's original rows, so
the caller's row-for-row contract with the change batch still holds and the accelerator still
applies every change. A superseded row carries its winner's derived columns, which is what keeps
the index and the table agreeing: the table resolves that key to the same winning change, so a
superseded row's own derived values are never observable.

Row identity is the declared `SearchIndex::primary_fields` under `arrow::row`'s encoding — the same
notion of identity the stores' upsert and `delete_by_keys` paths already assume. Three cases are
deliberately pass-through, leaving today's behaviour untouched: no declared primary key, a key
column the batch does not carry, and a row whose key is NULL (SQL never treats NULL as equal to
NULL, so such a row has no identity to resolve and is never coalesced with anything).

Applied at every `Index::compute_index` that maintains a store keyed by primary key: chunked,
compound, in-memory vector, S3 Vectors, both Elasticsearch indexes, and the full-text index. The
co-located indexes (`NativeVectorIndex`, `DuckDBVectorIndex`) are untouched on purpose — they only
augment the batch and the accelerated table resolves the key itself.

The fast path costs one key encoding per batch and nothing else: a batch whose keys are all
distinct is handed to the write untouched, and the NULL scan is skipped outright when no key column
has any nulls.

## Scope

Both production callers of `compute_index` — the CDC path (`crates/runtime/src/changes/mod.rs`) and
the sink write path (`runtime-datafusion-index`'s index scan) — hand over exactly one batch, so
per-batch resolution covers them. `reduce_batches` resolves across a whole slice anyway, for the
full-text index which indexes its batches as a set.

What this does **not** close is a shrink that spans two batches: a row rewritten from `'aaa bbb'`
to `'ccc'` in a *later* batch still leaves its `(1,1)` chunk behind, because the second write only
names the chunk ids the current text produces. That is a different mechanism — it needs the write
to know what the previous one left — and this issue does not report it. Measured on `trunk` and
filed as #13717.

## Test plan

- `make lint` — clean.
- `make nextest` — passes (`make signoff` runs both).
- New regression tests, each asserting **what the index holds after the write**, not what the write
  returned, and each verified to fail with the coalescing disabled:
  - `chunking`: a row changed twice in one batch is chunked only from its last change (the inner
    index holds `[(2,0,"ddd"), (1,0,"ccc")]`, not `[(1,0,"aaa"), (1,1,"bbb"), (2,0,"ddd"),
    (1,0,"ccc")]`), and the chunk-keyed primary key is unique in what it holds.
  - `chunking`: a search value cleared later in the batch is not chunked from its old text.
  - `memory`: a row changed twice in one batch is stored once, as the change that supersedes the
    other — asserted on the stored embedding, not just the key count.
  - `text_search`: the same row is one tantivy document, and its superseded content is not
    searchable.
  - `coalesce`: 11 unit tests over the helper — repeated key, no repeat, NULL search value, NULL
    keys, no declared key, a key column absent from the batch, a multi-column key, a write
    returning the wrong row count, and the cross-batch `reduce_batches` cases.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits"; `grok` not installed
- `/security-review`: no findings — the change builds no SQL, path, or outbound request, adds no dependency and no `unsafe`, and its two error strings carry configuration column names and row counts, never row data
- `/simplify`: applied — the NULL scan now short-circuits on `null_count()`, and the repeated call-site comment was cut to one line; light checks re-run green

Fixes #13713
Refs #13717

## Checklist

- [x] Regression tests fail on the old code and pass on the new
- [x] The whole bug class is covered, not the one reported index
- [x] No behaviour change for a batch whose primary keys are already distinct
- [x] `cargo fmt --all` clean
