### PR TITLE
build(spiced): move jemalloc heap profiling to its own feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21549,9 +21549,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -21559,9 +21559,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -855,7 +855,7 @@ Spice.ai acknowledges the following open source projects for making this project
 - tiktoken-rs 0.9.1, MIT 
   <br/>https://github.com/zurawiki/tiktoken-rs
 
-- tikv-jemallocator 0.6.1, Apache-2.0 OR MIT 
+- tikv-jemallocator 0.7.0, Apache-2.0 OR MIT 
   <br/>https://github.com/tikv/jemallocator
 
 - time 0.3.47, Apache-2.0 OR MIT 

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -123,7 +123,7 @@ tempfile.workspace = true
 [features]
 adbc = ["dep:connector-adbc", "runtime/adbc"]
 alloc-jemalloc = ["dep:tikv-jemallocator"]
-# Builds jemalloc with `--enable-prof`, without which `MALLOC_CONF=prof:true,…`
+# Builds jemalloc with `--enable-prof`, without which `_RJEM_MALLOC_CONF=prof:true`
 # is silently ignored. Reports as `jemalloc-profiling`, not `jemalloc`.
 alloc-jemalloc-profiling = ["alloc-jemalloc", "tikv-jemallocator/profiling"]
 alloc-mimalloc = ["dep:mimalloc"]

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -89,10 +89,7 @@ zeroize = "1.8"
 snmalloc-rs = { version = "0.3.6" }
 spice-cloud = { path = "../../crates/spice_cloud" }
 telemetry = { path = "../../crates/telemetry" }
-# Built without `--enable-prof`, so the allocation fast path carries no sampling
-# event: jemalloc compiles `te_alloc_prof_sample` into its per-allocation event
-# registry only under `JEMALLOC_PROF`. `alloc-jemalloc-profiling` turns prof on
-# for heap investigations.
+# No `profiling` feature here: `--enable-prof` belongs to `alloc-jemalloc-profiling`.
 tikv-jemallocator = { version = "0.7.0", optional = true }
 tokio.workspace = true
 # `CancellationToken` for the latches the connection report waits on.
@@ -126,11 +123,8 @@ tempfile.workspace = true
 [features]
 adbc = ["dep:connector-adbc", "runtime/adbc"]
 alloc-jemalloc = ["dep:tikv-jemallocator"]
-# Heap-profiling jemalloc: `--enable-prof` is what makes
-# `MALLOC_CONF=prof:true,prof_prefix=…` take effect — without it jemalloc ignores
-# those knobs silently. Reads as `jemalloc-profiling` in the startup banner and
-# the crash report, because a profiling build is not throughput-comparable with
-# a plain `alloc-jemalloc` one.
+# Builds jemalloc with `--enable-prof`, without which `MALLOC_CONF=prof:true,…`
+# is silently ignored. Reports as `jemalloc-profiling`, not `jemalloc`.
 alloc-jemalloc-profiling = ["alloc-jemalloc", "tikv-jemallocator/profiling"]
 alloc-mimalloc = ["dep:mimalloc"]
 alloc-snmalloc = []

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -89,13 +89,11 @@ zeroize = "1.8"
 snmalloc-rs = { version = "0.3.6" }
 spice-cloud = { path = "../../crates/spice_cloud" }
 telemetry = { path = "../../crates/telemetry" }
-# `profiling` builds jemalloc with `--enable-prof`, without which the heap
-# profiler cannot be turned on at all and `MALLOC_CONF=prof:true,prof_prefix=…`
-# is silently ignored. Costs a sample check in the allocator fast path even while
-# prof is inactive, so this opt-in `alloc-jemalloc` build is for heap
-# investigations, not for allocator throughput comparisons against the default
-# snmalloc build.
-tikv-jemallocator = { version = "0.6.0", optional = true, features = ["profiling"] }
+# Built without `--enable-prof`, so the allocation fast path carries no sampling
+# event: jemalloc compiles `te_alloc_prof_sample` into its per-allocation event
+# registry only under `JEMALLOC_PROF`. `alloc-jemalloc-profiling` turns prof on
+# for heap investigations.
+tikv-jemallocator = { version = "0.7.0", optional = true }
 tokio.workspace = true
 # `CancellationToken` for the latches the connection report waits on.
 tokio-util.workspace = true
@@ -128,6 +126,12 @@ tempfile.workspace = true
 [features]
 adbc = ["dep:connector-adbc", "runtime/adbc"]
 alloc-jemalloc = ["dep:tikv-jemallocator"]
+# Heap-profiling jemalloc: `--enable-prof` is what makes
+# `MALLOC_CONF=prof:true,prof_prefix=…` take effect — without it jemalloc ignores
+# those knobs silently. Reads as `jemalloc-profiling` in the startup banner and
+# the crash report, because a profiling build is not throughput-comparable with
+# a plain `alloc-jemalloc` one.
+alloc-jemalloc-profiling = ["alloc-jemalloc", "tikv-jemallocator/profiling"]
 alloc-mimalloc = ["dep:mimalloc"]
 alloc-snmalloc = []
 alloc-system = []

--- a/bin/spiced/build.rs
+++ b/bin/spiced/build.rs
@@ -78,8 +78,7 @@ fn build_features() -> String {
     let enabled: Vec<&str> = distinguishing
         .into_iter()
         .filter(|feature| {
-            // Cargo uppercases the feature name and maps `-` to `_`, so a hyphenated
-            // feature is never found under its own spelling.
+            // Cargo uppercases the feature name and maps `-` to `_`.
             let var = format!("CARGO_FEATURE_{}", feature.to_uppercase().replace('-', "_"));
             std::env::var_os(var).is_some()
         })

--- a/bin/spiced/build.rs
+++ b/bin/spiced/build.rs
@@ -71,13 +71,17 @@ fn build_features() -> String {
         "nfs",
         "smb",
         "alloc-jemalloc",
+        "alloc-jemalloc-profiling",
         "alloc-mimalloc",
         "alloc-system",
     ];
     let enabled: Vec<&str> = distinguishing
         .into_iter()
         .filter(|feature| {
-            std::env::var_os(format!("CARGO_FEATURE_{}", feature.to_uppercase())).is_some()
+            // Cargo uppercases the feature name and maps `-` to `_`, so a hyphenated
+            // feature is never found under its own spelling.
+            let var = format!("CARGO_FEATURE_{}", feature.to_uppercase().replace('-', "_"));
+            std::env::var_os(var).is_some()
         })
         .collect();
 

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -59,9 +59,6 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 // Function to determine the allocator name at compile time
 const fn get_allocator_name() -> Option<&'static str> {
     if cfg!(feature = "alloc-jemalloc-profiling") {
-        // Named apart from a plain jemalloc build: `--enable-prof` changes the
-        // allocation fast path, so a measurement taken here is not comparable
-        // with one taken on `alloc-jemalloc`.
         Some("jemalloc-profiling")
     } else if cfg!(feature = "alloc-jemalloc") {
         Some("jemalloc")

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -58,7 +58,12 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
 // Function to determine the allocator name at compile time
 const fn get_allocator_name() -> Option<&'static str> {
-    if cfg!(feature = "alloc-jemalloc") {
+    if cfg!(feature = "alloc-jemalloc-profiling") {
+        // Named apart from a plain jemalloc build: `--enable-prof` changes the
+        // allocation fast path, so a measurement taken here is not comparable
+        // with one taken on `alloc-jemalloc`.
+        Some("jemalloc-profiling")
+    } else if cfg!(feature = "alloc-jemalloc") {
         Some("jemalloc")
     } else if cfg!(feature = "alloc-mimalloc") {
         Some("mimalloc")

--- a/docs/DISTRIBUTIONS.md
+++ b/docs/DISTRIBUTIONS.md
@@ -187,14 +187,12 @@ Alternative allocator that may perform better for certain memory allocation patt
 docker pull ghcr.io/spiceai/spiceai-nightly:latest-jemalloc
 ```
 
-**Heap profiling:** the shipped jemalloc build has the heap profiler compiled out, so `MALLOC_CONF=prof:true,…` has no effect on it. Build with `alloc-jemalloc-profiling` to turn the profiler on:
+**Heap profiling:** the shipped jemalloc build has the heap profiler compiled out; build with `alloc-jemalloc-profiling` to turn the profiler on:
 
 ```bash
 make install SPICED_NON_DEFAULT_FEATURES="alloc-jemalloc-profiling"
 MALLOC_CONF=prof:true,prof_prefix=/tmp/spiced.prof spiced
 ```
-
-Such a build reports `allocator: jemalloc-profiling` at startup. Profile with it; measure allocator throughput without it.
 
 ### mimalloc
 

--- a/docs/DISTRIBUTIONS.md
+++ b/docs/DISTRIBUTIONS.md
@@ -187,17 +187,14 @@ Alternative allocator that may perform better for certain memory allocation patt
 docker pull ghcr.io/spiceai/spiceai-nightly:latest-jemalloc
 ```
 
-**Heap profiling:** the shipped jemalloc build has the heap profiler compiled out,
-so `MALLOC_CONF=prof:true,…` has no effect on it. Build with
-`alloc-jemalloc-profiling` to turn the profiler on:
+**Heap profiling:** the shipped jemalloc build has the heap profiler compiled out, so `MALLOC_CONF=prof:true,…` has no effect on it. Build with `alloc-jemalloc-profiling` to turn the profiler on:
 
 ```bash
 make install SPICED_NON_DEFAULT_FEATURES="alloc-jemalloc-profiling"
 MALLOC_CONF=prof:true,prof_prefix=/tmp/spiced.prof spiced
 ```
 
-Such a build reports `allocator: jemalloc-profiling` at startup. Profile with it;
-measure allocator throughput without it.
+Such a build reports `allocator: jemalloc-profiling` at startup. Profile with it; measure allocator throughput without it.
 
 ### mimalloc
 

--- a/docs/DISTRIBUTIONS.md
+++ b/docs/DISTRIBUTIONS.md
@@ -187,11 +187,11 @@ Alternative allocator that may perform better for certain memory allocation patt
 docker pull ghcr.io/spiceai/spiceai-nightly:latest-jemalloc
 ```
 
-**Heap profiling:** the shipped jemalloc build has the heap profiler compiled out; build with `alloc-jemalloc-profiling` to turn the profiler on:
+**Heap profiling:** the shipped jemalloc build has the heap profiler compiled out; build with `alloc-jemalloc-profiling` to turn the profiler on. jemalloc is built under the `_rjem_` prefix, so it reads `_RJEM_MALLOC_CONF`, not `MALLOC_CONF`:
 
 ```bash
 make install SPICED_NON_DEFAULT_FEATURES="alloc-jemalloc-profiling"
-MALLOC_CONF=prof:true,prof_prefix=/tmp/spiced.prof spiced
+_RJEM_MALLOC_CONF=prof:true,prof_final:true,prof_prefix:/tmp/spiced.prof spiced
 ```
 
 ### mimalloc

--- a/docs/DISTRIBUTIONS.md
+++ b/docs/DISTRIBUTIONS.md
@@ -187,6 +187,18 @@ Alternative allocator that may perform better for certain memory allocation patt
 docker pull ghcr.io/spiceai/spiceai-nightly:latest-jemalloc
 ```
 
+**Heap profiling:** the shipped jemalloc build has the heap profiler compiled out,
+so `MALLOC_CONF=prof:true,…` has no effect on it. Build with
+`alloc-jemalloc-profiling` to turn the profiler on:
+
+```bash
+make install SPICED_NON_DEFAULT_FEATURES="alloc-jemalloc-profiling"
+MALLOC_CONF=prof:true,prof_prefix=/tmp/spiced.prof spiced
+```
+
+Such a build reports `allocator: jemalloc-profiling` at startup. Profile with it;
+measure allocator throughput without it.
+
 ### mimalloc
 
 Microsoft's mimalloc allocator, designed for performance and security.


### PR DESCRIPTION
Splits jemalloc's heap profiler out of `alloc-jemalloc` so the shipped jemalloc build matches jemalloc's default configuration, and profiling is an explicit choice.

## Features

- `alloc-jemalloc` — jemalloc without `--enable-prof`.
- `alloc-jemalloc-profiling` — implies the above and adds `--enable-prof`. Reports as `jemalloc-profiling` at startup and in the crash report, so a profiling build is never mistaken for a plain one.

## Also in this PR

- **tikv-jemallocator 0.6.1 -> 0.7.0** (bundled jemalloc 5.3.0 -> 5.3.1).
- **Build-identity fix.** `build_features()` looked up `CARGO_FEATURE_ALLOC-JEMALLOC`, but Cargo uppercases a feature name and maps `-` to `_`. Every hyphenated feature — all three allocator features — was missing from `SPICED_BUILD_FEATURES`, which the crash report uses to identify the build.
- Documents heap profiling in `DISTRIBUTIONS.md`.