### PR TITLE
test(cayenne): stop test_cayenne_partitioned_deletion racing its own retention

### DIFF
--- a/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
+++ b/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
@@ -1865,6 +1865,10 @@ async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
 
     no_cache_context
         .scope(async {
+            const COUNT_SQL: &str = "SELECT COUNT(*) as cnt FROM partitioned_delete_test";
+            const BY_REGION_SQL: &str = "SELECT region, COUNT(*) as cnt FROM \
+                 partitioned_delete_test GROUP BY region ORDER BY region";
+
             let temp_dir = tempfile::tempdir()?;
             let data_dir = temp_dir.path().join("data");
             std::fs::create_dir_all(&data_dir)?;
@@ -1943,10 +1947,6 @@ async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
             }
 
             runtime_ready_check(&rt).await;
-
-            const COUNT_SQL: &str = "SELECT COUNT(*) as cnt FROM partitioned_delete_test";
-            const BY_REGION_SQL: &str = "SELECT region, COUNT(*) as cnt FROM \
-                 partitioned_delete_test GROUP BY region ORDER BY region";
 
             // Phase one: the whole fixture, and it stays the whole fixture however often
             // retention runs, because nothing in it matches `value > 400`. Asserting it here is

--- a/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
+++ b/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
@@ -1869,21 +1869,25 @@ async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
             let data_dir = temp_dir.path().join("data");
             std::fs::create_dir_all(&data_dir)?;
 
+            // Two phases, because no single end state can prove the deletion happened: six rows
+            // minus three retention matches leaves exactly what loading only the other three
+            // would leave, so a row-loss regression satisfies an end-state assertion unchanged.
+            //
+            // Phase one loads a fixture retention cannot touch — every value is below the
+            // predicate — and asserts all six rows across all three partitions. Nothing about
+            // that assertion races: there is no row for retention to remove, whenever it runs.
+            // Phase two rewrites one row per partition above the predicate, so the three rows
+            // that then disappear are three that were provably there.
             let csv_file = data_dir.join("partitioned_delete_test.csv");
             std::fs::write(
                 &csv_file,
-                // Every partition holds one row retention keeps and one it deletes, so the
-                // surviving state proves all three partitions loaded *and* that retention ran
-                // in each of them. A fixture whose deleted rows all sit in one partition cannot
-                // tell "retention removed that partition" apart from "that partition never
-                // loaded".
                 "id,region,name,value\n\
                  1,us,alpha,100\n\
-                 2,us,beta,500\n\
+                 2,us,beta,150\n\
                  3,eu,gamma,300\n\
-                 4,eu,delta,600\n\
+                 4,eu,delta,350\n\
                  5,asia,epsilon,200\n\
-                 6,asia,zeta,700\n",
+                 6,asia,zeta,250\n",
             )?;
 
             let cayenne_dir = temp_dir.path().join("cayenne_partitioned_delete");
@@ -1940,13 +1944,58 @@ async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
 
             runtime_ready_check(&rt).await;
 
-            // Cayenne applies `retention_sql` on every write, so the rows with `value > 400` can
-            // be gone before the load has even settled — no value of `retention_check_interval`
-            // holds that off. Asserting the pre-retention contents here is therefore unwinnable
-            // (see #13800). Wait for the deletion to land instead, then assert the surviving
-            // state, which with the fixture above still proves the load and the deletion.
             const COUNT_SQL: &str = "SELECT COUNT(*) as cnt FROM partitioned_delete_test";
+            const BY_REGION_SQL: &str = "SELECT region, COUNT(*) as cnt FROM \
+                 partitioned_delete_test GROUP BY region ORDER BY region";
 
+            // Phase one: the whole fixture, and it stays the whole fixture however often
+            // retention runs, because nothing in it matches `value > 400`. Asserting it here is
+            // what later lets the three missing rows mean "deleted" rather than "never loaded".
+            let result = execute_sql(&rt, COUNT_SQL).await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 6   |", "+-----+"];
+            assert_batches_eq!(expected, &result);
+
+            let result = execute_sql(&rt, BY_REGION_SQL).await?;
+            let expected = [
+                "+--------+-----+",
+                "| region | cnt |",
+                "+--------+-----+",
+                "| asia   | 2   |",
+                "| eu     | 2   |",
+                "| us     | 2   |",
+                "+--------+-----+",
+            ];
+            assert_batches_eq!(expected, &result);
+
+            // Phase two: lift one row per partition above the predicate, so every partition has
+            // something to delete and something to keep. A fixture whose deleted rows all sat in
+            // one partition could not tell "retention removed that partition" apart from "that
+            // partition never loaded".
+            std::fs::write(
+                &csv_file,
+                "id,region,name,value\n\
+                 1,us,alpha,100\n\
+                 2,us,beta,500\n\
+                 3,eu,gamma,300\n\
+                 4,eu,delta,600\n\
+                 5,asia,epsilon,200\n\
+                 6,asia,zeta,700\n",
+            )?;
+
+            let notifier = rt
+                .datafusion()
+                .refresh_table(&TableReference::from("partitioned_delete_test"), None)
+                .await?;
+            notifier
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no refresh notifier for 'partitioned_delete_test'")
+                })?
+                .wait()
+                .await;
+
+            // Cayenne applies `retention_sql` on every write, so the deletion may land as part of
+            // the refresh itself or on a later interval check. Poll for it rather than assuming
+            // which (see #13800) — and never assert the state before it, which is unwinnable.
             let converged = wait_until_true(std::time::Duration::from_secs(30), || async {
                 let Ok(result) = execute_sql(&rt, COUNT_SQL).await else {
                     return false;
@@ -1963,18 +2012,9 @@ async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
                 last = pretty_format_batches(&execute_sql(&rt, COUNT_SQL).await?)?
             );
 
-            // Three of the six rows exceed 400, one per partition, so exactly three survive.
-            let result = execute_sql(&rt, COUNT_SQL).await?;
-            let expected = ["+-----+", "| cnt |", "+-----+", "| 3   |", "+-----+"];
-            assert_batches_eq!(expected, &result);
-
             // Every partition must still be present with its one surviving row: a partition that
             // failed to load, or one retention emptied wholesale, fails here.
-            let result = execute_sql(
-                &rt,
-                "SELECT region, COUNT(*) as cnt FROM partitioned_delete_test GROUP BY region ORDER BY region",
-            )
-            .await?;
+            let result = execute_sql(&rt, BY_REGION_SQL).await?;
             let expected = [
                 "+--------+-----+",
                 "| region | cnt |",
@@ -1987,11 +2027,8 @@ async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
             assert_batches_eq!(expected, &result);
 
             // And the survivors must be exactly the rows retention did not match.
-            let result = execute_sql(
-                &rt,
-                "SELECT id FROM partitioned_delete_test ORDER BY id",
-            )
-            .await?;
+            let result =
+                execute_sql(&rt, "SELECT id FROM partitioned_delete_test ORDER BY id").await?;
             let expected = [
                 "+----+", "| id |", "+----+", "| 1  |", "| 3  |", "| 5  |", "+----+",
             ];

--- a/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
+++ b/crates/runtime/tests/acceleration/on_conflict_cayenne.rs
@@ -22,8 +22,10 @@ limitations under the License.
 use std::fmt::Write as _;
 use std::{collections::HashMap, sync::Arc};
 
+use anyhow::ensure;
 use app::AppBuilder;
 use arrow::array::RecordBatch;
+use arrow::util::pretty::pretty_format_batches;
 use datafusion::{
     assert_batches_eq, datasource::TableProvider, physical_plan::collect, prelude::*,
     sql::TableReference,
@@ -38,7 +40,7 @@ use spicepod::{
     partitioning::PartitionedBy,
 };
 
-use crate::utils::{runtime_ready_check, test_request_context};
+use crate::utils::{runtime_ready_check, test_request_context, wait_until_true};
 
 /// Test Cayenne `on_conflict`: upsert behavior
 ///
@@ -1870,13 +1872,18 @@ async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
             let csv_file = data_dir.join("partitioned_delete_test.csv");
             std::fs::write(
                 &csv_file,
+                // Every partition holds one row retention keeps and one it deletes, so the
+                // surviving state proves all three partitions loaded *and* that retention ran
+                // in each of them. A fixture whose deleted rows all sit in one partition cannot
+                // tell "retention removed that partition" apart from "that partition never
+                // loaded".
                 "id,region,name,value\n\
                  1,us,alpha,100\n\
-                 2,us,beta,200\n\
+                 2,us,beta,500\n\
                  3,eu,gamma,300\n\
-                 4,eu,delta,400\n\
-                 5,asia,epsilon,500\n\
-                 6,asia,zeta,600\n",
+                 4,eu,delta,600\n\
+                 5,asia,epsilon,200\n\
+                 6,asia,zeta,700\n",
             )?;
 
             let cayenne_dir = temp_dir.path().join("cayenne_partitioned_delete");
@@ -1933,13 +1940,36 @@ async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
 
             runtime_ready_check(&rt).await;
 
-            // Verify initial data
-            let result =
-                execute_sql(&rt, "SELECT COUNT(*) as cnt FROM partitioned_delete_test").await?;
-            let expected = ["+-----+", "| cnt |", "+-----+", "| 6   |", "+-----+"];
+            // Cayenne applies `retention_sql` on every write, so the rows with `value > 400` can
+            // be gone before the load has even settled — no value of `retention_check_interval`
+            // holds that off. Asserting the pre-retention contents here is therefore unwinnable
+            // (see #13800). Wait for the deletion to land instead, then assert the surviving
+            // state, which with the fixture above still proves the load and the deletion.
+            const COUNT_SQL: &str = "SELECT COUNT(*) as cnt FROM partitioned_delete_test";
+
+            let converged = wait_until_true(std::time::Duration::from_secs(30), || async {
+                let Ok(result) = execute_sql(&rt, COUNT_SQL).await else {
+                    return false;
+                };
+                pretty_format_batches(&result)
+                    .is_ok_and(|table| table.to_string().contains("| 3   |"))
+            })
+            .await;
+
+            ensure!(
+                converged,
+                "retention did not delete the rows with value > 400 from \
+                 'partitioned_delete_test' within 30s; last count was {last}",
+                last = pretty_format_batches(&execute_sql(&rt, COUNT_SQL).await?)?
+            );
+
+            // Three of the six rows exceed 400, one per partition, so exactly three survive.
+            let result = execute_sql(&rt, COUNT_SQL).await?;
+            let expected = ["+-----+", "| cnt |", "+-----+", "| 3   |", "+-----+"];
             assert_batches_eq!(expected, &result);
 
-            // Verify data per partition
+            // Every partition must still be present with its one surviving row: a partition that
+            // failed to load, or one retention emptied wholesale, fails here.
             let result = execute_sql(
                 &rt,
                 "SELECT region, COUNT(*) as cnt FROM partitioned_delete_test GROUP BY region ORDER BY region",
@@ -1949,35 +1979,21 @@ async fn test_cayenne_partitioned_deletion() -> Result<(), anyhow::Error> {
                 "+--------+-----+",
                 "| region | cnt |",
                 "+--------+-----+",
-                "| asia   | 2   |",
-                "| eu     | 2   |",
-                "| us     | 2   |",
+                "| asia   | 1   |",
+                "| eu     | 1   |",
+                "| us     | 1   |",
                 "+--------+-----+",
             ];
             assert_batches_eq!(expected, &result);
 
-            // Wait for retention to delete rows where value > 400
-            // Retention check interval is 1s, so wait a bit for it to run
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
-            // Verify data after retention deletion - should have 4 rows remaining
-            let result =
-                execute_sql(&rt, "SELECT COUNT(*) as cnt FROM partitioned_delete_test").await?;
-            let expected = ["+-----+", "| cnt |", "+-----+", "| 4   |", "+-----+"];
-            assert_batches_eq!(expected, &result);
-
+            // And the survivors must be exactly the rows retention did not match.
             let result = execute_sql(
                 &rt,
-                "SELECT region, COUNT(*) as cnt FROM partitioned_delete_test GROUP BY region ORDER BY region",
+                "SELECT id FROM partitioned_delete_test ORDER BY id",
             )
             .await?;
             let expected = [
-                "+--------+-----+",
-                "| region | cnt |",
-                "+--------+-----+",
-                "| eu     | 2   |",
-                "| us     | 2   |",
-                "+--------+-----+",
+                "+----+", "| id |", "+----+", "| 1  |", "| 3  |", "| 5  |", "+----+",
             ];
             assert_batches_eq!(expected, &result);
 


### PR DESCRIPTION
Closes #13800.

## The problem

`test_cayenne_partitioned_deletion` asserted the table's **pre-retention** contents. Cayenne
applies `retention_sql` **on every write**, so the rows matching `value > 400` can be gone before
the load has settled — no value of `retention_check_interval` holds that off, which makes those
assertions unwinnable rather than merely tight.

Because every row over 400 sat in the `asia` partition, the failure read as a partition
disappearing from an accelerated table, and was triaged as a data-loss regression more than once.

Measured on trunk, with none of the code that was under suspicion:

```
$ for i in $(seq 1 30); do ./integration-cfa3ef66443e617d \
    acceleration::on_conflict_cayenne::test_cayenne_partitioned_deletion --exact --test-threads=1; done
pass=22 fail=8   (of 30)
```

7 of the 8 failed at the per-region assertion and 1 at the count — byte-identical to the
merge-queue failures, including this pairing, which is what gives the mechanism away:

```
captured_output=[{"cnt":6}]                                        <- COUNT(*) before the delete lands
captured_output=[{"region":"eu","cnt":2},{"region":"us","cnt":2}]  <- GROUP BY 76ms later, after it
```

A later read seeing *fewer* rows is a write between the reads, not two scans disagreeing.

## The fix

Assert in two phases, because no single end state can prove the deletion happened — six rows minus
three retention matches leaves exactly what loading only the other three would leave.

**Phase one** loads a fixture every value of which is *below* the predicate and asserts all six
rows across all three partitions. That assertion cannot race: there is no row for retention to
remove, whenever it runs. This is what later lets missing rows mean "deleted".

**Phase two** lifts one row per partition above the predicate and refreshes via
`refresh_table(...).wait()` (the `retention_arrow.rs` pattern — no fixed sleep), then asserts the
three survivors. So the three rows that disappear are three that were provably there, and every
partition must survive with its one unmatched row.

Spreading the deleted rows across all three partitions also makes the fixture match what the test
is named for; previously every deleted row lived in one partition, so "deletion across partitions"
was never really exercised.

## Verification

Same command each time, against the integration binary:

| run | result |
|---|---|
| as written, 30 runs | **30/30 pass** |
| load never produces rows 2, 4, 6 — **phase one present** | **3/3 fail** at the phase-one count |
| load never produces rows 2, 4, 6 — **phase one removed** (the previous oracle) | **3/3 pass** — the gap this closes |
| `asia` partition never loads | **3/3 fail** |
| retention predicate matches nothing (zero deletion) | **3/3 fail** |

Two neuters I tried were **vacuous**, and are recorded because each looked like a result:
`retention_check_enabled: false` does not stop the deletion (`6 -> 3` in ~110 ms with it off), and
an end-state-only oracle cannot see row loss at all. Changing the predicate so it matches nothing
is the neuter that actually removes the deletion.

## Review gate

Attests both commits, `92db6b2643` and `f415077efe`.

- **Adversarial review, first commit:** `codex` — job `review-mtjif90f-1e1ytf` — scoped to
  `origin/trunk...92db6b2643`, `exit=0`, `verdict=needs-attention`. Returned a **valid no-ship**:
  asserting only the survivors meant a partition-load regression would pass with zero deletions.
- **Adversarial review, second commit:** **declared skip** — `codex` returned `exit=1`,
  *"Your workspace is out of credits"*; `grok` is `not-installed`, so `engine=none`. Precisely
  what that leaves: the two-phase **design** was adversarially reviewed — it is the remedy
  `copilot` asked for in
  [this thread](https://github.com/spiceai/spiceai/pull/13806#discussion_r3910735509), and the
  first pass's no-ship is what started it — but **this implementation of it was not**. The
  measurements above are what stands behind it instead.
- **`/security-review`:** no findings. Both commits touch one integration-test file; the added SQL
  is static literals, the added I/O is a `std::fs::write` into a `tempfile::tempdir()` path, and no
  untrusted input reaches either. Assessed inline, as this autonomous session cannot spawn the
  subagents that skill and `/simplify` normally fan out to.
- **`/simplify`:** hoisted the repeated count and by-region queries into `COUNT_SQL` /
  `BY_REGION_SQL`, and dropped the `COUNT(*)=3` assertion the poll made redundant. Re-ran green.

### Credit

The two-phase design came from `copilot`'s thread above and a concurrent review pass that drafted
it. I corrected one detail in that draft — `refresh_table` returns a `RefreshCompletionWaiter`, so
it is `.wait()`, not `.notified()` — and measured it.
