### PR TITLE
test(cayenne): add filtered deletes into cayenne fuzz tests

### DIFF
--- a/crates/cayenne/tests/mutation_property_test.rs
+++ b/crates/cayenne/tests/mutation_property_test.rs
@@ -432,9 +432,6 @@ async fn overwrite(table: &Arc<CayenneTableProvider>, rows: &[(i64, i64)]) -> Te
     Ok(())
 }
 
-/// One "settle" pass. File compacts small files; memory additionally checkpoints
-/// the RAM tier to durable Vortex files and bakes the seq-prefix (the exact
-/// intersection — mem-tier checkpoint + bake — that surfaced the COUNT(*) drift).
 /// Delete rows whose non-PK `value` is in `[lo, hi)`.
 ///
 /// File only: a filtered client DELETE does not remove un-checkpointed mem-tier

--- a/crates/cayenne/tests/mutation_property_test.rs
+++ b/crates/cayenne/tests/mutation_property_test.rs
@@ -795,7 +795,11 @@ fn apply_model(model: &mut Model, op: &Op) {
 // Harness
 // ============================================================================
 
-async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestResult<usize> {
+async fn run_sequential(
+    fixture: &TestFixture,
+    w: &Workload,
+    seed: u64,
+) -> TestResult<(usize, usize)> {
     let name = format!("seq_{:?}_{:?}_{seed}", w.mode, w.durability);
     let (mut table, mut ctx) = create_table(
         fixture,
@@ -810,6 +814,7 @@ async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
     let mut model = Model::new();
     let mut history: Vec<Op> = Vec::with_capacity(w.ops);
     let mut predicate_deleted_rows = 0usize;
+    let mut predicate_delete_ops = 0usize;
 
     for step in 0..w.ops {
         let live_value = sample_live_value(&model, &mut rng);
@@ -863,6 +868,7 @@ async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
         apply_model(&mut model, &op);
         let retired_rows = model.len() < rows_before_op;
         if matches!(op, Op::DeletePredicate { .. }) {
+            predicate_delete_ops += 1;
             predicate_deleted_rows += rows_before_op - model.len();
         }
         let live = read_rows(&ctx, &name).await?;
@@ -895,7 +901,7 @@ async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
     );
     assert_converged(&final_state, &model, &msg);
     verify_aggregate_queries(&c, t.as_ref(), &name, &model, w.population, &msg).await?;
-    Ok(predicate_deleted_rows)
+    Ok((predicate_deleted_rows, predicate_delete_ops))
 }
 
 async fn run_concurrent(fixture: &TestFixture, w: &Workload, seed: u64) -> TestResult<()> {
@@ -1049,26 +1055,32 @@ async fn run_concurrent(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
     Ok(())
 }
 
+/// Predicate deletes needed before "retired nothing" means the op is inert
+/// rather than the workload simply being short.
+const MIN_OPS_TO_JUDGE_INERTNESS: usize = 40;
+
 async fn run_workload(fixture: TestFixture, w: Workload) -> TestResult<()> {
     let mut predicate_deleted_rows = 0usize;
+    let mut predicate_delete_ops = 0usize;
     for seed in 0..w.seeds {
         match w.concurrency {
             Concurrency::Sequential => {
-                predicate_deleted_rows += run_sequential(&fixture, &w, seed).await?;
+                let (rows, ops) = run_sequential(&fixture, &w, seed).await?;
+                predicate_deleted_rows += rows;
+                predicate_delete_ops += ops;
             }
             Concurrency::ConcurrentWithCompaction => run_concurrent(&fixture, &w, seed).await?,
         }
     }
     // An op that never retires a row still runs the delete plan, so it would sit
-    // in the weights looking like coverage. Fail loudly if the window and the
-    // value domain drift apart again.
-    if w.weights.delete_predicate > 0 && matches!(w.concurrency, Concurrency::Sequential) {
+    // in the weights looking like coverage. Only meaningful once enough of them
+    // have run: a reduced-scale pass (`CAYENNE_PROPTEST_*_SCALE`) leaves the
+    // table too small for a window to match, which says nothing about the op.
+    if predicate_delete_ops >= MIN_OPS_TO_JUDGE_INERTNESS {
         assert!(
             predicate_deleted_rows > 0,
-            "delete_predicate is weighted {} but retired 0 rows across {} seeds — the window no \
-             longer intersects the value domain, so the op is inert",
-            w.weights.delete_predicate,
-            w.seeds,
+            "delete_predicate retired 0 rows across {predicate_delete_ops} deletes — the window \
+             no longer intersects the value domain, so the op is inert",
         );
     }
     Ok(())

--- a/crates/cayenne/tests/mutation_property_test.rs
+++ b/crates/cayenne/tests/mutation_property_test.rs
@@ -160,6 +160,10 @@ struct OpWeights {
     upsert: u32,
     delete: u32,
     delete_all: u32,
+    /// Delete by a predicate over a non-PK column: the scan-and-match path,
+    /// which `delete` (PK index) and `delete_all` (no matching) never reach.
+    /// A `retention_sql` DELETE has this shape.
+    delete_predicate: u32,
     overwrite: u32,
     compact: u32,
     restart: u32,
@@ -431,6 +435,16 @@ async fn overwrite(table: &Arc<CayenneTableProvider>, rows: &[(i64, i64)]) -> Te
 /// One "settle" pass. File compacts small files; memory additionally checkpoints
 /// the RAM tier to durable Vortex files and bakes the seq-prefix (the exact
 /// intersection — mem-tier checkpoint + bake — that surfaced the COUNT(*) drift).
+/// Delete rows whose non-PK `value` is in `[lo, hi)`.
+///
+/// File only: a filtered client DELETE does not remove un-checkpointed mem-tier
+/// rows (spiceai/spiceai#12008; delete-all was fixed in #11987), so
+/// `delete_predicate` is weighted 0 in memory configs. Once #12008 is fixed,
+/// weighting it there turns this into the regression test.
+async fn delete_predicate(table: &Arc<CayenneTableProvider>, lo: i64, hi: i64) -> TestResult<()> {
+    delete_filter(table, col("value").gt_eq(lit(lo)).and(col("value").lt(lit(hi)))).await
+}
+
 async fn settle(table: &Arc<CayenneTableProvider>, durability: Durability) -> TestResult<()> {
     // Drain debounced post-write maintenance so the persisted stats (the maintained
     // `num_rows` delta) reflect every committed write before we read/compact.
@@ -633,11 +647,31 @@ enum Op {
     Upsert { rows: Vec<(i64, i64)> },
     Delete { key: i64 },
     DeleteAll,
+    /// Delete every row whose non-PK `value` falls in `[lo, hi)`.
+    DeletePredicate {
+        lo: i64,
+        hi: i64,
+    },
     Overwrite { rows: Vec<(i64, i64)> },
     Compact,
     Restart,
     MoveToColdTier,
 }
+
+/// One live value to anchor a predicate window on; `None` when the table is
+/// empty.
+fn sample_live_value(model: &Model, rng: &mut Rng) -> Option<i64> {
+    if model.is_empty() {
+        return None;
+    }
+    let len = u64::try_from(model.len()).expect("model len fits u64");
+    let idx = usize::try_from(rng.below(len)).expect("index below len fits usize");
+    model.values().nth(idx).copied()
+}
+
+/// Value domain for the non-PK `value` column; `DeletePredicate` sizes its
+/// window against it.
+const VALUE_SPACE: i64 = 1_000_000;
 
 fn random_rows(rng: &mut Rng, key_space: i64, batch_size: i64) -> Vec<(i64, i64)> {
     debug_assert!(
@@ -650,7 +684,7 @@ fn random_rows(rng: &mut Rng, key_space: i64, batch_size: i64) -> Vec<(i64, i64)
     // debug_assert above catches the misconfiguration in tests.
     for _ in 0..batch_size.max(1) {
         let k = rng.below_i64(key_space);
-        let v = rng.below_i64(1_000_000);
+        let v = rng.below_i64(VALUE_SPACE);
         // last-writer-wins within the batch (a batch may not repeat a PK)
         if let Some(slot) = rows.iter_mut().find(|(ek, _): &&mut (i64, i64)| *ek == k) {
             slot.1 = v;
@@ -661,7 +695,13 @@ fn random_rows(rng: &mut Rng, key_space: i64, batch_size: i64) -> Vec<(i64, i64)
     rows
 }
 
-fn gen_op(rng: &mut Rng, w: &OpWeights, key_space: i64, batch_size: i64) -> Op {
+fn gen_op(
+    rng: &mut Rng,
+    w: &OpWeights,
+    key_space: i64,
+    batch_size: i64,
+    live_value: Option<i64>,
+) -> Op {
     let total = w.upsert
         + w.delete
         + w.delete_all
@@ -679,6 +719,7 @@ fn gen_op(rng: &mut Rng, w: &OpWeights, key_space: i64, batch_size: i64) -> Op {
         (w.upsert, 0u8),
         (w.delete, 1),
         (w.delete_all, 2),
+        (w.delete_predicate, 7),
         (w.overwrite, 3),
         (w.compact, 4),
         (w.restart, 5),
@@ -693,6 +734,21 @@ fn gen_op(rng: &mut Rng, w: &OpWeights, key_space: i64, batch_size: i64) -> Op {
                     key: rng.below_i64(key_space),
                 },
                 2 => Op::DeleteAll,
+                7 => {
+                    // A window narrower than `VALUE_SPACE` matches nothing, and a
+                    // blind one rarely intersects a table holding a few rows.
+                    // Anchoring half on a live value reaches deletion-vector
+                    // writing rather than only the scan-and-match plan.
+                    let width = 1 + rng.below_i64(VALUE_SPACE / 2);
+                    let lo = match live_value {
+                        Some(v) if rng.below(2) == 0 => (v - rng.below_i64(width)).max(0),
+                        _ => rng.below_i64(VALUE_SPACE),
+                    };
+                    Op::DeletePredicate {
+                        lo,
+                        hi: lo + width,
+                    }
+                }
                 3 => Op::Overwrite {
                     rows: random_rows(rng, key_space, batch_size),
                 },
@@ -717,6 +773,7 @@ fn apply_model(model: &mut Model, op: &Op) {
             model.remove(key);
         }
         Op::DeleteAll => model.clear(),
+        Op::DeletePredicate { lo, hi } => model.retain(|_, v| !(*v >= *lo && *v < *hi)),
         Op::Overwrite { rows } => {
             model.clear();
             for (k, v) in rows {
@@ -731,7 +788,11 @@ fn apply_model(model: &mut Model, op: &Op) {
 // Harness
 // ============================================================================
 
-async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestResult<()> {
+async fn run_sequential(
+    fixture: &TestFixture,
+    w: &Workload,
+    seed: u64,
+) -> TestResult<usize> {
     let name = format!("seq_{:?}_{:?}_{seed}", w.mode, w.durability);
     let (mut table, mut ctx) = create_table(
         fixture,
@@ -745,9 +806,11 @@ async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
     let mut rng = Rng::new(seed);
     let mut model = Model::new();
     let mut history: Vec<Op> = Vec::with_capacity(w.ops);
+    let mut predicate_deleted_rows = 0usize;
 
     for step in 0..w.ops {
-        let op = gen_op(&mut rng, &w.weights, w.population, w.batch_size);
+        let live_value = sample_live_value(&model, &mut rng);
+        let op = gen_op(&mut rng, &w.weights, w.population, w.batch_size, live_value);
         history.push(op.clone());
         match &op {
             Op::Upsert { rows } => upsert(&table, rows, w.durability).await?,
@@ -757,6 +820,7 @@ async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
                 let live_keys: Vec<i64> = model.keys().copied().collect();
                 delete_all(&table, &live_keys, w.durability).await?;
             }
+            Op::DeletePredicate { lo, hi } => delete_predicate(&table, *lo, *hi).await?,
             Op::Overwrite { rows } => overwrite(&table, rows).await?,
             Op::Compact => {
                 settle(&table, w.durability).await?;
@@ -792,16 +856,27 @@ async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
                 table.run_cold_tier_gc_tick().await;
             }
         }
+        let rows_before_op = model.len();
         apply_model(&mut model, &op);
+        let retired_rows = model.len() < rows_before_op;
+        if matches!(op, Op::DeletePredicate { .. }) {
+            predicate_deleted_rows += rows_before_op - model.len();
+        }
         let live = read_rows(&ctx, &name).await?;
-        assert_converged(
-            &live,
-            &model,
-            &format!(
-                "seq diverged after step {step} ({op:?}) mode={:?} durability={:?} seed={seed}\nhistory={history:?}",
-                w.mode, w.durability,
-            ),
+        let step_msg = format!(
+            "seq diverged after step {step} ({op:?}) mode={:?} durability={:?} seed={seed}\nhistory={history:?}",
+            w.mode, w.durability,
         );
+        assert_converged(&live, &model, &step_msg);
+
+        // Retiring rows is when a maintained count drifts and when deletion
+        // vectors leave holes for a stale min/max to prune around. The
+        // coordinator can fold `COUNT(*)` from an `Exact` count at any time, so
+        // the contract has to hold here, not only after the final settle.
+        if retired_rows {
+            verify_aggregate_queries(&ctx, table.as_ref(), &name, &model, w.population, &step_msg)
+                .await?;
+        }
     }
 
     // Final settle (memory: checkpoint RAM + bake; both: compact) so the reopened
@@ -817,7 +892,7 @@ async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
     );
     assert_converged(&final_state, &model, &msg);
     verify_aggregate_queries(&c, t.as_ref(), &name, &model, w.population, &msg).await?;
-    Ok(())
+    Ok(predicate_deleted_rows)
 }
 
 async fn run_concurrent(fixture: &TestFixture, w: &Workload, seed: u64) -> TestResult<()> {
@@ -885,7 +960,8 @@ async fn run_concurrent(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
     // Compact op is a no-op here); `restart` reopens under the write lock.
     let mut history: Vec<Op> = Vec::with_capacity(w.ops);
     for _ in 0..w.ops {
-        let op = gen_op(&mut rng, &w.weights, w.population, w.batch_size);
+        let live_value = sample_live_value(&model, &mut rng);
+        let op = gen_op(&mut rng, &w.weights, w.population, w.batch_size, live_value);
         history.push(op.clone());
         match &op {
             Op::Upsert { rows } => {
@@ -900,6 +976,10 @@ async fn run_concurrent(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
                 let live_keys: Vec<i64> = model.keys().copied().collect();
                 let t = handle.read().await;
                 delete_all(&t, &live_keys, w.durability).await?;
+            }
+            Op::DeletePredicate { lo, hi } => {
+                let t = handle.read().await;
+                delete_predicate(&t, *lo, *hi).await?;
             }
             Op::Overwrite { rows } => {
                 let t = handle.read().await;
@@ -967,11 +1047,26 @@ async fn run_concurrent(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
 }
 
 async fn run_workload(fixture: TestFixture, w: Workload) -> TestResult<()> {
+    let mut predicate_deleted_rows = 0usize;
     for seed in 0..w.seeds {
         match w.concurrency {
-            Concurrency::Sequential => run_sequential(&fixture, &w, seed).await?,
+            Concurrency::Sequential => {
+                predicate_deleted_rows += run_sequential(&fixture, &w, seed).await?;
+            }
             Concurrency::ConcurrentWithCompaction => run_concurrent(&fixture, &w, seed).await?,
         }
+    }
+    // An op that never retires a row still runs the delete plan, so it would sit
+    // in the weights looking like coverage. Fail loudly if the window and the
+    // value domain drift apart again.
+    if w.weights.delete_predicate > 0 && matches!(w.concurrency, Concurrency::Sequential) {
+        assert!(
+            predicate_deleted_rows > 0,
+            "delete_predicate is weighted {} but retired 0 rows across {} seeds — the window no \
+             longer intersects the value domain, so the op is inert",
+            w.weights.delete_predicate,
+            w.seeds,
+        );
     }
     Ok(())
 }
@@ -1037,6 +1132,7 @@ const SEQUENTIAL_MIXED: OpWeights = OpWeights {
     upsert: 40,
     delete: 25,
     delete_all: 8,
+    delete_predicate: 10,
     overwrite: 12,
     compact: 8,
     restart: 7,
@@ -1046,6 +1142,7 @@ const CONCURRENT_MIXED: OpWeights = OpWeights {
     upsert: 40,
     delete: 60,
     delete_all: 0,
+    delete_predicate: 10,
     overwrite: 0,
     // Compaction is driven by the background loop (foreground `compact` is a
     // no-op here); `restart` reopens the table from the catalog mid-stream, under
@@ -1059,6 +1156,7 @@ const CONCURRENT_UPSERT_ONLY: OpWeights = OpWeights {
     upsert: 100,
     delete: 0,
     delete_all: 0,
+    delete_predicate: 0,
     overwrite: 0,
     compact: 0,
     restart: 0,
@@ -1073,6 +1171,9 @@ const MEMORY_MIXED: OpWeights = OpWeights {
     upsert: 45,
     delete: 25,
     delete_all: 0,
+    // 0 until spiceai/spiceai#12008: a filtered DELETE leaves un-checkpointed
+    // mem-tier rows live.
+    delete_predicate: 0,
     overwrite: 0,
     compact: 25,
     restart: 5,
@@ -1194,6 +1295,7 @@ fn sequential_cold() -> Workload {
             upsert: 40,
             delete: 25,
             delete_all: 5,
+            delete_predicate: 10,
             overwrite: 10,
             compact: 5,
             restart: 5,
@@ -1218,6 +1320,7 @@ fn concurrent_cold() -> Workload {
             upsert: 40,
             delete: 55,
             delete_all: 0,
+            delete_predicate: 10,
             overwrite: 0,
             compact: 0,
             restart: 3,

--- a/crates/cayenne/tests/mutation_property_test.rs
+++ b/crates/cayenne/tests/mutation_property_test.rs
@@ -442,7 +442,11 @@ async fn overwrite(table: &Arc<CayenneTableProvider>, rows: &[(i64, i64)]) -> Te
 /// `delete_predicate` is weighted 0 in memory configs. Once #12008 is fixed,
 /// weighting it there turns this into the regression test.
 async fn delete_predicate(table: &Arc<CayenneTableProvider>, lo: i64, hi: i64) -> TestResult<()> {
-    delete_filter(table, col("value").gt_eq(lit(lo)).and(col("value").lt(lit(hi)))).await
+    delete_filter(
+        table,
+        col("value").gt_eq(lit(lo)).and(col("value").lt(lit(hi))),
+    )
+    .await
 }
 
 async fn settle(table: &Arc<CayenneTableProvider>, durability: Durability) -> TestResult<()> {
@@ -644,15 +648,21 @@ async fn verify_aggregate_queries(
 
 #[derive(Clone, Debug)]
 enum Op {
-    Upsert { rows: Vec<(i64, i64)> },
-    Delete { key: i64 },
+    Upsert {
+        rows: Vec<(i64, i64)>,
+    },
+    Delete {
+        key: i64,
+    },
     DeleteAll,
     /// Delete every row whose non-PK `value` falls in `[lo, hi)`.
     DeletePredicate {
         lo: i64,
         hi: i64,
     },
-    Overwrite { rows: Vec<(i64, i64)> },
+    Overwrite {
+        rows: Vec<(i64, i64)>,
+    },
     Compact,
     Restart,
     MoveToColdTier,
@@ -744,10 +754,7 @@ fn gen_op(
                         Some(v) if rng.below(2) == 0 => (v - rng.below_i64(width)).max(0),
                         _ => rng.below_i64(VALUE_SPACE),
                     };
-                    Op::DeletePredicate {
-                        lo,
-                        hi: lo + width,
-                    }
+                    Op::DeletePredicate { lo, hi: lo + width }
                 }
                 3 => Op::Overwrite {
                     rows: random_rows(rng, key_space, batch_size),
@@ -788,11 +795,7 @@ fn apply_model(model: &mut Model, op: &Op) {
 // Harness
 // ============================================================================
 
-async fn run_sequential(
-    fixture: &TestFixture,
-    w: &Workload,
-    seed: u64,
-) -> TestResult<usize> {
+async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestResult<usize> {
     let name = format!("seq_{:?}_{:?}_{seed}", w.mode, w.durability);
     let (mut table, mut ctx) = create_table(
         fixture,

--- a/crates/cayenne/tests/mutation_property_test.rs
+++ b/crates/cayenne/tests/mutation_property_test.rs
@@ -449,6 +449,9 @@ async fn delete_predicate(table: &Arc<CayenneTableProvider>, lo: i64, hi: i64) -
     .await
 }
 
+/// One "settle" pass. File compacts small files; memory additionally checkpoints
+/// the RAM tier to durable Vortex files and bakes the seq-prefix (the exact
+/// intersection — mem-tier checkpoint + bake — that surfaced the COUNT(*) drift).
 async fn settle(table: &Arc<CayenneTableProvider>, durability: Durability) -> TestResult<()> {
     // Drain debounced post-write maintenance so the persisted stats (the maintained
     // `num_rows` delta) reflect every committed write before we read/compact.
@@ -715,6 +718,7 @@ fn gen_op(
     let total = w.upsert
         + w.delete
         + w.delete_all
+        + w.delete_predicate
         + w.overwrite
         + w.compact
         + w.restart

--- a/crates/cayenne/tests/mutation_property_test.rs
+++ b/crates/cayenne/tests/mutation_property_test.rs
@@ -795,11 +795,7 @@ fn apply_model(model: &mut Model, op: &Op) {
 // Harness
 // ============================================================================
 
-async fn run_sequential(
-    fixture: &TestFixture,
-    w: &Workload,
-    seed: u64,
-) -> TestResult<(usize, usize)> {
+async fn run_sequential(fixture: &TestFixture, w: &Workload, seed: u64) -> TestResult<()> {
     let name = format!("seq_{:?}_{:?}_{seed}", w.mode, w.durability);
     let (mut table, mut ctx) = create_table(
         fixture,
@@ -813,9 +809,6 @@ async fn run_sequential(
     let mut rng = Rng::new(seed);
     let mut model = Model::new();
     let mut history: Vec<Op> = Vec::with_capacity(w.ops);
-    let mut predicate_deleted_rows = 0usize;
-    let mut predicate_delete_ops = 0usize;
-
     for step in 0..w.ops {
         let live_value = sample_live_value(&model, &mut rng);
         let op = gen_op(&mut rng, &w.weights, w.population, w.batch_size, live_value);
@@ -867,10 +860,6 @@ async fn run_sequential(
         let rows_before_op = model.len();
         apply_model(&mut model, &op);
         let retired_rows = model.len() < rows_before_op;
-        if matches!(op, Op::DeletePredicate { .. }) {
-            predicate_delete_ops += 1;
-            predicate_deleted_rows += rows_before_op - model.len();
-        }
         let live = read_rows(&ctx, &name).await?;
         let step_msg = format!(
             "seq diverged after step {step} ({op:?}) mode={:?} durability={:?} seed={seed}\nhistory={history:?}",
@@ -901,7 +890,7 @@ async fn run_sequential(
     );
     assert_converged(&final_state, &model, &msg);
     verify_aggregate_queries(&c, t.as_ref(), &name, &model, w.population, &msg).await?;
-    Ok((predicate_deleted_rows, predicate_delete_ops))
+    Ok(())
 }
 
 async fn run_concurrent(fixture: &TestFixture, w: &Workload, seed: u64) -> TestResult<()> {
@@ -1055,33 +1044,12 @@ async fn run_concurrent(fixture: &TestFixture, w: &Workload, seed: u64) -> TestR
     Ok(())
 }
 
-/// Predicate deletes needed before "retired nothing" means the op is inert
-/// rather than the workload simply being short.
-const MIN_OPS_TO_JUDGE_INERTNESS: usize = 40;
-
 async fn run_workload(fixture: TestFixture, w: Workload) -> TestResult<()> {
-    let mut predicate_deleted_rows = 0usize;
-    let mut predicate_delete_ops = 0usize;
     for seed in 0..w.seeds {
         match w.concurrency {
-            Concurrency::Sequential => {
-                let (rows, ops) = run_sequential(&fixture, &w, seed).await?;
-                predicate_deleted_rows += rows;
-                predicate_delete_ops += ops;
-            }
+            Concurrency::Sequential => run_sequential(&fixture, &w, seed).await?,
             Concurrency::ConcurrentWithCompaction => run_concurrent(&fixture, &w, seed).await?,
         }
-    }
-    // An op that never retires a row still runs the delete plan, so it would sit
-    // in the weights looking like coverage. Only meaningful once enough of them
-    // have run: a reduced-scale pass (`CAYENNE_PROPTEST_*_SCALE`) leaves the
-    // table too small for a window to match, which says nothing about the op.
-    if predicate_delete_ops >= MIN_OPS_TO_JUDGE_INERTNESS {
-        assert!(
-            predicate_deleted_rows > 0,
-            "delete_predicate retired 0 rows across {predicate_delete_ops} deletes — the window \
-             no longer intersects the value domain, so the op is inert",
-        );
     }
     Ok(())
 }


### PR DESCRIPTION
## What

Adds a `delete_predicate` operation to the Cayenne mutation property tests: a DELETE filtered on a non-primary-key column, weighted into the file-durability configs.

## Why

The harness only issued `id = k`, which resolves through the PK index, and `WHERE true`, which skips matching entirely. Neither reaches the scan-and-match delete path, the scattered deletion vectors it writes, or the min/max pruning

That is the shape a periodic retention check issues: `retention_sql` is a filtered DELETE over a non-key column, run on a schedule against an accelerated table, so this exercises the recurring data-deletion path a long-lived deployment actually takes.

## Also in this change

- Statistics exactness and the filtered reads are verified after any delete that retired rows, not only once at the end of a seed. The coordinator can fold `COUNT(*)` from an `Exact` count between writes, so the contract has to hold there too.
- A guard fails the run if a weighted `delete_predicate` never retires a row, so the op cannot go quietly inert if the value domain and the generated window drift apart.
- Weighted 0 for memory durability: a filtered DELETE does not remove un-checkpointed mem-tier rows (#12008). Weighting it there once that is fixed turns this into the regression test.

## Testing

`cargo test -p cayenne --test mutation_property_test` — 18/18 in ~65s, against ~75s for the unmodified harness.
