### PR TITLE
fix(caching): say when a caching accelerator has nothing bounding it (fixes #13525)

### DIFF
--- a/crates/runtime/src/datafusion/caching_retention.rs
+++ b/crates/runtime/src/datafusion/caching_retention.rs
@@ -129,20 +129,27 @@ pub(crate) fn caching_retention(
 /// retention policy bounds how long an entry is kept while keeping the
 /// stale-on-error fallback, and disabling the fallback gets the derived eviction
 /// back.
+///
+/// It says the accelerator has no retention policy *running*, never that the
+/// dataset declared none. The two are not the same and the difference is the
+/// awkward case this warning exists to cover: a policy that was declared and
+/// then assembled into nothing. Telling that operator their declaration is
+/// absent sends them to write one they have already written.
 pub(crate) fn unbounded_caching_retention_warning(dataset_name: &str) -> String {
     // `escape_debug` rather than the raw name: a Spicepod identifier may be
     // quoted, and a quoted one may legally contain a newline, so a validated
     // name can otherwise break this line in two and forge a second one.
     let dataset_name = dataset_name.escape_debug();
     format!(
-        "Dataset '{dataset_name}' sets `caching_stale_if_error: enabled` and declares no retention \
-        policy, so no cached entry is ever evicted and the accelerator grows with every distinct \
+        "Dataset '{dataset_name}' sets `caching_stale_if_error: enabled` and has no retention policy \
+        running, so no cached entry is ever evicted and the accelerator grows with every distinct \
         request it serves. An expired entry is the copy served when the source fails, so \
         `caching_ttl` and `caching_stale_while_revalidate_ttl` bound how long an entry is served \
-        fresh, not how long it is stored. Set `retention_check_enabled: true` with a \
-        `retention_period`, a `retention_check_interval` and the dataset's `time_column` to bound \
-        how long an entry is kept, or set `caching_stale_if_error: disabled` to evict at \
-        `caching_ttl` + `caching_stale_while_revalidate_ttl`. See: {CACHING_DOCS_URL}"
+        fresh, not how long it is stored. To bound how long an entry is kept, set \
+        `retention_check_enabled: true` with a `retention_period`, a `retention_check_interval` and \
+        the dataset's `time_column` — a policy missing any one of those starts nothing, so check \
+        all four if you have already set some. Or set `caching_stale_if_error: disabled` to evict \
+        at `caching_ttl` + `caching_stale_while_revalidate_ttl`. See: {CACHING_DOCS_URL}"
     )
 }
 
@@ -244,6 +251,10 @@ mod tests {
         let warning = unbounded_caching_retention_warning("api_cache");
 
         assert!(warning.contains("'api_cache'"), "{warning}");
+        assert!(warning.contains("no retention policy running"), "{warning}");
+        // Never a claim that the dataset declared nothing: this warning also
+        // covers a policy that was declared and did not build.
+        assert!(!warning.contains("declares no retention"), "{warning}");
         assert!(
             warning.contains("grows with every distinct request"),
             "{warning}"

--- a/crates/runtime/src/datafusion/caching_retention.rs
+++ b/crates/runtime/src/datafusion/caching_retention.rs
@@ -1,0 +1,272 @@
+/*
+Copyright 2024-2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! What bounds the size of a `refresh_mode: caching` accelerator.
+//!
+//! A caching accelerator stores one entry per distinct request and nothing in
+//! the read path removes one, so eviction is a retention policy or nothing.
+//! This module decides whether the caching parameters can supply that policy,
+//! and what to tell an operator whose configuration leaves the accelerator
+//! without one.
+//!
+//! Kept apart from the registration code that calls it, and expressed as a pure
+//! function over the parameters rather than as branches around a builder, so the
+//! decision and the wording an operator acts on are asserted by tests instead of
+//! inferred from whatever a log capture happens to retain.
+
+use std::time::Duration;
+
+/// `caching_ttl`'s own default, applied when the dataset does not set one.
+const DEFAULT_CACHING_TTL: Duration = Duration::from_secs(30);
+
+/// Floor on the derived check interval, so a sub-second `caching_ttl` does not
+/// put the accelerator under a delete every tick of it.
+const MIN_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Ceiling on the derived check interval.
+///
+/// The interval is derived from the retention period, and the period is as long
+/// as the operator's `caching_stale_while_revalidate_ttl` — which is routinely
+/// hours or longer. Uncapped, a year-long window schedules the *second* check
+/// for a year's time; `tokio::time::interval` fires its first tick immediately,
+/// so what an operator sees is one check at startup, over an accelerator that is
+/// still empty, and then no eviction for the life of the process. Everything
+/// this policy deletes is past `caching_ttl + caching_stale_while_revalidate_ttl`
+/// and can no longer be served, so checking more often than the period only ever
+/// costs a no-op delete: the ceiling is what makes the policy actually run.
+const MAX_CHECK_INTERVAL: Duration = Duration::from_hours(1);
+
+/// Where an operator reads about `refresh_mode: caching`.
+const CACHING_DOCS_URL: &str =
+    "https://spiceai.org/docs/features/data-acceleration/refresh-modes/caching";
+
+/// What the caching parameters can say about evicting cache entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CachingRetention {
+    /// Evict entries older than `period`, checking every `check_interval`.
+    /// This replaces whatever retention the dataset declared.
+    Derive {
+        period: Duration,
+        check_interval: Duration,
+    },
+    /// The caching parameters cannot supply a policy, and the dataset's own is
+    /// already running. Leave that one alone.
+    LeaveDeclared,
+    /// The caching parameters cannot supply a policy and no other one runs, so
+    /// nothing bounds the accelerator. The caller warns.
+    Unbounded,
+}
+
+/// Clamp a retention period into a check interval that will actually run.
+fn check_interval_for(period: Duration) -> Duration {
+    period.clamp(MIN_CHECK_INTERVAL, MAX_CHECK_INTERVAL)
+}
+
+/// What a `refresh_mode: caching` dataset's caching parameters imply about
+/// evicting its cache entries.
+///
+/// With `caching_stale_if_error` disabled, an entry past
+/// `caching_ttl + caching_stale_while_revalidate_ttl` can never be served again,
+/// so that sum is a retention period, and one derived from the caching
+/// parameters is more specific than anything the dataset declared.
+///
+/// Enabling `caching_stale_if_error` changes what an expired entry *is*: it is
+/// the copy served when the source fails, with no upper bound on its age.
+/// Evicting at the sum above would delete exactly the data the setting exists to
+/// serve, and no other duration in the caching parameters bounds one — so the
+/// caching parameters supply no policy at all, and the only thing that can bound
+/// the accelerator is a retention policy the dataset declares itself.
+///
+/// `declared_retention_runs` is whether one does — whether the dataset's
+/// retention policy *built*, not whether it was configured. The two differ, and
+/// the difference is the silent case: a policy missing its
+/// `retention_check_interval` or its `time_column` is assembled into nothing at
+/// all, with no task started and no error raised, so reading intent off the
+/// config would suppress this warning for an accelerator that is just as
+/// unbounded as one configured with no policy at all.
+pub(crate) fn caching_retention(
+    stale_if_error: bool,
+    caching_ttl: Option<Duration>,
+    caching_stale_while_revalidate_ttl: Option<Duration>,
+    declared_retention_runs: bool,
+) -> CachingRetention {
+    if !stale_if_error {
+        let period = caching_ttl.unwrap_or(DEFAULT_CACHING_TTL)
+            + caching_stale_while_revalidate_ttl.unwrap_or_default();
+
+        return CachingRetention::Derive {
+            period,
+            check_interval: check_interval_for(period),
+        };
+    }
+
+    if declared_retention_runs {
+        CachingRetention::LeaveDeclared
+    } else {
+        CachingRetention::Unbounded
+    }
+}
+
+/// What to tell an operator whose caching accelerator has no retention at all.
+///
+/// The consequence is the message: `caching_ttl` and
+/// `caching_stale_while_revalidate_ttl` read as size controls, and an operator
+/// who set them has no other reason to expect unbounded growth. Both remedies
+/// are named because they answer different questions — the dataset's own
+/// retention policy bounds how long an entry is kept while keeping the
+/// stale-on-error fallback, and disabling the fallback gets the derived eviction
+/// back.
+pub(crate) fn unbounded_caching_retention_warning(dataset_name: &str) -> String {
+    // `escape_debug` rather than the raw name: a Spicepod identifier may be
+    // quoted, and a quoted one may legally contain a newline, so a validated
+    // name can otherwise break this line in two and forge a second one.
+    let dataset_name = dataset_name.escape_debug();
+    format!(
+        "Dataset '{dataset_name}' sets `caching_stale_if_error: enabled` and declares no retention \
+        policy, so no cached entry is ever evicted and the accelerator grows with every distinct \
+        request it serves. An expired entry is the copy served when the source fails, so \
+        `caching_ttl` and `caching_stale_while_revalidate_ttl` bound how long an entry is served \
+        fresh, not how long it is stored. Set `retention_check_enabled: true` with a \
+        `retention_period`, a `retention_check_interval` and the dataset's `time_column` to bound \
+        how long an entry is kept, or set `caching_stale_if_error: disabled` to evict at \
+        `caching_ttl` + `caching_stale_while_revalidate_ttl`. See: {CACHING_DOCS_URL}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CachingRetention, MAX_CHECK_INTERVAL, MIN_CHECK_INTERVAL, caching_retention,
+        unbounded_caching_retention_warning,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn a_disabled_stale_if_error_evicts_at_ttl_plus_stale_while_revalidate() {
+        let retention = caching_retention(false, Some(Duration::from_secs(5)), None, false);
+
+        assert_eq!(
+            retention,
+            CachingRetention::Derive {
+                period: Duration::from_secs(5),
+                check_interval: MIN_CHECK_INTERVAL,
+            }
+        );
+    }
+
+    #[test]
+    fn an_unset_caching_ttl_falls_back_to_its_own_default() {
+        let CachingRetention::Derive { period, .. } =
+            caching_retention(false, None, Some(Duration::from_secs(10)), false)
+        else {
+            panic!("a dataset with `caching_stale_if_error` disabled always derives a policy");
+        };
+
+        assert_eq!(period, Duration::from_secs(30) + Duration::from_secs(10));
+    }
+
+    /// A derived policy is more specific than a declared one and replaces it, so
+    /// a running declared policy must not change what is derived.
+    #[test]
+    fn a_declared_retention_does_not_change_what_a_disabled_stale_if_error_derives() {
+        assert_eq!(
+            caching_retention(false, Some(Duration::from_secs(5)), None, true),
+            caching_retention(false, Some(Duration::from_secs(5)), None, false),
+        );
+    }
+
+    /// The reported half of #13525: enabling `caching_stale_if_error` left the
+    /// dataset with no retention policy at all, and said nothing about it.
+    #[test]
+    fn an_enabled_stale_if_error_with_no_declared_retention_is_unbounded() {
+        let retention = caching_retention(true, Some(Duration::from_secs(5)), None, false);
+
+        assert_eq!(retention, CachingRetention::Unbounded);
+    }
+
+    /// The dataset's own policy is the one thing that can bound a stale-on-error
+    /// cache, so the caching branch must leave it in place rather than replace it
+    /// with a policy keyed on a different column.
+    #[test]
+    fn an_enabled_stale_if_error_leaves_a_running_declared_retention_alone() {
+        let retention = caching_retention(true, Some(Duration::from_secs(5)), None, true);
+
+        assert_eq!(retention, CachingRetention::LeaveDeclared);
+    }
+
+    /// A retention policy that was configured but did not build — no
+    /// `retention_check_interval`, say — starts no task, so the accelerator is
+    /// exactly as unbounded as one with no policy configured and must be told so.
+    /// This is the caller's contract: it passes whether the policy *runs*.
+    #[test]
+    fn a_declared_retention_that_did_not_build_is_still_unbounded() {
+        let retention = caching_retention(true, Some(Duration::from_secs(5)), None, false);
+
+        assert_eq!(retention, CachingRetention::Unbounded);
+    }
+
+    /// The second half of #13525: a long `caching_stale_while_revalidate_ttl`
+    /// made the derived check interval as long as the retention period, so the
+    /// policy ran once at startup — over an accelerator still empty — and never
+    /// again.
+    #[test]
+    fn a_year_long_window_still_checks_within_the_hour() {
+        // Expressed as a multiple of the ceiling rather than a literal, so the
+        // assertion below reads against the bound it is testing.
+        let year = MAX_CHECK_INTERVAL * 24 * 365;
+        let CachingRetention::Derive {
+            period,
+            check_interval,
+        } = caching_retention(false, Some(Duration::from_secs(1)), Some(year), false)
+        else {
+            panic!("a dataset with `caching_stale_if_error` disabled always derives a policy");
+        };
+
+        assert_eq!(period, Duration::from_secs(1) + year);
+        assert_eq!(check_interval, MAX_CHECK_INTERVAL);
+    }
+
+    #[test]
+    fn the_warning_names_the_dataset_the_consequence_and_both_remedies() {
+        let warning = unbounded_caching_retention_warning("api_cache");
+
+        assert!(warning.contains("'api_cache'"), "{warning}");
+        assert!(
+            warning.contains("grows with every distinct request"),
+            "{warning}"
+        );
+        assert!(
+            warning.contains("`retention_check_enabled: true`"),
+            "{warning}"
+        );
+        assert!(warning.contains("`retention_period`"), "{warning}");
+        assert!(warning.contains("`retention_check_interval`"), "{warning}");
+        assert!(
+            warning.contains("`caching_stale_if_error: disabled`"),
+            "{warning}"
+        );
+        assert!(warning.contains("https://spiceai.org/docs"), "{warning}");
+        assert!(!warning.contains('\n'), "{warning}");
+    }
+
+    #[test]
+    fn a_dataset_name_carrying_a_newline_cannot_forge_a_second_log_line() {
+        let warning = unbounded_caching_retention_warning("api\ncache");
+
+        assert!(!warning.contains('\n'), "{warning}");
+        assert!(warning.contains(r"api\ncache"), "{warning}");
+    }
+}

--- a/crates/runtime/src/datafusion/mod.rs
+++ b/crates/runtime/src/datafusion/mod.rs
@@ -137,6 +137,7 @@ pub mod query;
 
 pub mod app_context_extension;
 pub mod builder;
+pub(crate) mod caching_retention;
 #[cfg(not(windows))]
 pub mod cayenne_ddl;
 pub use runtime_datafusion::composed_catalog;
@@ -2974,6 +2975,13 @@ impl DataFusion {
             .delete_expr(retention_delete_expr)
             .build();
 
+        // Whether a retention task will actually run, which is not the same as
+        // the dataset having configured one: the builder returns `None` for a
+        // policy it cannot assemble — no `retention_check_interval`, no
+        // `time_column`, no period or expression — and the caching branch below
+        // has to tell "bounded" from "configured to be bounded".
+        let declared_retention_runs = retention.is_some();
+
         accelerated_table_builder.retention(retention);
 
         accelerated_table_builder
@@ -3019,33 +3027,45 @@ impl DataFusion {
                 );
             }
 
-            // Auto-configure cache retention when stale_if_error is disabled.
-            // Expired cache entries (past max_age + SWR) are never served and waste storage.
-            if !acceleration_settings.caching_stale_if_error.is_enabled() {
-                if dataset.retention_period().is_some() {
+            // Nothing in the caching read path removes an entry, so the
+            // accelerator is bounded by a retention policy or by nothing at all.
+            match caching_retention::caching_retention(
+                acceleration_settings.caching_stale_if_error.is_enabled(),
+                acceleration_settings.caching_ttl,
+                acceleration_settings.caching_stale_while_revalidate_ttl,
+                declared_retention_runs,
+            ) {
+                caching_retention::CachingRetention::Derive {
+                    period,
+                    check_interval,
+                } => {
+                    if dataset.retention_period().is_some() {
+                        tracing::warn!(
+                            dataset = %dataset.name,
+                            "User-specified retention_period is overridden by automatic cache retention in caching mode",
+                        );
+                    }
+
+                    let cache_retention = Retention::builder()
+                        .time_column(Some(crate::accelerated::caching::CACHE_REFRESHED_AT_COLUMN))
+                        .time_period(Some(period))
+                        .check_interval(Some(check_interval))
+                        .enabled(true)
+                        .build();
+
+                    accelerated_table_builder.retention(cache_retention);
+                }
+                // The policy built above this block is the dataset's own, and it
+                // is the only thing that can bound a stale-on-error cache.
+                caching_retention::CachingRetention::LeaveDeclared => {}
+                caching_retention::CachingRetention::Unbounded => {
                     tracing::warn!(
-                        dataset = %dataset.name,
-                        "User-specified retention_period is overridden by automatic cache retention in caching mode",
+                        "{}",
+                        caching_retention::unbounded_caching_retention_warning(
+                            &dataset.name.to_string()
+                        )
                     );
                 }
-
-                let max_age = acceleration_settings
-                    .caching_ttl
-                    .unwrap_or(Duration::from_secs(30));
-                let swr = acceleration_settings
-                    .caching_stale_while_revalidate_ttl
-                    .unwrap_or_default();
-                let retention_period = max_age + swr;
-                let check_interval = retention_period.max(Duration::from_secs(30));
-
-                let cache_retention = Retention::builder()
-                    .time_column(Some(crate::accelerated::caching::CACHE_REFRESHED_AT_COLUMN))
-                    .time_period(Some(retention_period))
-                    .check_interval(Some(check_interval))
-                    .enabled(true)
-                    .build();
-
-                accelerated_table_builder.retention(cache_retention);
             }
 
             accelerated_table_builder.caching_ttl(acceleration_settings.caching_ttl);


### PR DESCRIPTION
## Summary

A `refresh_mode: caching` accelerator stores one entry per distinct request and nothing in the read path ever removes one, so it is bounded by a retention policy or by nothing at all. Retention was only derived when `caching_stale_if_error` was **disabled**:

```rust
// Auto-configure cache retention when stale_if_error is disabled.
if !acceleration_settings.caching_stale_if_error.is_enabled() {
```

Enabling it therefore skipped the derivation entirely, and `caching_ttl` / `caching_stale_while_revalidate_ttl` stopped bounding storage — with nothing said about it. The parameter reads as error-handling behaviour (*serve a stale entry if the origin is failing*); that it also means *and never evict anything* is a second, much larger consequence that nothing in its name, the docs, or the logs conveyed.

**The coupling itself is sound and is kept.** With `caching_stale_if_error` enabled an expired entry *is* the copy served when the source fails (`handle_cache_miss` passes the expired batches down its `stale_if_error` branch), so evicting at `caching_ttl + caching_stale_while_revalidate_ttl` would delete exactly the data the setting exists to serve, and no other duration in the caching parameters bounds one. What was missing is a way for an operator to know — which is the alternative #13525 names.

## Changes

- **A caching dataset with `caching_stale_if_error: enabled` and no retention policy running now warns at load**, naming the dataset, the growth, and both remedies. Built as a pure function so the wording an operator acts on is asserted by a test rather than inferred from a log capture.
- **"A policy running" is read off the `Option<Retention>` the runtime actually built, not off the configuration.** `RetentionBuilder::build` returns `None` for a policy it cannot assemble — a missing `retention_check_interval` or `time_column` — with no task started and no error raised, so a dataset that configured retention and got none is exactly as unbounded as one that configured nothing. Reading intent off the config instead would suppress the warning in precisely that case.
- **The caching branch keeps its hands off a policy the dataset declared.** It built nothing there before and must not start replacing one: the declared policy carries the dataset's own `time_column` and its parsed `retention_sql`, and a `_fetched_at`-keyed replacement would silently drop both.
- **The derived check interval is capped at an hour.** It was the retention period itself, so a `caching_stale_while_revalidate_ttl` of hours scheduled the *second* check hours away — and `tokio::time::interval` fires its first tick immediately, so a year-long window ran one check at startup, over an accelerator still empty, and none after. Everything the derived policy deletes is already past `ttl + swr` and unservable, so checking more often only ever costs a no-op delete.

No default changes for a dataset that does not enable `caching_stale_if_error`, beyond the check-interval cap.

## Test plan

`make lint` and `make test` (via `make signoff`).

New unit tests in `crates/runtime/src/datafusion/caching_retention.rs` (9, all passing) cover the decision table and the message wording, including that a dataset name carrying a newline cannot forge a second log line.

### Reproduced on `trunk` first, then re-measured on the branch

A `spiced` run against a local HTTP source, `caching_ttl: 5s`, twenty distinct cached requests, `caching_stale_if_error` the only variable.

**`caching_stale_if_error: disabled` on `trunk`** — retention runs and evicts:

```
[retention] Evicting data for cached where _fetched_at < 2026-09-01T23:45:42+00:00
[retention] Evicted 20 records for cached
```

**`caching_stale_if_error: enabled` on `trunk`**, same workload — nothing, ever:

```
retention log lines: 0
```

**Same configuration on this branch** — the accelerator is still unbounded (deliberately: evicting would delete the fallback), and now says so:

```
WARN runtime::datafusion: Dataset 'cached' sets `caching_stale_if_error: enabled` and has no
retention policy running, so no cached entry is ever evicted and the accelerator grows with every
distinct request it serves. An expired entry is the copy served when the source fails, so
`caching_ttl` and `caching_stale_while_revalidate_ttl` bound how long an entry is served fresh, not
how long it is stored. To bound how long an entry is kept, set `retention_check_enabled: true` with
a `retention_period`, a `retention_check_interval` and the dataset's `time_column` — a policy
missing any one of those starts nothing, so check all four if you have already set some. Or set
`caching_stale_if_error: disabled` to evict at `caching_ttl` + `caching_stale_while_revalidate_ttl`.
See: https://spiceai.org/docs/features/data-acceleration/refresh-modes/caching
```

It says the policy is not *running*, never that none was declared — the same warning covers a policy
that was declared and then assembled into nothing, and telling that operator their declaration is
absent would send them to write one they already have.

The remedy it names is measured, not assumed — the same dataset with a retention policy that runs evicts on `trunk` today, and still does on this branch, with no warning:

```
retention log lines: 113
  Evicted 12 records / Evicted 8 records     (the 20 cached entries)
unbounded warning: 0
```

And a policy that was *configured but did not build* — `retention_check_enabled: true`, `retention_period`, `time_column`, but no `retention_check_interval` — is reported rather than mistaken for a bound. On the intermediate branch build it was silent, which is the same defect in a new shape; on this one:

```
retention log lines: 0
unbounded warning: 1
```

Control, `caching_stale_if_error: disabled` on this branch — unchanged from `trunk`:

```
Evicted 20 records for cached
unbounded warning: 0
```

### The check-interval cap

Two `spiced` instances on the same host, same Spicepod (`caching_ttl: 5s`, `caching_stale_while_revalidate_ttl: 8760h`), run side by side for 61 minutes.

`trunk` — one tick at startup, over an empty accelerator, and the next scheduled a year out:

```
00:21:14Z  [retention] Evicting data for cached where _fetched_at < 2025-09-02T00:21:09+00:00
```

The branch — the same first tick, then again on the hour:

```
00:21:51Z  [retention] Evicting data for cached where _fetched_at < 2025-09-02T00:21:46+00:00
01:21:51Z  [retention] Evicting data for cached where _fetched_at < 2025-09-02T01:21:46+00:00
```

## Review gate

- Adversarial review: **skipped** — on the shipping HEAD `codex` exited 1: "Your workspace is out of credits"; `grok` not installed. Two earlier rounds did complete on earlier HEADs of this branch and both returned `[high]` findings, both fixed here rather than deferred: (1) replacing a declared retention policy with a `_fetched_at`-keyed one drops the dataset's `retention_sql` and `time_column` — that arm was removed, and the branch now leaves a declared policy alone; (2) reading retention off the configuration rather than off the built policy suppressed the warning for a policy that never assembled — reproduced on a real run, then fixed by reading `Option<Retention>`. The builder's own silence in that case is out of scope and filed as #13804.
- `/security-review`: no findings, re-run after the review-comment fix. The one surface it examines is the new log line; the dataset name is `escape_debug`d before formatting, matching `disabled_acceleration_warning`, and two unit tests pin it.
- Copilot: one finding, fixed — the warning claimed the dataset "declares no retention policy", which is false for the configured-but-unbuilt shape this PR deliberately routes to the same message. Reworded to "has no retention policy running", re-measured on both shapes, and pinned by an assertion that the message never claims a declaration is absent.
- `/simplify`: applied — hoisted a repeated `dataset.retention_period()` parse; light checks re-run green.

Fixes #13525

## Checklist

- [x] Reproduced on `trunk` before the fix, and the same commands re-run on the branch
- [x] Unit tests for the decision table and the message wording
- [x] No behaviour change for a dataset that does not enable `caching_stale_if_error`, beyond the check-interval cap
- [x] Out-of-scope finding filed (#13804) rather than folded in