### PR TITLE
test(adbc): fail the boundary test when the query never ran

### DIFF
--- a/crates/data-connectors/connector-adbc/tests/adbc_cancellation.rs
+++ b/crates/data-connectors/connector-adbc/tests/adbc_cancellation.rs
@@ -323,4 +323,3 @@ async fn dropping_the_stream_cancels_the_query_and_frees_the_pool_connection() {
         "a statement call arrived after that statement had been released"
     );
 }
-

--- a/crates/data-connectors/connector-adbc/tests/adbc_cancellation_boundary.rs
+++ b/crates/data-connectors/connector-adbc/tests/adbc_cancellation_boundary.rs
@@ -221,6 +221,15 @@ fn statement_cancel_during_execute() {
     let error = execute_outcome
         .expect_err("the cancelled query should have ended as an error, not returned rows");
     println!("statement.execute ended with: {error}");
+    // Nothing above distinguishes a cancelled query from one that failed before
+    // the cancel was even sent: that error also arrives quickly, and the
+    // saturating subtraction below would report it as having stopped instantly.
+    assert!(
+        execute_took >= config.wait_before_cancel,
+        "statement.execute returned after {execute_took:?}, before the {:?} this test waits \
+         before cancelling, so no query was running to cancel and nothing was measured: {error}",
+        config.wait_before_cancel
+    );
     let stopped_within = execute_took.saturating_sub(config.wait_before_cancel);
     assert!(
         stopped_within <= config.query_stop_bound,


### PR DESCRIPTION
Stacked on #13782, which adds the file. Test-only; no runtime change.

## WHAT

Makes `statement_cancel_during_execute` fail when the query never ran, instead of passing.

## WHY

The test judged how quickly the query stopped with:

```rust
let stopped_within = execute_took.saturating_sub(config.wait_before_cancel);
```

That clamps to zero whenever `execute` returns *before* the cancel is even sent. A run that fails early — a bad URI, a credential problem, unsupported SQL — then satisfies every assertion: the cancel returns quickly, `execute` returns an error, and the clamp hides that nothing ran. `expect_err` accepts any error, so a configuration error reads the same as a cancellation.

This is not hypothetical. A real run against a URI missing its dataset passes:

```
statement.cancel  returned after 178.875µs: Ok(())
statement.execute returned after 1.40475325s: Err("… Required parameter is missing: dataset_id ()")
test result: ok. 2 passed; 0 failed
```

A test whose purpose is to catch a driver that ignores cancellation is worse than no test if it reports green on a driver it never exercised.

## HOW

Require the query to still have been running when the cancel fired. This holds by construction for any genuine run — the cancel is sent only after sleeping `wait_before_cancel`, so `execute` cannot return earlier unless it failed before the query started — and it is driver-agnostic, unlike matching on error text.

## Evidence

Same broken URI as above, against this change:

```
statement.cancel  returned after 14.125µs: Ok(())
statement.execute returned after 2.280616333s: Err("… Required parameter is missing: dataset_id ()")

panicked at adbc_cancellation_boundary.rs:227:
statement.execute returned after 2.280616333s, before the 8s this test waits before cancelling,
so no query was running to cancel and nothing was measured: …

test result: FAILED. 0 passed; 1 failed
```

The genuine path is unaffected — a real cancelled query on the pinned driver returns at `8.007552041s` against an 8s wait, since `execute` only returns once the cancel lands:

```
statement.cancel  returned after 232.375µs: Ok(())
statement.execute returned after 8.007552041s: Err("Cancelled: [bq] cancelled poll job status: context canceled")
test result: ok. 2 passed; 0 failed
```

## Scope

The test is opt-in — it skips without `ADBC_CANCEL_DRIVER_PATH`, so it does not run in CI — and it is not the guard `docs/dev/fork_patches.md` names for the fork patches. Nothing about the shipped cancellation behaviour depends on it, which is why this is a follow-up rather than a change to #13782's head.
