### PR TITLE
test(testoperator): verify append query results, not just row counts

### DIFF
--- a/.github/workflows/testoperator_run_append.yml
+++ b/.github/workflows/testoperator_run_append.yml
@@ -78,6 +78,12 @@ on:
         required: false
         type: boolean
         default: false
+      # On by default: row counts alone don't catch appended rows with wrong values.
+      validate_results:
+        description: 'Validate the query results once the loads finish?'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   run-append:
@@ -157,7 +163,8 @@ jobs:
             --load-steps ${{ github.event.inputs.load_steps }} \
             ${{ github.event.inputs.query_overrides != '' && format('--query-overrides {0}', github.event.inputs.query_overrides) || '' }} \
             ${{ github.event.inputs.with_conflict_data == 'true' && '--with-conflict-data' || '' }} \
-            ${{ github.event.inputs.with_retention_data == 'true' && '--with-retention-data' || '' }}
+            ${{ github.event.inputs.with_retention_data == 'true' && '--with-retention-data' || '' }} \
+            --validate=${{ github.event.inputs.validate_results }}
         env:
           S3_ENDPOINT: ${{ secrets.TEST_MINIO_ENDPOINT }}
           S3_KEY: ${{ secrets.TEST_MINIO_ACCESS_KEY }}

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -133,7 +133,7 @@ static TPCH_ANSWERS: LazyLock<BTreeMap<Arc<str>, Vec<RecordBatch>>> = LazyLock::
 });
 
 #[must_use]
-pub fn has_static_tpch_answer(query: &Query) -> bool {
+pub(crate) fn has_static_tpch_answer(query: &Query) -> bool {
     TPCH_ANSWERS.contains_key(&query.name)
 }
 

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -133,12 +133,12 @@ static TPCH_ANSWERS: LazyLock<BTreeMap<Arc<str>, Vec<RecordBatch>>> = LazyLock::
 });
 
 #[must_use]
-pub(crate) fn has_static_tpch_answer(query: &Query) -> bool {
+pub fn has_static_tpch_answer(query: &Query) -> bool {
     TPCH_ANSWERS.contains_key(&query.name)
 }
 
 #[must_use]
-pub(crate) fn should_validate_with_static_tpch_answer(query: &Query, scale_factor: f64) -> bool {
+pub fn should_validate_with_static_tpch_answer(query: &Query, scale_factor: f64) -> bool {
     (scale_factor - 1.0).abs() < f64::EPSILON && has_static_tpch_answer(query)
 }
 

--- a/crates/test-framework/src/spicetest/append/sources/file.rs
+++ b/crates/test-framework/src/spicetest/append/sources/file.rs
@@ -60,6 +60,27 @@ fn tpch_primary_key(table_name: &str) -> Option<&'static str> {
         .map(|(_, pk)| *pk)
 }
 
+/// A non-key numeric column per TPC-H table, each one read by at least one TPC-H
+/// query. Negating it in a conflicting row makes that row's survival visible to
+/// the query results, so an `on_conflict` that keeps the superseded row fails
+/// the benchmark's own answers rather than passing unnoticed.
+const TPCH_CONFLICT_MARKER_COLUMNS: &[(&str, &str)] = &[
+    ("customer", "c_acctbal"),
+    ("lineitem", "l_extendedprice"),
+    ("orders", "o_totalprice"),
+    ("part", "p_size"),
+    ("partsupp", "ps_supplycost"),
+    ("supplier", "s_acctbal"),
+];
+
+/// Returns the column to negate in a conflicting copy of a TPC-H table's rows.
+fn tpch_conflict_marker_column(table_name: &str) -> Option<&'static str> {
+    TPCH_CONFLICT_MARKER_COLUMNS
+        .iter()
+        .find(|(t, _)| *t == table_name)
+        .map(|(_, column)| *column)
+}
+
 /// Generates SQL for TPC-H initial setup (step 0).
 /// Unlike `generate_tpch_sql`, this creates fresh tables rather than appending to existing ones.
 fn generate_tpch_setup_sql(
@@ -175,9 +196,21 @@ fn generate_tpch_sql(
 
         // Conflict data: same primary keys, will be handled by ON CONFLICT
         if generate_conflict_data {
-            write!(&mut sql, "ALTER TABLE {name}_conflict ADD COLUMN {column} TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;
-                             INSERT INTO {name} SELECT * FROM {name}_conflict;
-                             DROP TABLE {name}_conflict;\n").ok();
+            writeln!(&mut sql, "ALTER TABLE {name}_conflict ADD COLUMN {column} TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;").ok();
+
+            // The next step appends these same keys with their real values, so
+            // this copy is the one an upsert must discard. Negate a queried
+            // column to make keeping it change the query results.
+            if let Some(marker) = tpch_conflict_marker_column(name) {
+                writeln!(&mut sql, "UPDATE {name}_conflict SET {marker} = -{marker};").ok();
+            }
+
+            write!(
+                &mut sql,
+                "INSERT INTO {name} SELECT * FROM {name}_conflict;
+                             DROP TABLE {name}_conflict;\n"
+            )
+            .ok();
         }
 
         writeln!(
@@ -378,5 +411,55 @@ impl AppendableSource for FileAppendableSource {
 
     async fn teardown(&self, _worker: &AppendConfig) -> Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TableWithTimeColumn, generate_tpch_sql};
+    use std::path::Path;
+
+    fn tpch_sql(generate_conflict_data: bool, table: &'static str, column: &'static str) -> String {
+        generate_tpch_sql(
+            10,
+            1,
+            generate_conflict_data,
+            &[TableWithTimeColumn {
+                name: table,
+                column,
+            }],
+            Path::new("/tmp"),
+        )
+    }
+
+    #[test]
+    fn a_conflicting_copy_negates_a_queried_column_before_it_is_appended() {
+        let sql = tpch_sql(true, "lineitem", "l_created_at");
+        let update = sql
+            .find("UPDATE lineitem_conflict SET l_extendedprice = -l_extendedprice;")
+            .expect("the conflicting copy should have its marker column negated");
+        let insert = sql
+            .find("INSERT INTO lineitem SELECT * FROM lineitem_conflict")
+            .expect("the conflicting copy should be appended");
+
+        assert!(
+            update < insert,
+            "the marker column must be negated before the copy is appended"
+        );
+    }
+
+    #[test]
+    fn a_table_without_a_marker_column_is_appended_unchanged() {
+        let sql = tpch_sql(true, "nation", "n_created_at");
+        assert!(
+            !sql.contains("UPDATE nation_conflict"),
+            "nation has no marker column, so its conflicting copy is left alone"
+        );
+    }
+
+    #[test]
+    fn no_conflicting_copy_is_generated_without_conflict_data() {
+        let sql = tpch_sql(false, "lineitem", "l_created_at");
+        assert!(!sql.contains("_conflict"));
     }
 }

--- a/tools/testoperator/src/args/dispatch.rs
+++ b/tools/testoperator/src/args/dispatch.rs
@@ -250,6 +250,10 @@ pub struct AppendArgs {
     pub with_conflict_data: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub with_retention_data: Option<bool>,
+    /// Verify the query results against their expected answers once the loads
+    /// finish. Defaults to on in the workflow.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validate_results: Option<bool>,
 }
 
 /// Search benchmark workflow arguments, defined in the test files. Should match inputs in

--- a/tools/testoperator/src/commands/append/mod.rs
+++ b/tools/testoperator/src/commands/append/mod.rs
@@ -16,17 +16,28 @@ limitations under the License.
 
 use super::get_app_and_start_request;
 use crate::{args::AppendTestArgs, health::HealthMonitor};
-use std::time::Duration;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use test_framework::{
     TestType,
     anyhow::{self, Context},
     app::App,
-    arrow::{self, array::AsArray, util::pretty::print_batches},
+    arrow::{
+        self,
+        array::{AsArray, RecordBatch},
+        util::pretty::print_batches,
+    },
+    execution::{FlightExecutor, QueryExecutor},
     futures::TryStreamExt,
     metrics::{MetricCollector, NoExtendedMetrics, QueryMetrics},
     opentelemetry::KeyValue,
     opentelemetry_sdk::Resource,
-    queries::{QueryOverrides, QuerySet, TableWithRowCount},
+    queries::{
+        Query, QueryOverrides, QuerySet, TableWithRowCount,
+        validation::{self, QueryValidationResult},
+    },
     spiced::SpicedInstance,
     spicepod::acceleration::RefreshMode,
     spicetest::{SpiceTest, append::NotStarted},
@@ -34,6 +45,17 @@ use test_framework::{
     tokio_util::sync::CancellationToken,
     utils::observe_memory,
 };
+
+/// How long to wait for the tables to reach their expected row counts. The last
+/// load's refresh can still be in flight when the test window ends.
+const VERIFICATION_SETTLE_TIMEOUT: Duration = Duration::from_mins(3);
+
+/// How often to re-count the tables while waiting for them to settle.
+const VERIFICATION_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How many rows of a failing query's result to print. A TPC-H answer can run to
+/// thousands of rows, and the failure reason names the first row that diverged.
+const MAX_PRINTED_FAILURE_ROWS: usize = 20;
 
 pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
     if args.test_args.common.concurrency == 0 {
@@ -141,10 +163,12 @@ pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
         test_metrics = test_metrics.with_memory(max_memory, median_memory);
     }
 
-    let table_count_result = check_table_counts(
+    let verification_result = verify_appended_data(
         &spiced_instance,
         &query_set,
+        query_overrides,
         args.test_args.scale_factor.unwrap_or(1.0),
+        args.test_args.validate,
     )
     .await;
 
@@ -157,14 +181,14 @@ pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
 
     let health_report = health_monitor.stop().await;
 
-    // Test passes only if: (1) table row counts match expected values and (2) all queries succeeded
-    let test_status: TestStatus = (table_count_result.is_ok() && test_succeeded).into();
+    // Test passes only if the appended data verifies and every query succeeded.
+    let test_status: TestStatus = (verification_result.is_ok() && test_succeeded).into();
     test_metrics.emit(test_status).await?;
 
     spiced_instance.stop()?;
     let health_report = health_report?;
 
-    table_count_result?;
+    verification_result?;
     if let Some(message) = health_report.failure_message() {
         // Health check failures are logged as warnings but don't fail the test
         eprintln!("Warning: {message}");
@@ -324,14 +348,56 @@ fn check_app_is_appendable(app: &App) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn check_table_counts(
+/// Verifies the data the append test left behind.
+///
+/// Row counts prove only that the right *amount* of data arrived. Comparing the
+/// query results against the expected answers proves the right *data* arrived:
+/// a bad upsert resolution or a retention policy deleting the wrong row can
+/// still land on the expected row count.
+async fn verify_appended_data(
     spiced: &SpicedInstance,
     query_set: &QuerySet,
+    query_overrides: Option<QueryOverrides>,
     scale_factor: f64,
+    validate_results: bool,
 ) -> anyhow::Result<()> {
-    let spice_client = spiced.spice_client(None, false).await?;
+    println!("Verifying appended data");
+    check_table_counts(spiced, query_set, scale_factor).await?;
 
-    let mut any_count_mismatch = false;
+    if !validate_results {
+        println!("Skipping query result verification, pass --validate to enable it");
+        return Ok(());
+    }
+
+    check_query_results(spiced, query_set, query_overrides, scale_factor).await
+}
+
+/// A table whose row count doesn't match what the query set expects.
+struct TableCountMismatch {
+    name: &'static str,
+    expected: f64,
+    actual: f64,
+}
+
+impl std::fmt::Display for TableCountMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Table {} has {} rows, expected {}",
+            self.name, self.actual, self.expected
+        )
+    }
+}
+
+/// Counts every table in the query set, returning those outside a 0.01% margin
+/// of the expected count.
+async fn table_count_mismatches(
+    spice_client: &spiceai::Client,
+    query_set: &QuerySet,
+    scale_factor: f64,
+) -> anyhow::Result<Vec<TableCountMismatch>> {
+    let mut mismatches = Vec::new();
+
     for TableWithRowCount {
         name,
         count: expected_count,
@@ -361,16 +427,200 @@ async fn check_table_counts(
         let upper_bound = expected_count * 1.0001;
         let lower_bound = expected_count * 0.9999;
         if !(count <= upper_bound && count >= lower_bound) {
-            println!("Table {name} has {count} rows, expected {expected_count}");
-            any_count_mismatch = true;
+            mismatches.push(TableCountMismatch {
+                name,
+                expected: expected_count,
+                actual: count,
+            });
         }
     }
 
-    if any_count_mismatch {
+    Ok(mismatches)
+}
+
+/// Waits, up to [`VERIFICATION_SETTLE_TIMEOUT`], for every table to reach its
+/// expected row count, so verification runs against the fully loaded dataset.
+async fn check_table_counts(
+    spiced: &SpicedInstance,
+    query_set: &QuerySet,
+    scale_factor: f64,
+) -> anyhow::Result<()> {
+    // The same queries ran throughout the test against partially loaded data, so
+    // a cached result would report an earlier load step.
+    let spice_client = spiced.spice_client(None, true).await?;
+
+    let deadline = Instant::now() + VERIFICATION_SETTLE_TIMEOUT;
+    let mut mismatches = table_count_mismatches(&spice_client, query_set, scale_factor).await?;
+    while !mismatches.is_empty() && Instant::now() < deadline {
+        tokio::time::sleep(VERIFICATION_POLL_INTERVAL).await;
+        mismatches = table_count_mismatches(&spice_client, query_set, scale_factor).await?;
+    }
+
+    if !mismatches.is_empty() {
+        for mismatch in &mismatches {
+            println!("{mismatch}");
+        }
+
         return Err(anyhow::anyhow!(
             "Table row counts do not match expected values"
         ));
     }
 
     Ok(())
+}
+
+/// Explains why a query was not verified, so an all-skipped run isn't mistaken
+/// for a verified one.
+fn skip_reason(query: &Query, scale_factor: f64) -> String {
+    if validation::has_static_tpch_answer(query) {
+        format!(
+            "{}: an expected answer exists only at scale factor 1.0, this run is at scale factor {scale_factor}",
+            query.name
+        )
+    } else {
+        format!("{}: no expected answer", query.name)
+    }
+}
+
+/// Runs each query once against the appended data and compares the result
+/// against its expected answer.
+async fn check_query_results(
+    spiced: &SpicedInstance,
+    query_set: &QuerySet,
+    query_overrides: Option<QueryOverrides>,
+    scale_factor: f64,
+) -> anyhow::Result<()> {
+    let queries = query_set
+        .get_queries(query_overrides, None, None, Some(scale_factor))
+        .await?;
+    let spice_client = spiced.spice_client(None, true).await?;
+    let executor = FlightExecutor::new(Arc::new(spice_client));
+
+    println!(
+        "Verifying {} query results against the expected answers",
+        queries.len()
+    );
+
+    let mut validated = 0usize;
+    let mut skipped = Vec::new();
+    let mut failures = Vec::new();
+
+    for query in &queries {
+        if !validation::should_validate_with_static_tpch_answer(query, scale_factor) {
+            skipped.push(skip_reason(query, scale_factor));
+            continue;
+        }
+
+        let batches = match executor.execute(query, true).await {
+            Ok(result) => result.batches.unwrap_or_default(),
+            Err(e) => {
+                eprintln!("Query '{}' failed to run: {e}", query.name);
+                failures.push(format!("{}: failed to run: {e}", query.name));
+                continue;
+            }
+        };
+
+        match validation::validate_tpch_query(query, &batches)? {
+            QueryValidationResult::Pass => validated += 1,
+            QueryValidationResult::Fail(reason) => {
+                eprintln!("\nQuery '{}' returned unexpected results", query.name);
+                eprintln!("Query SQL: {}", query.sql);
+                eprintln!("Validation failure reason: {reason:?}");
+                eprintln!("\nActual results:");
+                print_result_head(&batches);
+                eprintln!();
+                failures.push(format!("{}: {reason:?}", query.name));
+            }
+        }
+    }
+
+    println!(
+        "Verified {validated}/{total} query results ({skipped_count} skipped, {failed_count} failed)",
+        total = queries.len(),
+        skipped_count = skipped.len(),
+        failed_count = failures.len(),
+    );
+    for reason in &skipped {
+        println!("  Skipped {reason}");
+    }
+
+    if !failures.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Query results do not match expected values: {}",
+            failures.join("; ")
+        ));
+    }
+
+    if validated == 0 {
+        eprintln!(
+            "Warning: no query in the {query_set} query set has an expected answer at scale factor {scale_factor}, so the appended data was verified by row count only"
+        );
+    }
+
+    Ok(())
+}
+
+/// Prints the first [`MAX_PRINTED_FAILURE_ROWS`] rows of a query result, so a
+/// large result doesn't bury the rest of the run's output.
+fn print_result_head(batches: &[RecordBatch]) {
+    let mut head = Vec::new();
+    let mut remaining = MAX_PRINTED_FAILURE_ROWS;
+    for batch in batches {
+        if remaining == 0 {
+            break;
+        }
+
+        let rows = remaining.min(batch.num_rows());
+        head.push(batch.slice(0, rows));
+        remaining -= rows;
+    }
+
+    match arrow::util::pretty::pretty_format_batches(&head) {
+        Ok(pretty) => eprintln!("{pretty}"),
+        Err(e) => eprintln!("Failed to format actual results: {e}"),
+    }
+
+    let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
+    if total_rows > MAX_PRINTED_FAILURE_ROWS {
+        eprintln!("... {} more rows", total_rows - MAX_PRINTED_FAILURE_ROWS);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{skip_reason, validation};
+    use test_framework::queries::Query;
+
+    fn query(name: &str) -> Query {
+        Query::new(name.into(), "SELECT 1".into(), false)
+    }
+
+    #[test]
+    fn a_tpch_query_is_validated_at_scale_factor_one() {
+        assert!(validation::should_validate_with_static_tpch_answer(
+            &query("tpch_q1"),
+            1.0
+        ));
+    }
+
+    #[test]
+    fn skip_reason_reports_a_query_without_an_expected_answer() {
+        assert_eq!(
+            skip_reason(&query("tpch_simple_q1"), 1.0),
+            "tpch_simple_q1: no expected answer"
+        );
+    }
+
+    #[test]
+    fn skip_reason_reports_a_scale_factor_the_answers_dont_cover() {
+        let reason = skip_reason(&query("tpch_q1"), 10.0);
+        assert!(
+            reason.contains("only at scale factor 1.0"),
+            "expected the reason to name the scale factor the answers cover, got: {reason}"
+        );
+        assert!(
+            reason.contains("scale factor 10"),
+            "expected the reason to name this run's scale factor, got: {reason}"
+        );
+    }
 }

--- a/tools/testoperator/src/commands/append/mod.rs
+++ b/tools/testoperator/src/commands/append/mod.rs
@@ -352,8 +352,11 @@ fn check_app_is_appendable(app: &App) -> anyhow::Result<()> {
 ///
 /// Row counts prove only that the right *amount* of data arrived. Comparing the
 /// query results against the expected answers proves the right *data* arrived:
-/// a bad upsert resolution or a retention policy deleting the wrong row can
-/// still land on the expected row count.
+/// a duplicated append, a retention policy deleting the wrong row, or a
+/// corrupted column can all land on the expected row count.
+///
+/// No expected-answer query selects the appended `*_created_at` column, so this
+/// pass does not observe which of two conflicting versions an upsert kept.
 async fn verify_appended_data(
     spiced: &SpicedInstance,
     query_set: &QuerySet,

--- a/tools/testoperator/src/commands/append/mod.rs
+++ b/tools/testoperator/src/commands/append/mod.rs
@@ -35,7 +35,7 @@ use test_framework::{
     opentelemetry::KeyValue,
     opentelemetry_sdk::Resource,
     queries::{
-        Query, QueryOverrides, QuerySet, TableWithRowCount,
+        QueryOverrides, QuerySet, TableWithRowCount,
         validation::{self, QueryValidationResult},
     },
     spiced::SpicedInstance,
@@ -362,40 +362,28 @@ async fn verify_appended_data(
     validate_results: bool,
 ) -> anyhow::Result<()> {
     println!("Verifying appended data");
-    check_table_counts(spiced, query_set, scale_factor).await?;
+
+    // The same queries ran throughout the test against partially loaded data, so
+    // a cached result would report an earlier load step.
+    let spice_client = Arc::new(spiced.spice_client(None, true).await?);
+
+    check_table_counts(&spice_client, query_set, scale_factor).await?;
 
     if !validate_results {
         println!("Skipping query result verification, pass --validate to enable it");
         return Ok(());
     }
 
-    check_query_results(spiced, query_set, query_overrides, scale_factor).await
+    check_query_results(&spice_client, query_set, query_overrides, scale_factor).await
 }
 
-/// A table whose row count doesn't match what the query set expects.
-struct TableCountMismatch {
-    name: &'static str,
-    expected: f64,
-    actual: f64,
-}
-
-impl std::fmt::Display for TableCountMismatch {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Table {} has {} rows, expected {}",
-            self.name, self.actual, self.expected
-        )
-    }
-}
-
-/// Counts every table in the query set, returning those outside a 0.01% margin
+/// Counts every table in the query set, describing those outside a 0.01% margin
 /// of the expected count.
 async fn table_count_mismatches(
     spice_client: &spiceai::Client,
     query_set: &QuerySet,
     scale_factor: f64,
-) -> anyhow::Result<Vec<TableCountMismatch>> {
+) -> anyhow::Result<Vec<String>> {
     let mut mismatches = Vec::new();
 
     for TableWithRowCount {
@@ -427,11 +415,9 @@ async fn table_count_mismatches(
         let upper_bound = expected_count * 1.0001;
         let lower_bound = expected_count * 0.9999;
         if !(count <= upper_bound && count >= lower_bound) {
-            mismatches.push(TableCountMismatch {
-                name,
-                expected: expected_count,
-                actual: count,
-            });
+            mismatches.push(format!(
+                "table {name} has {count} rows, expected {expected_count}"
+            ));
         }
     }
 
@@ -441,51 +427,34 @@ async fn table_count_mismatches(
 /// Waits, up to [`VERIFICATION_SETTLE_TIMEOUT`], for every table to reach its
 /// expected row count, so verification runs against the fully loaded dataset.
 async fn check_table_counts(
-    spiced: &SpicedInstance,
+    spice_client: &spiceai::Client,
     query_set: &QuerySet,
     scale_factor: f64,
 ) -> anyhow::Result<()> {
-    // The same queries ran throughout the test against partially loaded data, so
-    // a cached result would report an earlier load step.
-    let spice_client = spiced.spice_client(None, true).await?;
-
     let deadline = Instant::now() + VERIFICATION_SETTLE_TIMEOUT;
-    let mut mismatches = table_count_mismatches(&spice_client, query_set, scale_factor).await?;
-    while !mismatches.is_empty() && Instant::now() < deadline {
-        tokio::time::sleep(VERIFICATION_POLL_INTERVAL).await;
-        mismatches = table_count_mismatches(&spice_client, query_set, scale_factor).await?;
-    }
-
-    if !mismatches.is_empty() {
-        for mismatch in &mismatches {
-            println!("{mismatch}");
+    let mismatches = loop {
+        let mismatches = table_count_mismatches(spice_client, query_set, scale_factor).await?;
+        if mismatches.is_empty() || Instant::now() >= deadline {
+            break mismatches;
         }
 
+        tokio::time::sleep(VERIFICATION_POLL_INTERVAL).await;
+    };
+
+    if !mismatches.is_empty() {
         return Err(anyhow::anyhow!(
-            "Table row counts do not match expected values"
+            "Table row counts do not match expected values: {}",
+            mismatches.join("; ")
         ));
     }
 
     Ok(())
 }
 
-/// Explains why a query was not verified, so an all-skipped run isn't mistaken
-/// for a verified one.
-fn skip_reason(query: &Query, scale_factor: f64) -> String {
-    if validation::has_static_tpch_answer(query) {
-        format!(
-            "{}: an expected answer exists only at scale factor 1.0, this run is at scale factor {scale_factor}",
-            query.name
-        )
-    } else {
-        format!("{}: no expected answer", query.name)
-    }
-}
-
 /// Runs each query once against the appended data and compares the result
 /// against its expected answer.
 async fn check_query_results(
-    spiced: &SpicedInstance,
+    spice_client: &Arc<spiceai::Client>,
     query_set: &QuerySet,
     query_overrides: Option<QueryOverrides>,
     scale_factor: f64,
@@ -493,21 +462,21 @@ async fn check_query_results(
     let queries = query_set
         .get_queries(query_overrides, None, None, Some(scale_factor))
         .await?;
-    let spice_client = spiced.spice_client(None, true).await?;
-    let executor = FlightExecutor::new(Arc::new(spice_client));
+    let executor = FlightExecutor::new(Arc::clone(spice_client));
 
     println!(
         "Verifying {} query results against the expected answers",
         queries.len()
     );
 
-    let mut validated = 0usize;
     let mut skipped = Vec::new();
     let mut failures = Vec::new();
 
     for query in &queries {
+        // Gate before running the query, so a query that can't be validated
+        // isn't executed for a result nothing compares.
         if !validation::should_validate_with_static_tpch_answer(query, scale_factor) {
-            skipped.push(skip_reason(query, scale_factor));
+            skipped.push(query.name.as_ref());
             continue;
         }
 
@@ -520,29 +489,26 @@ async fn check_query_results(
             }
         };
 
-        match validation::validate_tpch_query(query, &batches)? {
-            QueryValidationResult::Pass => validated += 1,
-            QueryValidationResult::Fail(reason) => {
-                eprintln!("\nQuery '{}' returned unexpected results", query.name);
-                eprintln!("Query SQL: {}", query.sql);
-                eprintln!("Validation failure reason: {reason:?}");
-                eprintln!("\nActual results:");
-                print_result_head(&batches);
-                eprintln!();
-                failures.push(format!("{}: {reason:?}", query.name));
-            }
+        if let QueryValidationResult::Fail(reason) =
+            validation::validate_tpch_query(query, &batches)?
+        {
+            eprintln!("\nQuery '{}' returned unexpected results", query.name);
+            eprintln!("Query SQL: {}", query.sql);
+            eprintln!("Validation failure reason: {reason:?}");
+            eprintln!("\nActual results:");
+            print_result_head(&batches);
+            eprintln!();
+            failures.push(format!("{}: {reason:?}", query.name));
         }
     }
 
+    let validated = queries.len() - skipped.len() - failures.len();
     println!(
         "Verified {validated}/{total} query results ({skipped_count} skipped, {failed_count} failed)",
         total = queries.len(),
         skipped_count = skipped.len(),
         failed_count = failures.len(),
     );
-    for reason in &skipped {
-        println!("  Skipped {reason}");
-    }
 
     if !failures.is_empty() {
         return Err(anyhow::anyhow!(
@@ -553,7 +519,13 @@ async fn check_query_results(
 
     if validated == 0 {
         eprintln!(
-            "Warning: no query in the {query_set} query set has an expected answer at scale factor {scale_factor}, so the appended data was verified by row count only"
+            "Warning: no {query_set} query has an expected answer at scale factor {scale_factor}, so the appended data was verified by row count only"
+        );
+    } else if !skipped.is_empty() {
+        println!(
+            "Skipped {count} queries with no expected answer at scale factor {scale_factor}: {names}",
+            count = skipped.len(),
+            names = skipped.join(", "),
         );
     }
 
@@ -583,44 +555,5 @@ fn print_result_head(batches: &[RecordBatch]) {
     let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
     if total_rows > MAX_PRINTED_FAILURE_ROWS {
         eprintln!("... {} more rows", total_rows - MAX_PRINTED_FAILURE_ROWS);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{skip_reason, validation};
-    use test_framework::queries::Query;
-
-    fn query(name: &str) -> Query {
-        Query::new(name.into(), "SELECT 1".into(), false)
-    }
-
-    #[test]
-    fn a_tpch_query_is_validated_at_scale_factor_one() {
-        assert!(validation::should_validate_with_static_tpch_answer(
-            &query("tpch_q1"),
-            1.0
-        ));
-    }
-
-    #[test]
-    fn skip_reason_reports_a_query_without_an_expected_answer() {
-        assert_eq!(
-            skip_reason(&query("tpch_simple_q1"), 1.0),
-            "tpch_simple_q1: no expected answer"
-        );
-    }
-
-    #[test]
-    fn skip_reason_reports_a_scale_factor_the_answers_dont_cover() {
-        let reason = skip_reason(&query("tpch_q1"), 10.0);
-        assert!(
-            reason.contains("only at scale factor 1.0"),
-            "expected the reason to name the scale factor the answers cover, got: {reason}"
-        );
-        assert!(
-            reason.contains("scale factor 10"),
-            "expected the reason to name this run's scale factor, got: {reason}"
-        );
     }
 }

--- a/tools/testoperator/src/commands/append/mod.rs
+++ b/tools/testoperator/src/commands/append/mod.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use super::get_app_and_start_request;
 use crate::{args::AppendTestArgs, health::HealthMonitor};
 use std::{
+    path::Path,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -79,6 +80,10 @@ pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
         );
 
     check_app_is_appendable(&app)?;
+
+    // Captured before `start_request` is consumed: the append source writes its
+    // source parquet here, which conflict verification reads back.
+    let tempdir_path = start_request.get_tempdir_path();
 
     println!("Running append test");
 
@@ -165,10 +170,15 @@ pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
 
     let verification_result = verify_appended_data(
         &spiced_instance,
-        &query_set,
-        query_overrides,
-        args.test_args.scale_factor.unwrap_or(1.0),
-        args.test_args.validate,
+        &VerificationContext {
+            app: &app,
+            query_set: &query_set,
+            query_overrides,
+            scale_factor: args.test_args.scale_factor.unwrap_or(1.0),
+            validate_results: args.test_args.validate,
+            conflict_data: args.with_conflict_data && !args.with_retention_data,
+            tempdir_path: &tempdir_path,
+        },
     )
     .await;
 
@@ -357,12 +367,23 @@ fn check_app_is_appendable(app: &App) -> anyhow::Result<()> {
 ///
 /// No expected-answer query selects the appended `*_created_at` column, so this
 /// pass does not observe which of two conflicting versions an upsert kept.
-async fn verify_appended_data(
-    spiced: &SpicedInstance,
-    query_set: &QuerySet,
+/// What the end-of-test verification needs to know about the run it is checking.
+struct VerificationContext<'a> {
+    app: &'a App,
+    query_set: &'a QuerySet,
     query_overrides: Option<QueryOverrides>,
     scale_factor: f64,
     validate_results: bool,
+    /// Whether the run appended conflicting rows, so their resolution is worth
+    /// checking. Retention deletes rows the source parquet still holds, so the
+    /// two modes aren't verified together.
+    conflict_data: bool,
+    tempdir_path: &'a Path,
+}
+
+async fn verify_appended_data(
+    spiced: &SpicedInstance,
+    context: &VerificationContext<'_>,
 ) -> anyhow::Result<()> {
     println!("Verifying appended data");
 
@@ -370,14 +391,26 @@ async fn verify_appended_data(
     // a cached result would report an earlier load step.
     let spice_client = Arc::new(spiced.spice_client(None, true).await?);
 
-    check_table_counts(&spice_client, query_set, scale_factor).await?;
+    check_table_counts(&spice_client, context.query_set, context.scale_factor).await?;
 
-    if !validate_results {
+    if !context.validate_results {
         println!("Skipping query result verification, pass --validate to enable it");
         return Ok(());
     }
 
-    check_query_results(&spice_client, query_set, query_overrides, scale_factor).await
+    check_query_results(
+        &spice_client,
+        context.query_set,
+        context.query_overrides,
+        context.scale_factor,
+    )
+    .await?;
+
+    if context.conflict_data {
+        check_conflict_resolution(&spice_client, context.app, context.tempdir_path).await?;
+    }
+
+    Ok(())
 }
 
 /// Counts every table in the query set, describing those outside a 0.01% margin
@@ -558,5 +591,153 @@ fn print_result_head(batches: &[RecordBatch]) {
     let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
     if total_rows > MAX_PRINTED_FAILURE_ROWS {
         eprintln!("... {} more rows", total_rows - MAX_PRINTED_FAILURE_ROWS);
+    }
+}
+
+/// The primary-key columns an `acceleration.primary_key` names, with the
+/// parentheses a compound key is written with stripped.
+fn primary_key_columns(primary_key: &str) -> &str {
+    primary_key
+        .trim()
+        .strip_prefix('(')
+        .and_then(|key| key.strip_suffix(')'))
+        .unwrap_or(primary_key)
+        .trim()
+}
+
+/// Counts the rows the accelerated table holds at each distinct append
+/// timestamp, oldest first.
+async fn accelerated_timestamp_counts(
+    spice_client: &spiceai::Client,
+    table: &str,
+    time_column: &str,
+) -> anyhow::Result<Vec<u64>> {
+    let sql =
+        format!("SELECT COUNT(*) FROM {table} GROUP BY {time_column} ORDER BY {time_column} ASC");
+    let batches = spice_client
+        .sql(&sql)
+        .await?
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    let mut counts = Vec::new();
+    for batch in &batches {
+        let column = batch
+            .column(0)
+            .as_primitive_opt::<arrow::datatypes::Int64Type>()
+            .context("Failed to read the row count as an Int64Type")?;
+        for index in 0..column.len() {
+            counts.push(u64::try_from(column.value(index))?);
+        }
+    }
+
+    Ok(counts)
+}
+
+/// Counts the rows the source parquet holds at each distinct append timestamp,
+/// oldest first, keeping only the newest copy of each key. That is what an
+/// upsert that resolves a conflict in favour of the later row should leave.
+fn expected_timestamp_counts(
+    parquet_path: &Path,
+    primary_key: &str,
+    time_column: &str,
+) -> anyhow::Result<Vec<u64>> {
+    let keys = primary_key_columns(primary_key);
+    let sql = format!(
+        "SELECT COUNT(*) FROM (
+             SELECT {keys}, MAX({time_column}) AS {time_column}
+             FROM read_parquet('{path}') GROUP BY {keys}
+         ) GROUP BY {time_column} ORDER BY {time_column} ASC",
+        path = parquet_path.to_string_lossy()
+    );
+
+    let connection = duckdb::Connection::open_in_memory()?;
+    let mut statement = connection.prepare(&sql)?;
+    let counts = statement
+        .query_map([], |row| row.get::<_, i64>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    counts
+        .into_iter()
+        .map(|count| Ok(u64::try_from(count)?))
+        .collect()
+}
+
+/// Checks that each conflicting row was resolved in favour of the copy appended
+/// last.
+///
+/// A step's own rows and the conflicting copy it seeds for the next step share
+/// one transaction timestamp, so a row appended over a conflict carries the
+/// later of the two. Comparing per-timestamp row counts against the source
+/// parquet therefore distinguishes an upsert that kept the newer row from one
+/// that kept the stale one, which no expected-answer query can see.
+async fn check_conflict_resolution(
+    spice_client: &spiceai::Client,
+    app: &App,
+    tempdir_path: &Path,
+) -> anyhow::Result<()> {
+    let mut checked = 0usize;
+    let mut failures = Vec::new();
+
+    for dataset in &app.datasets {
+        let (Some(time_column), Some(primary_key)) = (
+            dataset.time_column.as_deref(),
+            dataset
+                .acceleration
+                .as_ref()
+                .and_then(|acceleration| acceleration.primary_key.as_deref()),
+        ) else {
+            continue;
+        };
+
+        let parquet_path = tempdir_path.join(format!("{}.parquet", dataset.name));
+        let path = parquet_path.clone();
+        let primary_key = primary_key.to_string();
+        let column = time_column.to_string();
+        let expected = tokio::task::spawn_blocking(move || {
+            expected_timestamp_counts(&path, &primary_key, &column)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {e}", parquet_path.display()))??;
+
+        let actual = accelerated_timestamp_counts(spice_client, &dataset.name, time_column).await?;
+
+        if actual == expected {
+            checked += 1;
+        } else {
+            failures.push(format!(
+                "{}: appended {actual:?} rows per timestamp, expected {expected:?}",
+                dataset.name
+            ));
+        }
+    }
+
+    println!("Verified conflict resolution for {checked} tables");
+
+    if !failures.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Conflicting rows did not resolve to the row appended last: {}",
+            failures.join("; ")
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::primary_key_columns;
+
+    #[test]
+    fn a_single_column_primary_key_is_used_as_written() {
+        assert_eq!(primary_key_columns("c_custkey"), "c_custkey");
+    }
+
+    #[test]
+    fn a_compound_primary_key_loses_its_parentheses() {
+        assert_eq!(
+            primary_key_columns("(l_orderkey, l_linenumber)"),
+            "l_orderkey, l_linenumber"
+        );
     }
 }

--- a/tools/testoperator/src/commands/append/mod.rs
+++ b/tools/testoperator/src/commands/append/mod.rs
@@ -17,7 +17,6 @@ limitations under the License.
 use super::get_app_and_start_request;
 use crate::{args::AppendTestArgs, health::HealthMonitor};
 use std::{
-    path::Path,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -80,10 +79,6 @@ pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
         );
 
     check_app_is_appendable(&app)?;
-
-    // Captured before `start_request` is consumed: the append source writes its
-    // source parquet here, which conflict verification reads back.
-    let tempdir_path = start_request.get_tempdir_path();
 
     println!("Running append test");
 
@@ -170,15 +165,10 @@ pub(crate) async fn run(args: &AppendTestArgs) -> anyhow::Result<()> {
 
     let verification_result = verify_appended_data(
         &spiced_instance,
-        &VerificationContext {
-            app: &app,
-            query_set: &query_set,
-            query_overrides,
-            scale_factor: args.test_args.scale_factor.unwrap_or(1.0),
-            validate_results: args.test_args.validate,
-            conflict_data: args.with_conflict_data && !args.with_retention_data,
-            tempdir_path: &tempdir_path,
-        },
+        &query_set,
+        query_overrides,
+        args.test_args.scale_factor.unwrap_or(1.0),
+        args.test_args.validate,
     )
     .await;
 
@@ -365,25 +355,15 @@ fn check_app_is_appendable(app: &App) -> anyhow::Result<()> {
 /// a duplicated append, a retention policy deleting the wrong row, or a
 /// corrupted column can all land on the expected row count.
 ///
-/// No expected-answer query selects the appended `*_created_at` column, so this
-/// pass does not observe which of two conflicting versions an upsert kept.
-/// What the end-of-test verification needs to know about the run it is checking.
-struct VerificationContext<'a> {
-    app: &'a App,
-    query_set: &'a QuerySet,
+/// Under `--with-conflict-data` it also covers conflict resolution: the copy an
+/// upsert must discard carries a negated queried column, so keeping it shows up
+/// in the query results.
+async fn verify_appended_data(
+    spiced: &SpicedInstance,
+    query_set: &QuerySet,
     query_overrides: Option<QueryOverrides>,
     scale_factor: f64,
     validate_results: bool,
-    /// Whether the run appended conflicting rows, so their resolution is worth
-    /// checking. Retention deletes rows the source parquet still holds, so the
-    /// two modes aren't verified together.
-    conflict_data: bool,
-    tempdir_path: &'a Path,
-}
-
-async fn verify_appended_data(
-    spiced: &SpicedInstance,
-    context: &VerificationContext<'_>,
 ) -> anyhow::Result<()> {
     println!("Verifying appended data");
 
@@ -391,26 +371,14 @@ async fn verify_appended_data(
     // a cached result would report an earlier load step.
     let spice_client = Arc::new(spiced.spice_client(None, true).await?);
 
-    check_table_counts(&spice_client, context.query_set, context.scale_factor).await?;
+    check_table_counts(&spice_client, query_set, scale_factor).await?;
 
-    if !context.validate_results {
+    if !validate_results {
         println!("Skipping query result verification, pass --validate to enable it");
         return Ok(());
     }
 
-    check_query_results(
-        &spice_client,
-        context.query_set,
-        context.query_overrides,
-        context.scale_factor,
-    )
-    .await?;
-
-    if context.conflict_data {
-        check_conflict_resolution(&spice_client, context.app, context.tempdir_path).await?;
-    }
-
-    Ok(())
+    check_query_results(&spice_client, query_set, query_overrides, scale_factor).await
 }
 
 /// Counts every table in the query set, describing those outside a 0.01% margin
@@ -591,153 +559,5 @@ fn print_result_head(batches: &[RecordBatch]) {
     let total_rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
     if total_rows > MAX_PRINTED_FAILURE_ROWS {
         eprintln!("... {} more rows", total_rows - MAX_PRINTED_FAILURE_ROWS);
-    }
-}
-
-/// The primary-key columns an `acceleration.primary_key` names, with the
-/// parentheses a compound key is written with stripped.
-fn primary_key_columns(primary_key: &str) -> &str {
-    primary_key
-        .trim()
-        .strip_prefix('(')
-        .and_then(|key| key.strip_suffix(')'))
-        .unwrap_or(primary_key)
-        .trim()
-}
-
-/// Counts the rows the accelerated table holds at each distinct append
-/// timestamp, oldest first.
-async fn accelerated_timestamp_counts(
-    spice_client: &spiceai::Client,
-    table: &str,
-    time_column: &str,
-) -> anyhow::Result<Vec<u64>> {
-    let sql =
-        format!("SELECT COUNT(*) FROM {table} GROUP BY {time_column} ORDER BY {time_column} ASC");
-    let batches = spice_client
-        .sql(&sql)
-        .await?
-        .try_collect::<Vec<_>>()
-        .await?;
-
-    let mut counts = Vec::new();
-    for batch in &batches {
-        let column = batch
-            .column(0)
-            .as_primitive_opt::<arrow::datatypes::Int64Type>()
-            .context("Failed to read the row count as an Int64Type")?;
-        for index in 0..column.len() {
-            counts.push(u64::try_from(column.value(index))?);
-        }
-    }
-
-    Ok(counts)
-}
-
-/// Counts the rows the source parquet holds at each distinct append timestamp,
-/// oldest first, keeping only the newest copy of each key. That is what an
-/// upsert that resolves a conflict in favour of the later row should leave.
-fn expected_timestamp_counts(
-    parquet_path: &Path,
-    primary_key: &str,
-    time_column: &str,
-) -> anyhow::Result<Vec<u64>> {
-    let keys = primary_key_columns(primary_key);
-    let sql = format!(
-        "SELECT COUNT(*) FROM (
-             SELECT {keys}, MAX({time_column}) AS {time_column}
-             FROM read_parquet('{path}') GROUP BY {keys}
-         ) GROUP BY {time_column} ORDER BY {time_column} ASC",
-        path = parquet_path.to_string_lossy()
-    );
-
-    let connection = duckdb::Connection::open_in_memory()?;
-    let mut statement = connection.prepare(&sql)?;
-    let counts = statement
-        .query_map([], |row| row.get::<_, i64>(0))?
-        .collect::<Result<Vec<_>, _>>()?;
-
-    counts
-        .into_iter()
-        .map(|count| Ok(u64::try_from(count)?))
-        .collect()
-}
-
-/// Checks that each conflicting row was resolved in favour of the copy appended
-/// last.
-///
-/// A step's own rows and the conflicting copy it seeds for the next step share
-/// one transaction timestamp, so a row appended over a conflict carries the
-/// later of the two. Comparing per-timestamp row counts against the source
-/// parquet therefore distinguishes an upsert that kept the newer row from one
-/// that kept the stale one, which no expected-answer query can see.
-async fn check_conflict_resolution(
-    spice_client: &spiceai::Client,
-    app: &App,
-    tempdir_path: &Path,
-) -> anyhow::Result<()> {
-    let mut checked = 0usize;
-    let mut failures = Vec::new();
-
-    for dataset in &app.datasets {
-        let (Some(time_column), Some(primary_key)) = (
-            dataset.time_column.as_deref(),
-            dataset
-                .acceleration
-                .as_ref()
-                .and_then(|acceleration| acceleration.primary_key.as_deref()),
-        ) else {
-            continue;
-        };
-
-        let parquet_path = tempdir_path.join(format!("{}.parquet", dataset.name));
-        let path = parquet_path.clone();
-        let primary_key = primary_key.to_string();
-        let column = time_column.to_string();
-        let expected = tokio::task::spawn_blocking(move || {
-            expected_timestamp_counts(&path, &primary_key, &column)
-        })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to read {}: {e}", parquet_path.display()))??;
-
-        let actual = accelerated_timestamp_counts(spice_client, &dataset.name, time_column).await?;
-
-        if actual == expected {
-            checked += 1;
-        } else {
-            failures.push(format!(
-                "{}: appended {actual:?} rows per timestamp, expected {expected:?}",
-                dataset.name
-            ));
-        }
-    }
-
-    println!("Verified conflict resolution for {checked} tables");
-
-    if !failures.is_empty() {
-        return Err(anyhow::anyhow!(
-            "Conflicting rows did not resolve to the row appended last: {}",
-            failures.join("; ")
-        ));
-    }
-
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::primary_key_columns;
-
-    #[test]
-    fn a_single_column_primary_key_is_used_as_written() {
-        assert_eq!(primary_key_columns("c_custkey"), "c_custkey");
-    }
-
-    #[test]
-    fn a_compound_primary_key_loses_its_parentheses() {
-        assert_eq!(
-            primary_key_columns("(l_orderkey, l_linenumber)"),
-            "l_orderkey, l_linenumber"
-        );
     }
 }


### PR DESCRIPTION
Fixes #13722.

`testoperator run append` accepted `--validate` — `AppendTestArgs` flattens `DatasetTestArgs`, which declares it — but never read it. Its only correctness check was `check_table_counts`: `SELECT COUNT(*)` per table against `QuerySet::row_counts()` within a 0.01% margin, so a bad upsert resolution, a retention policy deleting the wrong row, or a corrupted column all passed.

## Change

The flag is now respected. Once the loads finish, each query runs once against the final data and its result is compared against the expected answer (`validation::validate_tpch_query`), failing the test on a mismatch.

Three things the verification pass has to get right:

- **It runs at the end, not during.** The tables are still filling mid-run, which is why `with_validate_row_count(false)` is set today.
- **It bypasses the results cache.** The same queries ran throughout the test against partially loaded data, so a cached result would report an earlier load step.
- **It waits for the row counts to settle first** (bounded, 3 min), so it doesn't race the last refresh.

Queries with no static answer at the scale factor are reported as skipped, and a run that validates nothing warns rather than passing silently — TPC-DS and ClickBench have no static answers, so their append tests stay row-count-only and say so.

**Conflict resolution.** The `--with-conflict-data` generator now produces genuinely different data for the copy an upsert must discard — a queried non-key column is negated — instead of a copy byte-identical to its replacement apart from `*_created_at`, which no query selects. Correct resolution restores the real row and the TPC-H answers still match; a stale survivor moves an aggregate they cover, so the queries above exercise upsert correctness with no extra verification step.

`check_table_counts` was also reshaped to return its mismatches instead of printing them, which is what lets it poll; the tolerance and the failure output are unchanged.

## Wiring

- `.github/workflows/testoperator_run_append.yml` gains a `validate_results` input, defaulting to `true`, and always passes `--validate=`.
- `AppendArgs` gains `validate_results` so a dispatch config can opt out. No config sets it, so every append test validates.
- `has_static_tpch_answer` and `should_validate_with_static_tpch_answer` are now `pub` (were `pub(crate)`).

## Testing

`cargo clippy --tests` clean. 102 testoperator unit tests pass, plus three in `test-framework` over the generated conflict SQL: the marker column is negated before the copy is appended, a table without a marker column is left alone, and no conflicting copy is generated without `--with-conflict-data`. The end-to-end path needs a dispatched append run, on an upsert spicepod for the conflict half.
