### PR TITLE
build(spiced): move jemalloc heap profiling to its own feature (cherry-pick #13790)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21179,9 +21179,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -21189,9 +21189,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -1191,7 +1191,7 @@ Spice.ai acknowledges the following open source projects for making this project
 - tiktoken-rs 0.9.1, MIT 
   <br/>https://github.com/zurawiki/tiktoken-rs
 
-- tikv-jemallocator 0.6.1, Apache-2.0 OR MIT 
+- tikv-jemallocator 0.7.0, Apache-2.0 OR MIT 
   <br/>https://github.com/tikv/jemallocator
 
 - time 0.3.47, Apache-2.0 OR MIT 

--- a/bin/spiced/Cargo.toml
+++ b/bin/spiced/Cargo.toml
@@ -83,13 +83,8 @@ zeroize = "1.8"
 snmalloc-rs = { version = "0.3.6" }
 spice-cloud = { path = "../../crates/spice_cloud" }
 telemetry = { path = "../../crates/telemetry" }
-# `profiling` builds jemalloc with `--enable-prof`, without which the heap
-# profiler cannot be turned on at all and `MALLOC_CONF=prof:true,prof_prefix=…`
-# is silently ignored. Costs a sample check in the allocator fast path even while
-# prof is inactive, so this opt-in `alloc-jemalloc` build is for heap
-# investigations, not for allocator throughput comparisons against the default
-# snmalloc build.
-tikv-jemallocator = { version = "0.6.0", optional = true, features = ["profiling"] }
+# No `profiling` feature here: `--enable-prof` belongs to `alloc-jemalloc-profiling`.
+tikv-jemallocator = { version = "0.7.0", optional = true }
 tokio.workspace = true
 # `CancellationToken` for the latches the connection report waits on.
 tokio-util.workspace = true
@@ -119,6 +114,9 @@ tempfile.workspace = true
 [features]
 adbc = ["dep:connector-adbc", "runtime/adbc"]
 alloc-jemalloc = ["dep:tikv-jemallocator"]
+# Builds jemalloc with `--enable-prof`, without which `_RJEM_MALLOC_CONF=prof:true`
+# is silently ignored. Reports as `jemalloc-profiling`, not `jemalloc`.
+alloc-jemalloc-profiling = ["alloc-jemalloc", "tikv-jemallocator/profiling"]
 alloc-mimalloc = ["dep:mimalloc"]
 alloc-snmalloc = []
 alloc-system = []

--- a/bin/spiced/build.rs
+++ b/bin/spiced/build.rs
@@ -71,13 +71,16 @@ fn build_features() -> String {
         "nfs",
         "smb",
         "alloc-jemalloc",
+        "alloc-jemalloc-profiling",
         "alloc-mimalloc",
         "alloc-system",
     ];
     let enabled: Vec<&str> = distinguishing
         .into_iter()
         .filter(|feature| {
-            std::env::var_os(format!("CARGO_FEATURE_{}", feature.to_uppercase())).is_some()
+            // Cargo uppercases the feature name and maps `-` to `_`.
+            let var = format!("CARGO_FEATURE_{}", feature.to_uppercase().replace('-', "_"));
+            std::env::var_os(var).is_some()
         })
         .collect();
 

--- a/bin/spiced/src/main.rs
+++ b/bin/spiced/src/main.rs
@@ -58,7 +58,9 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
 // Function to determine the allocator name at compile time
 const fn get_allocator_name() -> Option<&'static str> {
-    if cfg!(feature = "alloc-jemalloc") {
+    if cfg!(feature = "alloc-jemalloc-profiling") {
+        Some("jemalloc-profiling")
+    } else if cfg!(feature = "alloc-jemalloc") {
         Some("jemalloc")
     } else if cfg!(feature = "alloc-mimalloc") {
         Some("mimalloc")

--- a/docs/DISTRIBUTIONS.md
+++ b/docs/DISTRIBUTIONS.md
@@ -185,6 +185,13 @@ Alternative allocator that may perform better for certain memory allocation patt
 docker pull ghcr.io/spiceai/spiceai-nightly:latest-jemalloc
 ```
 
+**Heap profiling:** the shipped jemalloc build has the heap profiler compiled out; build with `alloc-jemalloc-profiling` to turn the profiler on. jemalloc is built under the `_rjem_` prefix, so it reads `_RJEM_MALLOC_CONF`, not `MALLOC_CONF`:
+
+```bash
+make install SPICED_NON_DEFAULT_FEATURES="alloc-jemalloc-profiling"
+_RJEM_MALLOC_CONF=prof:true,prof_final:true,prof_prefix:/tmp/spiced.prof spiced
+```
+
 ### mimalloc
 
 Microsoft's mimalloc allocator, designed for performance and security.


### PR DESCRIPTION
Cherry-pick of #13790 onto `release/2.2`.

## What

Splits jemalloc heap profiling out of the `alloc-jemalloc` build into its own `alloc-jemalloc-profiling` feature, and bumps `tikv-jemallocator` 0.6.1 -> 0.7.0 (`tikv-jemalloc-sys` 0.6.1 -> 0.7.1).

- `alloc-jemalloc` no longer enables the upstream `profiling` feature, so the shipped jemalloc build is back to a plain one.
- `alloc-jemalloc-profiling = ["alloc-jemalloc", "tikv-jemallocator/profiling"]` is the opt-in build that compiles jemalloc with `--enable-prof`, and reports its allocator as `jemalloc-profiling` rather than `jemalloc`.
- `build.rs` picks up the new feature, and fixes the `CARGO_FEATURE_*` lookup: Cargo maps `-` to `_` in the env var name, so the previous `to_uppercase()`-only transform could never have matched a hyphenated feature.
- `docs/DISTRIBUTIONS.md` documents the opt-in build and that jemalloc is built under the `_rjem_` prefix, so it reads `_RJEM_MALLOC_CONF`, not `MALLOC_CONF`.

## Why

On `release/2.2` the default `alloc-jemalloc` build carries `--enable-prof`, which costs a sample check in the allocator fast path on every allocation even while profiling is inactive. That makes the jemalloc distribution unsuitable as an allocator-throughput baseline, and it is paid by everyone running that image whether or not they ever profile. Moving `--enable-prof` behind a separate feature keeps the shipped build clean and leaves heap investigations a build they can ask for explicitly.

## Provenance

Cherry-picked with `jj duplicate`, preserving the original author and the `(#13790)` subject so release audits that grep subjects for `(#NNNN)` can see it landed. Trunk commit: `e8eab310ba788d86515c0af9c789ddce7a36c4fe`.

## Verification

Executed on the cherry-picked tree at this branch head:

- Applied with **no conflicts**. All six files' hunk contexts were already byte-identical on `release/2.2`; `build.rs` and `main.rs` were identical files to trunk's pre-merge state.
- Diff equivalence: every `+`/`-` content line of this commit is identical to the trunk commit's. Only blob hashes and hunk line offsets differ, as expected on a different base.
- `cargo metadata --format-version 1 --locked` exits 0, so `Cargo.lock` resolves against `Cargo.toml` on this base and the two `tikv-jemalloc*` bumps are self-consistent.
- Grepped the branch for `alloc-jemalloc` outside the changed files: no other references on `release/2.2`, so nothing else needed updating.

Not executed here: a full build or test run of either allocator feature. CI covers that.
