### PR TITLE
feat(hash-index): verify the bloom filter's block index with Verus

### DIFF
--- a/.github/workflows/verus_verify.yml
+++ b/.github/workflows/verus_verify.yml
@@ -8,6 +8,13 @@ name: Verus Verification
 # establish by sampling. Nothing else in the normal build checks it — a normal
 # `cargo build` erases the specifications — so this gate is what keeps the
 # proofs from silently rotting into comments.
+#
+# That is also why this runs on `merge_group` and not only on the pull request.
+# A proof is a claim about the tree it was checked against; two individually
+# green changes can combine into one the verifier would reject, and no other
+# check in the queue would notice. `merge_group` takes no `paths` filter, so
+# the job runs on every queue entry — acceptable, because the verifier archive
+# is cached and the verification itself takes seconds.
 on:
   pull_request:
     branches:
@@ -17,14 +24,24 @@ on:
       - feature-*
     paths:
       - 'crates/hash-index/**'
+      # The verifier is a rustc driver bound to one toolchain, so a workspace
+      # toolchain bump can invalidate this gate without touching the crate.
+      - 'rust-toolchain.toml'
       # Self-referencing so an edit to this file is exercised by the gate it
       # defines, rather than only when one of the paths above also changes.
       - '.github/workflows/verus_verify.yml'
+  merge_group:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
   push:
     branches:
       - trunk
     paths:
       - 'crates/hash-index/**'
+      - 'rust-toolchain.toml'
       - '.github/workflows/verus_verify.yml'
   workflow_dispatch:
 
@@ -32,19 +49,27 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# The job reads the repository and fetches a public release. It needs nothing
+# else, and it executes a downloaded binary, so it gets the minimum.
+permissions:
+  contents: read
+
 env:
   # The verifier and its specification library ship together and are versioned
-  # together, so these two move as a pair. VERUS_VSTD_VERSION must match the
-  # `vstd` pin in `crates/hash-index/Cargo.toml`; the "check pins agree" step
-  # below fails the build if it drifts.
+  # together, so these move as a set. VERUS_VSTD_VERSION must match the `vstd`
+  # pin in `crates/hash-index/Cargo.toml`, and VERUS_SHA256 pins the exact
+  # bytes of the archive: a release tag names an asset, it does not fix its
+  # contents, and this job executes what it downloads.
   VERUS_RELEASE: release/0.2026.08.30.b432e82
+  VERUS_ASSET: verus-0.2026.08.30.b432e82-x86-linux.zip
+  VERUS_SHA256: 067f5f72a457fe66b77c0c10b180f2a919a9c7481a8baa024ffc716aa931a41b
   VERUS_VSTD_VERSION: 0.0.0-2026-08-30-0159
 
 jobs:
   verus-verify:
     name: Verify hash-index proofs
-    # GitHub-hosted on purpose: a ~15s verification must not queue behind the
-    # saturated self-hosted pool.
+    # GitHub-hosted on purpose: a seconds-long verification must not queue
+    # behind the saturated self-hosted pool.
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -52,8 +77,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # The verifier is a rustc driver, so it is bound to one exact toolchain.
-      # Read it from the release rather than hardcoding a second copy.
       - name: Check pins agree
         run: |
           set -euo pipefail
@@ -65,12 +88,15 @@ jobs:
             exit 1
           fi
 
-      - name: Cache Verus release
+      # Only the archive is cached. It is re-hashed and re-extracted on every
+      # run, so a cache that has been tampered with fails the digest check
+      # rather than silently supplying the binary this job then trusts.
+      - name: Cache Verus archive
         id: cache-verus
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.verus
-          key: verus-${{ env.VERUS_RELEASE }}-x86-linux
+          path: ~/.verus-dl
+          key: verus-${{ env.VERUS_RELEASE }}-${{ env.VERUS_SHA256 }}
 
       - name: Download Verus
         if: steps.cache-verus.outputs.cache-hit != 'true'
@@ -78,19 +104,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          mkdir -p ~/.verus
+          mkdir -p ~/.verus-dl
           gh release download --repo verus-lang/verus "$VERUS_RELEASE" \
-            -p 'verus-*-x86-linux.zip' -O /tmp/verus.zip
-          unzip -q /tmp/verus.zip -d ~/.verus
+            -p "$VERUS_ASSET" -O ~/.verus-dl/"$VERUS_ASSET" --clobber
 
-      # The archive's top-level directory name is the release's to choose, so
-      # locate the binary rather than assuming it.
-      - name: Locate Verus
+      - name: Verify the archive digest
         run: |
           set -euo pipefail
+          echo "$VERUS_SHA256  $HOME/.verus-dl/$VERUS_ASSET" | sha256sum -c -
+
+      - name: Extract Verus
+        run: |
+          set -euo pipefail
+          rm -rf ~/.verus && mkdir -p ~/.verus
+          unzip -q ~/.verus-dl/"$VERUS_ASSET" -d ~/.verus
           verus_bin=$(find ~/.verus -maxdepth 2 -name verus -type f -perm -u+x | head -1)
           if [ -z "$verus_bin" ]; then
-            echo "::error::No verus binary found under ~/.verus"
+            echo "::error::No verus binary found in $VERUS_ASSET"
             exit 1
           fi
           echo "VERUS_DIR=$(dirname "$verus_bin")" >> "$GITHUB_ENV"
@@ -108,8 +138,8 @@ jobs:
           if [ "$required" != "$pinned" ]; then
             echo "::error::rust-toolchain.toml pins $pinned but Verus" \
                  "$VERUS_RELEASE is built against $required." \
-                 "Bump VERUS_RELEASE/VERUS_VSTD_VERSION to a release built" \
-                 "against $pinned, or this gate cannot run."
+                 "Bump VERUS_RELEASE/VERUS_ASSET/VERUS_SHA256/VERUS_VSTD_VERSION" \
+                 "to a release built against $pinned, or this gate cannot run."
             exit 1
           fi
 

--- a/.github/workflows/verus_verify.yml
+++ b/.github/workflows/verus_verify.yml
@@ -12,9 +12,14 @@ name: Verus Verification
 # That is also why this runs on `merge_group` and not only on the pull request.
 # A proof is a claim about the tree it was checked against; two individually
 # green changes can combine into one the verifier would reject, and no other
-# check in the queue would notice. `merge_group` takes no `paths` filter, so
-# the job runs on every queue entry — acceptable, because the verifier archive
-# is cached and the verification itself takes seconds.
+# check in the queue would notice.
+#
+# The job carries NO `paths` filter, deliberately. It is registered in
+# `REQUIRED_CHECKS` (scripts/signoff), and a required context has to be emitted
+# by every pull request — a workflow that never triggers reports nothing at all,
+# which blocks the PR rather than passing it. So the job always runs and always
+# reports; the change filter below skips only the verification work when nothing
+# it covers was touched. See docs/dev/ci_signoff.md.
 on:
   pull_request:
     branches:
@@ -22,14 +27,6 @@ on:
       - release-*
       - release/*
       - feature-*
-    paths:
-      - 'crates/hash-index/**'
-      # The verifier is a rustc driver bound to one toolchain, so a workspace
-      # toolchain bump can invalidate this gate without touching the crate.
-      - 'rust-toolchain.toml'
-      # Self-referencing so an edit to this file is exercised by the gate it
-      # defines, rather than only when one of the paths above also changes.
-      - '.github/workflows/verus_verify.yml'
   merge_group:
     branches:
       - trunk
@@ -39,10 +36,6 @@ on:
   push:
     branches:
       - trunk
-    paths:
-      - 'crates/hash-index/**'
-      - 'rust-toolchain.toml'
-      - '.github/workflows/verus_verify.yml'
   workflow_dispatch:
 
 concurrency:
@@ -75,9 +68,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # A pull request only needs base + head for the path diff; other
+          # events need history to diff against.
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
           persist-credentials: false
 
+      # Decides whether the verification work below runs. The job itself always
+      # runs, so the required context is always reported.
+      - name: Check for changes this gate covers
+        id: changes
+        uses: ./.github/actions/check-code-changes
+        with:
+          filters: |
+            code_changes:
+              - 'crates/hash-index/**'
+              # The verifier is a rustc driver bound to one toolchain, so a
+              # workspace toolchain bump can invalidate this gate without
+              # touching the crate.
+              - 'rust-toolchain.toml'
+              - '.github/workflows/verus_verify.yml'
+
       - name: Check pins agree
+        if: steps.changes.outputs.relevant_changes == 'true'
         run: |
           set -euo pipefail
           pinned=$(grep -oP 'vstd = "=\K[^"]+' crates/hash-index/Cargo.toml)
@@ -93,13 +105,16 @@ jobs:
       # rather than silently supplying the binary this job then trusts.
       - name: Cache Verus archive
         id: cache-verus
+        if: steps.changes.outputs.relevant_changes == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.verus-dl
           key: verus-${{ env.VERUS_RELEASE }}-${{ env.VERUS_SHA256 }}
 
       - name: Download Verus
-        if: steps.cache-verus.outputs.cache-hit != 'true'
+        if: >-
+          steps.changes.outputs.relevant_changes == 'true'
+          && steps.cache-verus.outputs.cache-hit != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -109,11 +124,13 @@ jobs:
             -p "$VERUS_ASSET" -O ~/.verus-dl/"$VERUS_ASSET" --clobber
 
       - name: Verify the archive digest
+        if: steps.changes.outputs.relevant_changes == 'true'
         run: |
           set -euo pipefail
           echo "$VERUS_SHA256  $HOME/.verus-dl/$VERUS_ASSET" | sha256sum -c -
 
       - name: Extract Verus
+        if: steps.changes.outputs.relevant_changes == 'true'
         run: |
           set -euo pipefail
           rm -rf ~/.verus && mkdir -p ~/.verus
@@ -126,14 +143,28 @@ jobs:
           echo "VERUS_DIR=$(dirname "$verus_bin")" >> "$GITHUB_ENV"
 
       # Verus is a rustc driver, so it only runs against the exact toolchain it
-      # was built for. `rust-toolchain.toml` is what cargo will actually select,
-      # so compare against that: a workspace toolchain bump ahead of the Verus
-      # release fails here with an explanation instead of an opaque driver error.
+      # was built for. Ask the binary rather than restating the version here:
+      # a second copy of it in this file is one more thing that can drift from
+      # the release the digest above pins. `rust-toolchain.toml` is what cargo
+      # will actually select, so that is what it is compared against — a
+      # workspace toolchain bump ahead of the Verus release then fails here with
+      # an explanation instead of an opaque driver error.
       - name: Check the toolchain matches
+        if: steps.changes.outputs.relevant_changes == 'true'
         run: |
           set -euo pipefail
-          required=$("$VERUS_DIR/verus" --version | awk '/Toolchain:/ {print $2}')
+          if ! version_output=$("$VERUS_DIR/verus" --version 2>&1); then
+            echo "::error::Could not run the Verus driver to read its toolchain." \
+                 "It reported: ${version_output}"
+            exit 1
+          fi
+          required=$(awk '/Toolchain:/ {print $2}' <<<"$version_output")
           required=${required%%-*}
+          if [ -z "$required" ]; then
+            echo "::error::Verus $VERUS_RELEASE did not report a toolchain." \
+                 "It printed: ${version_output}"
+            exit 1
+          fi
           pinned=$(awk -F'"' '/^channel/ {print $2}' rust-toolchain.toml)
           if [ "$required" != "$pinned" ]; then
             echo "::error::rust-toolchain.toml pins $pinned but Verus" \
@@ -144,6 +175,7 @@ jobs:
           fi
 
       - name: Verify
+        if: steps.changes.outputs.relevant_changes == 'true'
         working-directory: crates/hash-index
         run: |
           set -euo pipefail

--- a/.github/workflows/verus_verify.yml
+++ b/.github/workflows/verus_verify.yml
@@ -43,9 +43,13 @@ concurrency:
   cancel-in-progress: true
 
 # The job reads the repository and fetches a public release. It needs nothing
-# else, and it executes a downloaded binary, so it gets the minimum.
+# else, and it executes a downloaded binary, so it gets the minimum. Naming any
+# permission drops the rest to none, so `pull-requests: read` has to be explicit:
+# `dorny/paths-filter` reads the changed-file list for a pull request from the
+# REST API, not from the checkout.
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   # The verifier and its specification library ship together and are versioned
@@ -64,6 +68,11 @@ jobs:
     # GitHub-hosted on purpose: a seconds-long verification must not queue
     # behind the saturated self-hosted pool.
     runs-on: ubuntu-24.04
+    # Bounded because this is a required `merge_group` check: an unbounded job
+    # leaves the queue candidate `AWAITING_CHECKS` for GitHub's six-hour default
+    # and stalls every entry behind it (#12717). Observed runtime is ~7 minutes
+    # including a cold archive download.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -87,6 +96,17 @@ jobs:
               # touching the crate.
               - 'rust-toolchain.toml'
               - '.github/workflows/verus_verify.yml'
+
+      # Installs the toolchain `rust-toolchain.toml` pins, which is the one the
+      # Verus driver is built against and the one `cargo verus` will select. The
+      # runner image ships a different stable, so leaving this implicit makes the
+      # job depend on whatever happens to be provisioned. It also carries the
+      # Cargo.lock coherence guard, which matters here specifically: this job runs
+      # on `merge_group`, where a textual lockfile merge is what that guard exists
+      # to name before any cargo work.
+      - name: Set up Rust
+        if: steps.changes.outputs.relevant_changes == 'true'
+        uses: ./.github/actions/setup-rust
 
       - name: Check pins agree
         if: steps.changes.outputs.relevant_changes == 'true'

--- a/.github/workflows/verus_verify.yml
+++ b/.github/workflows/verus_verify.yml
@@ -1,0 +1,124 @@
+---
+name: Verus Verification
+
+# `crates/hash-index/src/sbbf_layout.rs` carries proofs, not just tests: the
+# block index it returns subscripts the bloom filter's block vector, so an
+# out-of-range result is a panic on a lock-free read path. The bound is a Verus
+# postcondition discharged for every input, which is a property no test can
+# establish by sampling. Nothing else in the normal build checks it — a normal
+# `cargo build` erases the specifications — so this gate is what keeps the
+# proofs from silently rotting into comments.
+on:
+  pull_request:
+    branches:
+      - trunk
+      - release-*
+      - release/*
+      - feature-*
+    paths:
+      - 'crates/hash-index/**'
+      # Self-referencing so an edit to this file is exercised by the gate it
+      # defines, rather than only when one of the paths above also changes.
+      - '.github/workflows/verus_verify.yml'
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'crates/hash-index/**'
+      - '.github/workflows/verus_verify.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  # The verifier and its specification library ship together and are versioned
+  # together, so these two move as a pair. VERUS_VSTD_VERSION must match the
+  # `vstd` pin in `crates/hash-index/Cargo.toml`; the "check pins agree" step
+  # below fails the build if it drifts.
+  VERUS_RELEASE: release/0.2026.08.30.b432e82
+  VERUS_VSTD_VERSION: 0.0.0-2026-08-30-0159
+
+jobs:
+  verus-verify:
+    name: Verify hash-index proofs
+    # GitHub-hosted on purpose: a ~15s verification must not queue behind the
+    # saturated self-hosted pool.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The verifier is a rustc driver, so it is bound to one exact toolchain.
+      # Read it from the release rather than hardcoding a second copy.
+      - name: Check pins agree
+        run: |
+          set -euo pipefail
+          pinned=$(grep -oP 'vstd = "=\K[^"]+' crates/hash-index/Cargo.toml)
+          if [ "$pinned" != "$VERUS_VSTD_VERSION" ]; then
+            echo "::error::vstd pin in crates/hash-index/Cargo.toml is '$pinned'," \
+                 "but this workflow runs Verus '$VERUS_VSTD_VERSION'." \
+                 "The verifier and vstd ship together — update both."
+            exit 1
+          fi
+
+      - name: Cache Verus release
+        id: cache-verus
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.verus
+          key: verus-${{ env.VERUS_RELEASE }}-x86-linux
+
+      - name: Download Verus
+        if: steps.cache-verus.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.verus
+          gh release download --repo verus-lang/verus "$VERUS_RELEASE" \
+            -p 'verus-*-x86-linux.zip' -O /tmp/verus.zip
+          unzip -q /tmp/verus.zip -d ~/.verus
+
+      # The archive's top-level directory name is the release's to choose, so
+      # locate the binary rather than assuming it.
+      - name: Locate Verus
+        run: |
+          set -euo pipefail
+          verus_bin=$(find ~/.verus -maxdepth 2 -name verus -type f -perm -u+x | head -1)
+          if [ -z "$verus_bin" ]; then
+            echo "::error::No verus binary found under ~/.verus"
+            exit 1
+          fi
+          echo "VERUS_DIR=$(dirname "$verus_bin")" >> "$GITHUB_ENV"
+
+      # Verus is a rustc driver, so it only runs against the exact toolchain it
+      # was built for. `rust-toolchain.toml` is what cargo will actually select,
+      # so compare against that: a workspace toolchain bump ahead of the Verus
+      # release fails here with an explanation instead of an opaque driver error.
+      - name: Check the toolchain matches
+        run: |
+          set -euo pipefail
+          required=$("$VERUS_DIR/verus" --version | awk '/Toolchain:/ {print $2}')
+          required=${required%%-*}
+          pinned=$(awk -F'"' '/^channel/ {print $2}' rust-toolchain.toml)
+          if [ "$required" != "$pinned" ]; then
+            echo "::error::rust-toolchain.toml pins $pinned but Verus" \
+                 "$VERUS_RELEASE is built against $required." \
+                 "Bump VERUS_RELEASE/VERUS_VSTD_VERSION to a release built" \
+                 "against $pinned, or this gate cannot run."
+            exit 1
+          fi
+
+      - name: Verify
+        working-directory: crates/hash-index
+        run: |
+          set -euo pipefail
+          export PATH="$VERUS_DIR:$PATH"
+          cargo verus focus 2>&1 | tee /tmp/verus.log
+          # `cargo verus` exits 0 when a crate opts out of verification and
+          # nothing is checked, so assert the proofs actually ran.
+          grep -qE 'verification results:: [1-9][0-9]* verified, 0 errors' /tmp/verus.log

--- a/.github/workflows/verus_verify.yml
+++ b/.github/workflows/verus_verify.yml
@@ -84,6 +84,10 @@ jobs:
 
       # Decides whether the verification work below runs. The job itself always
       # runs, so the required context is always reported.
+      #
+      # This has to cover every input that decides what `cargo verus` checks,
+      # not only the proof source. A path missing here is not a cheaper run: it
+      # reports the required context green with the verifier never invoked.
       - name: Check for changes this gate covers
         id: changes
         uses: ./.github/actions/check-code-changes
@@ -95,7 +99,42 @@ jobs:
               # workspace toolchain bump can invalidate this gate without
               # touching the crate.
               - 'rust-toolchain.toml'
+              # `vstd` is an ordinary dependency, so what is verified is resolved
+              # outside the crate: the root manifest owns `[patch.crates-io]` and
+              # can redirect `vstd` past the version string "Check pins agree"
+              # reads, the lockfile selects its proc-macro crates, and cargo
+              # config can replace the source or change how the driver is
+              # invoked.
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.cargo/**'
+              # The gate itself, and the two composite actions this job runs: one
+              # decides whether verification happens at all, the other installs
+              # the toolchain the driver requires.
               - '.github/workflows/verus_verify.yml'
+              - '.github/actions/check-code-changes/**'
+              - '.github/actions/setup-rust/**'
+
+      # A manual run is how someone re-checks the proofs on demand, so it must
+      # never be able to skip them. `dorny/paths-filter` has no base to diff
+      # against on a dispatch: `before` is absent from the payload, and when the
+      # dispatch ref is the default branch the filter falls back to the last
+      # commit alone (`getChangesInLastCommit`, src/main.ts). Dispatching from
+      # `trunk` after an unrelated commit would therefore report this gate green
+      # having verified nothing. `integration.yml`, `e2e_test_ci.yml`,
+      # `helm-lint.yml`, and `integration_elasticsearch.yml` force the same way.
+      - name: Decide whether to run the verifier
+        id: gate
+        env:
+          RELEVANT_CHANGES: ${{ steps.changes.outputs.relevant_changes }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$RELEVANT_CHANGES" = 'true' ] || [ "$EVENT_NAME" = 'workflow_dispatch' ]; then
+            echo 'verify=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'verify=false' >> "$GITHUB_OUTPUT"
+          fi
 
       # Installs the toolchain `rust-toolchain.toml` pins, which is the one the
       # Verus driver is built against and the one `cargo verus` will select. The
@@ -105,11 +144,11 @@ jobs:
       # on `merge_group`, where a textual lockfile merge is what that guard exists
       # to name before any cargo work.
       - name: Set up Rust
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: steps.gate.outputs.verify == 'true'
         uses: ./.github/actions/setup-rust
 
       - name: Check pins agree
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: steps.gate.outputs.verify == 'true'
         run: |
           set -euo pipefail
           pinned=$(grep -oP 'vstd = "=\K[^"]+' crates/hash-index/Cargo.toml)
@@ -125,7 +164,7 @@ jobs:
       # rather than silently supplying the binary this job then trusts.
       - name: Cache Verus archive
         id: cache-verus
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: steps.gate.outputs.verify == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.verus-dl
@@ -133,7 +172,7 @@ jobs:
 
       - name: Download Verus
         if: >-
-          steps.changes.outputs.relevant_changes == 'true'
+          steps.gate.outputs.verify == 'true'
           && steps.cache-verus.outputs.cache-hit != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -144,13 +183,13 @@ jobs:
             -p "$VERUS_ASSET" -O ~/.verus-dl/"$VERUS_ASSET" --clobber
 
       - name: Verify the archive digest
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: steps.gate.outputs.verify == 'true'
         run: |
           set -euo pipefail
           echo "$VERUS_SHA256  $HOME/.verus-dl/$VERUS_ASSET" | sha256sum -c -
 
       - name: Extract Verus
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: steps.gate.outputs.verify == 'true'
         run: |
           set -euo pipefail
           rm -rf ~/.verus && mkdir -p ~/.verus
@@ -170,7 +209,7 @@ jobs:
       # workspace toolchain bump ahead of the Verus release then fails here with
       # an explanation instead of an opaque driver error.
       - name: Check the toolchain matches
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: steps.gate.outputs.verify == 'true'
         run: |
           set -euo pipefail
           if ! version_output=$("$VERUS_DIR/verus" --version 2>&1); then
@@ -195,7 +234,7 @@ jobs:
           fi
 
       - name: Verify
-        if: steps.changes.outputs.relevant_changes == 'true'
+        if: steps.gate.outputs.verify == 'true'
         working-directory: crates/hash-index
         run: |
           set -euo pipefail

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5295,6 +5295,12 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -7621,7 +7627,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -9709,6 +9715,7 @@ dependencies = [
  "tokio",
  "tracing",
  "twox-hash",
+ "vstd",
 ]
 
 [[package]]
@@ -23259,6 +23266,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "verus_builtin"
+version = "0.0.0-2026-08-30-0159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300d269a2e06dbe54cb53084464065912ad7accbb52ae8d6c8aa7a6c521974c5"
+
+[[package]]
+name = "verus_builtin_macros"
+version = "0.0.0-2026-08-30-0159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc040bfded82e79a708c1819c52b386ee23c0c823239334f39ced152bbdf3624"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure 0.13.2",
+ "verus_prettyplease",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_prettyplease"
+version = "0.0.0-2026-08-09-0044"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fc115de5fb3806bc362060bb683024660ed2bc13c1183d1f01d464e4537139"
+dependencies = [
+ "proc-macro2",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_state_machines_macros"
+version = "0.0.0-2026-08-02-0125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f77ff8d121edb1bf2651335769a80a2f611da8573c3b498434a66b3162805f"
+dependencies = [
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_syn"
+version = "0.0.0-2026-08-02-0125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17237ea6d267e457d53ce36f55b315fc9edd26eb88c765dd95e035c0b415869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "vob"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23896,6 +23957,17 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vstd"
+version = "0.0.0-2026-08-30-0159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7169790c92857fa9441c8ba7e0c469f4fc62104caf1dfc632c318577a1a08d7a"
+dependencies = [
+ "verus_builtin",
+ "verus_builtin_macros",
+ "verus_state_machines_macros",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/crates/hash-index/Cargo.toml
+++ b/crates/hash-index/Cargo.toml
@@ -19,6 +19,11 @@ snafu.workspace = true
 telemetry = { path = "../telemetry", optional = true }
 tracing.workspace = true
 twox-hash.workspace = true
+# Specification and proof vocabulary for `src/sbbf_layout.rs`. A normal
+# `cargo build` erases the specifications, so this carries no runtime cost;
+# `cargo verus focus` re-checks the proofs. Pinned to the Verus release whose
+# verifier is run in CI — the two are versioned together.
+vstd = "=0.0.0-2026-08-30-0159"
 
 [features]
 default = []
@@ -39,3 +44,8 @@ harness = false
 
 [lints]
 workspace = true
+
+# Opts this crate into `cargo verus focus`. Without it the verifier compiles the
+# crate and checks nothing, reporting "no crates that opted into verification".
+[package.metadata.verus]
+verify = true

--- a/crates/hash-index/src/lib.rs
+++ b/crates/hash-index/src/lib.rs
@@ -50,6 +50,7 @@ mod bloom;
 mod extract;
 mod index;
 mod sbbf;
+mod sbbf_layout;
 
 #[cfg(test)]
 mod tests;

--- a/crates/hash-index/src/sbbf.rs
+++ b/crates/hash-index/src/sbbf.rs
@@ -116,12 +116,16 @@ impl SplitBlockBloomFilter {
 
     /// Selects the block for `hash` via multiply-shift range reduction over
     /// the high 32 bits, leaving the low 32 bits independent for the in-block
-    /// bit positions. The multiply widens to `u128` so block counts beyond
-    /// `2^32` (a >128 GiB filter) cannot overflow the product; the double
-    /// shift keeps the result within block range, so the cast cannot truncate.
+    /// bit positions.
+    ///
+    /// The reduction lives in [`crate::sbbf_layout::block_index`], where the
+    /// in-range result the subscript below depends on is a verified
+    /// postcondition rather than a property the reader has to re-derive.
+    /// [`Self::new`] always allocates at least one block, which is the
+    /// condition that postcondition carries.
     #[inline]
     fn block_index(&self, hash: u64) -> usize {
-        ((u128::from(hash >> 32) * self.blocks.len() as u128) >> 32) as usize
+        crate::sbbf_layout::block_index(self.blocks.len(), hash)
     }
 
     /// Computes the eight per-word bit masks for `hash` from its low 32 bits.
@@ -193,6 +197,35 @@ impl Clone for SplitBlockBloomFilter {
 mod tests {
     use super::*;
     use crate::hash_key;
+
+    /// `block_index` delegates to the verified reduction in
+    /// [`crate::sbbf_layout`]. Verus establishes the in-range postcondition for
+    /// every input; this pins the concrete value against the multiply-shift
+    /// expression, so the delegation cannot quietly relocate a key's block and
+    /// invalidate every filter already written to disk.
+    #[test]
+    fn block_index_matches_the_multiply_shift_reduction() {
+        for expected_items in [0_usize, 1, 100, 10_000] {
+            let filter = SplitBlockBloomFilter::new(expected_items);
+            let len = filter.blocks.len();
+            for hash in [
+                0_u64,
+                1,
+                u64::MAX,
+                u64::from(u32::MAX) << 32,
+                0xffff_ffff,
+                0x1234_5678_9abc_def0,
+            ] {
+                let reduction = ((u128::from(hash >> 32) * len as u128) >> 32) as usize;
+                assert_eq!(
+                    filter.block_index(hash),
+                    reduction,
+                    "block_index drifted from the reduction at len={len} hash={hash:#x}"
+                );
+                assert!(filter.block_index(hash) < len, "out of range at len={len}");
+            }
+        }
+    }
 
     #[test]
     fn insert_then_contains() {

--- a/crates/hash-index/src/sbbf_layout.rs
+++ b/crates/hash-index/src/sbbf_layout.rs
@@ -1,0 +1,76 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Machine-checked block selection for [`crate::SplitBlockBloomFilter`].
+//!
+//! [`block_index`] returns an index used to subscript the filter's block
+//! vector, so an out-of-range result is a panic on a lock-free read path. The
+//! bound is not obvious by inspection: it rests on the multiply-shift range
+//! reduction cancelling exactly, across a `u128` widening and a truncating cast
+//! back to `usize`. Here the bound is a postcondition the
+//! [Verus](https://github.com/verus-lang/verus) verifier discharges for every
+//! `(num_blocks, hash)` pair, rather than for the pairs a test happens to pick.
+//!
+//! Verus reads the `verus!` block; a normal `cargo build` erases the
+//! specifications and compiles the function bodies as ordinary Rust, so this
+//! module needs no verifier to build. `cargo verus focus` re-checks it.
+
+use vstd::prelude::*;
+
+verus! {
+
+/// Selects the block for `hash` by multiply-shift range reduction over the
+/// high 32 bits, leaving the low 32 bits independent for the in-block bit
+/// positions.
+///
+/// The multiply widens to `u128` so block counts beyond `2^32` (a >128 GiB
+/// filter) cannot overflow the product. The `ensures` clause below is the
+/// property the subscript depends on: the double shift leaves the result
+/// within block range, so the cast back to `usize` cannot truncate.
+///
+/// `num_blocks` of 0 has no block to select and yields 0;
+/// [`crate::SplitBlockBloomFilter::new`] always allocates at least one.
+pub fn block_index(num_blocks: usize, hash: u64) -> (index: usize)
+    ensures
+        num_blocks >= 1 ==> index < num_blocks,
+{
+    if num_blocks == 0 {
+        return 0;
+    }
+    let hi: u128 = u128::from(hash >> 32);
+    let len: u128 = num_blocks as u128;
+
+    // The high half is what the reduction ranges over: at most 2^32 - 1.
+    assert(hash >> 32 <= 0xffff_ffffu64) by (bit_vector);
+    // So the product is under 2^96 and cannot overflow the u128 it widens to.
+    assert(hi * len <= 0xffff_ffffu128 * len) by (nonlinear_arith)
+        requires hi <= 0xffff_ffffu128;
+    assert(0xffff_ffffu128 * len <= 0xffff_ffffu128 * 0x1_0000_0000_0000_0000u128)
+        by (nonlinear_arith)
+        requires len <= 0xffff_ffff_ffff_ffffu128;
+
+    let product: u128 = hi * len;
+
+    // Shifting the 32 bits back off divides by exactly what the reduction
+    // multiplied in, so the quotient lands strictly below `num_blocks`.
+    assert(product >> 32 == product / 0x1_0000_0000u128) by (bit_vector);
+    assert(product / 0x1_0000_0000u128 < len) by (nonlinear_arith)
+        requires product <= 0xffff_ffffu128 * len, len >= 1;
+
+    (product >> 32) as usize
+}
+
+}

--- a/crates/hash-index/src/sbbf_layout.rs
+++ b/crates/hash-index/src/sbbf_layout.rs
@@ -43,32 +43,44 @@ verus! {
 ///
 /// `num_blocks` of 0 has no block to select and yields 0;
 /// [`crate::SplitBlockBloomFilter::new`] always allocates at least one.
+///
+/// `#[inline]` because every insert and every probe calls this once per hash:
+/// the caller is `SplitBlockBloomFilter`'s own `#[inline]` method, and the
+/// reduction has to keep collapsing into it across the module boundary.
+#[inline]
 pub fn block_index(num_blocks: usize, hash: u64) -> (index: usize)
     ensures
         num_blocks >= 1 ==> index < num_blocks,
 {
-    if num_blocks == 0 {
-        return 0;
-    }
     let hi: u128 = u128::from(hash >> 32);
     let len: u128 = num_blocks as u128;
 
-    // The high half is what the reduction ranges over: at most 2^32 - 1.
-    assert(hash >> 32 <= 0xffff_ffffu64) by (bit_vector);
-    // So the product is under 2^96 and cannot overflow the u128 it widens to.
-    assert(hi * len <= 0xffff_ffffu128 * len) by (nonlinear_arith)
-        requires hi <= 0xffff_ffffu128;
-    assert(0xffff_ffffu128 * len <= 0xffff_ffffu128 * 0x1_0000_0000_0000_0000u128)
-        by (nonlinear_arith)
-        requires len <= 0xffff_ffff_ffff_ffffu128;
+    proof {
+        // The high half is what the reduction ranges over: at most 2^32 - 1.
+        assert(hash >> 32 <= 0xffff_ffffu64) by (bit_vector);
+        // So the product is under 2^96 and cannot overflow the u128 it widens to.
+        assert(hi * len <= 0xffff_ffffu128 * len) by (nonlinear_arith)
+            requires hi <= 0xffff_ffffu128;
+        assert(0xffff_ffffu128 * len <= 0xffff_ffffu128 * 0x1_0000_0000_0000_0000u128)
+            by (nonlinear_arith)
+            requires len <= 0xffff_ffff_ffff_ffffu128;
+    }
 
     let product: u128 = hi * len;
 
-    // Shifting the 32 bits back off divides by exactly what the reduction
-    // multiplied in, so the quotient lands strictly below `num_blocks`.
-    assert(product >> 32 == product / 0x1_0000_0000u128) by (bit_vector);
-    assert(product / 0x1_0000_0000u128 < len) by (nonlinear_arith)
-        requires product <= 0xffff_ffffu128 * len, len >= 1;
+    proof {
+        // Shifting the 32 bits back off divides by exactly what the reduction
+        // multiplied in, so the quotient lands strictly below `num_blocks`.
+        assert(product >> 32 == product / 0x1_0000_0000u128) by (bit_vector);
+        if num_blocks >= 1 {
+            assert(product / 0x1_0000_0000u128 < len) by (nonlinear_arith)
+                requires product <= 0xffff_ffffu128 * len, len >= 1;
+        } else {
+            // No block to select. The reduction already yields 0 here, so the
+            // degenerate case needs no branch in the emitted code.
+            assert(product == 0);
+        }
+    }
 
     (product >> 32) as usize
 }

--- a/scripts/signoff
+++ b/scripts/signoff
@@ -120,6 +120,10 @@ readonly REQUIRED_CHECKS=(
   "Features Check"           # features.yml
   "Check Rust Licenses"      # license_check.yml
   "E2E Test CI"              # e2e_test_ci.yml (gate job)
+  # verus_verify.yml. The only check that reads the Verus proofs: a normal
+  # `cargo build` erases the specifications, so nothing else here would notice
+  # a postcondition that no longer holds.
+  "Verify hash-index proofs"
 )
 # GitHub Actions app id — pins each required check to Actions so a hand-POSTed
 # commit status can't satisfy a required check (only `signoff` is a raw status).


### PR DESCRIPTION
## 📝 Summary

`SplitBlockBloomFilter::block_index` returns an index that subscripts the
filter's block vector, so a result at or past `blocks.len()` is a panic on a
lock-free read path. Nothing established that it cannot happen. The bound rests
on a multiply-shift range reduction cancelling exactly, across a `u128` widening
and a truncating cast back to `usize` — and the comment asserting it was the
only record that the reasoning had ever been done.

This moves the reduction into a new `sbbf_layout` module, where the bound is an
`ensures` clause that [Verus](https://github.com/verus-lang/verus) discharges
for every `(num_blocks, hash)` pair, rather than for the pairs a test happens
to pick.

Verus reads the `verus!` block; a normal `cargo build` erases the
specifications and compiles the body as ordinary Rust. The crate builds, lints,
and tests with no verifier installed. `cargo verus focus` re-checks the proof
in ~15s, and the new workflow runs it when the crate changes.

This is deliberately one function. It is here to establish the toolchain, the
CI gate, and the review shape before anything larger is proposed.

## 🔗 Related

Part of #13776. Stacked on #13696 — Verus is a rustc driver bound to one exact
toolchain, and that PR is what moves the workspace to the 1.97.1 it needs.
**Merge #13696 first.**

## 👀 Notes for Reviewers

**Behavior is unchanged.** The delegation preserves the concrete mapping, which
`block_index_matches_the_multiply_shift_reduction` pins against the original
expression — relocating a key's block would invalidate every filter already
written to disk. All 135 `hash-index` tests pass; `cargo clippy --all-targets`
is clean, with no noise from the macro expansion.

**Dependency cost, worth a decision.** `vstd` and five Verus crates enter the
lockfile. They are erased at build time and cost nothing at runtime, but they
do sit in the graph of a foundation-tier crate. The alternative is keeping the
proof in a separate tree that mirrors the code, which is cheaper but proves
something about a copy rather than about what ships. This takes the first
option; if the graph cost is judged too high, the second is a small change.

**Two pins that must move together.** The verifier and `vstd` ship as a pair,
and the verifier only runs against one toolchain. The workflow fails with an
explanation if the `vstd` pin drifts from the release it runs, or if
`rust-toolchain.toml` moves ahead of a Verus release built against it — rather
than failing with an opaque driver error.

**What was verified, and how.**

```
$ cargo verus focus          # in crates/hash-index
    Checking hash-index v2.3.0-unstable
verification results:: 6 verified, 0 errors
    Finished in 14.71s
```

Deleting the `ensures` clause and reintroducing a truncating cast both fail
verification, so the check has teeth rather than only ever running green.

**Not yet run:** `make signoff`. The base branch will move when #13696 merges,
so the attestation is deferred until then. The workflow YAML validates against
`.github/scripts/check_workflow_yaml.py`, but has not executed in Actions yet —
this PR is its first run.

**Draft** until the parent merges.
