### PR TITLE
fix(snapshot): conform a recorded snapshot schema to the Arrow map layout (fixes #13694)

### DIFF
--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -2439,8 +2439,7 @@ impl SnapshotManager {
                         tracing::debug!(
                             dataset = %dataset_name,
                             schema_id = recorded.schema_id,
-                            "snapshot upload: left recorded schema {} of dataset '{dataset_name}' unchanged, it could not be read: {source}",
-                            recorded.schema_id
+                            "snapshot upload: could not read a recorded schema of dataset '{dataset_name}', so it was left as written. Cause: {source}"
                         );
                         continue;
                     }
@@ -2456,8 +2455,7 @@ impl SnapshotManager {
                     tracing::info!(
                         dataset = %dataset_name,
                         schema_id = recorded.schema_id,
-                        "snapshot upload: recorded schema {} of dataset '{dataset_name}' declared a MAP's `entries` field nullable, which the Arrow layout forbids and no accelerator can hold; rewrote it in place so restoring this snapshot no longer reports a schema mismatch",
-                        recorded.schema_id
+                        "snapshot upload: a recorded schema of dataset '{dataset_name}' declared a MAP's `entries` field nullable, which the Arrow layout forbids; rewrote it so restoring this snapshot no longer reports a schema mismatch"
                     );
                 }
             }

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -2423,6 +2423,45 @@ impl SnapshotManager {
             // Always update engine to match the current engine
             dataset_entry.engine = Some(engine_str);
 
+            // Metadata written before recorded schemas were conformed keeps the invalid
+            // declaration in the *published* JSON. `to_schema_ref` repairs what this process
+            // reads, but the repaired form then compares equal to the live accelerator schema,
+            // so the evolution arm below writes no new version and nothing ever rewrites what
+            // the next reader downloads. Repaired in place, under the same schema id: a
+            // declaration the Arrow layout forbids was never a different schema, so correcting
+            // it is not a schema change and must not mint a version.
+            for recorded in &mut dataset_entry.schemas {
+                let raw = match serde_json::from_value::<Schema>(recorded.schema.clone()) {
+                    Ok(raw) => Arc::new(raw),
+                    // A recorded version this build cannot parse is left as it is; the paths
+                    // that actually read one report the failure with the dataset named.
+                    Err(source) => {
+                        tracing::debug!(
+                            dataset = %dataset_name,
+                            schema_id = recorded.schema_id,
+                            "snapshot upload: left recorded schema {} of dataset '{dataset_name}' unchanged, it could not be read: {source}",
+                            recorded.schema_id
+                        );
+                        continue;
+                    }
+                };
+                let conformed = conforming_schema(Arc::clone(&raw));
+                if !Arc::ptr_eq(&raw, &conformed) {
+                    recorded.schema = serde_json::to_value(&conformed).map_err(|source| {
+                        SnapshotUploadError::UploadSchemaSerialize {
+                            dataset: dataset_name.clone(),
+                            source,
+                        }
+                    })?;
+                    tracing::info!(
+                        dataset = %dataset_name,
+                        schema_id = recorded.schema_id,
+                        "snapshot upload: recorded schema {} of dataset '{dataset_name}' declared a MAP's `entries` field nullable, which the Arrow layout forbids and no accelerator can hold; rewrote it in place so restoring this snapshot no longer reports a schema mismatch",
+                        recorded.schema_id
+                    );
+                }
+            }
+
             if dataset_entry.schemas.is_empty() {
                 let schema_metadata = SchemaMetadata::from_schema(0, schema).map_err(|source| {
                     SnapshotUploadError::UploadSchemaSerialize {
@@ -6815,6 +6854,90 @@ mod tests {
         assert!(
             !declares_nullable_entries(&restored),
             "a checkpoint written before schemas were conformed must not be handed back as-is"
+        );
+    }
+
+    /// A snapshot written before recorded schemas were conformed keeps the invalid declaration
+    /// in its *published* JSON. Reading repairs what this process sees, but the next upload
+    /// finds the conformed form equal to the live schema and writes no new schema version — so
+    /// nothing ever rewrites what the next reader downloads.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn uploading_over_legacy_metadata_repairs_the_published_schema() {
+        let store = Arc::new(InMemory::new());
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let local_path = temp_dir.path().join("snapshot.db");
+        write_sample_local_db(&local_path, &AccelerationEngine::DuckDB);
+
+        // The accelerator's own schema conforms — it is the only form it can hold.
+        let forbidden = nullable_map_entries_schema();
+        let live_schema = conforming_schema(Arc::clone(&forbidden));
+
+        // Metadata written by an older build, carrying the declaration verbatim.
+        let metadata_path = Path::from(SNAPSHOT_BASE_PATH).join(METADATA_FILE_NAME);
+        let mut metadata = SnapshotMetadata::empty(SNAPSHOT_URI_PREFIX.to_string(), 0);
+        metadata.datasets.insert(
+            DATASET_NAME.to_string(),
+            DatasetMetadata {
+                name: DATASET_NAME.to_string(),
+                engine: Some(AccelerationEngine::DuckDB.to_string()),
+                schemas: vec![legacy_recorded_schema(0, &forbidden)],
+                current_schema_id: 0,
+                ..Default::default()
+            },
+        );
+        write_metadata(&store, &metadata_path, &metadata).await;
+
+        let manager = build_manager(
+            Arc::clone(&store),
+            local_path,
+            BootstrapOnFailureBehavior::Warn,
+            &live_schema,
+            false,
+        );
+        let mutex = Arc::new(Mutex::new(()));
+        manager
+            .create_snapshot(
+                &live_schema,
+                mutex.lock_owned().await,
+                None,
+                None,
+                ForceCreate(true),
+            )
+            .await
+            .expect("create snapshot");
+
+        let published: SnapshotMetadata = serde_json::from_slice(
+            &store
+                .get(&metadata_path)
+                .await
+                .expect("metadata stored")
+                .bytes()
+                .await
+                .expect("read metadata"),
+        )
+        .expect("parse metadata");
+        let dataset = published
+            .datasets
+            .get(DATASET_NAME)
+            .expect("dataset metadata present");
+
+        assert_eq!(
+            dataset.schemas.len(),
+            1,
+            "repairing the declaration is not a schema change and must not mint a new version"
+        );
+        let raw: Schema = serde_json::from_value(
+            dataset
+                .current_schema()
+                .expect("current schema")
+                .schema
+                .clone(),
+        )
+        .expect("published schema");
+        assert!(
+            !declares_nullable_entries(&raw),
+            "the published snapshot metadata must not keep a Map declaration MapArray::try_new refuses"
         );
     }
 }

--- a/crates/runtime-acceleration/src/snapshot/mod.rs
+++ b/crates/runtime-acceleration/src/snapshot/mod.rs
@@ -14,6 +14,7 @@ limitations under the License.
 //! Supports loading and saving snapshots of accelerated database files to and from object storage.
 
 use arrow_schema::{Schema, SchemaRef};
+use arrow_tools::map_entries::conforming_schema;
 use arrow_tools::schema_evolution::{EvolutionContext, SchemaEvolution, WideningPlan, classify};
 use aws_sdk_credential_bridge::object_store_builder::{
     S3ObjectStoreBuilder, S3ObjectStoreBuilderError,
@@ -292,13 +293,32 @@ enum MetadataLoadError {
 }
 
 impl SchemaMetadata {
+    /// The recorded schema, in the Arrow-conforming form.
+    ///
+    /// A recorded schema is a foreign declaration — JSON written by whichever build produced
+    /// the snapshot — and everything downstream takes it at face value: it bootstraps the
+    /// checkpoint, it is one side of the `classify` comparison, and `download_if_newer` hands
+    /// it to a validator that compares it field by field against the live accelerator schema.
+    /// A `Map` declaring its `entries` field nullable is not a difference the other side of
+    /// that comparison can ever hold — `MapArray::try_new` refuses the declaration — so left
+    /// in, it reads as a schema mismatch no snapshot can satisfy. Conformed on the way out for
+    /// the same reason every other decode point conforms one; see
+    /// [`arrow_tools::type_rewrite::MapEntriesNonNullable`].
     fn to_schema_ref(&self) -> Result<SchemaRef, serde_json::Error> {
         let schema: Schema = serde_json::from_value(self.schema.clone())?;
-        Ok(Arc::new(schema))
+        Ok(conforming_schema(Arc::new(schema)))
     }
 
+    /// Records `schema` in the Arrow-conforming form, so a snapshot written from here on
+    /// carries a declaration an accelerator can hold. Paired with [`Self::to_schema_ref`],
+    /// which repairs the ones already written.
+    ///
+    /// Only the layout-conformance rule is applied, not `normalize_for_comparison`: that
+    /// helper also unwraps `Dictionary` encoding, which is transparent when *comparing* two
+    /// schemas but is real information in one that is persisted and later compared against a
+    /// live accelerator schema that still carries it.
     fn from_schema(schema_id: u64, schema: &SchemaRef) -> Result<Self, serde_json::Error> {
-        let schema_json = serde_json::to_value(schema)?;
+        let schema_json = serde_json::to_value(conforming_schema(Arc::clone(schema)))?;
         Ok(Self {
             schema_id,
             schema: schema_json,
@@ -1886,10 +1906,14 @@ impl SnapshotManager {
                 source,
             })?;
 
+        // The checkpoint is a third store of a schema, written by whichever build last
+        // checkpointed this dataset, and `final_schema` below is returned from it. Conformed
+        // for the same reason the recorded schema is.
         let local_schema = checkpointer
             .get_schema()
             .await
-            .map_err(|source| SnapshotDownloadError::CheckpointerSchema { source })?;
+            .map_err(|source| SnapshotDownloadError::CheckpointerSchema { source })?
+            .map(conforming_schema);
         let final_schema = if let Some(schema) = local_schema {
             if schema.as_ref() != metadata_schema.as_ref() {
                 let ctx = EvolutionContext {
@@ -3112,7 +3136,7 @@ mod tests {
     use async_trait::async_trait;
     use bytes::Bytes;
     use chrono::{TimeZone, Utc};
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema};
     use object_store::{memory::InMemory, path::Path};
     use std::{io::Write, path::PathBuf, sync::Arc, time::SystemTime};
     use tempfile::{NamedTempFile, TempDir};
@@ -6546,6 +6570,251 @@ mod tests {
             snapshot_json["snapshot-row-count"],
             serde_json::json!(100),
             "snapshot-row-count should be serialized"
+        );
+    }
+
+    /// A schema whose `Map` column declares its `entries` field nullable — the declaration the
+    /// Arrow layout forbids and `MapArray::try_new` refuses, so no accelerator can hold a
+    /// column declared that way.
+    fn nullable_map_entries_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new(
+            "m",
+            DataType::Map(
+                Arc::new(Field::new(
+                    "entries",
+                    DataType::Struct(Fields::from(vec![
+                        Field::new("keys", DataType::Utf8, false),
+                        Field::new("values", DataType::Int32, true),
+                    ])),
+                    true,
+                )),
+                false,
+            ),
+            true,
+        )]))
+    }
+
+    /// Whether the schema's single `Map` column declares its `entries` field nullable.
+    fn declares_nullable_entries(schema: &Schema) -> bool {
+        match schema.field(0).data_type() {
+            DataType::Map(entries, _) => entries.is_nullable(),
+            other => panic!("expected a Map column, got {other}"),
+        }
+    }
+
+    /// A `SchemaMetadata` holding exactly the JSON an older build wrote, before recorded
+    /// schemas were conformed — built by hand rather than through `from_schema`, which now
+    /// conforms on the way in.
+    fn legacy_recorded_schema(schema_id: u64, schema: &SchemaRef) -> SchemaMetadata {
+        SchemaMetadata {
+            schema_id,
+            schema: serde_json::to_value(schema).expect("serialize schema"),
+        }
+    }
+
+    #[test]
+    fn recording_a_snapshot_schema_conforms_a_map_declaration_arrow_refuses() {
+        let recorded = SchemaMetadata::from_schema(0, &nullable_map_entries_schema())
+            .expect("serialize schema");
+        let round_tripped = recorded.to_schema_ref().expect("deserialize schema");
+
+        assert!(
+            !declares_nullable_entries(&round_tripped),
+            "a recorded snapshot schema must not carry a Map declaration MapArray::try_new refuses"
+        );
+    }
+
+    /// The half that reaches snapshots already written: the JSON on the wire still carries the
+    /// forbidden declaration, and reading it is what has to repair it.
+    #[test]
+    fn reading_a_legacy_recorded_schema_conforms_its_map_declaration() {
+        let forbidden = nullable_map_entries_schema();
+        let legacy = legacy_recorded_schema(0, &forbidden);
+
+        assert!(
+            declares_nullable_entries(
+                &serde_json::from_value::<Schema>(legacy.schema.clone()).expect("raw schema")
+            ),
+            "the fixture must hold the declaration an older build recorded"
+        );
+        assert!(
+            !declares_nullable_entries(&legacy.to_schema_ref().expect("deserialize schema")),
+            "reading a snapshot written before recorded schemas were conformed must repair it"
+        );
+    }
+
+    /// Only the layout-conformance rule is applied, not `normalize_for_comparison`: unwrapping
+    /// `Dictionary` encoding is transparent when *comparing* two schemas, but a recorded schema
+    /// is later compared against a live accelerator schema that still carries it.
+    #[test]
+    fn recording_a_snapshot_schema_preserves_dictionary_encoding() {
+        let dictionary_schema: SchemaRef = Arc::new(Schema::new(vec![Field::new(
+            "d",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            true,
+        )]));
+
+        let round_tripped = SchemaMetadata::from_schema(0, &dictionary_schema)
+            .expect("serialize schema")
+            .to_schema_ref()
+            .expect("deserialize schema");
+
+        assert_eq!(
+            round_tripped.field(0).data_type(),
+            dictionary_schema.field(0).data_type(),
+            "recording a snapshot schema must not unwrap dictionary encoding"
+        );
+    }
+
+    /// A checkpointer that records what `checkpoint` was handed, so a test can assert what the
+    /// checkpoint holds after a restore rather than what the restore acknowledged.
+    #[derive(Clone)]
+    struct RecordingCheckpointer {
+        /// `None` drives the restore path's bootstrap branch — the steady state for engines
+        /// whose archive ships no `_dataset_checkpoint` row, Cayenne most notably.
+        schema: Option<SchemaRef>,
+        checkpointed: Arc<Mutex<Option<SchemaRef>>>,
+    }
+
+    #[async_trait]
+    impl DatasetCheckpointer for RecordingCheckpointer {
+        async fn exists(&self) -> bool {
+            true
+        }
+
+        async fn checkpoint(
+            &self,
+            schema: &SchemaRef,
+            _refresh_sql: Option<&str>,
+        ) -> DatasetCheckpointResult<()> {
+            *self.checkpointed.lock().await = Some(Arc::clone(schema));
+            Ok(())
+        }
+
+        async fn get_schema(&self) -> DatasetCheckpointResult<Option<SchemaRef>> {
+            Ok(self.schema.clone())
+        }
+
+        async fn last_checkpoint_time(&self) -> DatasetCheckpointResult<Option<SystemTime>> {
+            Ok(None)
+        }
+
+        async fn get_refresh_sql(&self) -> DatasetCheckpointResult<Option<String>> {
+            Ok(None)
+        }
+
+        async fn delete(&self) -> DatasetCheckpointResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Restores a snapshot whose recorded schema is `recorded` against a checkpoint holding
+    /// `checkpoint_schema`, and returns `(what checkpoint() was handed, the restore's schema)`.
+    #[cfg(feature = "duckdb")]
+    async fn restore_snapshot_recording_schema(
+        snapshot_schema: SchemaMetadata,
+        checkpoint_schema: Option<SchemaRef>,
+    ) -> (Option<SchemaRef>, SchemaRef) {
+        let store = Arc::new(InMemory::new());
+        let base = Path::from(SNAPSHOT_BASE_PATH);
+        let layout = SnapshotPathLayout::new(DATASET_NAME, &AccelerationEngine::DuckDB);
+        let instant = Utc
+            .with_ymd_and_hms(2025, 6, 1, 12, 0, 0)
+            .single()
+            .expect("valid time");
+        let location = layout.build_location(&base, instant);
+        let contents = Bytes::from_static(b"snapshot-bytes");
+        store
+            .put(&location, contents.clone().into())
+            .await
+            .expect("write snapshot");
+
+        let entry = SnapshotEntry {
+            snapshot_id: 3,
+            timestamp_ms: instant.timestamp_millis(),
+            snapshot: snapshot_uri(&location),
+            snapshot_checksum: compute_sha256_hex(contents.as_ref()),
+            snapshot_checksum_algorithm: SNAPSHOT_CHECKSUM_ALGORITHM.to_string(),
+            snapshot_size: contents.len() as u64,
+            snapshot_engine: None,
+            snapshot_row_count: None,
+            snapshot_last_updated_at_ms: None,
+        };
+        let metadata = DatasetMetadata {
+            name: DATASET_NAME.to_string(),
+            engine: None,
+            schemas: vec![snapshot_schema],
+            current_schema_id: 0,
+            snapshots: vec![entry.clone()],
+            current_snapshot_id: Some(3),
+            ..Default::default()
+        };
+
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let handed_to_checkpoint = Arc::new(Mutex::new(None));
+        let recorder = RecordingCheckpointer {
+            schema: checkpoint_schema,
+            checkpointed: Arc::clone(&handed_to_checkpoint),
+        };
+        let factory: DatasetCheckpointerFactory = Arc::new(move || {
+            let recorder = recorder.clone();
+            Box::pin(async move { Ok::<Arc<dyn DatasetCheckpointer>, _>(Arc::new(recorder)) })
+        });
+
+        let mut manager = build_manager(
+            Arc::clone(&store),
+            temp_dir.path().join("snapshot.db"),
+            BootstrapOnFailureBehavior::Warn,
+            &sample_schema(),
+            false,
+        );
+        manager.checkpointer_factory = Some(Arc::clone(&factory));
+
+        let info = manager
+            .download_snapshot_entry(&entry, &metadata, factory)
+            .await
+            .expect("restore snapshot");
+
+        let handed = handed_to_checkpoint.lock().await.clone();
+        (handed, info.schema)
+    }
+
+    /// The acceptance case: a snapshot written before recorded schemas were conformed
+    /// bootstraps the checkpoint, and what the checkpoint ends up holding must be a
+    /// declaration an accelerator can hold.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn restoring_a_legacy_snapshot_bootstraps_a_conforming_checkpoint() {
+        let forbidden = nullable_map_entries_schema();
+        let (checkpointed, restored) =
+            restore_snapshot_recording_schema(legacy_recorded_schema(0, &forbidden), None).await;
+
+        let checkpointed = checkpointed.expect("the bootstrap branch checkpoints the schema");
+        assert!(
+            !declares_nullable_entries(&checkpointed),
+            "the bootstrapped checkpoint must not be given a Map declaration MapArray::try_new refuses"
+        );
+        assert!(
+            !declares_nullable_entries(&restored),
+            "the restore must not hand back a Map declaration MapArray::try_new refuses"
+        );
+    }
+
+    /// The checkpoint is a third store of a schema. One written by an older build carries the
+    /// same declaration, and it is what the restore returns on this branch.
+    #[cfg(feature = "duckdb")]
+    #[tokio::test]
+    async fn restoring_over_a_legacy_checkpoint_conforms_the_schema_it_returns() {
+        let forbidden = nullable_map_entries_schema();
+        let (_, restored) = restore_snapshot_recording_schema(
+            legacy_recorded_schema(0, &forbidden),
+            Some(Arc::clone(&forbidden)),
+        )
+        .await;
+
+        assert!(
+            !declares_nullable_entries(&restored),
+            "a checkpoint written before schemas were conformed must not be handed back as-is"
         );
     }
 }


### PR DESCRIPTION
## Summary

A snapshot's recorded schema is a **foreign declaration** — JSON written by whichever build
produced the snapshot — and three paths take it at face value: the checkpoint bootstrap writes it
into `_dataset_checkpoint`, `classify` uses it as one side of the restore comparison, and
`download_if_newer` hands it to a validator that compares it field by field against the live
accelerator schema.

A `Map` declaring its `entries` field nullable is a declaration **`MapArray::try_new` refuses**,
so no accelerator can hold a column declared that way. Left in a recorded schema it is a
difference the other side of every one of those comparisons can never match — and
`swappable::schemas_compatible` (which `refresh_task` uses to gate the swap) compares `Map` by
`DataType` equality, so the restored schema fails it and the refresh is refused **permanently**,
with a remedy — "recreate the snapshot from the current dataset" — that does not help.

`arrow_tools::type_rewrite`'s own doc already prescribes where this rule belongs: *"wherever a
foreign declaration is taken at face value — where that source's data enters, and where two
schemas are compared."* Snapshot metadata is such a decode point and was not one of its homes.

## Changes

`crates/runtime-acceleration/src/snapshot/mod.rs`, using the existing
`arrow_tools::map_entries::conforming_schema` (which shares the same `Arc` back when nothing needs
correcting, so a conforming schema costs nothing):

- **`SchemaMetadata::from_schema`** — records the conforming form, so a snapshot written from here
  on carries a declaration an accelerator can hold.
- **`SchemaMetadata::to_schema_ref`** — repairs the ones already written, which is the half that
  reaches existing snapshots. This covers all four readers: the bootstrap, the `classify`
  comparison, the upload path's own read-back, and the `download_if_newer` validator.
- **The restore path's local checkpoint schema** — the checkpoint is a third store of a schema and
  is what `final_schema` is returned from on that branch.
- **The upload path repairs the recorded schemas in place**, under the same schema id. Conforming
  on read makes the repaired form compare *equal* to the live schema, so the evolution arm writes
  no new version and nothing would ever rewrite the JSON the next reader downloads. A declaration
  the Arrow layout forbids was never a different schema, so correcting it is not a schema change
  and must not mint a version. **This one came from the adversarial review — see below.**

**Deliberately *not* `normalize_for_comparison`**, which the issue suggests by name. That helper
also unwraps `Dictionary` encoding — transparent when *comparing* two schemas, but real
information in one that is persisted and later compared against a live accelerator schema that
still carries it. `conforming_schema` applies the layout rule alone. A regression test pins this,
and it fails under `normalize_for_comparison` (measured below).

## Test plan

**The failure, reproduced on unmodified `trunk` first.** A probe calling the production
`download_snapshot_entry` with a recorded schema carrying the declaration, plus
`MapArray::try_new` on that same declaration:

```
PROBE[0] MapArray::try_new on the recorded declaration => Err(Invalid argument error: MapArray entries cannot contain nulls)
PROBE[1] upload-path recorded entries nullable = true
PROBE[2] checkpoint() received entries nullable = true
PROBE[3] final_schema entries nullable        = true
PROBE[4] final_schema Map DataType == live conforming Map DataType = false
```

`PROBE[4]` is the impact: the restored schema is not the one an accelerator can hold, so the very
next gate refuses the swap. The same probe on this branch:

```
PROBE[0] MapArray::try_new on the recorded declaration => Err(Invalid argument error: MapArray entries cannot contain nulls)
PROBE[1] upload-path recorded entries nullable = false
PROBE[2] checkpoint() received entries nullable = false
PROBE[3] final_schema entries nullable        = false
PROBE[4] final_schema Map DataType == live conforming Map DataType = true
```

**Six regression tests**, all asserting what the checkpoint or the published metadata *holds*
rather than what the write acknowledged, and each neuter-verified:

| test | on the un-fixed code |
|---|---|
| `recording_a_snapshot_schema_conforms_a_map_declaration_arrow_refuses` | FAILED |
| `reading_a_legacy_recorded_schema_conforms_its_map_declaration` | FAILED |
| `restoring_a_legacy_snapshot_bootstraps_a_conforming_checkpoint` | FAILED |
| `restoring_over_a_legacy_checkpoint_conforms_the_schema_it_returns` | FAILED |
| `uploading_over_legacy_metadata_repairs_the_published_schema` | FAILED |
| `recording_a_snapshot_schema_preserves_dictionary_encoding` | FAILED under `normalize_for_comparison` |

Reverting the three conformance sites: `test result: FAILED. 60 passed; 4 failed`. Swapping
`conforming_schema` for `normalize_for_comparison` in `from_schema`: the dictionary guard alone
fails — `assertion left == right failed: recording a snapshot schema must not unwrap dictionary
encoding` — so it is not a vacuous guard.

Gates:

- `make lint`
- `make nextest`
- `make signoff` (run after the push; the `Attestation` check is re-run from it)

## Review gate

- Adversarial review: **skipped** — `codex` started and died mid-turn out of workspace credits
  (receipt `engine=none exit=1`, log ends `Codex error: Your workspace is out of credits.`), and
  `grok` is not installed on this host, so no fallback engine was available. Recorded as a skip
  because no completed review exists to cite a job id for.
- `/security-review`: no HIGH or MEDIUM findings.
- `/simplify`: one fix applied, two findings skipped — details below.

**The partial Codex run was not empty, and it earned its keep.** Before running out it read the
diff, `snapshots.rs`, `refresh_task`, and the arrow-tools rules, and emitted one specific
hypothesis:

> *A version-skew risk is emerging in the existing-metadata upload path: the new serializer is
> bypassed when a legacy schema compares as logically identical. I'm reproducing whether a newly
> published snapshot can therefore retain the old invalid wire schema.*

**Confirmed by running it**, not by agreeing with it: `uploading_over_legacy_metadata_repairs_the_published_schema`
fails on the preceding commit with the published JSON still carrying the declaration. Fixed by the
in-place repair described under *Changes*. Because the engine had no credits left, the amended diff
could not be re-reviewed — that is a declared partial, not a clean pass.

**`/security-review` detail.** It examined the one angle that could apply: this relaxes a
schema-shape check on a remotely-fetched artifact. Not a security control — the snapshot location
is operator-configured, the integrity controls (SHA-256, size, checksum-algorithm allowlist) are
untouched, and the difference normalized away is one the other side can never legitimately hold,
since nullability is type metadata and no buffer or offset is affected.

**`/simplify` detail.** Applied: both new log lines carried `schema_id` as a structured field *and*
again positionally in the message, diverging from the `snapshot upload:` log beside them; the
`debug!` line was also reworded to the problem/impact/cause shape. Skipped, with reasons: avoiding
the `Value` clone in the repair loop would need a `serde::Deserialize` import for no measurable gain
against a function that already clones the whole metadata around a database-file upload; and pushing
the repair down into `load_metadata` would make read-only callers pay for a rewrite they never
publish, while the conditional write-back would still need the explicit repair.

Fixes #13694

## Checklist

- [x] Reproduced the reported failure on `trunk` before writing the fix
- [x] Regression tests fail on the un-fixed code and pass on this branch
- [x] Guard test pins the design choice (`conforming_schema`, not `normalize_for_comparison`)
- [x] Adversarial review dispatched; its one finding confirmed by measurement and fixed
- [x] `/security-review` and `/simplify` run and recorded above
- [ ] `make signoff` green and `Attestation` re-run