### PR TITLE
fix(duckdb): stop federating cosine_distance to a function that answers differently (fixes #13728)

### DIFF
--- a/crates/data-connectors/connector-duckdb/src/lib.rs
+++ b/crates/data-connectors/connector-duckdb/src/lib.rs
@@ -78,14 +78,14 @@ impl DuckDB {
     /// `can_execute_plan` refuse such plans so `DataFusion` evaluates the affected
     /// expressions locally instead. We use [`deny_spice_functions_for_duckdb`]
     /// (rather than the generic deny-list) so functions `DuckDB` *does* support
-    /// natively — e.g. `cosine_distance`, which `DuckDB` unparses to
-    /// `array_cosine_distance` — still federate. See issue #10703.
+    /// natively — e.g. `inner_product`, which `DuckDB` unparses to
+    /// `array_inner_product` — still federate. See issue #10703.
     fn with_spice_deny_list(factory: DuckDBTableFactory) -> DuckDBTableFactory {
         // The spiceai table-providers fork restores the `with_function_support`
         // deny-list seam on DuckDBTableFactory (see issue #10703). Install the
         // DuckDB-aware deny-list so Spice-only UDFs that DuckDB can't run are
         // evaluated locally, while functions DuckDB's dialect can rewrite (e.g.
-        // cosine_distance -> array_cosine_distance) still federate. The factory's
+        // inner_product -> array_inner_product) still federate. The factory's
         // seam takes the table-providers FunctionSupport type, so we build the
         // deny-list directly in that type from the runtime's shared name list.
         factory.with_function_support(deny_spice_functions_for_duckdb_table_providers())

--- a/crates/data-connectors/connector-ducklake/src/lib.rs
+++ b/crates/data-connectors/connector-ducklake/src/lib.rs
@@ -38,6 +38,7 @@ use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConne
 use duckdb::AccessMode;
 use runtime_component::dataset::DatasetSpec;
 use runtime_datafusion::dialect::new_duckdb_dialect;
+use runtime_datafusion::function_support::deny_spice_functions_for_duckdb_table_providers;
 use runtime_parameters::ParameterSpec;
 use snafu::prelude::*;
 use std::any::Any;
@@ -258,7 +259,14 @@ fn create_ducklake_factory(
             source: Box::new(e),
         })?;
 
-    let factory = DuckDBTableFactory::new(Arc::clone(&pool)).with_dialect(new_duckdb_dialect());
+    // The dialect and the deny-list are two halves of one decision: the dialect
+    // says what can be rewritten, the deny-list refuses to federate everything
+    // else. Installed alone, the dialect lets a plan holding any other Spice UDF
+    // federate and the unparser emits that function verbatim into SQL DuckDB
+    // cannot run. Every other DuckDB-backed factory installs both.
+    let factory = DuckDBTableFactory::new(Arc::clone(&pool))
+        .with_dialect(new_duckdb_dialect())
+        .with_function_support(deny_spice_functions_for_duckdb_table_providers());
     Ok((factory, pool, catalog_name.to_string()))
 }
 

--- a/crates/data_components/src/ducklake/provider.rs
+++ b/crates/data_components/src/ducklake/provider.rs
@@ -104,6 +104,13 @@ impl DuckLakeCatalogProvider {
     ///
     /// # Arguments
     /// * `pool` - `DuckDB` connection pool with `ducklake` extension loaded
+    /// * `duckdb_factory` - The factory catalog tables are read through. The
+    ///   caller supplies it because the unparser dialect and the federation
+    ///   deny-list are two halves of one decision and both live above this
+    ///   crate: the dialect says what can be rewritten into `DuckDB` SQL, and
+    ///   the deny-list refuses to federate everything else. A bare factory
+    ///   federates a Spice-only UDF and emits it verbatim into SQL `DuckDB`
+    ///   cannot run.
     /// * `catalog_name` - The catalog name as attached in `DuckDB`
     /// * `writable` - Whether write operations (INSERT, UPDATE, DELETE) are allowed
     /// * `ddl_enabled` - Whether DDL operations (CREATE TABLE, DROP TABLE) are allowed
@@ -111,13 +118,13 @@ impl DuckLakeCatalogProvider {
     #[must_use]
     pub fn new(
         pool: Arc<DuckDbConnectionPool>,
+        duckdb_factory: DuckDBTableFactory,
         catalog_name: String,
         writable: bool,
         ddl_enabled: bool,
         selector: TableSelector,
     ) -> Self {
-        // Create a table factory that uses the same pool (with ducklake already attached)
-        let duckdb_factory = Arc::new(DuckDBTableFactory::new(Arc::clone(&pool)));
+        let duckdb_factory = Arc::new(duckdb_factory);
         Self {
             pool,
             duckdb_factory,

--- a/crates/runtime-datafusion/src/dialect/duckdb.rs
+++ b/crates/runtime-datafusion/src/dialect/duckdb.rs
@@ -116,15 +116,6 @@ fn spice_array_fn_to_sql(
     Ok(Some(ast_fn))
 }
 
-/// Converts the `cosine_distance` UDF into `DuckDB`'s `array_cosine_distance`:
-/// `https://duckdb.org/docs/sql/functions/array.html#array_cosine_distancearray1-array2`
-pub(crate) fn cosine_distance_to_sql(
-    unparser: &datafusion::sql::unparser::Unparser,
-    args: &[Expr],
-) -> Result<Option<datafusion::sql::sqlparser::ast::Expr>, DataFusionError> {
-    spice_array_fn_to_sql(unparser, args, "array_cosine_distance")
-}
-
 /// Converts the `inner_product` UDF into `DuckDB`'s `array_inner_product` (dot
 /// product, `sum(a[i] * b[i])`): both compute the same value, so federating the
 /// call to `DuckDB` (>= 1.5.3) is exact.
@@ -428,7 +419,7 @@ mod tests {
         common::{Column, Spans},
         functions_nested::make_array::make_array_udf,
         logical_expr::expr::ScalarFunction,
-        prelude::{Expr, lit},
+        prelude::Expr,
         scalar::ScalarValue,
         sql::{TableReference, unparser::Unparser},
     };
@@ -445,65 +436,6 @@ mod tests {
     }
 
     use super::*;
-
-    #[test]
-    fn test_cosine_distance_to_sql_scalars() {
-        let dialect = new_duckdb_dialect();
-        let unparser = Unparser::new(dialect.as_ref());
-        let args = vec![
-            // raw values
-            Expr::ScalarFunction(ScalarFunction::new_udf(
-                make_array_udf(),
-                vec![lit(1.0), lit(2.0), lit(3.0)],
-            )),
-            // values wrapped as literals
-            Expr::ScalarFunction(ScalarFunction::new_udf(
-                make_array_udf(),
-                vec![
-                    Expr::Literal(ScalarValue::Float32(Some(4.0)), None),
-                    Expr::Literal(ScalarValue::Float32(Some(5.0)), None),
-                    Expr::Literal(ScalarValue::Float32(Some(6.0)), None),
-                ],
-            )),
-        ];
-        let result = cosine_distance_to_sql(&unparser, &args)
-            .expect("should execute successfully")
-            .expect("should return expression");
-
-        let expected =
-            "array_cosine_distance([1.0, 2.0, 3.0]::FLOAT[3], [4.0, 5.0, 6.0]::FLOAT[3])";
-
-        assert_eq!(result.to_string(), expected);
-    }
-
-    #[test]
-    fn test_cosine_distance_to_sql_column_and_scalar() {
-        let dialect = new_duckdb_dialect();
-        let unparser = Unparser::new(dialect.as_ref());
-        let args = vec![
-            Expr::Column(Column {
-                relation: Some(TableReference::from("table_name")),
-                name: "column_name".to_string(),
-                spans: Spans::new(),
-            }),
-            Expr::ScalarFunction(ScalarFunction::new_udf(
-                make_array_udf(),
-                vec![
-                    Expr::Literal(ScalarValue::Float32(Some(4.0)), None),
-                    Expr::Literal(ScalarValue::Float32(Some(5.0)), None),
-                    Expr::Literal(ScalarValue::Float32(Some(6.0)), None),
-                ],
-            )),
-        ];
-
-        let result = cosine_distance_to_sql(&unparser, &args)
-            .expect("should execute successfully")
-            .expect("should return expression");
-        let expected =
-            r#"array_cosine_distance("table_name"."column_name", [4.0, 5.0, 6.0]::FLOAT[3])"#;
-
-        assert_eq!(result.to_string(), expected);
-    }
 
     #[test]
     fn test_inner_product_to_sql_column_and_scalar() {
@@ -590,13 +522,19 @@ mod tests {
 
     #[test]
     fn duckdb_native_function_names_advertises_denylisted_pushables() {
-        // The federation deny-list relies on these names to let `cosine_distance`
-        // and `rand` push down to DuckDB, so the dialect must advertise them.
+        // The federation deny-list derives its carve-out from these names, so a
+        // name here federates and a name missing here stays denied.
         let names = crate::dialect::duckdb_native_function_names();
+
+        // `cosine_distance` must be absent: DuckDB's `array_cosine_distance`
+        // answers a different number (see the comment on
+        // `duckdb_scalar_overrides`), so the deny-list has to keep denying it.
         assert!(
-            names.contains(&runtime_datafusion_udfs::cosine_distance::COSINE_DISTANCE_UDF_NAME),
-            "duckdb_native_function_names() missing cosine_distance; got {names:?}"
+            !names.contains(&runtime_datafusion_udfs::cosine_distance::COSINE_DISTANCE_UDF_NAME),
+            "cosine_distance must not be carved out of the DuckDB deny-list — DuckDB's \
+             array_cosine_distance is not the same function; got {names:?}"
         );
+        // `inner_product` and `rand` do have real DuckDB equivalents.
         assert!(
             names.contains(&runtime_datafusion_udfs::inner_product::INNER_PRODUCT_UDF_NAME),
             "duckdb_native_function_names() missing inner_product; got {names:?}"

--- a/crates/runtime-datafusion/src/dialect/mod.rs
+++ b/crates/runtime-datafusion/src/dialect/mod.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 use datafusion::logical_expr::expr::ScalarFunction;
 use datafusion::sql::unparser::dialect::{Dialect, DuckDBDialect, ScalarFnToSqlHandler};
 
-use runtime_datafusion_udfs::cosine_distance::COSINE_DISTANCE_UDF_NAME;
 use runtime_datafusion_udfs::inner_product::INNER_PRODUCT_UDF_NAME;
 
 mod bigquery;
@@ -47,10 +46,17 @@ const REGEXP_COUNT_NAME: &str = "regexp_count";
 /// and the deny-list carve-out can never drift apart.
 fn duckdb_scalar_overrides() -> Vec<(&'static str, ScalarFnToSqlHandler)> {
     vec![
-        (
-            COSINE_DISTANCE_UDF_NAME,
-            Box::new(duckdb::cosine_distance_to_sql) as ScalarFnToSqlHandler,
-        ),
+        // `cosine_distance` is deliberately absent: `DuckDB`'s
+        // `array_cosine_distance` is a different function, not another spelling
+        // of this one. It ranges over [0, 2] where the UDF ranges over [0, 1],
+        // and it evaluates in FLOAT where the kernel evaluates in f64. The scale
+        // is a constant factor that the emitted SQL could divide out; the width
+        // is not. On DuckDB 1.4.4 a pair of *identical* finite vectors
+        // `[1e-30, 0, 0]` answers 2.0 — maximally distant — because each squared
+        // component underflows FLOAT, where the kernel answers 0; `[1e20, 0, 0]`
+        // overflows to the same answer. So the name stays deny-listed and the UDF
+        // is evaluated locally. See spiceai/spiceai#13728, and #11263 for which
+        // formula `cosine_distance` should define in the first place.
         (
             INNER_PRODUCT_UDF_NAME,
             Box::new(duckdb::inner_product_to_sql) as ScalarFnToSqlHandler,

--- a/crates/runtime/src/catalogconnector/ducklake.rs
+++ b/crates/runtime/src/catalogconnector/ducklake.rs
@@ -32,9 +32,12 @@ use data_components::ducklake::provider::DuckLakeCatalogProvider;
 use data_components::ducklake::{
     DuckLakeS3Params, build_ducklake_attach_sql, configure_duckdb_httpfs,
 };
+use datafusion_table_providers::duckdb::DuckDBTableFactory;
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::duckdbconn::DuckDbConnection;
 use datafusion_table_providers::sql::db_connection_pool::duckdbpool::DuckDbConnectionPool;
 use duckdb::AccessMode;
+use runtime_datafusion::dialect::new_duckdb_dialect;
+use runtime_datafusion::function_support::deny_spice_functions_for_duckdb_table_providers;
 use snafu::prelude::*;
 use std::any::Any;
 use std::sync::Arc;
@@ -315,8 +318,17 @@ impl CatalogConnector for DuckLakeCatalog {
             })??;
 
         // Create the catalog provider with the pool (which has ducklake extension and catalog attached)
+        // Same pairing the ducklake *dataset* connector installs: the DuckDB
+        // dialect for what can genuinely be rewritten, and the deny-list so
+        // every other Spice UDF is evaluated locally rather than unparsed into
+        // SQL DuckDB cannot run.
+        let duckdb_factory = DuckDBTableFactory::new(Arc::clone(&pool))
+            .with_dialect(new_duckdb_dialect())
+            .with_function_support(deny_spice_functions_for_duckdb_table_providers());
+
         let catalog_provider = Arc::new(DuckLakeCatalogProvider::new(
             pool,
+            duckdb_factory,
             catalog_name,
             writable,
             ddl_enabled,

--- a/crates/runtime/src/datafusion/udf.rs
+++ b/crates/runtime/src/datafusion/udf.rs
@@ -1057,20 +1057,21 @@ mod tests {
     #[test]
     fn duckdb_deny_list_allows_dialect_native_functions() {
         // The DuckDB unparser dialect rewrites these into native DuckDB SQL
-        // (cosine_distance -> array_cosine_distance, inner_product ->
-        // array_inner_product, rand -> random()), so they must federate rather
-        // than be denied. Note `rand` is allowed purely by virtue of being in the
-        // dialect — no manual carve-out.
+        // (inner_product -> array_inner_product, rand -> random()), so they must
+        // federate rather than be denied. Note `rand` is allowed purely by virtue
+        // of being in the dialect — no manual carve-out.
         let support = deny_spice_functions_for_duckdb();
-        for name in [COSINE_DISTANCE_UDF_NAME, INNER_PRODUCT_UDF_NAME, "rand"] {
+        for name in [INNER_PRODUCT_UDF_NAME, "rand"] {
             assert!(
                 support.supports(&make_named_expr(name)),
                 "{name} has a native DuckDB equivalent and should be pushed down"
             );
         }
-        // No native DuckDB equivalent — must stay denied.
+        // `array_cosine_distance` exists in DuckDB but is not the same function
+        // as `cosine_distance` (different range, and it evaluates in FLOAT where
+        // the kernel uses f64), so it must stay denied. See spiceai/spiceai#13728.
         let json_name = json_get_str_udf().name().to_string();
-        for name in [EMBED_UDF_NAME, json_name.as_str()] {
+        for name in [EMBED_UDF_NAME, COSINE_DISTANCE_UDF_NAME, json_name.as_str()] {
             assert!(
                 !support.supports(&make_named_expr(name)),
                 "{name} has no native DuckDB equivalent and must stay denied"
@@ -1135,10 +1136,10 @@ mod tests {
         // can/can't partition explicit: if a dialect change makes another Spice
         // function pushable (or stops one), this test must be updated on purpose.
         //
-        // `cosine_distance` -> array_cosine_distance, `inner_product` ->
-        // array_inner_product, `rand` -> random(). (Note: l2 distance federates
-        // via the non-deny-listed `array_distance` UDF, so it isn't part of this
-        // deny-list carve-out.)
+        // `inner_product` -> array_inner_product, `rand` -> random(). (Note: l2
+        // distance federates via the non-deny-listed `array_distance` UDF, so it
+        // isn't part of this deny-list carve-out. `cosine_distance` is
+        // deliberately absent — see spiceai/spiceai#13728.)
         use std::collections::BTreeSet;
         let support = deny_spice_functions_for_duckdb();
         let denied_names = builtin_denied_names();
@@ -1149,7 +1150,7 @@ mod tests {
             .collect();
         assert_eq!(
             pushable,
-            BTreeSet::from([COSINE_DISTANCE_UDF_NAME, INNER_PRODUCT_UDF_NAME, "rand"]),
+            BTreeSet::from([INNER_PRODUCT_UDF_NAME, "rand"]),
             "unexpected change to the set of Spice functions pushable to DuckDB"
         );
     }

--- a/crates/runtime/tests/duckdb/mod.rs
+++ b/crates/runtime/tests/duckdb/mod.rs
@@ -627,6 +627,225 @@ async fn duckdb_connector_does_not_push_down_spice_functions() -> Result<(), Str
         .await
 }
 
+/// Regression test for spiceai/spiceai#13728: `cosine_distance` must answer the
+/// same number whether or not the subtree it sits in federates.
+///
+/// `DuckDB`'s `array_cosine_distance` is not the same function. It is
+/// `1 - cosine_similarity` over `[0, 2]` where the UDF is
+/// `(1 - cosine_similarity) / 2` over `[0, 1]`, and it evaluates in FLOAT where
+/// the kernel evaluates in f64 — so a pair of *identical* finite vectors whose
+/// squared components underflow FLOAT (`[1e-30, 0, 0]`) comes back as maximally
+/// distant instead of identical. The constant factor could be rescaled in the
+/// emitted SQL; the width cannot, which is why the name is denied rather than
+/// rewritten.
+///
+/// `fed` has no acceleration, so its scan is pushed to `DuckDB`; `local` is
+/// accelerated into Arrow, so it is evaluated by the Spice kernel. Both read the
+/// same rows, so the two must agree — and `inner_product`, which `DuckDB` *does*
+/// implement identically, must still federate.
+#[tokio::test]
+async fn duckdb_cosine_distance_is_not_federated_to_a_different_function() -> Result<(), String> {
+    let _tracing = init_tracing(Some("integration=debug,info"));
+    register_test_connectors().await;
+
+    let duck_tempdir = tempfile::tempdir().expect("duckdb tempdir");
+    let db_path = duck_tempdir.path().join("vectors.duckdb");
+    {
+        let conn = duckdb::Connection::open(&db_path).expect("open duckdb");
+        // Each row is (vector, probe). Rows 1-3 walk an ordinary direction from
+        // near-parallel to opposite; rows 4 and 5 compare a vector with itself at
+        // magnitudes whose squares underflow and overflow FLOAT respectively.
+        // Those two are the rows a rescaling of DuckDB's answer cannot fix: the
+        // correct distance is 0, and DuckDB answers its maximum.
+        conn.execute_batch(
+            "CREATE TABLE vecs (id BIGINT, emb FLOAT[3], probe FLOAT[3]);
+             INSERT INTO vecs VALUES
+               (1, [4.0, 5.0, 6.0],    [1.0, 2.0, 3.0]),
+               (2, [1.0, 2.0, 3.0],    [1.0, 2.0, 3.0]),
+               (3, [-1.0, -2.0, -3.0], [1.0, 2.0, 3.0]),
+               (4, [1e-30, 0.0, 0.0],  [1e-30, 0.0, 0.0]),
+               (5, [1e20, 0.0, 0.0],   [1e20, 0.0, 0.0]);",
+        )
+        .expect("populate duckdb");
+    }
+
+    test_request_context()
+        .scope(async {
+            let duckdb_open =
+                spicepod::param::Params::from_string_map(std::collections::HashMap::from([(
+                    "duckdb_open".to_string(),
+                    db_path.display().to_string(),
+                )]));
+
+            let mut federated = Dataset::new("duckdb:vecs".to_string(), "fed".to_string());
+            federated.params = Some(duckdb_open.clone());
+
+            let mut local = Dataset::new("duckdb:vecs".to_string(), "local".to_string());
+            local.params = Some(duckdb_open);
+            local.acceleration = Some(Acceleration {
+                enabled: true,
+                mode: Mode::Memory,
+                refresh_mode: Some(RefreshMode::Full),
+                ..Acceleration::default()
+            });
+
+            let app = AppBuilder::new("duckdb_cosine_distance_federation")
+                .with_dataset(federated)
+                .with_dataset(local)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Runtime::builder().with_app(app).build().await;
+            let cloned_rt = Arc::new(rt.clone());
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_mins(1)) => {
+                    return Err("Timed out waiting for datasets to load".to_string());
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            let batches = async |sql: String| -> Result<Vec<RecordBatch>, String> {
+                rt.datafusion()
+                    .query_builder(&sql)
+                    .build()
+                    .run()
+                    .await
+                    .map_err(|e| format!("query `{sql}` failed: {e}"))?
+                    .data
+                    .try_collect()
+                    .await
+                    .map_err(|e| format!("query `{sql}` collect failed: {e}"))
+            };
+
+            // The named column of a query, as `f64`, with NULL mapped to NaN so a
+            // NULL can never silently compare equal to a number.
+            let column = async |sql: String, name: &str| -> Result<Vec<f64>, String> {
+                let mut out = Vec::new();
+                for batch in &batches(sql.clone()).await? {
+                    let col = batch
+                        .column_by_name(name)
+                        .ok_or_else(|| format!("`{sql}` returned no `{name}` column"))?;
+                    let col = col
+                        .as_any()
+                        .downcast_ref::<arrow::array::Float64Array>()
+                        .ok_or_else(|| {
+                            format!("`{name}` is {:?}, expected Float64", col.data_type())
+                        })?;
+                    out.extend(col.iter().map(|v| v.unwrap_or(f64::NAN)));
+                }
+                Ok(out)
+            };
+
+            let cosine = |table: &str| {
+                format!("SELECT id, cosine_distance(emb, probe) AS d FROM {table} ORDER BY id")
+            };
+
+            let federated_d = column(cosine("fed"), "d").await?;
+            let local_d = column(cosine("local"), "d").await?;
+
+            assert_eq!(federated_d.len(), 5, "expected 5 rows, got {federated_d:?}");
+            assert_eq!(
+                local_d.len(),
+                federated_d.len(),
+                "row counts differ: {federated_d:?} vs {local_d:?}"
+            );
+
+            for (row, (fed, loc)) in federated_d.iter().zip(&local_d).enumerate() {
+                assert!(
+                    (fed - loc).abs() < 1e-9,
+                    "row {} of cosine_distance disagrees across the federation \
+                     boundary: fed {fed}, local {loc}. federated={federated_d:?} \
+                     local={local_d:?}",
+                    row + 1
+                );
+            }
+
+            // Rows 4 and 5 are a vector against itself, so the distance is 0. If
+            // the call ever federates to `array_cosine_distance` again these read
+            // 2.0 (or 1.0 if something rescales them), which is why they are
+            // asserted on their own rather than only against each other.
+            assert!(
+                local_d[3] == 0.0 && local_d[4] == 0.0,
+                "a vector's distance to itself must be 0 at every magnitude, got \
+                 {:?} and {:?}",
+                local_d[3],
+                local_d[4]
+            );
+
+            // The scan must still be pushed down, but without the function.
+            let explain = batches(format!("EXPLAIN {}", cosine("fed"))).await?;
+            let plan = arrow::util::pretty::pretty_format_batches(&explain)
+                .map_err(|e| format!("format explain: {e}"))?
+                .to_string();
+            let pushed: Vec<&str> = plan
+                .lines()
+                .filter(|l| l.contains("base_sql=") || l.contains("DuckSqlExec sql="))
+                .collect();
+            assert!(
+                !pushed.is_empty(),
+                "expected the connector to push a scan down to DuckDB; plan was:\n{plan}"
+            );
+            for line in pushed {
+                assert!(
+                    !line.contains("array_cosine_distance"),
+                    "cosine_distance was federated to DuckDB's array_cosine_distance, \
+                     which answers a different number:\n{line}"
+                );
+            }
+            assert!(
+                plan.contains("cosine_distance"),
+                "cosine_distance must still appear in the plan, evaluated locally:\n{plan}"
+            );
+
+            // `inner_product` is the control: DuckDB's `array_inner_product`
+            // computes the same value, so it must still federate and must still
+            // agree across the boundary.
+            let inner = |table: &str| {
+                format!("SELECT id, inner_product(emb, probe) AS ip FROM {table} ORDER BY id")
+            };
+            let federated_ip = column(inner("fed"), "ip").await?;
+            let local_ip = column(inner("local"), "ip").await?;
+            // Rows 1-4, whose dot products are finite, must agree exactly.
+            for (row, (fed, loc)) in federated_ip.iter().zip(&local_ip).take(4).enumerate() {
+                assert!(
+                    (fed - loc).abs() < 1e-9,
+                    "row {} of inner_product disagrees across the federation \
+                     boundary: fed {fed}, local {loc}",
+                    row + 1
+                );
+            }
+            // Row 5's true dot product is 1e40, which no f32 accumulator holds.
+            // The kernel calls that undefined and returns NULL; DuckDB returns
+            // +Inf. That divergence is real but is not what this change is about
+            // — it needs input screening in the emitted SQL rather than a
+            // different function — so it is pinned here rather than left to be
+            // rediscovered. Tracked in spiceai/spiceai#13787.
+            assert!(
+                federated_ip[4].is_infinite() && local_ip[4].is_nan(),
+                "the known non-finite inner_product divergence changed shape: fed \
+                 {}, local {} (NaN here means the kernel returned NULL). If this \
+                 was fixed on purpose, update this assertion and close #13787.",
+                federated_ip[4],
+                local_ip[4]
+            );
+            let inner_explain = batches(format!("EXPLAIN {}", inner("fed"))).await?;
+            let inner_plan = arrow::util::pretty::pretty_format_batches(&inner_explain)
+                .map_err(|e| format!("format explain: {e}"))?
+                .to_string();
+            assert!(
+                inner_plan.contains("array_inner_product"),
+                "inner_product must still federate to DuckDB's array_inner_product:\n\
+                 {inner_plan}"
+            );
+
+            Ok(())
+        })
+        .await
+}
+
 #[tokio::test]
 async fn test_duckdb_settings_persist() -> Result<(), String> {
     use spicepod::param::Params;

--- a/crates/runtime/tests/duckdb/mod.rs
+++ b/crates/runtime/tests/duckdb/mod.rs
@@ -641,8 +641,10 @@ async fn duckdb_connector_does_not_push_down_spice_functions() -> Result<(), Str
 ///
 /// `fed` has no acceleration, so its scan is pushed to `DuckDB`; `local` is
 /// accelerated into Arrow, so it is evaluated by the Spice kernel. Both read the
-/// same rows, so the two must agree — and `inner_product`, which `DuckDB` *does*
-/// implement identically, must still federate.
+/// same rows, so the two must agree — and `inner_product` must still federate,
+/// since `DuckDB`'s `array_inner_product` agrees wherever the result is
+/// representable. Where it is not, the two still diverge (`+Inf` against the
+/// kernel's NULL); that is pinned below and tracked in spiceai/spiceai#13787.
 #[tokio::test]
 async fn duckdb_cosine_distance_is_not_federated_to_a_different_function() -> Result<(), String> {
     let _tracing = init_tracing(Some("integration=debug,info"));
@@ -801,8 +803,9 @@ async fn duckdb_cosine_distance_is_not_federated_to_a_different_function() -> Re
             );
 
             // `inner_product` is the control: DuckDB's `array_inner_product`
-            // computes the same value, so it must still federate and must still
-            // agree across the boundary.
+            // computes the same value wherever that value is representable, so
+            // it must still federate and still agree on those rows. The one row
+            // whose result is not representable is asserted separately below.
             let inner = |table: &str| {
                 format!("SELECT id, inner_product(emb, probe) AS ip FROM {table} ORDER BY id")
             };

--- a/crates/runtime/tests/ducklake/mod.rs
+++ b/crates/runtime/tests/ducklake/mod.rs
@@ -442,7 +442,6 @@ async fn ducklake_standalone_dataset() -> Result<(), anyhow::Error> {
         .await
 }
 
-/// Tests that INSERT works on a standalone `DuckLake` dataset when `access: read_write` is set.
 /// Both `DuckLake` read paths must install the `DuckDB` federation deny-list.
 ///
 /// `connector-ducklake` and `DuckLakeCatalogProvider` each build a
@@ -452,9 +451,11 @@ async fn ducklake_standalone_dataset() -> Result<(), anyhow::Error> {
 /// Spice-only UDF federate, and the unparser emits it into the SQL sent to
 /// `DuckDB`.
 ///
-/// `cosine_distance` is the case that matters (spiceai/spiceai#13728): `DuckDB`
-/// has a similarly-named `array_cosine_distance` that answers a *different
-/// number*, so a missing deny-list here is a wrong result rather than an error.
+/// `cosine_distance` is the case that matters (spiceai/spiceai#13728). No
+/// handler renders it any more, so an un-denied call is emitted verbatim and
+/// `DuckDB`, which has no `cosine_distance`, refuses to bind the query: the
+/// deny-list is what keeps the refusal a Spice-side planner decision instead
+/// of a binder error on pushed-down SQL.
 /// The argument references a column so the expression cannot be constant-folded
 /// out of the plan before federation is decided.
 #[tokio::test]
@@ -521,8 +522,8 @@ async fn ducklake_does_not_push_down_spice_functions() -> Result<(), anyhow::Err
 
                 // 2. The scan is still pushed down, but the function is not.
                 //    Deleting the `.with_function_support(..)` call on either
-                //    factory turns this into `array_cosine_distance`, which
-                //    answers twice the local value.
+                //    factory pushes `cosine_distance` down verbatim, which
+                //    DuckDB cannot bind.
                 let plan = explain_plan(&rt, &sql).await;
                 let pushed: Vec<&str> = plan
                     .lines()
@@ -551,6 +552,7 @@ async fn ducklake_does_not_push_down_spice_functions() -> Result<(), anyhow::Err
         .await
 }
 
+/// Tests that INSERT works on a standalone `DuckLake` dataset when `access: read_write` is set.
 #[tokio::test]
 async fn ducklake_standalone_read_write_insert() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("runtime=DEBUG,data_components=DEBUG"));

--- a/crates/runtime/tests/ducklake/mod.rs
+++ b/crates/runtime/tests/ducklake/mod.rs
@@ -443,6 +443,114 @@ async fn ducklake_standalone_dataset() -> Result<(), anyhow::Error> {
 }
 
 /// Tests that INSERT works on a standalone `DuckLake` dataset when `access: read_write` is set.
+/// Both `DuckLake` read paths must install the `DuckDB` federation deny-list.
+///
+/// `connector-ducklake` and `DuckLakeCatalogProvider` each build a
+/// `DuckDBTableFactory` over the same pool, and each installs the `DuckDB`
+/// unparser dialect. The dialect and the deny-list are two halves of one
+/// decision: without the deny-list, `can_execute_plan` lets a plan holding a
+/// Spice-only UDF federate, and the unparser emits it into the SQL sent to
+/// `DuckDB`.
+///
+/// `cosine_distance` is the case that matters (spiceai/spiceai#13728): `DuckDB`
+/// has a similarly-named `array_cosine_distance` that answers a *different
+/// number*, so a missing deny-list here is a wrong result rather than an error.
+/// The argument references a column so the expression cannot be constant-folded
+/// out of the plan before federation is decided.
+#[tokio::test]
+async fn ducklake_does_not_push_down_spice_functions() -> Result<(), anyhow::Error> {
+    let _tracing = init_tracing(Some("runtime=DEBUG,data_components=DEBUG"));
+    register_test_connectors().await;
+
+    let tmp_dir = TempDir::new()?;
+    let metadata_path = tmp_dir
+        .path()
+        .join("test_denylist.ducklake")
+        .display()
+        .to_string();
+    let data_path = tmp_dir.path().join("data_denylist").display().to_string();
+    std::fs::create_dir_all(&data_path)?;
+
+    bootstrap_ducklake(&metadata_path, &data_path);
+
+    test_request_context()
+        .scope(async {
+            // One dataset (connector path) and one catalog (catalog-provider
+            // path) over the same DuckLake, so both factories are exercised.
+            let mut dataset = Dataset::new(
+                "ducklake:main.products".to_string(),
+                "standalone_products".to_string(),
+            );
+            dataset.params = Some(Params::from_string_map(HashMap::from([(
+                "ducklake_connection_string".to_string(),
+                metadata_path.clone(),
+            )])));
+
+            let mut catalog = Catalog::new("ducklake".to_string(), "lake".to_string());
+            catalog.params = Some(make_ducklake_catalog_params(&metadata_path));
+
+            let app = AppBuilder::new("ducklake_denylist_test")
+                .with_dataset(dataset)
+                .with_catalog(catalog)
+                .build();
+
+            configure_test_datafusion();
+            let rt = Arc::new(Runtime::builder().with_app(app).build().await);
+            let cloned_rt = Arc::clone(&rt);
+
+            tokio::select! {
+                () = tokio::time::sleep(std::time::Duration::from_mins(1)) => {
+                    panic!("Timeout waiting for components to load");
+                }
+                () = cloned_rt.load_components() => {}
+            }
+
+            runtime_ready_check(&rt).await;
+
+            for table in ["standalone_products", "lake.main.products"] {
+                let sql = format!(
+                    "SELECT id, cosine_distance(make_array(price, price, price),                      make_array(1.0, 2.0, 3.0)) AS d FROM {table} ORDER BY id"
+                );
+
+                // 1. The query runs. A federated `cosine_distance` that DuckDB
+                //    could not bind would fail here instead.
+                let result = rt.datafusion().query_builder(&sql).build().run().await?;
+                let rows: Vec<RecordBatch> = result.data.try_collect().await?;
+                let total: usize = rows.iter().map(RecordBatch::num_rows).sum();
+                assert_eq!(total, 2, "expected 2 rows from {table}");
+
+                // 2. The scan is still pushed down, but the function is not.
+                //    Deleting the `.with_function_support(..)` call on either
+                //    factory turns this into `array_cosine_distance`, which
+                //    answers twice the local value.
+                let plan = explain_plan(&rt, &sql).await;
+                let pushed: Vec<&str> = plan
+                    .lines()
+                    .filter(|l| l.contains("base_sql=") || l.contains("DuckSqlExec sql="))
+                    .collect();
+                assert!(
+                    !pushed.is_empty(),
+                    "expected {table} to push a scan down to DuckDB; plan was:\n{plan}"
+                );
+                for line in pushed {
+                    assert!(
+                        !line.contains("array_cosine_distance"),
+                        "{table}: cosine_distance was federated to DuckDB's \
+                         array_cosine_distance, which answers a different number:\n{line}"
+                    );
+                }
+                assert!(
+                    plan.contains("cosine_distance"),
+                    "{table}: cosine_distance must still appear in the plan, \
+                     evaluated locally:\n{plan}"
+                );
+            }
+
+            Ok(())
+        })
+        .await
+}
+
 #[tokio::test]
 async fn ducklake_standalone_read_write_insert() -> Result<(), anyhow::Error> {
     let _tracing = init_tracing(Some("runtime=DEBUG,data_components=DEBUG"));


### PR DESCRIPTION
## Summary

`cosine_distance` answered a different number depending on whether its subtree
federated. The `DuckDB` dialect carve-out let the call push down, where it was
rewritten to `array_cosine_distance` — which is a **different function**, not
another spelling of the same one:

| | range | arithmetic |
|---|---|---|
| `cosine_distance` (Spice kernel) | `(1 - cos) / 2` over `[0, 1]` | f64 |
| `DuckDB` `array_cosine_distance` | `1 - cos` over `[0, 2]` | FLOAT |

The scale is a constant factor the emitted SQL could have divided out. **The
width is not.** On DuckDB 1.4.4 a pair of *identical, finite* vectors
`[1e-30, 0, 0]` answers `2.0` — maximally distant — because each squared
component underflows FLOAT, where the kernel answers `0`. `[1e20, 0, 0]`
overflows to the same answer. No rescaling reconciles that, so the name comes
out of the carve-out and the UDF is evaluated locally, which is what every other
backend already does.

`inner_product` stays carved out: `array_inner_product` computes the same value,
and it is measured agreeing across the boundary on every row whose result is
representable. Where the result is *not* representable it still diverges — that
is #13787, pinned by the test and discussed below.

## Changes

- `dialect/mod.rs`: drop `cosine_distance` from `duckdb_scalar_overrides()`, the
  single source of both the dialect handlers and the deny-list carve-out. The
  entry is replaced by a comment recording the measurement, so the obvious
  re-add is answered in place.
- `dialect/duckdb.rs`: delete the now-unreachable `cosine_distance_to_sql` and
  its two handler tests; flip the carve-out test to assert the name is absent.
- `datafusion/udf.rs`: update the three tests that pinned the pushable set.
- `connector-ducklake`: install the DuckDB deny-list. It builds the same factory
  with the same dialect but no function support, so without this the removed
  handler would leave it unparsing `cosine_distance` verbatim into SQL DuckDB
  cannot run — an error where it previously returned a wrong number.
- `data_components/ducklake/provider.rs` + `runtime/catalogconnector/ducklake.rs`:
  `DuckLakeCatalogProvider` built its own **bare** factory — neither dialect nor
  deny-list — so DuckLake *catalog* tables sat outside that pairing. The dialect
  and the deny-list live above `data_components`, so the factory is now supplied
  by the caller in `runtime`. All five `DuckDBTableFactory::new` sites now pair
  them.
- `connector-duckdb`: two comments named `cosine_distance` as the worked example
  of a function that still federates. It no longer is.

## Test plan

`make lint` and `make test` (via `make signoff`), plus the end-to-end
reproduction below.

**Repro.** Two datasets over one DuckDB table holding `FLOAT[3]` vectors: `fed`
unaccelerated, so its projection is unparsed into DuckDB SQL; `localmem`
accelerated into Arrow, so the same expression is evaluated by the kernel. Rows
1-3 walk an ordinary direction; rows 4 and 5 compare a vector with **itself** at
magnitudes whose squares underflow and overflow FLOAT.

```
SELECT id, cosine_distance(emb, q) AS d FROM <table> ORDER BY id
```

Before, on `dd85b6510b`:

```
fed      [0.025368094444274902, 0.0,             2.0,               2.0, 2.0]
localmem [0.012684076975384906, 1.2506769069e-10, 0.9999999998749323, 0.0, 0.0]
```

Rows 1-3 are the factor of two. Rows 4 and 5 are a vector against itself:
federated says maximally distant, the kernel says identical. A threshold
predicate splits with them —

```
SELECT id FROM fed      WHERE cosine_distance(emb, q) < 0.02  ->  [2]
SELECT id FROM localmem WHERE cosine_distance(emb, q) < 0.02  ->  [1, 2]
```

After, on this branch — both sides identical on all five rows, and the
predicates agree:

```
fed      [0.012684076975384906, 1.2506769069e-10, 0.9999999998749323, 0.0, 0.0]
localmem [0.012684076975384906, 1.2506769069e-10, 0.9999999998749323, 0.0, 0.0]

WHERE ... < 0.02  ->  [1, 2, 4, 5]   on both
```

The scan still pushes down; only the function is evaluated locally:

```
base_sql=SELECT "vecs"."id", "vecs"."emb", "vecs"."q" FROM "vecs"
ProjectionExec: expr=[id@0 as id, cosine_distance(emb@1, q@2) as d]
```

and `inner_product` still federates, unchanged:

```
base_sql=SELECT "vecs"."id", array_inner_product("vecs"."emb", "vecs"."q") AS "ip" FROM "vecs"
```

**Two regression tests.** `duckdb_cosine_distance_is_not_federated_to_a_different_function`
in `crates/runtime/tests/duckdb/mod.rs`, built on the same two datasets, and
`ducklake_does_not_push_down_spice_functions` in `tests/ducklake/mod.rs`, which
covers both DuckLake read paths (standalone dataset and catalog). Verified in
both directions:

```
# production files reverted to origin/trunk, test kept:
row 1 of cosine_distance disagrees across the federation boundary:
  fed 0.025368094444274902, local 0.012684076975384906.
  federated=[0.025368094444274902, 0.0, 2.0, 2.0, 2.0]
  local=[0.012684076975384906, 1.2506769069042988e-10, 0.9999999998749323, 0.0, 0.0]
test result: FAILED. 0 passed; 1 failed

# on this branch:
test duckdb::duckdb_cosine_distance_is_not_federated_to_a_different_function ... ok
test result: ok. 1 passed; 0 failed
```

The DuckLake test is neutered the same way — drop either
`.with_function_support(..)` call and it fails at the query itself, since with
the handler gone the unparser emits the UDF verbatim:

```
Catalog Error: Scalar Function with name cosine_distance does not exist!
Did you mean "cos"?
LINE 1: WITH fetch_schema AS ( SELECT "id", cosine_distance(["products"."price", ...
test result: FAILED. 0 passed; 1 failed

# restored:
test result: ok. 8 passed; 0 failed      # both new tests + the 6 existing DuckLake tests
```

Unit tests: `cargo test -p runtime-datafusion --lib dialect::duckdb` — 5 passed;
`cargo test -p runtime --lib --features duckdb datafusion::udf` — 18 passed.

## Performance impact

A `cosine_distance` call over a DuckDB dataset or accelerator no longer pushes
into DuckDB: the scan is still federated, the function is evaluated by
DataFusion. For `ORDER BY cosine_distance(...) LIMIT k` that means the sort no
longer happens DuckDB-side. **The vector-search path is not affected** — the
DuckDB search index builds its own SQL in
`crates/search/src/index/duckdb/metric.rs` (`array_cosine_distance` directly,
against DuckDB's own definition) and never goes through this UDF or the
deny-list, so HNSW-backed `/v1/search` is untouched. The cost lands on
hand-written SQL calling the UDF against a DuckDB-backed dataset, which is the
price of that SQL returning the number it returns everywhere else.

## Review gate

| Pass | Engine | Job | Outcome |
|---|---|---|---|
| 1 | `codex:adversarial-review` | `bawuhmtp9` | `needs-attention` — **rewrote this PR** |
| 2 | `codex:adversarial-review` | `bp37lnbg6` | **Declared skip**: "Your workspace is out of credits." `grok` is not installed on this host, so no second engine was available. |
| — | `/security-review` | — | No findings. |
| — | `/simplify` | — | Applied; details below. |
| — | *(none)* | — | **Declared skip** for the `89db8ad2dd` doc-comment push: comment-only, no executable line changed, `cargo fmt --check` clean. |

**Pass 1 changed the approach.** The first version of this PR rescaled the
rewrite to `array_cosine_distance(..) / 2`. Codex rejected it, reporting that
`/2` fixes only the nominal scale and that identical vectors at `1e-30` and
`1e20` still answer `1` instead of `0`. I reproduced that on this rig, through
the real `spiced` path with the `/2` patch applied — `fed` gave `1.0` on both
rows where `localmem` gave `0.0` — and abandoned the rescaling for the
deny-list. Its other two findings (a `/2` quotient defeats DuckDB's
`HNSW_INDEX_SCAN`; the name-only carve-out federates call shapes DuckDB's
binder rejects) are both moot under the current change, since the call no longer
federates at all; the second is the pre-existing issue #13665.

**Copilot found a real gap in the claim above.** Its first review pointed out
that `DuckLakeCatalogProvider` constructs a fifth, bare `DuckDBTableFactory`, so
DuckLake catalog tables were outside the pairing this PR asserted. Confirmed —
`grep -rn "DuckDBTableFactory::new"` returns five sites and that one had neither
half. Fixed by threading the configured factory through, and covered by the new
DuckLake test. It also asked for that test (the DuckLake wiring had none) and
caught the `inner_product` overclaim in a doc comment; both are addressed.

**`/simplify`** trimmed a comment that restated a shared helper's rationale,
condensed the comment in `duckdb_scalar_overrides`, and split a test's comments
onto their own assertions. One finding skipped: `new_duckdb_dialect()` and the
deny-list are separable at every call site, so a future connector can repeat
ducklake's omission. All four sites pair them after this change, so there is no
outstanding instance, and restructuring factory construction is beyond this diff.

## A correction, and a defect found while testing

An earlier reading of mine had `inner_product` agreeing across the boundary on
every row. That was wrong, and the way it was wrong is worth recording: the
`/v1/sql` JSON encoder renders `+Inf` as `null`, so a federated `inf` and a
kernel `NULL` printed identically. The regression test, reading the Arrow array
directly, caught it. Confirmed with `IS NULL`:

```
[{"src":"local","is_null":true,"as_text":null},
 {"src":"fed","is_null":false,"as_text":"inf"}]
```

So a federated `inner_product` returns `+Inf` where the kernel returns `NULL`,
and in DuckDB `NaN`/`Inf` sort above every number under `ORDER BY … DESC`. That
is the ranking failure #13091 fixed locally, still reachable when federated —
but only for results that overflow, needing components around `1e19`, unlike the
`cosine_distance` divergence which was on ordinary values. Filed separately as
#13787 rather than folded in here, and the test pins the current behaviour so
whoever fixes it sees that assertion fail.

## Open question this does not settle

#11263 asks which formula `cosine_distance` should define at all — every other
cosine path in the runtime (the DuckDB HNSW index, the documented `_score`)
agrees on `1 - cos`, and only the local kernel uses `(1 - cos) / 2`. That is a
maintainer decision about user-visible score values and stays open. This change
is orthogonal: whatever formula wins, the federated answer has to equal the
local one.

Fixes #13728

## Checklist

- [x] Reproduced on `trunk` before the fix, with the artifact above
- [x] Regression test fails on unfixed production code and passes on the branch
- [x] Bug-class swept: all three carved-out array functions checked against their
      kernels; `array_distance` is a DataFusion built-in, not deny-listed;
      `inner_product`'s residual filed as #13787
- [x] Adversarial review + `/security-review` + `/simplify` run and recorded above
- [ ] `make signoff` green and `Attestation` re-run — re-running against `89db8ad2dd` after the doc-comment push invalidated the attestation earned at `0a98e6db`

