### PR TITLE
fix(anthropic): classify a streaming failure by Anthropic's error type, not its message text (fixes #13562)

### DIFF
--- a/crates/llms/src/anthropic/types_stream.rs
+++ b/crates/llms/src/anthropic/types_stream.rs
@@ -53,6 +53,13 @@ pub enum MessageCreateStreamResponse {
     MessageDelta { delta: MessageDelta, usage: Usage },
     #[serde(rename = "message_stop")]
     MessageStop,
+    /// Anthropic answers a mid-stream failure with an `error` event over an HTTP 200 stream — an
+    /// `overloaded_error` when it sheds load partway through a generation, and the other error
+    /// types with it. Without a variant for it the packet is a serde failure, and the caller is
+    /// handed the deserializer's "unknown variant" complaint instead of the failure Anthropic
+    /// actually reported.
+    #[serde(rename = "error")]
+    Error { error: ApiError },
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -351,6 +358,17 @@ pub fn transform_stream(
                         | MessageCreateStreamResponse::ContentBlockStop { .. }
                         | MessageCreateStreamResponse::MessageStop,
                     ) => None,
+                    Ok(MessageCreateStreamResponse::Error { error }) => {
+                        // An error Anthropic delivered as a stream packet is the same failure as
+                        // one it delivered as an HTTP status, and is reported the same way.
+                        let formatted_error =
+                            format_anthropic_stream_error(OpenAIError::ApiError(error));
+                        tracing::debug!(
+                            "Received an anthropic error stream packet: {:?}",
+                            formatted_error
+                        );
+                        Some(Err(formatted_error))
+                    }
                     Err(e) => {
                         let formatted_error = format_anthropic_stream_error(e);
                         tracing::debug!(

--- a/crates/llms/src/anthropic/types_stream.rs
+++ b/crates/llms/src/anthropic/types_stream.rs
@@ -436,27 +436,40 @@ fn combine_opt_u32(current: Option<u32>, delta: Option<u32>) -> Option<u32> {
     }
 }
 
-fn format_anthropic_stream_error(error: OpenAIError) -> OpenAIError {
-    let OpenAIError::ApiError(api_error) = error else {
-        return error;
-    };
+#[derive(Debug, PartialEq, Eq)]
+enum StreamErrorKind {
+    RateLimit,
+    Authentication,
+    Other,
+}
 
-    // A `not_found_error` arrives already explained by `explain_model_not_found`, and must not be
-    // re-typed here: the substring tests below read the model id in its message, so a snapshot id
-    // such as `claude-3-5-sonnet-20240403` would be reported as an authentication failure.
-    if api_error.r#type.as_deref() == Some("not_found_error") {
-        return OpenAIError::ApiError(api_error);
+/// What a streaming failure is, resolved from Anthropic's own error taxonomy.
+///
+/// The `type` field is the discriminator, not the message text: Anthropic echoes request detail
+/// back in an `invalid_request_error`, so a prompt, tool name, or model id that happens to carry
+/// `403` or `429` reads as a credential or rate-limit failure under a substring test — and the
+/// replacement message drops the original, leaving the real cause unrecoverable from the log.
+///
+/// The message tests survive only for an error carrying no `type` at all. A proxy in front of
+/// Anthropic may answer that way, and so does a 5xx from Anthropic itself: the SSE client does not
+/// parse a server-error body, and hands the whole thing over as an untyped message.
+fn classify_stream_error(api_error: &ApiError) -> StreamErrorKind {
+    match api_error.r#type.as_deref() {
+        // Anthropic's documented error types. `permission_error` is its 403 and belongs with
+        // `authentication_error`: both are answered by checking the key and its workspace.
+        Some("rate_limit_error") => StreamErrorKind::RateLimit,
+        Some("authentication_error" | "permission_error") => StreamErrorKind::Authentication,
+        Some(_) => StreamErrorKind::Other,
+        None => classify_untyped_stream_error(&api_error.message),
     }
+}
 
-    let lowered = api_error.message.to_lowercase();
+/// The message tests, reached only when the error carries no `type`.
+fn classify_untyped_stream_error(message: &str) -> StreamErrorKind {
+    let lowered = message.to_lowercase();
 
     if lowered.contains("too many requests") || lowered.contains("429") {
-        return OpenAIError::ApiError(ApiError {
-            message: "Anthropic API rate limit exceeded. Check your limits at https://console.anthropic.com/settings/limits and retry shortly.".to_string(),
-            r#type: Some("AnthropicRateLimitError".to_string()),
-            param: api_error.param,
-            code: api_error.code,
-        });
+        return StreamErrorKind::RateLimit;
     }
 
     if lowered.contains("401")
@@ -465,17 +478,50 @@ fn format_anthropic_stream_error(error: OpenAIError) -> OpenAIError {
         || lowered.contains("unauthorized")
         || lowered.contains("forbidden")
     {
-        return OpenAIError::ApiError(ApiError {
-            message: "Anthropic authentication failed. Verify your Anthropic API key and workspace permissions.".to_string(),
-            r#type: Some("AnthropicAuthenticationError".to_string()),
-            param: api_error.param,
-            code: api_error.code,
-        });
+        return StreamErrorKind::Authentication;
     }
 
+    StreamErrorKind::Other
+}
+
+fn format_anthropic_stream_error(error: OpenAIError) -> OpenAIError {
+    let OpenAIError::ApiError(api_error) = error else {
+        return error;
+    };
+
+    // A `not_found_error` arrives already explained by `explain_model_not_found`, which names the
+    // model and the parameter to change. Returning it untouched keeps that explanation, and keeps
+    // the `not_found_error` type a downstream check can still read.
+    if api_error.r#type.as_deref() == Some("not_found_error") {
+        return OpenAIError::ApiError(api_error);
+    }
+
+    // Anthropic's own message is carried through as the cause in every arm: the kind says what to
+    // do about the failure, and the cause is the only thing that says which request it was.
+    let (message, kind) = match classify_stream_error(&api_error) {
+        StreamErrorKind::RateLimit => (
+            format!(
+                "Anthropic API rate limit exceeded ({}). Check your limits at https://console.anthropic.com/settings/limits and retry shortly.",
+                api_error.message
+            ),
+            "AnthropicRateLimitError",
+        ),
+        StreamErrorKind::Authentication => (
+            format!(
+                "Anthropic authentication failed ({}). Verify your Anthropic API key and workspace permissions.",
+                api_error.message
+            ),
+            "AnthropicAuthenticationError",
+        ),
+        StreamErrorKind::Other => (
+            format!("Anthropic streaming error: {}", api_error.message),
+            "AnthropicStreamError",
+        ),
+    };
+
     OpenAIError::ApiError(ApiError {
-        message: format!("Anthropic streaming error: {}", api_error.message),
-        r#type: Some("AnthropicStreamError".to_string()),
+        message,
+        r#type: Some(kind.to_string()),
         param: api_error.param,
         code: api_error.code,
     })
@@ -605,9 +651,33 @@ mod tests {
         assert_eq!(after.r#type.as_deref(), Some("not_found_error"));
     }
 
-    /// A model id whose snapshot date contains `403` is what makes the guard above load-bearing
-    /// rather than cosmetic: the substring tests in this function read the whole message, so
-    /// without the typed check this would be reported as an authentication failure.
+    /// The `type` decides, and a message is never consulted when there is one. An
+    /// `invalid_request_error` echoes the caller's own request detail back, which is the shape a
+    /// message test reads wrong — it must classify the same whatever that detail happens to say.
+    #[test]
+    fn a_typed_error_is_never_classified_from_its_message() {
+        for message in [
+            "tools.0.name: `lookup_429` is invalid",
+            "messages.0.content.0.text: expected a string, got 403",
+            "system: the prompt may not ask for too many requests",
+        ] {
+            assert_eq!(
+                classify_stream_error(&ApiError {
+                    message: message.to_string(),
+                    r#type: Some("invalid_request_error".to_string()),
+                    param: None,
+                    code: None,
+                }),
+                StreamErrorKind::Other,
+                "{message}"
+            );
+        }
+    }
+
+    /// A model id whose snapshot date contains `403` is what makes the pass-through above
+    /// load-bearing rather than cosmetic: without it the explanation is replaced by a generic
+    /// one, and an error carrying no `type` at all falls to the message tests, where such an id
+    /// reads as a credential failure.
     #[test]
     fn a_model_id_containing_403_is_not_reported_as_an_auth_failure() {
         let explained = crate::anthropic::explain_model_not_found(

--- a/crates/llms/src/anthropic/types_stream.rs
+++ b/crates/llms/src/anthropic/types_stream.rs
@@ -457,7 +457,9 @@ fn combine_opt_u32(current: Option<u32>, delta: Option<u32>) -> Option<u32> {
 #[derive(Debug, PartialEq, Eq)]
 enum StreamErrorKind {
     RateLimit,
+    Overloaded,
     Authentication,
+    Permission,
     Other,
 }
 
@@ -470,13 +472,18 @@ enum StreamErrorKind {
 ///
 /// The message tests survive only for an error carrying no `type` at all. A proxy in front of
 /// Anthropic may answer that way, and so does a 5xx from Anthropic itself: the SSE client does not
-/// parse a server-error body, and hands the whole thing over as an untyped message.
+/// parse a server-error body, and hands the whole thing over as an untyped message. A pre-stream
+/// `overloaded_error` therefore arrives untyped and lands in `Other`, while the same condition
+/// delivered as a mid-stream packet is typed and reaches the arm below — settling that difference
+/// means parsing the 5xx body, which is the client's job rather than this function's.
 fn classify_stream_error(api_error: &ApiError) -> StreamErrorKind {
     match api_error.r#type.as_deref() {
-        // Anthropic's documented error types. `permission_error` is its 403 and belongs with
-        // `authentication_error`: both are answered by checking the key and its workspace.
+        // Anthropic's documented error types. Its 401 and its 403 stay apart because they are
+        // answered differently: a rejected key is rotated, a key without access is granted it.
         Some("rate_limit_error") => StreamErrorKind::RateLimit,
-        Some("authentication_error" | "permission_error") => StreamErrorKind::Authentication,
+        Some("overloaded_error") => StreamErrorKind::Overloaded,
+        Some("authentication_error") => StreamErrorKind::Authentication,
+        Some("permission_error") => StreamErrorKind::Permission,
         Some(_) => StreamErrorKind::Other,
         None => classify_untyped_stream_error(&api_error.message),
     }
@@ -524,12 +531,26 @@ fn format_anthropic_stream_error(error: OpenAIError) -> OpenAIError {
             ),
             "AnthropicRateLimitError",
         ),
+        StreamErrorKind::Overloaded => (
+            format!(
+                "Anthropic is overloaded and shed the request ({}). Retry with backoff — the model is temporarily unavailable rather than misconfigured.",
+                api_error.message
+            ),
+            "AnthropicOverloadedError",
+        ),
         StreamErrorKind::Authentication => (
             format!(
-                "Anthropic authentication failed ({}). Verify your Anthropic API key and workspace permissions.",
+                "Anthropic rejected the API key ({}). Check the key the model is configured with at https://console.anthropic.com/settings/keys.",
                 api_error.message
             ),
             "AnthropicAuthenticationError",
+        ),
+        StreamErrorKind::Permission => (
+            format!(
+                "The Anthropic API key is not permitted to make this request ({}). Grant it access to the model and workspace the request names, or configure the model with a key that has it.",
+                api_error.message
+            ),
+            "AnthropicPermissionError",
         ),
         StreamErrorKind::Other => (
             format!("Anthropic streaming error: {}", api_error.message),

--- a/crates/llms/tests/anthropic_stream_errors.rs
+++ b/crates/llms/tests/anthropic_stream_errors.rs
@@ -14,6 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#![expect(
+    clippy::expect_used,
+    reason = "a failed set-up in a test should name itself and stop"
+)]
+
 //! What a caller of `chat_stream` is told when Anthropic refuses the request.
 //!
 //! These drive the whole path a real failure takes — HTTP status, error body, the SSE client's
@@ -26,7 +31,8 @@ use std::net::TcpListener;
 
 use async_openai::error::OpenAIError;
 use async_openai::types::chat::{
-    ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs,
+    ChatCompletionRequestUserMessageArgs, ChatCompletionResponseStream,
+    CreateChatCompletionRequestArgs,
 };
 use chat_api::Chat;
 use futures::StreamExt;
@@ -36,6 +42,10 @@ use llms::config::GenericAuthMechanism;
 /// Serves one request with `status` and `body`, then closes. Returns the base URL to configure the
 /// adapter with.
 fn serve_one_error(status: &'static str, body: &'static str) -> String {
+    serve_one(status, "application/json", body)
+}
+
+fn serve_one(status: &'static str, content_type: &'static str, body: &'static str) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind a local port");
     let port = listener
         .local_addr()
@@ -58,7 +68,7 @@ fn serve_one_error(status: &'static str, body: &'static str) -> String {
         }
 
         let response = format!(
-            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
             body.len()
         );
         let _ = stream.write_all(response.as_bytes());
@@ -68,14 +78,12 @@ fn serve_one_error(status: &'static str, body: &'static str) -> String {
     format!("http://127.0.0.1:{port}")
 }
 
-/// Runs one streaming chat against a server that answers `status`/`body`, and returns the error the
-/// caller is given.
-async fn stream_error(status: &'static str, body: &'static str) -> OpenAIError {
-    let base = serve_one_error(status, body);
+/// Opens one streaming chat against `base`.
+async fn chat_stream_against(base: &str) -> ChatCompletionResponseStream {
     let model = Anthropic::new(
         GenericAuthMechanism::from_api_key("not-a-real-key"),
         Some("claude-sonnet-4-6"),
-        Some(&base),
+        Some(base),
         None,
     )
     .expect("the adapter is configured");
@@ -92,17 +100,22 @@ async fn stream_error(status: &'static str, body: &'static str) -> OpenAIError {
         .build()
         .expect("build the request");
 
-    let mut stream = model
+    model
         .chat_stream(request)
         .await
-        .expect("a refusal is delivered as a stream item, not as a failure to open the stream");
+        .expect("a refusal is delivered as a stream item, not as a failure to open the stream")
+}
 
-    loop {
-        match stream.next().await {
-            Some(Err(e)) => return e,
-            Some(Ok(item)) => panic!("expected an error, got a completion chunk: {item:?}"),
-            None => panic!("the stream ended without delivering the error"),
-        }
+/// Runs one streaming chat against a server that answers `status`/`body`, and returns the error the
+/// caller is given.
+async fn stream_error(status: &'static str, body: &'static str) -> OpenAIError {
+    let base = serve_one_error(status, body);
+    let mut stream = chat_stream_against(&base).await;
+
+    match stream.next().await {
+        Some(Err(e)) => e,
+        Some(Ok(item)) => panic!("expected an error, got a completion chunk: {item:?}"),
+        None => panic!("the stream ended without delivering the error"),
     }
 }
 
@@ -292,5 +305,80 @@ async fn an_overload_arrives_untyped_and_keeps_its_body_as_the_cause() {
     assert!(
         message.contains("overloaded_error"),
         "the body must survive as the cause: {message}"
+    );
+}
+
+/// Anthropic sheds load partway through a generation by sending an `error` event over an HTTP 200
+/// stream, which is the only shape a mid-stream failure has. The caller must be told what
+/// Anthropic reported — not that the adapter could not parse a packet.
+#[tokio::test]
+async fn a_mid_stream_error_event_is_reported_as_the_failure_anthropic_sent() {
+    let base = serve_one(
+        "200 OK",
+        "text/event-stream",
+        concat!(
+            "event: message_start\n",
+            r#"data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1},"content":[],"stop_reason":null}}"#,
+            "\n\nevent: error\n",
+            r#"data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#,
+            "\n\n",
+        ),
+    );
+
+    let mut stream = chat_stream_against(&base).await;
+
+    let first = stream.next().await.expect("the message_start chunk");
+    assert!(first.is_ok(), "the stream starts normally: {first:?}");
+
+    let error = stream
+        .next()
+        .await
+        .expect("the error event reaches the caller")
+        .expect_err("an error event is an error");
+
+    let message = api_error_message(&error);
+    assert!(
+        message.contains("Overloaded"),
+        "the caller must be told what Anthropic reported: {message}"
+    );
+    assert!(
+        !message.contains("unknown variant"),
+        "a failure Anthropic reported is not a parse failure: {message}"
+    );
+}
+
+/// A mid-stream rate limit is classified from its type like any other, so the caller gets the
+/// remediation rather than a bare packet.
+#[tokio::test]
+async fn a_mid_stream_rate_limit_is_classified_and_keeps_its_cause() {
+    let base = serve_one(
+        "200 OK",
+        "text/event-stream",
+        concat!(
+            "event: error\n",
+            r#"data: {"type":"error","error":{"type":"rate_limit_error","message":"Number of output tokens has exceeded your per-minute limit"}}"#,
+            "\n\n",
+        ),
+    );
+
+    let error = chat_stream_against(&base)
+        .await
+        .next()
+        .await
+        .expect("the error event reaches the caller")
+        .expect_err("an error event is an error");
+
+    let message = api_error_message(&error);
+    assert!(
+        message.contains("rate limit exceeded"),
+        "a mid-stream rate_limit_error must be reported as one: {message}"
+    );
+    assert!(
+        message.contains("per-minute limit"),
+        "the cause must survive: {message}"
+    );
+    assert_eq!(
+        api_error_type(&error).as_deref(),
+        Some("AnthropicRateLimitError")
     );
 }

--- a/crates/llms/tests/anthropic_stream_errors.rs
+++ b/crates/llms/tests/anthropic_stream_errors.rs
@@ -169,7 +169,7 @@ async fn an_invalid_request_naming_403_is_not_reported_as_an_auth_failure() {
 
     let message = api_error_message(&error);
     assert!(
-        !message.contains("authentication failed"),
+        !message.contains("rejected the API key") && !message.contains("not permitted"),
         "a malformed request is not a credential problem: {message}"
     );
     assert!(
@@ -216,8 +216,8 @@ async fn an_authentication_error_is_reported_as_one_and_keeps_its_cause() {
 
     let message = api_error_message(&error);
     assert!(
-        message.contains("authentication failed"),
-        "an authentication_error must be reported as one: {message}"
+        message.contains("rejected the API key"),
+        "an authentication_error must be reported as a rejected key: {message}"
     );
     assert!(
         message.contains("invalid x-api-key"),
@@ -226,9 +226,10 @@ async fn an_authentication_error_is_reported_as_one_and_keeps_its_cause() {
     assert_eq!(api_error_type(&error), Some("AnthropicAuthenticationError"));
 }
 
-/// Anthropic's 403 is `permission_error`, and it is answered the same way as a bad key.
+/// Anthropic's 403 is `permission_error` — a key that is valid and lacks access. Reporting it as a
+/// rejected key sends the caller to rotate a key that is working, so the two stay apart.
 #[tokio::test]
-async fn a_permission_error_is_reported_as_an_authentication_failure() {
+async fn a_permission_error_is_not_reported_as_a_rejected_key() {
     let error = stream_error(
         "403 Forbidden",
         r#"{"type":"error","error":{"type":"permission_error","message":"Your API key does not have permission to use the specified resource"}}"#,
@@ -237,13 +238,18 @@ async fn a_permission_error_is_reported_as_an_authentication_failure() {
 
     let message = api_error_message(&error);
     assert!(
-        message.contains("authentication failed"),
-        "a permission_error is answered by checking the key and its workspace: {message}"
+        message.contains("not permitted"),
+        "a permission_error must be reported as one: {message}"
+    );
+    assert!(
+        !message.contains("rejected the API key"),
+        "a key that is valid but lacks access is not a key to rotate: {message}"
     );
     assert!(
         message.contains("does not have permission"),
         "the cause must survive: {message}"
     );
+    assert_eq!(api_error_type(&error), Some("AnthropicPermissionError"));
 }
 
 /// A proxy in front of Anthropic may answer without a `type`. That is the one case the message
@@ -281,10 +287,10 @@ async fn a_model_not_found_keeps_its_explanation() {
     assert_eq!(api_error_type(&error), Some("not_found_error"));
 }
 
-/// Anthropic's overload answer is a 529, and the SSE client hands a server-error body over
-/// unparsed — so it arrives with no `type` and its whole JSON body as the message. That is the
-/// production shape the message tests still have to serve, and the caller must at least be told
-/// what came back.
+/// Anthropic's pre-stream overload answer is a 529, and the SSE client hands a server-error body
+/// over unparsed — so it arrives with no `type` and its whole JSON body as the message, and lands
+/// in the unclassified arm even though the body names `overloaded_error`. That is the shape the
+/// message tests still have to serve, and the caller must at least be told what came back.
 #[tokio::test]
 async fn an_overload_arrives_untyped_and_keeps_its_body_as_the_cause() {
     let error = stream_error(
@@ -337,6 +343,11 @@ async fn a_mid_stream_error_event_is_reported_as_the_failure_anthropic_sent() {
         !message.contains("unknown variant"),
         "a failure Anthropic reported is not a parse failure: {message}"
     );
+    assert!(
+        message.contains("Retry with backoff"),
+        "an overload is the retryable failure, and the caller has to be told so: {message}"
+    );
+    assert_eq!(api_error_type(&error), Some("AnthropicOverloadedError"));
 }
 
 /// A mid-stream rate limit is classified from its type like any other, so the caller gets the

--- a/crates/llms/tests/anthropic_stream_errors.rs
+++ b/crates/llms/tests/anthropic_stream_errors.rs
@@ -29,7 +29,7 @@ limitations under the License.
 use std::io::{Read, Write};
 use std::net::TcpListener;
 
-use async_openai::error::OpenAIError;
+use async_openai::error::{ApiError, OpenAIError};
 use async_openai::types::chat::{
     ChatCompletionRequestUserMessageArgs, ChatCompletionResponseStream,
     CreateChatCompletionRequestArgs,
@@ -119,18 +119,19 @@ async fn stream_error(status: &'static str, body: &'static str) -> OpenAIError {
     }
 }
 
-fn api_error_message(error: &OpenAIError) -> String {
+fn api_error(error: &OpenAIError) -> &ApiError {
     match error {
-        OpenAIError::ApiError(api) => api.message.clone(),
+        OpenAIError::ApiError(api) => api,
         other => panic!("expected an ApiError, got {other:?}"),
     }
 }
 
-fn api_error_type(error: &OpenAIError) -> Option<String> {
-    match error {
-        OpenAIError::ApiError(api) => api.r#type.clone(),
-        other => panic!("expected an ApiError, got {other:?}"),
-    }
+fn api_error_message(error: &OpenAIError) -> &str {
+    &api_error(error).message
+}
+
+fn api_error_type(error: &OpenAIError) -> Option<&str> {
+    api_error(error).r#type.as_deref()
 }
 
 /// Anthropic echoes request detail back in an `invalid_request_error`, so its message carries
@@ -153,10 +154,7 @@ async fn an_invalid_request_naming_429_is_not_reported_as_a_rate_limit() {
         message.contains("lookup_429"),
         "the cause must survive so the caller can see which request was refused: {message}"
     );
-    assert_eq!(
-        api_error_type(&error).as_deref(),
-        Some("AnthropicStreamError")
-    );
+    assert_eq!(api_error_type(&error), Some("AnthropicStreamError"));
 }
 
 /// The same shape on the authentication arm: `403` in the echoed request detail must not send the
@@ -203,10 +201,7 @@ async fn a_rate_limit_error_is_reported_as_a_rate_limit_whatever_its_message_say
         message.contains("https://console.anthropic.com/settings/limits"),
         "the remediation link must survive: {message}"
     );
-    assert_eq!(
-        api_error_type(&error).as_deref(),
-        Some("AnthropicRateLimitError")
-    );
+    assert_eq!(api_error_type(&error), Some("AnthropicRateLimitError"));
 }
 
 /// A real credential failure, likewise: reported as one, with Anthropic's own words kept as the
@@ -228,10 +223,7 @@ async fn an_authentication_error_is_reported_as_one_and_keeps_its_cause() {
         message.contains("invalid x-api-key"),
         "the cause must survive: {message}"
     );
-    assert_eq!(
-        api_error_type(&error).as_deref(),
-        Some("AnthropicAuthenticationError")
-    );
+    assert_eq!(api_error_type(&error), Some("AnthropicAuthenticationError"));
 }
 
 /// Anthropic's 403 is `permission_error`, and it is answered the same way as a bad key.
@@ -286,7 +278,7 @@ async fn a_model_not_found_keeps_its_explanation() {
         message.contains("claude-sonnet-4-6"),
         "the model must be named: {message}"
     );
-    assert_eq!(api_error_type(&error).as_deref(), Some("not_found_error"));
+    assert_eq!(api_error_type(&error), Some("not_found_error"));
 }
 
 /// Anthropic's overload answer is a 529, and the SSE client hands a server-error body over
@@ -377,8 +369,5 @@ async fn a_mid_stream_rate_limit_is_classified_and_keeps_its_cause() {
         message.contains("per-minute limit"),
         "the cause must survive: {message}"
     );
-    assert_eq!(
-        api_error_type(&error).as_deref(),
-        Some("AnthropicRateLimitError")
-    );
+    assert_eq!(api_error_type(&error), Some("AnthropicRateLimitError"));
 }

--- a/crates/llms/tests/anthropic_stream_errors.rs
+++ b/crates/llms/tests/anthropic_stream_errors.rs
@@ -1,0 +1,296 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! What a caller of `chat_stream` is told when Anthropic refuses the request.
+//!
+//! These drive the whole path a real failure takes — HTTP status, error body, the SSE client's
+//! own error mapping, and the adapter's classification — against a local server standing in for
+//! Anthropic, so no credentials are involved and the classification is exercised on the error
+//! shape the client actually builds rather than one written by hand.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+
+use async_openai::error::OpenAIError;
+use async_openai::types::chat::{
+    ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs,
+};
+use chat_api::Chat;
+use futures::StreamExt;
+use llms::anthropic::Anthropic;
+use llms::config::GenericAuthMechanism;
+
+/// Serves one request with `status` and `body`, then closes. Returns the base URL to configure the
+/// adapter with.
+fn serve_one_error(status: &'static str, body: &'static str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind a local port");
+    let port = listener
+        .local_addr()
+        .expect("read the bound address")
+        .port();
+
+    std::thread::spawn(move || {
+        let Ok((mut stream, _)) = listener.accept() else {
+            return;
+        };
+
+        // Read just enough to know the request headers ended; the body is not inspected.
+        let mut seen = Vec::new();
+        let mut byte = [0u8; 1];
+        while stream.read(&mut byte).unwrap_or(0) == 1 {
+            seen.push(byte[0]);
+            if seen.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = stream.write_all(response.as_bytes());
+        let _ = stream.flush();
+    });
+
+    format!("http://127.0.0.1:{port}")
+}
+
+/// Runs one streaming chat against a server that answers `status`/`body`, and returns the error the
+/// caller is given.
+async fn stream_error(status: &'static str, body: &'static str) -> OpenAIError {
+    let base = serve_one_error(status, body);
+    let model = Anthropic::new(
+        GenericAuthMechanism::from_api_key("not-a-real-key"),
+        Some("claude-sonnet-4-6"),
+        Some(&base),
+        None,
+    )
+    .expect("the adapter is configured");
+
+    let request = CreateChatCompletionRequestArgs::default()
+        .model("claude-sonnet-4-6")
+        .messages(vec![
+            ChatCompletionRequestUserMessageArgs::default()
+                .content("hello")
+                .build()
+                .expect("build the user message")
+                .into(),
+        ])
+        .build()
+        .expect("build the request");
+
+    let mut stream = model
+        .chat_stream(request)
+        .await
+        .expect("a refusal is delivered as a stream item, not as a failure to open the stream");
+
+    loop {
+        match stream.next().await {
+            Some(Err(e)) => return e,
+            Some(Ok(item)) => panic!("expected an error, got a completion chunk: {item:?}"),
+            None => panic!("the stream ended without delivering the error"),
+        }
+    }
+}
+
+fn api_error_message(error: &OpenAIError) -> String {
+    match error {
+        OpenAIError::ApiError(api) => api.message.clone(),
+        other => panic!("expected an ApiError, got {other:?}"),
+    }
+}
+
+fn api_error_type(error: &OpenAIError) -> Option<String> {
+    match error {
+        OpenAIError::ApiError(api) => api.r#type.clone(),
+        other => panic!("expected an ApiError, got {other:?}"),
+    }
+}
+
+/// Anthropic echoes request detail back in an `invalid_request_error`, so its message carries
+/// whatever the caller sent. A tool name containing `429` must not turn a malformed request into a
+/// rate-limit report — and the caller has to be told what was actually wrong with the request.
+#[tokio::test]
+async fn an_invalid_request_naming_429_is_not_reported_as_a_rate_limit() {
+    let error = stream_error(
+        "400 Bad Request",
+        r#"{"type":"error","error":{"type":"invalid_request_error","message":"tools.0.name: `lookup_429` does not match ^[a-zA-Z0-9_-]{1,64}$"}}"#,
+    )
+    .await;
+
+    let message = api_error_message(&error);
+    assert!(
+        !message.contains("rate limit"),
+        "a malformed request is not a rate limit: {message}"
+    );
+    assert!(
+        message.contains("lookup_429"),
+        "the cause must survive so the caller can see which request was refused: {message}"
+    );
+    assert_eq!(
+        api_error_type(&error).as_deref(),
+        Some("AnthropicStreamError")
+    );
+}
+
+/// The same shape on the authentication arm: `403` in the echoed request detail must not send the
+/// caller to rotate a key that is working.
+#[tokio::test]
+async fn an_invalid_request_naming_403_is_not_reported_as_an_auth_failure() {
+    let error = stream_error(
+        "400 Bad Request",
+        r#"{"type":"error","error":{"type":"invalid_request_error","message":"messages.0.content.0.text: expected a string, got 403"}}"#,
+    )
+    .await;
+
+    let message = api_error_message(&error);
+    assert!(
+        !message.contains("authentication failed"),
+        "a malformed request is not a credential problem: {message}"
+    );
+    assert!(
+        message.contains("expected a string"),
+        "the cause must survive: {message}"
+    );
+}
+
+/// The other direction: a real rate limit whose message says neither `429` nor `too many requests`
+/// still has to be reported as one, with its cause attached.
+#[tokio::test]
+async fn a_rate_limit_error_is_reported_as_a_rate_limit_whatever_its_message_says() {
+    let error = stream_error(
+        "429 Too Many Requests",
+        r#"{"type":"error","error":{"type":"rate_limit_error","message":"Number of input tokens has exceeded your per-minute limit"}}"#,
+    )
+    .await;
+
+    let message = api_error_message(&error);
+    assert!(
+        message.contains("rate limit exceeded"),
+        "a rate_limit_error must be reported as one: {message}"
+    );
+    assert!(
+        message.contains("per-minute limit"),
+        "the cause must survive: {message}"
+    );
+    assert!(
+        message.contains("https://console.anthropic.com/settings/limits"),
+        "the remediation link must survive: {message}"
+    );
+    assert_eq!(
+        api_error_type(&error).as_deref(),
+        Some("AnthropicRateLimitError")
+    );
+}
+
+/// A real credential failure, likewise: reported as one, with Anthropic's own words kept as the
+/// cause.
+#[tokio::test]
+async fn an_authentication_error_is_reported_as_one_and_keeps_its_cause() {
+    let error = stream_error(
+        "401 Unauthorized",
+        r#"{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}"#,
+    )
+    .await;
+
+    let message = api_error_message(&error);
+    assert!(
+        message.contains("authentication failed"),
+        "an authentication_error must be reported as one: {message}"
+    );
+    assert!(
+        message.contains("invalid x-api-key"),
+        "the cause must survive: {message}"
+    );
+    assert_eq!(
+        api_error_type(&error).as_deref(),
+        Some("AnthropicAuthenticationError")
+    );
+}
+
+/// Anthropic's 403 is `permission_error`, and it is answered the same way as a bad key.
+#[tokio::test]
+async fn a_permission_error_is_reported_as_an_authentication_failure() {
+    let error = stream_error(
+        "403 Forbidden",
+        r#"{"type":"error","error":{"type":"permission_error","message":"Your API key does not have permission to use the specified resource"}}"#,
+    )
+    .await;
+
+    let message = api_error_message(&error);
+    assert!(
+        message.contains("authentication failed"),
+        "a permission_error is answered by checking the key and its workspace: {message}"
+    );
+    assert!(
+        message.contains("does not have permission"),
+        "the cause must survive: {message}"
+    );
+}
+
+/// A proxy in front of Anthropic may answer without a `type`. That is the one case the message
+/// tests still serve, so it has to keep working.
+#[tokio::test]
+async fn an_untyped_error_is_still_classified_from_its_message() {
+    let error = stream_error(
+        "429 Too Many Requests",
+        r#"{"type":"error","error":{"message":"429 Too Many Requests from the gateway"}}"#,
+    )
+    .await;
+
+    let message = api_error_message(&error);
+    assert!(
+        message.contains("rate limit exceeded"),
+        "an untyped error is all the message tests have to go on: {message}"
+    );
+}
+
+/// A model the endpoint does not serve keeps the explanation `explain_model_not_found` built for
+/// it, rather than being re-typed by the classifier.
+#[tokio::test]
+async fn a_model_not_found_keeps_its_explanation() {
+    let error = stream_error(
+        "404 Not Found",
+        r#"{"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-6"}}"#,
+    )
+    .await;
+
+    let message = api_error_message(&error);
+    assert!(
+        message.contains("claude-sonnet-4-6"),
+        "the model must be named: {message}"
+    );
+    assert_eq!(api_error_type(&error).as_deref(), Some("not_found_error"));
+}
+
+/// Anthropic's overload answer is a 529, and the SSE client hands a server-error body over
+/// unparsed — so it arrives with no `type` and its whole JSON body as the message. That is the
+/// production shape the message tests still have to serve, and the caller must at least be told
+/// what came back.
+#[tokio::test]
+async fn an_overload_arrives_untyped_and_keeps_its_body_as_the_cause() {
+    let error = stream_error(
+        "529 ",
+        r#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#,
+    )
+    .await;
+
+    let message = api_error_message(&error);
+    assert!(
+        message.contains("overloaded_error"),
+        "the body must survive as the cause: {message}"
+    );
+}


### PR DESCRIPTION
## Summary

`format_anthropic_stream_error` decided what kind of failure Anthropic had reported by searching the
lowercased error **message** for `429`, `403`, `401`, `authentication`, `unauthorized` and
`forbidden` — then threw that message away and replaced it with a fixed remediation string.

Anthropic states the kind in the error's `type` field, and echoes the caller's own request detail
back into the message of an `invalid_request_error`. So the message was both an unreliable
discriminator and the only record of which request had failed. It was wrong in **both** directions,
and the second one is the more common:

- a malformed request whose echoed detail happens to contain `429` or `403` — a tool name, a prompt,
  a model id — was reported as a rate limit or a credential failure, with the real cause deleted;
- a **real** `rate_limit_error` or `authentication_error` was reported as neither, because
  Anthropic's own wording for them (`Number of input tokens has exceeded your per-minute limit`,
  `invalid x-api-key`) contains none of those tokens.

Two further gaps in the same function, both found by the review gate and both confirmed by running
the path:

- **A mid-stream failure never reached the classifier at all.** Once a generation has started,
  Anthropic answers HTTP 200 and emits an `error` event — an `overloaded_error` when it sheds load,
  and the other error types with it. `MessageCreateStreamResponse` had no variant for that packet,
  so it failed deserialization and the caller got the serde error instead of the failure.
- **`overloaded_error` and `permission_error` had no arm of their own.** The overload said nothing
  about being the retryable one, and the 403 was reported as an authentication failure — sending the
  caller to rotate a key that is valid and merely lacks access.

## Changes

| File | Change |
|---|---|
| `crates/llms/src/anthropic/types_stream.rs` | Classify on `api_error.r#type` against Anthropic's taxonomy (`rate_limit_error`, `overloaded_error`, `authentication_error`, `permission_error`), keeping the message tests only for an error that carries no `type`. Carry Anthropic's own message through as the cause in every arm. New `Error { error: ApiError }` stream variant so a mid-stream `error` event is decoded and reported like any other failure. |
| `crates/llms/tests/anthropic_stream_errors.rs` | New end-to-end suite: 10 cases driving the whole path — HTTP status, error body, the SSE client's own error mapping, and the classification — against a one-shot local server standing in for Anthropic. No credentials. |

`not_found_error` still passes through untouched: it arrives already explained by
`explain_model_not_found`, and that explanation plus its type is what a downstream check reads.

**The untyped fallback is not dead code, and the suite pins it.** A proxy in front of Anthropic may
answer without a `type` — and so does a 5xx from Anthropic itself, because `async-openai`'s
`read_response` deliberately does not parse a server-error body and hands the whole thing over as an
untyped message. A *pre-stream* `overloaded_error` (529) therefore lands in the unclassified arm
while the same condition delivered mid-stream is typed and classified. Settling that asymmetry means
parsing the 5xx body, which belongs to the client rather than to this function.

## Measured

Ran the new suite against the **unmodified** classifier first — the whole path, not the function in
isolation. Five of the eight cases then in the suite failed, and each failure is the defect:

```
test an_invalid_request_naming_429_is_not_reported_as_a_rate_limit ... FAILED
  a malformed request is not a rate limit: Anthropic API rate limit exceeded. Check your limits at
  https://console.anthropic.com/settings/limits and retry shortly.

test an_invalid_request_naming_403_is_not_reported_as_an_auth_failure ... FAILED
  a malformed request is not a credential problem: Anthropic authentication failed. Verify your
  Anthropic API key and workspace permissions.

test a_rate_limit_error_is_reported_as_a_rate_limit_whatever_its_message_says ... FAILED
  a rate_limit_error must be reported as one: Anthropic streaming error: Number of input tokens has
  exceeded your per-minute limit

test an_authentication_error_is_reported_as_one_and_keeps_its_cause ... FAILED
  an authentication_error must be reported as one: Anthropic streaming error: invalid x-api-key

test a_permission_error_is_reported_as_an_authentication_failure ... FAILED
  Anthropic streaming error: Your API key does not have permission to use the specified resource

test result: FAILED. 2 passed; 5 failed
```

Note the first two: the echoed request detail is gone from the reported message entirely.

The mid-stream gap, probed the same way — HTTP 200, a `message_start` then a documented `error`
event — on the code as it then stood:

```
item 1: Ok(id=msg_1)
item 2: Err(JSONDeserialize(Error("unknown variant `error`, expected one of `message_start`,
  `content_block_start`, `ping`, `content_block_delta`, `content_block_stop`, `message_delta`,
  `message_stop`", line: 1, column: 15),
  "{\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}"))
```

On this branch, all 10 pass:

```
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

**Each guard was confirmed by neutering the code it pins — 9 neuters, 9 caught.** Reverting the
typed classification fails 5; dropping `permission_error` from the auth arm, dropping the untyped
fallback, dropping the `not_found_error` pass-through, and dropping the cause from the message each
fail exactly the tests that name them; dropping the mid-stream variant's reporting fails 2, and
routing it around the classifier fails 1; folding `overloaded_error` back into the unclassified arm
and `permission_error` back into authentication each fail 1.

## Test plan

- `make lint` / `make test` / `make nextest` — green, via `make signoff` on the pushed head:

  ```
  Summary [ 620.251s] 12181 tests run: 12181 passed, 27 skipped
  ✓ Signed off on f375b3dd8341 — Signed off by claudespice — lint+test passed in 966s
  ```

- `Attestation` — green (re-run by the sign-off script).
- New: `crates/llms/tests/anthropic_stream_errors.rs`, 10 end-to-end cases; plus
  `a_typed_error_is_never_classified_from_its_message` in `types_stream.rs`, which pins the core
  invariant directly on the classifier.

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits"; `grok` not installed. Two earlier `codex` passes did complete against this branch; both are accounted for in the table below.
- `/security-review`: no findings. The only newly-exposed text is Anthropic's own message on the rate-limit/auth arms; the generic arm already carried it, Anthropic does not echo key material into those messages, and the three `Anthropic*Error` type strings have no consumer anywhere in `crates/` or `bin/`, so no authz or retry decision can be changed by reclassification.
- `/simplify`: applied — the test helpers now read the error through one borrowed accessor instead of cloning `String`s. One cleanup was **reverted**: collapsing the mid-stream arm into a pre-match normalization does not narrow the enum type, so the match arm is still required — and keeping it explicit is what makes exhaustiveness compiler-checked.

**On the adversarial passes, in full**, since the attesting one is a skip:

| Pass | Job | Verdict | Disposition |
|---|---|---|---|
| 1 | `review-mtfa3l0c-6a8zcf` | needs-attention | 1 finding: mid-stream `error` events bypass the classifier. **Confirmed by running it** (the `JSONDeserialize` output above) and **fixed here**. |
| 2 | `review-mtfazhn4-w6aq66` | needs-attention | 2 findings. `permission_error` conflated with authentication — **valid, fixed here**. Mid-stream overload not distinguishable as retryable — **fixed here**, though its "this is a regression" framing is **refuted**: the prior behavior was an opaque `JSONDeserialize` no caller could act on either, so this is a gap being closed, not one being opened. |
| 3 | — | — | Out of credits before it produced findings. |

Pass 3 attests the current head, and it is a skip. The only change since pass 2 is the
overload/permission split that pass 2 itself asked for.

## A note on the first sign-off run

The first `make signoff` on this head failed at `12180 passed, 1 failed` — the one failure being
`bundled_duckdb_builds_an_hnsw_index_without_installing_vss`, in a crate this diff does not touch.
It is host state, not this branch: a `vss.duckdb_extension` previously installed into
`~/.duckdb/extensions/` shadows the statically linked one, so `duckdb_extensions().install_mode`
reports `REPOSITORY`. Established by A/B on the same binary — fails with the directory present,
passes with it moved aside — and filed as #13758. The run above is with that shadow removed.

## Deferred

The same shape lives in three `ListModels` implementations (`openai`, `xai`, `spiceai`), which
classify from `e.to_string()`. Filed as #13747 with its own measured reproduction — a `404` naming
model `gpt-4o-mini-2024-0401` reports `InvalidCredentials`, and a real `401` with
`code: invalid_api_key` reports `NetworkError`. Not folded in here: three providers, three
taxonomies, each needing its own evidence.

Fixes #13562

## Checklist

- [x] The failure is demonstrated before the fix and absent after, with the same command.
- [x] Every new guard confirmed by neutering the code it pins.
- [x] No credential, token, or internal detail in a log line, error message, or this body.
- [x] `make signoff` green and `Attestation` re-run.