### PR TITLE
fix(views): apply a view's acceleration.ready_state instead of dropping it (fixes #13615)

### DIFF
--- a/crates/runtime/src/component/dataset/builder.rs
+++ b/crates/runtime/src/component/dataset/builder.rs
@@ -23,6 +23,7 @@ use super::{
 };
 use crate::Runtime;
 use crate::component::access::AccessMode;
+use crate::component::{AcceleratedComponent, deprecated_ready_state_warning};
 use app::App;
 use datafusion::sql::TableReference;
 use runtime_acceleration::snapshot::SnapshotBehavior;
@@ -78,8 +79,8 @@ impl TryFrom<spicepod_dataset::Dataset> for DatasetBuilder {
         let ready_state = match dataset.acceleration.as_ref().map(|a| a.ready_state) {
             Some(Some(ready_state)) => {
                 tracing::warn!(
-                    "{}: `dataset.acceleration.ready_state` is deprecated, use `dataset.ready_state` instead.",
-                    dataset.name
+                    "{}",
+                    deprecated_ready_state_warning(AcceleratedComponent::Dataset, &dataset.name)
                 );
                 ReadyState::from(ready_state)
             }

--- a/crates/runtime/src/component/mod.rs
+++ b/crates/runtime/src/component/mod.rs
@@ -72,6 +72,45 @@ impl AcceleratedComponent {
             Self::View => "https://spiceai.org/docs/reference/spicepod/views#acceleration",
         }
     }
+
+    /// This component's Spicepod reference, unanchored. The `#acceleration` anchor
+    /// is wrong for a setting whose remedy is a field *outside* the acceleration
+    /// block, which is what the `ready_state` deprecation asks for.
+    const fn reference_url(self) -> &'static str {
+        match self {
+            Self::Dataset => "https://spiceai.org/docs/reference/spicepod/datasets",
+            Self::View => "https://spiceai.org/docs/reference/spicepod/views",
+        }
+    }
+}
+
+/// Warns that a component set `acceleration.ready_state`, which is honoured but
+/// deprecated in favour of the component's own top-level `ready_state`.
+///
+/// One function for both components because it is one deprecation of one key: a
+/// dataset and a view that write the same thing should be told the same thing,
+/// and a second copy is where the two drift apart.
+///
+/// Built as a pure function so the wording an operator acts on — which component,
+/// the field to move the setting to, and the reference page — is asserted by a
+/// test rather than through whatever a log capture happens to retain.
+pub(crate) fn deprecated_ready_state_warning(
+    component: AcceleratedComponent,
+    name: &str,
+) -> String {
+    // `escape_debug` for the same reason as `disabled_acceleration_warning`:
+    // `validate_identifier` accepts a *quoted* identifier, and a quoted one may
+    // legally contain a newline, so a validated name can still break this line in
+    // two and forge a second one.
+    let name = name.escape_debug();
+    let noun = component.noun();
+    let reference = component.reference_url();
+    format!(
+        "{titled} '{name}' sets `acceleration.ready_state`, which is deprecated and will be removed. \
+        Move the setting to the {noun}'s own `ready_state` to keep it working. \
+        See: {reference}",
+        titled = component.titled_noun()
+    )
 }
 
 /// What to tell an operator whose dataset or view sets `acceleration.enabled:
@@ -122,7 +161,9 @@ pub(crate) fn disabled_acceleration_warning(
 
 #[cfg(test)]
 mod tests {
-    use super::{AcceleratedComponent, disabled_acceleration_warning};
+    use super::{
+        AcceleratedComponent, deprecated_ready_state_warning, disabled_acceleration_warning,
+    };
 
     #[test]
     fn the_warning_names_the_component_the_fields_and_the_remedy() {
@@ -213,5 +254,64 @@ mod tests {
             "the message must scope itself to the listed fields: {warning}"
         );
         assert!(!warning.contains("ready_state"), "{warning}");
+    }
+
+    #[test]
+    fn the_ready_state_deprecation_names_the_replacement_and_the_components_reference() {
+        // The operator has to learn three things from this line: that the key is
+        // going away, which field to move it to, and where that field is written
+        // up. The reference is the component's page *unanchored* — the remedy is
+        // a top-level field, so `#acceleration` would land them back inside the
+        // block they are being told to move the setting out of.
+        let warning = deprecated_ready_state_warning(AcceleratedComponent::Dataset, "api_data");
+        assert!(warning.starts_with("Dataset 'api_data'"), "{warning}");
+        assert!(warning.contains("`acceleration.ready_state`"), "{warning}");
+        assert!(warning.contains("deprecated"), "{warning}");
+        assert!(
+            warning.contains("the dataset's own `ready_state`"),
+            "{warning}"
+        );
+        assert!(
+            warning.contains("/reference/spicepod/datasets"),
+            "{warning}"
+        );
+        assert!(!warning.contains("#acceleration"), "{warning}");
+        assert!(!warning.contains('\n'), "{warning}");
+    }
+
+    #[test]
+    fn the_ready_state_deprecation_calls_a_view_a_view() {
+        // One function serves both components, so the noun and the link have to
+        // follow the component rather than defaulting to the dataset — a view
+        // told to edit "the dataset's" field is sent to a component it is not.
+        //
+        // Asserted on the specific phrases rather than `!contains("dataset")`:
+        // the datasets URL legitimately contains that substring.
+        let warning = deprecated_ready_state_warning(AcceleratedComponent::View, "daily_totals");
+        assert!(warning.starts_with("View 'daily_totals'"), "{warning}");
+        assert!(
+            warning.contains("the view's own `ready_state`"),
+            "{warning}"
+        );
+        assert!(warning.contains("/reference/spicepod/views"), "{warning}");
+        assert!(!warning.contains("Dataset"), "{warning}");
+        assert!(!warning.contains("the dataset"), "{warning}");
+    }
+
+    #[test]
+    fn a_control_character_in_the_name_cannot_break_the_ready_state_line_in_two() {
+        // Same exposure as `disabled_acceleration_warning`, and the same reason:
+        // `validate_identifier` accepts a quoted identifier, which may legally
+        // carry a newline, so an unescaped name could write a second log record.
+        let warning =
+            deprecated_ready_state_warning(AcceleratedComponent::View, "api\nWARN forged");
+        assert!(
+            !warning.contains('\n'),
+            "the message must stay one line: {warning}"
+        );
+        assert!(
+            warning.contains("WARN forged"),
+            "the name is still reported, only escaped: {warning}"
+        );
     }
 }

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -24,11 +24,12 @@ use std::{collections::HashMap, fs, sync::Arc};
 use crate::{Runtime, dataaccelerator::AccelerationSource};
 
 use super::{
+    AcceleratedComponent,
     dataset::{
         Dataset, ReadyState,
         acceleration::{self, Acceleration},
     },
-    validate_identifier,
+    deprecated_ready_state_warning, validate_identifier,
 };
 use spicepod::semantic::Column;
 
@@ -108,24 +109,6 @@ impl View {
     }
 }
 
-/// Warns that a view set `acceleration.ready_state`, which the view honours but which is
-/// deprecated in favour of the view's own `ready_state`.
-///
-/// Built as a pure function so the wording a user depends on — the view's name, the key to move
-/// the setting to, and the docs link — is asserted directly by a unit test rather than only
-/// through whatever a log capture happens to retain.
-fn deprecated_acceleration_ready_state_warning(view_name: &str) -> String {
-    // `escape_debug` rather than the raw name, matching `disabled_acceleration_warning`:
-    // `validate_identifier` accepts a *quoted* identifier, and a quoted one may legally contain a
-    // newline, so a validated name can still break this line in two and forge a second one.
-    let view_name = view_name.escape_debug();
-    format!(
-        "View '{view_name}' sets `acceleration.ready_state`, which is deprecated and will be removed. \
-        Move the setting to the view's own `ready_state` to keep it working. \
-        See: https://spiceai.org/docs/reference/spicepod/views"
-    )
-}
-
 pub struct ViewBuilder {
     pub name: TableReference,
     pub sql: String,
@@ -167,7 +150,7 @@ impl TryFrom<spicepod_view::View> for ViewBuilder {
             Some(Some(ready_state)) => {
                 tracing::warn!(
                     "{}",
-                    deprecated_acceleration_ready_state_warning(&view.name)
+                    deprecated_ready_state_warning(AcceleratedComponent::View, &view.name)
                 );
                 ReadyState::from(ready_state)
             }
@@ -362,7 +345,7 @@ impl ViewBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::{ReadyState, ViewBuilder, deprecated_acceleration_ready_state_warning};
+    use super::{AcceleratedComponent, ReadyState, ViewBuilder, deprecated_ready_state_warning};
     use spicepod::component::view as spicepod_view;
 
     /// Resolves a view from its Spicepod YAML, so the test covers the same parse that a
@@ -479,35 +462,9 @@ sql: SELECT 1
         );
     }
 
-    /// The warning is the only thing that tells an operator to move the setting, so assert the
-    /// three parts they act on rather than that some warning was emitted.
-    #[test]
-    fn the_deprecation_warning_names_the_view_the_replacement_and_the_docs() {
-        let message = deprecated_acceleration_ready_state_warning("daily_totals");
-
-        assert!(
-            message.contains("'daily_totals'"),
-            "the warning must name the view: {message}"
-        );
-        assert!(
-            message.contains("`acceleration.ready_state`"),
-            "the warning must name the deprecated key: {message}"
-        );
-        assert!(
-            message.contains("`ready_state`") && message.contains("deprecated"),
-            "the warning must say the key is deprecated and name the replacement: {message}"
-        );
-        assert!(
-            message.contains("https://spiceai.org/docs/reference/spicepod/views"),
-            "the warning must link the docs: {message}"
-        );
-        assert!(
-            !message.contains('\n'),
-            "a log message stays on one line: {message}"
-        );
-    }
-
-    /// The single-line assertion above uses a benign name, so it cannot see this: a *quoted*
+    /// The wording itself is asserted beside the shared builder in `component::tests`. What is
+    /// specific to the view — and what makes that escaping load-bearing rather than decorative — is
+    /// that a name carrying a newline gets through `ViewBuilder::try_from` at all: a *quoted*
     /// identifier may legally contain a newline, and `validate_identifier` accepts one, so a name
     /// that passes validation could otherwise break the line in two and forge a second record.
     /// `disabled_acceleration_warning` escapes for exactly this reason.
@@ -525,7 +482,7 @@ sql: SELECT 1
              makes escaping load-bearing rather than decorative"
         );
 
-        let message = deprecated_acceleration_ready_state_warning(hostile);
+        let message = deprecated_ready_state_warning(AcceleratedComponent::View, hostile);
         assert!(
             !message.contains('\n'),
             "an embedded newline must not survive into the log line: {message:?}"

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -115,6 +115,10 @@ impl View {
 /// the setting to, and the docs link — is asserted directly by a unit test rather than only
 /// through whatever a log capture happens to retain.
 fn deprecated_acceleration_ready_state_warning(view_name: &str) -> String {
+    // `escape_debug` rather than the raw name, matching `disabled_acceleration_warning`:
+    // `validate_identifier` accepts a *quoted* identifier, and a quoted one may legally contain a
+    // newline, so a validated name can still break this line in two and forge a second one.
+    let view_name = view_name.escape_debug();
     format!(
         "View '{view_name}' sets `acceleration.ready_state`, which is deprecated and will be removed. \
         Move the setting to the view's own `ready_state` to keep it working. \
@@ -500,6 +504,35 @@ sql: SELECT 1
         assert!(
             !message.contains('\n'),
             "a log message stays on one line: {message}"
+        );
+    }
+
+    /// The single-line assertion above uses a benign name, so it cannot see this: a *quoted*
+    /// identifier may legally contain a newline, and `validate_identifier` accepts one, so a name
+    /// that passes validation could otherwise break the line in two and forge a second record.
+    /// `disabled_acceleration_warning` escapes for exactly this reason.
+    #[test]
+    fn a_view_name_carrying_a_newline_cannot_forge_a_second_log_line() {
+        let hostile = "\"api\nWARN forged\"";
+
+        // The escaping only matters if such a name reaches the warning at all, so assert that
+        // the builder accepts it rather than assuming it does.
+        let view: spicepod_view::View =
+            yaml::from_str(&format!("name: {hostile:?}\nsql: SELECT 1\n")).expect("yaml parses");
+        assert!(
+            ViewBuilder::try_from(view).is_ok(),
+            "a quoted identifier containing a newline is accepted by the builder, which is what \
+             makes escaping load-bearing rather than decorative"
+        );
+
+        let message = deprecated_acceleration_ready_state_warning(hostile);
+        assert!(
+            !message.contains('\n'),
+            "an embedded newline must not survive into the log line: {message:?}"
+        );
+        assert!(
+            message.contains("WARN forged"),
+            "the name is still reported in full, only escaped: {message:?}"
         );
     }
 }

--- a/crates/runtime/src/component/view.rs
+++ b/crates/runtime/src/component/view.rs
@@ -108,6 +108,20 @@ impl View {
     }
 }
 
+/// Warns that a view set `acceleration.ready_state`, which the view honours but which is
+/// deprecated in favour of the view's own `ready_state`.
+///
+/// Built as a pure function so the wording a user depends on — the view's name, the key to move
+/// the setting to, and the docs link — is asserted directly by a unit test rather than only
+/// through whatever a log capture happens to retain.
+fn deprecated_acceleration_ready_state_warning(view_name: &str) -> String {
+    format!(
+        "View '{view_name}' sets `acceleration.ready_state`, which is deprecated and will be removed. \
+        Move the setting to the view's own `ready_state` to keep it working. \
+        See: https://spiceai.org/docs/reference/spicepod/views"
+    )
+}
+
 pub struct ViewBuilder {
     pub name: TableReference,
     pub sql: String,
@@ -139,6 +153,23 @@ impl TryFrom<spicepod_view::View> for ViewBuilder {
 
         let metadata = view.metadata();
 
+        // `acceleration.ready_state` is a legitimate member of the acceleration block, so it
+        // parses cleanly on a view as well as on a dataset. A dataset reads it out of the block
+        // and applies it; resolve it the same way here so the key means one thing wherever it is
+        // written, rather than being accepted and dropped on one of the two components. See
+        // `DatasetBuilder::try_from` for the dataset side.
+        #[expect(deprecated)]
+        let ready_state = match view.acceleration.as_ref().map(|a| a.ready_state) {
+            Some(Some(ready_state)) => {
+                tracing::warn!(
+                    "{}",
+                    deprecated_acceleration_ready_state_warning(&view.name)
+                );
+                ReadyState::from(ready_state)
+            }
+            _ => ReadyState::from(view.ready_state),
+        };
+
         let acceleration = view
             .acceleration
             .map(acceleration::Acceleration::try_from)
@@ -169,7 +200,7 @@ impl TryFrom<spicepod_view::View> for ViewBuilder {
             metadata,
             columns: view.columns,
             acceleration,
-            ready_state: ReadyState::from(view.ready_state),
+            ready_state,
             vectors: view.vectors,
             params: view
                 .params
@@ -322,5 +353,153 @@ impl ViewBuilder {
             runtime,
             app,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ReadyState, ViewBuilder, deprecated_acceleration_ready_state_warning};
+    use spicepod::component::view as spicepod_view;
+
+    /// Resolves a view from its Spicepod YAML, so the test covers the same parse that a
+    /// `spicepod.yaml` goes through rather than a hand-built struct that could disagree with it.
+    fn ready_state_of(view_yaml: &str) -> ReadyState {
+        let view: spicepod_view::View = yaml::from_str(view_yaml).expect("view yaml parses");
+        ViewBuilder::try_from(view)
+            .expect("view builds")
+            .ready_state
+    }
+
+    /// Regression test for #13615. The key parses on a view whether or not anything reads it, so
+    /// assert the value the built view carries rather than that the Spicepod was accepted.
+    #[test]
+    fn acceleration_ready_state_is_applied_to_a_view() {
+        let ready_state = ready_state_of(
+            r"
+name: daily_totals
+sql: SELECT 1
+acceleration:
+  enabled: true
+  ready_state: on_registration
+",
+        );
+
+        assert_eq!(
+            ready_state,
+            ReadyState::OnRegistration,
+            "a view's `acceleration.ready_state` must reach the built view"
+        );
+    }
+
+    /// The block being switched off does not discard the setting, matching the dataset. That is
+    /// what `spicepod`'s `CONSUMED_WHEN_DISABLED` relies on when it leaves `ready_state` out of
+    /// the "discarded because `enabled: false`" warning.
+    #[test]
+    fn acceleration_ready_state_is_applied_even_when_acceleration_is_disabled() {
+        let ready_state = ready_state_of(
+            r"
+name: daily_totals
+sql: SELECT 1
+acceleration:
+  enabled: false
+  ready_state: on_schema_resolved
+",
+        );
+
+        assert_eq!(ready_state, ReadyState::OnSchemaResolved);
+    }
+
+    /// The deprecated key wins over the view's own field, the same precedence `DatasetBuilder`
+    /// applies, so the two components cannot resolve the same pair of settings differently.
+    ///
+    /// Both values are non-default and differ from each other. `on_load` would be useless on
+    /// either side: it is the `#[default]`, so a written-out `ready_state: on_load` is
+    /// indistinguishable from an omitted one, and the assertion would hold for an implementation
+    /// that ignored one of the two fields entirely.
+    #[test]
+    fn acceleration_ready_state_takes_precedence_over_the_views_own_field() {
+        let ready_state = ready_state_of(
+            r"
+name: daily_totals
+sql: SELECT 1
+ready_state: on_schema_resolved
+acceleration:
+  enabled: true
+  ready_state: on_registration
+",
+        );
+
+        assert_eq!(
+            ready_state,
+            ReadyState::OnRegistration,
+            "the acceleration block's value must win over the view's own"
+        );
+    }
+
+    #[test]
+    fn the_views_own_ready_state_is_used_when_the_acceleration_block_omits_it() {
+        let ready_state = ready_state_of(
+            r"
+name: daily_totals
+sql: SELECT 1
+ready_state: on_registration
+acceleration:
+  enabled: true
+",
+        );
+
+        assert_eq!(ready_state, ReadyState::OnRegistration);
+    }
+
+    #[test]
+    fn a_view_with_no_acceleration_block_uses_its_own_ready_state() {
+        assert_eq!(
+            ready_state_of(
+                r"
+name: daily_totals
+sql: SELECT 1
+ready_state: on_schema_resolved
+"
+            ),
+            ReadyState::OnSchemaResolved
+        );
+        assert_eq!(
+            ready_state_of(
+                r"
+name: daily_totals
+sql: SELECT 1
+"
+            ),
+            ReadyState::OnLoad,
+            "an unset `ready_state` keeps the default"
+        );
+    }
+
+    /// The warning is the only thing that tells an operator to move the setting, so assert the
+    /// three parts they act on rather than that some warning was emitted.
+    #[test]
+    fn the_deprecation_warning_names_the_view_the_replacement_and_the_docs() {
+        let message = deprecated_acceleration_ready_state_warning("daily_totals");
+
+        assert!(
+            message.contains("'daily_totals'"),
+            "the warning must name the view: {message}"
+        );
+        assert!(
+            message.contains("`acceleration.ready_state`"),
+            "the warning must name the deprecated key: {message}"
+        );
+        assert!(
+            message.contains("`ready_state`") && message.contains("deprecated"),
+            "the warning must say the key is deprecated and name the replacement: {message}"
+        );
+        assert!(
+            message.contains("https://spiceai.org/docs/reference/spicepod/views"),
+            "the warning must link the docs: {message}"
+        );
+        assert!(
+            !message.contains('\n'),
+            "a log message stays on one line: {message}"
+        );
     }
 }

--- a/crates/spicepod/src/acceleration/mod.rs
+++ b/crates/spicepod/src/acceleration/mod.rs
@@ -541,7 +541,10 @@ pub struct Acceleration {
     pub on_zero_results: ZeroResultsAction,
 
     #[serde(default)]
-    #[deprecated(since = "1.0.0-rc.1", note = "Use `dataset.ready_state` instead.")]
+    #[deprecated(
+        since = "1.0.0-rc.1",
+        note = "Use the dataset's or view's own `ready_state` instead."
+    )]
     pub ready_state: Option<ReadyState>,
 
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -651,14 +654,10 @@ const fn default_true() -> bool {
 /// `enabled: false`": the switch itself, and `ready_state`.
 ///
 /// `ready_state` is excluded for both components that carry an acceleration
-/// block, but not for the same reason. A dataset reads
-/// `acceleration.ready_state` out of the block and applies it whether or not
-/// acceleration is enabled (deprecated, but honoured) — so it is genuinely not
-/// discarded. `ViewBuilder` never reads it at all, enabled or disabled, so for
-/// a view it *is* dropped — but unconditionally, not because of `enabled:
-/// false`, which makes "remove `enabled: false` to apply them" a false remedy
-/// for it. Either way this warning is the wrong place to raise it; the view
-/// case is #13615.
+/// block, for the same reason on each: `DatasetBuilder` and `ViewBuilder` both
+/// read `acceleration.ready_state` out of the block and apply it whether or not
+/// acceleration is enabled (deprecated, but honoured), so it is genuinely not
+/// discarded by `enabled: false` on either component.
 const CONSUMED_WHEN_DISABLED: [&str; 2] = ["enabled", "ready_state"];
 
 impl Acceleration {


### PR DESCRIPTION
## Summary

A view's `acceleration.ready_state` was accepted by the schema, accepted by the parser, and then
never applied. `ViewBuilder::try_from` built `ready_state` from the view's own top-level field
unconditionally, so the key silently did nothing — while the identical key in the identical
position on a **dataset** is read out of the block and honoured by `DatasetBuilder::try_from`.
Same spelling, same place, two different meanings, and nothing told the operator which one they
had written.

This takes the first of the two shapes #13615 offers, which is the one it prefers: the view now
resolves the key the way the dataset does, deprecation notice included.

It is not gated on `acceleration.enabled`, which is why enabling acceleration did not make the
view honour it either, and why the "remove `enabled: false` to apply them" warning added by
#13602 deliberately excludes this field.

## Evidence

`spiced` (dev build) against a Spicepod carrying one dataset and one view that set
`ready_state: on_registration` in the same position, over an 83 MB / 3 M-row CSV accelerated to
DuckDB. One `spiced` start per row, `.spice` deleted between runs, page cache warmed by a
discarded first run:

| `spiced` | `/v1/ready` → 200 | warnings for the dataset | warnings for the view |
|---|---|---|---|
| `trunk` | **8.97 s** | 10 | **0** |
| this branch | **0.98 s** | 10 | **5** |

The warning counts are the deterministic half and are the direct proof: on `trunk` the dataset
reports the deprecated key ten times and the view reports it **not at all**, because the view path
never reads it. The readiness time is the consequence — `trunk` ignores the view's
`on_registration` and therefore blocks the runtime on the view's initial load, while the branch
honours it and the runtime is ready in under a second.

A control confirms the readiness figure is about *where the key is written* and not about the
data: with the same value moved to each component's own top-level `ready_state`, `trunk` is ready
in 0.72–0.73 s. Timing here is noisy and the first run of any configuration is an outlier (cold
page cache on the 83 MB file), so the figures above are from warmed runs and the deterministic
warning counts are what the claim rests on.

Unit tests alone would not have shown this: they run `kind(=lib)` only, and the resolved value has
to reach `datafusion::register_view` before anything observable changes.

**Neutered to check the guards are load-bearing** — 5 applied, 5 caught. One of them
(`flip-precedence`) initially **survived**, because the precedence test wrote the losing side as
`on_load`, which is the `#[default]` and so indistinguishable from an unset field; it now uses two
distinct non-default values and the same neuter fails it.

## Changes

- `crates/runtime/src/component/view.rs` — resolve `ready_state` from `acceleration.ready_state`
  when set, falling back to the view's own field, matching `DatasetBuilder::try_from` including
  which of the two wins.
- `crates/runtime/src/component/mod.rs` — one `deprecated_ready_state_warning`, beside the
  `disabled_acceleration_warning` it mirrors and keyed by the existing `AcceleratedComponent`, so
  the noun and the reference page follow the component. `AcceleratedComponent` gains
  `reference_url` (unanchored): the remedy is a *top-level* field, so `#acceleration` would send
  the reader back inside the block they are being told to move the setting out of.
- `crates/runtime/src/component/dataset/builder.rs` — the dataset's inline message folds onto that
  shared one, so the two cannot drift.
- `crates/spicepod/src/acceleration/mod.rs` — the `CONSUMED_WHEN_DISABLED` doc comment asserted
  that `ViewBuilder` never reads the field and pointed at this issue; it now states the one reason
  the field is excluded for both components. The `#[deprecated]` note named only the dataset's
  replacement and now names the view's too.

### Scope

Checked the class rather than only the reported field: the only other members of the acceleration
block that `DatasetBuilder::try_from` resolves out of the block are `snapshots` and
`snapshots_compaction`, and a view already receives both through `Acceleration` at registration,
so `ready_state` was the only one dropped. #13477 is reworking view snapshots, so this stays off
that path.

Folding the dataset onto the shared message is in scope under the same rule: its inline version
interpolated the component name **unescaped**, which is the same defect the adversarial pass found
in mine, on the path that has shipped it longest.

## Behavior change

A view that sets `acceleration.ready_state` gets the default (`on_load`) today and gets what it
asked for after this, plus a deprecation warning naming the field to move to. A view cannot have
depended on the value it configured being discarded, but this does change when such a view is
reported ready, so it is worth calling out.

The dataset's deprecation message also changes wording — it gains the remedy sentence and a docs
link, and escapes the name. Nothing asserts its previous text.

## Follow-up filed

- #13749 — the warning prints 10–15 times per startup rather than once per component, because
  `TryFrom` cannot see `LogErrors`. Pre-existing for datasets on `trunk` (the 10 above); measured
  rather than assumed, and deferred because the fix belongs at the `load_*` site for both
  components.

## Test plan
- [x] Added regression test for a view's `acceleration.ready_state` reaching the built view
- [x] Added edge case tests for a disabled acceleration block, the precedence between the deprecated key and the view's own field, the block omitting the key, no acceleration block, and the default
- [x] Added a test that a name carrying a newline survives `ViewBuilder::try_from` and still cannot forge a second log line
- [x] `make lint` passes (workspace-wide `cargo fmt --all -- --check` + full clippy — not a per-crate scoped invocation)
- [x] `make test` passes
- [x] `make signoff` run after the final push (`Attestation` check is green)

## Review gate

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits. Ask your workspace owner to refill in order to continue."; `grok` not installed. An earlier pass on this branch's first commit *did* run (`codex`, job `review-mtf9hm8m-1fhp4v`, verdict `needs-attention`) and returned one finding: the new deprecation warning interpolated the view name unescaped, so a quoted identifier carrying a newline could break the log line in two and forge a second record. It backed that with a reproduction rather than an assertion. Verified against the repo — `validate_identifier` does accept such a name and `disabled_acceleration_warning` already escapes for this exact reason — then fixed in 592579dd23 with a regression test, and extended to the dataset's copy of the same message in 288b047a4e. The credits ran out before that fix could itself be re-reviewed, so the two later commits carry no adversarial pass.
- `/security-review`: no findings. Considered and dismissed: the log-interpolation above (log spoofing is excluded by that review's rules, and it is fixed here anyway on log-integrity grounds), YAML deserialization in the new tests (typed serde into a `deny_unknown_fields` struct, test-only), and the readiness change itself (operator-elected configuration, no privilege or data boundary crossed, and the same behavior a dataset already had).
- `/simplify`: applied — folded the view's and the dataset's duplicate deprecation text onto one shared builder keyed by the existing `AcceleratedComponent`, moved the wording assertions beside it so they cover both components, and added the unanchored `reference_url`. Light checks re-run green afterwards (`cargo fmt --all`, plus the targeted component unit tests: 55 passed).

Fixes #13615