### PR TITLE
fix(adbc): federate a BigQuery statement spanning datasets as one query

### DIFF
--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -848,10 +848,22 @@ fn compute_adbc_cache_key(params: &ConnectorParams) -> String {
 
     let mut hasher = blake3::Hasher::new();
     for k in &keys {
-        let v = params.parameters.get(k).expose().ok().unwrap_or("");
+        let v = params.parameters.get(k).expose().ok();
         hasher.update(k.as_bytes());
         hasher.update(b"\0");
-        hasher.update(v.as_bytes());
+        // Presence is part of the key, as it is for the namespace below: an absent
+        // parameter and an empty one are different connection configurations, and
+        // collapsing them here would hand both the same pooled connection.
+        match v {
+            Some(value) => {
+                hasher.update(b"1");
+                hasher.update(b"\0");
+                hasher.update(value.as_bytes());
+            }
+            None => {
+                hasher.update(b"0");
+            }
+        }
         hasher.update(b"\0");
     }
 
@@ -1757,6 +1769,40 @@ mod tests {
         assert_ne!(
             compute_adbc_cache_key(&params_a),
             compute_adbc_cache_key(&params_b)
+        );
+    }
+
+    /// The pool cache decides which connector instance is reused, so it has to make
+    /// the same distinctions the join identity does. If it collapses them, two
+    /// configurations share one pool and the join identity never sees them apart.
+    #[tokio::test]
+    async fn test_cache_key_distinguishes_absent_from_empty_password() {
+        let dataset = test_dataset("adbc:ds.table", "table").await;
+
+        let make_params = |password: Option<&str>| {
+            let mut entries = vec![
+                ("driver".to_string(), SecretString::from("bigquery")),
+                (
+                    "uri".to_string(),
+                    SecretString::from("bigquery:///my-project"),
+                ),
+            ];
+            if let Some(password) = password {
+                entries.push(("password".to_string(), SecretString::from(password)));
+            }
+
+            ConnectorParams {
+                parameters: Parameters::new(entries, "adbc", PARAMETERS),
+                unsupported_type_action: None,
+                component: ConnectorComponent::from(&dataset),
+                io_runtime: tokio::runtime::Handle::current(),
+            }
+        };
+
+        assert_ne!(
+            compute_adbc_cache_key(&make_params(None)),
+            compute_adbc_cache_key(&make_params(Some(""))),
+            "an absent password and an empty one must not share a pooled connector"
         );
     }
 

--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -370,30 +370,20 @@ impl AdbcFactory {
         let driver_options = params.parameters.get("driver_options").expose().ok();
         let db_options = build_db_options(&uri_str, username, password, driver_options);
 
-        let connection_namespace =
-            resolve_connection_namespace(&driver_name_owned, &params.component, &params.parameters)
-                .map_err(|e| DataConnectorError::InvalidConfigurationSourceOnly {
+        let pool_identity =
+            resolve_pool_identity(&driver_name_owned, &uri_str, &params).map_err(|e| {
+                DataConnectorError::InvalidConfigurationSourceOnly {
                     dataconnector: "adbc".to_string(),
                     connector_component: params.component.clone(),
                     source: Box::new(e),
-                })?;
+                }
+            })?;
 
         let conn_options = build_conn_options(
-            connection_namespace.catalog.as_deref(),
-            connection_namespace.schema.as_deref(),
+            pool_identity.connection_namespace.catalog.as_deref(),
+            pool_identity.connection_namespace.schema.as_deref(),
         );
-
-        // Identity used to decide whether two ADBC-backed tables can be joined
-        // in one federated pushdown: DataFusion's federation optimizer only
-        // merges sub-plans whose `compute_context()` strings match, and
-        // `SqlTable::compute_context()` derives that string from this pool's
-        // `join_push_down()`.
-        let join_context = build_join_context(
-            &uri_str,
-            username,
-            connection_namespace.catalog.as_deref(),
-            connection_namespace.schema.as_deref(),
-        );
+        let join_context = pool_identity.join_context;
 
         let federation_enabled = is_query_federation_enabled(&params.parameters).map_err(|e| {
             DataConnectorError::InvalidConfigurationNoSource {
@@ -940,25 +930,98 @@ fn optional_connection_name(params: &Parameters, name: &str) -> Result<Option<St
     }
 }
 
-fn resolve_connection_namespace(
+/// The two namespaces a connector derives from its configuration.
+///
+/// They are not the same thing, and conflating them is what splits a federated
+/// plan: one says where a connection points by default, the other says which
+/// remote engine a table belongs to.
+#[derive(Debug)]
+struct ResolvedNamespaces {
+    /// Applied to every pooled connection as its default catalog and schema.
+    connection: ConnectionNamespace,
+    /// Identifies the remote engine for join pushdown.
+    join: ConnectionNamespace,
+}
+
+/// What a pool takes from its configuration: the namespace its connections
+/// default to, and the identity deciding which tables may be joined in one
+/// pushed-down statement.
+///
+/// The federation optimizer only merges sub-plans whose `compute_context()`
+/// strings match, and `SqlTable::compute_context()` returns this pool's
+/// `join_push_down()` value verbatim — so `join_context` is what decides whether
+/// one inbound statement reaches the remote engine as one query.
+///
+/// `join_context` is a hash, so it is safe to print in `EXPLAIN` and logs.
+#[derive(Debug)]
+struct PoolIdentity {
+    connection_namespace: ConnectionNamespace,
+    join_context: String,
+}
+
+fn resolve_pool_identity(
+    driver_name: &str,
+    uri: &str,
+    params: &ConnectorParams,
+) -> Result<PoolIdentity> {
+    let namespaces = resolve_namespaces(driver_name, &params.component, &params.parameters)?;
+    let join_context = build_join_context(&JoinIdentity {
+        driver: driver_name,
+        uri,
+        username: params.parameters.get("username").expose().ok(),
+        password: params.parameters.get("password").expose().ok(),
+        driver_options: params.parameters.get("driver_options").expose().ok(),
+        catalog: namespaces.join.catalog.as_deref(),
+        schema: namespaces.join.schema.as_deref(),
+    });
+
+    Ok(PoolIdentity {
+        connection_namespace: namespaces.connection,
+        join_context,
+    })
+}
+
+fn resolve_namespaces(
     driver_name: &str,
     component: &ConnectorComponent,
     params: &Parameters,
-) -> Result<ConnectionNamespace> {
+) -> Result<ResolvedNamespaces> {
     let explicit = ConnectionNamespace {
         catalog: optional_connection_name(params, "catalog")?,
         schema: optional_connection_name(params, "schema")?,
     };
 
     if driver_name != "bigquery" {
-        return Ok(explicit);
+        return Ok(ResolvedNamespaces {
+            connection: explicit.clone(),
+            join: explicit,
+        });
     }
 
     let inferred = infer_bigquery_namespace(component);
-    Ok(ConnectionNamespace {
-        catalog: explicit.catalog.or(inferred.catalog),
-        schema: explicit.schema.or(inferred.schema),
-    })
+    let connection = ConnectionNamespace {
+        catalog: explicit.catalog.clone().or(inferred.catalog),
+        schema: explicit.schema.clone().or(inferred.schema),
+    };
+
+    // BigQuery resolves a dataset-qualified reference anywhere in the project, so
+    // one job can span datasets and the dataset a connection defaults to is not
+    // part of the execution boundary. Dividing on it would put each dataset in its
+    // own federated sub-plan and so its own job. The project (catalog) and the
+    // credential do bound execution, and stay in the identity.
+    //
+    // Only the *inferred* dataset is dropped. It exists only when the dataset path
+    // is dataset-qualified, which is exactly when the emitted SQL qualifies the
+    // table, so tables keep resolving correctly inside a merged statement. An
+    // explicitly configured `schema` is kept: a bare table reference resolves
+    // against it, so two connections defaulting to different schemas are not
+    // interchangeable.
+    let join = ConnectionNamespace {
+        catalog: connection.catalog.clone(),
+        schema: explicit.schema,
+    };
+
+    Ok(ResolvedNamespaces { connection, join })
 }
 
 fn infer_bigquery_namespace(component: &ConnectorComponent) -> ConnectionNamespace {
@@ -1075,37 +1138,53 @@ fn build_conn_options(
     if opts.is_empty() { None } else { Some(opts) }
 }
 
+/// Everything that decides which remote engine an ADBC table is executed by.
+///
+/// Two tables may be joined in one pushed-down statement exactly when every field
+/// here matches: same driver, same endpoint, same credential, same namespace.
+struct JoinIdentity<'a> {
+    driver: &'a str,
+    uri: &'a str,
+    username: Option<&'a str>,
+    password: Option<&'a str>,
+    /// Driver-specific options. For `BigQuery` these carry the service-account
+    /// credential, which is why they belong to the identity: the same project
+    /// reached as two identities is two engines, not one.
+    driver_options: Option<&'a str>,
+    catalog: Option<&'a str>,
+    schema: Option<&'a str>,
+}
+
 /// Builds a hashed join-pushdown context identifier for ADBC connections.
 ///
-/// ADBC URIs are driver-vendor-specific and can mix sensitive credentials
-/// with critical identity information (e.g. `bigquery:///project?DatasetId=x`)
-/// in ways that cannot be reliably parsed. We hash all identity-relevant
-/// parts together (similar to the ODBC connector approach) so that:
+/// ADBC URIs and driver options are driver-vendor-specific and can mix sensitive
+/// credentials with critical identity information (e.g.
+/// `bigquery:///project?DatasetId=x`) in ways that cannot be reliably parsed. We
+/// hash all identity-relevant parts together (similar to the ODBC connector
+/// approach) so that:
 ///
 /// - No secrets are ever exposed in `EXPLAIN` plans (`compute_context=...`)
-/// - Two connections to the same database instance produce the same hash,
-///   enabling federated join pushdown
-/// - Different usernames, catalogs, or schemas produce different hashes,
-///   preventing incorrect cross-credential pushdown
-fn build_join_context(
-    uri: &str,
-    username: Option<&str>,
-    catalog: Option<&str>,
-    schema: Option<&str>,
-) -> String {
+/// - Two connections to the same database instance under the same identity
+///   produce the same hash, enabling federated join pushdown
+/// - A different driver, endpoint, credential, catalog or schema produces a
+///   different hash, preventing incorrect cross-credential pushdown
+fn build_join_context(identity: &JoinIdentity<'_>) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(uri.as_bytes());
-    hasher.update(b"\0");
-    if let Some(u) = username {
-        hasher.update(u.as_bytes());
-    }
-    hasher.update(b"\0");
-    if let Some(c) = catalog {
-        hasher.update(c.as_bytes());
-    }
-    hasher.update(b"\0");
-    if let Some(s) = schema {
-        hasher.update(s.as_bytes());
+    // A NUL between fields keeps concatenations from colliding; no configuration
+    // value can contain one.
+    for field in [
+        Some(identity.driver),
+        Some(identity.uri),
+        identity.username,
+        identity.password,
+        identity.driver_options,
+        identity.catalog,
+        identity.schema,
+    ] {
+        if let Some(value) = field {
+            hasher.update(value.as_bytes());
+        }
+        hasher.update(b"\0");
     }
     hasher.finalize().iter().fold(String::new(), |mut hash, b| {
         let _ = write!(hash, "{b:02x}");
@@ -1662,8 +1741,111 @@ mod tests {
         );
     }
 
+    const TEST_CREDENTIAL_A: &str = "adbc.bigquery.sql.auth_type=adbc.bigquery.sql.auth_type.json_credential_string;\
+adbc.bigquery.sql.auth_credentials={\"client_email\":\"a@example.iam.gserviceaccount.com\"}";
+    const TEST_CREDENTIAL_B: &str = "adbc.bigquery.sql.auth_type=adbc.bigquery.sql.auth_type.json_credential_string;\
+adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceaccount.com\"}";
+
+    async fn bigquery_pool_identity(path: &str, uri: &str, credential: &str) -> PoolIdentity {
+        let dataset = test_dataset(path, "t").await;
+        let parameters = Parameters::new(
+            vec![
+                ("driver".to_string(), SecretString::from("bigquery")),
+                ("uri".to_string(), SecretString::from(uri)),
+                ("driver_options".to_string(), SecretString::from(credential)),
+            ],
+            "adbc",
+            PARAMETERS,
+        );
+
+        let params = ConnectorParams {
+            parameters,
+            unsupported_type_action: None,
+            component: ConnectorComponent::from(&dataset),
+            io_runtime: tokio::runtime::Handle::current(),
+        };
+
+        resolve_pool_identity("bigquery", uri, &params).expect("pool identity should resolve")
+    }
+
+    /// The customer-shaped case. A statement joining two `BigQuery` datasets in one
+    /// project under one credential is eligible to run as a single `BigQuery` job,
+    /// which requires both tables to carry one federation compute context — the
+    /// optimizer splits the plan into a sub-plan per context, and each sub-plan
+    /// becomes its own job.
     #[tokio::test]
-    async fn test_resolve_connection_namespace_bigquery_infers_from_hyphenated_project_path() {
+    async fn test_pool_identity_bigquery_datasets_share_join_context() {
+        let core = bigquery_pool_identity(
+            "adbc:core_ds.clients",
+            "bigquery:///proj",
+            TEST_CREDENTIAL_A,
+        )
+        .await;
+        let ledger = bigquery_pool_identity(
+            "adbc:ledger_ds.entries",
+            "bigquery:///proj",
+            TEST_CREDENTIAL_A,
+        )
+        .await;
+
+        assert_eq!(
+            core.join_context, ledger.join_context,
+            "datasets in one project under one credential must share a join context"
+        );
+
+        // Each connection still defaults to its own dataset; only the join
+        // identity is shared.
+        assert_eq!(core.connection_namespace.schema.as_deref(), Some("core_ds"));
+        assert_eq!(
+            ledger.connection_namespace.schema.as_deref(),
+            Some("ledger_ds")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pool_identity_bigquery_projects_are_isolated() {
+        let a = bigquery_pool_identity(
+            "adbc:proj-a.shared_ds.t",
+            "bigquery:///proj-a",
+            TEST_CREDENTIAL_A,
+        )
+        .await;
+        let b = bigquery_pool_identity(
+            "adbc:proj-b.shared_ds.t",
+            "bigquery:///proj-b",
+            TEST_CREDENTIAL_A,
+        )
+        .await;
+
+        assert_ne!(
+            a.join_context, b.join_context,
+            "different projects must not share a join context"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pool_identity_bigquery_credentials_are_isolated() {
+        let a = bigquery_pool_identity(
+            "adbc:core_ds.clients",
+            "bigquery:///proj",
+            TEST_CREDENTIAL_A,
+        )
+        .await;
+        let b = bigquery_pool_identity(
+            "adbc:core_ds.clients",
+            "bigquery:///proj",
+            TEST_CREDENTIAL_B,
+        )
+        .await;
+
+        assert_ne!(
+            a.join_context, b.join_context,
+            "different service-account identities must not share a join context"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_namespaces_bigquery_infers_from_hyphenated_project_path() {
         let dataset = test_dataset("adbc:my-project.my_dataset.my_table", "my_table").await;
 
         let parameters = Parameters::new(
@@ -1678,19 +1860,17 @@ mod tests {
             PARAMETERS,
         );
 
-        let namespace = resolve_connection_namespace(
-            "bigquery",
-            &ConnectorComponent::from(&dataset),
-            &parameters,
-        )
-        .expect("bigquery namespace should resolve");
+        let namespace =
+            resolve_namespaces("bigquery", &ConnectorComponent::from(&dataset), &parameters)
+                .expect("bigquery namespace should resolve")
+                .connection;
 
         assert_eq!(namespace.catalog.as_deref(), Some("my-project"));
         assert_eq!(namespace.schema.as_deref(), Some("my_dataset"));
     }
 
     #[tokio::test]
-    async fn test_resolve_connection_namespace_bigquery_preserves_explicit_values() {
+    async fn test_resolve_namespaces_bigquery_preserves_explicit_values() {
         let dataset = test_dataset("adbc:my-project.path_dataset.my_table", "my_table").await;
 
         let parameters = Parameters::new(
@@ -1713,19 +1893,17 @@ mod tests {
             PARAMETERS,
         );
 
-        let namespace = resolve_connection_namespace(
-            "bigquery",
-            &ConnectorComponent::from(&dataset),
-            &parameters,
-        )
-        .expect("explicit namespace should be preserved");
+        let namespace =
+            resolve_namespaces("bigquery", &ConnectorComponent::from(&dataset), &parameters)
+                .expect("explicit namespace should be preserved")
+                .connection;
 
         assert_eq!(namespace.catalog.as_deref(), Some("configured-project"));
         assert_eq!(namespace.schema.as_deref(), Some("configured_dataset"));
     }
 
     #[tokio::test]
-    async fn test_resolve_connection_namespace_rejects_empty_schema() {
+    async fn test_resolve_namespaces_rejects_empty_schema() {
         let dataset = test_dataset("adbc:my_dataset.my_table", "my_table").await;
 
         let parameters = Parameters::new(
@@ -1741,12 +1919,8 @@ mod tests {
             PARAMETERS,
         );
 
-        let err = resolve_connection_namespace(
-            "bigquery",
-            &ConnectorComponent::from(&dataset),
-            &parameters,
-        )
-        .expect_err("empty schema should be rejected");
+        let err = resolve_namespaces("bigquery", &ConnectorComponent::from(&dataset), &parameters)
+            .expect_err("empty schema should be rejected");
 
         assert_eq!(
             err.to_string(),
@@ -1894,14 +2068,34 @@ mod tests {
         is_query_federation_enabled(&params).expect_err("should error on invalid value");
     }
 
+    fn bigquery_identity<'a>(
+        uri: &'a str,
+        driver_options: Option<&'a str>,
+        catalog: Option<&'a str>,
+        schema: Option<&'a str>,
+    ) -> JoinIdentity<'a> {
+        JoinIdentity {
+            driver: "bigquery",
+            uri,
+            username: None,
+            password: None,
+            driver_options,
+            catalog,
+            schema,
+        }
+    }
+
     #[test]
     fn test_build_join_context_no_secrets_in_output() {
-        let ctx = build_join_context(
-            "bigquery:///project?DatasetId=tpch_sf1&token=SECRET123",
-            Some("admin"),
-            Some("my_catalog"),
-            Some("my_schema"),
-        );
+        let ctx = build_join_context(&JoinIdentity {
+            driver: "bigquery",
+            uri: "bigquery:///project?DatasetId=tpch_sf1&token=SECRET123",
+            username: Some("admin"),
+            password: Some("hunter2"),
+            driver_options: Some("adbc.bigquery.sql.auth_credentials=SECRET_KEY_MATERIAL"),
+            catalog: Some("my_catalog"),
+            schema: Some("my_schema"),
+        });
         // Hash output must not contain any raw URI or credential fragments
         assert!(
             !ctx.contains("SECRET123"),
@@ -1919,6 +2113,14 @@ mod tests {
             !ctx.contains("my_catalog"),
             "context must not contain raw catalog"
         );
+        assert!(
+            !ctx.contains("hunter2"),
+            "context must not contain raw password"
+        );
+        assert!(
+            !ctx.contains("SECRET_KEY_MATERIAL"),
+            "context must not contain raw credential material from driver options"
+        );
         // Must be a fixed-length hex string (SHA-256 = 64 hex chars)
         assert_eq!(
             ctx.len(),
@@ -1931,17 +2133,35 @@ mod tests {
         );
     }
 
+    fn postgres_identity<'a>(uri: &'a str, username: Option<&'a str>) -> JoinIdentity<'a> {
+        JoinIdentity {
+            driver: "postgresql",
+            uri,
+            username,
+            password: None,
+            driver_options: None,
+            catalog: None,
+            schema: None,
+        }
+    }
+
     #[test]
     fn test_build_join_context_deterministic() {
-        let ctx1 = build_join_context("postgresql://host:5432/db", Some("user"), None, None);
-        let ctx2 = build_join_context("postgresql://host:5432/db", Some("user"), None, None);
+        let ctx1 = build_join_context(&postgres_identity(
+            "postgresql://host:5432/db",
+            Some("user"),
+        ));
+        let ctx2 = build_join_context(&postgres_identity(
+            "postgresql://host:5432/db",
+            Some("user"),
+        ));
         assert_eq!(ctx1, ctx2, "same inputs must produce the same hash");
     }
 
     #[test]
     fn test_build_join_context_differs_by_username() {
-        let ctx_a = build_join_context("postgresql://host/db", Some("alice"), None, None);
-        let ctx_b = build_join_context("postgresql://host/db", Some("bob"), None, None);
+        let ctx_a = build_join_context(&postgres_identity("postgresql://host/db", Some("alice")));
+        let ctx_b = build_join_context(&postgres_identity("postgresql://host/db", Some("bob")));
         assert_ne!(
             ctx_a, ctx_b,
             "different usernames must produce different hashes"
@@ -1950,9 +2170,109 @@ mod tests {
 
     #[test]
     fn test_build_join_context_differs_by_uri() {
-        let ctx_a = build_join_context("bigquery:///project-a?DatasetId=ds1", None, None, None);
-        let ctx_b = build_join_context("bigquery:///project-b?DatasetId=ds1", None, None, None);
+        let ctx_a = build_join_context(&bigquery_identity(
+            "bigquery:///project-a?DatasetId=ds1",
+            None,
+            None,
+            None,
+        ));
+        let ctx_b = build_join_context(&bigquery_identity(
+            "bigquery:///project-b?DatasetId=ds1",
+            None,
+            None,
+            None,
+        ));
         assert_ne!(ctx_a, ctx_b, "different URIs must produce different hashes");
+    }
+
+    /// Two `BigQuery` datasets in one project under one credential are one remote
+    /// engine, so they must share a join context and federate as a single job.
+    #[test]
+    fn test_build_join_context_bigquery_same_project_spans_datasets() {
+        let credential = Some("adbc.bigquery.sql.auth_credentials=service-account-a");
+        let ctx_a = build_join_context(&bigquery_identity(
+            "bigquery:///my-project",
+            credential,
+            Some("my-project"),
+            None,
+        ));
+        let ctx_b = build_join_context(&bigquery_identity(
+            "bigquery:///my-project",
+            credential,
+            Some("my-project"),
+            None,
+        ));
+        assert_eq!(
+            ctx_a, ctx_b,
+            "datasets in one project under one credential must share a join context"
+        );
+    }
+
+    #[test]
+    fn test_build_join_context_bigquery_differs_by_project() {
+        let credential = Some("adbc.bigquery.sql.auth_credentials=service-account-a");
+        let ctx_a = build_join_context(&bigquery_identity(
+            "bigquery:///project-a",
+            credential,
+            Some("project-a"),
+            None,
+        ));
+        let ctx_b = build_join_context(&bigquery_identity(
+            "bigquery:///project-b",
+            credential,
+            Some("project-b"),
+            None,
+        ));
+        assert_ne!(
+            ctx_a, ctx_b,
+            "different projects must not share a join context"
+        );
+    }
+
+    /// The credential lives in the driver options, not the URI, so identity must
+    /// be taken from them; otherwise one project reached as two service accounts
+    /// would look like one engine.
+    #[test]
+    fn test_build_join_context_bigquery_differs_by_credential() {
+        let ctx_a = build_join_context(&bigquery_identity(
+            "bigquery:///my-project",
+            Some("adbc.bigquery.sql.auth_credentials=service-account-a"),
+            Some("my-project"),
+            None,
+        ));
+        let ctx_b = build_join_context(&bigquery_identity(
+            "bigquery:///my-project",
+            Some("adbc.bigquery.sql.auth_credentials=service-account-b"),
+            Some("my-project"),
+            None,
+        ));
+        assert_ne!(
+            ctx_a, ctx_b,
+            "different service-account identities must not share a join context"
+        );
+    }
+
+    /// A bare table reference resolves against the connection's default schema, so
+    /// two connections defaulting to different schemas are not interchangeable.
+    #[test]
+    fn test_build_join_context_differs_by_explicit_schema() {
+        let credential = Some("adbc.bigquery.sql.auth_credentials=service-account-a");
+        let ctx_a = build_join_context(&bigquery_identity(
+            "bigquery:///my-project",
+            credential,
+            Some("my-project"),
+            Some("configured_a"),
+        ));
+        let ctx_b = build_join_context(&bigquery_identity(
+            "bigquery:///my-project",
+            credential,
+            Some("my-project"),
+            Some("configured_b"),
+        ));
+        assert_ne!(
+            ctx_a, ctx_b,
+            "different explicitly configured schemas must not share a join context"
+        );
     }
 }
 

--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -941,6 +941,9 @@ struct ResolvedNamespaces {
     connection: ConnectionNamespace,
     /// Identifies the remote engine for join pushdown.
     join: ConnectionNamespace,
+    /// Whether the dataset path named the dataset, and so whether the emitted SQL
+    /// will qualify the table with it.
+    dataset_qualified_path: bool,
 }
 
 /// What a pool takes from its configuration: the namespace its connections
@@ -967,6 +970,7 @@ fn resolve_pool_identity(
     let namespaces = resolve_namespaces(driver_name, &params.component, &params.parameters)?;
     let driver_options = driver_options_for_identity(
         driver_name,
+        namespaces.dataset_qualified_path,
         params.parameters.get("driver_options").expose().ok(),
     );
     let join_context = build_join_context(&JoinIdentity {
@@ -997,10 +1001,12 @@ fn resolve_namespaces(
         return Ok(ResolvedNamespaces {
             connection: explicit.clone(),
             join: explicit,
+            dataset_qualified_path: false,
         });
     }
 
     let inferred = infer_bigquery_namespace(component);
+    let inferred_schema = inferred.schema.clone();
     let connection = ConnectionNamespace {
         catalog: explicit.catalog.clone().or(inferred.catalog),
         schema: explicit.schema.clone().or(inferred.schema),
@@ -1023,7 +1029,11 @@ fn resolve_namespaces(
         schema: explicit.schema,
     };
 
-    Ok(ResolvedNamespaces { connection, join })
+    Ok(ResolvedNamespaces {
+        connection,
+        join,
+        dataset_qualified_path: inferred_schema.is_some(),
+    })
 }
 
 fn infer_bigquery_namespace(component: &ConnectorComponent) -> ConnectionNamespace {
@@ -1159,19 +1169,30 @@ struct JoinIdentity<'a> {
 /// The `BigQuery` driver option naming the dataset a connection defaults to.
 const BIGQUERY_DATASET_OPTION: &str = "adbc.bigquery.sql.dataset_id=";
 
-/// Strips the default dataset out of the driver options for identity purposes.
+/// Strips the default dataset out of the driver options for identity purposes,
+/// but only when the emitted SQL will name the dataset itself.
 ///
 /// A `BigQuery` dataset can reach the connector two ways: as the first part of a
 /// dataset-qualified dataset path, or as `adbc.bigquery.sql.dataset_id` in the
-/// driver options. Neither bounds where a query can execute — `BigQuery` resolves
-/// a dataset-qualified reference anywhere in the project — so neither may divide
-/// the identity. Leaving this one in splits a statement into a query per dataset
-/// exactly as the inferred path would.
+/// driver options. Where the path carries it, the unparsed reference carries it
+/// too, so the dataset does not bound where the query can execute and must not
+/// divide the identity — leaving it in splits a statement into a query per
+/// dataset exactly as the inferred path would.
 ///
-/// Everything else in the options stays, the credential included.
-fn driver_options_for_identity(driver_name: &str, driver_options: Option<&str>) -> Option<String> {
+/// Where the path does **not** carry it, the reference is emitted bare and only
+/// the connection's default dataset says which table it means. Two such
+/// connections are not interchangeable: merging them runs every bare name against
+/// whichever pool executes the statement, which silently reads the wrong table.
+/// So the option stays in the identity there, and the statement stays split.
+///
+/// Everything else in the options stays either way, the credential included.
+fn driver_options_for_identity(
+    driver_name: &str,
+    dataset_qualified_path: bool,
+    driver_options: Option<&str>,
+) -> Option<String> {
     let options = driver_options?;
-    if driver_name != "bigquery" {
+    if driver_name != "bigquery" || !dataset_qualified_path {
         return Some(options.to_string());
     }
 
@@ -1857,11 +1878,56 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
         );
     }
 
+    /// A bare dataset path is emitted as a bare table reference, so only the
+    /// connection's default dataset says which table it means. Two such
+    /// connections must stay apart: merging them reads every bare name from
+    /// whichever pool ran the statement.
+    #[tokio::test]
+    async fn test_pool_identity_bigquery_bare_paths_stay_split() {
+        let a = bigquery_pool_identity(
+            "adbc:t",
+            "bigquery:///proj",
+            &format!(
+                "adbc.bigquery.sql.project_id=proj;adbc.bigquery.sql.dataset_id=ds_a;{TEST_CREDENTIAL_A}"
+            ),
+        )
+        .await;
+        let b = bigquery_pool_identity(
+            "adbc:t",
+            "bigquery:///proj",
+            &format!(
+                "adbc.bigquery.sql.project_id=proj;adbc.bigquery.sql.dataset_id=ds_b;{TEST_CREDENTIAL_A}"
+            ),
+        )
+        .await;
+
+        assert_ne!(
+            a.join_context, b.join_context,
+            "bare table references resolve against the connection's dataset, so two \
+             connections defaulting to different datasets must not share a join context"
+        );
+    }
+
+    #[test]
+    fn test_driver_options_for_identity_keeps_dataset_for_bare_paths() {
+        let options = Some("adbc.bigquery.sql.dataset_id=ds_a;adbc.bigquery.sql.project_id=proj");
+        assert_eq!(
+            driver_options_for_identity("bigquery", false, options).as_deref(),
+            options,
+            "a bare path needs the dataset kept, or two of them merge and read one table"
+        );
+        assert_eq!(
+            driver_options_for_identity("bigquery", true, options).as_deref(),
+            Some("adbc.bigquery.sql.project_id=proj"),
+            "a dataset-qualified path emits the dataset itself, so it leaves the identity"
+        );
+    }
+
     #[test]
     fn test_driver_options_for_identity_leaves_other_drivers_alone() {
         let options = Some("Database=sales;Uid=reader");
         assert_eq!(
-            driver_options_for_identity("postgresql", options).as_deref(),
+            driver_options_for_identity("postgresql", true, options).as_deref(),
             options,
             "only BigQuery's default dataset is stripped"
         );

--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -370,19 +370,13 @@ impl AdbcFactory {
         let driver_options = params.parameters.get("driver_options").expose().ok();
         let db_options = build_db_options(&uri_str, username, password, driver_options);
 
-        let pool_identity = resolve_pool_identity(
-            &driver_name_owned,
-            &driver_location,
-            &uri_str,
-            &params,
-        )
-        .map_err(|e| {
-                DataConnectorError::InvalidConfigurationSourceOnly {
+        let pool_identity =
+            resolve_pool_identity(&driver_name_owned, &driver_location, &uri_str, &params)
+                .map_err(|e| DataConnectorError::InvalidConfigurationSourceOnly {
                     dataconnector: "adbc".to_string(),
                     connector_component: params.component.clone(),
                     source: Box::new(e),
-                }
-            })?;
+                })?;
 
         let conn_options = build_conn_options(
             pool_identity.connection_namespace.catalog.as_deref(),

--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -1170,8 +1170,6 @@ struct JoinIdentity<'a> {
 ///   different hash, preventing incorrect cross-credential pushdown
 fn build_join_context(identity: &JoinIdentity<'_>) -> String {
     let mut hasher = Sha256::new();
-    // A NUL between fields keeps concatenations from colliding; no configuration
-    // value can contain one.
     for field in [
         Some(identity.driver),
         Some(identity.uri),
@@ -1181,9 +1179,19 @@ fn build_join_context(identity: &JoinIdentity<'_>) -> String {
         identity.catalog,
         identity.schema,
     ] {
-        if let Some(value) = field {
-            hasher.update(value.as_bytes());
+        // The presence marker keeps an absent option distinct from an empty one.
+        // They are different connection configurations -- `build_db_options` sends
+        // no option for the first and an empty-valued one for the second -- and
+        // without the marker each would contribute nothing but the separator.
+        match field {
+            Some(value) => {
+                hasher.update(b"1");
+                hasher.update(value.as_bytes());
+            }
+            None => hasher.update(b"0"),
         }
+        // A NUL between fields keeps concatenations from colliding; no
+        // configuration value can contain one.
         hasher.update(b"\0");
     }
     hasher.finalize().iter().fold(String::new(), |mut hash, b| {
@@ -2249,6 +2257,35 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
         assert_ne!(
             ctx_a, ctx_b,
             "different service-account identities must not share a join context"
+        );
+    }
+
+    /// An absent option and an empty one are different connection configurations --
+    /// `build_db_options` sends no password option for the first and `Password("")`
+    /// for the second -- so they must not share a join context.
+    #[test]
+    fn test_build_join_context_distinguishes_absent_from_empty() {
+        let absent = build_join_context(&JoinIdentity {
+            driver: "postgresql",
+            uri: "postgresql://host/db",
+            username: Some("user"),
+            password: None,
+            driver_options: None,
+            catalog: None,
+            schema: None,
+        });
+        let empty = build_join_context(&JoinIdentity {
+            driver: "postgresql",
+            uri: "postgresql://host/db",
+            username: Some("user"),
+            password: Some(""),
+            driver_options: None,
+            catalog: None,
+            schema: None,
+        });
+        assert_ne!(
+            absent, empty,
+            "an absent option and an empty one must not share a join context"
         );
     }
 

--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -370,8 +370,13 @@ impl AdbcFactory {
         let driver_options = params.parameters.get("driver_options").expose().ok();
         let db_options = build_db_options(&uri_str, username, password, driver_options);
 
-        let pool_identity =
-            resolve_pool_identity(&driver_name_owned, &uri_str, &params).map_err(|e| {
+        let pool_identity = resolve_pool_identity(
+            &driver_name_owned,
+            &driver_location,
+            &uri_str,
+            &params,
+        )
+        .map_err(|e| {
                 DataConnectorError::InvalidConfigurationSourceOnly {
                     dataconnector: "adbc".to_string(),
                     connector_component: params.component.clone(),
@@ -961,12 +966,14 @@ struct PoolIdentity {
 
 fn resolve_pool_identity(
     driver_name: &str,
+    driver_location: &str,
     uri: &str,
     params: &ConnectorParams,
 ) -> Result<PoolIdentity> {
     let namespaces = resolve_namespaces(driver_name, &params.component, &params.parameters)?;
     let join_context = build_join_context(&JoinIdentity {
         driver: driver_name,
+        driver_location,
         uri,
         username: params.parameters.get("username").expose().ok(),
         password: params.parameters.get("password").expose().ok(),
@@ -1144,6 +1151,9 @@ fn build_conn_options(
 /// here matches: same driver, same endpoint, same credential, same namespace.
 struct JoinIdentity<'a> {
     driver: &'a str,
+    /// The driver binary actually loaded (`driver_path` when set, else the driver
+    /// name). Two different driver implementations are not one engine.
+    driver_location: &'a str,
     uri: &'a str,
     username: Option<&'a str>,
     password: Option<&'a str>,
@@ -1172,6 +1182,7 @@ fn build_join_context(identity: &JoinIdentity<'_>) -> String {
     let mut hasher = Sha256::new();
     for field in [
         Some(identity.driver),
+        Some(identity.driver_location),
         Some(identity.uri),
         identity.username,
         identity.password,
@@ -1773,7 +1784,8 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
             io_runtime: tokio::runtime::Handle::current(),
         };
 
-        resolve_pool_identity("bigquery", uri, &params).expect("pool identity should resolve")
+        resolve_pool_identity("bigquery", "bigquery", uri, &params)
+            .expect("pool identity should resolve")
     }
 
     /// The customer-shaped case. A statement joining two `BigQuery` datasets in one
@@ -2084,6 +2096,7 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
     ) -> JoinIdentity<'a> {
         JoinIdentity {
             driver: "bigquery",
+            driver_location: "bigquery",
             uri,
             username: None,
             password: None,
@@ -2097,6 +2110,7 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
     fn test_build_join_context_no_secrets_in_output() {
         let ctx = build_join_context(&JoinIdentity {
             driver: "bigquery",
+            driver_location: "/drivers/libadbc_driver_bigquery.so",
             uri: "bigquery:///project?DatasetId=tpch_sf1&token=SECRET123",
             username: Some("admin"),
             password: Some("hunter2"),
@@ -2144,6 +2158,7 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
     fn postgres_identity<'a>(uri: &'a str, username: Option<&'a str>) -> JoinIdentity<'a> {
         JoinIdentity {
             driver: "postgresql",
+            driver_location: "postgresql",
             uri,
             username,
             password: None,
@@ -2260,6 +2275,36 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
         );
     }
 
+    /// `driver_path` selects the driver binary that is loaded, so two configurations
+    /// naming different binaries are not one remote engine.
+    #[test]
+    fn test_build_join_context_differs_by_driver_location() {
+        let a = build_join_context(&JoinIdentity {
+            driver: "bigquery",
+            driver_location: "/drivers/a/libadbc_driver_bigquery.so",
+            uri: "bigquery:///my-project",
+            username: None,
+            password: None,
+            driver_options: None,
+            catalog: Some("my-project"),
+            schema: None,
+        });
+        let b = build_join_context(&JoinIdentity {
+            driver: "bigquery",
+            driver_location: "/drivers/b/libadbc_driver_bigquery.so",
+            uri: "bigquery:///my-project",
+            username: None,
+            password: None,
+            driver_options: None,
+            catalog: Some("my-project"),
+            schema: None,
+        });
+        assert_ne!(
+            a, b,
+            "different driver binaries must not share a join context"
+        );
+    }
+
     /// An absent option and an empty one are different connection configurations --
     /// `build_db_options` sends no password option for the first and `Password("")`
     /// for the second -- so they must not share a join context.
@@ -2267,6 +2312,7 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
     fn test_build_join_context_distinguishes_absent_from_empty() {
         let absent = build_join_context(&JoinIdentity {
             driver: "postgresql",
+            driver_location: "postgresql",
             uri: "postgresql://host/db",
             username: Some("user"),
             password: None,
@@ -2276,6 +2322,7 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
         });
         let empty = build_join_context(&JoinIdentity {
             driver: "postgresql",
+            driver_location: "postgresql",
             uri: "postgresql://host/db",
             username: Some("user"),
             password: Some(""),

--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -371,12 +371,13 @@ impl AdbcFactory {
         let db_options = build_db_options(&uri_str, username, password, driver_options);
 
         let pool_identity =
-            resolve_pool_identity(&driver_name_owned, &driver_location, &uri_str, &params)
-                .map_err(|e| DataConnectorError::InvalidConfigurationSourceOnly {
+            resolve_pool_identity(&driver_name_owned, &uri_str, &params).map_err(|e| {
+                DataConnectorError::InvalidConfigurationSourceOnly {
                     dataconnector: "adbc".to_string(),
                     connector_component: params.component.clone(),
                     source: Box::new(e),
-                })?;
+                }
+            })?;
 
         let conn_options = build_conn_options(
             pool_identity.connection_namespace.catalog.as_deref(),
@@ -842,22 +843,10 @@ fn compute_adbc_cache_key(params: &ConnectorParams) -> String {
 
     let mut hasher = blake3::Hasher::new();
     for k in &keys {
-        let v = params.parameters.get(k).expose().ok();
+        let v = params.parameters.get(k).expose().ok().unwrap_or("");
         hasher.update(k.as_bytes());
         hasher.update(b"\0");
-        // Presence is part of the key, as it is for the namespace below: an absent
-        // parameter and an empty one are different connection configurations, and
-        // collapsing them here would hand both the same pooled connection.
-        match v {
-            Some(value) => {
-                hasher.update(b"1");
-                hasher.update(b"\0");
-                hasher.update(value.as_bytes());
-            }
-            None => {
-                hasher.update(b"0");
-            }
-        }
+        hasher.update(v.as_bytes());
         hasher.update(b"\0");
     }
 
@@ -972,18 +961,18 @@ struct PoolIdentity {
 
 fn resolve_pool_identity(
     driver_name: &str,
-    driver_location: &str,
     uri: &str,
     params: &ConnectorParams,
 ) -> Result<PoolIdentity> {
     let namespaces = resolve_namespaces(driver_name, &params.component, &params.parameters)?;
+    let driver_options = driver_options_for_identity(
+        driver_name,
+        params.parameters.get("driver_options").expose().ok(),
+    );
     let join_context = build_join_context(&JoinIdentity {
-        driver: driver_name,
-        driver_location,
         uri,
         username: params.parameters.get("username").expose().ok(),
-        password: params.parameters.get("password").expose().ok(),
-        driver_options: params.parameters.get("driver_options").expose().ok(),
+        driver_options: driver_options.as_deref(),
         catalog: namespaces.join.catalog.as_deref(),
         schema: namespaces.join.schema.as_deref(),
     });
@@ -1154,21 +1143,45 @@ fn build_conn_options(
 /// Everything that decides which remote engine an ADBC table is executed by.
 ///
 /// Two tables may be joined in one pushed-down statement exactly when every field
-/// here matches: same driver, same endpoint, same credential, same namespace.
+/// here matches: same endpoint, same credential, same namespace.
 struct JoinIdentity<'a> {
-    driver: &'a str,
-    /// The driver binary actually loaded (`driver_path` when set, else the driver
-    /// name). Two different driver implementations are not one engine.
-    driver_location: &'a str,
     uri: &'a str,
     username: Option<&'a str>,
-    password: Option<&'a str>,
-    /// Driver-specific options. For `BigQuery` these carry the service-account
-    /// credential, which is why they belong to the identity: the same project
-    /// reached as two identities is two engines, not one.
+    /// Driver options with anything naming a namespace removed — see
+    /// [`driver_options_for_identity`]. For `BigQuery` these carry the
+    /// service-account credential, so the same project reached as two identities
+    /// stays two engines.
     driver_options: Option<&'a str>,
     catalog: Option<&'a str>,
     schema: Option<&'a str>,
+}
+
+/// The `BigQuery` driver option naming the dataset a connection defaults to.
+const BIGQUERY_DATASET_OPTION: &str = "adbc.bigquery.sql.dataset_id=";
+
+/// Strips the default dataset out of the driver options for identity purposes.
+///
+/// A `BigQuery` dataset can reach the connector two ways: as the first part of a
+/// dataset-qualified dataset path, or as `adbc.bigquery.sql.dataset_id` in the
+/// driver options. Neither bounds where a query can execute — `BigQuery` resolves
+/// a dataset-qualified reference anywhere in the project — so neither may divide
+/// the identity. Leaving this one in splits a statement into a query per dataset
+/// exactly as the inferred path would.
+///
+/// Everything else in the options stays, the credential included.
+fn driver_options_for_identity(driver_name: &str, driver_options: Option<&str>) -> Option<String> {
+    let options = driver_options?;
+    if driver_name != "bigquery" {
+        return Some(options.to_string());
+    }
+
+    Some(
+        options
+            .split(';')
+            .filter(|option| !option.trim_start().starts_with(BIGQUERY_DATASET_OPTION))
+            .collect::<Vec<_>>()
+            .join(";"),
+    )
 }
 
 /// Builds a hashed join-pushdown context identifier for ADBC connections.
@@ -1186,29 +1199,18 @@ struct JoinIdentity<'a> {
 ///   different hash, preventing incorrect cross-credential pushdown
 fn build_join_context(identity: &JoinIdentity<'_>) -> String {
     let mut hasher = Sha256::new();
+    // A NUL between fields keeps concatenations from colliding; no configuration
+    // value can contain one.
     for field in [
-        Some(identity.driver),
-        Some(identity.driver_location),
         Some(identity.uri),
         identity.username,
-        identity.password,
         identity.driver_options,
         identity.catalog,
         identity.schema,
     ] {
-        // The presence marker keeps an absent option distinct from an empty one.
-        // They are different connection configurations -- `build_db_options` sends
-        // no option for the first and an empty-valued one for the second -- and
-        // without the marker each would contribute nothing but the separator.
-        match field {
-            Some(value) => {
-                hasher.update(b"1");
-                hasher.update(value.as_bytes());
-            }
-            None => hasher.update(b"0"),
+        if let Some(value) = field {
+            hasher.update(value.as_bytes());
         }
-        // A NUL between fields keeps concatenations from colliding; no
-        // configuration value can contain one.
         hasher.update(b"\0");
     }
     hasher.finalize().iter().fold(String::new(), |mut hash, b| {
@@ -1766,40 +1768,6 @@ mod tests {
         );
     }
 
-    /// The pool cache decides which connector instance is reused, so it has to make
-    /// the same distinctions the join identity does. If it collapses them, two
-    /// configurations share one pool and the join identity never sees them apart.
-    #[tokio::test]
-    async fn test_cache_key_distinguishes_absent_from_empty_password() {
-        let dataset = test_dataset("adbc:ds.table", "table").await;
-
-        let make_params = |password: Option<&str>| {
-            let mut entries = vec![
-                ("driver".to_string(), SecretString::from("bigquery")),
-                (
-                    "uri".to_string(),
-                    SecretString::from("bigquery:///my-project"),
-                ),
-            ];
-            if let Some(password) = password {
-                entries.push(("password".to_string(), SecretString::from(password)));
-            }
-
-            ConnectorParams {
-                parameters: Parameters::new(entries, "adbc", PARAMETERS),
-                unsupported_type_action: None,
-                component: ConnectorComponent::from(&dataset),
-                io_runtime: tokio::runtime::Handle::current(),
-            }
-        };
-
-        assert_ne!(
-            compute_adbc_cache_key(&make_params(None)),
-            compute_adbc_cache_key(&make_params(Some(""))),
-            "an absent password and an empty one must not share a pooled connector"
-        );
-    }
-
     const TEST_CREDENTIAL_A: &str = "adbc.bigquery.sql.auth_type=adbc.bigquery.sql.auth_type.json_credential_string;\
 adbc.bigquery.sql.auth_credentials={\"client_email\":\"a@example.iam.gserviceaccount.com\"}";
     const TEST_CREDENTIAL_B: &str = "adbc.bigquery.sql.auth_type=adbc.bigquery.sql.auth_type.json_credential_string;\
@@ -1824,8 +1792,7 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
             io_runtime: tokio::runtime::Handle::current(),
         };
 
-        resolve_pool_identity("bigquery", "bigquery", uri, &params)
-            .expect("pool identity should resolve")
+        resolve_pool_identity("bigquery", uri, &params).expect("pool identity should resolve")
     }
 
     /// The customer-shaped case. A statement joining two `BigQuery` datasets in one
@@ -1859,6 +1826,44 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
         assert_eq!(
             ledger.connection_namespace.schema.as_deref(),
             Some("ledger_ds")
+        );
+    }
+
+    /// The dataset can also arrive as `adbc.bigquery.sql.dataset_id` in the driver
+    /// options rather than in the dataset path. It is the same dataset either way,
+    /// so it must not divide the identity either way.
+    #[tokio::test]
+    async fn test_pool_identity_bigquery_dataset_option_does_not_split() {
+        let core = bigquery_pool_identity(
+            "adbc:core_ds.clients",
+            "bigquery:///proj",
+            &format!(
+                "adbc.bigquery.sql.project_id=proj;adbc.bigquery.sql.dataset_id=core_ds;{TEST_CREDENTIAL_A}"
+            ),
+        )
+        .await;
+        let ledger = bigquery_pool_identity(
+            "adbc:ledger_ds.entries",
+            "bigquery:///proj",
+            &format!(
+                "adbc.bigquery.sql.project_id=proj;adbc.bigquery.sql.dataset_id=ledger_ds;{TEST_CREDENTIAL_A}"
+            ),
+        )
+        .await;
+
+        assert_eq!(
+            core.join_context, ledger.join_context,
+            "the default dataset must not divide the join context, in the path or the driver options"
+        );
+    }
+
+    #[test]
+    fn test_driver_options_for_identity_leaves_other_drivers_alone() {
+        let options = Some("Database=sales;Uid=reader");
+        assert_eq!(
+            driver_options_for_identity("postgresql", options).as_deref(),
+            options,
+            "only BigQuery's default dataset is stripped"
         );
     }
 
@@ -2135,11 +2140,8 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
         schema: Option<&'a str>,
     ) -> JoinIdentity<'a> {
         JoinIdentity {
-            driver: "bigquery",
-            driver_location: "bigquery",
             uri,
             username: None,
-            password: None,
             driver_options,
             catalog,
             schema,
@@ -2149,11 +2151,8 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
     #[test]
     fn test_build_join_context_no_secrets_in_output() {
         let ctx = build_join_context(&JoinIdentity {
-            driver: "bigquery",
-            driver_location: "/drivers/libadbc_driver_bigquery.so",
             uri: "bigquery:///project?DatasetId=tpch_sf1&token=SECRET123",
             username: Some("admin"),
-            password: Some("hunter2"),
             driver_options: Some("adbc.bigquery.sql.auth_credentials=SECRET_KEY_MATERIAL"),
             catalog: Some("my_catalog"),
             schema: Some("my_schema"),
@@ -2176,10 +2175,6 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
             "context must not contain raw catalog"
         );
         assert!(
-            !ctx.contains("hunter2"),
-            "context must not contain raw password"
-        );
-        assert!(
             !ctx.contains("SECRET_KEY_MATERIAL"),
             "context must not contain raw credential material from driver options"
         );
@@ -2197,11 +2192,8 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
 
     fn postgres_identity<'a>(uri: &'a str, username: Option<&'a str>) -> JoinIdentity<'a> {
         JoinIdentity {
-            driver: "postgresql",
-            driver_location: "postgresql",
             uri,
             username,
-            password: None,
             driver_options: None,
             catalog: None,
             schema: None,
@@ -2312,67 +2304,6 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
         assert_ne!(
             ctx_a, ctx_b,
             "different service-account identities must not share a join context"
-        );
-    }
-
-    /// `driver_path` selects the driver binary that is loaded, so two configurations
-    /// naming different binaries are not one remote engine.
-    #[test]
-    fn test_build_join_context_differs_by_driver_location() {
-        let a = build_join_context(&JoinIdentity {
-            driver: "bigquery",
-            driver_location: "/drivers/a/libadbc_driver_bigquery.so",
-            uri: "bigquery:///my-project",
-            username: None,
-            password: None,
-            driver_options: None,
-            catalog: Some("my-project"),
-            schema: None,
-        });
-        let b = build_join_context(&JoinIdentity {
-            driver: "bigquery",
-            driver_location: "/drivers/b/libadbc_driver_bigquery.so",
-            uri: "bigquery:///my-project",
-            username: None,
-            password: None,
-            driver_options: None,
-            catalog: Some("my-project"),
-            schema: None,
-        });
-        assert_ne!(
-            a, b,
-            "different driver binaries must not share a join context"
-        );
-    }
-
-    /// An absent option and an empty one are different connection configurations --
-    /// `build_db_options` sends no password option for the first and `Password("")`
-    /// for the second -- so they must not share a join context.
-    #[test]
-    fn test_build_join_context_distinguishes_absent_from_empty() {
-        let absent = build_join_context(&JoinIdentity {
-            driver: "postgresql",
-            driver_location: "postgresql",
-            uri: "postgresql://host/db",
-            username: Some("user"),
-            password: None,
-            driver_options: None,
-            catalog: None,
-            schema: None,
-        });
-        let empty = build_join_context(&JoinIdentity {
-            driver: "postgresql",
-            driver_location: "postgresql",
-            uri: "postgresql://host/db",
-            username: Some("user"),
-            password: Some(""),
-            driver_options: None,
-            catalog: None,
-            schema: None,
-        });
-        assert_ne!(
-            absent, empty,
-            "an absent option and an empty one must not share a join context"
         );
     }
 

--- a/crates/data-connectors/connector-adbc/src/lib.rs
+++ b/crates/data-connectors/connector-adbc/src/lib.rs
@@ -874,6 +874,17 @@ fn compute_adbc_cache_key(params: &ConnectorParams) -> String {
 }
 
 /// Builds the list of ADBC database options from connector parameters.
+/// Applies the `adbc.` prefix a driver-option key takes when it is written without
+/// one. `bigquery.sql.dataset_id` and `adbc.bigquery.sql.dataset_id` name the same
+/// option, so anything matching on a key has to agree on the spelling.
+fn normalize_driver_option_key(key: &str) -> String {
+    if key.starts_with("adbc.") {
+        key.to_string()
+    } else {
+        format!("adbc.{key}")
+    }
+}
+
 pub(crate) fn build_db_options(
     uri: &str,
     username: Option<&str>,
@@ -899,12 +910,10 @@ pub(crate) fn build_db_options(
                     tracing::warn!("Ignoring ADBC driver option with empty key");
                     continue;
                 }
-                let key = if key.starts_with("adbc.") {
-                    key.to_string()
-                } else {
-                    format!("adbc.{key}")
-                };
-                opts.push((OptionDatabase::Other(key), value.trim().into()));
+                opts.push((
+                    OptionDatabase::Other(normalize_driver_option_key(key)),
+                    value.trim().into(),
+                ));
             } else {
                 tracing::warn!("Ignoring malformed ADBC driver option (expected 'key=value')");
             }
@@ -1166,8 +1175,9 @@ struct JoinIdentity<'a> {
     schema: Option<&'a str>,
 }
 
-/// The `BigQuery` driver option naming the dataset a connection defaults to.
-const BIGQUERY_DATASET_OPTION: &str = "adbc.bigquery.sql.dataset_id=";
+/// The `BigQuery` driver option naming the dataset a connection defaults to, in the
+/// normalized spelling [`normalize_driver_option_key`] produces.
+const BIGQUERY_DATASET_OPTION: &str = "adbc.bigquery.sql.dataset_id";
 
 /// Strips the default dataset out of the driver options for identity purposes,
 /// but only when the emitted SQL will name the dataset itself.
@@ -1199,7 +1209,16 @@ fn driver_options_for_identity(
     Some(
         options
             .split(';')
-            .filter(|option| !option.trim_start().starts_with(BIGQUERY_DATASET_OPTION))
+            .filter(|option| {
+                // Match the key the way the driver will receive it, not the way it
+                // happens to be written: the prefix is optional and the separator
+                // may be padded.
+                option
+                    .split_once('=')
+                    .map(|(key, _)| normalize_driver_option_key(key.trim()))
+                    .as_deref()
+                    != Some(BIGQUERY_DATASET_OPTION)
+            })
             .collect::<Vec<_>>()
             .join(";"),
     )
@@ -1906,6 +1925,22 @@ adbc.bigquery.sql.auth_credentials={\"client_email\":\"b@example.iam.gserviceacc
             "bare table references resolve against the connection's dataset, so two \
              connections defaulting to different datasets must not share a join context"
         );
+    }
+
+    #[test]
+    fn test_driver_options_for_identity_matches_every_spelling_of_the_key() {
+        for written in [
+            "adbc.bigquery.sql.dataset_id=ds_a",
+            "bigquery.sql.dataset_id=ds_a",
+            " adbc.bigquery.sql.dataset_id = ds_a ",
+        ] {
+            let options = format!("{written};adbc.bigquery.sql.project_id=proj");
+            assert_eq!(
+                driver_options_for_identity("bigquery", true, Some(&options)).as_deref(),
+                Some("adbc.bigquery.sql.project_id=proj"),
+                "the dataset option was not recognised written as `{written}`"
+            );
+        }
     }
 
     #[test]

--- a/test/scripts/bigquery-federation.sh
+++ b/test/scripts/bigquery-federation.sh
@@ -22,4 +22,4 @@ fi
 
 repo_root=$(cd "$(dirname "$0")/../.." && pwd)
 exec uv run --with google-cloud-bigquery==3.38.0 \
-  python "$repo_root/test/scripts/bigquery_federation.py"
+  python "$repo_root/test/scripts/bigquery_federation.py" "$@"

--- a/test/scripts/bigquery-federation.sh
+++ b/test/scripts/bigquery-federation.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: uv is required to run the real-BigQuery federation harness." >&2
+  exit 1
+fi
+
+repo_root=$(cd "$(dirname "$0")/../.." && pwd)
+exec uv run --with google-cloud-bigquery==3.38.0 \
+  python "$repo_root/test/scripts/bigquery_federation.py"

--- a/test/scripts/bigquery_federation.py
+++ b/test/scripts/bigquery_federation.py
@@ -20,7 +20,7 @@ is eligible to run as a single BigQuery job. This harness runs such a statement
 through a real ``spiced`` and counts the jobs BigQuery actually received, so the
 count is observed rather than inferred from a plan.
 
-Two scenarios run against the same pod:
+Three scenarios run against the same pod:
 
 ``same-dataset``
     Every table is in one BigQuery dataset. The statement references a CTE three
@@ -31,8 +31,14 @@ Two scenarios run against the same pod:
     The same statement shape, with one table moved to a second dataset in the
     same project under the same credential.
 
-Both scenarios are compared against the identical statement submitted straight
-to BigQuery, so a job-count change is only meaningful alongside matching rows.
+``json-cross-dataset``
+    The cross-dataset shape, projecting ``json_get_str``. A function the unparser
+    cannot render is left above the federated scan and evaluated locally, which
+    the job count alone would not reveal, so this scenario also asserts that the
+    BigQuery JSON calls appear in the pushed SQL.
+
+Every scenario is compared against the identical statement submitted straight to
+BigQuery, so a job-count change is only meaningful alongside matching rows.
 
 This is an opt-in integration harness, not a vacuous skip. It fails at startup
 unless a service-account credential and the ADBC BigQuery driver are supplied.
@@ -56,7 +62,7 @@ harness never falls back to application-default credentials.
 Job counting reads ``INFORMATION_SCHEMA.JOBS_BY_USER``, which reports the jobs
 this credential itself created, so it needs no project-wide job-list permission.
 
-Exit status is 0 when both scenarios return correct rows as a single BigQuery
+Exit status is 0 when every scenario returns correct rows as a single BigQuery
 job. ``BIGQUERY_EXPECT=split`` inverts the job-count expectation for the
 cross-dataset scenario, which is how the pre-fix reproduction is recorded as a
 pass rather than as a failed run.

--- a/test/scripts/bigquery_federation.py
+++ b/test/scripts/bigquery_federation.py
@@ -597,7 +597,12 @@ def main() -> int:
                 latest = data_jobs(
                     client, project, location, since, until, (core, ledger), harness_jobs
                 )
-                stable = stable + 1 if len(latest) == len(observed) else 0
+                # Every scenario runs at least one job, so an empty sample means
+                # JOBS_BY_USER has not caught up yet, never that counting is done.
+                if latest and len(latest) == len(observed):
+                    stable += 1
+                else:
+                    stable = 0
                 observed = latest
 
             texts = [job["query"] for job in observed]

--- a/test/scripts/bigquery_federation.py
+++ b/test/scripts/bigquery_federation.py
@@ -467,6 +467,10 @@ def main() -> int:
         (output / "setup.sql").write_text(setup, encoding="utf-8")
         setup_job = client.query(setup, location=location)
         setup_job.result()
+        # The setup job references both datasets, so it matches the same predicates
+        # the job census uses. A scenario's window opens five seconds before its
+        # query, which a fast startup could stretch back over this job.
+        harness_jobs = {setup_job.job_id}
         print(f"setup_job={setup_job.job_id} datasets={project}.{{{core},{ledger}}} location={location}")
 
         pod = spicepod(project, core, ledger, driver)
@@ -580,9 +584,9 @@ def main() -> int:
             control = [
                 {key: value for key, value in dict(row).items()} for row in control_job.result()
             ]
-            # This credential is spiced's too, so the control and the job-log reads
-            # would otherwise show up as jobs spiced ran.
-            harness_jobs = {control_job.job_id}
+            # This credential is spiced's too, so the harness's own queries would
+            # otherwise show up as jobs spiced ran.
+            harness_jobs.add(control_job.job_id)
 
             # JOBS_BY_USER lags job creation, so poll until it stops growing.
             observed: list[dict[str, Any]] = []

--- a/test/scripts/bigquery_federation.py
+++ b/test/scripts/bigquery_federation.py
@@ -61,6 +61,10 @@ harness never falls back to application-default credentials.
 
 Job counting reads ``INFORMATION_SCHEMA.JOBS_BY_USER``, which reports the jobs
 this credential itself created, so it needs no project-wide job-list permission.
+That view makes a job visible some time after it is created, so each scenario
+watches it for a fixed window (``JOB_OBSERVATION_SECONDS``) rather than stopping
+when the count settles, and treats the plan's statement count as a floor -- see
+``observe_jobs``. Run ``--self-test`` to check that criterion without credentials.
 
 Exit status is 0 when every scenario returns correct rows as a single BigQuery
 job. ``BIGQUERY_EXPECT=split`` inverts the job-count expectation for the
@@ -94,6 +98,11 @@ DEFAULT_SPICED = ROOT / "target" / "debug" / "spiced"
 DATASET_PREFIX = "spice_bigquery_federation"
 DATASET_ID_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 PROJECT_ID_PATTERN = re.compile(r"^[a-z][a-z0-9-]{4,61}[a-z0-9]$")
+
+# How long to watch the job census, and how often to read it. See `observe_jobs`
+# for why this is a fixed window rather than a settle detector.
+JOB_OBSERVATION_SECONDS = 90
+JOB_POLL_SECONDS = 5
 
 # `clients` is referenced three times, so DataFusion inlines three copies of its
 # subtree. The two scenarios differ only in which dataset `entries` is read from.
@@ -263,32 +272,39 @@ SELECT * FROM UNNEST([
 
 
 def spicepod(project: str, core: str, ledger: str, driver: Path) -> str:
-    # One params block, so every dataset shares one URI, one credential and one
-    # project. Paths are dataset-qualified, which is the only difference between
-    # the tables the two scenarios read.
-    params = f"""      adbc_driver: bigquery
+    """Build the pod the way a real one is written.
+
+    Every dataset shares one URI, one project and one credential, and names its own
+    dataset twice over — once as the first part of a dataset-qualified path, and
+    once as `adbc.bigquery.sql.dataset_id` in the driver options. Both are how a
+    dataset actually reaches the connector, so both belong in the fixture.
+    """
+
+    def dataset(name: str, schema: str, table: str) -> str:
+        return f"""  - from: adbc:{schema}.{table}
+    name: {name}
+    params:
+      adbc_driver: bigquery
       adbc_driver_path: {driver}
-      adbc_driver_options: adbc.bigquery.sql.auth_type=adbc.bigquery.sql.auth_type.json_credential_string;adbc.bigquery.sql.auth_credentials=${{secrets:BIGQUERY_SERVICE_ACCOUNT_JSON}}
-      adbc_uri: bigquery:///{project}"""
+      adbc_driver_options: adbc.bigquery.sql.project_id={project};adbc.bigquery.sql.dataset_id={schema};adbc.bigquery.sql.auth_type=adbc.bigquery.sql.auth_type.json_credential_string;adbc.bigquery.sql.auth_credentials=${{secrets:BIGQUERY_SERVICE_ACCOUNT_JSON}}
+      adbc_uri: bigquery:///{project}
+      connection_pool_size: 8
+"""
+
+    entries = "".join(
+        [
+            dataset("clients", core, "clients"),
+            dataset("advances", core, "advances"),
+            dataset("entries_core", core, "entries_core"),
+            dataset("entries_ledger", ledger, "entries_ledger"),
+        ]
+    )
     return f"""version: v1
 kind: Spicepod
 name: bigquery-federation
 
 datasets:
-  - from: adbc:{core}.clients
-    name: clients
-    params: &bigquery_params
-{params}
-  - from: adbc:{core}.advances
-    name: advances
-    params: *bigquery_params
-  - from: adbc:{core}.entries_core
-    name: entries_core
-    params: *bigquery_params
-  - from: adbc:{ledger}.entries_ledger
-    name: entries_ledger
-    params: *bigquery_params
-"""
+{entries}"""
 
 
 def http_sql(http_port: int, sql: str, timeout: int = 120) -> tuple[int, dict[str, str], str]:
@@ -417,6 +433,143 @@ ORDER BY creation_time
     )
     rows = list(client.query(sql, location=location, job_config=config).result())
     return [dict(row) for row in rows if row["job_id"] not in exclude]
+
+
+def observe_jobs(
+    sample: Any,
+    expected: int,
+    *,
+    window: int = JOB_OBSERVATION_SECONDS,
+    interval: int = JOB_POLL_SECONDS,
+    sleep: Any = time.sleep,
+    clock: Any = time.monotonic,
+) -> list[dict[str, Any]]:
+    """Watch the job census for a fixed window and return the final reading.
+
+    `INFORMATION_SCHEMA.JOBS_BY_USER` makes a job visible some time after it is
+    created, and nothing the harness can see bounds that lag. Stopping as soon as
+    the count holds steady therefore cannot tell "the engine ran one job" apart
+    from "the rest are not visible yet" — and a split becomes visible one job at a
+    time, so the first steady reading of three jobs is usually one. That criterion
+    fails towards a pass, which is the one direction this measurement must never
+    fail in, since a single job is what the fix claims.
+
+    So the window is fixed and always runs to completion, and `expected` — the
+    number of statements the plan will push — is a floor. A census that never
+    reaches it has not observed the run and says so, rather than returning a
+    partial count for an assertion to read as success.
+    """
+    deadline = clock() + window
+    observed: list[dict[str, Any]] = []
+    while clock() < deadline:
+        sleep(interval)
+        observed = sample()
+    if len(observed) < expected:
+        raise HarnessError(
+            f"the job census saw {len(observed)} job(s) in {window}s but the plan pushes "
+            f"{expected} statement(s); the run was not observed, so its job count is unknown"
+        )
+    return observed
+
+
+class _StepClock:
+    """A clock that only advances when the code under test sleeps."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _scheduled_sample(schedule: list[list[str]]) -> Any:
+    """A census that returns `schedule[n]` on the nth read, holding the last entry."""
+    reads = {"n": 0}
+
+    def sample() -> list[dict[str, Any]]:
+        index = min(reads["n"], len(schedule) - 1)
+        reads["n"] += 1
+        return [{"job_id": job_id, "query": ""} for job_id in schedule[index]]
+
+    return sample
+
+
+def _stops_when_steady(
+    sample: Any, *, interval: int, sleep: Any, clock: Any, window: int = 120
+) -> list[dict[str, Any]]:
+    """Stop as soon as the count holds steady for three reads.
+
+    This is the tempting way to end the observation, and `observe_jobs` must never
+    be simplified back into it: a split becomes visible one job at a time, so this
+    returns the first job on its own and an assertion of "exactly one job" reads
+    that as success. `self_test` keeps a counter-example on hand.
+    """
+    deadline = clock() + window
+    observed: list[dict[str, Any]] = []
+    stable = 0
+    while clock() < deadline and stable < 3:
+        sleep(interval)
+        latest = sample()
+        if latest and len(latest) == len(observed):
+            stable += 1
+        else:
+            stable = 0
+        observed = latest
+    return observed
+
+
+def self_test() -> int:
+    """Check the observation criterion without touching BigQuery."""
+    failures: list[str] = []
+
+    # One job visible first, the other two only after four reads -- what a split
+    # looks like through a lagging census.
+    delayed = [["a"], ["a"], ["a"], ["a"], ["a", "b", "c"]]
+
+    clock = _StepClock()
+    steady = _stops_when_steady(
+        _scheduled_sample(delayed), interval=JOB_POLL_SECONDS, sleep=clock.sleep, clock=clock
+    )
+    if len(steady) != 1:
+        failures.append(
+            f"counter-example did not reproduce: a settle detector returned {len(steady)}, expected 1"
+        )
+
+    clock = _StepClock()
+    observed = observe_jobs(
+        _scheduled_sample(delayed), 3, sleep=clock.sleep, clock=clock
+    )
+    if len(observed) != 3:
+        failures.append(
+            f"a delayed split was miscounted: observed {len(observed)} job(s), expected 3"
+        )
+
+    clock = _StepClock()
+    single = observe_jobs(_scheduled_sample([["a"]]), 1, sleep=clock.sleep, clock=clock)
+    if len(single) != 1:
+        failures.append(f"a steady single job was miscounted as {len(single)}")
+
+    clock = _StepClock()
+    try:
+        observe_jobs(_scheduled_sample([["a"]]), 3, sleep=clock.sleep, clock=clock)
+    except HarnessError:
+        pass
+    else:
+        failures.append("a census short of the plan's statement count did not fail")
+
+    for failure in failures:
+        print(f"FAIL: {failure}", file=sys.stderr)
+    if failures:
+        return 1
+    print(
+        "self-test ok: a settle detector reports 1 job for a delayed split; "
+        "the fixed window reports 3, counts a steady single job as 1, and fails "
+        "when the census never reaches the plan's statement count"
+    )
+    return 0
 
 
 def main() -> int:
@@ -594,22 +747,12 @@ def main() -> int:
             # otherwise show up as jobs spiced ran.
             harness_jobs.add(control_job.job_id)
 
-            # JOBS_BY_USER lags job creation, so poll until it stops growing.
-            observed: list[dict[str, Any]] = []
-            stable = 0
-            deadline = time.monotonic() + 120
-            while time.monotonic() < deadline and stable < 3:
-                time.sleep(5)
-                latest = data_jobs(
+            observed = observe_jobs(
+                lambda: data_jobs(
                     client, project, location, since, until, (core, ledger), harness_jobs
-                )
-                # Every scenario runs at least one job, so an empty sample means
-                # JOBS_BY_USER has not caught up yet, never that counting is done.
-                if latest and len(latest) == len(observed):
-                    stable += 1
-                else:
-                    stable = 0
-                observed = latest
+                ),
+                len(statements),
+            )
 
             texts = [job["query"] for job in observed]
             scenario = {
@@ -686,6 +829,8 @@ def main() -> int:
 
 if __name__ == "__main__":
     try:
+        if "--self-test" in sys.argv[1:]:
+            raise SystemExit(self_test())
         raise SystemExit(main())
     except HarnessError as error:
         print(f"ERROR: {error}", file=sys.stderr)

--- a/test/scripts/bigquery_federation.py
+++ b/test/scripts/bigquery_federation.py
@@ -178,6 +178,25 @@ SCENARIOS = {
 
 JSON_SCENARIO = "json-cross-dataset"
 
+# Two datasets hold a table of the same name with different rows, reached by bare
+# paths. Nothing in the emitted SQL says which dataset a bare name means, so if
+# these are merged the statement reads one table twice and answers with the wrong
+# rows -- silently. This scenario is a correctness check, not a job count.
+BARE_SCENARIO = "bare-path-datasets"
+BARE_STATEMENT = """SELECT
+  a.src AS core_src,
+  b.src AS ledger_src,
+  a.n + b.n AS total
+FROM t_core AS a
+CROSS JOIN t_ledger AS b"""
+BARE_CONTROL_TEMPLATE = """SELECT
+  a.src AS core_src,
+  b.src AS ledger_src,
+  a.n + b.n AS total
+FROM {core_t} AS a
+CROSS JOIN {ledger_t} AS b"""
+BARE_EXPECTED_ROWS = [{"core_src": "from_core", "ledger_src": "from_ledger", "total": 3}]
+
 
 class HarnessError(RuntimeError):
     """A harness precondition or assertion failed."""
@@ -235,7 +254,7 @@ def distinct_free_ports() -> tuple[int, int]:
     return first, second
 
 
-def setup_sql(project: str, core: str, ledger: str) -> str:
+def setup_sql(project: str, core: str, ledger: str, bare_table: str) -> str:
     return f"""CREATE OR REPLACE TABLE `{project}.{core}.clients` AS
 SELECT * FROM UNNEST([
   STRUCT(1 AS client_id, 'tok-a' AS token, CAST(NULL AS TIMESTAMP) AS archived_at,
@@ -261,6 +280,10 @@ SELECT * FROM UNNEST([
   STRUCT(4, 3, 42.0)
 ]);
 
+CREATE OR REPLACE TABLE `{project}.{core}.{bare_table}` AS SELECT 'from_core' AS src, 1 AS n;
+
+CREATE OR REPLACE TABLE `{project}.{ledger}.{bare_table}` AS SELECT 'from_ledger' AS src, 2 AS n;
+
 CREATE OR REPLACE TABLE `{project}.{ledger}.entries_ledger` AS
 SELECT * FROM UNNEST([
   STRUCT(1 AS entry_id, 1 AS client_id, 5.5 AS amount),
@@ -271,7 +294,7 @@ SELECT * FROM UNNEST([
 """
 
 
-def spicepod(project: str, core: str, ledger: str, driver: Path) -> str:
+def spicepod(project: str, core: str, ledger: str, driver: Path, bare_table: str) -> str:
     """Build the pod the way a real one is written.
 
     Every dataset shares one URI, one project and one credential, and names its own
@@ -291,12 +314,30 @@ def spicepod(project: str, core: str, ledger: str, driver: Path) -> str:
       connection_pool_size: 8
 """
 
+    def bare_dataset(name: str, schema: str, table: str) -> str:
+        """A dataset named only by its table, with the dataset in the driver options.
+
+        The emitted reference is bare, so these two must not be joined into one
+        statement however alike their configuration looks.
+        """
+        return f"""  - from: adbc:{table}
+    name: {name}
+    params:
+      adbc_driver: bigquery
+      adbc_driver_path: {driver}
+      adbc_driver_options: adbc.bigquery.sql.project_id={project};adbc.bigquery.sql.dataset_id={schema};adbc.bigquery.sql.auth_type=adbc.bigquery.sql.auth_type.json_credential_string;adbc.bigquery.sql.auth_credentials=${{secrets:BIGQUERY_SERVICE_ACCOUNT_JSON}}
+      adbc_uri: bigquery:///{project}
+      connection_pool_size: 8
+"""
+
     entries = "".join(
         [
             dataset("clients", core, "clients"),
             dataset("advances", core, "advances"),
             dataset("entries_core", core, "entries_core"),
             dataset("entries_ledger", ledger, "entries_ledger"),
+            bare_dataset("t_core", core, bare_table),
+            bare_dataset("t_ledger", ledger, bare_table),
         ]
     )
     return f"""version: v1
@@ -588,6 +629,10 @@ def main() -> int:
     stamp = f"{utc_stamp().lower()}_{os.getpid()}"
     core = f"{DATASET_PREFIX}_{stamp}_core"
     ledger = f"{DATASET_PREFIX}_{stamp}_ledger"
+    # Both datasets hold a table of this name. It is stamped so the job census can
+    # match it: a bare reference does not name its dataset, so the dataset-name
+    # predicate cannot find those jobs.
+    bare_table = f"t_{stamp}"
     for dataset in (core, ledger):
         if not DATASET_ID_PATTERN.fullmatch(dataset):
             raise HarnessError(f"Invalid dataset id: {dataset!r}")
@@ -622,7 +667,7 @@ def main() -> int:
                     f"Dataset {project}.{dataset} already exists; rerun for a fresh stamp"
                 ) from error
 
-        setup = setup_sql(project, core, ledger)
+        setup = setup_sql(project, core, ledger, bare_table)
         (output / "setup.sql").write_text(setup, encoding="utf-8")
         setup_job = client.query(setup, location=location)
         setup_job.result()
@@ -632,7 +677,7 @@ def main() -> int:
         harness_jobs = {setup_job.job_id}
         print(f"setup_job={setup_job.job_id} datasets={project}.{{{core},{ledger}}} location={location}")
 
-        pod = spicepod(project, core, ledger, driver)
+        pod = spicepod(project, core, ledger, driver, bare_table)
         pod_path = output / "spicepod.yaml"
         pod_path.write_text(pod, encoding="utf-8")
 
@@ -707,6 +752,17 @@ def main() -> int:
             )
         )
 
+        plan.append(
+            (
+                BARE_SCENARIO,
+                BARE_STATEMENT,
+                BARE_CONTROL_TEMPLATE.format(
+                    core_t=f"`{project}.{core}.{bare_table}`",
+                    ledger_t=f"`{project}.{ledger}.{bare_table}`",
+                ),
+            )
+        )
+
         for name, statement, control_statement in plan:
             (output / f"{name}.sql").write_text(statement + ";\n", encoding="utf-8")
 
@@ -749,7 +805,13 @@ def main() -> int:
 
             observed = observe_jobs(
                 lambda: data_jobs(
-                    client, project, location, since, until, (core, ledger), harness_jobs
+                    client,
+                    project,
+                    location,
+                    since,
+                    until,
+                    (core, ledger, bare_table),
+                    harness_jobs,
                 ),
                 len(statements),
             )
@@ -782,7 +844,9 @@ def main() -> int:
                     f"{name}: rows differ from the direct BigQuery control\n"
                     f"  spice  ={rows!r}\n  bigquery={control!r}"
                 )
-            expected_single = expect == "single" or name == "same-dataset"
+            expected_single = (
+                expect == "single" or name == "same-dataset"
+            ) and name != BARE_SCENARIO
             if expected_single and len(observed) != 1:
                 failures.append(
                     f"{name}: expected one BigQuery job, observed {len(observed)} "
@@ -793,6 +857,17 @@ def main() -> int:
                     f"{name}: BIGQUERY_EXPECT=split expected more than one BigQuery job, "
                     f"observed {len(observed)}"
                 )
+            if name == BARE_SCENARIO:
+                if rows != BARE_EXPECTED_ROWS:
+                    failures.append(
+                        f"{name}: bare table references were resolved against the wrong "
+                        f"dataset\n  expected={BARE_EXPECTED_ROWS!r}\n  actual  ={rows!r}"
+                    )
+                if len(contexts) < 2:
+                    failures.append(
+                        f"{name}: the two datasets share one compute context, so a merged "
+                        f"statement can read one table twice; contexts={contexts}"
+                    )
             if name == JSON_SCENARIO:
                 pushed = "\n".join(statements)
                 missing = [

--- a/test/scripts/bigquery_federation.py
+++ b/test/scripts/bigquery_federation.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The Spice.ai OSS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measure how many BigQuery jobs one inbound statement becomes.
+
+A statement whose tables all live in one BigQuery project under one credential
+is eligible to run as a single BigQuery job. This harness runs such a statement
+through a real ``spiced`` and counts the jobs BigQuery actually received, so the
+count is observed rather than inferred from a plan.
+
+Two scenarios run against the same pod:
+
+``same-dataset``
+    Every table is in one BigQuery dataset. The statement references a CTE three
+    times, so DataFusion inlines three copies of its subtree. This is the control
+    that shows CTE inlining alone does not split the statement.
+
+``cross-dataset``
+    The same statement shape, with one table moved to a second dataset in the
+    same project under the same credential.
+
+Both scenarios are compared against the identical statement submitted straight
+to BigQuery, so a job-count change is only meaningful alongside matching rows.
+
+This is an opt-in integration harness, not a vacuous skip. It fails at startup
+unless a service-account credential and the ADBC BigQuery driver are supplied.
+The companion shell script installs the one Python dependency at a pinned
+version.
+
+Run from the repository root:
+
+    BIGQUERY_SERVICE_ACCOUNT_JSON_FILE=/path/to/service-account.json \
+      ADBC_BIGQUERY_DRIVER_PATH=/path/to/libadbc_driver_bigquery.dylib \
+      SPICED_BIN=target/debug/spiced \
+      test/scripts/bigquery-federation.sh
+
+The credential's own project is used unless ``BIGQUERY_PROJECT_ID`` overrides it,
+and ``BIGQUERY_LOCATION`` (default ``US``) selects the region. Two datasets are
+created and deleted on exit; ``BIGQUERY_TEST_CLEANUP`` accepts ``always``,
+``on_success``, or ``never``. ``BIGQUERY_SERVICE_ACCOUNT_JSON`` accepts the raw
+credential instead of a file; setting both credential variables is an error. The
+harness never falls back to application-default credentials.
+
+Job counting reads ``INFORMATION_SCHEMA.JOBS_BY_USER``, which reports the jobs
+this credential itself created, so it needs no project-wide job-list permission.
+
+Exit status is 0 when both scenarios return correct rows as a single BigQuery
+job. ``BIGQUERY_EXPECT=split`` inverts the job-count expectation for the
+cross-dataset scenario, which is how the pre-fix reproduction is recorded as a
+pass rather than as a failed run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from google.api_core.exceptions import Conflict
+from google.cloud import bigquery
+from google.oauth2 import service_account
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SPICED = ROOT / "target" / "debug" / "spiced"
+DATASET_PREFIX = "spice_bigquery_federation"
+DATASET_ID_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+PROJECT_ID_PATTERN = re.compile(r"^[a-z][a-z0-9-]{4,61}[a-z0-9]$")
+
+# `clients` is referenced three times, so DataFusion inlines three copies of its
+# subtree. The two scenarios differ only in which dataset `entries` is read from.
+STATEMENT_TEMPLATE = """WITH active_clients AS (
+  SELECT client_id, token
+  FROM {clients}
+  WHERE archived_at IS NULL
+),
+advance_totals AS (
+  SELECT a.client_id, SUM(a.amount) AS advance_total
+  FROM {advances} AS a
+  JOIN active_clients AS c ON c.client_id = a.client_id
+  GROUP BY a.client_id
+),
+entry_totals AS (
+  SELECT e.client_id, SUM(e.amount) AS entry_total
+  FROM {entries} AS e
+  JOIN active_clients AS c ON c.client_id = e.client_id
+  GROUP BY e.client_id
+)
+SELECT
+  c.token AS token,
+  COALESCE(a.advance_total, 0) AS advance_total,
+  COALESCE(t.entry_total, 0) AS entry_total
+FROM active_clients AS c
+LEFT JOIN advance_totals AS a ON a.client_id = c.client_id
+LEFT JOIN entry_totals AS t ON t.client_id = c.client_id
+ORDER BY c.token"""
+
+SCENARIOS = {
+    "same-dataset": {"clients": "clients", "advances": "advances", "entries": "entries_core"},
+    "cross-dataset": {"clients": "clients", "advances": "advances", "entries": "entries_ledger"},
+}
+
+
+class HarnessError(RuntimeError):
+    """A harness precondition or assertion failed."""
+
+
+def utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def required_path(name: str, default: Path | None = None) -> Path:
+    value = os.environ.get(name)
+    if value:
+        return Path(value).expanduser().resolve()
+    if default is not None and default.exists():
+        return default.resolve()
+    raise HarnessError(f"Set {name} to an existing path.")
+
+
+def credential_info() -> tuple[dict[str, Any], str]:
+    raw = os.environ.get("BIGQUERY_SERVICE_ACCOUNT_JSON")
+    credential_file = os.environ.get("BIGQUERY_SERVICE_ACCOUNT_JSON_FILE")
+    if not raw and not credential_file:
+        raise HarnessError(
+            "Set BIGQUERY_SERVICE_ACCOUNT_JSON or BIGQUERY_SERVICE_ACCOUNT_JSON_FILE. "
+            "The harness never falls back to application-default credentials."
+        )
+    if raw and credential_file:
+        raise HarnessError(
+            "Set exactly one of BIGQUERY_SERVICE_ACCOUNT_JSON and "
+            "BIGQUERY_SERVICE_ACCOUNT_JSON_FILE."
+        )
+    if credential_file:
+        path = required_path("BIGQUERY_SERVICE_ACCOUNT_JSON_FILE")
+        raw = path.read_text(encoding="utf-8")
+    try:
+        info = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise HarnessError("The credential is not valid JSON.") from error
+    if info.get("type") != "service_account" or not info.get("project_id"):
+        raise HarnessError("The credential must be a service-account key with a project_id.")
+    return info, json.dumps(info, separators=(",", ":"))
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def distinct_free_ports() -> tuple[int, int]:
+    first = free_port()
+    second = free_port()
+    while second == first:
+        second = free_port()
+    return first, second
+
+
+def setup_sql(project: str, core: str, ledger: str) -> str:
+    return f"""CREATE OR REPLACE TABLE `{project}.{core}.clients` AS
+SELECT * FROM UNNEST([
+  STRUCT(1 AS client_id, 'tok-a' AS token, CAST(NULL AS TIMESTAMP) AS archived_at),
+  STRUCT(2, 'tok-b', CAST(NULL AS TIMESTAMP)),
+  STRUCT(3, 'tok-c', TIMESTAMP '2026-01-01 00:00:00+00'),
+  STRUCT(4, 'tok-d', CAST(NULL AS TIMESTAMP))
+]);
+
+CREATE OR REPLACE TABLE `{project}.{core}.advances` AS
+SELECT * FROM UNNEST([
+  STRUCT(1 AS advance_id, 1 AS client_id, 100.5 AS amount),
+  STRUCT(2, 1, 20.25),
+  STRUCT(3, 2, 7.0),
+  STRUCT(4, 3, 999.0)
+]);
+
+CREATE OR REPLACE TABLE `{project}.{core}.entries_core` AS
+SELECT * FROM UNNEST([
+  STRUCT(1 AS entry_id, 1 AS client_id, 5.5 AS amount),
+  STRUCT(2, 2, 11.25),
+  STRUCT(3, 2, 3.25),
+  STRUCT(4, 3, 42.0)
+]);
+
+CREATE OR REPLACE TABLE `{project}.{ledger}.entries_ledger` AS
+SELECT * FROM UNNEST([
+  STRUCT(1 AS entry_id, 1 AS client_id, 5.5 AS amount),
+  STRUCT(2, 2, 11.25),
+  STRUCT(3, 2, 3.25),
+  STRUCT(4, 3, 42.0)
+]);
+"""
+
+
+def spicepod(project: str, core: str, ledger: str, driver: Path) -> str:
+    # One params block, so every dataset shares one URI, one credential and one
+    # project. Paths are dataset-qualified, which is the only difference between
+    # the tables the two scenarios read.
+    params = f"""      adbc_driver: bigquery
+      adbc_driver_path: {driver}
+      adbc_driver_options: adbc.bigquery.sql.auth_type=adbc.bigquery.sql.auth_type.json_credential_string;adbc.bigquery.sql.auth_credentials=${{secrets:BIGQUERY_SERVICE_ACCOUNT_JSON}}
+      adbc_uri: bigquery:///{project}"""
+    return f"""version: v1
+kind: Spicepod
+name: bigquery-federation
+
+datasets:
+  - from: adbc:{core}.clients
+    name: clients
+    params: &bigquery_params
+{params}
+  - from: adbc:{core}.advances
+    name: advances
+    params: *bigquery_params
+  - from: adbc:{core}.entries_core
+    name: entries_core
+    params: *bigquery_params
+  - from: adbc:{ledger}.entries_ledger
+    name: entries_ledger
+    params: *bigquery_params
+"""
+
+
+def http_sql(http_port: int, sql: str, timeout: int = 120) -> tuple[int, dict[str, str], str]:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{http_port}/v1/sql",
+        data=sql.encode(),
+        headers={"Content-Type": "text/plain", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, dict(response.headers.items()), response.read().decode()
+    except urllib.error.HTTPError as error:
+        return error.code, dict(error.headers.items()), error.read().decode()
+
+
+def wait_until_ready(process: subprocess.Popen[bytes], http_port: int, timeout: int) -> None:
+    deadline = time.monotonic() + timeout
+    last_observation = "no response"
+    while time.monotonic() < deadline:
+        return_code = process.poll()
+        if return_code is not None:
+            raise HarnessError(f"spiced exited before readiness with status {return_code}")
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{http_port}/v1/ready", timeout=2
+            ) as response:
+                body = response.read().decode()
+                last_observation = f"HTTP {response.status}: {body}"
+                if response.status == 200 and body.strip() == "ready":
+                    return
+        except (urllib.error.URLError, TimeoutError) as error:
+            last_observation = str(error)
+        time.sleep(0.5)
+    raise HarnessError(f"spiced was not ready after {timeout}s; last observation: {last_observation}")
+
+
+def physical_plan(explain_body: str) -> str:
+    plans = json.loads(explain_body)
+    plan = next(
+        (entry["plan"] for entry in plans if entry["plan_type"] == "initial_physical_plan"),
+        None,
+    )
+    if plan is None:
+        raise HarnessError("EXPLAIN VERBOSE did not contain an initial physical plan")
+    return plan
+
+
+def logical_plan(explain_body: str) -> str:
+    plans = json.loads(explain_body)
+    plan = next(
+        (entry["plan"] for entry in plans if entry["plan_type"] == "logical_plan"),
+        None,
+    )
+    if plan is None:
+        raise HarnessError("EXPLAIN VERBOSE did not contain a logical plan")
+    return plan
+
+
+VIRTUAL_PLAN = re.compile(
+    r"VirtualExecutionPlan name=(?P<name>\S+) compute_context=(?P<context>\S+) base_sql=(?P<sql>.*)"
+)
+
+
+def federated_nodes(plan: str) -> list[dict[str, str]]:
+    """Each VirtualExecutionPlan is one federated sub-plan, so one remote statement.
+
+    `compute_context` is the identity the federation optimizer groups on: sub-plans
+    only merge when it matches. For ADBC it is a hash, so it names the boundary
+    without disclosing the connection.
+    """
+    return [match.groupdict() for match in VIRTUAL_PLAN.finditer(plan)]
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
+
+
+def stop_spiced(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
+        return
+    process.send_signal(signal.SIGINT)
+    try:
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def data_jobs(
+    client: bigquery.Client,
+    project: str,
+    location: str,
+    since: datetime,
+    until: datetime,
+    datasets: tuple[str, ...],
+    exclude: set[str],
+) -> list[dict[str, Any]]:
+    """Return the query jobs spiced ran against the synthetic tables.
+
+    The harness shares one credential with spiced, so its own control query would
+    otherwise be counted too; `exclude` drops it. Schema discovery reads
+    INFORMATION_SCHEMA and is excluded as well, being no part of executing the
+    statement.
+    """
+    region = f"region-{location.lower()}"
+    predicate = " OR ".join(f"STRPOS(query, '{dataset}') > 0" for dataset in datasets)
+    sql = f"""
+SELECT job_id, creation_time, query, total_bytes_processed, state, error_result
+FROM `{project}`.`{region}`.INFORMATION_SCHEMA.JOBS_BY_USER
+WHERE job_type = 'QUERY'
+  AND creation_time BETWEEN @since AND @until
+  AND ({predicate})
+  AND STRPOS(UPPER(query), 'INFORMATION_SCHEMA') = 0
+ORDER BY creation_time
+"""
+    config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("since", "TIMESTAMP", since),
+            bigquery.ScalarQueryParameter("until", "TIMESTAMP", until),
+        ]
+    )
+    rows = list(client.query(sql, location=location, job_config=config).result())
+    return [dict(row) for row in rows if row["job_id"] not in exclude]
+
+
+def main() -> int:
+    info, compact_credential = credential_info()
+    project = os.environ.get("BIGQUERY_PROJECT_ID", str(info["project_id"]))
+    if not PROJECT_ID_PATTERN.fullmatch(project):
+        raise HarnessError(f"Invalid BIGQUERY_PROJECT_ID: {project!r}")
+    location = os.environ.get("BIGQUERY_LOCATION", "US")
+    cleanup = os.environ.get("BIGQUERY_TEST_CLEANUP", "always")
+    if cleanup not in {"always", "on_success", "never"}:
+        raise HarnessError("BIGQUERY_TEST_CLEANUP must be always, on_success, or never")
+    expect = os.environ.get("BIGQUERY_EXPECT", "single")
+    if expect not in {"single", "split"}:
+        raise HarnessError("BIGQUERY_EXPECT must be single or split")
+
+    stamp = f"{utc_stamp().lower()}_{os.getpid()}"
+    core = f"{DATASET_PREFIX}_{stamp}_core"
+    ledger = f"{DATASET_PREFIX}_{stamp}_ledger"
+    for dataset in (core, ledger):
+        if not DATASET_ID_PATTERN.fullmatch(dataset):
+            raise HarnessError(f"Invalid dataset id: {dataset!r}")
+
+    driver = required_path("ADBC_BIGQUERY_DRIVER_PATH")
+    spiced = required_path("SPICED_BIN", DEFAULT_SPICED)
+    output = Path(
+        os.environ.get(
+            "BIGQUERY_TEST_OUTPUT",
+            ROOT / "target" / "bigquery-federation-evidence" / utc_stamp(),
+        )
+    ).resolve()
+    output.mkdir(parents=True, exist_ok=False)
+
+    credentials = service_account.Credentials.from_service_account_info(info)
+    client = bigquery.Client(project=project, credentials=credentials)
+    created: list[bigquery.Dataset] = []
+    succeeded = False
+    process: subprocess.Popen[bytes] | None = None
+    log_handle = None
+    failures: list[str] = []
+
+    try:
+        for dataset in (core, ledger):
+            reference = bigquery.Dataset(f"{project}.{dataset}")
+            reference.location = location
+            reference.labels = {"purpose": "spice-bigquery-federation"}
+            try:
+                created.append(client.create_dataset(reference))
+            except Conflict as error:
+                raise HarnessError(
+                    f"Dataset {project}.{dataset} already exists; rerun for a fresh stamp"
+                ) from error
+
+        setup = setup_sql(project, core, ledger)
+        (output / "setup.sql").write_text(setup, encoding="utf-8")
+        setup_job = client.query(setup, location=location)
+        setup_job.result()
+        print(f"setup_job={setup_job.job_id} datasets={project}.{{{core},{ledger}}} location={location}")
+
+        pod = spicepod(project, core, ledger, driver)
+        pod_path = output / "spicepod.yaml"
+        pod_path.write_text(pod, encoding="utf-8")
+
+        binary_hash = hashlib.sha256(spiced.read_bytes()).hexdigest()
+        version = subprocess.run([str(spiced), "--version"], check=False, capture_output=True, text=True)
+        (output / "candidate.txt").write_text(
+            f"path={spiced}\nsha256={binary_hash}\nstdout={version.stdout.strip()}\n"
+            f"stderr={version.stderr.strip()}\nexit={version.returncode}\n",
+            encoding="utf-8",
+        )
+        print(f"spiced={spiced} sha256={binary_hash} version={version.stdout.strip()}")
+
+        http_port, flight_port = distinct_free_ports()
+        log_handle = (output / "spiced.log").open("wb")
+        environment = os.environ.copy()
+        environment["BIGQUERY_SERVICE_ACCOUNT_JSON"] = compact_credential
+        # Planning this statement recurses deeply enough to overflow a worker
+        # thread's default 2 MiB stack in an unoptimized build, which aborts the
+        # process. Tokio's workers take std's default stack size, so raising it
+        # here keeps a debug `spiced` usable as the harness binary.
+        environment.setdefault("RUST_MIN_STACK", str(64 * 1024 * 1024))
+        process = subprocess.Popen(
+            [
+                str(spiced),
+                "--http", f"127.0.0.1:{http_port}",
+                "--flight", f"127.0.0.1:{flight_port}",
+                "--telemetry-enabled", "false",
+                str(pod_path),
+            ],
+            cwd=ROOT,
+            env=environment,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+        )
+        wait_until_ready(process, http_port, timeout=300)
+
+        summary: dict[str, Any] = {
+            "project": project,
+            "location": location,
+            "datasets": {"core": core, "ledger": ledger},
+            "spiced_sha256": binary_hash,
+            "expect": expect,
+            "scenarios": {},
+        }
+
+        for name, tables in SCENARIOS.items():
+            statement = STATEMENT_TEMPLATE.format(**tables)
+            (output / f"{name}.sql").write_text(statement + ";\n", encoding="utf-8")
+
+            status, _, explain_body = http_sql(http_port, f"EXPLAIN VERBOSE {statement}")
+            if status != 200:
+                raise HarnessError(f"{name} EXPLAIN returned HTTP {status}: {explain_body}")
+            physical = physical_plan(explain_body)
+            logical = logical_plan(explain_body)
+            (output / f"{name}.physical_plan.txt").write_text(physical, encoding="utf-8")
+            (output / f"{name}.logical_plan.txt").write_text(logical, encoding="utf-8")
+            nodes = federated_nodes(physical)
+            statements = [node["sql"].strip() for node in nodes]
+            contexts = sorted({node["context"] for node in nodes})
+            (output / f"{name}.pushed_sql.txt").write_text(
+                "\n\n".join(statements) + "\n", encoding="utf-8"
+            )
+            federated_markers = len(re.findall(r"^\s*Federated\s*$", logical, re.MULTILINE))
+
+            # A margin either side absorbs clock skew between this host and
+            # BigQuery's own creation_time.
+            since = datetime.now(timezone.utc) - timedelta(seconds=5)
+            status, headers, body = http_sql(http_port, statement)
+            until = datetime.now(timezone.utc) + timedelta(seconds=5)
+            write_json(output / f"{name}.headers.json", headers)
+            (output / f"{name}.body").write_text(body, encoding="utf-8")
+            if status != 200:
+                raise HarnessError(f"{name} returned HTTP {status}: {body}")
+            rows = json.loads(body)
+
+            control_job = client.query(
+                STATEMENT_TEMPLATE.format(
+                    clients=f"`{project}.{core}.clients`",
+                    advances=f"`{project}.{core}.advances`",
+                    entries=f"`{project}.{core}.entries_core`"
+                    if name == "same-dataset"
+                    else f"`{project}.{ledger}.entries_ledger`",
+                ),
+                location=location,
+            )
+            control = [
+                {key: value for key, value in dict(row).items()} for row in control_job.result()
+            ]
+            # This credential is spiced's too, so the control and the job-log reads
+            # would otherwise show up as jobs spiced ran.
+            harness_jobs = {control_job.job_id}
+
+            # JOBS_BY_USER lags job creation, so poll until it stops growing.
+            observed: list[dict[str, Any]] = []
+            stable = 0
+            deadline = time.monotonic() + 120
+            while time.monotonic() < deadline and stable < 3:
+                time.sleep(5)
+                latest = data_jobs(
+                    client, project, location, since, until, (core, ledger), harness_jobs
+                )
+                stable = stable + 1 if len(latest) == len(observed) else 0
+                observed = latest
+
+            texts = [job["query"] for job in observed]
+            scenario = {
+                "statement": statement,
+                "federated_logical_nodes": federated_markers,
+                "federated_sql_statements": len(statements),
+                "distinct_compute_contexts": contexts,
+                "bigquery_job_count": len(observed),
+                "distinct_bigquery_sql": len(set(texts)),
+                "bigquery_job_ids": [job["job_id"] for job in observed],
+                "rows": rows,
+                "control_rows": control,
+                "control_job_id": control_job.job_id,
+                "rows_match_control": rows == control,
+            }
+            summary["scenarios"][name] = scenario
+            write_json(output / f"{name}.jobs.json", observed)
+
+            print(
+                f"{name}: federated_roots={federated_markers} federated_sql={len(statements)} "
+                f"compute_contexts={len(contexts)} bigquery_jobs={len(observed)} "
+                f"distinct_sql={len(set(texts))} rows_match_control={rows == control}"
+            )
+
+            if rows != control:
+                failures.append(
+                    f"{name}: rows differ from the direct BigQuery control\n"
+                    f"  spice  ={rows!r}\n  bigquery={control!r}"
+                )
+            expected_single = expect == "single" or name == "same-dataset"
+            if expected_single and len(observed) != 1:
+                failures.append(
+                    f"{name}: expected one BigQuery job, observed {len(observed)} "
+                    f"({len(set(texts))} distinct SQL texts)"
+                )
+            if not expected_single and len(observed) <= 1:
+                failures.append(
+                    f"{name}: BIGQUERY_EXPECT=split expected more than one BigQuery job, "
+                    f"observed {len(observed)}"
+                )
+
+        write_json(output / "summary.json", summary)
+        succeeded = not failures
+        if failures:
+            print("\nFAILED:", file=sys.stderr)
+            for failure in failures:
+                print(f"  {failure}", file=sys.stderr)
+        print(f"\nevidence={output}")
+        return 0 if succeeded else 1
+    finally:
+        if process is not None:
+            stop_spiced(process)
+        if log_handle is not None:
+            log_handle.close()
+        if cleanup == "always" or (cleanup == "on_success" and succeeded):
+            for dataset in created:
+                client.delete_dataset(dataset.reference, delete_contents=True, not_found_ok=True)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except HarnessError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(2) from error

--- a/test/scripts/bigquery_federation.py
+++ b/test/scripts/bigquery_federation.py
@@ -117,10 +117,51 @@ LEFT JOIN advance_totals AS a ON a.client_id = c.client_id
 LEFT JOIN entry_totals AS t ON t.client_id = c.client_id
 ORDER BY c.token"""
 
+# `json_get_str` is a Spice function with no BigQuery spelling of its own. If the
+# unparser cannot render it, DataFusion leaves it above the federated scan and the
+# JSON work happens locally, so this scenario asserts the pushed SQL carries the
+# BigQuery JSON calls as well as counting the jobs.
+JSON_STATEMENT = """WITH active_clients AS (
+  SELECT client_id, token, {tier} AS tier
+  FROM {clients}
+  WHERE archived_at IS NULL
+),
+entry_totals AS (
+  SELECT e.client_id, SUM(e.amount) AS entry_total
+  FROM {entries} AS e
+  JOIN active_clients AS c ON c.client_id = e.client_id
+  GROUP BY e.client_id
+)
+SELECT
+  c.token AS token,
+  c.tier AS tier,
+  COALESCE(t.entry_total, 0) AS entry_total
+FROM active_clients AS c
+LEFT JOIN entry_totals AS t ON t.client_id = c.client_id
+ORDER BY c.token"""
+
+SPICE_TIER = "json_get_str(metadata, 'tier')"
+# What `json_get_str` means in BigQuery: the value only when the node is a JSON
+# string, NULL for every other kind.
+BIGQUERY_TIER = (
+    "CASE WHEN STARTS_WITH(FORMAT('%t', JSON_QUERY(metadata, '$.\"tier\"')), '\"') "
+    "THEN JSON_VALUE(metadata, '$.\"tier\"') END"
+)
+
+# `json_get_str` answers for a JSON string node only: 'gold' is one, 42 is a number,
+# and tok-d has no `tier` at all. tok-c is archived and filtered out.
+JSON_EXPECTED_ROWS = [
+    {"token": "tok-a", "tier": "gold", "entry_total": 5.5},
+    {"token": "tok-b", "tier": None, "entry_total": 14.5},
+    {"token": "tok-d", "tier": None, "entry_total": 0.0},
+]
+
 SCENARIOS = {
     "same-dataset": {"clients": "clients", "advances": "advances", "entries": "entries_core"},
     "cross-dataset": {"clients": "clients", "advances": "advances", "entries": "entries_ledger"},
 }
+
+JSON_SCENARIO = "json-cross-dataset"
 
 
 class HarnessError(RuntimeError):
@@ -182,10 +223,11 @@ def distinct_free_ports() -> tuple[int, int]:
 def setup_sql(project: str, core: str, ledger: str) -> str:
     return f"""CREATE OR REPLACE TABLE `{project}.{core}.clients` AS
 SELECT * FROM UNNEST([
-  STRUCT(1 AS client_id, 'tok-a' AS token, CAST(NULL AS TIMESTAMP) AS archived_at),
-  STRUCT(2, 'tok-b', CAST(NULL AS TIMESTAMP)),
-  STRUCT(3, 'tok-c', TIMESTAMP '2026-01-01 00:00:00+00'),
-  STRUCT(4, 'tok-d', CAST(NULL AS TIMESTAMP))
+  STRUCT(1 AS client_id, 'tok-a' AS token, CAST(NULL AS TIMESTAMP) AS archived_at,
+         JSON '{{"tier":"gold"}}' AS metadata),
+  STRUCT(2, 'tok-b', CAST(NULL AS TIMESTAMP), JSON '{{"tier":42}}'),
+  STRUCT(3, 'tok-c', TIMESTAMP '2026-01-01 00:00:00+00', JSON '{{"tier":"bronze"}}'),
+  STRUCT(4, 'tok-d', CAST(NULL AS TIMESTAMP), JSON '{{"other":"x"}}')
 ]);
 
 CREATE OR REPLACE TABLE `{project}.{core}.advances` AS
@@ -473,8 +515,36 @@ def main() -> int:
             "scenarios": {},
         }
 
+        plan = []
         for name, tables in SCENARIOS.items():
-            statement = STATEMENT_TEMPLATE.format(**tables)
+            plan.append(
+                (
+                    name,
+                    STATEMENT_TEMPLATE.format(**tables),
+                    STATEMENT_TEMPLATE.format(
+                        clients=f"`{project}.{core}.clients`",
+                        advances=f"`{project}.{core}.advances`",
+                        entries=f"`{project}.{core}.entries_core`"
+                        if name == "same-dataset"
+                        else f"`{project}.{ledger}.entries_ledger`",
+                    ),
+                )
+            )
+        plan.append(
+            (
+                JSON_SCENARIO,
+                JSON_STATEMENT.format(
+                    clients="clients", entries="entries_ledger", tier=SPICE_TIER
+                ),
+                JSON_STATEMENT.format(
+                    clients=f"`{project}.{core}.clients`",
+                    entries=f"`{project}.{ledger}.entries_ledger`",
+                    tier=BIGQUERY_TIER,
+                ),
+            )
+        )
+
+        for name, statement, control_statement in plan:
             (output / f"{name}.sql").write_text(statement + ";\n", encoding="utf-8")
 
             status, _, explain_body = http_sql(http_port, f"EXPLAIN VERBOSE {statement}")
@@ -503,16 +573,10 @@ def main() -> int:
                 raise HarnessError(f"{name} returned HTTP {status}: {body}")
             rows = json.loads(body)
 
-            control_job = client.query(
-                STATEMENT_TEMPLATE.format(
-                    clients=f"`{project}.{core}.clients`",
-                    advances=f"`{project}.{core}.advances`",
-                    entries=f"`{project}.{core}.entries_core`"
-                    if name == "same-dataset"
-                    else f"`{project}.{ledger}.entries_ledger`",
-                ),
-                location=location,
+            (output / f"{name}.control.sql").write_text(
+                control_statement + ";\n", encoding="utf-8"
             )
+            control_job = client.query(control_statement, location=location)
             control = [
                 {key: value for key, value in dict(row).items()} for row in control_job.result()
             ]
@@ -571,6 +635,21 @@ def main() -> int:
                     f"{name}: BIGQUERY_EXPECT=split expected more than one BigQuery job, "
                     f"observed {len(observed)}"
                 )
+            if name == JSON_SCENARIO:
+                pushed = "\n".join(statements)
+                missing = [
+                    call for call in ("JSON_QUERY", "JSON_VALUE") if call not in pushed
+                ]
+                if missing:
+                    failures.append(
+                        f"{name}: json_get_str was not pushed to BigQuery; the generated SQL "
+                        f"is missing {missing}. It is being evaluated locally instead."
+                    )
+                if rows != JSON_EXPECTED_ROWS:
+                    failures.append(
+                        f"{name}: json_get_str returned the wrong rows\n"
+                        f"  expected={JSON_EXPECTED_ROWS!r}\n  actual  ={rows!r}"
+                    )
 
         write_json(output / "summary.json", summary)
         succeeded = not failures


### PR DESCRIPTION
## WHAT

A query reading BigQuery tables from several datasets of one project now runs as a single
BigQuery query rather than one per dataset. It also no longer returns rows from the wrong dataset
when two datasets hold a table of the same name.

## WHY

The dataset a connection defaults to was treated as part of a table's remote identity, so tables
in one project appeared to live on different engines and could not be joined in one pushed-down
query.

## HOW

The join-pushdown identity no longer covers that dataset, whether it arrives as the first part of
a dataset-qualified dataset path or as `adbc.bigquery.sql.dataset_id` in the driver options; the
project and the credential stay in it, so different projects and different service accounts remain
separate engines. The dataset is only excluded when the dataset path names it, because that is
when the generated SQL qualifies the table — a bare path keeps it, since a bare reference resolves
against whichever connection runs the statement.

Verified against real BigQuery through `test/scripts/bigquery-federation.sh`, retained in the repo,
alongside unit coverage at the connector boundary.
