### PR TITLE
Downgrade DuckDB to v1.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4319,7 +4319,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=0d24a546748b54fd3ff48853739d85a6d351058f#0d24a546748b54fd3ff48853739d85a6d351058f"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=b20bad9047ea8fdd3e7e0c423f4a131cc97b2f3c#b20bad9047ea8fdd3e7e0c423f4a131cc97b2f3c"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -7872,12 +7872,12 @@ checksum = "ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7"
 
 [[package]]
 name = "duckdb"
-version = "1.10505.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=7229b20daf24765c84d294c52cf4b4165ca79073#7229b20daf24765c84d294c52cf4b4165ca79073"
+version = "1.4.4"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=e55a90af7d6b37536e5acedc33b7ff7660361b0c#e55a90af7d6b37536e5acedc33b7ff7660361b0c"
 dependencies = [
  "arrow",
+ "calamine",
  "cast",
- "comfy-table",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
@@ -7885,6 +7885,7 @@ dependencies = [
  "num",
  "num-integer",
  "r2d2",
+ "rust_decimal",
  "strum 0.27.2",
 ]
 
@@ -9228,8 +9229,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -10399,7 +10400,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -11553,16 +11554,16 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10505.0"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=7229b20daf24765c84d294c52cf4b4165ca79073#7229b20daf24765c84d294c52cf4b4165ca79073"
+version = "1.4.4"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=e55a90af7d6b37536e5acedc33b7ff7660361b0c#e55a90af7d6b37536e5acedc33b7ff7660361b0c"
 dependencies = [
  "cc",
  "flate2",
  "pkg-config",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "tar",
- "ureq 3.3.0",
  "vcpkg",
  "zip 6.0.0",
 ]
@@ -15192,7 +15193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6705a26ad89d241a989a5395641931ba37076f5ab5fbd19ee92402414a43af32"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
+ "hashbrown 0.5.0",
  "parking_lot",
  "rand 0.8.6",
 ]
@@ -15681,7 +15682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -15702,7 +15703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -19178,7 +19179,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -24529,7 +24530,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7308,7 +7308,7 @@ dependencies = [
 [[package]]
 name = "datafusion-table-providers"
 version = "0.1.0"
-source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=b20bad9047ea8fdd3e7e0c423f4a131cc97b2f3c#b20bad9047ea8fdd3e7e0c423f4a131cc97b2f3c"
+source = "git+https://github.com/spiceai/datafusion-table-providers.git?rev=642e121192fcc4c3430e28e01e660ee5d189d517#642e121192fcc4c3430e28e01e660ee5d189d517"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
@@ -7873,7 +7873,7 @@ checksum = "ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7"
 [[package]]
 name = "duckdb"
 version = "1.4.4"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=e55a90af7d6b37536e5acedc33b7ff7660361b0c#e55a90af7d6b37536e5acedc33b7ff7660361b0c"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=9d7be742f060d70066fc041319af787772716e0d#9d7be742f060d70066fc041319af787772716e0d"
 dependencies = [
  "arrow",
  "calamine",
@@ -10365,7 +10365,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -11555,7 +11555,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libduckdb-sys"
 version = "1.4.4"
-source = "git+https://github.com/spiceai/duckdb-rs.git?rev=e55a90af7d6b37536e5acedc33b7ff7660361b0c#e55a90af7d6b37536e5acedc33b7ff7660361b0c"
+source = "git+https://github.com/spiceai/duckdb-rs.git?rev=9d7be742f060d70066fc041319af787772716e0d#9d7be742f060d70066fc041319af787772716e0d"
 dependencies = [
  "cc",
  "flate2",
@@ -15681,7 +15681,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.10.5",
  "log",
  "multimap",
@@ -16031,7 +16031,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -16070,7 +16070,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -19740,7 +19740,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -21388,7 +21388,7 @@ dependencies = [
  "ahash 0.8.12",
  "auto_enums",
  "either",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "itertools 0.13.0",
  "once_cell",
  "pulldown-cmark 0.12.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "0d24a546748b54fd3ff48853739d85a6d351058f" } # branch: spiceai-54
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "b20bad9047ea8fdd3e7e0c423f4a131cc97b2f3c" } # branch: sgrebnov/duckdb-1.4.4-with-memory-soak (spiceai-54 + DuckDB 1.4.4; this crate pins duckdb by git rev, so patch.crates-io alone cannot move it)
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",
@@ -280,7 +280,7 @@ delta_kernel = { version = "0.23.0", features = [
 derive_builder = "0.20.2"
 dotenv = { path = "crates/dotenv" }
 duration-parse = { path = "crates/duration-parse" }
-duckdb = "1.10505" # 1.10505.x corresponds to DuckDB v1.5.5
+duckdb = "1.4.4" # the crate version that matches DuckDB v1.4.4
 dyn-hash = "1.0.0"
 encoding_rs = "0.8.34"
 fs4 = "0.13.1"
@@ -556,7 +556,7 @@ candle-index-select-cu = { git = "https://github.com/spiceai/candle-index-select
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "714d64fd5369efc4835109be0fd718db5a3be0aa" } # branch: spiceai-0.23.0
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "7229b20daf24765c84d294c52cf4b4165ca79073" } # branch: spiceai-1.5.5
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "e55a90af7d6b37536e5acedc33b7ff7660361b0c" } # branch: sgrebnov/duckdb-1.4.4-arrow58 (DuckDB v1.4.4, arrow 58)
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "e39c9c46dea1f0983cd8d87dabb69b41c9efe1fd" } # master @ tip (PR #2 merged: rusqlite 0.40.1 + bundled-decimal)
 tokio-rusqlite = { git = "https://github.com/spiceai/tokio-rusqlite.git", rev = "b10df82e3bbc4f4700562a14a3a00714cbc2f0c7" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,7 +271,7 @@ datafusion-proto-common = "54.1.0"
 datafusion-pruning = "54.1.0"
 datafusion-spark = "54.1.0"
 datafusion-substrait = "54.1.0"
-datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "b20bad9047ea8fdd3e7e0c423f4a131cc97b2f3c" } # branch: sgrebnov/duckdb-1.4.4-with-memory-soak (spiceai-54 + DuckDB 1.4.4; this crate pins duckdb by git rev, so patch.crates-io alone cannot move it)
+datafusion-table-providers = { git = "https://github.com/spiceai/datafusion-table-providers.git", rev = "642e121192fcc4c3430e28e01e660ee5d189d517" } # branch: spiceai-54 (DuckDB 1.4.4; this crate pins duckdb by git rev, so patch.crates-io alone cannot move it)
 delta_kernel = { version = "0.23.0", features = [
     "default-engine-rustls",
     "arrow-58",
@@ -556,7 +556,7 @@ candle-index-select-cu = { git = "https://github.com/spiceai/candle-index-select
 
 delta_kernel = { git = "https://github.com/spiceai/delta-kernel-rs.git", rev = "714d64fd5369efc4835109be0fd718db5a3be0aa" } # branch: spiceai-0.23.0
 
-duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "e55a90af7d6b37536e5acedc33b7ff7660361b0c" } # branch: sgrebnov/duckdb-1.4.4-arrow58 (DuckDB v1.4.4, arrow 58)
+duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "9d7be742f060d70066fc041319af787772716e0d" } # branch: spiceai-1.4.4 (DuckDB v1.4.4, arrow 58; must match the rev datafusion-table-providers pins, or cargo resolves two copies of duckdb)
 rusqlite = { git = "https://github.com/spiceai/rusqlite.git", rev = "e39c9c46dea1f0983cd8d87dabb69b41c9efe1fd" } # master @ tip (PR #2 merged: rusqlite 0.40.1 + bundled-decimal)
 tokio-rusqlite = { git = "https://github.com/spiceai/tokio-rusqlite.git", rev = "b10df82e3bbc4f4700562a14a3a00714cbc2f0c7" }
 

--- a/crates/accelerators/accelerator-duckdb/src/lib.rs
+++ b/crates/accelerators/accelerator-duckdb/src/lib.rs
@@ -3711,15 +3711,37 @@ mod tests {
     /// the dataset loads, and the first query touching a time zone fails, in an
     /// environment that may have no network to install the extension from.
     ///
+    /// An in-memory `DuckDB` cut off from the host's extension cache and from the
+    /// network, so an extension is available only if it is compiled in.
+    ///
+    /// Both guards below need this. `duckdb_extensions()` lets a downloaded copy
+    /// shadow a statically linked one — the disk scan marks the extension
+    /// installed, and the loaded-extension pass then leaves `install_mode` alone —
+    /// so a host with a warm `~/.duckdb` cache reports `REPOSITORY` for an
+    /// extension that is in fact linked in. In the other direction, autoinstall
+    /// would let a download satisfy the behavioural queries on a build that had
+    /// lost the static link. An empty extension directory closes both.
+    ///
+    /// The `TempDir` is returned because dropping it removes the directory.
+    fn isolated_duckdb() -> (tempfile::TempDir, duckdb::Connection) {
+        let dir = tempfile::tempdir().expect("temp extension directory");
+        let db = duckdb::Connection::open_in_memory().expect("opens an in-memory DuckDB");
+        db.execute_batch(&format!(
+            "SET extension_directory = '{}';
+             SET autoinstall_known_extensions = false;
+             SET autoload_known_extensions = false;",
+            dir.path().display()
+        ))
+        .expect("isolates DuckDB from the host extension cache");
+        (dir, db)
+    }
+
     /// How the bundled engine says it obtained `name`.
     ///
     /// `STATICALLY_LINKED` is the only answer that proves the fork patch is
-    /// present. `DuckDB` installs and loads a known extension automatically, so a
-    /// runner with a network or a warm extension cache satisfies a behavioural
-    /// query either way — which would leave the guards below green on a build that
-    /// had lost the static link, and failing only for whoever runs offline.
+    /// present.
     fn bundled_extension_install_mode(name: &str) -> String {
-        let db = duckdb::Connection::open_in_memory().expect("opens an in-memory DuckDB");
+        let (_dir, db) = isolated_duckdb();
         db.query_row(
             "SELECT install_mode FROM duckdb_extensions() WHERE extension_name = ?",
             [name],
@@ -3738,7 +3760,7 @@ mod tests {
             "ICU has to be compiled in, not installed at runtime"
         );
 
-        let db = duckdb::Connection::open_in_memory().expect("opens an in-memory DuckDB");
+        let (_dir, db) = isolated_duckdb();
         let local: String = db
             .query_row(
                 "SELECT strftime(TIMESTAMPTZ '2026-01-01 00:00:00+00' AT TIME ZONE \
@@ -3767,7 +3789,7 @@ mod tests {
             "VSS has to be compiled in, not installed at runtime"
         );
 
-        let db = duckdb::Connection::open_in_memory().expect("opens an in-memory DuckDB");
+        let (_dir, db) = isolated_duckdb();
         db.execute_batch(
             "CREATE TABLE embeddings (v FLOAT[3]);
              INSERT INTO embeddings VALUES ([1.0, 2.0, 3.0]), ([2.0, 3.0, 4.0]);

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -96,10 +96,10 @@ own section below — a count here would be one more thing to keep true by hand.
 | [datafusion-ballista](#datafusion-ballista) | `f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0` | `spiceai-54` |
 | [datafusion-federation](#datafusion-federation-and-datafusion-table-providers) | `0cb3781608b89f40c6585618ec3071f83345671a` | `spiceai-54` |
 | [datafusion-functions-json](#datafusion-functions-json) | `ca9d4c6e5a0de3bfa9fe20a683a9f7d58e36e2cc` | `spiceai-54` |
-| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `0d24a546748b54fd3ff48853739d85a6d351058f` | `spiceai-54` |
+| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `b20bad9047ea8fdd3e7e0c423f4a131cc97b2f3c` | `sgrebnov/duckdb-1.4.4-with-memory-soak` |
 | [delta-kernel-rs](#delta-kernel-rs) | `714d64fd5369efc4835109be0fd718db5a3be0aa` | `spiceai-0.23.0` |
 | [docx-rs](#docx-rs) | `2a85dce57d0128e2cd7c369545516c347cb8c529` | `spiceai` |
-| [duckdb-rs](#duckdb-rs) | `7229b20daf24765c84d294c52cf4b4165ca79073` | `spiceai-1.5.5` |
+| [duckdb-rs](#duckdb-rs) | `e55a90af7d6b37536e5acedc33b7ff7660361b0c` | `sgrebnov/duckdb-1.4.4-arrow58` |
 | [graph-rs-sdk](#graph-rs-sdk) | `af383410a9c86915263fbd1145b8becfc1e317b5` | `spiceai` |
 | [iceberg-rust](#iceberg-rust) | `351d1bc7b6ac9a835397e248e9c687f305e947d1` | `spiceai-0.10.1-df-54` |
 | [mistral.rs](#mistralrs-and-text-embeddings-inference) | `2d15d171236803481d582a9fbf8a80869bf74d8c` | `spiceai` |
@@ -274,7 +274,7 @@ the case named:
 ## duckdb-rs
 
 Upstream [duckdb/duckdb-rs](https://github.com/duckdb/duckdb-rs), branch
-`spiceai-1.5.5`.
+`sgrebnov/duckdb-1.4.4-arrow58`.
 
 | Patch | What breaks if it is lost | Loss | Guard |
 |---|---|---|---|

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -274,7 +274,7 @@ the case named:
 ## duckdb-rs
 
 Upstream [duckdb/duckdb-rs](https://github.com/duckdb/duckdb-rs), branch
-`sgrebnov/duckdb-1.4.4-arrow58`.
+`spiceai-1.4.4`.
 
 | Patch | What breaks if it is lost | Loss | Guard |
 |---|---|---|---|

--- a/docs/dev/fork_patches.md
+++ b/docs/dev/fork_patches.md
@@ -96,10 +96,10 @@ own section below — a count here would be one more thing to keep true by hand.
 | [datafusion-ballista](#datafusion-ballista) | `f3b8c4b49d251cb5f1326b69fe4846dc09d36ac0` | `spiceai-54` |
 | [datafusion-federation](#datafusion-federation-and-datafusion-table-providers) | `0cb3781608b89f40c6585618ec3071f83345671a` | `spiceai-54` |
 | [datafusion-functions-json](#datafusion-functions-json) | `ca9d4c6e5a0de3bfa9fe20a683a9f7d58e36e2cc` | `spiceai-54` |
-| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `b20bad9047ea8fdd3e7e0c423f4a131cc97b2f3c` | `sgrebnov/duckdb-1.4.4-with-memory-soak` |
+| [datafusion-table-providers](#datafusion-federation-and-datafusion-table-providers) | `642e121192fcc4c3430e28e01e660ee5d189d517` | `spiceai-54` |
 | [delta-kernel-rs](#delta-kernel-rs) | `714d64fd5369efc4835109be0fd718db5a3be0aa` | `spiceai-0.23.0` |
 | [docx-rs](#docx-rs) | `2a85dce57d0128e2cd7c369545516c347cb8c529` | `spiceai` |
-| [duckdb-rs](#duckdb-rs) | `e55a90af7d6b37536e5acedc33b7ff7660361b0c` | `sgrebnov/duckdb-1.4.4-arrow58` |
+| [duckdb-rs](#duckdb-rs) | `9d7be742f060d70066fc041319af787772716e0d` | `spiceai-1.4.4` |
 | [graph-rs-sdk](#graph-rs-sdk) | `af383410a9c86915263fbd1145b8becfc1e317b5` | `spiceai` |
 | [iceberg-rust](#iceberg-rust) | `351d1bc7b6ac9a835397e248e9c687f305e947d1` | `spiceai-0.10.1-df-54` |
 | [mistral.rs](#mistralrs-and-text-embeddings-inference) | `2d15d171236803481d582a9fbf8a80869bf74d8c` | `spiceai` |


### PR DESCRIPTION
Downgrades the bundled DuckDB from v1.5.5 to v1.4.4.

## Why

On v1.5.5 the write path an accelerated dataset uses — an `ON CONFLICT ... DO UPDATE` upsert per refresh — grows memory without bound at a steady row count. DuckDB's own `ALLOCATOR` accounting climbs about 6 MiB per cycle while `BASE_TABLE` and the database file stay flat, until the write fails:

```
Error: Out of Memory Error: failed to pin block of size 256.0 KiB (243.9 MiB/244.1 MiB used)
```

## The change

Three pins in `Cargo.toml`, plus the matching `fork_patches.md` rows:

| | from | to |
|---|---|---|
| `duckdb` (version) | `1.10505` (v1.5.5) | `1.4.4` |
| `duckdb` (git rev) | `7229b20` | `9d7be74` |
| `datafusion-table-providers` | `0d24a54` | `642e121` |

`datafusion-table-providers` pins `duckdb` by git rev, and `[patch.crates-io]` cannot reach that. Both must name the same revision or cargo resolves two copies of DuckDB, so the `duckdb` pin here is the revision table-providers pins rather than the squash-merge commit on `spiceai-1.4.4`.

Upstream, both merged:

- [spiceai/datafusion-table-providers#63](https://github.com/spiceai/datafusion-table-providers/pull/63) — the 1.4.4 pin plus a memory-growth soak test covering this workload
- [spiceai/duckdb-rs#43](https://github.com/spiceai/duckdb-rs/pull/43) — arrow 58, statically linked VSS

All four duckdb-rs fork patches were re-audited at the new revision: the arrow scan view, ICU and VSS statically linked, and the bundled version pinned to the release.
